### PR TITLE
[feat] Add an audit remote connector to audit remote op and verify checksum

### DIFF
--- a/lmcache/experimental/config.py
+++ b/lmcache/experimental/config.py
@@ -66,6 +66,9 @@ class LMCacheEngineConfig:
     # HACK: explicit option to enable/disable nixl GC before it's mature enough
     nixl_enable_gc: Optional[bool] = False
 
+    # The url of the actual remote lmcache instance for auditing
+    audit_actual_remote_url: Optional[str] = None
+
     @staticmethod
     def from_defaults(
         chunk_size: int = 256,
@@ -95,6 +98,7 @@ class LMCacheEngineConfig:
         nixl_buffer_size: Optional[int] = None,
         nixl_buffer_device: Optional[str] = None,
         nixl_enable_gc: Optional[bool] = False,
+        audit_actual_remote_url: Optional[str] = None,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
         return LMCacheEngineConfig(
@@ -105,7 +109,8 @@ class LMCacheEngineConfig:
             error_handling, enable_controller, lmcache_instance_id,
             controller_url, lmcache_worker_url, enable_nixl, nixl_role,
             nixl_peer_host, nixl_peer_port, nixl_buffer_size,
-            nixl_buffer_device, nixl_enable_gc).validate()
+            nixl_buffer_device, nixl_enable_gc,
+            audit_actual_remote_url).validate()
 
     @staticmethod
     def from_legacy(
@@ -217,6 +222,8 @@ class LMCacheEngineConfig:
         nixl_buffer_device = config.get("nixl_buffer_device", None)
         nixl_enable_gc = config.get("nixl_enable_gc", False)
 
+        audit_actual_remote_url = config.get("audit_actual_remote_url", None)
+
         match local_disk:
             case None:
                 local_disk_path = None
@@ -260,6 +267,7 @@ class LMCacheEngineConfig:
             nixl_buffer_size,
             nixl_buffer_device,
             nixl_enable_gc,
+            audit_actual_remote_url,
         ).validate().log_config()
 
     @staticmethod
@@ -368,6 +376,9 @@ class LMCacheEngineConfig:
             get_env_name("nixl_buffer_device"), config.nixl_buffer_device)
         config.nixl_enable_gc = to_bool(
             parse_env(get_env_name("nixl_enable_gc"), config.nixl_enable_gc))
+        config.audit_actual_remote_url = parse_env(
+            get_env_name("audit_actual_remote_url"),
+            config.audit_actual_remote_url)
         return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:

--- a/lmcache/experimental/storage_backend/connector/audit_connector.py
+++ b/lmcache/experimental/storage_backend/connector/audit_connector.py
@@ -57,45 +57,47 @@ class AuditConnector(RemoteConnector):
         """Store data with optional checksum tracking"""
         data = memory_obj.byte_array
         checksum = self._calculate_checksum(data)
-
+        data_size = len(data)
         self.logger.debug(
-            f"[REMOTE_AUDIT]:PUT|START|Key: {key}|Size: {len(data)} bytes|"
-            f"Checksum: {checksum[:8]}|Saved: {len(self.checksum_registry)}")
+            f"[REMOTE_AUDIT]:PUT|START|Size:{data_size}|"
+            f"Checksum:{checksum[:8]}|Saved:{len(self.checksum_registry)}|Key:{key}"
+        )
 
         try:
             t1 = time.perf_counter()
             await self.real_connector.put(key, memory_obj)
             t2 = time.perf_counter()
+            cost = (t2 - t1) * 1000
             if self.registry_lock:
                 with self.registry_lock:
                     self.checksum_registry[key] = checksum
-            cost = (t2 - t1) * 1000
             self.logger.info(
-                f"[REMOTE_AUDIT]PUT|SUCCESS|Key: {key}|Size: {len(data)} bytes|"
-                f"Checksum: {checksum[:8]}|Cost: {cost:.6f}ms|Saved: "
-                f"{len(self.checksum_registry)}")
+                f"[REMOTE_AUDIT]PUT|SUCCESS|Size:{data_size}|"
+                f"Checksum:{checksum[:8]}|Cost:{cost:.6f}ms|Saved:"
+                f"{len(self.checksum_registry)}|Key:{key}")
 
         except Exception as e:
