### PR TITLE
[feat] Add configuration logging

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -231,7 +231,28 @@ class LMCacheEngineConfig:
             parse_env(get_env_name("blend_add_special_in_precomp"),
                       config.blend_add_special_in_precomp))
 
-        return config
+        return config.log_config()
+
+    def log_config(self) -> 'LMCacheEngineConfig':
+        """Log all configuration settings
+        """
+        config_dict = {
+            'chunk_size': self.chunk_size,
+            'local_device': self.local_device,
+            'max_local_cache_size': f"{self.max_local_cache_size} GB",
+            'remote_url': self.remote_url,
+            'remote_serde': self.remote_serde,
+            'pipelined_backend': self.pipelined_backend,
+            'save_decode_cache': self.save_decode_cache,
+            'enable_blending': self.enable_blending,
+            'blend_recompute_ratio': self.blend_recompute_ratio,
+            'blend_min_tokens': self.blend_min_tokens,
+            'blend_separator': self.blend_separator,
+            'blend_add_special_in_precomp': self.blend_add_special_in_precomp
+        }
+        logger.info(f"LMCache Configuration: {config_dict}")
+
+        return self
 
 
 ### SOME GLOBAL CONFIGS

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -5,7 +5,9 @@ from typing import Any, Optional, Tuple
 
 import torch
 import yaml
+from lmcache.logging import init_logger
 
+logger = init_logger(__name__)
 
 @dataclass
 class LMCacheEngineMetadata:
@@ -114,7 +116,7 @@ class LMCacheEngineConfig:
             blend_min_tokens=256,
             blend_separator=blend_default_separator,
             blend_add_special_in_precomp=False,
-        )
+        ).log_config()
 
     @staticmethod
     def from_file(file_path: str) -> "LMCacheEngineConfig":
@@ -170,7 +172,7 @@ class LMCacheEngineConfig:
             blend_min_tokens,
             blend_separator,
             blend_add_special_in_precomp,
-        )
+        ).log_config()
 
     @staticmethod
     def from_env() -> "LMCacheEngineConfig":
@@ -227,7 +229,29 @@ class LMCacheEngineConfig:
             parse_env(get_env_name("blend_add_special_in_precomp"),
                       config.blend_add_special_in_precomp))
 
-        return config
+        return config.log_config()
+    
+    def log_config(self) -> 'LMCacheEngineConfig':
+        """Log all configuration settings
+        """
+
+        config_dict = {
+            'chunk_size': self.chunk_size,
+            'local_device': self.local_device,
+            'max_local_cache_size': f"{self.max_local_cache_size} GB",
+            'remote_url': self.remote_url,
+            'remote_serde': self.remote_serde,
+            'pipelined_backend': self.pipelined_backend,
+            'save_decode_cache': self.save_decode_cache,
+            'enable_blending': self.enable_blending,
+            'blend_recompute_ratio': self.blend_recompute_ratio,
+            'blend_min_tokens': self.blend_min_tokens,
+            'blend_separator': self.blend_separator,
+            'blend_add_special_in_precomp': self.blend_add_special_in_precomp
+        }
+        logger.info(f"LMCache Configuration: {config_dict}")
+        
+        return self
 
 
 ### SOME GLOBAL CONFIGS

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -6,6 +6,10 @@ from typing import Any, Optional, Tuple
 import torch
 import yaml
 
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
 
 @dataclass
 class LMCacheEngineMetadata:
@@ -114,7 +118,7 @@ class LMCacheEngineConfig:
             blend_min_tokens=256,
             blend_separator=blend_default_separator,
             blend_add_special_in_precomp=False,
-        )
+        ).log_config()
 
     @staticmethod
     def from_file(file_path: str) -> "LMCacheEngineConfig":
@@ -170,7 +174,7 @@ class LMCacheEngineConfig:
             blend_min_tokens,
             blend_separator,
             blend_add_special_in_precomp,
-        )
+        ).log_config()
 
     @staticmethod
     def from_env() -> "LMCacheEngineConfig":
@@ -227,7 +231,28 @@ class LMCacheEngineConfig:
             parse_env(get_env_name("blend_add_special_in_precomp"),
                       config.blend_add_special_in_precomp))
 
-        return config
+        return config.log_config()
+    
+    def log_config(self) -> 'LMCacheEngineConfig':
+        """Log all configuration settings
+        """
+        config_dict = {
+            'chunk_size': self.chunk_size,
+            'local_device': self.local_device,
+            'max_local_cache_size': f"{self.max_local_cache_size} GB",
+            'remote_url': self.remote_url,
+            'remote_serde': self.remote_serde,
+            'pipelined_backend': self.pipelined_backend,
+            'save_decode_cache': self.save_decode_cache,
+            'enable_blending': self.enable_blending,
+            'blend_recompute_ratio': self.blend_recompute_ratio,
+            'blend_min_tokens': self.blend_min_tokens,
+            'blend_separator': self.blend_separator,
+            'blend_add_special_in_precomp': self.blend_add_special_in_precomp
+        }
+        logger.info(f"LMCache Configuration: {config_dict}")
+        
+        return self
 
 
 ### SOME GLOBAL CONFIGS

