### PR TITLE
[feat] Adding observability metrics and prometheus support

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -1,8 +1,13 @@
-from typing import List, Dict, Tuple
+import threading
 import time
 from dataclasses import dataclass
+from typing import Dict, List, Union
+
+import prometheus_client
 
 from lmcache.config import LMCacheEngineMetadata
+from lmcache.utils import thread_safe
+
 
 @dataclass
 class LMCacheStats:
@@ -12,24 +17,22 @@ class LMCacheStats:
 
     # Real time value measurements
     total_cache_hit_rate: float
-    local_cache_hit_rate: float 
-    remote_cache_hit_rate: float
 
-    local_cache_usage_bytes: int    # Size of the used local cache in bytes
-    remote_cache_usage_bytes: int   # Size of the used remote cache in bytes
+    local_cache_usage_bytes: int  # Size of the used local cache in bytes
+    remote_cache_usage_bytes: int  # Size of the used remote cache in bytes
 
     # Distribution measurements
     time_to_retrieve: List[float]
     time_to_store: List[float]
-    retrieve_speed: List[float] # Tokens per second
-    store_speed: List[float]    # Tokens per second
+    retrieve_speed: List[float]  # Tokens per second
+    store_speed: List[float]  # Tokens per second
 
 
 @dataclass
 class RetrieveRequestStats:
     num_tokens: int
     local_hit_tokens: int
-    remote_hit_tokens: int
+    remote_hit_tokens: int  # Not used for now
     start_time: float
     end_time: float
 
@@ -41,7 +44,9 @@ class RetrieveRequestStats:
     def retrieve_speed(self):
         if self.time_to_retrieve() == 0:
             return 0
-        return self.num_tokens / self.time_to_retrieve()
+        return (self.local_hit_tokens + self.remote_hit_tokens) /\
+                self.time_to_retrieve()
+
 
 @dataclass
 class StoreRequestStats:
@@ -59,89 +64,88 @@ class StoreRequestStats:
             return 0
         return self.num_tokens / self.time_to_store()
 
-    
+
 class LMCStatsMonitor:
+
     def __init__(self):
         self.num_retrieve_requests = 0
         self.num_store_requests = 0
 
         self.total_retrieve_tokens = 0
-        self.total_local_hit_tokens = 0
-        self.total_remote_hit_tokens = 0
+        self.total_hit_tokens = 0
 
         self.local_cache_usage_bytes = 0
         self.remote_cache_usage_bytes = 0
-        
+
         self.retrieve_requests: Dict[int, RetrieveRequestStats] = {}
         self.store_requests: Dict[int, StoreRequestStats] = {}
 
         self.retrieve_request_id = 0
         self.store_request_id = 0
 
+    @thread_safe
     def on_retrieve_request(self, num_tokens: int) -> int:
         """
-        Returns the internal "request id" that will be used in on_retrieve_finished
+        Returns the internal "request id" that will be used in 
+        on_retrieve_finished
         """
         curr_time = time.time()
-        retrieve_stats = RetrieveRequestStats(
-            num_tokens=num_tokens,
-            local_hit_tokens=0,
-            remote_hit_tokens=0,
-            start_time=curr_time,
-            end_time=0
-        )
+        retrieve_stats = RetrieveRequestStats(num_tokens=num_tokens,
+                                              local_hit_tokens=0,
+                                              remote_hit_tokens=0,
+                                              start_time=curr_time,
+                                              end_time=0)
         self.total_retrieve_tokens += num_tokens
         self.num_retrieve_requests += 1
         self.retrieve_requests[self.retrieve_request_id] = retrieve_stats
         self.retrieve_request_id += 1
         return self.retrieve_request_id - 1
 
-    def on_retrieve_finished(self, request_id: int, 
-                             local_retrieved_tokens: int, 
-                             remote_retrieved_tokens: int):
+    @thread_safe
+    def on_retrieve_finished(self, request_id: int, retrieved_tokens: int):
         curr_time = time.time()
         assert request_id in self.retrieve_requests
         retrieve_stats = self.retrieve_requests[request_id]
