### PR TITLE
Using `frombuffer` instead of load for deserialization 

### DIFF
--- a/lmcache/storage_backend/serde/__init__.py
+++ b/lmcache/storage_backend/serde/__init__.py
@@ -3,6 +3,7 @@ from lmcache.storage_backend.serde.torch_serde import TorchSerializer, TorchDese
 from lmcache.storage_backend.serde.safe_serde import SafeSerializer, SafeDeserializer
 from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
+from lmcache.storage_backend.serde.fast_serde import FastSerializer, FastDeserializer
 from lmcache.config import LMCacheEngineConfig, LMCacheEngineMetadata, GlobalConfig
 
 def CreateSerde(serde_type: str, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
@@ -12,6 +13,8 @@ def CreateSerde(serde_type: str, config: LMCacheEngineConfig, metadata: LMCacheE
         s, d = SafeSerializer(), SafeDeserializer()
     elif serde_type == "cachegen":
         s, d = CacheGenSerializer(config, metadata), CacheGenDeserializer(config, metadata)
+    elif serde_type == "fast":
+        s, d = FastSerializer(), FastDeserializer()
     else:
         raise ValueError(f"Invalid serde type: {serde_type}")
 

--- a/lmcache/storage_backend/serde/fast_serde.py
+++ b/lmcache/storage_backend/serde/fast_serde.py
@@ -15,7 +15,7 @@ class FastSerializer(Serializer):
     def to_bytes(self, t: torch.Tensor) -> bytes:
         # FIXME: only support fp16 for now
         assert t.dtype == torch.float16
-        return t.contiguous().numpy().tobytes()
+        return t.contiguous().cpu().numpy().tobytes()
 
 class FastDeserializer(Deserializer):
     def __init__(self):

--- a/lmcache/storage_backend/serde/fast_serde.py
+++ b/lmcache/storage_backend/serde/fast_serde.py
@@ -1,6 +1,7 @@
 import torch
 import io
 import time
+import numpy as np
 
 from lmcache.storage_backend.serde.serde import Serializer, Deserializer
 from lmcache.logging import init_logger
@@ -8,21 +9,34 @@ from lmcache.config import GlobalConfig
 
 logger = init_logger(__name__)
 
+DTYPE_TO_TAG = {
+    torch.bfloat16: 0,
+    torch.float16: 1,
+    torch.float32: 2,
+    torch.float64: 3,
+}
+
+TAG_TO_DTYPE = {v: k for k, v in DTYPE_TO_TAG.items()}
+
 class FastSerializer(Serializer):
     def __init__(self):
         super().__init__()
 
     def to_bytes(self, t: torch.Tensor) -> bytes:
-        # FIXME: only support fp16 for now
-        assert t.dtype == torch.float16
-        return t.contiguous().cpu().numpy().tobytes()
+        # make dtype into bit stream
+        tag = DTYPE_TO_TAG[t.dtype]
+        # make tensor into bit stream
+        buf = t.contiguous().cpu().view(torch.uint8).numpy().tobytes()
+        return tag.to_bytes(1, byteorder='big') + buf
 
 class FastDeserializer(Deserializer):
     def __init__(self):
         super().__init__()
 
     def from_bytes_normal(self, b: bytes) -> torch.Tensor:
-        return torch.frombuffer(b, dtype=torch.float16)
+        tag = int.from_bytes(buf[:1], byteorder='big')
+        buffer = b[:-1] # make it l-val
+        return torch.frombuffer(buffer, dtype=TAG_TO_DTYPE[tag])
 
     def from_bytes(self, b: bytes) -> torch.Tensor:
         return self.from_bytes_normal(b)

--- a/lmcache/storage_backend/serde/fast_serde.py
+++ b/lmcache/storage_backend/serde/fast_serde.py
@@ -35,7 +35,7 @@ class FastDeserializer(Deserializer):
 
     def from_bytes_normal(self, b: bytes) -> torch.Tensor:
         tag = int.from_bytes(b[:1], byteorder='big')
-        buffer = b[:-1] # make it l-val
+        buffer = b[1:] # make it l-val
         return torch.frombuffer(buffer, dtype=TAG_TO_DTYPE[tag])
 
     def from_bytes(self, b: bytes) -> torch.Tensor:

--- a/lmcache/storage_backend/serde/fast_serde.py
+++ b/lmcache/storage_backend/serde/fast_serde.py
@@ -34,7 +34,7 @@ class FastDeserializer(Deserializer):
         super().__init__()
 
     def from_bytes_normal(self, b: bytes) -> torch.Tensor:
-        tag = int.from_bytes(buf[:1], byteorder='big')
+        tag = int.from_bytes(b[:1], byteorder='big')
         buffer = b[:-1] # make it l-val
         return torch.frombuffer(buffer, dtype=TAG_TO_DTYPE[tag])
 

--- a/lmcache/storage_backend/serde/fast_serde.py
+++ b/lmcache/storage_backend/serde/fast_serde.py
@@ -9,34 +9,21 @@ from lmcache.config import GlobalConfig
 
 logger = init_logger(__name__)
 
-DTYPE_TO_TAG = {
-    torch.bfloat16: 0,
-    torch.float16: 1,
-    torch.float32: 2,
-    torch.float64: 3,
-}
-
-TAG_TO_DTYPE = {v: k for k, v in DTYPE_TO_TAG.items()}
-
 class FastSerializer(Serializer):
     def __init__(self):
         super().__init__()
 
     def to_bytes(self, t: torch.Tensor) -> bytes:
-        # make dtype into bit stream
-        tag = DTYPE_TO_TAG[t.dtype]
         # make tensor into bit stream
         buf = t.contiguous().cpu().view(torch.uint8).numpy().tobytes()
-        return tag.to_bytes(1, byteorder='big') + buf
+        return buf
 
 class FastDeserializer(Deserializer):
     def __init__(self):
         super().__init__()
 
-    def from_bytes_normal(self, b: bytes) -> torch.Tensor:
-        tag = int.from_bytes(b[:1], byteorder='big')
-        buffer = b[1:] # make it l-val
-        return torch.frombuffer(buffer, dtype=TAG_TO_DTYPE[tag])
+    def from_bytes_normal(self, b: bytes, dtype=torch.bfloat16) -> torch.Tensor:
+        return torch.frombuffer(buffer, dtype=dtype)
 
     def from_bytes(self, b: bytes) -> torch.Tensor:
         return self.from_bytes_normal(b)

--- a/lmcache/storage_backend/serde/fast_serde.py
+++ b/lmcache/storage_backend/serde/fast_serde.py
@@ -1,0 +1,28 @@
+import torch
+import io
+import time
+
+from lmcache.storage_backend.serde.serde import Serializer, Deserializer
+from lmcache.logging import init_logger
+from lmcache.config import GlobalConfig
+
+logger = init_logger(__name__)
+
+class FastSerializer(Serializer):
+    def __init__(self):
+        super().__init__()
+
+    def to_bytes(self, t: torch.Tensor) -> bytes:
+        # FIXME: only support fp16 for now
+        assert t.dtype == torch.float16
+        return t.contiguous().numpy().tobytes()
+
+class FastDeserializer(Deserializer):
+    def __init__(self):
+        super().__init__()
+
+    def from_bytes_normal(self, b: bytes) -> torch.Tensor:
+        return torch.frombuffer(b, dtype=torch.float16)
+
+    def from_bytes(self, b: bytes) -> torch.Tensor:
+        return self.from_bytes_normal(b)


### PR DESCRIPTION
Default serde is single threaded and is too slow which takes about 800ms to deserialize kv cache of 1000 tokens in a 7B model. This code use `frombuffer` to deser KV cache which only takes 0.06ms 