### PR TITLE
[Misc] Support configuring LMCache through environment variables

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -1,8 +1,7 @@
-import re
 import os
+import re
 from dataclasses import dataclass
-from typing import Optional, Tuple, Any
-
+from typing import Any, Optional, Tuple
 
 import torch
 import yaml
@@ -55,8 +54,8 @@ class LMCacheEngineConfig:
         chunk_size: int = 256,
         local_device: str = "cuda",
         max_local_cache_size: int = 5,
-        remote_url: str = "redis://localhost:6379",
-        remote_serde: str = "torch",
+        remote_url: Optional[str] = "redis://localhost:6379",
+        remote_serde: Optional[str] = "torch",
         pipelined_backend: bool = False,
         save_decode_cache: bool = False,
         enable_blending: bool = False,
@@ -169,42 +168,46 @@ class LMCacheEngineConfig:
         
         :note: the default configuration only uses cpu
         """
+
         def get_env_name(attr_name: str) -> str:
             return f"LMCACHE_{attr_name.upper()}"
 
-        def parse_env(name: str, default: str) -> str:
-            return os.getenv(name, default)
+        def parse_env(name: str, default: Optional[Any]):
+            if default is not None:
+                return os.getenv(name, str(default))
+            else:
+                return os.getenv(name)
 
-        config = LMCacheEngineConfig.from_defaults(
-                local_device = "cpu",
-                remote_url = None,
-                remote_serde = None)
+        config = LMCacheEngineConfig.from_defaults(local_device="cpu",
+                                                   remote_url=None,
+                                                   remote_serde=None)
 
-        config.chunk_size = int(parse_env(get_env_name("chunk_size"),
-                                          str(config.chunk_size)))
+        config.chunk_size = int(
+            parse_env(get_env_name("chunk_size"), config.chunk_size))
         config.local_device = parse_env(get_env_name("local_device"),
                                         config.local_device)
-        config.max_local_cache_size = int(parse_env(
-            get_env_name("max_local_cache_size"),
-            str(config.max_local_cache_size)))
+        config.max_local_cache_size = int(
+            parse_env(get_env_name("max_local_cache_size"),
+                      config.max_local_cache_size))
         config.remote_url = parse_env(get_env_name("remote_url"),
                                       config.remote_url)
         config.remote_serde = parse_env(get_env_name("remote_serde"),
                                         config.remote_serde)
         config.pipelined_backend = parse_env(get_env_name("pipelined_backend"),
-                                             str(config.pipelined_backend))
+                                             config.pipelined_backend)
         config.save_decode_cache = parse_env(get_env_name("save_decode_cache"),
-                                             str(config.save_decode_cache))
+                                             config.save_decode_cache)
         config.enable_blending = parse_env(get_env_name("enable_blending"),
-                                           str(config.enable_blending))
-        config.blend_recompute_ratio = float(parse_env(
-            get_env_name("blend_recompute_ratio"),
-            str(config.blend_recompute_ratio)))
-        config.blend_min_tokens = int(parse_env(
-            get_env_name("blend_min_tokens"),
-            str(config.blend_min_tokens)))
+                                           config.enable_blending)
+        config.blend_recompute_ratio = float(
+            parse_env(get_env_name("blend_recompute_ratio"),
+                      config.blend_recompute_ratio))
+        config.blend_min_tokens = int(
+            parse_env(get_env_name("blend_min_tokens"),
+                      config.blend_min_tokens))
 
         return config
+
 
 ### SOME GLOBAL CONFIGS
 # TODO: it needs to be manually updated in the code here, but cannot be really

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -1,6 +1,8 @@
 import re
+import os
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
+
 
 import torch
 import yaml
@@ -155,6 +157,48 @@ class LMCacheEngineConfig:
             blend_min_tokens,
         )
 
+    @staticmethod
+    def from_env() -> "LMCacheEngineConfig":
+        """Load the config from the environment variables
+
+        It will first create a config by `from_defaults` and overwrite
+        the configuration values from the environment variables.
+
+        The environment variables should starts with LMCACHE and be in
+        uppercase. For example, `LMCACHE_CHUNK_SIZE`.
+        """
+        def get_env_name(attr_name: str) -> str:
+            return f"LMCACHE_{attr_name.upper()}"
+
+        def parse_env(name: str, default: str) -> str:
+            return os.getenv(name, default)
+
+        config = LMCacheEngineConfig.from_defaults()
+        config.chunk_size = int(parse_env(get_env_name("chunk_size"),
+                                          str(config.chunk_size)))
+        config.local_device = parse_env(get_env_name("local_device"),
+                                        config.local_device)
+        config.max_local_cache_size = int(parse_env(
+            get_env_name("max_local_cache_size"),
+            str(config.max_local_cache_size)))
+        config.remote_url = parse_env(get_env_name("remote_url"),
+                                      config.remote_url)
+        config.remote_serde = parse_env(get_env_name("remote_serde"),
+                                        config.remote_serde)
+        config.pipelined_backend = parse_env(get_env_name("pipelined_backend"),
+                                             str(config.pipelined_backend))
+        config.save_decode_cache = parse_env(get_env_name("save_decode_cache"),
+                                             str(config.save_decode_cache))
+        config.enable_blending = parse_env(get_env_name("enable_blending"),
+                                           str(config.enable_blending))
+        config.blend_recompute_ratio = float(parse_env(
+            get_env_name("blend_recompute_ratio"),
+            str(config.blend_recompute_ratio)))
+        config.blend_min_tokens = int(parse_env(
+            get_env_name("blend_min_tokens"),
+            str(config.blend_min_tokens)))
+
+        return config
 
 ### SOME GLOBAL CONFIGS
 # TODO: it needs to be manually updated in the code here, but cannot be really

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -166,6 +166,8 @@ class LMCacheEngineConfig:
 
         The environment variables should starts with LMCACHE and be in
         uppercase. For example, `LMCACHE_CHUNK_SIZE`.
+        
+        :note: the default configuration only uses cpu
         """
         def get_env_name(attr_name: str) -> str:
             return f"LMCACHE_{attr_name.upper()}"
