### PR TITLE
Fix cpu buffer memory leak

### DIFF
--- a/lmcache/storage_backend/local_backend.py
+++ b/lmcache/storage_backend/local_backend.py
@@ -295,6 +295,8 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         self.put_thread = threading.Thread(target=self.put_worker, args=())
         self.put_thread.start()
 
+        self.future_pool: Dict[CacheEngineKey, Tuple[Future, KVObj]] = {}
+
         self.sweeper_thread = threading.Thread(target=self.buffer_sweeper,
                                                args=())
         self.sweeper_thread.start()
@@ -306,8 +308,6 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         # cpu backend but big enough to avoid stalls in save
         # TODO(Jiayi): share the buffer if both cpu and disk backend are enabled
         self.cpu_mbufferpool = LocalCPUBufferPool(metadata)
-
-        self.future_pool: Dict[CacheEngineKey, Tuple[Future, KVObj]] = {}
 
         self.proc_pool_executor = ProcessPoolExecutor(max_workers=4)
 
@@ -370,16 +370,20 @@ class LMCLocalDiskBackend(LMCBackendInterface):
             self.put_nonblocking(key, value)
 
     def buffer_sweeper(self, ):
+        """
+        Sweep the future pool to free up memory.
+        """
         while True:
+            logger.debug("Sweeping memory buffer")
             self.update_lock.acquire()
-            for key, value in self.future_pool.items():
-                future = value[0]
-                kv_obj = value[1]
+            for key in list(self.future_pool.keys()):
+                future = self.future_pool[key][0]
+                kv_obj = self.future_pool[key][1]
                 if not future.done():
                     continue
                 self.cpu_mbufferpool.free(kv_obj)
                 del self.future_pool[key]
-            self.update_lock.acquire()
+            self.update_lock.release()
 
             # sweep the memory every 30s
             time.sleep(30)

--- a/lmcache/storage_backend/local_backend.py
+++ b/lmcache/storage_backend/local_backend.py
@@ -443,9 +443,8 @@ class LMCLocalDiskBackend(LMCBackendInterface):
                                            self.evictor.get_size(kv_obj.data))
         # NOTE(Jiayi): the following `free` will result in data corruption
         # The serialized object (`kv_obj.data` in `submit`) may reference
-        # the external memory, and if the tensor is deleted, the underlying
-        # data buffer might be invalidated or freed. This results in
-        # incomplete or corrupted data in the worker process.
+        # the external memory (cpu tensor might be shared in multiprocessing),
+        # and if the tensor is deleted, it might be invalidated.
         # self.cpu_mbufferpool.free(kv_obj)
         self.update_lock.release()
 

--- a/lmcache/storage_backend/local_backend.py
+++ b/lmcache/storage_backend/local_backend.py
@@ -296,7 +296,7 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         self.put_thread.start()
 
         self.future_pool: Dict[CacheEngineKey, Tuple[Future, KVObj]] = {}
-
+        self.stop_event = threading.Event()
         self.sweeper_thread = threading.Thread(target=self.buffer_sweeper,
                                                args=())
         self.sweeper_thread.start()
@@ -373,7 +373,7 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         """
         Sweep the future pool to free up memory.
         """
-        while True:
+        while not self.stop_event:
             logger.debug("Sweeping memory buffer")
             self.update_lock.acquire()
             for key in list(self.future_pool.keys()):
@@ -559,6 +559,7 @@ class LMCLocalDiskBackend(LMCBackendInterface):
             self.put_thread.join()
 
         if self.sweeper_thread is not None and self.sweeper_thread.is_alive():
+            self.stop_event.set()
             self.sweeper_thread.join()
 
         self.proc_pool_executor.shutdown()

--- a/lmcache/storage_backend/local_backend.py
+++ b/lmcache/storage_backend/local_backend.py
@@ -294,7 +294,10 @@ class LMCLocalDiskBackend(LMCBackendInterface):
                   LocalBackendEndSignal]] = queue.Queue()
         self.put_thread = threading.Thread(target=self.put_worker, args=())
         self.put_thread.start()
-        self.update_lock = threading.Lock()
+
+        self.sweeper_thread = threading.Thread(target=self.buffer_sweeper,
+                                               args=())
+        self.sweeper_thread.start()
 
         # TODO(Jiayi): The storage size and caching policy for both
         # evictor and mpool need to be configured dynamically
@@ -366,6 +369,21 @@ class LMCLocalDiskBackend(LMCBackendInterface):
             key, value = item
             self.put_nonblocking(key, value)
 
+    def buffer_sweeper(self, ):
+        while True:
+            self.update_lock.acquire()
+            for key, value in self.future_pool.items():
+                future = value[0]
+                kv_obj = value[1]
+                if not future.done():
+                    continue
+                self.cpu_mbufferpool.free(kv_obj)
+                del self.future_pool[key]
+            self.update_lock.acquire()
+
+            # sweep the memory every 30s
+            time.sleep(30)
+
     @_lmcache_nvtx_annotate
     @torch.inference_mode()
     def put_nonblocking(
@@ -423,6 +441,12 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         self.future_pool[key] = (future, kv_obj)
         self.dict[key] = DiskCacheMetadata(path,
                                            self.evictor.get_size(kv_obj.data))
+        # NOTE(Jiayi): the following `free` will result in data corruption
+        # The serialized object (`kv_obj.data` in `submit`) may reference
+        # the external memory, and if the tensor is deleted, the underlying
+        # data buffer might be invalidated or freed. This results in
+        # incomplete or corrupted data in the worker process.
+        # self.cpu_mbufferpool.free(kv_obj)
         self.update_lock.release()
 
     @_lmcache_nvtx_annotate
@@ -530,8 +554,12 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         if self.put_thread is not None and self.put_thread.is_alive():
             self.put_queue.put(LocalBackendEndSignal())
             self.put_thread.join()
-            logger.info("Closed the put worker in local disk backend")
+
+        if self.sweeper_thread is not None and self.sweeper_thread.is_alive():
+            self.sweeper_thread.join()
+
         self.proc_pool_executor.shutdown()
+        logger.info("Closed the workers in local disk backend")
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
Fix cpu buffer memory leak.
Previously, in local disk setting, cpu buffer is only freed when it is retrieved in `get`. This will result in memory leak if the saved cache is not used.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <a href="https://github.com/LMCache/LMCache/blob/dev/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.