### PR TITLE
[Fix/CI] Fix issue in buldkite env where conda not enabled

### DIFF
--- a/.buildkite/install-env-e2e.sh
+++ b/.buildkite/install-env-e2e.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Enable conda
+if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+    . "$HOME/miniconda3/etc/profile.d/conda.sh"
+else
+    export PATH="$HOME/miniconda3/bin:$PATH"
+fi
+
 CONDA_ENV_NAME="buildkite-e2e"
 PYTHON_VERSION=3.10
 

--- a/.buildkite/install-env.sh
+++ b/.buildkite/install-env.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Enable conda
+if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+    . "$HOME/miniconda3/etc/profile.d/conda.sh"
+else
+    export PATH="$HOME/miniconda3/bin:$PATH"
+fi
+
 CONDA_ENV_NAME="buildkite"
 PYTHON_VERSION=3.10
 


### PR DESCRIPTION
This PR fixes the Buildkite error:

```console
Preparing working directory
$ cd /var/lib/buildkite-agent/builds/unit-end-to-end-test-1/lmcache/lmcache-unittests
Pseudo-terminal will not be allocated because stdin is not a terminal.
# Host "github.com" already in list of known hosts at "/var/lib/buildkite-agent/.ssh/known_hosts"
$ git clean -ffxdq
# Fetch and checkout pull request head from GitHub
$ git fetch -v --prune -- origin refs/pull/611/head
From github.com:LMCache/LMCache
 * branch            refs/pull/611/head -> FETCH_HEAD
# FETCH_HEAD is now `4d2a5a943d9aac4e1c5d51a066c1f98aa323bd23`
$ git fetch -v --prune -- origin 4d2a5a943d9aac4e1c5d51a066c1f98aa323bd23
From github.com:LMCache/LMCache
 * branch            4d2a5a943d9aac4e1c5d51a066c1f98aa323bd23 -> FETCH_HEAD
$ git checkout -f 4d2a5a943d9aac4e1c5d51a066c1f98aa323bd23
HEAD is now at 4d2a5a9 Add publishing to TestPyPi and refactor PyPi publish
# Cleaning again to catch any post-checkout changes
$ git clean -ffxdq
# Checking to see if git commit information needs to be sent to Buildkite...
# BUILDKITE_COMMIT is already resolved and meta-data populated, skipping
Running commands
$ eval "$(conda shell.bash hook)"
conda activate buildkite
bash .buildkite/install-lmcache.sh
LMCACHE_TRACK_USAGE="false" coverage run --source=lmcache/ -m pytest -xsv --junitxml=junit/test-results.xml --ignore=tests/disagg --ignore=tests/experimental/test_pos_kernels.py
coverage report -m > coverage.txt
/bin/bash: line 1: conda: command not found
/bin/bash: line 2: conda: command not found
🚨 Error: The command exited with status 127
user command error: exit status 127
```