### PR TITLE
[#481] Add a simple valkey remote backend

### DIFF
--- a/lmcache/experimental/protocol.py
+++ b/lmcache/experimental/protocol.py
@@ -8,6 +8,7 @@ from lmcache.experimental.memory_management import MemoryFormat
 from lmcache.utils import CacheEngineKey
 
 MAX_KEY_LENGTH = 150
+METADATA_BYTES_LEN = 28
 
 
 class Constants:

--- a/lmcache/experimental/storage_backend/connector/__init__.py
+++ b/lmcache/experimental/storage_backend/connector/__init__.py
@@ -157,6 +157,15 @@ def CreateConnector(
                     f"Valkey connector only supports a single host, but got"
                     f" url: {url}")
 
+        case "valkey-sentinel":
+            # lasy import to avoid missing dependency
+            from .valkey_connector import ValkeySentinelConnector
+            connector = ValkeySentinelConnector(
+                list(zip(parsed_url.hosts, parsed_url.ports)),
+                loop,
+                memory_allocator,
+            )
+
         case "lm":
             if num_hosts == 1:
                 host, port = parsed_url.hosts[0], parsed_url.ports[0]

--- a/lmcache/experimental/storage_backend/connector/__init__.py
+++ b/lmcache/experimental/storage_backend/connector/__init__.py
@@ -146,6 +146,17 @@ def CreateConnector(
                 memory_allocator,
             )
 
+        case "valkey":
+            if num_hosts == 1:
+                host, port = parsed_url.hosts[0], parsed_url.ports[0]
+                # lasy import to avoid missing dependency
+                from .valkey_connector import ValkeyConnector
+                connector = ValkeyConnector(host, port, loop, memory_allocator)
+            else:
+                raise ValueError(
+                    f"Valkey connector only supports a single host, but got"
+                    f" url: {url}")
+
         case "lm":
             if num_hosts == 1:
                 host, port = parsed_url.hosts[0], parsed_url.ports[0]

--- a/lmcache/experimental/storage_backend/connector/valkey_connector.py
+++ b/lmcache/experimental/storage_backend/connector/valkey_connector.py
@@ -14,7 +14,8 @@
 
 import asyncio
 import inspect
-from typing import List, Optional, no_type_check
+import os
+from typing import List, Optional, Tuple, Union, no_type_check
 
 import valkey
 
@@ -110,3 +111,118 @@ class ValkeyConnector(RemoteConnector):
     async def close(self):
         self.connection.close()
         logger.info("Closed the valkey connection")
+
+
+class ValkeySentinelConnector(RemoteConnector):
+    """
+    Uses valkey.Sentinel to connect to a Valkey cluster.
+    The hosts are specified in the config file, started with "valkey-sentinel://"
+    and separated by commas.
+
+    Example:
+        remote_url: "valkey-sentinel://localhost:26379,localhost:26380,localhost:26381"
+
+    Extra environment variables:
+    - VALKEY_SERVICE_NAME (required) -- service name for valkey.
+    - VALKEY_TIMEOUT (optional) -- Timeout in seconds, default is 1 if not set
+    """
+
+    ENV_VALKEY_TIMEOUT = "VALKEY_TIMEOUT"
+    ENV_VALKEY_SERVICE_NAME = "VALKEY_SERVICE_NAME"
+
+    def __init__(self, hosts_and_ports: List[Tuple[str, Union[str, int]]],
+                 loop: asyncio.AbstractEventLoop,
+                 memory_allocator: MemoryAllocatorInterface):
+        # Get service name
+        match os.environ.get(self.ENV_VALKEY_SERVICE_NAME):
+            case None:
+                logger.warning(
+                    f"Environment variable {self.ENV_VALKEY_SERVICE_NAME} is "
+                    f"not found, using default value 'valkeymaster'")
+                service_name = "valkeymaster"
+            case value:
+                service_name = value
+
+        timeout: float = -1000.0
+
+        # Get timeout
+        match os.environ.get(self.ENV_VALKEY_TIMEOUT):
+            case None:
+                timeout = 1
+            case value:
+                timeout = float(value)
+
+        logger.info(f"Host and ports: {hosts_and_ports}")
+        self.sentinel = valkey.Sentinel(hosts_and_ports, timeout)
+        self.master = self.sentinel.master_for(service_name,
+                                               socket_timeout=timeout)
+        self.slave = self.sentinel.slave_for(service_name,
+                                             socket_timeout=timeout)
+
+        self.memory_allocator = memory_allocator
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return self.slave.exists(key.to_string() + "metadata")
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        key_str = key.to_string()
+        valkey_metadata_bytes = self.slave.get(key_str + "metadata")
+
+        if valkey_metadata_bytes is None:
+            return None
+
+        assert not inspect.isawaitable(valkey_metadata_bytes)
+
+        valkey_metadata = RedisMetadata.deserialize(valkey_metadata_bytes)
+
+        memory_obj = self.memory_allocator.allocate(
+            valkey_metadata.shape,
+            valkey_metadata.dtype,
+            valkey_metadata.fmt,
+        )
+        if memory_obj is None:
+            logger.warning("Failed to allocate memory during remote receive")
+            return None
+
+        kv_bytes = self.slave.get(key_str + "kv_bytes")
+
+        assert not inspect.isawaitable(kv_bytes)
+
+        if kv_bytes is None:
+            # consistency issues.
+            # for the sake of performance.
+            logger.warning("Key exists but KV cache does not exist."
+                           "Might happen when the cache is evicted by valkey.")
+            self.master.delete(key_str + "metadata")
+            return None
+
+        view = memoryview(memory_obj.byte_array)
+        view[0:valkey_metadata.length] = kv_bytes
+
+        return memory_obj
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        # Please use a function like `memory_obj.to_meta()`.
+        kv_bytes = memory_obj.byte_array
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        valkey_metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape,
+                                              kv_dtype,
+                                              memory_format).serialize()
+
+        key_str = key.to_string()
+        self.master.set(key_str + "metadata", valkey_metadata_bytes)
+        self.master.set(key_str + "kv_bytes", kv_bytes)
+
+        self.memory_allocator.ref_count_down(memory_obj)
+
+    # TODO
+    @no_type_check
+    async def list(self) -> List[str]:
+        pass
+
+    async def close(self):
+        self.master.close()
+        self.slave.close()