-        retrieve_stats.local_hit_tokens = local_retrieved_tokens
-        retrieve_stats.remote_hit_tokens = remote_retrieved_tokens
-        self.total_local_hit_tokens = local_retrieved_tokens
-        self.total_remote_hit_tokens = remote_retrieved_tokens
+        retrieve_stats.local_hit_tokens = retrieved_tokens
         retrieve_stats.end_time = curr_time
+        self.total_hit_tokens += retrieved_tokens
 
+    @thread_safe
     def on_store_request(self, num_tokens: int) -> int:
         """
         Returns the internal "request id" that will be used in on_store_finished
         """
         curr_time = time.time()
-        store_stats = StoreRequestStats(
-            num_tokens=num_tokens,
-            start_time=curr_time,
-            end_time=0
-        )
+        store_stats = StoreRequestStats(num_tokens=num_tokens,
+                                        start_time=curr_time,
+                                        end_time=0)
         self.num_store_requests += 1
         self.store_requests[self.store_request_id] = store_stats
         self.store_request_id += 1
         return self.store_request_id - 1
 
+    @thread_safe
     def on_store_finished(self, request_id: int):
         curr_time = time.time()
         assert request_id in self.store_requests
         store_stats = self.store_requests[request_id]
         store_stats.end_time = curr_time
 
+    @thread_safe
     def update_local_cache_usage(self, usage: int):
         self.local_cache_usage_bytes = usage
 
+    @thread_safe
     def update_remote_cache_usage(self, usage: int):
         self.remote_cache_usage_bytes = usage
 
+    @thread_safe
     def _clear(self):
         """
         Clear all the distribution stats 
         """
         self.total_retrieve_tokens = 0
-        self.total_local_hit_tokens = 0
-        self.total_remote_hit_tokens = 0
+        self.total_hit_tokens = 0
 
         new_retrieve_requests = {}
         for request_id, retrieve_stats in self.retrieve_requests.items():
@@ -155,6 +159,7 @@ class LMCStatsMonitor:
                 new_store_requests[request_id] = store_stats
         self.store_requests = new_store_requests
 
+    @thread_safe
     def get_stats_and_clear(self) -> LMCacheStats:
         """
         This function should be called with by prometheus adapter with 
@@ -162,37 +167,32 @@ class LMCStatsMonitor:
         The function will return the latest states between the current 
         call and the previous call.
         """
-        local_cache_hit_rate = 0 if self.total_retrieve_tokens == 0 else \
-                self.total_local_hit_tokens / self.total_retrieve_tokens
-        remote_cache_hit_rate = 0 if self.total_retrieve_tokens == 0 else \
-                self.total_remote_hit_tokens / self.total_retrieve_tokens
-        total_cache_hit_rate = local_cache_hit_rate + remote_cache_hit_rate
+        total_cache_hit_rate = 0 if self.total_retrieve_tokens == 0 else \
+                self.total_hit_tokens / self.total_retrieve_tokens
 
         def filter_out_invalid(stats: List[float]):
             return [x for x in stats if x != 0]
 
-        time_to_retrieve = filter_out_invalid(
-                [stats.time_to_retrieve() 
-                 for stats in self.retrieve_requests.values()])
+        time_to_retrieve = filter_out_invalid([
+            stats.time_to_retrieve()
+            for stats in self.retrieve_requests.values()
+        ])
 
         time_to_store = filter_out_invalid(
-                [stats.time_to_store() 
-                 for stats in self.store_requests.values()])
+            [stats.time_to_store() for stats in self.store_requests.values()])
 
