### PR TITLE
Refactor: rename RedisMetadata to RemoteMetadata

### DIFF
--- a/lmcache/experimental/protocol.py
+++ b/lmcache/experimental/protocol.py
@@ -48,7 +48,7 @@ INT_TO_DTYPE = {
 
 
 @dataclass
-class RedisMetadata:
+class CommonMetadata:
     length: int
     shape: torch.Size
     dtype: Optional[torch.dtype]
@@ -89,12 +89,12 @@ class RedisMetadata:
         return packed_bytes
 
     @staticmethod
-    def deserialize(s: bytes) -> "RedisMetadata":
+    def deserialize(s: bytes) -> "CommonMetadata":
         length, fmt, dtype, shape0, shape1, shape2, shape3 = \
             struct.unpack_from("iiiiiii", s)
-        return RedisMetadata(length,
-                             torch.Size([shape0, shape1, shape2, shape3]),
-                             INT_TO_DTYPE[dtype], MemoryFormat(fmt))
+        return CommonMetadata(length,
+                              torch.Size([shape0, shape1, shape2, shape3]),
+                              INT_TO_DTYPE[dtype], MemoryFormat(fmt))
 
 
 @dataclass

--- a/lmcache/experimental/protocol.py
+++ b/lmcache/experimental/protocol.py
@@ -48,7 +48,7 @@ INT_TO_DTYPE = {
 
 
 @dataclass
-class CommonMetadata:
+class RemoteMetadata:
     length: int
     shape: torch.Size
     dtype: Optional[torch.dtype]
@@ -89,10 +89,10 @@ class CommonMetadata:
         return packed_bytes
 
     @staticmethod
-    def deserialize(s: bytes) -> "CommonMetadata":
+    def deserialize(s: bytes) -> "RemoteMetadata":
         length, fmt, dtype, shape0, shape1, shape2, shape3 = \
             struct.unpack_from("iiiiiii", s)
-        return CommonMetadata(length,
+        return RemoteMetadata(length,
                               torch.Size([shape0, shape1, shape2, shape3]),
                               INT_TO_DTYPE[dtype], MemoryFormat(fmt))
 

--- a/lmcache/experimental/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/infinistore_connector.py
@@ -25,7 +25,7 @@ from lmcache.experimental.memory_management import (CopyLessMemoryObj,
                                                     MemoryAllocatorInterface,
                                                     MemoryObj)
 # reuse
-from lmcache.experimental.protocol import CommonMetadata
+from lmcache.experimental.protocol import RemoteMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -102,7 +102,7 @@ class InfinistoreConnector(RemoteConnector):
             self.recv_queue.put_nowait(buf_idx)
             return None
 
-        metadata = CommonMetadata.deserialize(buffer)
+        metadata = RemoteMetadata.deserialize(buffer)
 
         def callback():
             self.recv_queue.put_nowait(buf_idx)
@@ -134,7 +134,7 @@ class InfinistoreConnector(RemoteConnector):
         buf_idx = await self.send_queue.get()
         buffer = self.send_buffers[buf_idx]
 
-        CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
+        RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype,
                        memory_format).serialize_into(buffer)
 
         buffer[METADATA_BYTES_LEN:METADATA_BYTES_LEN +

--- a/lmcache/experimental/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/infinistore_connector.py
@@ -25,7 +25,7 @@ from lmcache.experimental.memory_management import (CopyLessMemoryObj,
                                                     MemoryAllocatorInterface,
                                                     MemoryObj)
 # reuse
-from lmcache.experimental.protocol import RedisMetadata
+from lmcache.experimental.protocol import CommonMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -102,7 +102,7 @@ class InfinistoreConnector(RemoteConnector):
             self.recv_queue.put_nowait(buf_idx)
             return None
 
-        metadata = RedisMetadata.deserialize(buffer)
+        metadata = CommonMetadata.deserialize(buffer)
 
         def callback():
             self.recv_queue.put_nowait(buf_idx)
@@ -134,8 +134,8 @@ class InfinistoreConnector(RemoteConnector):
         buf_idx = await self.send_queue.get()
         buffer = self.send_buffers[buf_idx]
 
-        RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
-                      memory_format).serialize_into(buffer)
+        CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
+                       memory_format).serialize_into(buffer)
 
         buffer[METADATA_BYTES_LEN:METADATA_BYTES_LEN +
                len(kv_bytes)] = kv_bytes

--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -25,7 +25,7 @@ import torch
 from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
                                                     MemoryObj)
 # reuse
-from lmcache.experimental.protocol import RedisMetadata
+from lmcache.experimental.protocol import CommonMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -131,7 +131,7 @@ class MooncakestoreConnector(RemoteConnector):
         if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
             return None
 
-        metadata = RedisMetadata.deserialize(metadata_bytes)
+        metadata = CommonMetadata.deserialize(metadata_bytes)
 
         memory_obj = self.memory_allocator.allocate(
             metadata.shape,
@@ -165,7 +165,7 @@ class MooncakestoreConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
+        metadata_bytes = CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
                                        memory_format).serialize()
         assert len(metadata_bytes) == METADATA_BYTES_LEN
         key_str = key.to_string()

--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -25,7 +25,7 @@ import torch
 from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
                                                     MemoryObj)
 # reuse
-from lmcache.experimental.protocol import CommonMetadata
+from lmcache.experimental.protocol import RemoteMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -131,7 +131,7 @@ class MooncakestoreConnector(RemoteConnector):
         if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
             return None
 
-        metadata = CommonMetadata.deserialize(metadata_bytes)
+        metadata = RemoteMetadata.deserialize(metadata_bytes)
 
         memory_obj = self.memory_allocator.allocate(
             metadata.shape,
@@ -165,8 +165,8 @@ class MooncakestoreConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata_bytes = CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
-                                       memory_format).serialize()
+        metadata_bytes = RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype,
+                                        memory_format).serialize()
         assert len(metadata_bytes) == METADATA_BYTES_LEN
         key_str = key.to_string()
 