--- a/lmcache/experimental/storage_backend/connector/valkey_connector.py
+++ b/lmcache/experimental/storage_backend/connector/valkey_connector.py
@@ -31,21 +31,25 @@ from lmcache.utils import CacheEngineKey
 logger = init_logger(__name__)
 
 
-class BaseValkeyConnector(RemoteConnector):
-    """Base Valkey connector with common operations"""
+class ValkeyConnector(RemoteConnector):
+    """
+    The remote url should start with "valkey://" and only have one
+    host-port pair
+    """
 
-    def __init__(self, memory_allocator: MemoryAllocatorInterface):
+    def __init__(self, host: str, port: int, loop: asyncio.AbstractEventLoop,
+                 memory_allocator: MemoryAllocatorInterface):
         self.memory_allocator = memory_allocator
+        self._client = Valkey(host=host, port=port, decode_responses=False)
+        self.loop = loop
 
     @property
     def read_client(self) -> Valkey:
-        """Client for read operations (to be implemented by subclasses)"""
-        raise NotImplementedError
+        return self._client
 
     @property
     def write_client(self) -> Valkey:
-        """Client for write operations (to be implemented by subclasses)"""
-        raise NotImplementedError
+        return self._client
 
     async def exists(self, key: CacheEngineKey) -> bool:
         return bool(self.read_client.exists(key.to_string()))
@@ -98,37 +102,16 @@ class BaseValkeyConnector(RemoteConnector):
 
         self.memory_allocator.ref_count_down(memory_obj)
 
+    async def close(self):
+        self._client.close()
+
     # TODO
     @no_type_check
     async def list(self) -> List[str]:
         pass
 
 
