### PR TITLE
[CI/Build] Remove obsolete vLLM patch from Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,18 +85,4 @@ RUN --mount=type=bind,from=build,src=/workspace/LMCache/dist_lmcache,target=/vll
 --mount=type=cache,target=/root/.cache/pip \
 pip install dist_lmcache/*.whl --verbose
 
-# Copy lmc_connector patch into vllm
-COPY patch/factory.py \
-    /usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/
-COPY patch/lmcache_connector.py \
-    /usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/
-
-# Use diff if file is too large
-COPY patch/parallel_state.patch \
-    /usr/local/lib/python3.12/dist-packages/vllm/distributed/
-
-RUN patch /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.py \
-    /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.patch
-
-
 ENTRYPOINT ["vllm", "serve"]


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

- Docker build file has a patch currently for vllm, but seems vllm fixed it in recent release and hence it breaks the docker build:

```
 => ERROR [vllm-openai 6/6] RUN patch /usr/local/lib/python3.12/dist-packages/vllm/dis  0.3s
------
 > [vllm-openai 6/6] RUN patch /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.py     /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.patch:
0.206 patching file /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.py
0.206 Hunk #1 FAILED at 1069.
0.206 1 out of 1 hunk FAILED -- saving rejects to file /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.py.rej
------
Dockerfile:98
--------------------
  97 |     
  98 | >>> RUN patch /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.py \
  99 | >>>     /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.patch
 100 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c patch /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.py     /usr/local/lib/python3.12/dist-packages/vllm/distributed/parallel_state.patch" did not complete successfully: exit code: 1
```

- Removing the patch, which is obsolete fixes the build

FIX #xxxx (*link existing issues this PR will resolve*)

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <a href="https://github.com/LMCache/LMCache/blob/dev/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

To trigger a new version of lmcache, follow the steps:
`git tag vx.x.x`
`git push origin vx.x.x` (same version again)
In case the workflow fails, delete the tag and try again:
`git tag -d vx.x.x`
`git push origin :refs/tags/vx.x.x`

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
