### PR TITLE
Dongmao/refactory infinistore connector

### DIFF
--- a/lmcache/experimental/memory_management.py
+++ b/lmcache/experimental/memory_management.py
@@ -203,6 +203,16 @@ class TensorMemoryObj(MemoryObj):
         return memoryview(byte_array)
 
 
+class CopyLessMemoryObj(TensorMemoryObj):
+
+    def __init__(self, raw_data, metadata, callback):
+        super().__init__(raw_data, metadata)
+        self.callback = callback
+
+    def __del__(self):
+        self.callback()
+
+
 class BytesBufferMemoryObj(MemoryObj):
     """
     Wraps a raw flat tensor with some metadata

--- a/lmcache/experimental/protocol.py
+++ b/lmcache/experimental/protocol.py
@@ -54,6 +54,22 @@ class RedisMetadata:
     dtype: Optional[torch.dtype]
     fmt: MemoryFormat
 
+    def serialize_into(self, buffer):
+        assert (len(self.shape) == 4), "Shape dimension should be 4"
+
+        struct.pack_into(
+            "iiiiiii",
+            buffer,
+            0,
+            self.length,
+            int(self.fmt.value),
+            DTYPE_TO_INT[self.dtype],
+            self.shape[0],
+            self.shape[1],
+            self.shape[2],
+            self.shape[3],
+        )
+
     def serialize(self) -> bytes:
 
         # NOTE(Jiayi): 4 is the maximum dimension of memory object.
@@ -75,7 +91,7 @@ class RedisMetadata:
     @staticmethod
     def deserialize(s: bytes) -> "RedisMetadata":
         length, fmt, dtype, shape0, shape1, shape2, shape3 = \
-            struct.unpack("iiiiiii", s)
+            struct.unpack_from("iiiiiii", s)
         return RedisMetadata(length,
                              torch.Size([shape0, shape1, shape2, shape3]),
                              INT_TO_DTYPE[dtype], MemoryFormat(fmt))

--- a/lmcache/experimental/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/infinistore_connector.py
@@ -1,17 +1,15 @@
 import asyncio
 import ctypes
+import operator
+from functools import reduce
 from typing import List, Optional, Union, no_type_check
 
 import infinistore
 import torch
-import operator
-import numpy as np
 
-from functools import reduce
-
-from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
-                                                    MemoryObj,
-                                                    CopyLessMemoryObj)
+from lmcache.experimental.memory_management import (CopyLessMemoryObj,
+                                                    MemoryAllocatorInterface,
+                                                    MemoryObj)
 # reuse
 from lmcache.experimental.protocol import RedisMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
@@ -21,8 +19,8 @@ from lmcache.utils import CacheEngineKey
 
 logger = init_logger(__name__)
 
+MAX_BUFFER_SIZE = 40 << 20  # 40MB
 METADATA_BYTES_LEN = 28
-
 MAX_BUFFER_CNT = 16
 
 
@@ -57,8 +55,7 @@ class InfinistoreConnector(RemoteConnector):
         self.recv_queue: asyncio.Queue[int] = asyncio.Queue(
             maxsize=MAX_BUFFER_CNT)
 
-        # 40MB
-        self.buffer_size = 40 << 20
+        self.buffer_size = MAX_BUFFER_SIZE
         for i in range(MAX_BUFFER_CNT):
             send_buffer = bytearray(self.buffer_size)
             self.rdma_conn.register_mr(_get_ptr(send_buffer), self.buffer_size)
@@ -130,11 +127,12 @@ class InfinistoreConnector(RemoteConnector):
                len(kv_bytes)] = kv_bytes
 
         size = memory_obj.get_size()
-        if size + METADATA_BYTES_LEN > (40 << 20):
-            raise Exception(
-                f"value is bigger than hard coded 40MB, please decrease chunk_size"
-            )
 
+        if size + METADATA_BYTES_LEN > self.buffer_size:
+            raise ValueError(
+                f"Value size ({size + METADATA_BYTES_LEN} bytes)"
+                f"exceeds the maximum allowed size"
+                f"({self.buffer_size} bytes). Please decrease chunk_size.")
         try:
             await self.rdma_conn.rdma_write_cache_async(
                 [(key_str, 0)], METADATA_BYTES_LEN + size, _get_ptr(buffer))

--- a/lmcache/experimental/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/infinistore_connector.py
@@ -3,9 +3,15 @@ import ctypes
 from typing import List, Optional, Union, no_type_check
 
 import infinistore
+import torch
+import operator
+import numpy as np
+
+from functools import reduce
 
 from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
-                                                    MemoryObj)
+                                                    MemoryObj,
+                                                    CopyLessMemoryObj)
 # reuse
 from lmcache.experimental.protocol import RedisMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
@@ -16,6 +22,8 @@ from lmcache.utils import CacheEngineKey
 logger = init_logger(__name__)
 
 METADATA_BYTES_LEN = 28
+
+MAX_BUFFER_CNT = 16
 
 
 def _get_ptr(mv: Union[bytearray, memoryview]) -> int:
@@ -39,98 +47,105 @@ class InfinistoreConnector(RemoteConnector):
 
         self.rdma_conn = infinistore.InfinityConnection(config)
 
-        self.memory_allocator = memory_allocator
         self.loop = loop
         self.rdma_conn.connect()
 
-        # allocate 4KB buffer for RDMA read
-        self.buffer_size = 4 << 10
-        self.buffer = bytearray(self.buffer_size)
-        self.rdma_conn.register_mr(_get_ptr(self.buffer), self.buffer_size)
+        self.send_buffers = []
+        self.recv_buffers = []
+        self.send_queue: asyncio.Queue[int] = asyncio.Queue(
+            maxsize=MAX_BUFFER_CNT)
+        self.recv_queue: asyncio.Queue[int] = asyncio.Queue(
+            maxsize=MAX_BUFFER_CNT)
+
+        # 40MB
+        self.buffer_size = 40 << 20
+        for i in range(MAX_BUFFER_CNT):
+            send_buffer = bytearray(self.buffer_size)
+            self.rdma_conn.register_mr(_get_ptr(send_buffer), self.buffer_size)
+            self.send_buffers.append(send_buffer)
+            self.send_queue.put_nowait(i)
+
+            recv_buffer = bytearray(self.buffer_size)
+            self.rdma_conn.register_mr(_get_ptr(recv_buffer), self.buffer_size)
+            self.recv_buffers.append(recv_buffer)
+            self.recv_queue.put_nowait(i)
 
     async def exists(self, key: CacheEngineKey) -> bool:
 
         def blocking_io():
-            return self.rdma_conn.check_exist(key.to_string() + "metadata")
+            return self.rdma_conn.check_exist(key.to_string())
 
         return await self.loop.run_in_executor(None, blocking_io)
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
 
+        buf_idx = await self.recv_queue.get()
+        buffer = self.recv_buffers[buf_idx]
         try:
-            await self.rdma_conn.read_cache_single_async(
-                key_str + "metadata", _get_ptr(self.buffer), len(self.buffer))
-        except infinistore.lib.InfiniStoreKeyNotFound:
+            await self.rdma_conn.rdma_read_cache_async([(key_str, 0)],
+                                                       self.buffer_size,
+                                                       _get_ptr(buffer))
+        except Exception as e:
+            logger.warning(f"get failed: {e}")
+            self.recv_queue.put_nowait(buf_idx)
             return None
 
-        metadata = RedisMetadata.deserialize(self.buffer[:METADATA_BYTES_LEN])
+        metadata = RedisMetadata.deserialize(buffer)
 
-        memory_obj = self.memory_allocator.allocate(
-            metadata.shape,
-            metadata.dtype,
-            metadata.fmt,
-        )
-        if memory_obj is None:
-            logger.warning("Failed to allocate memory during remote receive")
-            return None
+        def callback():
+            self.recv_queue.put_nowait(buf_idx)
 
-        # TODO: we could have memory allocator which pre-allocate
-        # and register RDMA memory.
-        # register memory is a heavy operation, so we should avoid it.
+        num_elements = reduce(operator.mul, metadata.shape)
+        assert metadata.dtype is not None
+        temp_tensor = torch.frombuffer(buffer,
+                                       dtype=metadata.dtype,
+                                       offset=METADATA_BYTES_LEN,
+                                       count=num_elements).reshape(
+                                           metadata.shape)
 
-        kv_bytes = bytes(memory_obj.get_size())
-        pointer = ctypes.cast(ctypes.c_char_p(kv_bytes),
-                              ctypes.POINTER(ctypes.c_char))
-        ptr = ctypes.addressof(pointer.contents)
-        size = memory_obj.get_size()
+        memory_obj = CopyLessMemoryObj(raw_data=temp_tensor,
+                                       metadata=metadata,
+                                       callback=callback)
 
-        await self.loop.run_in_executor(None, self.rdma_conn.register_mr, ptr,
-                                        size)
-
-        try:
-            await self.rdma_conn.read_cache_single_async(
-                key_str + "kv_bytes", ptr, size)
-        except infinistore.lib.InfiniStoreKeyNotFound:
-            return None
-
-        view = memoryview(memory_obj.byte_array)
-        view[:metadata.length] = kv_bytes
-
+        logger.debug(f"get key: {key_str} done, {memory_obj.get_shape()}")
         return memory_obj
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # TODO(Jiayi): The following code is ugly.
-        # Please use a function like `memory_obj.to_meta()`.
+
+        key_str = key.to_string()
+
         kv_bytes = memory_obj.byte_array
         kv_shape = memory_obj.get_shape()
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
-                                       memory_format).serialize()
+        buf_idx = await self.send_queue.get()
+        buffer = self.send_buffers[buf_idx]
 
-        # not likely to happen
-        assert len(metadata_bytes
-                   ) <= self.buffer_size, "metadata size exceeds buffer size"
+        RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
+                      memory_format).serialize_into(buffer)
 
-        # copy metadata to self.buffer
-        self.buffer[:len(metadata_bytes)] = metadata_bytes
+        buffer[METADATA_BYTES_LEN:METADATA_BYTES_LEN +
+               len(kv_bytes)] = kv_bytes
 
-        await self.rdma_conn.rdma_write_cache_single_async(
-            key.to_string() + "metadata", _get_ptr(self.buffer),
-            len(self.buffer))
-
-        pointer = ctypes.cast(ctypes.c_char_p(memory_obj.byte_array),
-                              ctypes.POINTER(ctypes.c_char))
-        ptr = ctypes.addressof(pointer.contents)
         size = memory_obj.get_size()
-        await self.loop.run_in_executor(None, self.rdma_conn.register_mr, ptr,
-                                        size)
-        await self.rdma_conn.rdma_write_cache_single_async(
-            key.to_string() + "kv_bytes", ptr, size)
+        if size + METADATA_BYTES_LEN > (40 << 20):
+            raise Exception(
+                f"value is bigger than hard coded 40MB, please decrease chunk_size"
+            )
 
-        self.memory_allocator.ref_count_down(memory_obj)
+        try:
+            await self.rdma_conn.rdma_write_cache_async(
+                [(key_str, 0)], METADATA_BYTES_LEN + size, _get_ptr(buffer))
+        except Exception as e:
+            logger.warning(
+                f"exception happens in rdma_write_cache_async kv_bytes {e}")
+            return
+        finally:
+            self.send_queue.put_nowait(buf_idx)
+
+        logger.debug(f"put key: {key.to_string()}, {memory_obj.get_shape()}")
 
     # TODO
     @no_type_check


### PR DESCRIPTION
hi, upstream

   this is a PR which deprecate #413, for the following reasons:

1. we  found that register_memory is not thread-safe, and should not execute in threadpool. so in the new connector, we pre alllocated buffer to recv and send tensor.
2. CopyLessMemoryObj is introduced here to avoid memcopy in Get() API. But memcpy still happens on Put() API 
3. Known issues: we have preallocated 40MB buffer.  But if chunk size or model is too big. it will raise an excepiton.
4. it includes a new unit-test.

this is my benchmark result comparing all backend using this branch : 
https://github.com/bytedance-iaas/LMCache/tree/release which added additional thread to download kvcache BEFORE decoding.

bench command:

```
python3 vllm/benchmarks/benchmark_serving.py --backend openai-chat --model /data/models/QwQ-32B --base-url http://127.0.0.1:8080 --endpoint /v1/chat/completions --num-prompts 16  --request-rate 1 --metric_percentiles '50,90,95,99' --goodput ttft:5000 tpot:50 --max-concurrency 16 --random-input-len 1000 --random-output-len 250 --dataset-name random --ignore-eos --seed 114
```

TTFT/TPOP results:

|   ----         | PD infinistore      | PD lmcache  | PD redis| origin vllm|
|----------|-------------------|----------------|------|---------|
| TTFT  |1872ms  | 3700ms     |2700ms| 1712ms |
| TPOT   | 50ms   |  59ms  |86ms| 84ms|


compared to origin vllm, infinistore in PD shows very stable and shorter TPOT.  while all TTFT still have to improve.