@@ -173,7 +175,11 @@ class LMCacheEngineConfig:
         def parse_env(name: str, default: str) -> str:
             return os.getenv(name, default)
 
-        config = LMCacheEngineConfig.from_defaults()
+        config = LMCacheEngineConfig.from_defaults(
+                local_device = "cpu",
+                remote_url = None,
+                remote_serde = None)
+
         config.chunk_size = int(parse_env(get_env_name("chunk_size"),
                                           str(config.chunk_size)))
         config.local_device = parse_env(get_env_name("local_device"),

--- a/tests/test_cache_engine.py
+++ b/tests/test_cache_engine.py
@@ -1,4 +1,6 @@
 import shlex
+from dataclasses import fields
+import os
 import subprocess
 import time
 
@@ -431,3 +433,24 @@ def test_builder(autorelease):
 
     with pytest.raises(ValueError):
         LMCacheEngineBuilder.get_or_create(instance_id, cfg2, dumb_metadata())
+
+def test_env_configure():
+    # Test the parsing of the configurations
+    config = LMCacheEngineConfig.from_defaults()
+    for attr in fields(config):
+        expected_env_name = f"LMCACHE_{attr.name.upper()}"
+        os.environ[expected_env_name] = "0"
+    newconfig = LMCacheEngineConfig.from_env()
+    for attr in fields(newconfig):
+        value = getattr(newconfig, attr.name)
+        if isinstance(value, int) or isinstance(value, float):
+            assert value == 0
+        elif isinstance(value, bool):
+            assert value is bool("0") 
+        elif isinstance(value, str):
+            assert value == "0"
+        else:
+            assert False, "Unexpected type in LMCacheEngineConfig"
+
+        expected_env_name = f"LMCACHE_{attr.name.upper()}"
+        del os.environ[expected_env_name]

--- a/tests/test_cache_engine.py
+++ b/tests/test_cache_engine.py
@@ -1,8 +1,8 @@
-import shlex
-from dataclasses import fields
 import os
+import shlex
 import subprocess
 import time
+from dataclasses import fields
 
 import pytest
 import torch
@@ -434,6 +434,7 @@ def test_builder(autorelease):
     with pytest.raises(ValueError):
         LMCacheEngineBuilder.get_or_create(instance_id, cfg2, dumb_metadata())
 
+
 def test_env_configure():
     # Test the parsing of the configurations
     config = LMCacheEngineConfig.from_defaults()
@@ -446,11 +447,19 @@ def test_env_configure():
         if isinstance(value, int) or isinstance(value, float):
             assert value == 0
         elif isinstance(value, bool):
-            assert value is bool("0") 
+            assert value is bool("0")
         elif isinstance(value, str):
             assert value == "0"
         else:
-            assert False, "Unexpected type in LMCacheEngineConfig"
+            raise AssertionError("Unexpected type in LMCacheEngineConfig")
 
+    exclude_env_name = "LMCACHE_REMOTE_URL"
+    del os.environ[exclude_env_name]
+
+    newconfig2 = LMCacheEngineConfig.from_env()
+    assert newconfig2.remote_url is None
+
+    for attr in fields(newconfig):
         expected_env_name = f"LMCACHE_{attr.name.upper()}"
-        del os.environ[expected_env_name]
+        if expected_env_name in os.environ:
+            del os.environ[expected_env_name]


### PR DESCRIPTION
This PR fixes #257 .

It adds a new function to load LMCacheEngineConfig from the environment variables.

See also LMCache/lmcache-vllm#47

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <a href="https://github.com/LMCache/LMCache/blob/dev/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.