-class ValkeyConnector(BaseValkeyConnector):
-    """
-    The remote url should start with "valkey://" and only have one
-    host-port pair
-    """
-
-    def __init__(self, host: str, port: int, loop: asyncio.AbstractEventLoop,
-                 memory_allocator: MemoryAllocatorInterface):
-        super().__init__(memory_allocator)
-        self._client = Valkey(host=host, port=port, decode_responses=False)
-        self.loop = loop
-
-    @property
-    def read_client(self) -> Valkey:
-        return self._client
-
-    @property
-    def write_client(self) -> Valkey:
-        return self._client
-
-    async def close(self):
-        self._client.close()
-
-
-class ValkeySentinelConnector(BaseValkeyConnector):
+class ValkeySentinelConnector(ValkeyConnector):
     """
     Uses valkey.Sentinel to connect to a Valkey cluster.
     The hosts are specified in the config file, started with "valkey-sentinel://"
@@ -148,7 +131,7 @@ class ValkeySentinelConnector(BaseValkeyConnector):
     def __init__(self, hosts_and_ports: List[Tuple[str, Union[str, int]]],
                  loop: asyncio.AbstractEventLoop,
                  memory_allocator: MemoryAllocatorInterface):
-        super().__init__(memory_allocator)
+        self.memory_allocator = memory_allocator
         # Get service name
         match os.environ.get(self.ENV_VALKEY_SERVICE_NAME):
             case None:

--- a/lmcache/experimental/storage_backend/connector/valkey_connector.py
+++ b/lmcache/experimental/storage_backend/connector/valkey_connector.py
@@ -18,10 +18,11 @@ import os
 from typing import List, Optional, Tuple, Union, no_type_check
 
 import valkey
+from valkey import Valkey
 
 from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
                                                     MemoryObj)
-from lmcache.experimental.protocol import RedisMetadata
+from lmcache.experimental.protocol import METADATA_BYTES_LEN, RedisMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -30,35 +31,36 @@ from lmcache.utils import CacheEngineKey
 logger = init_logger(__name__)
 
 
-class ValkeyConnector(RemoteConnector):
-    """
-    The remote url should start with "valkey://" and only have one
-    host-port pair
-    """
+class BaseValkeyConnector(RemoteConnector):
+    """Base Valkey connector with common operations"""
 
-    def __init__(self, host: str, port: int, loop: asyncio.AbstractEventLoop,
-                 memory_allocator: MemoryAllocatorInterface):
-        self.connection = valkey.Valkey(host=host,
-                                        port=port,
-                                        decode_responses=False)
-
+    def __init__(self, memory_allocator: MemoryAllocatorInterface):
         self.memory_allocator = memory_allocator
-        self.loop = loop
+
+    @property
+    def read_client(self) -> Valkey:
+        """Client for read operations (to be implemented by subclasses)"""
+        raise NotImplementedError
+
+    @property
+    def write_client(self) -> Valkey:
+        """Client for write operations (to be implemented by subclasses)"""
+        raise NotImplementedError
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return bool(self.connection.exists(key.to_string() + "metadata"))
+        return bool(self.read_client.exists(key.to_string()))
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        key_str = key.to_string()
-        valkey_metadata_bytes = self.connection.get(key_str + "metadata")
-
-        if valkey_metadata_bytes is None:
+        combined_bytes = self.read_client.get(key.to_string())
+        if combined_bytes is None:
             return None
 
-        assert not inspect.isawaitable(valkey_metadata_bytes)
+        assert not inspect.isawaitable(combined_bytes)
 
         valkey_metadata = RedisMetadata.deserialize(
-            memoryview(valkey_metadata_bytes))
+            memoryview(combined_bytes[:METADATA_BYTES_LEN]))
+        kv_bytes = combined_bytes[METADATA_BYTES_LEN:METADATA_BYTES_LEN +
+                                  valkey_metadata.length]
 
         memory_obj = self.memory_allocator.allocate(
             valkey_metadata.shape,
@@ -69,37 +71,25 @@ class ValkeyConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        kv_bytes = self.connection.get(key_str + "kv_bytes")
-
-        assert not inspect.isawaitable(kv_bytes)
-
-        if kv_bytes is None:
-            # consistency issues.
-            # and kv cache in one key.
-            logger.warning("Key exists but KV cache does not exist."
-                           "Might happen when the cache is evicted by valkey.")
-            self.connection.delete(key_str + "metadata")
-            return None
-
         view = memoryview(memory_obj.byte_array)
         view[:valkey_metadata.length] = kv_bytes
 
         return memory_obj
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # Please use a function like `memory_obj.to_meta()`.
-        kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        valkey_metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape,
-                                              kv_dtype,
-                                              memory_format).serialize()
-
         key_str = key.to_string()
-        self.connection.set(key_str + "metadata", valkey_metadata_bytes)
-        self.connection.set(key_str + "kv_bytes", kv_bytes)
+        kv_bytes = memory_obj.byte_array
+        valkey_metadata = RedisMetadata(len(kv_bytes), memory_obj.get_shape(),
+                                        memory_obj.get_dtype(),
+                                        memory_obj.get_memory_format())
+
+        combined_bytes = valkey_metadata.serialize() + kv_bytes
+        try:
+            self.write_client.set(key_str, combined_bytes)
+        except Exception as e:
+            logger.error(f"Failed to put key {key_str},"
+                         f"meta type: {type(valkey_metadata)},"
+                         f"data: {type(kv_bytes)}: {e}")
 
         self.memory_allocator.ref_count_down(memory_obj)
 
@@ -108,12 +98,32 @@ class ValkeyConnector(RemoteConnector):
     async def list(self) -> List[str]:
         pass
 
+
+class ValkeyConnector(BaseValkeyConnector):
+    """
+    The remote url should start with "valkey://" and only have one
+    host-port pair
+    """
+
+    def __init__(self, host: str, port: int, loop: asyncio.AbstractEventLoop,
+                 memory_allocator: MemoryAllocatorInterface):
+        super().__init__(memory_allocator)
+        self._client = Valkey(host=host, port=port, decode_responses=False)
+        self.loop = loop
+
+    @property
+    def read_client(self) -> Valkey:
+        return self._client
+
+    @property
+    def write_client(self) -> Valkey:
+        return self._client
+
     async def close(self):
-        self.connection.close()
-        logger.info("Closed the valkey connection")
+        self._client.close()
 
 
-class ValkeySentinelConnector(RemoteConnector):
+class ValkeySentinelConnector(BaseValkeyConnector):
     """
     Uses valkey.Sentinel to connect to a Valkey cluster.
     The hosts are specified in the config file, started with "valkey-sentinel://"
