### PR TITLE
Support saving decode KV cache to boost multi-turn conversation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ perf-test.py
 
 # example output
 /examples/offline_inference/offline_inference_outputs.jsonl
+/examples/offline_inference/buggy_example.py
+/examples/test_example
 
 # disk cache
 /remote_disk

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ perf-test.py
 
 # example output
 /examples/offline_inference/offline_inference_outputs.jsonl
+/examples/save_decode_cache/offline_inference_outputs.jsonl
 /examples/offline_inference/buggy_example.py
 /examples/test_example
 

--- a/examples/offline_inference/offline_inference.py
+++ b/examples/offline_inference/offline_inference.py
@@ -7,8 +7,6 @@ from lmcache_vllm.vllm import LLM, SamplingParams
 from transformers import AutoTokenizer
 
 model_name = "mistralai/Mistral-7B-Instruct-v0.2"
-#model_name = "Qwen/Qwen-7B"
-#model_name = "meta-llama/Llama-3.1-8B-Instruct"
 context_file = os.path.join(os.pardir, 'ffmpeg.txt')
 output_file = "offline_inference_outputs.jsonl"
 

--- a/examples/save_decode_cache/README.md
+++ b/examples/save_decode_cache/README.md
@@ -1,0 +1,13 @@
+# Saving decode cache to boost multi-turn conversation
+This will help with offline inference on vLLM + LMCache.  
+The example consists of two runs.
+The first run asks the LLM to write a lengthy document about FFmpeg.
+The second run asks the LLM to score its own generation.   
+## Prerequisites
+Your server should have at least 1 GPU.  
+
+This will use port 65432(for LMCache).  
+## Steps
+1.  ```lmcache_server localhost 65432```  
+And wait until it's ready.  
+2. ```LMCACHE_CONFIG_FILE=example.yaml CUDA_VISIBLE_DEVICES=0 python3 offline_inference.py```  

--- a/examples/save_decode_cache/example.yaml
+++ b/examples/save_decode_cache/example.yaml
@@ -1,0 +1,10 @@
+chunk_size: 256
+local_device: "cpu"
+remote_url: "lm://localhost:65433"
+remote_serde: "cachegen"
+
+# Whether retrieve() is pipelined or not
+pipelined_backend: False
+
+# Whether save the kv cache for decoded tokens
+save_decode_cache: True

--- a/examples/save_decode_cache/example.yaml
+++ b/examples/save_decode_cache/example.yaml
@@ -1,6 +1,6 @@
 chunk_size: 256
 local_device: "cpu"
-remote_url: "lm://localhost:65433"
+remote_url: "lm://localhost:65432"
 remote_serde: "cachegen"
 
 # Whether retrieve() is pipelined or not

