### PR TITLE
[Misc] Update usage with mooncake lib in MooncakestoreConnector

### DIFF
--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -74,7 +74,7 @@ class MooncakestoreConnector(RemoteConnector):
                  loop: asyncio.AbstractEventLoop,
                  memory_allocator: MemoryAllocatorInterface):
         try:
-            from mooncake_vllm_adaptor import MooncakeDistributedStore
+            from mooncake.store import MooncakeDistributedStore
         except ImportError as e:
             raise ImportError(
                 "Please install mooncake by following the instructions at "
@@ -110,7 +110,7 @@ class MooncakestoreConnector(RemoteConnector):
         self.loop = loop
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return self.store.isExist(key.to_string() + "metadata")
+        return self.store.is_exist(key.to_string() + "metadata")
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()


### PR DESCRIPTION
Mooncake lib has just updated the usage of MooncakeDistributedStore recently. 
Modifications have been made in vllm:  https://github.com/vllm-project/vllm/pull/16523/files#diff-aa12f4e1966d5c19dd0d7725ea466e835a968f8ea36ab9bc664b8a390c5ef44dR73
The MooncakestoreConnector of lmcache needs to be updated synchronously; otherwise, the latest mooncake store cannot be used