@@ -133,12 +143,13 @@ class ValkeySentinelConnector(RemoteConnector):
     def __init__(self, hosts_and_ports: List[Tuple[str, Union[str, int]]],
                  loop: asyncio.AbstractEventLoop,
                  memory_allocator: MemoryAllocatorInterface):
+        super().__init__(memory_allocator)
         # Get service name
         match os.environ.get(self.ENV_VALKEY_SERVICE_NAME):
             case None:
                 logger.warning(
-                    f"Environment variable {self.ENV_VALKEY_SERVICE_NAME} is "
-                    f"not found, using default value 'valkeymaster'")
+                    f"Environment variable {self.ENV_VALKEY_SERVICE_NAME} is"
+                    f" not found, using default value 'valkeymaster'")
                 service_name = "valkeymaster"
             case value:
                 service_name = value
@@ -154,75 +165,20 @@ class ValkeySentinelConnector(RemoteConnector):
 
         logger.info(f"Host and ports: {hosts_and_ports}")
         self.sentinel = valkey.Sentinel(hosts_and_ports, timeout)
-        self.master = self.sentinel.master_for(service_name,
-                                               socket_timeout=timeout)
-        self.slave = self.sentinel.slave_for(service_name,
-                                             socket_timeout=timeout)
+        # FIXME(maobaolong):  _master would be changed to _slave
+        self._master = self.sentinel.master_for(service_name,
+                                                socket_timeout=timeout)
+        self._slave = self.sentinel.slave_for(service_name,
+                                              socket_timeout=timeout)
 
