### PR TITLE
refactor(connector): support connector storing tensor directly without serde

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -110,7 +110,7 @@ class LMCacheEngineConfig:
         chunk_size = config.get("chunk_size", 256)
         local_device = config.get("local_device", None)
         remote_url = config.get("remote_url", None)
-        remote_serde = config.get("remote_serde", "torch")
+        remote_serde = config.get("remote_serde", None)
         pipelined_backend = config.get("pipelined_backend", False)
         save_decode_cache = config.get("save_decode_cache", False)
         enable_blending = config.get("enable_blending", False)

--- a/lmcache/storage_backend/connector/__init__.py
+++ b/lmcache/storage_backend/connector/__init__.py
@@ -57,7 +57,7 @@ def parse_remote_url(url: str) -> ParsedRemoteURL:
     return ParsedRemoteURL(connector_type, hosts, ports)
 
 
-def CreateConnector(url: str) -> RemoteConnector:
+def CreateConnector(url: str, device=None) -> RemoteConnector:
     """
     Creates the corresponding remote connector from the given URL.
     """

--- a/lmcache/storage_backend/connector/base_connector.py
+++ b/lmcache/storage_backend/connector/base_connector.py
@@ -1,11 +1,19 @@
 import abc
 import time
+from enum import Enum
 from typing import List, Optional
+
+import torch
 
 from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
 
 logger = init_logger(__name__)
+
+
+class ConnectorType(Enum):
+    BYTES = 1
+    TENSOR = 2
 
 
 class RemoteConnector(metaclass=abc.ABCMeta):
@@ -27,27 +35,28 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get(self, key: str) -> Optional[bytes]:
+    def get(self, key: str) -> Optional[bytes | torch.Tensor]:
         """
-        Get the objects (bytes) of the corresponding key
+        Get the objects (bytes or Tensor) of the corresponding key
 
         Input:
             key: the key of the corresponding object
 
         Returns:
-            The object (bytes) of the corresponding key
+            The objects (bytes or Tensor) of the corresponding key
             Return None if the key does not exist
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set(self, key: str, obj: bytes) -> None:
+    def set(self, key: str, obj: bytes | torch.Tensor) -> None:
         """
-        Send the objects (bytes) with the corresponding key to the remote server
+        Send the objects (bytes or Tensor) with the corresponding key directly
+        to the remote server
 
         Input:
             key: the key of the corresponding object
