### PR TITLE
[metrics] add remote backend metrics

### DIFF
--- a/lmcache/experimental/storage_backend/remote_backend.py
+++ b/lmcache/experimental/storage_backend/remote_backend.py
@@ -14,6 +14,7 @@ from lmcache.experimental.storage_backend.abstract_backend import \
 from lmcache.experimental.storage_backend.connector import CreateConnector
 from lmcache.experimental.storage_backend.naive_serde import CreateSerde
 from lmcache.logging import init_logger
+from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 
 logger = init_logger(__name__)
@@ -54,6 +55,8 @@ class RemoteBackend(StorageBackendInterface):
         # TODO(Jiayi): If we want to have cache admission policies,
         # we must make decision (whether to send or not) at the local side
 
+        self.stats_monitor = LMCStatsMonitor.GetOrCreate()
+
     def __str__(self):
         return self.__class__.__name__
 
@@ -89,7 +92,7 @@ class RemoteBackend(StorageBackendInterface):
         compressed_memory_obj = self.serializer.serialize(memory_obj)
 
         future = asyncio.run_coroutine_threadsafe(
-            self.connection.put(key, compressed_memory_obj), self.loop)
+            self.connection_put_wrapper(key, compressed_memory_obj), self.loop)
 
         self.memory_allocator.ref_count_down(memory_obj)
 
@@ -114,18 +117,16 @@ class RemoteBackend(StorageBackendInterface):
         Blocking get function.
         """
         t1 = time.perf_counter()
-        future = asyncio.run_coroutine_threadsafe(self.connection.get(key),
+        future = asyncio.run_coroutine_threadsafe(self.connection_get_wrapper(key),
                                                   self.loop)
         memory_obj = future.result()
-
         t2 = time.perf_counter()
+        self.stats_monitor.update_interval_remote_time_to_get_sync((t2 - t1) * 1000)
         if memory_obj is None:
             return None
-        obj_size = memory_obj.get_size()
         decompressed_memory_obj = self.deserializer.deserialize(memory_obj)
         t3 = time.perf_counter()
         logger.debug(f"Get takes {(t2 - t1) * 1000:.6f} msec, "
-                     f"Bytes loaded: {obj_size / 1e6:.4f} MBytes, "
                      f"deserialization takes {(t3 - t2) * 1000:.6f} msec")
         return decompressed_memory_obj
 
@@ -134,3 +135,23 @@ class RemoteBackend(StorageBackendInterface):
                                                   self.loop)
         future.result()
         logger.info("Remote backend closed.")
+
+    async def connection_put_wrapper(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        obj_size = memory_obj.get_size()
+        begin = time.perf_counter()
+        await self.connection.put(key, memory_obj)
+        end = time.perf_counter()
+        self.stats_monitor.update_interval_remote_time_to_put((end - begin) * 1000)
+        self.stats_monitor.update_interval_remote_write_metrics(obj_size)
+        logger.debug(f"Bytes offloaded: {obj_size / 1e6:.4f} MBytes, ")
+
+    async def connection_get_wrapper(self, key: CacheEngineKey):
+        begin = time.perf_counter()
+        memory_obj = await self.connection.get(key)
+        end = time.perf_counter()
+        self.stats_monitor.update_interval_remote_time_to_get((end - begin) * 1000)
+        if memory_obj is not None:
+            obj_size = memory_obj.get_size()
+            self.stats_monitor.update_interval_remote_read_metrics(obj_size)
+            logger.debug(f"Bytes loaded: {obj_size / 1e6:.4f} MBytes, ")
+        return memory_obj

--- a/lmcache/experimental/storage_backend/remote_backend.py
+++ b/lmcache/experimental/storage_backend/remote_backend.py
@@ -137,8 +137,7 @@ class RemoteBackend(StorageBackendInterface):
         future.result()
         logger.info("Remote backend closed.")
 
-    async def connection_put_wrapper(self,
-                                     key: CacheEngineKey,
+    async def connection_put_wrapper(self, key: CacheEngineKey,
                                      memory_obj: MemoryObj):
         obj_size = memory_obj.get_size()
         begin = time.perf_counter()

--- a/lmcache/experimental/storage_backend/remote_backend.py
+++ b/lmcache/experimental/storage_backend/remote_backend.py
@@ -117,11 +117,12 @@ class RemoteBackend(StorageBackendInterface):
         Blocking get function.
         """
         t1 = time.perf_counter()