-        self.memory_allocator = memory_allocator
+    @property
+    def read_client(self) -> Valkey:
+        return self._slave
 
-    async def exists(self, key: CacheEngineKey) -> bool:
-        return self.slave.exists(key.to_string() + "metadata")
-
-    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        key_str = key.to_string()
-        valkey_metadata_bytes = self.slave.get(key_str + "metadata")
-
-        if valkey_metadata_bytes is None:
-            return None
-
-        assert not inspect.isawaitable(valkey_metadata_bytes)
-
-        valkey_metadata = RedisMetadata.deserialize(valkey_metadata_bytes)
-
-        memory_obj = self.memory_allocator.allocate(
-            valkey_metadata.shape,
-            valkey_metadata.dtype,
-            valkey_metadata.fmt,
-        )
-        if memory_obj is None:
-            logger.warning("Failed to allocate memory during remote receive")
-            return None
-
-        kv_bytes = self.slave.get(key_str + "kv_bytes")
-
-        assert not inspect.isawaitable(kv_bytes)
-
-        if kv_bytes is None:
-            # consistency issues.
-            # for the sake of performance.
-            logger.warning("Key exists but KV cache does not exist."
-                           "Might happen when the cache is evicted by valkey.")
-            self.master.delete(key_str + "metadata")
-            return None
-
-        view = memoryview(memory_obj.byte_array)
-        view[0:valkey_metadata.length] = kv_bytes
-
-        return memory_obj
-
-    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # Please use a function like `memory_obj.to_meta()`.
-        kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        valkey_metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape,
-                                              kv_dtype,
-                                              memory_format).serialize()
-
-        key_str = key.to_string()
-        self.master.set(key_str + "metadata", valkey_metadata_bytes)
-        self.master.set(key_str + "kv_bytes", kv_bytes)
-
-        self.memory_allocator.ref_count_down(memory_obj)
-
-    # TODO
-    @no_type_check
-    async def list(self) -> List[str]:
-        pass
+    @property
+    def write_client(self) -> Valkey:
+        return self._master
 
     async def close(self):
-        self.master.close()
-        self.slave.close()
+        self._master.close()
+        self._slave.close()

--- a/lmcache/experimental/storage_backend/connector/valkey_connector.py
+++ b/lmcache/experimental/storage_backend/connector/valkey_connector.py
@@ -71,7 +71,12 @@ class BaseValkeyConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        view = memoryview(memory_obj.byte_array)
+        if isinstance(memory_obj.byte_array, memoryview):
+            view = memory_obj.byte_array
+            if view.format == "<B":
+                view = view.cast("B")
+        else:
+            view = memoryview(memory_obj.byte_array)
         view[:valkey_metadata.length] = kv_bytes
 
         return memory_obj

