### PR TITLE
[Doc]: Add comments on torch version and how its synchronized with vLLM

### DIFF
--- a/docker/requirements-build.txt
+++ b/docker/requirements-build.txt
@@ -5,5 +5,10 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools_scm>=8
-torch==2.6.0 # Should correspond to the version used by latest vLLM package
+
+# Should correspond to the version used by latest vLLM package
+# This may not be the version as specified in vLLM `main` branch
+# Check using `pip show vllm` command
+torch==2.6.0
+
 wheel

--- a/docker/requirements-build.txt
+++ b/docker/requirements-build.txt
@@ -5,10 +5,5 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools_scm>=8
-
-# Should correspond to the version used by latest vLLM package
-# This may not be the version as specified in vLLM `main` branch
-# Check using `pip show vllm` command
-torch==2.6.0
-
+torch==2.7.0  # Should correspond to the version used by vLLM main branch
 wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Should be mirrored in docker/requirements-build.txt
-requires = ["ninja", "packaging>=24.2", "setuptools>=77.0.3,<80.0.0", "setuptools_scm>=8", "torch==2.6.0", "wheel"]
+requires = ["ninja", "packaging>=24.2", "setuptools>=77.0.3,<80.0.0", "setuptools_scm>=8", "torch==2.7.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Should be mirrored in docker/requirements-build.txt
-requires = ["ninja", "packaging>=24.2", "setuptools>=77.0.3,<80.0.0", "setuptools_scm>=8", "torch==2.7.0", "wheel"]
+requires = ["ninja", "packaging>=24.2", "setuptools>=77.0.3,<80.0.0", "setuptools_scm>=8", "torch==2.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,5 @@ pyzmq >= 25.0.0
 redis
 safetensors
 sortedcontainers
-
-# Should correspond to the version used by latest vLLM package
-# This may not be the version as specified in vLLM `main` branch
-# Check using `pip show vllm` command
-torch==2.6.0
-
+torch==2.7.0  # Should correspond to the version used by vLLM main branch
 transformers >= 4.51.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,10 @@ pyzmq >= 25.0.0
 redis
 safetensors
 sortedcontainers
-torch==2.7.0 # Should correspond to the version used by latest vLLM package
+
+# Should correspond to the version used by latest vLLM package
+# This may not be the version as specified in vLLM `main` branch
+# Check using `pip show vllm` command
+torch==2.6.0
+
 transformers >= 4.51.1


### PR DESCRIPTION
~Rollback changes from #628 as it breaks compatibility with latest vLLM release.
FIX #585~

Discussed with @YaoJiayi and understanding as follows:

LMCache release will synchronize with the torch version of the vLLM release it is associated with.
The LMCache default branch (`dev`) will synchronize with the torch version of the vLLM default (`main`) branch.
