### PR TITLE
[Bugfix] Fix assertion bug in vllm v1 adapter

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -570,18 +570,18 @@ class LMCacheConnectorV1Impl:
             # No KV tokens from external KV cache, return
             return
 
-        assert num_external_tokens == \
+        if num_external_tokens == 0:
+            # No need to load anything
+            self.load_specs[request.request_id].can_load = False
+            return
+
+        assert num_external_tokens > 0 and num_external_tokens == \
             self.load_specs[request.request_id].lmcache_cached_tokens - \
             self.load_specs[request.request_id].vllm_cached_tokens, \
             f"Mismatch in number of tokens: {num_external_tokens} vs " \
             f"{self.load_specs[request.request_id].lmcache_cached_tokens} - " \
             f"{self.load_specs[request.request_id].vllm_cached_tokens}" \
             f" for request {request.request_id}"
-
-        if num_external_tokens == 0:
-            # No need to load anything
-            self.load_specs[request.request_id].can_load = False
-            return
 
         self.load_specs[request.request_id].can_load = True
 


### PR DESCRIPTION
Bug: If vLLM cannot allocate a page in the GPU page table, ``num_external_tokens`` is 0 and the assertion check fails due to mismatch.

Fix: Early return if ``num_external_tokens==0`` before the assertion check.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <a href="https://github.com/LMCache/LMCache/blob/dev/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.