--- a/lmcache/experimental/storage_backend/connector/valkey_connector.py
+++ b/lmcache/experimental/storage_backend/connector/valkey_connector.py
@@ -1,0 +1,112 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import inspect
+from typing import List, Optional, no_type_check
+
+import valkey
+
+from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
+                                                    MemoryObj)
+from lmcache.experimental.protocol import RedisMetadata
+from lmcache.experimental.storage_backend.connector.base_connector import \
+    RemoteConnector
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+
+logger = init_logger(__name__)
+
+
+class ValkeyConnector(RemoteConnector):
+    """
+    The remote url should start with "valkey://" and only have one
+    host-port pair
+    """
+
+    def __init__(self, host: str, port: int, loop: asyncio.AbstractEventLoop,
+                 memory_allocator: MemoryAllocatorInterface):
+        self.connection = valkey.Valkey(host=host,
+                                        port=port,
+                                        decode_responses=False)
+
+        self.memory_allocator = memory_allocator
+        self.loop = loop
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return bool(self.connection.exists(key.to_string() + "metadata"))
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        key_str = key.to_string()
+        valkey_metadata_bytes = self.connection.get(key_str + "metadata")
+
+        if valkey_metadata_bytes is None:
+            return None
+
+        assert not inspect.isawaitable(valkey_metadata_bytes)
+
+        valkey_metadata = RedisMetadata.deserialize(
+            memoryview(valkey_metadata_bytes))
+
+        memory_obj = self.memory_allocator.allocate(
+            valkey_metadata.shape,
+            valkey_metadata.dtype,
+            valkey_metadata.fmt,
+        )
+        if memory_obj is None:
+            logger.warning("Failed to allocate memory during remote receive")
+            return None
+
+        kv_bytes = self.connection.get(key_str + "kv_bytes")
+
+        assert not inspect.isawaitable(kv_bytes)
+
+        if kv_bytes is None:
+            # consistency issues.
+            # and kv cache in one key.
+            logger.warning("Key exists but KV cache does not exist."
+                           "Might happen when the cache is evicted by valkey.")
+            self.connection.delete(key_str + "metadata")
+            return None
+
+        view = memoryview(memory_obj.byte_array)
+        view[:valkey_metadata.length] = kv_bytes
+
+        return memory_obj
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        # Please use a function like `memory_obj.to_meta()`.
+        kv_bytes = memory_obj.byte_array
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        valkey_metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape,
+                                              kv_dtype,
+                                              memory_format).serialize()
+
+        key_str = key.to_string()
+        self.connection.set(key_str + "metadata", valkey_metadata_bytes)
+        self.connection.set(key_str + "kv_bytes", kv_bytes)
+
+        self.memory_allocator.ref_count_down(memory_obj)
+
+    # TODO
+    @no_type_check
+    async def list(self) -> List[str]:
+        pass
+
+    async def close(self):
+        self.connection.close()
+        logger.info("Closed the valkey connection")


### PR DESCRIPTION
FIX #481 

- This is a simple way to use valkey as a first step, base on this, we can extend to support rdma and async io.
- Also, this PR did some abstract to make code simplify and clear.
- Meanwhile, I combine the metadata and kvbytes to one key, to reduce the kv count and this would increase the performance during put and get.

# How to test

## start valkey by docker
```bash
docker run --name valkey -p 6379:6379 \
-v /data1/v1connector/valkey/conf:/usr/local/etc/valkey \
-v /data1/v1connector/valkey/valkey-data:/data \
valkey/valkey valkey-server /usr/local/etc/valkey/valkey.conf \
--appendonly yes
```

## Start vllm with  lmcache and set remote url to valkey://localhost:6379/ 

```Console
VLLM_USE_V1=0 \
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
LMCACHE_CHUNK_SIZE=16 LMCACHE_LOCAL_CPU=False LMCACHE_MAX_LOCAL_CPU_SIZE=5.0 \
LMCACHE_REMOTE_URL=valkey://localhost:6379/ \
LMCACHE_REMOTE_SERDE="cachegen" \
vllm serve /disc/f/models/opt-125m/ \
           --served-model-name "facebook/opt-125m" \
           --enforce-eager  \
           --port 8000 \
           --gpu-memory-utilization 0.8 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}' \
           --trust-remote-code

```

## Tested by curl

```Console
curl http://localhost:8000/v1/completions     -H "Content-Type: application/json"     -d '{
        "model": "facebook/opt-125m",
        "prompt": "San Francisco is a 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15",
        "max_tokens": 10,
        "temperature": 0
    }'
```

## Check valkey storage by redis tools

![image](https://github.com/user-attachments/assets/a264c731-6f6b-44e8-8a23-db5e86271094)


## Test Sentinel valkey also

<img width="943" alt="image" src="https://github.com/user-attachments/assets/3bed14b0-80f8-4f59-9e41-532052716e3c" />

