### PR TITLE
[Build/CI] Read requirements.txt from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.2.0
+torch==2.6.0
 numpy==1.26.4
 aiofiles
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,26 @@
 from setuptools import find_packages, setup
 from torch.utils import cpp_extension
 
+# Taken from https://github.com/vllm-project/vllm/blob/main/setup.py
+def get_requirements() -> list[str]:
+    """Get Python package dependencies from requirements.txt."""
+    requirements_dir = ROOT_DIR
+
+    def _read_requirements(filename: str) -> list[str]:
+        with open(requirements_dir / filename) as f:
+            requirements = f.read().strip().split("\n")
+        resolved_requirements = []
+        for line in requirements:
+            if line.startswith("-r "):
+                resolved_requirements += _read_requirements(line.split()[1])
+            elif not line.startswith("--") and not line.startswith(
+                    "#") and line.strip() != "":
+                resolved_requirements.append(line)
+        return resolved_requirements
+
+    requirements = _read_requirements("requirements.txt")
+    return requirements
+
 ext_modules = [
     cpp_extension.CUDAExtension(
         'lmcache.c_ops',
@@ -25,11 +45,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("csrc")),
-    install_requires=[
-        "torch == 2.5.1", "numpy==1.26.4", "aiofiles", "pyyaml", "redis",
-        "nvtx", "safetensors", "transformers", "torchac_cuda >= 0.2.5",
-        "sortedcontainers", "prometheus_client", "infinistore", "msgspec"
-    ],
+    install_requires=get_requirements(),
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from setuptools import find_packages, setup
 from torch.utils import cpp_extension
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
+from pathlib import Path
 from setuptools import find_packages, setup
 from torch.utils import cpp_extension
+
+ROOT_DIR = Path(__file__).parent
 
 # Taken from https://github.com/vllm-project/vllm/blob/main/setup.py
 def get_requirements() -> list[str]:

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from torch.utils import cpp_extension
 
 ROOT_DIR = Path(__file__).parent
 
+
 # Taken from https://github.com/vllm-project/vllm/blob/main/setup.py
 def get_requirements() -> list[str]:
     """Get Python package dependencies from requirements.txt."""
@@ -23,6 +24,7 @@ def get_requirements() -> list[str]:
 
     requirements = _read_requirements("requirements.txt")
     return requirements
+
 
 ext_modules = [
     cpp_extension.CUDAExtension(


### PR DESCRIPTION
Establish a single source of truth for requirements by reading `install_requires` from `requirements.txt`, using the same approach as in vLLM.

Also pin torch to 2.6.0, to match vLLM.