### PR TITLE
Refactor: handle memory_obj.ref_count_down in the RemoteBackend

### DIFF
--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -30,6 +30,7 @@ from .audit_connector import AuditConnector
 from .blackhole_connector import BlackholeConnector
 from .fs_connector import FSConnector
 from .infinistore_connector import InfinistoreConnector
+from .instrumented_connector import InstrumentedRemoteConnector
 from .mooncakestore_connector import MooncakestoreConnector
 
 logger = init_logger(__name__)
@@ -206,4 +207,4 @@ def CreateConnector(
                              f"(url is: {url})")
 
     logger.info(f"Created connector {connector} for {connector_type}")
-    return connector
+    return InstrumentedRemoteConnector(connector)

--- a/lmcache/v1/storage_backend/connector/blackhole_connector.py
+++ b/lmcache/v1/storage_backend/connector/blackhole_connector.py
@@ -35,7 +35,7 @@ class BlackholeConnector(RemoteConnector):
         return None
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        memory_obj.ref_count_down()
+        pass
 
     @no_type_check
     async def list(self) -> List[str]:

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -129,8 +129,6 @@ class FSConnector(RemoteConnector):
             if temp_path.exists():
                 temp_path.unlink()  # Remove corrupted file
             raise
-        finally:
-            memory_obj.ref_count_down()
 
     @no_type_check
     async def list(self) -> List[str]:

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -1,0 +1,72 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from typing import List, Optional
+
+from lmcache.logging import init_logger
+from lmcache.observability import LMCStatsMonitor
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class InstrumentedRemoteConnector(RemoteConnector):
+    """
+    A connector that instruments the underlying connector with
+    metrics collection and logging capabilities.
+    """
+
+    def __init__(self, connector: RemoteConnector):
+        self._connector = connector
+        self._stats_monitor = LMCStatsMonitor.GetOrCreate()
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj) -> None:
+        obj_size = memory_obj.get_size()
+        begin = time.perf_counter()
+        try:
+            await self._connector.put(key, memory_obj)
+        finally:
+            # Ensure reference count is decreased even if exception occurs
+            memory_obj.ref_count_down()
+
+        end = time.perf_counter()
+        self._stats_monitor.update_interval_remote_time_to_put(
+            (end - begin) * 1000)
+        self._stats_monitor.update_interval_remote_write_metrics(obj_size)
+        logger.debug(f"Bytes offloaded: {obj_size / 1e6:.4f} MBytes")
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        begin = time.perf_counter()
+        memory_obj = await self._connector.get(key)
+        end = time.perf_counter()
+        self._stats_monitor.update_interval_remote_time_to_get(
+            (end - begin) * 1000)
+        if memory_obj is not None:
+            obj_size = memory_obj.get_size()
+            self._stats_monitor.update_interval_remote_read_metrics(obj_size)
+            logger.debug(f"Bytes loaded: {obj_size / 1e6:.4f} MBytes")
+        return memory_obj
+
+    # Delegate all other methods to the underlying connector
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return await self._connector.exists(key)
+
+    async def list(self) -> List[str]:
+        return await self._connector.list()
+
+    async def close(self) -> None:
+        await self._connector.close()

--- a/lmcache/v1/storage_backend/connector/lm_connector.py
+++ b/lmcache/v1/storage_backend/connector/lm_connector.py
@@ -116,8 +116,6 @@ class LMCServerConnector(RemoteConnector):
 
             await self.loop.sock_sendall(self.client_socket, kv_bytes)
 
-        memory_obj.ref_count_down()
-
     # TODO(Jiayi): This should be an async function
     @_lmcache_nvtx_annotate
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -180,8 +180,6 @@ class MooncakestoreConnector(RemoteConnector):
                          f"meta type: {type(metadata_bytes)},"
                          f"data: {type(kv_bytes)}: {e}")
 
-        memory_obj.ref_count_down()
-
     @no_type_check
     async def list(self) -> List[str]:
         pass

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -110,8 +110,6 @@ class RedisConnector(RemoteConnector):
         self.connection.set(key_str + "metadata", metadata_bytes)
         self.connection.set(key_str + "kv_bytes", kv_bytes)
 
-        memory_obj.ref_count_down()
-
     # TODO
     @no_type_check
     async def list(self) -> List[str]:


### PR DESCRIPTION
# Motivation

As there are some backend accidentally forget to add `memory_obj.ref_count_down()` to the end of `put` method, the memory object would never be evicted, it will cause leak. Reference to https://github.com/LMCache/LMCache/pull/517#issuecomment-2829073481

So I propose to abstract this call out of each connector, and place it into the `remote_backend#connection_put_wrapper` so that other remote connector implement developer can never care about this.