-        retrieve_speed = filter_out_invalid(
-                [stats.retrieve_speed() 
-                 for stats in self.retrieve_requests.values()])
+        retrieve_speed = filter_out_invalid([
+            stats.retrieve_speed()
+            for stats in self.retrieve_requests.values()
+        ])
 
         store_speed = filter_out_invalid(
-                [stats.store_speed() 
-                 for stats in self.store_requests.values()])
+            [stats.store_speed() for stats in self.store_requests.values()])
 
         ret = LMCacheStats(
             num_retrieve_requests=self.num_retrieve_requests,
             num_store_requests=self.num_store_requests,
             total_cache_hit_rate=total_cache_hit_rate,
-            local_cache_hit_rate=local_cache_hit_rate,
-            remote_cache_hit_rate=remote_cache_hit_rate,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
             time_to_retrieve=time_to_retrieve,
@@ -214,3 +214,176 @@ class LMCStatsMonitor:
     @staticmethod
     def DestoryInstane():
         LMCStatsMonitor._instance = None
+
+
+class PrometheusLogger:
+    _gauge_cls = prometheus_client.Gauge
+    _counter_cls = prometheus_client.Counter
+    _histogram_cls = prometheus_client.Histogram
+
+    def __init__(self, metadata: LMCacheEngineMetadata):
+        self.metadata = metadata
+
+        self.labels = self._metadata_to_labels(metadata)
+        labelnames = list(self.labels.keys())
+
+        self.counter_num_retrieve_requests = self._counter_cls(
+            name="lmcache:num_retrieve_requests",
+            documentation="Number of retrieve requests sent to lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_store_requests = self._counter_cls(
+            name="lmcache:num_store_requests",
+            documentation="Number of store requests sent to lmcache",
+            labelnames=labelnames,
+        )
+
+        self.gauge_cache_hit_rate = self._gauge_cls(
+            name="lmcache:cache_hit_rate",
+            documentation="Cache hit rate of lmcache",
+            labelnames=labelnames,
+            multiprocess_mode="livemostrecent")
+
+        self.gauge_local_cache_usage = self._gauge_cls(
+            name="lmcache:local_cache_usage",
+            documentation="Local cache usage (bytes) of lmcache",
+            labelnames=labelnames,
+            multiprocess_mode="sum")
+
+        self.gauge_remote_cache_usage = self._gauge_cls(
+            name="lmcache:remote_cache_usage",
+            documentation="Remote cache usage (bytes) of lmcache",
+            labelnames=labelnames,
+            multiprocess_mode="sum")
+
+        time_to_retrieve_buckets = [
+            0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 0.75,
+            1.0, 2.5, 5.0, 7.5, 10.0
+        ]
+        self.histogram_time_to_retrieve = self._histogram_cls(
+            name="lmcache:time_to_retrieve",
+            documentation="Time to retrieve from lmcache (seconds)",
+            labelnames=labelnames,
+            buckets=time_to_retrieve_buckets,
+        )
+
+        time_to_store_buckets = [
+            0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 0.75,
+            1.0, 2.5, 5.0, 7.5, 10.0
+        ]
+        self.histogram_time_to_store = self._histogram_cls(
+            name="lmcache:time_to_store",
+            documentation="Time to store to lmcache (seconds)",
+            labelnames=labelnames,
+            buckets=time_to_store_buckets,
+        )
+
+        retrieve_speed_buckets = [
+            1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+            32768, 65536
+        ]
+        self.histogram_retrieve_speed = self._histogram_cls(
+            name="lmcache:retrieve_speed",
+            documentation="Retrieve speed of lmcache (tokens per second)",
+            labelnames=labelnames,
+            buckets=retrieve_speed_buckets,
+        )
+
+        store_speed_buckets = [
+            1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+            32768, 65536
+        ]
+        self.histogram_store_speed = self._histogram_cls(
+            name="lmcache:store_speed",
+            documentation="Store speed of lmcache (tokens per second)",
+            labelnames=labelnames,
+            buckets=store_speed_buckets,
+        )
+
+    def _log_gauge(self, gauge, data: Union[int, float]) -> None:
+        # Convenience function for logging to gauge.
+        gauge.labels(**self.labels).set(data)
+
+    def _log_counter(self, counter, data: Union[int, float]) -> None:
+        # Convenience function for logging to counter.
+        # Prevent ValueError from negative increment
+        if data < 0:
+            return
+        counter.labels(**self.labels).inc(data)
+
+    def _log_histogram(self, histogram, data: Union[List[int],
+                                                    List[float]]) -> None:
+        # Convenience function for logging to histogram.
+        for value in data:
+            histogram.labels(**self.labels).observe(value)
+
+    def log_prometheus(self, stats: LMCacheStats):
+        self._log_counter(self.counter_num_retrieve_requests,
+                          stats.num_retrieve_requests)
+        self._log_counter(self.counter_num_store_requests,
+                          stats.num_store_requests)
+
+        self._log_gauge(self.gauge_cache_hit_rate, stats.total_cache_hit_rate)
+
+        self._log_gauge(self.gauge_local_cache_usage,
+                        stats.local_cache_usage_bytes)
+
+        self._log_gauge(self.gauge_remote_cache_usage,
+                        stats.remote_cache_usage_bytes)
+
+        self._log_histogram(self.histogram_time_to_retrieve,
+                            stats.time_to_retrieve)
+
+        self._log_histogram(self.histogram_time_to_store, stats.time_to_store)
+
+        self._log_histogram(self.histogram_retrieve_speed,
+                            stats.retrieve_speed)
+
+        self._log_histogram(self.histogram_store_speed, stats.store_speed)
+
+    @staticmethod
+    def _metadata_to_labels(metadata: LMCacheEngineMetadata):
+        return {
+            "model_name": metadata.model_name,
+            "worker_id": metadata.worker_id
+        }
+
+    _instance = None
+
+    @staticmethod
+    def GetOrCreate(metadata: LMCacheEngineMetadata) -> "PrometheusLogger":
+        if PrometheusLogger._instance is None:
+            PrometheusLogger._instance = PrometheusLogger(metadata)
+        assert PrometheusLogger._instance.metadata == metadata, \
+            "PrometheusLogger instance already created with different metadata"
+        return PrometheusLogger._instance
+
+    @staticmethod
+    def GetInstance() -> "PrometheusLogger":
+        assert PrometheusLogger._instance is not None, \
+            "PrometheusLogger instance not created yet"
+        return PrometheusLogger._instance
+
+
+class LMCacheStatsLogger:
+
+    def __init__(self, metadata: LMCacheEngineMetadata, log_interval: int):
+        self.metadata = metadata
+        self.log_interval = log_interval
+        self.monitor = LMCStatsMonitor.GetOrCreate()
+        self.prometheus_logger = PrometheusLogger.GetOrCreate(metadata)
+        self.is_running = True
+
+        self.thread = threading.Thread(target=self.log_worker, daemon=True)
+        self.thread.start()
+
+    def log_worker(self):
+        while self.is_running:
+            stats = self.monitor.get_stats_and_clear()
+            self.prometheus_logger.log_prometheus(stats)
+            time.sleep(self.log_interval)
+
+    def shutdown(self):
+        self.is_running = False
+        self.thread.join()

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -1,0 +1,216 @@
+from typing import List, Dict, Tuple
+import time
+from dataclasses import dataclass
+
+from lmcache.config import LMCacheEngineMetadata
+
+@dataclass
+class LMCacheStats:
+    # Counter
+    num_retrieve_requests: int
+    num_store_requests: int
+
+    # Real time value measurements
+    total_cache_hit_rate: float
+    local_cache_hit_rate: float 
+    remote_cache_hit_rate: float
+
+    local_cache_usage_bytes: int    # Size of the used local cache in bytes
+    remote_cache_usage_bytes: int   # Size of the used remote cache in bytes
+
+    # Distribution measurements
+    time_to_retrieve: List[float]
+    time_to_store: List[float]
+    retrieve_speed: List[float] # Tokens per second
+    store_speed: List[float]    # Tokens per second
+
+
+@dataclass
+class RetrieveRequestStats:
+    num_tokens: int
+    local_hit_tokens: int
+    remote_hit_tokens: int
+    start_time: float
+    end_time: float
+
+    def time_to_retrieve(self):
+        if self.end_time == 0:
+            return 0
+        return self.end_time - self.start_time
+
+    def retrieve_speed(self):
+        if self.time_to_retrieve() == 0:
+            return 0
+        return self.num_tokens / self.time_to_retrieve()
+
+@dataclass
+class StoreRequestStats:
+    num_tokens: int
+    start_time: float
+    end_time: float
+
+    def time_to_store(self):
+        if self.end_time == 0:
+            return 0
+        return self.end_time - self.start_time
+
+    def store_speed(self):
+        if self.time_to_store() == 0:
+            return 0
+        return self.num_tokens / self.time_to_store()
+
+    
+class LMCStatsMonitor:
+    def __init__(self):
+        self.num_retrieve_requests = 0
+        self.num_store_requests = 0
+
+        self.total_retrieve_tokens = 0
+        self.total_local_hit_tokens = 0
+        self.total_remote_hit_tokens = 0
+
+        self.local_cache_usage_bytes = 0
+        self.remote_cache_usage_bytes = 0
+        
+        self.retrieve_requests: Dict[int, RetrieveRequestStats] = {}
+        self.store_requests: Dict[int, StoreRequestStats] = {}
+
+        self.retrieve_request_id = 0
+        self.store_request_id = 0
+
+    def on_retrieve_request(self, num_tokens: int) -> int:
+        """
+        Returns the internal "request id" that will be used in on_retrieve_finished
+        """
+        curr_time = time.time()
+        retrieve_stats = RetrieveRequestStats(
+            num_tokens=num_tokens,
+            local_hit_tokens=0,
+            remote_hit_tokens=0,
+            start_time=curr_time,
+            end_time=0
+        )
+        self.total_retrieve_tokens += num_tokens
+        self.num_retrieve_requests += 1
+        self.retrieve_requests[self.retrieve_request_id] = retrieve_stats
+        self.retrieve_request_id += 1
+        return self.retrieve_request_id - 1
+
+    def on_retrieve_finished(self, request_id: int, 
+                             local_retrieved_tokens: int, 
+                             remote_retrieved_tokens: int):
+        curr_time = time.time()
+        assert request_id in self.retrieve_requests
+        retrieve_stats = self.retrieve_requests[request_id]
+        retrieve_stats.local_hit_tokens = local_retrieved_tokens
+        retrieve_stats.remote_hit_tokens = remote_retrieved_tokens
+        self.total_local_hit_tokens = local_retrieved_tokens
+        self.total_remote_hit_tokens = remote_retrieved_tokens
+        retrieve_stats.end_time = curr_time
+
+    def on_store_request(self, num_tokens: int) -> int:
+        """
+        Returns the internal "request id" that will be used in on_store_finished
+        """
+        curr_time = time.time()
+        store_stats = StoreRequestStats(
+            num_tokens=num_tokens,
+            start_time=curr_time,
+            end_time=0
+        )
+        self.num_store_requests += 1
+        self.store_requests[self.store_request_id] = store_stats
+        self.store_request_id += 1
+        return self.store_request_id - 1
+
+    def on_store_finished(self, request_id: int):
+        curr_time = time.time()
+        assert request_id in self.store_requests
+        store_stats = self.store_requests[request_id]
+        store_stats.end_time = curr_time
+
+    def update_local_cache_usage(self, usage: int):
+        self.local_cache_usage_bytes = usage
+
+    def update_remote_cache_usage(self, usage: int):
+        self.remote_cache_usage_bytes = usage
+
+    def _clear(self):
+        """
+        Clear all the distribution stats 
+        """
+        self.total_retrieve_tokens = 0
+        self.total_local_hit_tokens = 0
+        self.total_remote_hit_tokens = 0
+
+        new_retrieve_requests = {}
+        for request_id, retrieve_stats in self.retrieve_requests.items():
+            if retrieve_stats.end_time == 0:
+                new_retrieve_requests[request_id] = retrieve_stats
+        self.retrieve_requests = new_retrieve_requests
+
+        new_store_requests = {}
+        for request_id, store_stats in self.store_requests.items():
+            if store_stats.end_time == 0:
+                new_store_requests[request_id] = store_stats
+        self.store_requests = new_store_requests
+
+    def get_stats_and_clear(self) -> LMCacheStats:
+        """
+        This function should be called with by prometheus adapter with 
+        a specific interval.
+        The function will return the latest states between the current 
+        call and the previous call.
+        """
+        local_cache_hit_rate = 0 if self.total_retrieve_tokens == 0 else \
+                self.total_local_hit_tokens / self.total_retrieve_tokens
+        remote_cache_hit_rate = 0 if self.total_retrieve_tokens == 0 else \
+                self.total_remote_hit_tokens / self.total_retrieve_tokens
+        total_cache_hit_rate = local_cache_hit_rate + remote_cache_hit_rate
+
+        def filter_out_invalid(stats: List[float]):
+            return [x for x in stats if x != 0]
+
+        time_to_retrieve = filter_out_invalid(
+                [stats.time_to_retrieve() 
+                 for stats in self.retrieve_requests.values()])
+
+        time_to_store = filter_out_invalid(
+                [stats.time_to_store() 
+                 for stats in self.store_requests.values()])
+
+        retrieve_speed = filter_out_invalid(
+                [stats.retrieve_speed() 
+                 for stats in self.retrieve_requests.values()])
+
+        store_speed = filter_out_invalid(
+                [stats.store_speed() 
+                 for stats in self.store_requests.values()])
+
+        ret = LMCacheStats(
+            num_retrieve_requests=self.num_retrieve_requests,
+            num_store_requests=self.num_store_requests,
+            total_cache_hit_rate=total_cache_hit_rate,
+            local_cache_hit_rate=local_cache_hit_rate,
+            remote_cache_hit_rate=remote_cache_hit_rate,
+            local_cache_usage_bytes=self.local_cache_usage_bytes,
+            remote_cache_usage_bytes=self.remote_cache_usage_bytes,
+            time_to_retrieve=time_to_retrieve,
+            time_to_store=time_to_store,
+            retrieve_speed=retrieve_speed,
+            store_speed=store_speed,
+        )
+        self._clear()
+        return ret
+
+    _instance = None
+
+    @staticmethod
+    def GetOrCreate() -> "LMCStatsMonitor":
+        if LMCStatsMonitor._instance is None:
+            LMCStatsMonitor._instance = LMCStatsMonitor()
+        return LMCStatsMonitor._instance
+
+    @staticmethod
+    def DestoryInstane():
+        LMCStatsMonitor._instance = None

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import threading
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -80,3 +81,14 @@ def _lmcache_nvtx_annotate(func, domain="lmcache"):
         color=_get_color_for_nvtx(func.__qualname__),
         domain=domain,
     )(func)
