### PR TITLE
[CI/Build] Fix pytorch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools >= 49.4.0",
     "wheel",
     "packaging",
-    "torch >= 2.2.0",
+    "torch == 2.4.0",
     "ninja",
     "pybind11",
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("csrc")),
     install_requires=[
-        "torch >= 2.2.0",
+        "torch == 2.4.0",
         "numpy==1.26.4",
         "aiofiles",
         "pyyaml",


### PR DESCRIPTION
Fix the following bug:

```bash
Traceback (most recent call last):
  File "/dataheart/yihua98/Applications/anaconda3/envs/buildkite-bm/bin/lmcache_vllm", line 33, in <module>
    sys.exit(load_entry_point('lmcache-vllm', 'console_scripts', 'lmcache_vllm')())
  File "/dataheart/yihua98/Applications/anaconda3/envs/buildkite-bm/bin/lmcache_vllm", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/dataheart/yihua98/Applications/anaconda3/envs/buildkite-bm/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/dataheart/yihua98/Applications/anaconda3/envs/buildkite-bm/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/local/yihua98/.buildkite-agent/builds/nature-1/lmcache/lmcache-vllm/lmcache_vllm/__init__.py", line 6, in <module>
    from lmcache_vllm.experimental.vllm_injection import InitLMCacheExperimentalEnvironment
  File "/local/yihua98/.buildkite-agent/builds/nature-1/lmcache/lmcache-vllm/lmcache_vllm/experimental/vllm_injection.py", line 18, in <module>
    from lmcache_vllm.experimental.vllm_adapter import (init_lmcache_engine, 
  File "/local/yihua98/.buildkite-agent/builds/nature-1/lmcache/lmcache-vllm/lmcache_vllm/experimental/vllm_adapter.py", line 23, in <module>
    from lmcache.experimental.cache_engine import LMCacheEngine, LMCacheEngineBuilder
  File "/local/yihua98/.buildkite-agent/builds/nature-1/lmcache/benchmark/lmcache/experimental/cache_engine.py", line 8, in <module>
    from lmcache.experimental.gpu_connector import GPUConnectorInterface
  File "/local/yihua98/.buildkite-agent/builds/nature-1/lmcache/benchmark/lmcache/experimental/gpu_connector.py", line 6, in <module>
    import lmcache.c_ops as lmc_ops
ImportError: /local/yihua98/.buildkite-agent/builds/nature-1/lmcache/benchmark/lmcache/c_ops.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZNK3c1011StorageImpl27throw_data_ptr_access_errorEv
```