### PR TITLE
[Core] Optimize the computation of prefix hashes for chunks

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -19,7 +19,7 @@ class LMCacheEngineMetadata:
     fmt: str
     """ the data type of kv tensors """
     kv_dtype: torch.dtype
-    """ the data type of kv tensors """
+    """ the shape of kv tensors """
     """ (num_layer, 2, chunk_size, num_kv_head, head_size) """
     kv_shape: tuple[int, int, int, int, int]
 


### PR DESCRIPTION
## Method
Optimize prefix hash computation through the following methods:
1. Avoid frequent device to host (D2H) operations.
2. Use the `update` function to prevent temporary object generation.

## Performance test
```py
import hashlib
import timeit
import torch
from typing import List, Optional, Iterable

torch.manual_seed(1024)

class OldChunkPrefixHasher:
    def __init__(self, chunk_size):
        self.chunk_size = chunk_size
    
    def _get_init_hash(self) -> str:
        return ""
    
    def _hash(
        self, 
        tokens: torch.Tensor, 
        prefix_hash: str, 
    ) -> str:
        return hashlib.sha256(
            prefix_hash.encode("ascii") +
            tokens.cpu().numpy().tobytes()).hexdigest()
    
    def _prefix_hash(
        self, 
        token_chunks: Iterable[torch.Tensor], 
        num_skip_chunk: Optional[int] = 0, 
    ) -> List[str]:
        prefix_hash = self._get_init_hash()
        prefix_hashes = []
        for token_chunk in token_chunks:
            prefix_hash = self._hash(token_chunk, prefix_hash)
            prefix_hashes.append(prefix_hash)
        return prefix_hashes[num_skip_chunk:]
    
    def _chunk_tokens(
        self, 
        tokens: torch.Tensor,
    ) -> Iterable[torch.Tensor]:
        for i in range(0, len(tokens), self.chunk_size):
            yield tokens[i:i + self.chunk_size]
    
    def get_prefix_hashes(
        self, 
        tokens: torch.Tensor,
    ) -> List[str]:
        return self._prefix_hash(self._chunk_tokens(tokens))


class NewChunkPrefixHasher:
    def __init__(self, chunk_size):
        self.chunk_size = chunk_size
    
    def _get_init_hash(self) -> str:
        return ""
    
    def _hash(
        self, 
        tokens: torch.Tensor, 
        prefix_hash: str, 
    ) -> str:
        hasher = hashlib.sha256()
        hasher.update(prefix_hash.encode("ascii"))
        hasher.update(tokens.numpy().tobytes())
        return hasher.hexdigest()
    
    def _prefix_hash(
        self, 
        token_chunks: Iterable[torch.Tensor], 
        num_skip_chunk: Optional[int] = 0, 
    ) -> List[str]:
        prefix_hash = self._get_init_hash()
        prefix_hashes = []
        for token_chunk in token_chunks:
            prefix_hash = self._hash(token_chunk, prefix_hash)
            prefix_hashes.append(prefix_hash)
        return prefix_hashes[num_skip_chunk:]
    
    def _chunk_tokens(
        self, 
        tokens: torch.Tensor,
    ) -> Iterable[torch.Tensor]:
        tokens = tokens.cpu()
        for i in range(0, len(tokens), self.chunk_size):
            yield tokens[i:i + self.chunk_size]
    
    def get_prefix_hashes(
        self, 
        tokens: torch.Tensor,
    ) -> List[str]:
        return self._prefix_hash(self._chunk_tokens(tokens))


def generate_test_data(seq_len, device) -> torch.Tensor:
    return torch.randint(0, seq_len, (seq_len,), device=device)

def test_performance(
    hasher_class, 
    tokens: torch.Tensor, 
    chunk_size: int, 
    num_runs: int,
):
    hasher = hasher_class(chunk_size=chunk_size)
    hashes = hasher.get_prefix_hashes(tokens)  # warmup
    def run():
        return hasher.get_prefix_hashes(tokens)
    time_taken = timeit.timeit(run, number=num_runs)
    avg_time = time_taken / num_runs
    return avg_time, hashes


if __name__ == "__main__":
    device = "cuda"
    seq_len = 1 * 1024 * 1024
    chunk_size = 1024
    # seq_len = 128 * 1024
    # chunk_size = 256
    num_runs = 20
    
    print(f"## Sequence length: {seq_len}, Chunk size: {chunk_size} ##")
    
    tokens = generate_test_data(seq_len, device)
    
    print("Testing OldChunkPrefixHasher...")
    old_time, old_hashes = test_performance(
        OldChunkPrefixHasher, tokens, chunk_size, num_runs)
    print(f"Average time: {old_time * 1000:.2f} ms")
    
    print("Testing NewChunkPrefixHasher...")
    new_time, new_hashes = test_performance(
        NewChunkPrefixHasher, tokens, chunk_size, num_runs)
    print(f"Average time: {new_time * 1000:.2f} ms")
    
    assert old_hashes == new_hashes, "Hash results mismatch!"
    print("Results verified: Both implementations produce identical hashes.")
    
    speedup = old_time / new_time
    print(f"Speedup: New is {speedup:.2f}x faster than Old")
```

## Result
1. `seq_len` is 128K, `chunk_size` is 256:
```
## Sequence length: 131072, Chunk size: 256 ##
Testing OldChunkPrefixHasher...
Average time: 15.44 ms
Testing NewChunkPrefixHasher...
Average time: 5.34 ms
Results verified: Both implementations produce identical hashes.
Speedup: New is 2.89x faster than Old
```

2. `seq_len` is 1M, `chunk_size` is 1024:
```
## Sequence length: 1048576, Chunk size: 1024 ##
Testing OldChunkPrefixHasher...
Average time: 35.77 ms
Testing NewChunkPrefixHasher...
Average time: 16.55 ms
Results verified: Both implementations produce identical hashes.
Speedup: New is 2.16x faster than Old
```
It can be seen that the performance has been improved by 2-3 times after optimization.
