### PR TITLE
fix runtime error:Invalid device for infinistore(#502)

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -359,16 +359,6 @@ class TensorMemoryObj(MemoryObj):
         return self.metadata.is_pin
 
 
-# TODO(Jiayi): Need to make this compatible with pin/unpin semantics
-class CopyLessMemoryObj(TensorMemoryObj):
-    def __init__(self, raw_data, metadata, callback, parent_allocator=None):
-        super().__init__(raw_data, metadata, parent_allocator)
-        self.callback = callback
-
-    def __del__(self):
-        self.callback()
-
-
 class BytesBufferMemoryObj(MemoryObj):
     """
     Wraps a raw flat tensor with some metadata

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -173,7 +173,9 @@ def CreateConnector(
         case "infinistore":
             host, port = parsed_url.hosts[0], parsed_url.ports[0]
             device_name = parsed_url.query_params[0].get("device", "mlx5_0")
-            connector = InfinistoreConnector(host, port, device_name, loop)
+            connector = InfinistoreConnector(
+                host, port, device_name, loop, local_cpu_backend
+            )
         case "mooncakestore":
             host, port = parsed_url.hosts[0], parsed_url.ports[0]
             device_name = parsed_url.query_params[0].get("device", "")


### PR DESCRIPTION
Since update_hot_cache do not deep copy anymore, infinistore connector should do the deepcopy.
