### PR TITLE
[feat] Add a filesystem remote connector

### DIFF
--- a/lmcache/experimental/storage_backend/connector/__init__.py
+++ b/lmcache/experimental/storage_backend/connector/__init__.py
@@ -30,6 +30,7 @@ from lmcache.logging import init_logger
 
 from .audit_connector import AuditConnector
 from .blackhole_connector import BlackholeConnector
+from .fs_connector import FSConnector
 from .infinistore_connector import InfinistoreConnector
 from .mooncakestore_connector import MooncakestoreConnector
 
@@ -174,6 +175,17 @@ def CreateConnector(
                                                local_cpu_backend)
         case "blackhole":
             connector = BlackholeConnector()
+        case "fs":
+            if num_hosts != 1:
+                raise ValueError(
+                    f"FS connector only supports a single path, but got url:"
+                    f"{url}")
+            # For fs connector path is the base path of the url
+            base_path = parsed_url.paths[0]
+            # Ensure path starts with '/'
+            if not base_path.startswith('/'):
+                base_path = '/' + base_path
+            connector = FSConnector(base_path, loop, local_cpu_backend)
         case "audit":
             if num_hosts != 1:
                 raise ValueError(

--- a/lmcache/experimental/storage_backend/connector/fs_connector.py
+++ b/lmcache/experimental/storage_backend/connector/fs_connector.py
@@ -1,0 +1,144 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from pathlib import Path
+from typing import List, Optional, no_type_check
+
+from lmcache.experimental.memory_management import MemoryObj
+from lmcache.experimental.protocol import RemoteMetadata
+from lmcache.experimental.storage_backend.connector.base_connector import \
+    RemoteConnector
+from lmcache.experimental.storage_backend.local_cpu_backend import \
+    LocalCPUBackend
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+
+logger = init_logger(__name__)
+
+METADATA_BYTES_LEN = 28
+
+
+class FSConnector(RemoteConnector):
+    """File system based connector that stores data in local files.
+
+    Data is stored in the following format:
+    - Each key is stored as a separate file
+    - File content: metadata (METADATA_BYTES_LEN bytes) + serialized data
+    """
+
+    def __init__(self, base_path: str, loop: asyncio.AbstractEventLoop,
+                 local_cpu_backend: LocalCPUBackend):
+        """
+        Args:
+            base_path: Root directory to store all cache files
+            loop: Asyncio event loop
+            memory_allocator: Memory allocator interface
+        """
+        self.base_path = Path(base_path)
+        self.loop = loop
+        self.local_cpu_backend = local_cpu_backend
+
+        logger.info(f"Initialized FSConnector with base path {base_path}")
+        # Create base directory if not exists
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def _get_file_path(self, key: CacheEngineKey) -> Path:
+        """Get file path for the given key"""
+        key_path = key.to_string().replace("/", "-") + ".data"
+        # Use key's string representation as filename
+        return self.base_path / key_path
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        """Check if key exists in file system"""
+        file_path = self._get_file_path(key)
+        return file_path.exists()
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        """Get data from file system"""
+        file_path = self._get_file_path(key)
+        if not file_path.exists():
+            return None
+
+        try:
+            # Read file content
+            with open(file_path, 'rb') as f:
+                data = f.read()
+
+            # Split metadata and actual data
+            metadata = RemoteMetadata.deserialize(
+                memoryview(data[:METADATA_BYTES_LEN]))
+            kv_bytes = data[METADATA_BYTES_LEN:METADATA_BYTES_LEN +
+                            metadata.length]
+
+            # Allocate memory and copy data
+            memory_obj = self.local_cpu_backend.allocate(
+                metadata.shape,
+                metadata.dtype,
+                metadata.fmt,
+            )
+            if memory_obj is None:
+                logger.warning("Failed to allocate memory during file read")
+                return None
+
+            if isinstance(memory_obj.byte_array, memoryview):
+                view = memory_obj.byte_array
+                if view.format == "<B":
+                    view = view.cast("B")
+            else:
+                view = memoryview(memory_obj.byte_array)
+            view[:metadata.length] = kv_bytes
+
+            return memory_obj
+
+        except Exception as e:
+            logger.error(f"Failed to read from file {file_path}: {str(e)}")
+            return None
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        """Store data to file system"""
+        final_path = self._get_file_path(key)
+        temp_path = final_path.with_suffix('.tmp')
+
+        try:
+            # Prepare metadata
+            metadata = RemoteMetadata(len(memory_obj.byte_array),
+                                      memory_obj.get_shape(),
+                                      memory_obj.get_dtype(),
+                                      memory_obj.get_memory_format())
+
+            # Write to file (metadata + data)
+            with open(temp_path, 'wb') as f:
+                f.write(metadata.serialize())
+                f.write(memory_obj.byte_array)
+
+            # Atomically rename temp file to final destination
+            temp_path.replace(final_path)
+
+        except Exception as e:
+            logger.error(f"Failed to write file {final_path}: {str(e)}")
+            if temp_path.exists():
+                temp_path.unlink()  # Remove corrupted file
+            raise
+        finally:
+            memory_obj.ref_count_down()
+
+    @no_type_check
+    async def list(self) -> List[str]:
+        """List all keys in file system"""
+        return [f.stem for f in self.base_path.glob("*.data")]
+
+    async def close(self):
+        """Clean up resources"""
+        logger.info("Closed the file system connector")


### PR DESCRIPTION
Introduce a filesystem remote connector, compare to localdisk backend, this filesystem should be a shared filesystem and provide as a posix api, usually, it could be fuse mounted filesystem.

Base on this 3fs, hdfs, cephfs, juicefs... so many distributed filesystem can be backend of lmcache by mounted to the node.

# How to use
- Start vLLM and specify the lmcache config file
lmcache.yaml
```yaml
chunk_size: 256
local_device: "cpu"
remote_url: "fs://host:0/disc/data1/fs_data/"
remote_serde: "naive"
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 10
```
start_vllm.sh
```shell
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=0 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}'
```

- curl test
```shell
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "hi hi hi hi hi hi hi hi hi hi 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256"}],
    "max_tokens": 60,
    "temperature": 0
    }'
```


- Check file existance
```
ls -l /disc/data1/fs_data/
```