### PR TITLE
[Bugfix] Fix warnings

### DIFF
--- a/csrc/ac_dec.cu
+++ b/csrc/ac_dec.cu
@@ -237,7 +237,7 @@ __global__ void decode_prefix_with_accessor_kernel(
 
     // copy bytestreams[layer_id, global_channel_offset:global_channel_offset+BLOCK_SIZE, :] to shared memory, do this channel by channel
     for (int i = 0; i < BLOCK_SIZE; i++) {
-        const int channel_id = global_channel_offset + i;
+        [[maybe_unused]] const int channel_id = global_channel_offset + i;
         const int start_offset = sum_lengths_shared[i];
         const int end_offset = sum_lengths_shared[i + 1];
         const int length = end_offset - start_offset;

--- a/csrc/cal_cdf.cu
+++ b/csrc/cal_cdf.cu
@@ -95,8 +95,8 @@ at::Tensor calculate_cdf(
 
     auto output = torch::zeros({nlayers, nchannels, max_bins + 1}, input.options().dtype(at::kShort));
 
-    auto input_accessor = input.packed_accessor<int8_t, 3>();
-    auto output_accessor = output.packed_accessor<int16_t, 3>();
+    auto input_accessor = input.packed_accessor64<int8_t, 3>();
+    auto output_accessor = output.packed_accessor64<int16_t, 3>();
 
     int block_size = get_block_size(nchannels);
     dim3 block_dim(block_size, 1, 1);


### PR DESCRIPTION
Small PR to fix up a couple of warnings I hit while building:
* An unused variable in `ac_dec.cu`
* `packed_accessor` is deprecated in favor of either `packed_accessor32` or `packed_accessor64`