### PR TITLE
Upgrade torch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools >= 49.4.0",
     "wheel",
     "packaging",
-    "torch == 2.6.0",
+    "torch>=2.6.0",
     "ninja",
     "pybind11",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.6.0
+torch>=2.6.0
 numpy==1.26.4
 aiofiles
 pyyaml


### PR DESCRIPTION
The latest vLLM main branch and v0.8.5 require torch 2.7.0 and 2.6.0, respectively.