--- a/lmcache/experimental/storage_backend/connector/redis_connector.py
+++ b/lmcache/experimental/storage_backend/connector/redis_connector.py
@@ -21,7 +21,7 @@ import redis
 
 from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
                                                     MemoryObj)
-from lmcache.experimental.protocol import CommonMetadata
+from lmcache.experimental.protocol import RemoteMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -61,7 +61,7 @@ class RedisConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = CommonMetadata.deserialize(memoryview(metadata_bytes))
+        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
         memory_obj = self.memory_allocator.allocate(
             metadata.shape,
@@ -100,7 +100,7 @@ class RedisConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata_bytes = CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
+        metadata_bytes = RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype,
                                         memory_format).serialize()
 
         key_str = key.to_string()
@@ -179,7 +179,7 @@ class RedisSentinelConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = CommonMetadata.deserialize(metadata_bytes)
+        metadata = RemoteMetadata.deserialize(metadata_bytes)
 
         memory_obj = self.memory_allocator.allocate(
             metadata.shape,
@@ -218,7 +218,7 @@ class RedisSentinelConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata_bytes = CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
+        metadata_bytes = RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype,
                                         memory_format).serialize()
 
         key_str = key.to_string()

--- a/lmcache/experimental/storage_backend/connector/redis_connector.py
+++ b/lmcache/experimental/storage_backend/connector/redis_connector.py
@@ -21,7 +21,7 @@ import redis
 
 from lmcache.experimental.memory_management import (MemoryAllocatorInterface,
                                                     MemoryObj)
-from lmcache.experimental.protocol import RedisMetadata
+from lmcache.experimental.protocol import CommonMetadata
 from lmcache.experimental.storage_backend.connector.base_connector import \
     RemoteConnector
 from lmcache.logging import init_logger
@@ -54,20 +54,19 @@ class RedisConnector(RemoteConnector):
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        redis_metadata_bytes = self.connection.get(key_str + "metadata")
+        metadata_bytes = self.connection.get(key_str + "metadata")
 
-        if redis_metadata_bytes is None:
+        if metadata_bytes is None:
             return None
 
-        assert not inspect.isawaitable(redis_metadata_bytes)
+        assert not inspect.isawaitable(metadata_bytes)
 
-        redis_metadata = RedisMetadata.deserialize(
-            memoryview(redis_metadata_bytes))
+        metadata = CommonMetadata.deserialize(memoryview(metadata_bytes))
 
         memory_obj = self.memory_allocator.allocate(
-            redis_metadata.shape,
-            redis_metadata.dtype,
-            redis_metadata.fmt,
+            metadata.shape,
+            metadata.dtype,
+            metadata.fmt,
         )
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
@@ -89,7 +88,7 @@ class RedisConnector(RemoteConnector):
             return None
 
         view = memoryview(memory_obj.byte_array)
-        view[:redis_metadata.length] = kv_bytes
+        view[:metadata.length] = kv_bytes
 
         return memory_obj
 
@@ -101,11 +100,11 @@ class RedisConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        redis_metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
-                                             memory_format).serialize()
+        metadata_bytes = CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
+                                        memory_format).serialize()
 
         key_str = key.to_string()
-        self.connection.set(key_str + "metadata", redis_metadata_bytes)
+        self.connection.set(key_str + "metadata", metadata_bytes)
         self.connection.set(key_str + "kv_bytes", kv_bytes)
 
         self.memory_allocator.ref_count_down(memory_obj)
@@ -173,19 +172,19 @@ class RedisSentinelConnector(RemoteConnector):
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        redis_metadata_bytes = self.slave.get(key_str + "metadata")
+        metadata_bytes = self.slave.get(key_str + "metadata")
 
-        if redis_metadata_bytes is None:
+        if metadata_bytes is None:
             return None
 
-        assert not inspect.isawaitable(redis_metadata_bytes)
+        assert not inspect.isawaitable(metadata_bytes)
 
-        redis_metadata = RedisMetadata.deserialize(redis_metadata_bytes)
+        metadata = CommonMetadata.deserialize(metadata_bytes)
 
         memory_obj = self.memory_allocator.allocate(
-            redis_metadata.shape,
-            redis_metadata.dtype,
-            redis_metadata.fmt,
+            metadata.shape,
+            metadata.dtype,
+            metadata.fmt,
         )
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
@@ -207,7 +206,7 @@ class RedisSentinelConnector(RemoteConnector):
             return None
 
         view = memoryview(memory_obj.byte_array)
-        view[0:redis_metadata.length] = kv_bytes
+        view[0:metadata.length] = kv_bytes
 
         return memory_obj
 
@@ -219,11 +218,11 @@ class RedisSentinelConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        redis_metadata_bytes = RedisMetadata(len(kv_bytes), kv_shape, kv_dtype,
-                                             memory_format).serialize()
+        metadata_bytes = CommonMetadata(len(kv_bytes), kv_shape, kv_dtype,
+                                        memory_format).serialize()
 
         key_str = key.to_string()
-        self.master.set(key_str + "metadata", redis_metadata_bytes)
+        self.master.set(key_str + "metadata", metadata_bytes)
         self.master.set(key_str + "kv_bytes", kv_bytes)
 
         self.memory_allocator.ref_count_down(memory_obj)


### PR DESCRIPTION
As https://github.com/LMCache/LMCache/pull/506#discussion_r2053295670 motioned, do this refactor in this PR.

Since the RedisMetadata is used by many connectors already.