-        future = asyncio.run_coroutine_threadsafe(self.connection_get_wrapper(key),
-                                                  self.loop)
+        future = asyncio.run_coroutine_threadsafe(
+            self.connection_get_wrapper(key), self.loop)
         memory_obj = future.result()
         t2 = time.perf_counter()
-        self.stats_monitor.update_interval_remote_time_to_get_sync((t2 - t1) * 1000)
+        self.stats_monitor.update_interval_remote_time_to_get_sync(
+            (t2 - t1) * 1000)
         if memory_obj is None:
             return None
         decompressed_memory_obj = self.deserializer.deserialize(memory_obj)
@@ -136,12 +137,15 @@ class RemoteBackend(StorageBackendInterface):
         future.result()
         logger.info("Remote backend closed.")
 
-    async def connection_put_wrapper(self, key: CacheEngineKey, memory_obj: MemoryObj):
+    async def connection_put_wrapper(self,
+                                     key: CacheEngineKey,
+                                     memory_obj: MemoryObj):
         obj_size = memory_obj.get_size()
         begin = time.perf_counter()
         await self.connection.put(key, memory_obj)
         end = time.perf_counter()
-        self.stats_monitor.update_interval_remote_time_to_put((end - begin) * 1000)
+        self.stats_monitor.update_interval_remote_time_to_put(
+            (end - begin) * 1000)
         self.stats_monitor.update_interval_remote_write_metrics(obj_size)
         logger.debug(f"Bytes offloaded: {obj_size / 1e6:.4f} MBytes, ")
 
@@ -149,7 +153,8 @@ class RemoteBackend(StorageBackendInterface):
         begin = time.perf_counter()
         memory_obj = await self.connection.get(key)
         end = time.perf_counter()
-        self.stats_monitor.update_interval_remote_time_to_get((end - begin) * 1000)
+        self.stats_monitor.update_interval_remote_time_to_get(
+            (end - begin) * 1000)
         if memory_obj is not None:
             obj_size = memory_obj.get_size()
             self.stats_monitor.update_interval_remote_read_metrics(obj_size)

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -21,6 +21,15 @@ class LMCacheStats:
     interval_requested_tokens: int
     interval_hit_tokens: int
 
+    interval_remote_read_requests: int
+    interval_remote_read_bytes: int
+    interval_remote_write_requests: int
+    interval_remote_write_bytes: int
+
+    interval_remote_time_to_get: List[float]
+    interval_remote_time_to_put: List[float]
+    interval_remote_time_to_get_sync: List[float]
+
     # Real time value measurements (will be reset after each log)
     cache_hit_rate: float
 
@@ -81,6 +90,19 @@ class LMCStatsMonitor:
         self.interval_store_requests = 0
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
+
+        # remote backends read/write metrics
+        self.interval_remote_read_requests = 0
+        self.interval_remote_read_bytes = 0
+        self.interval_remote_write_requests = 0
+        self.interval_remote_write_bytes = 0
+
+        # remote backends get/put cost time metrics
+        self.interval_remote_time_to_get: List[float] = []
+        self.interval_remote_time_to_put: List[float] = []
+        # the time of get value from remote backends synchronously,
+        # which includes rpc and schedule time
+        self.interval_remote_time_to_get_sync: List[float] = []
 
         self.local_cache_usage_bytes = 0
         self.remote_cache_usage_bytes = 0
@@ -153,6 +175,28 @@ class LMCStatsMonitor:
         self.local_storage_usage_bytes = usage
 
     @thread_safe
