### PR TITLE
Update installation.rst  'ERROR: Could not find a version that satisfies the requirement vllm==0.6.2.3'

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -56,7 +56,7 @@ You can install the latest code from the GitHub repository:
 .. code-block:: console
 
     # Install vLLM version
-    $ pip install vllm==0.6.2.3
+    $ pip install vllm==0.6.2
 
     # Clone and install LMCache
     $ git clone git@github.com:LMCache/LMCache.git


### PR DESCRIPTION
![屏幕截图 2025-04-14 162517](https://github.com/user-attachments/assets/7efcca4d-3614-45c0-8680-9d55a97dddfb)

**[Doc] Fix incorrect `vllm` version in installation guide**

This PR updates the installation command in the documentation to use the correct version of the `vllm` package.  
The version `0.6.2.3` does not exist on PyPI and causes an installation failure.  
We change it to `vllm==0.6.2`, which is a valid release and compatible with the project setup.

### Changes
- Update [installation.rst](https://github.com/LMCache/LMCache/blob/dev/docs/source/getting_started/installation.rst) to fix `pip install vllm==0.6.2.3` → `pip install vllm==0.6.2`

### Related Issues
None officially reported yet.

---

<details>
<summary><b> PR Checklist (Click to Expand) </b></summary>

### PR Title and Classification
- [x] **[Doc]** for documentation fixes and improvements

### Code Quality
- [x] No code changes involved
- [x] No linting or formatting issues
- [x] No tests required for doc-only PR

### Review Notes
This is a documentation-only fix. Should be quick to review and merge.

</details>