-            obj: the object (bytes) of the corresponding key
+            obj: the object (bytes or Tensor) of the corresponding key
         """
         raise NotImplementedError
 
@@ -70,6 +79,14 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
+class RemoteBytesConnector(RemoteConnector):
+    pass
+
+
+class RemoteTensorConnector(RemoteConnector):
+    pass
+
+
 class RemoteConnectorDebugWrapper(RemoteConnector):
 
     def __init__(self, connector: RemoteConnector):
@@ -79,7 +96,7 @@ class RemoteConnectorDebugWrapper(RemoteConnector):
         return self.connector.exists(key)
 
     @_lmcache_nvtx_annotate
-    def get(self, key: str) -> Optional[bytes]:
+    def get(self, key: str) -> Optional[bytes | torch.Tensor]:
         start = time.perf_counter()
         ret = self.connector.get(key)
         end = time.perf_counter()
@@ -89,25 +106,58 @@ class RemoteConnectorDebugWrapper(RemoteConnector):
                 "Didn't get any data from the remote backend, key is {key}")
             return None
 
-        logger.debug(
-            "Get %.2f MBytes data from the remote backend takes %.2f ms",
-            len(ret) / 1e6,
-            (end - start) * 1e3,
-        )
+        if check_connector_type(self.connector) == ConnectorType.BYTES:
+            assert isinstance(ret, bytes)
+            logger.debug(
+                "Get %.2f MBytes data from the remote backend takes %.2f ms",
+                len(ret) / 1e6,
+                (end - start) * 1e3,
+            )
+        elif check_connector_type(self.connector) == ConnectorType.TENSOR:
+            assert isinstance(ret, torch.Tensor)
+            logger.debug(
+                "Get %.2f MBytes data from the remote backend takes %.2f ms",
+                (ret.element_size() * ret.numel()) / 1e6,
+                (end - start) * 1e3,
+            )
+
         return ret
 
-    def set(self, key: str, obj: bytes) -> None:
+    def set(self, key: str, obj: bytes | torch.Tensor) -> None:
         start = time.perf_counter()
         self.connector.set(key, obj)
         end = time.perf_counter()
-        logger.debug(
-            "Put %.2f MBytes data to the remote backend takes %.2f ms",
-            len(obj) / 1e6,
-            (end - start) * 1e3,
-        )
+
+        if isinstance(self.connector, RemoteBytesConnector):
+            assert isinstance(obj, bytes)
+            logger.debug(
+                "Put %.2f MBytes data to the remote backend takes %.2f ms",
+                len(obj) / 1e6,
+                (end - start) * 1e3,
+            )
+        elif isinstance(self.connector, RemoteTensorConnector):
+            assert isinstance(obj, torch.Tensor)
+            logger.debug(
+                "Put %.2f MBytes data to the remote backend takes %.2f ms",
+                (obj.element_size() * obj.numel()) / 1e6,
+                (end - start) * 1e3,
+            )
 
     def list(self) -> List[str]:
         return self.connector.list()
 
     def close(self) -> None:
         return self.connector.close()
+
+
+def check_connector_type(connector: RemoteConnector) -> ConnectorType:
+    if isinstance(connector, RemoteBytesConnector):
+        return ConnectorType.BYTES
+    elif isinstance(connector, RemoteTensorConnector):
+        return ConnectorType.TENSOR
+
+    if isinstance(connector, RemoteConnectorDebugWrapper):
+        # TODO: avoid possible recursive deadlock
+        return check_connector_type(connector.connector)
+
+    raise ValueError('Unsupported connector type')

--- a/lmcache/storage_backend/connector/lm_connector.py
+++ b/lmcache/storage_backend/connector/lm_connector.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 
 from lmcache.logging import init_logger
 from lmcache.protocol import ClientMetaMessage, Constants, ServerMetaMessage
-from lmcache.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.storage_backend.connector.base_connector import \
+    RemoteBytesConnector
 from lmcache.utils import _lmcache_nvtx_annotate
 
 logger = init_logger(__name__)
@@ -12,7 +13,7 @@ logger = init_logger(__name__)
 
 # TODO: performance optimization for this class, consider using C/C++/Rust
 # for communication + deserialization
-class LMCServerConnector(RemoteConnector):
+class LMCServerConnector(RemoteBytesConnector):
 
     def __init__(self, host, port):
         self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -43,7 +44,7 @@ class LMCServerConnector(RemoteConnector):
         return (ServerMetaMessage.deserialize(response).code ==
                 Constants.SERVER_SUCCESS)
 
-    def set(self, key: str, obj: bytes):
+    def set(self, key: str, obj: bytes):  # type: ignore[override]
         logger.debug("Call to set()!")
         self.send_all(
             ClientMetaMessage(Constants.CLIENT_PUT, key, len(obj)).serialize())
@@ -64,7 +65,7 @@ class LMCServerConnector(RemoteConnector):
             return None
         length = meta.length
         data = self.receive_all(length)
-        return data
+        return data if data is None else bytes(data)
 
     def list(self) -> List[str]:
         self.send_all(

--- a/lmcache/storage_backend/connector/redis_connector.py
+++ b/lmcache/storage_backend/connector/redis_connector.py
@@ -5,12 +5,13 @@ from typing import List, Optional, Tuple, Union
 import redis
 
 from lmcache.logging import init_logger
-from lmcache.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.storage_backend.connector.base_connector import \
+    RemoteBytesConnector
 
 logger = init_logger(__name__)
 
 
-class RedisConnector(RemoteConnector):
+class RedisConnector(RemoteBytesConnector):
     """
     The remote url should start with "redis://" and only have one host-port pair
     """
@@ -29,7 +30,7 @@ class RedisConnector(RemoteConnector):
 
         return result if result is None else bytes(result)
 
-    def set(self, key: str, obj: bytes) -> None:
+    def set(self, key: str, obj: bytes) -> None:  # type: ignore[override]
         self.connection.set(key, obj)
 
     def list(self):
@@ -50,7 +51,7 @@ class RedisConnector(RemoteConnector):
         self.connection.close()
 
 
-class RedisSentinelConnector(RemoteConnector):
+class RedisSentinelConnector(RemoteBytesConnector):
     """
     Uses redis.Sentinel to connect to a Redis cluster.
     The hosts are specified in the config file, started with "redis-sentinel://" 
@@ -68,7 +69,6 @@ class RedisSentinelConnector(RemoteConnector):
     ENV_REDIS_SERVICE_NAME = "REDIS_SERVICE_NAME"
 
     def __init__(self, hosts_and_ports: List[Tuple[str, Union[str, int]]]):
-
         # Get service name
         match os.environ.get(self.ENV_REDIS_SERVICE_NAME):
             case None:
@@ -100,7 +100,7 @@ class RedisSentinelConnector(RemoteConnector):
     def get(self, key: str) -> Optional[bytes]:
         return self.slave.get(key)
 
-    def set(self, key: str, obj: bytes) -> None:
+    def set(self, key: str, obj: bytes) -> None:  # type: ignore[override]
         self.master.set(key, obj)
 
     def list(self):

--- a/lmcache/storage_backend/hybrid_backend.py
+++ b/lmcache/storage_backend/hybrid_backend.py
@@ -31,7 +31,7 @@ class LMCHybridBackend(LMCBackendInterface):
         self.local_store = LMCLocalBackend(config, mpool_metadata, dst_device)
 
         self.remote_store: Union[LMCPipelinedRemoteBackend, LMCRemoteBackend]
-        if config.pipelined_backend:
+        if config.pipelined_backend and config.remote_serde is not None:
             self.remote_store = LMCPipelinedRemoteBackend(
                 config, metadata, dst_device)
         else:


### PR DESCRIPTION
A simply refactor to remote backend storage, just move `serde` into `connection`.

This resolves #237 