### PR TITLE
fix: Pin precise torch version to avoid vLLM compatability issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,6 @@ The first step is to install the necessary Python packages required for developm
 pip install -e .
 pip install -r requirements-lint.txt
 pip install -r requirements-test.txt
-pip install -r requirements.txt
 ```
 
 Before pushing changes to GitHub, you need to run the tests and coding style as shown below.

--- a/docker/requirements-build.txt
+++ b/docker/requirements-build.txt
@@ -1,9 +1,9 @@
 # Should be mirrored in pyproject.toml
 cmake>=3.26
-ninja
-packaging
-setuptools>=61
-setuptools-scm>=8
-torch==2.4.0
-wheel
 jinja2
+ninja
+packaging>=24.2
+setuptools>=77.0.3,<80.0.0
+setuptools_scm>=8
+torch==2.6.0 # Should correspond to the version used by latest vLLM package
+wheel

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -8,7 +8,6 @@ Prerequisites
 
 - Python 3.10+
 - CUDA 12.4+
-- PyTorch 2.6+
 
 Setup using Python
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-# Should be mirrored in requirements-build.txt
+# Should be mirrored in docker/requirements-build.txt
 requires = ["ninja", "packaging>=24.2", "setuptools>=77.0.3,<80.0.0", "setuptools_scm>=8", "torch==2.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,6 @@
 [build-system]
 # Should be mirrored in requirements-build.txt
-requires = [
-    "setuptools >=70.1.0",
-    "wheel",
-    "packaging",
-    "torch",
-    "ninja",
-    "pybind11",
-]
+requires = ["ninja", "packaging>=24.2", "setuptools>=77.0.3,<80.0.0", "setuptools_scm>=8", "torch==2.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,5 +2,5 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools_scm>=8
-torch==2.6.0 # for vLLM 0.8.5
+torch==2.6.0 # Should correspond to the version used by latest vLLM package
 wheel

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,0 @@
-ninja
-packaging>=24.2
-setuptools>=77.0.3,<80.0.0
-setuptools_scm>=8
-torch==2.6.0 # Should correspond to the version used by latest vLLM package
-wheel

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,6 @@
+ninja
+packaging>=24.2
+setuptools>=77.0.3,<80.0.0
+setuptools_scm>=8
+torch==2.6.0 # for vLLM 0.8.5
+wheel

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,15 +1,15 @@
 # formatting
-yapf==0.40.0
-toml==0.10.2
-tomli==2.0.1
-ruff==0.6.5
+clang-format==18.1.5
 codespell==2.3.0
 isort==5.13.2
-clang-format==18.1.5
+ruff==0.6.5
+toml==0.10.2
+tomli==2.0.1
+yapf==0.40.0
 
 # type checking
-mypy==1.11.2
+mypy==1.15.0
+types-aiofiles
 types-PyYAML
 types-requests
 types-setuptools
-types-aiofiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-torch
-numpy
 aiofiles
-pyyaml
-redis
-nvtx
-safetensors
-transformers
-psutil
 aiohttp
-sortedcontainers
-prometheus_client
 infinistore
 msgspec
-pyzmq
-transformers
+nixl==0.2.0
+numpy
+nvtx
+prometheus_client >= 0.18.0
+psutil
+pyyaml
+pyzmq >= 25.0.0
+redis
+safetensors
+sortedcontainers
+torch==2.6.0 # for vLLM 0.8.5
+transformers >= 4.51.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pyzmq >= 25.0.0
 redis
 safetensors
 sortedcontainers
-torch==2.6.0 # for vLLM 0.8.5
+torch==2.6.0 # Should correspond to the version used by latest vLLM package
 transformers >= 4.51.1


### PR DESCRIPTION
Pin torch version which is compatible with the latest vLLM version. Otherwise LMCache will not work with vLLM.
At the moment latest vLLM is `v0.8.5.post1`. This requires torch `v2.6.0`.

Note: [vLLM Update PyTorch to 2.7.0](https://github.com/vllm-project/vllm/pull/16859) does not seem to be be pulled into `v0.8.5.post1`. 

This commit also:

- Adds versioning to other packages
- Adds build file which is referenced by the [Dockerfile](https://github.com/LMCache/LMCache/blob/dev/docker/Dockerfile#L60)
- Updates mypy version
- Organizes the packages in alphabetical  order
- Updates documentation where necessary

FIX #585