+
+
+##### Threading related #####
+def thread_safe(func):
+    lock = threading.Lock()
+
+    def wrapper(*args, **kwargs):
+        with lock:
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psutil
 aiohttp
 torchac_cuda>=0.2.5
 sortedcontainers
+prometheus_client

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "transformers",
         "torchac_cuda >= 0.2.5",
         "sortedcontainers",
+        "prometheus_client",
     ],
     ext_modules=ext_modules,
     cmdclass=cmdclass,

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -5,8 +5,8 @@ from lmcache.observability import LMCStatsMonitor
 
 @pytest.fixture(scope="function")
 def stats_monitor():
-    yield LMCStatsMonitor.GetOrCreate()
     LMCStatsMonitor.DestoryInstane()
+    return LMCStatsMonitor.GetOrCreate()
 
 
 def test_on_retrieve_request(stats_monitor):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,76 @@
+import time
+import pytest
+from lmcache.observability import LMCStatsMonitor, LMCacheStats
+
+@pytest.fixture(scope="function")
+def stats_monitor():
+    yield LMCStatsMonitor.GetOrCreate()
+    LMCStatsMonitor.DestoryInstane()
+
+def test_on_retrieve_request(stats_monitor):
+    stats_monitor.on_retrieve_request(num_tokens=100)
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.num_retrieve_requests == 1
+    assert stats.total_cache_hit_rate == 0
+    assert stats.local_cache_hit_rate == 0
+    assert stats.remote_cache_hit_rate == 0
+    assert stats.local_cache_usage_bytes == 0
+    assert stats.remote_cache_usage_bytes == 0
+    assert len(stats.time_to_retrieve) == 0
+
+def test_on_retrieve_finished(stats_monitor):
+    request_id = stats_monitor.on_retrieve_request(num_tokens=100)
+    stats_monitor.on_retrieve_finished(
+        request_id=request_id,
+        local_retrieved_tokens=80,
+        remote_retrieved_tokens=20
+    )
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.num_retrieve_requests == 1
+    assert stats.local_cache_hit_rate == 0.8
+    assert stats.remote_cache_hit_rate == 0.2
+    assert stats.total_cache_hit_rate == 1.0
+    assert len(stats.time_to_retrieve) == 1
+
+def test_on_store_request_and_finished(stats_monitor):
+    request_id = stats_monitor.on_store_request(num_tokens=50)
+    stats_monitor.on_store_finished(request_id=request_id)
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.num_store_requests == 1
+    assert len(stats.time_to_store) == 1
+
+def test_update_local_cache_usage(stats_monitor):
+    stats_monitor.update_local_cache_usage(usage=1024)
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.local_cache_usage_bytes == 1024
+
+def test_update_remote_cache_usage(stats_monitor):
+    stats_monitor.update_remote_cache_usage(usage=2048)
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.remote_cache_usage_bytes == 2048
+
+def test_combined_operations(stats_monitor):
+    retrieve_id = stats_monitor.on_retrieve_request(num_tokens=200)
+    stats_monitor.on_retrieve_finished(
+        request_id=retrieve_id,
+        local_retrieved_tokens=150,
+        remote_retrieved_tokens=50
+    )
+    store_id = stats_monitor.on_store_request(num_tokens=100)
+    stats_monitor.on_store_finished(store_id)
+    stats_monitor.update_local_cache_usage(usage=512)
+    stats_monitor.update_remote_cache_usage(usage=1024)
+
+    stats_monitor2 = LMCStatsMonitor.GetOrCreate()
+    stats = stats_monitor2.get_stats_and_clear()
+
+    assert stats.num_retrieve_requests == 1
+    assert stats.num_store_requests == 1
+    assert stats.local_cache_hit_rate == 0.75
+    assert stats.remote_cache_hit_rate == 0.25
+    assert stats.total_cache_hit_rate == 1.0
+    assert stats.local_cache_usage_bytes == 512
+    assert stats.remote_cache_usage_bytes == 1024
+    assert len(stats.time_to_retrieve) == 1
+    assert len(stats.time_to_store) == 1
+

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,36 +1,35 @@
-import time
 import pytest
