### PR TITLE
[bugfix] fix counter type prometheus metrics error

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -363,7 +363,8 @@ class PrometheusLogger:
 
         self._log_counter(self.counter_num_requested_tokens,
                           stats.interval_requested_tokens)
-        self._log_counter(self.counter_num_hit_tokens, stats.interval_hit_tokens)
+        self._log_counter(self.counter_num_hit_tokens,
+                          stats.interval_hit_tokens)
 
         self._log_gauge(self.gauge_cache_hit_rate, stats.cache_hit_rate)
 

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -14,12 +14,12 @@ logger = init_logger(__name__)
 
 @dataclass
 class LMCacheStats:
-    # Counter (will accumulate over time)
-    num_retrieve_requests: int
-    num_store_requests: int
-
-    num_requested_tokens: int
-    num_hit_tokens: int
+    # Counter (Note that these are incremental values,
+    # which will accumulate over time in Counter)
+    interval_retrieve_requests: int
+    interval_store_requests: int
+    interval_requested_tokens: int
+    interval_hit_tokens: int
 
     # Real time value measurements (will be reset after each log)
     cache_hit_rate: float
@@ -75,14 +75,10 @@ class StoreRequestStats:
 class LMCStatsMonitor:
 
     def __init__(self):
-        # Accumulated stats over time
-        self.num_retrieve_requests = 0
-        self.num_store_requests = 0
-
-        self.num_requested_tokens = 0
-        self.num_hit_tokens = 0
-
         # Interval metrics that will be reset after each log
+        # Accumulate incremental values in the Prometheus Counter
+        self.interval_retrieve_requests = 0
+        self.interval_store_requests = 0
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
 
@@ -109,8 +105,7 @@ class LMCStatsMonitor:
                                               start_time=curr_time,
                                               end_time=0)
         self.interval_requested_tokens += num_tokens
-        self.num_requested_tokens += num_tokens
-        self.num_retrieve_requests += 1
+        self.interval_retrieve_requests += 1
         self.retrieve_requests[self.retrieve_request_id] = retrieve_stats
         self.retrieve_request_id += 1
         return self.retrieve_request_id - 1
@@ -123,7 +118,6 @@ class LMCStatsMonitor:
         retrieve_stats.local_hit_tokens = retrieved_tokens
         retrieve_stats.end_time = curr_time
         self.interval_hit_tokens += retrieved_tokens
-        self.num_hit_tokens += retrieved_tokens
 
     @thread_safe
     def on_store_request(self, num_tokens: int) -> int:
@@ -134,7 +128,7 @@ class LMCStatsMonitor:
         store_stats = StoreRequestStats(num_tokens=num_tokens,
                                         start_time=curr_time,
                                         end_time=0)
-        self.num_store_requests += 1
+        self.interval_store_requests += 1
         self.store_requests[self.store_request_id] = store_stats
         self.store_request_id += 1
         return self.store_request_id - 1
@@ -163,6 +157,9 @@ class LMCStatsMonitor:
         """
         Clear all the distribution stats 
         """
+        self.interval_retrieve_requests = 0
+        self.interval_store_requests = 0
+
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
 
@@ -209,10 +206,10 @@ class LMCStatsMonitor:
             [stats.store_speed() for stats in self.store_requests.values()])
 
         ret = LMCacheStats(
-            num_retrieve_requests=self.num_retrieve_requests,
-            num_store_requests=self.num_store_requests,
-            num_requested_tokens=self.num_requested_tokens,
-            num_hit_tokens=self.num_hit_tokens,
+            interval_retrieve_requests=self.interval_retrieve_requests,
+            interval_store_requests=self.interval_store_requests,
+            interval_requested_tokens=self.interval_requested_tokens,
+            interval_hit_tokens=self.interval_hit_tokens,
             cache_hit_rate=cache_hit_rate,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
@@ -360,13 +357,13 @@ class PrometheusLogger:
 
     def log_prometheus(self, stats: LMCacheStats):
         self._log_counter(self.counter_num_retrieve_requests,
-                          stats.num_retrieve_requests)
+                          stats.interval_retrieve_requests)
         self._log_counter(self.counter_num_store_requests,
-                          stats.num_store_requests)
+                          stats.interval_store_requests)
 
         self._log_counter(self.counter_num_requested_tokens,
-                          stats.num_requested_tokens)
-        self._log_counter(self.counter_num_hit_tokens, stats.num_hit_tokens)
+                          stats.interval_requested_tokens)
+        self._log_counter(self.counter_num_hit_tokens, stats.interval_hit_tokens)
 
         self._log_gauge(self.gauge_cache_hit_rate, stats.cache_hit_rate)
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -12,7 +12,7 @@ def stats_monitor():
 def test_on_retrieve_request(stats_monitor):
     stats_monitor.on_retrieve_request(num_tokens=100)
     stats = stats_monitor.get_stats_and_clear()
-    assert stats.num_retrieve_requests == 1
+    assert stats.interval_retrieve_requests == 1
     assert stats.cache_hit_rate == 0
     assert stats.local_cache_usage_bytes == 0
     assert stats.remote_cache_usage_bytes == 0
@@ -26,7 +26,7 @@ def test_on_retrieve_finished(stats_monitor):
         retrieved_tokens=100,
     )
     stats = stats_monitor.get_stats_and_clear()
-    assert stats.num_retrieve_requests == 1
+    assert stats.interval_retrieve_requests == 1
     assert stats.cache_hit_rate == 1.0
     assert len(stats.time_to_retrieve) == 1
 
@@ -35,7 +35,7 @@ def test_on_store_request_and_finished(stats_monitor):
     request_id = stats_monitor.on_store_request(num_tokens=50)
     stats_monitor.on_store_finished(request_id=request_id)
     stats = stats_monitor.get_stats_and_clear()
-    assert stats.num_store_requests == 1
+    assert stats.interval_store_requests == 1
     assert len(stats.time_to_store) == 1
 
 
@@ -65,8 +65,8 @@ def test_combined_operations(stats_monitor):
     stats_monitor2 = LMCStatsMonitor.GetOrCreate()
     stats = stats_monitor2.get_stats_and_clear()
 
-    assert stats.num_retrieve_requests == 1
-    assert stats.num_store_requests == 1
+    assert stats.interval_retrieve_requests == 1
+    assert stats.interval_store_requests == 1
     assert stats.cache_hit_rate == 1.0
     assert stats.local_cache_usage_bytes == 512
     assert stats.remote_cache_usage_bytes == 1024


### PR DESCRIPTION
In our grafana, VLLM is in an idle state, but we found that the following metrics are constantly increasing
- `lmcache:num_retrieve_requests`
- `lmcache:num_store_requests`
- `lmcache:num_requested_tokens`
- `lmcache:num_hit_tokens`

These four Counter type metrics update data through `_log_counter()`, which implementation is as follows:
```
def _log_counter(self, counter, data: Union[int, float]) -> None:
    # Convenience function for logging to counter.
    # Prevent ValueError from negative increment
    if data < 0:
        return
    counter.labels(**self.labels).inc(data)
```

`counter.labels(**self.labels).inc(data)` use `inc()` to update data, so we must use incremental data to update metrics instead of full data.