--- a/examples/save_decode_cache/offline_inference.py
+++ b/examples/save_decode_cache/offline_inference.py
@@ -1,0 +1,121 @@
+import copy
+import json
+import os
+import time
+
+from lmcache_vllm.vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+model_name = "mistralai/Mistral-7B-Instruct-v0.2"
+#model_name = "Qwen/Qwen-7B"
+#model_name = "meta-llama/Llama-3.1-8B-Instruct"
+context_file = os.path.join(os.pardir, 'ffmpeg.txt')
+output_file = "offline_inference_outputs.jsonl"
+
+context_text = None
+with open(context_file, 'r') as f:
+    context_text = f.read()
+assert context_text is not None
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+context_messages = [
+    {
+        "role":
+        "user",
+        "content":
+        "You are a helpgul assistant."
+    },
+    {
+        "role": "assistant",
+        "content": "Got it."
+    },
+]
+user_inputs_batch = [
+    "What is FFmpeg?"
+    "Please include some details."
+    "Your answer should be around 5k words",
+]
+
+
+def get_context_length(tokenizer, context_messages):
+    return len(tokenizer.apply_chat_template(context_messages, tokenize=False))
+
+
+def gen_prompts(tokenizer, context_messages, user_inputs_of_batch):
+    generated_prompts = []
+    for user_input in user_inputs_of_batch:
+        copyed_context_messages = copy.deepcopy(context_messages)
+        copyed_context_messages.append({"role": "user", "content": user_input})
+        generated_prompts.append(
+            tokenizer.apply_chat_template(copyed_context_messages,
+                                          tokenize=False))
+    return generated_prompts
+
+
+def append_outputs(output_file_name, outputs, context_length, time_taken):
+    user_inputs = []
+    generated_texts = []
+    for output in outputs:
+        prompt = output.prompt
+        user_input = prompt[context_length:]
+        user_inputs.append(user_input)
+        generated_text = output.outputs[0].text
+        generated_texts.append(f"{generated_text!r}")
+    json_dict = {
+        "user_inputs": user_inputs,
+        "generated_texts": generated_texts,
+        "time in seconds": time_taken
+    }
+    with open(output_file_name, "a") as f:
+        f.write(json.dumps(json_dict) + '\n')
+
+
+context_length = get_context_length(tokenizer, context_messages)
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=1024)
+prompts = gen_prompts(tokenizer, context_messages, user_inputs_batch)
+# Create an LLM.
+llm = LLM(model=model_name,
+          gpu_memory_utilization=0.8,
+          enable_chunked_prefill=False,
+          max_model_len=32768)
+
+import pdb
+pdb.set_trace()
+
+# Clear output file.
+with open(output_file, "w") as f:
+    pass
+
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+t1 = time.perf_counter()
+first_outputs = llm.generate(prompts, sampling_params)
+t2 = time.perf_counter()
+print(f"\n\nFirst request Time: {t2 - t1} seconds\n\n")
+append_outputs(output_file, first_outputs, context_length, t2 - t1)
+
+context_messages.extend(
+    [
+        {
+            "role": "user",
+            "content":
+            user_inputs_batch[0]
+        },
+        {
+            "role": "assistant",
+            "content": 
+            first_outputs[0].outputs[0].text
+        },
+    ]
+)
+user_inputs_batch = [
+    "Score your answer from 1-10",
+]
+context_length = get_context_length(tokenizer, context_messages)
+prompts = gen_prompts(tokenizer, context_messages, user_inputs_batch)
+t3 = time.perf_counter()
+second_outputs = llm.generate(prompts, sampling_params)
+t4 = time.perf_counter()
+print(f"\n\nSecond request Time: {t4 - t3} seconds\n\n")
+append_outputs(output_file, second_outputs, context_length, t4 - t3)

--- a/examples/save_decode_cache/offline_inference.py
+++ b/examples/save_decode_cache/offline_inference.py
@@ -68,7 +68,7 @@ def append_outputs(output_file_name, outputs, context_length, time_taken):
 
 context_length = get_context_length(tokenizer, context_messages)
 # Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=1024)