-from lmcache.observability import LMCStatsMonitor, LMCacheStats
+
+from lmcache.observability import LMCStatsMonitor
+
 
 @pytest.fixture(scope="function")
 def stats_monitor():
     yield LMCStatsMonitor.GetOrCreate()
     LMCStatsMonitor.DestoryInstane()
 
+
 def test_on_retrieve_request(stats_monitor):
     stats_monitor.on_retrieve_request(num_tokens=100)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.num_retrieve_requests == 1
     assert stats.total_cache_hit_rate == 0
-    assert stats.local_cache_hit_rate == 0
-    assert stats.remote_cache_hit_rate == 0
     assert stats.local_cache_usage_bytes == 0
     assert stats.remote_cache_usage_bytes == 0
     assert len(stats.time_to_retrieve) == 0
+
 
 def test_on_retrieve_finished(stats_monitor):
     request_id = stats_monitor.on_retrieve_request(num_tokens=100)
     stats_monitor.on_retrieve_finished(
         request_id=request_id,
-        local_retrieved_tokens=80,
-        remote_retrieved_tokens=20
+        retrieved_tokens=100,
     )
     stats = stats_monitor.get_stats_and_clear()
     assert stats.num_retrieve_requests == 1
-    assert stats.local_cache_hit_rate == 0.8
-    assert stats.remote_cache_hit_rate == 0.2
     assert stats.total_cache_hit_rate == 1.0
     assert len(stats.time_to_retrieve) == 1
