### PR TITLE
fix: the RuntimeError "Boolean value of Tensor..." of mooncakestore_connector.py

### DIFF
--- a/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/experimental/storage_backend/connector/mooncakestore_connector.py
@@ -144,7 +144,7 @@ class MooncakestoreConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        if memory_obj.tensor:
+        if memory_obj.tensor is not None:
             assert metadata.dtype is not None
             num_elements = reduce(operator.mul, metadata.shape)
             temp_tensor = torch.frombuffer(buffer,


### PR DESCRIPTION
This is a runtime error, python cannot allow check a non boolean type value in the condition.

This error will through before fix
```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```