+sampling_params = SamplingParams(temperature=1.0, top_p=0.95, max_tokens=1024)
 prompts = gen_prompts(tokenizer, context_messages, user_inputs_batch)
 # Create an LLM.
 llm = LLM(model=model_name,
@@ -102,6 +102,7 @@ user_inputs_batch = [
     "Score your answer from 1-10",
 ]
 context_length = get_context_length(tokenizer, context_messages)
+sampling_params = SamplingParams(temperature=1.0, top_p=0.95, max_tokens=10)
 prompts = gen_prompts(tokenizer, context_messages, user_inputs_batch)
 t3 = time.perf_counter()
 second_outputs = llm.generate(prompts, sampling_params)

--- a/examples/save_decode_cache/offline_inference.py
+++ b/examples/save_decode_cache/offline_inference.py
@@ -20,10 +20,8 @@ tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 context_messages = [
     {
-        "role":
-        "user",
-        "content":
-        "You are a helpgul assistant."
+        "role": "user",
+        "content": "You are a helpgul assistant."
     },
     {
         "role": "assistant",
@@ -80,7 +78,6 @@ llm = LLM(model=model_name,
           enable_chunked_prefill=False,
           max_model_len=32768)
 
-
 # Clear output file.
 with open(output_file, "w") as f:
     pass
@@ -93,20 +90,16 @@ t2 = time.perf_counter()
 print(f"\n\nFirst request Time: {t2 - t1} seconds\n\n")
 append_outputs(output_file, first_outputs, context_length, t2 - t1)
 
-context_messages.extend(
-    [
-        {
-            "role": "user",
-            "content":
-            user_inputs_batch[0]
-        },
-        {
-            "role": "assistant",
-            "content": 
-            first_outputs[0].outputs[0].text
-        },
-    ]
-)
+context_messages.extend([
+    {
+        "role": "user",
+        "content": user_inputs_batch[0]
+    },
+    {
+        "role": "assistant",
+        "content": first_outputs[0].outputs[0].text
+    },
+])
 user_inputs_batch = [
     "Score your answer from 1-10",
 ]

--- a/examples/save_decode_cache/offline_inference.py
+++ b/examples/save_decode_cache/offline_inference.py
@@ -7,8 +7,6 @@ from lmcache_vllm.vllm import LLM, SamplingParams
 from transformers import AutoTokenizer
 
 model_name = "mistralai/Mistral-7B-Instruct-v0.2"
-#model_name = "Qwen/Qwen-7B"
-#model_name = "meta-llama/Llama-3.1-8B-Instruct"
 context_file = os.path.join(os.pardir, 'ffmpeg.txt')
 output_file = "offline_inference_outputs.jsonl"
 
@@ -21,7 +19,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_name)
 context_messages = [
     {
         "role": "user",
-        "content": "You are a helpgul assistant."
+        "content": "You are a helpful assistant."
     },
     {
         "role": "assistant",

--- a/examples/save_decode_cache/offline_inference.py
+++ b/examples/save_decode_cache/offline_inference.py
@@ -80,8 +80,6 @@ llm = LLM(model=model_name,
           enable_chunked_prefill=False,
           max_model_len=32768)
 
-import pdb
-pdb.set_trace()
 
 # Clear output file.
 with open(output_file, "w") as f:

--- a/lmcache/cache_engine.py
+++ b/lmcache/cache_engine.py
@@ -29,6 +29,7 @@ class LMCacheEngine:
         self.config = config
         self.metadata = metadata
         self.chunk_size = config.chunk_size
+        self.save_decode_cache = config.save_decode_cache
 
         self.engine_ = CreateStorageBackend(config, metadata)
         logger.debug(f"Current storage backend type {type(self.engine_)}")
@@ -175,7 +176,7 @@ class LMCacheEngine:
         """
         return self._slice_kv_at(0, kv_tensors, fmt)
 
-    def _make_chunks_skip_exsiting(
+    def _make_chunks_skip_existing(
         self,
         tokens: torch.Tensor,
         kv_tensors: torch.Tensor,
@@ -213,7 +214,7 @@ class LMCacheEngine:
         Returns a generator of zipped (chunk_hash, chunk_kv) tuples
         """
         if skip_existing:
-            return self._make_chunks_skip_exsiting(tokens, kv_tensors, fmt)
+            return self._make_chunks_skip_existing(tokens, kv_tensors, fmt)
         else:
             return zip(
                 self._prefix_hash(self._chunk_tokens(tokens)),
@@ -234,7 +235,7 @@ class LMCacheEngine:
 
         Input:
             tokens: the input tokens, with shape [seq_len]
-            kv_tensors: the kv cache of the tokens, in the format of nested 
+            kv_tensors_raw: the kv cache of the tokens, in the format of nested 
             tuples
             
             format: either 'huggingface' or 'vllm'

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -26,8 +26,8 @@ class LMCacheEngineConfig:
     remote_serde: Optional[str]  # Can be "torch" or "cachegen"
 
     pipelined_backend: bool
-    
-    save_decode_cache: bool # whether to store decode kv cache
+
+    save_decode_cache: bool  # whether to store decode kv cache
 
     @staticmethod
     def from_defaults(
@@ -94,7 +94,7 @@ class LMCacheEngineConfig:
         remote_serde = config.get("remote_serde", "torch")
         pipelined_backend = config.get("pipelined_backend", False)
         save_decode_cache = config.get("save_decode_cache", False)
-        
+
         match local_device:
             case "cpu" | "cuda" | None:
                 pass

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -26,6 +26,8 @@ class LMCacheEngineConfig:
     remote_serde: Optional[str]  # Can be "torch" or "cachegen"
 
     pipelined_backend: bool
+    
+    save_decode_cache: bool # whether to store decode kv cache
 
     @staticmethod
     def from_defaults(
@@ -34,6 +36,7 @@ class LMCacheEngineConfig:
         remote_url: str = "redis://localhost:6379",
         remote_serde: str = "torch",
         pipelined_backend: bool = False,
+        save_decode_cache: bool = False,
     ) -> "LMCacheEngineConfig":
         return LMCacheEngineConfig(
             chunk_size,
@@ -41,6 +44,7 @@ class LMCacheEngineConfig:
             remote_url,
             remote_serde,
             pipelined_backend,
+            save_decode_cache,
         )
 
     @staticmethod
@@ -50,6 +54,7 @@ class LMCacheEngineConfig:
         persist_path: Optional[str] = None,
         remote_serde: Optional[str] = "torch",
         pipelined_backend: bool = False,
+        save_decode_cache: bool = False,
     ) -> "LMCacheEngineConfig":
 
         local_device: Optional[str] = None
@@ -72,6 +77,7 @@ class LMCacheEngineConfig:
             remote_url,
             remote_serde,
             pipelined_backend,
+            save_decode_cache,
         )
 
     @staticmethod
@@ -87,7 +93,8 @@ class LMCacheEngineConfig:
         remote_url = config.get("remote_url", None)
         remote_serde = config.get("remote_serde", "torch")
         pipelined_backend = config.get("pipelined_backend", False)
-
+        save_decode_cache = config.get("save_decode_cache", False)
+        
         match local_device:
             case "cpu" | "cuda" | None:
                 pass
@@ -112,6 +119,7 @@ class LMCacheEngineConfig:
             remote_url,
             remote_serde,
             pipelined_backend,
+            save_decode_cache,
         )
 
 


### PR DESCRIPTION
This PR resolves #129 .

Currently, decode cache is saved if seqlen (prompt tokens+generated tokens) % chunk_size == 0
By default, this feature is disabled.
To enable this feature, we need to specify "save_decode_cache: True" in config yaml. 
@Siddhant-Ray Please update the doc as well.

Currently, we only support mistral-7b.
There should be a patch per model. For example, in mistral-7b, assume the first run is text 1 -> text 2. Then input of the second run should take in text 1 + text 2. However, there's always an empty padding token 28705 between text 1 and text 2, making the cache for text 2 not reusable.
See https://github.com/LMCache/lmcache-vllm/pull/17/files#diff-ebeb6ecf30c81dd3fac7c2a4ec1b9ed188a07dd005a6fa94b1d5eabfcea68d1aR175 for solution.
Created an issue to support more models #151 .

@Shaoting-Feng There should be more tests for this feature.

@XbzOnGit There's a naive example at https://github.com/LMCache/LMCache/pull/149/files#diff-3fb66e5f1f5c6e784cf25f543303d240b9130723481a3ea0481d3e38dcfbcb1dR1 .
Please refine this example and also other examples (see #142).

Created an issue to improve the performance #150.