+
 
 def test_on_store_request_and_finished(stats_monitor):
     request_id = stats_monitor.on_store_request(num_tokens=50)
@@ -39,22 +38,24 @@ def test_on_store_request_and_finished(stats_monitor):
     assert stats.num_store_requests == 1
     assert len(stats.time_to_store) == 1
 
+
 def test_update_local_cache_usage(stats_monitor):
     stats_monitor.update_local_cache_usage(usage=1024)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.local_cache_usage_bytes == 1024
+
 
 def test_update_remote_cache_usage(stats_monitor):
     stats_monitor.update_remote_cache_usage(usage=2048)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.remote_cache_usage_bytes == 2048
 
+
 def test_combined_operations(stats_monitor):
     retrieve_id = stats_monitor.on_retrieve_request(num_tokens=200)
     stats_monitor.on_retrieve_finished(
         request_id=retrieve_id,
-        local_retrieved_tokens=150,
-        remote_retrieved_tokens=50
+        retrieved_tokens=200,
     )
     store_id = stats_monitor.on_store_request(num_tokens=100)
     stats_monitor.on_store_finished(store_id)
@@ -66,11 +67,8 @@ def test_combined_operations(stats_monitor):
 
     assert stats.num_retrieve_requests == 1
     assert stats.num_store_requests == 1
