### PR TITLE
[Add] support for redis.Sentinel

### DIFF
--- a/lmcache/storage_backend/connector/__init__.py
+++ b/lmcache/storage_backend/connector/__init__.py
@@ -1,9 +1,54 @@
 import re
+from dataclasses import dataclass
+from typing import Optional, List
 
 from lmcache.storage_backend.connector.base_connector import RemoteConnector, RemoteConnectorDebugWrapper
-from lmcache.storage_backend.connector.redis_connector import RedisConnector
+from lmcache.storage_backend.connector.redis_connector import RedisConnector, RedisSentinelConnector
 from lmcache.storage_backend.connector.lm_connector import LMCServerConnector
 from lmcache.config import GlobalConfig
+
+from lmcache.logging import init_logger
+logger = init_logger(__name__)
+
+@dataclass
+class ParsedRemoteURL:
+    """
+    The parsed URL of the format:
+    <connector_type>://<host>:<port>,<host2>:<port2>,...
+    """
+    connector_type: str
+    hosts: List[str]
+    ports: List[int]
+
+def parse_remote_url(url: str) -> ParsedRemoteURL:
+    """
+    Parses the remote URL into its constituent parts.
+
+    Raises:
+        ValueError: If the URL is invalid.
+    """
+    pattern = r"(.+)://(.*)"
+    m = re.match(pattern, url)
+    if m is None:
+        logger.error(f"Cannot parse remote_url {url} in the config")
+        raise ValueError(f"Invalid remote url {url}")
+
+    connector_type, hosts_and_ports = m.group(1), m.group(2)
+
+    hosts = []
+    ports = []
+    for body in hosts_and_ports.split(","):
+        m = re.match(r"(.+):(\d+)", body)
+        if m is None:
+            logger.error(f"Cannot parse url body {body} from remote_url {url} in the config")
+            raise ValueError(f"Invalid remote url {url}")
+
+        host, port = m.group(1), int(m.group(2))
+        hosts.append(host)
+        ports.append(port)
+
+    return ParsedRemoteURL(connector_type, hosts, ports)
+
 
 def CreateConnector(url: str) -> RemoteConnector:
     """
@@ -12,15 +57,32 @@ def CreateConnector(url: str) -> RemoteConnector:
     m = re.match(r"(.*)://(.*):(\d+)", url)
     if m is None:
         raise ValueError(f"Invalid remote url {url}")
-    connector_type, host, port = m.group(1), m.group(2), int(m.group(3))
+
+    parsed_url = parse_remote_url(url)
+    num_hosts = len(parsed_url.hosts)
+
     connector = None
 
-    match connector_type:
+    match parsed_url.connector_type:
         case "redis":
-            connector = RedisConnector(host, port)
+            if num_hosts == 1:
+                host, port = parsed_url.hosts[0], parsed_url.ports[0]
+                connector = RedisConnector(host, port)
+            else:
+                raise ValueError(f"Redis connector only supports a single host, but got url: {url}")
+
+        case "redis-sentinel":
+            connector = RedisSentinelConnector(list(zip(parsed_url.hosts, parsed_url.ports)))
+
         case "lm":
-            connector = LMCServerConnector(host, port)
+            if num_hosts == 1:
+                host, port = parsed_url.hosts[0], parsed_url.ports[0]
+                connector = LMCServerConnector(host, port)
+            else:
+                raise ValueError(f"LM connector only supports a single host, but got url: {url}")
+
         case _:
             raise ValueError(f"Unknown connector type {connector_type} (url is: {url})")
 
     return connector if not GlobalConfig.is_debug() else RemoteConnectorDebugWrapper(connector)
+

--- a/lmcache/storage_backend/connector/redis_connector.py
+++ b/lmcache/storage_backend/connector/redis_connector.py
@@ -1,8 +1,15 @@
 import redis
-from typing import Optional
+import os
+from typing import Optional, List, Tuple, Union
 from lmcache.storage_backend.connector.base_connector import RemoteConnector
 
+from lmcache.logging import init_logger
+logger = init_logger(__name__)
+
 class RedisConnector(RemoteConnector):
+    """
+    The remote url should start with "redis://" and only have one host-port pair
+    """
     def __init__(self, host: str, port: int):
         self.connection = redis.Redis(host=host, port=port)
 
@@ -29,3 +36,68 @@ class RedisConnector(RemoteConnector):
 
     def close(self):
         self.connection.close()
+
+class RedisSentinelConnector(RemoteConnector):
+    """
+    Uses redis.Sentinel to connect to a Redis cluster.
+    The hosts are specified in the config file, started with "redis-sentinel://" and separated by commas.
+    Example:
+        remote_url: "redis-sentinel://localhost:26379,localhost:26380,localhost:26381"
+
+    Extra environment variables:
+    - REDIS_SERVICE_NAME (required) -- service name for redis.
+    - REDIS_TIMEOUT (optional) -- Timeout in seconds, default is 1 if not set
+    """
+
+    ENV_REDIS_TIMEOUT = 'REDIS_TIMEOUT'
+    ENV_REDIS_SERVICE_NAME = 'REDIS_SERVICE_NAME'
+
+    def __init__(
+            self, 
+            hosts_and_ports: List[Tuple[str, Union[str, int]]]
+        ):
+
+        # Get service name
+        match os.environ.get(self.ENV_REDIS_SERVICE_NAME):
+            case None:
+                logger.warning(f"Environment variable {self.ENV_REDIS_SERVICE_NAME} is not found, using default value 'mymaster'")
+                service_name = "mymaster"
+            case value:
+                service_name = value
+
+        # Get timeout
+        match os.environ.get(self.ENV_REDIS_TIMEOUT):
+            case None:
+                timeout = 1
+            case value:
+                timeout = float(value)
+
+        
+        self.sentinel = redis.Sentinel(hosts_and_ports, timeout)
+        self.master = self.sentinel.master_for(service_name, socket_timeout = timeout)
+        self.slave = self.sentinel.slave_for(service_name, socket_timeout = timeout)
+
+    def exists(self, key: str) -> bool:
+        return self.slave.exists(key)
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self.slave.get(key)
+
+    def set(self, key: str, obj: bytes) -> None:
+        self.master.set(key, obj)
+
+    def list(self):
+        cursor = 0
+        all_keys = []
+    
+        while True:
+            cursor, keys = self.slave.scan(cursor=cursor, match='*')
+            all_keys.extend(keys)
+            if cursor == 0:
+                break
+    
+        return [key.decode('utf-8') for key in all_keys]
+
+    def close(self):
+        self.master.close()
+        self.slave.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,24 @@ class MockRedis:
     def close(self):
         pass
 
+class MockRedisSentinel:
+    def __init__(self, hosts_and_ports, socket_timeout):
+        self.redis = MockRedis("", "")
+
+    def master_for(self, service_name, socket_timeout):
+        return self.redis
+
+    def slave_for(self, service_name, socket_timeout):
+        return self.redis
+
 @pytest.fixture(scope="function", autouse=True)
 def mock_redis():
     with patch('redis.Redis', new_callable=lambda: MockRedis) as mock:
+        yield mock
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_redis_sentinel():
+    with patch('redis.Sentinel', new_callable=lambda: MockRedisSentinel) as mock:
         yield mock
 
 @pytest.fixture(scope='module')  

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -15,10 +15,11 @@ def random_string(N):
 @pytest.mark.parametrize("url",
                          [
                              "redis://localhost:6379",
+                             "redis-sentinel://localhost:6379,localhost:6380,localhost:6381",
                              "lm://localhost:65000",
                          ])
 def test_lm_connector(url, autorelease, lmserver_process):
-    url = "lm://localhost:65000"
+    #url = "lm://localhost:65000"
     connector = autorelease(CreateConnector(url))
     
     assert not connector.exists("some-special-key-12345")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -19,7 +19,6 @@ def random_string(N):
                              "lm://localhost:65000",
                          ])
 def test_lm_connector(url, autorelease, lmserver_process):
-    #url = "lm://localhost:65000"
     connector = autorelease(CreateConnector(url))
     
     assert not connector.exists("some-special-key-12345")


### PR DESCRIPTION
This PR resolves #85 

To use redis sentinel, put the hosts and ports `remote_url` in the configuration yaml file.
The URL should start with `redis-sentinel`, and the `host:port` pairs are separated by commas.

Example:
```yaml
remote_url: "redis-sentinel://localhost:26379,localhost:26380,localhost:26381"
```

It also introduces 2 new environment variables:
- `REDIS_SERVICE_NAME`: the service name when using redis.Sentinel. Default is "mymaster"
- `REDIS_TIMEOUT`: the `socket_timeout` passed to redis.Sentinel. Default value is 1 (second)