### PR TITLE
Fix get absent condition of mooncakestore connector

### DIFF
--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -116,7 +116,7 @@ class MooncakestoreConnector(RemoteConnector):
         key_str = key.to_string()
 
         metadata_bytes = self.store.get(key_str + "metadata")
-        if metadata_bytes is None:
+        if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
             return None
 
         assert not inspect.isawaitable(metadata_bytes)


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

FIX get absent issue of #430 

Since the get absent condition of mooncake store is not none, it is 0 length.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/6880b047-ef4a-4683-ad84-db682b6b0d53" />

The following screenshot is took while debug this code.



# How to Test

- verified by debug 

![image](https://github.com/user-attachments/assets/342a81df-c061-4955-a0aa-8b64a8eefbcd)


- verified by mooncake master log
```Console
root@docker-desktop:/vllm-workspace#  /opt/venv/lib/python3.12/site-packages/mooncake/mooncake_master -v=1
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0419 11:27:00.543995 11694 master.cpp:27] Master service started on port 50051, enable_gc=0, max_threads=4
I0419 11:27:00.547537 11694 master_service.cpp:77] action=gc_disabled
I0419 11:30:48.482245 11704 scoped_vlog_timer.h:42] MountSegment request: buffer=140171659968512, size=3355443200, segment_name=localhost:14084
I0419 11:30:48.482733 11704 allocator.cpp:24] initializing_buffer_allocator segment_name=localhost:14084 base_address=0x7f7c42000000 size=3355443200
I0419 11:30:48.483237 11704 allocator.cpp:50] buffer_allocator_initialized pool_id=0
I0419 11:30:48.483371 11704 scoped_vlog_timer.h:77] MountSegment response: {"error_code":0}, latency=1207us



I0419 11:35:27.660279 11704 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata
I0419 11:35:27.660926 11704 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata, info=object_not_found
I0419 11:35:27.660970 11704 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=1314us
I0419 11:35:27.875080 11704 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata
I0419 11:35:27.875128 11704 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata, info=object_not_found
I0419 11:35:27.875134 11704 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=62us
I0419 11:35:27.876541 11704 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata
I0419 11:35:27.876587 11704 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata, info=object_not_found
I0419 11:35:27.876595 11704 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=62us
I0419 11:35:28.068993 11704 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata, value_length=28, slice_lengths=1
I0419 11:35:28.069042 11704 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata, value_length=28, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 11:35:28.069553 11704 allocator.cpp:75] allocation_succeeded size=28 segment=localhost:14084 address=0x7f7c42000000
I0419 11:35:28.069615 11704 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:14084, size: 28, status: INIT, buffer_ptr: 0x7f7c42000000 }, action=slice_allocated
I0419 11:35:28.069651 11704 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:14084","size_":28,"buffer_address_":140171659968512,"status_":0}],"status":2}],"error_code":0}, latency=666us
I0419 11:35:28.146965 11704 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754metadata
I0419 11:35:28.147085 11704 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=136us
I0419 11:35:28.149541 11704 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754kv_bytes, value_length=1383977, slice_lengths=1
I0419 11:35:28.149634 11704 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754kv_bytes, value_length=1383977, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 11:35:28.150255 11704 allocator.cpp:75] allocation_succeeded size=1383977 segment=localhost:14084 address=0x7f7c43000000
I0419 11:35:28.150338 11704 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754kv_bytes, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:14084, size: 1383977, status: INIT, buffer_ptr: 0x7f7c43000000 }, action=slice_allocated
I0419 11:35:28.150390 11704 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:14084","size_":1383977,"buffer_address_":140171676745728,"status_":0}],"status":2}],"error_code":0}, latency=866us
I0419 11:35:28.152994 11704 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754kv_bytes
I0419 11:35:28.153080 11704 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=109us
I0419 11:35:28.154078 11704 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60metadata
I0419 11:35:28.154582 11704 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60metadata, info=object_not_found
I0419 11:35:28.154656 11704 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=596us
I0419 11:35:28.166846 11704 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60metadata, value_length=28, slice_lengths=1
I0419 11:35:28.166895 11704 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60metadata, value_length=28, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 11:35:28.166925 11704 allocator.cpp:75] allocation_succeeded size=28 segment=localhost:14084 address=0x7f7c42000048
I0419 11:35:28.166950 11704 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60metadata, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:14084, size: 28, status: INIT, buffer_ptr: 0x7f7c42000048 }, action=slice_allocated
I0419 11:35:28.166980 11704 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:14084","size_":28,"buffer_address_":140171659968584,"status_":0}],"status":2}],"error_code":0}, latency=146us
I0419 11:35:28.167366 11704 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60metadata
I0419 11:35:28.167416 11704 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=55us
I0419 11:35:28.168087 11704 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60kv_bytes, value_length=1315393, slice_lengths=1
I0419 11:35:28.168138 11704 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60kv_bytes, value_length=1315393, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 11:35:28.168525 11704 allocator.cpp:75] allocation_succeeded size=1315393 segment=localhost:14084 address=0x7f7c4316fbb8
I0419 11:35:28.168618 11704 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60kv_bytes, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:14084, size: 1315393, status: INIT, buffer_ptr: 0x7f7c4316fbb8 }, action=slice_allocated
I0419 11:35:28.168673 11704 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:14084","size_":1315393,"buffer_address_":140171678251960,"status_":0}],"status":2}],"error_code":0}, latency=595us
I0419 11:35:28.170497 11704 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60kv_bytes
I0419 11:35:28.170554 11704 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=74us
```