--- a/lmcache/experimental/config.py
+++ b/lmcache/experimental/config.py
@@ -6,6 +6,9 @@ from typing import Any, Optional
 import yaml
 
 import lmcache.config as orig_config
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -166,7 +169,7 @@ class LMCacheEngineConfig:
                                    enable_blending, blend_recompute_ratio,
                                    blend_min_tokens, blend_special_str,
                                    enable_p2p, lookup_url, distributed_url,
-                                   error_handling).validate()
+                                   error_handling).validate().log_config()
 
     @staticmethod
     def from_file(file_path: str) -> "LMCacheEngineConfig":
@@ -257,7 +260,7 @@ class LMCacheEngineConfig:
             nixl_buffer_size,
             nixl_buffer_device,
             nixl_enable_gc,
-        ).validate()
+        ).validate().log_config()
 
     @staticmethod
     def from_env() -> "LMCacheEngineConfig":
@@ -365,7 +368,7 @@ class LMCacheEngineConfig:
             get_env_name("nixl_buffer_device"), config.nixl_buffer_device)
         config.nixl_enable_gc = to_bool(
             parse_env(get_env_name("nixl_enable_gc"), config.nixl_enable_gc))
-        return config.validate()
+        return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:
         # NOTE: This function is purely for UsageContext compatibility
@@ -414,5 +417,38 @@ class LMCacheEngineConfig:
                     "Nixl only supports save_decode_cache=False"
             assert self.enable_p2p is False, \
                     "Nixl only supports enable_p2p=False"
+
+        return self
+
+    def log_config(self) -> 'LMCacheEngineConfig':
+        """log the configuration in LMCache
+        """
+        config_dict = {
+            'chunk_size': self.chunk_size,
+            'local_cpu': self.local_cpu,
+            'max_local_cpu_size': f"{self.max_local_cpu_size} GB",
+            'local_disk': self.local_disk,
+            'max_local_disk_size': f"{self.max_local_disk_size} GB",
+            'remote_url': self.remote_url,
+            'remote_serde': self.remote_serde,
+            'save_decode_cache': self.save_decode_cache,
+            'enable_blending': self.enable_blending,
+            'blend_recompute_ratio': self.blend_recompute_ratio,
+            'blend_min_tokens': self.blend_min_tokens,
+            'enable_p2p': self.enable_p2p,
+            'lookup_url': self.lookup_url,
+            'distributed_url': self.distributed_url,
+            'error_handling': self.error_handling,
+            'enable_controller': self.enable_controller,
+            'lmcache_instance_id': self.lmcache_instance_id,
+            'enable_nixl': self.enable_nixl,
+            'nixl_role': self.nixl_role,
+            'nixl_peer_host': self.nixl_peer_host,
+            'nixl_peer_port': self.nixl_peer_port,
+            'nixl_buffer_size': self.nixl_buffer_size,
+            'nixl_buffer_device': self.nixl_buffer_device,
+            'nixl_enable_gc': self.nixl_enable_gc
+        }
+        logger.info(f"LMCache Configuration: {config_dict}")
 
         return self

--- a/lmcache/experimental/config.py
+++ b/lmcache/experimental/config.py
@@ -10,6 +10,7 @@ from lmcache.logging import init_logger
 
 logger = init_logger(__name__)
 
+
 @dataclass
 class LMCacheEngineConfig:
     chunk_size: int
@@ -416,5 +417,38 @@ class LMCacheEngineConfig:
                     "Nixl only supports save_decode_cache=False"
             assert self.enable_p2p is False, \
                     "Nixl only supports enable_p2p=False"
+
+        return self
+
+    def log_config(self) -> 'LMCacheEngineConfig':
+        """log the configuration in LMCache
+        """
+        config_dict = {
+            'chunk_size': self.chunk_size,
+            'local_cpu': self.local_cpu,
+            'max_local_cpu_size': f"{self.max_local_cpu_size} GB",
+            'local_disk': self.local_disk,
+            'max_local_disk_size': f"{self.max_local_disk_size} GB",
+            'remote_url': self.remote_url,
+            'remote_serde': self.remote_serde,
+            'save_decode_cache': self.save_decode_cache,
+            'enable_blending': self.enable_blending,
+            'blend_recompute_ratio': self.blend_recompute_ratio,
+            'blend_min_tokens': self.blend_min_tokens,
+            'enable_p2p': self.enable_p2p,
+            'lookup_url': self.lookup_url,
+            'distributed_url': self.distributed_url,
+            'error_handling': self.error_handling,
+            'enable_controller': self.enable_controller,
+            'lmcache_instance_id': self.lmcache_instance_id,
+            'enable_nixl': self.enable_nixl,
+            'nixl_role': self.nixl_role,
+            'nixl_peer_host': self.nixl_peer_host,
+            'nixl_peer_port': self.nixl_peer_port,
+            'nixl_buffer_size': self.nixl_buffer_size,
+            'nixl_buffer_device': self.nixl_buffer_device,
+            'nixl_enable_gc': self.nixl_enable_gc
+        }
+        logger.info(f"LMCache Configuration: {config_dict}")
 
         return self

