### PR TITLE
Improve mooncake connector to support naive serde

### DIFF
--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -135,7 +135,12 @@ class MooncakestoreConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        view = memoryview(memory_obj.byte_array)
+        if isinstance(memory_obj.byte_array, memoryview):
+            view = memory_obj.byte_array
+            if view.format == "<B":
+                view = view.cast("B")
+        else:
+            view = memoryview(memory_obj.byte_array)
         view[:metadata.length] = kv_bytes
 
         return memory_obj

--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -116,7 +116,7 @@ class MooncakestoreConnector(RemoteConnector):
         key_str = key.to_string()
 
         combined_bytes = self.store.get(key_str)
-        if combined_bytes is None:
+        if combined_bytes is None or len(combined_bytes) <= METADATA_BYTES_LEN:
             return None
 
         assert not inspect.isawaitable(combined_bytes)
@@ -144,8 +144,8 @@ class MooncakestoreConnector(RemoteConnector):
         key_str = key.to_string()
         kv_bytes = memory_obj.byte_array
         metadata = RedisMetadata(len(kv_bytes), memory_obj.get_shape(),
-                                        memory_obj.get_dtype(),
-                                        memory_obj.get_memory_format())
+                                 memory_obj.get_dtype(),
+                                 memory_obj.get_memory_format())
 
         combined_bytes = metadata.serialize() + kv_bytes
 

--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -110,18 +110,21 @@ class MooncakestoreConnector(RemoteConnector):
         self.loop = loop
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return self.store.is_exist(key.to_string() + "metadata")
+        return self.store.is_exist(key.to_string())
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
 
-        metadata_bytes = self.store.get(key_str + "metadata")
-        if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
+        combined_bytes = self.store.get(key_str)
+        if combined_bytes is None:
             return None
 
-        assert not inspect.isawaitable(metadata_bytes)
+        assert not inspect.isawaitable(combined_bytes)
 
-        metadata = RedisMetadata.deserialize(memoryview(metadata_bytes))
+        metadata = RedisMetadata.deserialize(
+            memoryview(combined_bytes[:METADATA_BYTES_LEN]))
+        kv_bytes = combined_bytes[METADATA_BYTES_LEN:METADATA_BYTES_LEN +
+                                  metadata.length]
 
         memory_obj = self.memory_allocator.allocate(
             metadata.shape,
@@ -132,33 +135,25 @@ class MooncakestoreConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        kv_bytes = self.store.get(key_str + "kv_bytes")
-        assert not inspect.isawaitable(kv_bytes)
-        assert kv_bytes is not None
-
         view = memoryview(memory_obj.byte_array)
         view[:metadata.length] = kv_bytes
 
         return memory_obj
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # Please use a function like `memory_obj.to_meta()`.
-        kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
-                                       memory_format).serialize()
-
         key_str = key.to_string()
-        self.store.put(key_str + "metadata", metadata_bytes)
-        key_byte_str = key_str + "kv_bytes"
+        kv_bytes = memory_obj.byte_array
+        metadata = RedisMetadata(len(kv_bytes), memory_obj.get_shape(),
+                                        memory_obj.get_dtype(),
+                                        memory_obj.get_memory_format())
+
+        combined_bytes = metadata.serialize() + kv_bytes
+
         try:
-            self.store.put(key_byte_str, kv_bytes)
+            self.store.put(key_str, combined_bytes)
         except Exception as e:
