### PR TITLE
Update quickstart.rst, fix the error of the quickstart tutorial's example can't run

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -35,13 +35,14 @@ To use vLLM's offline inference with LMCache, just simply add ``lmcache_vllm`` b
 .. code-block:: python
 
     import lmcache_vllm.vllm as vllm
-    from lmcache_vllm.vllm import LLM 
-
+    from lmcache_vllm.vllm import LLM
+    
     # Load the model
-    model = LLM.from_pretrained("lmsys/longchat-7b-16k")
-
+    sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95)
+    model = LLM("lmsys/longchat-7b-16k")
+    
     # Use the model
-    model.generate("Hello, my name is", max_length=100)
+    model.generate("Hello, my name is", sampling_params)
 
 
 


### PR DESCRIPTION
### [Bugfix] Fix `LLM.from_pretrained` and incorrect `generate()` usage in Quickstart

**Related Issue**: FIX #468  (replace this with actual issue number if available)

---

#### Description
This PR addresses two bugs in the `Quickstart` section of the LMCache documentation/code sample:

1. `LLM.from_pretrained(...)` results in an `AttributeError` because the `LLM` class does not expose a `from_pretrained` method. The correct way to instantiate the model is directly via `LLM(...)`.
![屏幕截图 2025-04-15 151756](https://github.com/user-attachments/assets/46f374fd-0ccc-4b74-a310-40366d9a5413)

2. The method call `model.generate("Hello, my name is", max_length=100)` leads to a `TypeError` because the `generate()` method does not accept `max_length` directly. Instead, a `SamplingParams` object should be created and passed as a second argument.
![屏幕截图 2025-04-15 151845](https://github.com/user-attachments/assets/eddbb52d-5e04-4392-9f15-a736c9053504)

---

#### Fix Summary
- Replaced incorrect instantiation `LLM.from_pretrained(...)` with `LLM(...)`.
- Introduced `SamplingParams` from `vllm` and passed it into `generate()`.

```python
import lmcache_vllm.vllm as vllm
from lmcache_vllm.vllm import LLM

# Load the model
sampling_params = vllm.SamplingParams(temperature=0.8, top_p=0.95)
model = LLM("lmsys/longchat-7b-16k")

# Use the model
model.generate("Hello, my name is", sampling_params)
```

---

#### Checklist
- [x] Code runs successfully and mirrors expected behavior
- [x] Fix tested in local environment with compatible model
- [x] Improved code comments and documentation clarity