--- a/lmcache/experimental/config.py
+++ b/lmcache/experimental/config.py
@@ -6,6 +6,9 @@ from typing import Any, Optional
 import yaml
 
 import lmcache.config as orig_config
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -166,7 +169,7 @@ class LMCacheEngineConfig:
                                    enable_blending, blend_recompute_ratio,
                                    blend_min_tokens, blend_special_str,
                                    enable_p2p, lookup_url, distributed_url,
-                                   error_handling).validate()
+                                   error_handling).validate().log_config()
 
     @staticmethod
     def from_file(file_path: str) -> "LMCacheEngineConfig":
@@ -257,7 +260,7 @@ class LMCacheEngineConfig:
             nixl_buffer_size,
             nixl_buffer_device,
             nixl_enable_gc,
-        ).validate()
+        ).validate().log_config()
 
     @staticmethod
     def from_env() -> "LMCacheEngineConfig":
@@ -365,7 +368,7 @@ class LMCacheEngineConfig:
             get_env_name("nixl_buffer_device"), config.nixl_buffer_device)
         config.nixl_enable_gc = to_bool(
             parse_env(get_env_name("nixl_enable_gc"), config.nixl_enable_gc))
-        return config.validate()
+        return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:
         # NOTE: This function is purely for UsageContext compatibility
@@ -414,5 +417,40 @@ class LMCacheEngineConfig:
                     "Nixl only supports save_decode_cache=False"
             assert self.enable_p2p is False, \
                     "Nixl only supports enable_p2p=False"
+
+        return self
+
+    def log_config(self) -> 'LMCacheEngineConfig':
+        """log the configuration in LMCache
+        """
+
+        # Log all configuration variables
+        config_dict = {
+            'chunk_size': self.chunk_size,
+            'local_cpu': self.local_cpu,
+            'max_local_cpu_size': f"{self.max_local_cpu_size} GB",
+            'local_disk': self.local_disk,
+            'max_local_disk_size': f"{self.max_local_disk_size} GB",
+            'remote_url': self.remote_url,
+            'remote_serde': self.remote_serde,
+            'save_decode_cache': self.save_decode_cache,
+            'enable_blending': self.enable_blending,
+            'blend_recompute_ratio': self.blend_recompute_ratio,
+            'blend_min_tokens': self.blend_min_tokens,
+            'enable_p2p': self.enable_p2p,
+            'lookup_url': self.lookup_url,
+            'distributed_url': self.distributed_url,
+            'error_handling': self.error_handling,
+            'enable_controller': self.enable_controller,
+            'lmcache_instance_id': self.lmcache_instance_id,
+            'enable_nixl': self.enable_nixl,
+            'nixl_role': self.nixl_role,
+            'nixl_peer_host': self.nixl_peer_host,
+            'nixl_peer_port': self.nixl_peer_port,
+            'nixl_buffer_size': self.nixl_buffer_size,
+            'nixl_buffer_device': self.nixl_buffer_device,
+            'nixl_enable_gc': self.nixl_enable_gc
+        }
+        logger.info(f"LMCache Configuration: {config_dict}")
 
         return self


### PR DESCRIPTION
This commit adds consistent configuration logging functionality to both the main and experimental versions of LMCache.

The new functionality helps with debugging and monitoring by providing a clear view of the active configuration when LMCache is initialized. This is particularly useful in complex deployment scenarios where configuration might come from multiple sources.

Sample log output:
```
[2025-04-25 05:40:22,373] LMCache WARNING: You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE (utils.py:27:lmcache.integration.vllm.utils)
[2025-04-25 05:40:22,373] LMCache INFO: LMCache Configuration: {'chunk_size': 128, 'local_cpu': True, 'max_local_cpu_size': '200.0 GB', 'local_disk': None, 'max_local_disk_size': '0.0 GB', 'remote_url': None, 'remote_serde': None, 'save_decode_cache': False, 'enable_blending': False, 'blend_recompute_ratio': 0.15, 'blend_min_tokens': 256, 'enable_p2p': False, 'lookup_url': None, 'distributed_url': None, 'error_handling': False, 'enable_controller': False, 'lmcache_instance_id': 'lmcache_default_instance', 'enable_nixl': False, 'nixl_role': None, 'nixl_peer_host': None, 'nixl_peer_port': 0, 'nixl_buffer_size': 0, 'nixl_buffer_device': None, 'nixl_enable_gc': False} (config.py:454:lmcache.experimental.config)
[2025-04-25 05:40:22,376] LMCache INFO: Creating LMCacheEngine instance vllm-instance (cache_engine.py:422:lmcache.experimental.cache_engine)
```