### PR TITLE
[SMALLFIX] Fix typo issue while init RedisSentinelConnector without ENV_REDIS_SERVICE_NAME

### DIFF
--- a/lmcache/experimental/storage_backend/connector/redis_connector.py
+++ b/lmcache/experimental/storage_backend/connector/redis_connector.py
@@ -144,8 +144,8 @@ class RedisSentinelConnector(RemoteConnector):
         match os.environ.get(self.ENV_REDIS_SERVICE_NAME):
             case None:
                 logger.warning(
-                    f"Environment variable {self.ENV_REDIS_SERVICE_NAME} is not"
-                    f"found, using default value 'redismaster'")
+                    f"Environment variable {self.ENV_REDIS_SERVICE_NAME} is "
+                    f"not found, using default value 'redismaster'")
                 service_name = "redismaster"
             case value:
                 service_name = value


### PR DESCRIPTION
Just a small fix about log. There should have an extra blank between `notfound` not and found
```
[2025-04-16 14:41:12,831] LMCache WARNING: Environment variable REDIS_SERVICE_NAME is notfound, using default value 'redismaster' (redis_connector.py:146:lmcache.experimental.storage_backend.connector.redis_connector)
```