-    assert stats.local_cache_hit_rate == 0.75
-    assert stats.remote_cache_hit_rate == 0.25
     assert stats.total_cache_hit_rate == 1.0
     assert stats.local_cache_usage_bytes == 512
     assert stats.remote_cache_usage_bytes == 1024
     assert len(stats.time_to_retrieve) == 1
     assert len(stats.time_to_store) == 1
-


### PR DESCRIPTION
This PR adds the observability metrics and Prometheus support. Now, when running together with vLLM, LMCache supports the following metrics
- **time_to_retrieve**: the histogram of the time consumed by the "retrieve" function call
- **time_to_store**: the histogram of the time consumed by the "store" function call
- **retrieve_speed**: the histogram of the speed of retrieving KV caches (in tokens per second)
- **storing_speed**: the histogram of the speed of storing KV caches (in tokens per second)
- **num_retrieve_requests**: total number of "retrieves" being called
- **num_store_requests**: total number of "stores" being called
- **local_cache_usage**: total size of the local cache being used
- **remote_cache_usage**: total size of the remote cache being used (**Currently unavailable**)
- **cache_hit_rate**: the cache hit rate during the last time window, calculated by "number of retrieved tokens / total number of tokens in retrieve requests"


Example of the Prometheus output:
```plaintext
# HELP lmcache:time_to_retrieve Time to retrieve from lmcache (seconds)
# TYPE lmcache:time_to_retrieve histogram
lmcache:time_to_retrieve_sum{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0323789119720459
lmcache:time_to_retrieve_bucket{le="0.001",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 1.0
...
lmcache:time_to_retrieve_bucket{le="+Inf",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 4.0
lmcache:time_to_retrieve_count{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 4.0
# HELP lmcache:time_to_store Time to store to lmcache (seconds)
# TYPE lmcache:time_to_store histogram
lmcache:time_to_store_sum{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0052034854888916016
lmcache:time_to_store_bucket{le="0.001",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0
...
lmcache:time_to_store_bucket{le="+Inf",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 1.0
lmcache:time_to_store_count{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 1.0
# HELP lmcache:store_speed Store speed of lmcache (tokens per second)
# TYPE lmcache:store_speed histogram
lmcache:store_speed_sum{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 60728.52526918671
lmcache:store_speed_bucket{le="1.0",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0
...
lmcache:store_speed_bucket{le="+Inf",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 1.0
lmcache:store_speed_count{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 1.0
# HELP lmcache:retrieve_speed Retrieve speed of lmcache (tokens per second)
# TYPE lmcache:retrieve_speed histogram
lmcache:retrieve_speed_sum{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 90656.4018959451
lmcache:retrieve_speed_bucket{le="1.0",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0
...
lmcache:retrieve_speed_bucket{le="+Inf",model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 3.0
lmcache:retrieve_speed_count{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 3.0
# HELP lmcache:num_retrieve_requests_total Number of retrieve requests sent to lmcache
# TYPE lmcache:num_retrieve_requests_total counter
lmcache:num_retrieve_requests_total{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 6.0
# HELP lmcache:num_store_requests_total Number of store requests sent to lmcache
# TYPE lmcache:num_store_requests_total counter
lmcache:num_store_requests_total{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 3.0
# HELP lmcache:local_cache_usage Local cache usage (bytes) of lmcache
# TYPE lmcache:local_cache_usage gauge
lmcache:local_cache_usage{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0
# HELP lmcache:remote_cache_usage Remote cache usage (bytes) of lmcache
# TYPE lmcache:remote_cache_usage gauge
lmcache:remote_cache_usage{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 0.0
# HELP lmcache:cache_hit_rate Cache hit rate of lmcache
# TYPE lmcache:cache_hit_rate gauge
lmcache:cache_hit_rate{model_name="mistralai/Mistral-7B-Instruct-v0.2",worker_id="0"} 1.0
```

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <a href="https://github.com/LMCache/LMCache/blob/dev/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.