### PR TITLE
[Bugfix] fix cachegen crash when TP > 1

### DIFF
--- a/lmcache/storage_backend/serde/cachegen_basics.py
+++ b/lmcache/storage_backend/serde/cachegen_basics.py
@@ -4,6 +4,8 @@ import pickle
 from dataclasses import dataclass
 from typing import List
 from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.logging import init_logger
+logger = init_logger(__name__)
 
 CACHEGEN_GPU_MAX_TOKENS_PER_CHUNK = 256
 
@@ -114,3 +116,11 @@ class CacheGenGPUEncoderOutput:
     def from_bytes(bs: bytes) -> "CacheGenGPUEncoderOutput":
         with io.BytesIO(bs) as f:
             return pickle.load(f)
+
+    def debug_print_device(self):
+        logger.debug(f"bytestream device: {self.data_chunks[0].bytestream.device}")
+        logger.debug(f"bytestream_lengths device: {self.data_chunks[0].bytestream_lengths.device}")
+        logger.debug(f"cdf device: {self.cdf.device}")
+        logger.debug(f"max_tensors_key device: {self.max_tensors_key.device}")
+        logger.debug(f"max_tensors_value device: {self.max_tensors_value.device}")
+

--- a/lmcache/storage_backend/serde/cachegen_decoder.py
+++ b/lmcache/storage_backend/serde/cachegen_decoder.py
@@ -34,12 +34,6 @@ def do_dequantize(t: torch.Tensor, bins: torch.Tensor, maxtensors: torch.Tensor)
     return t
 
 @_lmcache_nvtx_annotate
-def bytes_to_tensor(bs: bytes, device="cuda") -> torch.Tensor:
-    np_array = np.frombuffer(bs, dtype=np.uint8)
-    concated_string = torch.from_numpy(np_array).to(device)
-    return concated_string
-
-@_lmcache_nvtx_annotate
 def recombine_bytes(bytes_tensor, output_lengths) -> torch.Tensor:
     output_buffer_size = CGBasics.CACHEGEN_GPU_MAX_TOKENS_PER_CHUNK
     offsets = output_lengths.flatten().cumsum(0).roll(1).reshape(output_lengths.shape)
@@ -59,13 +53,6 @@ def decode_chunk(
     Write the decode output in target_buffer
     Expected shape: [nlayers (kv in total), ntokens, nchannels]
     """
-    #recombined_output = recombine_bytes(bytes_to_tensor(data_chunk.bytestream), data_chunk.bytestream_lengths)
-    #torchac_cuda.decode_fast_new(
-    #        cdf,
-    #        recombined_output,
-    #        data_chunk.bytestream_lengths,
-    #        target_buffer)
-    #bytes_tensor = bytes_to_tensor(data_chunk.bytestream)
     bytes_tensor = data_chunk.bytestream
     length_prefsum = data_chunk.bytestream_lengths.flatten().cumsum(0).reshape(data_chunk.bytestream_lengths.shape)
     torchac_cuda.decode_fast_prefsum(
@@ -155,6 +142,16 @@ class CacheGenDeserializer(Deserializer):
                 ntokens,
                 self.get_output_buffer(encoder_output.cdf.shape[0] // 2, encoder_output.cdf.shape[1], ntokens)
             )
+
+        # Temporary fix for #83: change the device of key_bins and value_bins to the device of key and value
+        # This reqiures a long-term fix in the future. Currently, CacheGenGPUEncoderOutput has implicit device in itself.
+        # More specifically, if the encoder encodes the tensor on GPU0, the from_bytes will also return a tensor on GPU0
+        # We may want to dyanmically configure the device based on config and metadata in the future
+        if self.key_bins.device != key.device:
+            self.key_bins = self.key_bins.to(key.device)
+
+        if self.value_bins.device != value.device:
+            self.value_bins = self.value_bins.cuda()
 
         key = do_dequantize(key, self.key_bins, encoder_output.max_tensors_key)
         value = do_dequantize(value, self.value_bins, encoder_output.max_tensors_value)

--- a/lmcache/storage_backend/serde/cachegen_encoder.py
+++ b/lmcache/storage_backend/serde/cachegen_encoder.py
@@ -337,6 +337,16 @@ class CacheGenSerializer(Serializer):
         Returns:
             bytes: the serialized bytes
         """
+        # Temporary fix for issue #83: encoder will have the default device 0 
+        # on all the ray workers. Need to set it to the correct device. 
+        # Also need to figure out why this happens.
+        if torch.cuda.current_device != tensor.device:
+            torch.cuda.set_device(tensor.device)
+        if tensor.device != self.key_bins.device:
+            self.key_bins = self.key_bins.to(tensor.device)
+        if tensor.device != self.value_bins.device:
+            self.value_bins = self.value_bins.to(tensor.device)
+
         # TODO: permute is expensive here, need a better way to do it at lower level
         if self.fmt == "huggingface":
             tensor = tensor.permute(0, 1, 3, 2, 4)

--- a/tests/data/test_creation_from_file/remote.yaml
+++ b/tests/data/test_creation_from_file/remote.yaml
@@ -1,6 +1,6 @@
 chunk_size: 256
 local_device: null
-remote_url: "lm://localhost:65432"
+remote_url: "lm://localhost:65000"
 remote_serde: "cachegen"
 
 # Whether retrieve() is pipelined or not


### PR DESCRIPTION
This PR resolves #83 

It fixes the problem by checking the current device and the input tensor's device in an ad-hoc manner.

We will have a more systematic version to handle the device insistence problem when addressing issue #48.