-            self.logger.error(
-                f"[REMOTE_AUDIT]PUT|FAILED|Key: {key}|Error: {str(e)}")
+            self.logger.error(f"[REMOTE_AUDIT]PUT|FAILED|Size:{data_size}"
+                              f"|Key:{key}|Error: {str(e)}")
             raise
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Retrieve data with optional integrity check"""
-        self.logger.debug(f"[REMOTE_AUDIT]GET|START|Key: {key}|"
-                          f"Saved: {len(self.checksum_registry)}")
+        self.logger.debug(f"[REMOTE_AUDIT]GET|START|"
+                          f"Saved:{len(self.checksum_registry)}|Key:{key}")
 
         try:
             t1 = time.perf_counter()
             result = await self.real_connector.get(key)
             t2 = time.perf_counter()
             if result is None:
-                self.logger.info(f"[REMOTE_AUDIT]GET|MISS|Key: {key}|"
+                self.logger.info(f"[REMOTE_AUDIT]GET|MISS|Key:{key}|"
                                  f"Saved: {len(self.checksum_registry)}")
                 return None
 
             current_data = result.byte_array
             current_checksum = self._calculate_checksum(current_data)
+            data_size = len(current_data)
 
             if self.registry_lock:
                 with self.registry_lock:
@@ -103,26 +105,27 @@ class AuditConnector(RemoteConnector):
 
                 if expected_checksum and current_checksum != expected_checksum:
                     self.logger.error(
-                        f"[REMOTE_AUDIT]GET|CHECKSUM MISMATCH|Key: {key}|"
-                        f"Expected: {expected_checksum[:8]}|"
-                        f"Actual: {current_checksum[:8]}")
+                        f"[REMOTE_AUDIT]GET|MISMATCH|Size:{data_size}|"
+                        f"Expected:<{expected_checksum[:8]}>|"
+                        f"Actual:<{current_checksum[:8]}>|Key:{key}")
                     return None
 
             cost = (t2 - t1) * 1000
             self.logger.info(
-                f"[REMOTE_AUDIT]GET|SUCCESS|Key: {key}|"
-                f"Checksum: {current_checksum[:8]}|"
-                f"Cost: {cost:.6f}ms|Saved: {len(self.checksum_registry)}")
+                f"[REMOTE_AUDIT]GET|SUCCESS|"
+                f"Checksum:{current_checksum[:8]}|"
+                f"Cost:{cost:.6f}ms|Saved:{len(self.checksum_registry)}|Key:{key}"
+            )
             return result
 
         except Exception as e:
             self.logger.error(
-                f"[REMOTE_AUDIT]GET|FAILED|Key: {key}|Error: {str(e)}")
+                f"[REMOTE_AUDIT]GET|FAILED|Key:{key}|Error: {str(e)}")
             raise
 
     async def exists(self, key: CacheEngineKey) -> bool:
         """Check key existence with audit log"""
-        self.logger.debug(f"[REMOTE_AUDIT]EXISTS|START|Key: {key}")
+        self.logger.debug(f"[REMOTE_AUDIT]EXISTS|START|Key:{key}")
         result = await self.real_connector.exists(key)
         self.logger.info(f"[REMOTE_AUDIT]EXISTS|{result}|Key: {key}")
         return result
@@ -131,8 +134,7 @@ class AuditConnector(RemoteConnector):
         """List keys with audit log"""
         self.logger.debug("[REMOTE_AUDIT]LIST|START")
         result = await self.real_connector.list()
-        self.logger.info(
-            f"[REMOTE_AUDIT]LIST|SUCCESS|Found {len(result)} keys")
+        self.logger.info(f"[REMOTE_AUDIT]LIST|SUCCESS|Size:{len(result)}")
         return result
 
     async def close(self):

--- a/lmcache/experimental/storage_backend/connector/audit_connector.py
+++ b/lmcache/experimental/storage_backend/connector/audit_connector.py
@@ -1,0 +1,142 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import time
+from threading import Lock
+from typing import Dict, List, Optional
+
+from lmcache.experimental.memory_management import MemoryObj
+from lmcache.experimental.storage_backend.connector.base_connector import \
+    RemoteConnector
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+
+logger = init_logger(__name__)
+
+
+class AuditConnector(RemoteConnector):
+    """Audit wrapper for RemoteConnector that verifies data integrity
+    and logs operations.
+
+    Features:
+    - Wraps any RemoteConnector implementation
+    - Configurable checksum verification via URL parameter
+    - Logs all operations with timestamps
+    - Optional checksum validation for put/get operations
+    """
+
+    def __init__(self,
+                 real_connector: RemoteConnector,
+                 verify_checksum: bool = False):
+        self.real_connector = real_connector
+
+        self.verify_checksum = verify_checksum
+        self.checksum_registry: Dict[CacheEngineKey, str] = {}
+        self.registry_lock = Lock() if verify_checksum else None
+        self.logger = logger.getChild("audit")
+        logger.info(
+            f"[REMOTE_AUDIT]INITIALIZED|Verify Checksum: {verify_checksum}")
+
+    def _calculate_checksum(self, data: bytes) -> str:
+        """Calculate SHA-256 checksum for data validation"""
+        return hashlib.sha256(data).hexdigest()
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        """Store data with optional checksum tracking"""
+        data = memory_obj.byte_array
+        checksum = self._calculate_checksum(data)
+
+        self.logger.debug(
+            f"[REMOTE_AUDIT]:PUT|START|Key: {key}|Size: {len(data)} bytes|"
+            f"Checksum: {checksum[:8]}|Saved: {len(self.checksum_registry)}")
+
+        try:
+            t1 = time.perf_counter()
+            await self.real_connector.put(key, memory_obj)
+            t2 = time.perf_counter()
+            if self.registry_lock:
+                with self.registry_lock:
+                    self.checksum_registry[key] = checksum
+            cost = (t2 - t1) * 1000
+            self.logger.info(
+                f"[REMOTE_AUDIT]PUT|SUCCESS|Key: {key}|Size: {len(data)} bytes|"
+                f"Checksum: {checksum[:8]}|Cost: {cost:.6f}ms|Saved: "
+                f"{len(self.checksum_registry)}")
+
+        except Exception as e:
+            self.logger.error(
+                f"[REMOTE_AUDIT]PUT|FAILED|Key: {key}|Error: {str(e)}")
+            raise
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        """Retrieve data with optional integrity check"""
+        self.logger.debug(f"[REMOTE_AUDIT]GET|START|Key: {key}|"
+                          f"Saved: {len(self.checksum_registry)}")
+
+        try:
+            t1 = time.perf_counter()
+            result = await self.real_connector.get(key)
+            t2 = time.perf_counter()
+            if result is None:
+                self.logger.info(f"[REMOTE_AUDIT]GET|MISS|Key: {key}|"
+                                 f"Saved: {len(self.checksum_registry)}")
+                return None
+
+            current_data = result.byte_array
+            current_checksum = self._calculate_checksum(current_data)
+
+            if self.registry_lock:
+                with self.registry_lock:
+                    expected_checksum = self.checksum_registry.get(key)
+
+                if expected_checksum and current_checksum != expected_checksum:
+                    self.logger.error(
+                        f"[REMOTE_AUDIT]GET|CHECKSUM MISMATCH|Key: {key}|"
+                        f"Expected: {expected_checksum[:8]}|"
+                        f"Actual: {current_checksum[:8]}")
+                    return None
+
+            cost = (t2 - t1) * 1000
+            self.logger.info(
+                f"[REMOTE_AUDIT]GET|SUCCESS|Key: {key}|"
+                f"Checksum: {current_checksum[:8]}|"
+                f"Cost: {cost:.6f}ms|Saved: {len(self.checksum_registry)}")
+            return result
+
+        except Exception as e:
+            self.logger.error(
+                f"[REMOTE_AUDIT]GET|FAILED|Key: {key}|Error: {str(e)}")
+            raise
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        """Check key existence with audit log"""
+        self.logger.debug(f"[REMOTE_AUDIT]EXISTS|START|Key: {key}")
+        result = await self.real_connector.exists(key)
+        self.logger.info(f"[REMOTE_AUDIT]EXISTS|{result}|Key: {key}")
+        return result
+
+    async def list(self) -> List[str]:
+        """List keys with audit log"""
+        self.logger.debug("[REMOTE_AUDIT]LIST|START")
+        result = await self.real_connector.list()
+        self.logger.info(
+            f"[REMOTE_AUDIT]LIST|SUCCESS|Found {len(result)} keys")
+        return result
+
+    async def close(self):
+        """Cleanup resources with audit log"""
+        self.logger.debug("[REMOTE_AUDIT]CLOSE|START")
+        await self.real_connector.close()
+        self.logger.info("[REMOTE_AUDIT]CLOSE|SUCCESS")

--- a/lmcache/experimental/storage_backend/remote_backend.py
+++ b/lmcache/experimental/storage_backend/remote_backend.py
@@ -37,7 +37,7 @@ class RemoteBackend(StorageBackendInterface):
         assert config.remote_url is not None
         # Initialize connection
         self.connection = CreateConnector(config.remote_url, loop,
-                                          memory_allocator)
+                                          memory_allocator, config)
 
         self.remote_url = config.remote_url
 


### PR DESCRIPTION
# Motivation

This feature is used for verify the bytes for one key with put and get operation are the same, and we can clear find the expected operation and related byte length checksum and cost.

# Description
This audit connector is a warp of actual remote connector, it just wrap the actual operation, and did some record.

# How to use
- lmcache_audit.yaml  (fs actual remote connector as example)
```yaml
chunk_size: 256
local_device: "cpu"
remote_url: "audit://host:0/?verify"
audit_actual_remote_url: "fs://host:0/disc/data1/baoloongmao/fs_data/"
#remote_serde: "cachegen"
remote_serde: "naive"
# Whether retrieve() is pipelined or not
pipelined_backend: False
local_cpu: False
```

```console
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_USE_V1=0 LMCACHE_CONFIG_FILE=./lmcache_audit.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 2 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}'
```

# How to test

- Start vllm with audit connector
- Submit curl to trigger put and save file to fs
Expected: `*.data` file saved in `/disc/data1/baoloongmao/fs_data/` and so many `AUDIT LOG` print in console.

```
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "hi hi hi hi hi hi hi hi hi hi 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256"}],
    "max_tokens": 60,
    "temperature": 0
    }'
```


```
INFO 04-28 12:09:30 [chat_utils.py:396] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
INFO 04-28 12:09:30 [logger.py:39] Received request chatcmpl-18fe3cff37084741a22d86bafedcff2c: prompt: '<｜begin▁of▁sentence｜>User: hi hi hi hi hi hi hi hi hi hi 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=60, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 04-28 12:09:30 [engine.py:310] Added request chatcmpl-18fe3cff37084741a22d86bafedcff2c.
[2025-04-28 12:09:31,277] LMCache INFO: [REMOTE_AUDIT]GET|MISS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5')|Saved: 0 (audit_connector.py:92:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,277] LMCache INFO: [REMOTE_AUDIT]GET|MISS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5')|Saved: 0 (audit_connector.py:92:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,420] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,420] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,420] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,421] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,429] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5')|Size: 7962624 bytes|Checksum: a70722a2|Cost: 2.882753ms|Saved: 1 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,429] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,429] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5')|Size: 7962624 bytes|Checksum: a70722a2|Cost: 3.122032ms|Saved: 1 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,429] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,437] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c')|Size: 7962624 bytes|Checksum: 239ee8e7|Cost: 2.500714ms|Saved: 2 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,437] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,437] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c')|Size: 7962624 bytes|Checksum: 239ee8e7|Cost: 3.133116ms|Saved: 2 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,437] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,444] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2')|Size: 7962624 bytes|Checksum: fea201c9|Cost: 2.386359ms|Saved: 3 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,445] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,445] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2')|Size: 7962624 bytes|Checksum: fea201c9|Cost: 2.636996ms|Saved: 3 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:09:31,445] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:09:31,450] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac')|Size: 5132160 bytes|Checksum: c855706e|Cost: 2.154162ms|Saved: 4 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
INFO 04-28 12:09:31 [metrics.py:489] Avg prompt throughput: 90.1 tokens/s, Avg generation throughput: 0.1 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
[2025-04-28 12:09:31,451] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac')|Size: 5132160 bytes|Checksum: c855706e|Cost: 2.464700ms|Saved: 4 (audit_connector.py:72:lmcache.experimental.storage_backend.connector.audit_connector.audit)
```
- Submit curl to trigger exist and get operation without `CHECKSUM MISMATCH`

```
INFO 04-28 12:10:30 [logger.py:39] Received request chatcmpl-600e00031f8f400f9e0aa8b4eec83512: prompt: '<｜begin▁of▁sentence｜>User: hi hi hi hi hi hi hi hi hi hi 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=60, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 04-28 12:10:30 [engine.py:310] Added request chatcmpl-600e00031f8f400f9e0aa8b4eec83512.
[2025-04-28 12:10:30,250] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5')|Checksum: a70722a2|Cost: 8.788922ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,251] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5')|Checksum: a70722a2|Cost: 8.939851ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,259] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c')|Checksum: 239ee8e7|Cost: 2.532990ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,259] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c')|Checksum: 239ee8e7|Cost: 2.619887ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,267] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2')|Checksum: fea201c9|Cost: 2.568255ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,267] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2')|Checksum: fea201c9|Cost: 2.487013ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,273] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac')|Checksum: c855706e|Cost: 1.752649ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,273] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac')|Checksum: c855706e|Cost: 1.711583ms|Saved: 4 (audit_connector.py:112:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,341] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,341] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='49c0c005ef9454da178f46dbce1290ea7cc3814c569934c6c704347cb1940ca5') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,342] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,342] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,342] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='0f60c00afe94df6db7ebdd7011fef54825570a490fc3aad8bb334709de41823c') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
[2025-04-28 12:10:30,342] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=0, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,342] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
(VllmWorkerProcess pid=107002) [2025-04-28 12:10:30,342] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=2, worker_id=1, chunk_hash='c9d7ba772bbae41b8c8139ded12de7396fd3d63a9ceed93339ff807ad7d441ac') (audit_connector.py:126:lmcache.experimental.storage_backend.connector.audit_connector.audit)
INFO 04-28 12:10:30 [metrics.py:489] Avg prompt throughput: 108.5 tokens/s, Avg generation throughput: 0.1 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
```
- Modify the file in `/disc/data1/baoloongmao/fs_data/` 
```Console
root@TENCENT64:/disc/data1/baoloongmao# bash hex_op.sh fs_data/vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@1@eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2.data 100
0x5c
root@TENCENT64:/disc/data1/baoloongmao# bash hex_op.sh fs_data/vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@1@eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2.data 100 6c

root@TENCENT64:/disc/data1/baoloongmao# bash hex_op.sh fs_data/vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@1@eae7f91fd1275cf61cb6bd9e719ff667200ed5cea3dd3c617cca6cc0586c40a2.data 100
0x6c
```
- Submit curl to trigger exist and get operation with `CHECKSUM MISMATCH`
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/81592ea7-f681-43a1-976b-f2f57549febb" />



