### PR TITLE
[Doc] Fix port and typo issue within README.md of p2p

### DIFF
--- a/examples/p2p/README.md
+++ b/examples/p2p/README.md
@@ -28,7 +28,7 @@ Note that the two distributed cache servers will start at port 8200 and 8201.
 
 3. Send request to vllm engine 1:  
 ```bash
-curl -X POST http://localhost:8000/v1/completions \ 
+curl -X POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
@@ -39,7 +39,7 @@ curl -X POST http://localhost:8000/v1/completions \
 
 4. Send request to vllm engine 2:  
 ```bash
-curl -X POST http://localhost:8000/v1/completions \ 
+curl -X POST http://localhost:8001/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",


### PR DESCRIPTION
Fix the port and typo issue within README.md of p2p, so that user can run the example successfully.