+    def update_interval_remote_read_metrics(self, read_bytes: int):
+        self.interval_remote_read_requests += 1
+        self.interval_remote_read_bytes += read_bytes
+
+    @thread_safe
+    def update_interval_remote_write_metrics(self, write_bytes: int):
+        self.interval_remote_write_requests += 1
+        self.interval_remote_write_bytes += write_bytes
+
+    @thread_safe
+    def update_interval_remote_time_to_get(self, get_time: float):
+        self.interval_remote_time_to_get.append(get_time)
+
+    @thread_safe
+    def update_interval_remote_time_to_put(self, put_time: float):
+        self.interval_remote_time_to_put.append(put_time)
+
+    @thread_safe
+    def update_interval_remote_time_to_get_sync(self, get_time_sync: float):
+        self.interval_remote_time_to_get_sync.append(get_time_sync)
+
+    @thread_safe
     def _clear(self):
         """
         Clear all the distribution stats 
@@ -162,6 +206,15 @@ class LMCStatsMonitor:
 
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
+
+        self.interval_remote_read_requests = 0
+        self.interval_remote_read_bytes = 0
+        self.interval_remote_write_requests = 0
+        self.interval_remote_write_bytes = 0
+
+        self.interval_remote_time_to_get.clear()
+        self.interval_remote_time_to_put.clear()
+        self.interval_remote_time_to_get_sync.clear()
 
         new_retrieve_requests = {}
         for request_id, retrieve_stats in self.retrieve_requests.items():
@@ -210,6 +263,13 @@ class LMCStatsMonitor:
             interval_store_requests=self.interval_store_requests,
             interval_requested_tokens=self.interval_requested_tokens,
             interval_hit_tokens=self.interval_hit_tokens,
+            interval_remote_read_requests=self.interval_remote_read_requests,
+            interval_remote_read_bytes=self.interval_remote_read_bytes,
+            interval_remote_write_requests=self.interval_remote_write_requests,
+            interval_remote_write_bytes=self.interval_remote_write_bytes,
+            interval_remote_time_to_get=self.interval_remote_time_to_get.copy(),
+            interval_remote_time_to_put=self.interval_remote_time_to_put.copy(),
+            interval_remote_time_to_get_sync=self.interval_remote_time_to_get_sync.copy(),
             cache_hit_rate=cache_hit_rate,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
@@ -267,6 +327,30 @@ class PrometheusLogger:
         self.counter_num_hit_tokens = self._counter_cls(
             name="lmcache:num_hit_tokens",
             documentation="Total number of tokens hit in lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_remote_read_requests = self._counter_cls(
+            name="lmcache:num_remote_read_requests",
+            documentation="Total number of requests read from remote backends in lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_remote_read_bytes = self._counter_cls(
+            name="lmcache:num_remote_read_bytes",
+            documentation="Total number of bytes read from remote backends in lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_remote_write_requests = self._counter_cls(
+            name="lmcache:num_remote_write_requests",
+            documentation="Total number of requests write to remote backends in lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_remote_write_bytes = self._counter_cls(
+            name="lmcache:num_remote_write_bytes",
+            documentation="Total number of bytes write to remote backends in lmcache",
             labelnames=labelnames,
         )
 
@@ -338,6 +422,39 @@ class PrometheusLogger:
             buckets=store_speed_buckets,
         )
 
+        remote_time_to_get = [
+            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750,
+            1000, 2500, 5000, 7500, 10000
+        ]
+        self.histogram_remote_time_to_get = self._histogram_cls(
+            name="lmcache:remote_time_to_get",
+            documentation="Time to get from remote backends (ms)",
+            labelnames=labelnames,
+            buckets=remote_time_to_get,
+        )
+
+        remote_time_to_put = [
+            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750,
+            1000, 2500, 5000, 7500, 10000
+        ]
+        self.histogram_remote_time_to_put = self._histogram_cls(
+            name="lmcache:remote_time_to_put",
+            documentation="Time to put to remote backends (ms)",
+            labelnames=labelnames,
+            buckets=remote_time_to_put,
+        )
+
+        remote_time_to_get_sync = [
+            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750,
+            1000, 2500, 5000, 7500, 10000
+        ]
+        self.histogram_remote_time_to_get_sync = self._histogram_cls(
+            name="lmcache:remote_time_to_get_sync",
+            documentation="Time to get from remote backends synchronously(ms)",
+            labelnames=labelnames,
+            buckets=remote_time_to_get_sync,
+        )
+
     def _log_gauge(self, gauge, data: Union[int, float]) -> None:
         # Convenience function for logging to gauge.
         gauge.labels(**self.labels).set(data)
@@ -366,6 +483,15 @@ class PrometheusLogger:
         self._log_counter(self.counter_num_hit_tokens,
                           stats.interval_hit_tokens)
 
+        self._log_counter(self.counter_num_remote_read_requests,
+                          stats.interval_remote_read_requests)
+        self._log_counter(self.counter_num_remote_read_bytes,
+                          stats.interval_remote_read_bytes)
+        self._log_counter(self.counter_num_remote_write_requests,
+                          stats.interval_remote_write_requests)
+        self._log_counter(self.counter_num_remote_write_bytes,
+                          stats.interval_remote_write_bytes)
+
         self._log_gauge(self.gauge_cache_hit_rate, stats.cache_hit_rate)
 
         self._log_gauge(self.gauge_local_cache_usage,
@@ -386,6 +512,13 @@ class PrometheusLogger:
                             stats.retrieve_speed)
 
         self._log_histogram(self.histogram_store_speed, stats.store_speed)
+
+        self._log_histogram(self.histogram_remote_time_to_get,
+                            stats.interval_remote_time_to_get)
+        self._log_histogram(self.histogram_remote_time_to_put,
+                            stats.interval_remote_time_to_put)
+        self._log_histogram(self.histogram_remote_time_to_get_sync,
+                            stats.interval_remote_time_to_get_sync)
 
     @staticmethod
     def _metadata_to_labels(metadata: LMCacheEngineMetadata):

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -332,25 +332,29 @@ class PrometheusLogger:
 
         self.counter_num_remote_read_requests = self._counter_cls(
             name="lmcache:num_remote_read_requests",
-            documentation="Total number of requests read from remote backends in lmcache",
+            documentation="Total number of requests read from "
+                          "remote backends in lmcache",
             labelnames=labelnames,
         )
 
         self.counter_num_remote_read_bytes = self._counter_cls(
             name="lmcache:num_remote_read_bytes",
-            documentation="Total number of bytes read from remote backends in lmcache",
+            documentation="Total number of bytes read from "
+                          "remote backends in lmcache",
             labelnames=labelnames,
         )
 
         self.counter_num_remote_write_requests = self._counter_cls(
             name="lmcache:num_remote_write_requests",
-            documentation="Total number of requests write to remote backends in lmcache",
+            documentation="Total number of requests write to "
+                          "remote backends in lmcache",
             labelnames=labelnames,
         )
 
         self.counter_num_remote_write_bytes = self._counter_cls(
             name="lmcache:num_remote_write_bytes",
-            documentation="Total number of bytes write to remote backends in lmcache",
+            documentation="Total number of bytes write to "
+                          "remote backends in lmcache",
             labelnames=labelnames,
         )
 

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -267,10 +267,10 @@ class LMCStatsMonitor:
             interval_remote_read_bytes=self.interval_remote_read_bytes,
             interval_remote_write_requests=self.interval_remote_write_requests,
             interval_remote_write_bytes=self.interval_remote_write_bytes,
-            interval_remote_time_to_get=self.
-            interval_remote_time_to_get.copy(),
-            interval_remote_time_to_put=self.
-            interval_remote_time_to_put.copy(),
+            interval_remote_time_to_get=self.interval_remote_time_to_get.copy(
+            ),
+            interval_remote_time_to_put=self.interval_remote_time_to_put.copy(
+            ),
             interval_remote_time_to_get_sync=self.
             interval_remote_time_to_get_sync.copy(),
             cache_hit_rate=cache_hit_rate,

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -267,9 +267,12 @@ class LMCStatsMonitor:
             interval_remote_read_bytes=self.interval_remote_read_bytes,
             interval_remote_write_requests=self.interval_remote_write_requests,
             interval_remote_write_bytes=self.interval_remote_write_bytes,
-            interval_remote_time_to_get=self.interval_remote_time_to_get.copy(),
-            interval_remote_time_to_put=self.interval_remote_time_to_put.copy(),
-            interval_remote_time_to_get_sync=self.interval_remote_time_to_get_sync.copy(),
+            interval_remote_time_to_get=self.
+            interval_remote_time_to_get.copy(),
+            interval_remote_time_to_put=self.
+            interval_remote_time_to_put.copy(),
+            interval_remote_time_to_get_sync=self.
+            interval_remote_time_to_get_sync.copy(),
             cache_hit_rate=cache_hit_rate,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
@@ -333,28 +336,28 @@ class PrometheusLogger:
         self.counter_num_remote_read_requests = self._counter_cls(
             name="lmcache:num_remote_read_requests",
             documentation="Total number of requests read from "
-                          "remote backends in lmcache",
+            "remote backends in lmcache",
             labelnames=labelnames,
         )
 
         self.counter_num_remote_read_bytes = self._counter_cls(
             name="lmcache:num_remote_read_bytes",
             documentation="Total number of bytes read from "
-                          "remote backends in lmcache",
+            "remote backends in lmcache",
             labelnames=labelnames,
         )
 
         self.counter_num_remote_write_requests = self._counter_cls(
             name="lmcache:num_remote_write_requests",
             documentation="Total number of requests write to "
-                          "remote backends in lmcache",
+            "remote backends in lmcache",
             labelnames=labelnames,
         )
 
         self.counter_num_remote_write_bytes = self._counter_cls(
             name="lmcache:num_remote_write_bytes",
             documentation="Total number of bytes write to "
-                          "remote backends in lmcache",
+            "remote backends in lmcache",
             labelnames=labelnames,
         )
 
@@ -427,8 +430,8 @@ class PrometheusLogger:
         )
 
         remote_time_to_get = [
-            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750,
-            1000, 2500, 5000, 7500, 10000
+            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750, 1000, 2500, 5000,
+            7500, 10000
         ]
         self.histogram_remote_time_to_get = self._histogram_cls(
             name="lmcache:remote_time_to_get",
@@ -438,8 +441,8 @@ class PrometheusLogger:
         )
 
         remote_time_to_put = [
-            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750,
-            1000, 2500, 5000, 7500, 10000
+            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750, 1000, 2500, 5000,
+            7500, 10000
         ]
         self.histogram_remote_time_to_put = self._histogram_cls(
             name="lmcache:remote_time_to_put",
@@ -449,8 +452,8 @@ class PrometheusLogger:
         )
 
         remote_time_to_get_sync = [
-            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750,
-            1000, 2500, 5000, 7500, 10000
+            1, 5, 10, 20, 40, 60, 80, 100, 250, 500, 750, 1000, 2500, 5000,
+            7500, 10000
         ]
         self.histogram_remote_time_to_get_sync = self._histogram_cls(
             name="lmcache:remote_time_to_get_sync",


### PR DESCRIPTION
This PR add some remote backends related metrics, which makes it easier for us to directly view the performance of remote backends.

The metrics includes:
Counter:
- `lmcache:num_remote_read_requests`
- `lmcache:num_remote_read_bytes`
- `lmcache:num_remote_write_requests`
- `lmcache:num_remote_write_bytes`

Histogram:
- `lmcache:remote_time_to_get`
- `lmcache:remote_time_to_put`
- `lmcache:remote_time_to_get_sync`

The display in our testing cluster is as follows:
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/0f6e987e-5c11-4e38-8d9b-d633ccad38e9" />
<img width="1709" alt="image" src="https://github.com/user-attachments/assets/90b7ef16-6dd2-4a8d-9cfb-bc3820c2a074" />
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/420dccc9-0329-475b-a707-ac4e7708ebfd" />
<img width="850" alt="image" src="https://github.com/user-attachments/assets/c5549425-70c7-4bda-afed-3bae7763279e" />


Could you help with the review？  @ApostaC @maobaolong 