-            logger.error(f"Failed to put key {key_byte_str},"
-                         f"meta type: {type(metadata_bytes)},"
+            logger.error(f"Failed to put key {key_str},"
+                         f"meta type: {type(metadata)},"
                          f"data: {type(kv_bytes)}: {e}")
 
         self.memory_allocator.ref_count_down(memory_obj)

--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -110,21 +110,18 @@ class MooncakestoreConnector(RemoteConnector):
         self.loop = loop
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return self.store.is_exist(key.to_string())
+        return self.store.is_exist(key.to_string() + "metadata")
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
 
-        combined_bytes = self.store.get(key_str)
-        if combined_bytes is None or len(combined_bytes) <= METADATA_BYTES_LEN:
+        metadata_bytes = self.store.get(key_str + "metadata")
+        if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
             return None
 
-        assert not inspect.isawaitable(combined_bytes)
+        assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RedisMetadata.deserialize(
-            memoryview(combined_bytes[:METADATA_BYTES_LEN]))
-        kv_bytes = combined_bytes[METADATA_BYTES_LEN:METADATA_BYTES_LEN +
-                                  metadata.length]
+        metadata = RedisMetadata.deserialize(memoryview(metadata_bytes))
 
         memory_obj = self.memory_allocator.allocate(
             metadata.shape,
@@ -134,6 +131,10 @@ class MooncakestoreConnector(RemoteConnector):
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
             return None
+
+        kv_bytes = self.store.get(key_str + "kv_bytes")
+        assert not inspect.isawaitable(kv_bytes)
+        assert kv_bytes is not None
 
         if isinstance(memory_obj.byte_array, memoryview):
             view = memory_obj.byte_array
@@ -146,19 +147,23 @@ class MooncakestoreConnector(RemoteConnector):
         return memory_obj
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        key_str = key.to_string()
+        # Please use a function like `memory_obj.to_meta()`.
         kv_bytes = memory_obj.byte_array
-        metadata = RedisMetadata(len(kv_bytes), memory_obj.get_shape(),
-                                 memory_obj.get_dtype(),
-                                 memory_obj.get_memory_format())
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
 
-        combined_bytes = metadata.serialize() + kv_bytes
+        metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
+                                       memory_format).serialize()
 
+        key_str = key.to_string()
+        self.store.put(key_str + "metadata", metadata_bytes)
+        key_byte_str = key_str + "kv_bytes"
         try:
-            self.store.put(key_str, combined_bytes)
+            self.store.put(key_byte_str, kv_bytes)
         except Exception as e:
-            logger.error(f"Failed to put key {key_str},"
-                         f"meta type: {type(metadata)},"
+            logger.error(f"Failed to put key {key_byte_str},"
+                         f"meta type: {type(metadata_bytes)},"
                          f"data: {type(kv_bytes)}: {e}")
 
         self.memory_allocator.ref_count_down(memory_obj)


### PR DESCRIPTION
# PR description
- combine metadata and kvbytes
- support naive serde

# Testing and verification

- combine metadata and kvbytes can reduce 2.1% TTFT for cache miss(First Time).
- combine metadata and kvbytes can reduce 10.3% TTFT for cache hit(second Time).
- naive and cachegen serde can work and pass our benchmark test.

## Test for cachegen serde

I tested cachegen and naive type use facebook-125m model, set chunk size to 16 to simplify the test.

- Check mooncake server log
 There are only one object for one lmcache chunk.

```
root@docker-desktop:/vllm-workspace# /opt/venv/lib/python3.12/site-packages/mooncake/mooncake_master -v=1
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0419 14:41:06.556012 12693 master.cpp:27] Master service started on port 50051, enable_gc=0, max_threads=4
I0419 14:41:06.559537 12693 master_service.cpp:77] action=gc_disabled



I0419 14:42:04.932854 12703 scoped_vlog_timer.h:42] MountSegment request: buffer=140097034911744, size=3355443200, segment_name=localhost:13503
I0419 14:42:04.933364 12703 allocator.cpp:24] initializing_buffer_allocator segment_name=localhost:13503 base_address=0x7f6ae2000000 size=3355443200
I0419 14:42:04.933933 12703 allocator.cpp:50] buffer_allocator_initialized pool_id=0
I0419 14:42:04.934000 12703 scoped_vlog_timer.h:77] MountSegment response: {"error_code":0}, latency=1163us


I0419 14:42:47.904599 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 14:42:47.906082 12703 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, info=object_not_found
I0419 14:42:47.906311 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=2480us
I0419 14:42:48.147836 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 14:42:48.147917 12703 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, info=object_not_found
I0419 14:42:48.147954 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=125us
I0419 14:42:48.149864 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 14:42:48.149912 12703 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, info=object_not_found
I0419 14:42:48.149919 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=66us
I0419 14:42:49.235935 12703 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, value_length=1384015, slice_lengths=1
I0419 14:42:49.248529 12703 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, value_length=1384015, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 14:42:49.261435 12703 allocator.cpp:75] allocation_succeeded size=1384015 segment=localhost:13503 address=0x7f6ae2000000
I0419 14:42:49.261528 12703 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:13503, size: 1384015, status: INIT, buffer_ptr: 0x7f6ae2000000 }, action=slice_allocated
I0419 14:42:49.261662 12703 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13503","size_":1384015,"buffer_address_":140097034911744,"status_":0}],"status":2}],"error_code":0}, latency=26121us
I0419 14:42:49.512735 12703 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 14:42:49.512790 12703 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=65us
I0419 14:42:49.514432 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 14:42:49.515123 12703 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, info=object_not_found
I0419 14:42:49.515190 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=768us
I0419 14:42:49.541345 12703 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, value_length=1315431, slice_lengths=1
I0419 14:42:49.541409 12703 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, value_length=1315431, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 14:42:49.541421 12703 allocator.cpp:75] allocation_succeeded size=1315431 segment=localhost:13503 address=0x7f6ae216fbb8
I0419 14:42:49.541425 12703 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:13503, size: 1315431, status: INIT, buffer_ptr: 0x7f6ae216fbb8 }, action=slice_allocated
I0419 14:42:49.541462 12703 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13503","size_":1315431,"buffer_address_":140097036417976,"status_":0}],"status":2}],"error_code":0}, latency=126us
I0419 14:42:49.559959 12703 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 14:42:49.560063 12703 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=212us





I0419 14:43:04.882916 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 14:43:04.883111 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13503","size_":1384015,"buffer_address_":140097034911744,"status_":1}],"status":3}],"error_code":0}, latency=238us
I0419 14:43:05.049643 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 14:43:05.049695 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13503","size_":1315431,"buffer_address_":140097036417976,"status_":1}],"status":3}],"error_code":0}, latency=59us
I0419 14:43:05.105633 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 14:43:05.105705 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13503","size_":1384015,"buffer_address_":140097034911744,"status_":1}],"status":3}],"error_code":0}, latency=80us
I0419 14:43:05.106576 12703 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 14:43:05.106652 12703 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13503","size_":1315431,"buffer_address_":140097036417976,"status_":1}],"status":3}],"error_code":0}, latency=86us
``` 

## Test for naive serde

```
root@docker-desktop:/vllm-workspace# /opt/venv/lib/python3.12/site-packages/mooncake/mooncake_master -v=1
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0419 15:02:53.625651 13347 master.cpp:27] Master service started on port 50051, enable_gc=0, max_threads=4
I0419 15:02:53.627743 13347 master_service.cpp:77] action=gc_disabled
I0419 15:03:25.460749 13357 scoped_vlog_timer.h:42] MountSegment request: buffer=139849336094720, size=3355443200, segment_name=localhost:13395
I0419 15:03:25.460856 13357 allocator.cpp:24] initializing_buffer_allocator segment_name=localhost:13395 base_address=0x7f3136000000 size=3355443200
I0419 15:03:25.461154 13357 allocator.cpp:50] buffer_allocator_initialized pool_id=0
I0419 15:03:25.461184 13357 scoped_vlog_timer.h:77] MountSegment response: {"error_code":0}, latency=449us


I0419 15:03:59.603291 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 15:03:59.603718 13357 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, info=object_not_found
I0419 15:03:59.603726 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=473us
I0419 15:03:59.677393 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 15:03:59.677440 13357 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, info=object_not_found
I0419 15:03:59.677448 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=63us
I0419 15:03:59.679128 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 15:03:59.679184 13357 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, info=object_not_found
I0419 15:03:59.679191 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=74us
I0419 15:03:59.697081 13357 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, value_length=589852, slice_lengths=1
I0419 15:03:59.697129 13357 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, value_length=589852, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 15:03:59.697185 13357 allocator.cpp:75] allocation_succeeded size=589852 segment=localhost:13395 address=0x7f3136000000
I0419 15:03:59.697211 13357 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:13395, size: 589852, status: INIT, buffer_ptr: 0x7f3136000000 }, action=slice_allocated
I0419 15:03:59.697224 13357 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13395","size_":589852,"buffer_address_":139849336094720,"status_":0}],"status":2}],"error_code":0}, latency=153us
I0419 15:03:59.767378 13357 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 15:03:59.767426 13357 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=56us
I0419 15:03:59.767958 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 15:03:59.767990 13357 master_service.cpp:116] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, info=object_not_found
I0419 15:03:59.768018 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[],"error_code":-704}, latency=62us
I0419 15:03:59.770275 13357 scoped_vlog_timer.h:42] PutStart request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, value_length=184348, slice_lengths=1
I0419 15:03:59.770318 13357 master_service.cpp:175] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, value_length=184348, slice_count=1, config=ReplicateConfig: { replica_num: 1 }, action=put_start_begin
I0419 15:03:59.770347 13357 allocator.cpp:75] allocation_succeeded size=184348 segment=localhost:13395 address=0x7f3137000000
I0419 15:03:59.770357 13357 master_service.cpp:221] key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60, replica_id=0, slice_index=0, handle=AllocatedBuffer: { segment_name: localhost:13395, size: 184348, status: INIT, buffer_ptr: 0x7f3137000000 }, action=slice_allocated
I0419 15:03:59.770366 13357 scoped_vlog_timer.h:77] PutStart response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13395","size_":184348,"buffer_address_":139849352871936,"status_":0}],"status":2}],"error_code":0}, latency=99us
I0419 15:03:59.771054 13357 scoped_vlog_timer.h:42] PutEnd request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 15:03:59.771103 13357 scoped_vlog_timer.h:77] PutEnd response: {"error_code":0}, latency=60us



I0419 15:04:10.478915 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 15:04:10.479260 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13395","size_":589852,"buffer_address_":139849336094720,"status_":1}],"status":3}],"error_code":0}, latency=350us
I0419 15:04:10.482981 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 15:04:10.483033 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13395","size_":184348,"buffer_address_":139849352871936,"status_":1}],"status":3}],"error_code":0}, latency=62us
I0419 15:04:10.507964 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@3d29b85e7dc2d3eaa9b1a4f3ecbbb70e2b239d6b8d00ea82b88b1758b00ad754
I0419 15:04:10.508014 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13395","size_":589852,"buffer_address_":139849336094720,"status_":1}],"status":3}],"error_code":0}, latency=57us
I0419 15:04:10.508654 13357 scoped_vlog_timer.h:42] GetReplicaList request: key=vllm@/disc/f/models/opt-125m/@1@0@a7301c544c86fe97d973cb0e2a154e1d54aba116874e07c18df1efc6ffdddd60
I0419 15:04:10.508689 13357 scoped_vlog_timer.h:77] GetReplicaList response: {"replica_list":[{"buffer_descriptors":[{"segment_name_":"localhost:13395","size_":184348,"buffer_address_":139849352871936,"status_":1}],"status":3}],"error_code":0}, latency=38us
```