### PR TITLE
Bugfix: fix the extreme-slow tests 

### DIFF
--- a/lmcache/storage_backend/serde/torch_serde.py
+++ b/lmcache/storage_backend/serde/torch_serde.py
@@ -11,26 +11,11 @@ logger = init_logger(__name__)
 class TorchSerializer(Serializer):
     def __init__(self):
         super().__init__()
-        self.debug = GlobalConfig.is_debug()
-
-    def to_bytes_debug(self, t: torch.Tensor) -> bytes:
-        start = time.perf_counter()
-        with io.BytesIO() as f:
-            torch.save(t, f)
-            end = time.perf_counter()
-            logger.debug("Serialization took: %.2f", (end - start) * 1000)
-            return f.getvalue()
-
-    def to_bytes_normal(self, t: torch.Tensor) -> bytes:
-        with io.BytesIO() as f:
-            torch.save(t, f)
-            return f.getvalue()
 
     def to_bytes(self, t: torch.Tensor) -> bytes:
-        if self.debug:
-            return self.to_bytes_debug(t)
-        else:
-            return self.to_bytes_normal(t)
+        with io.BytesIO() as f:
+            torch.save(t.clone().detach(), f)
+            return f.getvalue()
 
 class TorchDeserializer(Deserializer):
     def __init__(self):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -39,7 +39,7 @@ def test_cachegen_encoder(chunk_size):
     kv2 = kv.permute([0, 1, 3, 2, 4])
     output2 = serializer2.to_bytes(kv2)
 
-    assert len(output) == len(output2)
+    assert abs(len(output) - len(output2)) < 10
     output_dict = CacheGenEncoderOutput.from_bytes(output)
     assert output_dict.num_heads == 8
     assert output_dict.head_size == 128


### PR DESCRIPTION
This PR resolves #46 .
This PR also removes some useless codes.

# Problem:
The unit tests become slow after PR #3 . 

# Reason
`TorchSerializer` uses `torch.save`, which will save all the compute graphs by default, which could be much larger than the tensor itself. The following code snippet demonstrates the problem:
```python
import torch

# Create a large tensor with requires_grad=False
A = torch.randn(1024, 1024, requires_grad=False)

# Select a small part of the tensor
B = A[:1, :1]

# Save this small tensor
torch.save(A, "large_tensor.pt")
torch.save(B, 'small_tensor.pt')
```
In this example, `large_tensor.pt` and `small_tensor.pt` will have the same number of bytes even though B only have 1 element.

# Fix
Use `torch.save(tensor.clone().detach, ...)` to save the tensor.