### PR TITLE
[feature] support heartbeat in lmcache worker

### DIFF
--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -24,6 +24,7 @@ from lmcache.v1.cache_controller.message import (  # isort: skip
     DecompressMsg,
     DeRegisterMsg,
     HealthMsg,
+    HeartbeatMsg,
     KVAdmitMsg,
     KVEvictMsg,
     LookupMsg,
@@ -99,6 +100,8 @@ class LMCacheControllerManager:
             await self.kv_controller.admit(msg)
         elif isinstance(msg, KVEvictMsg):
             await self.kv_controller.evict(msg)
+        elif isinstance(msg, HeartbeatMsg):
+            await self.reg_controller.heartbeat(msg)
         else:
             logger.error(f"Unknown worker message type: {msg}")
 

--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -92,7 +92,9 @@ class LMCacheControllerManager:
         # asyncio.run_coroutine_threadsafe(self.start_all(), self.loop)
 
     async def handle_worker_message(self, msg: WorkerMsg) -> None:
-        if isinstance(msg, RegisterMsg):
+        if isinstance(msg, HeartbeatMsg):
+            await self.reg_controller.heartbeat(msg)
+        elif isinstance(msg, RegisterMsg):
             await self.reg_controller.register(msg)
         elif isinstance(msg, DeRegisterMsg):
             await self.reg_controller.deregister(msg)
@@ -100,8 +102,6 @@ class LMCacheControllerManager:
             await self.kv_controller.admit(msg)
         elif isinstance(msg, KVEvictMsg):
             await self.kv_controller.evict(msg)
-        elif isinstance(msg, HeartbeatMsg):
-            await self.reg_controller.heartbeat(msg)
         else:
             logger.error(f"Unknown worker message type: {msg}")
 

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -39,6 +39,7 @@ class WorkerInfo:
     registration_time: float
     last_heartbeat_time: float
 
+
 class RegistrationController:
     def __init__(self):
         # Mapping from `instance_id` -> `worker_ids`

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from dataclasses import dataclass
 from typing import Optional
+import time
 
 # Third Party
 import zmq
@@ -12,6 +14,7 @@ from lmcache.v1.cache_controller.message import (
     DeRegisterMsg,
     HealthMsg,
     HealthRetMsg,
+    HeartbeatMsg,
     QueryInstMsg,
     QueryInstRetMsg,
     RegisterMsg,
@@ -24,6 +27,17 @@ from lmcache.v1.rpc_utils import (
 
 logger = init_logger(__name__)
 
+
+@dataclass
+class WorkerInfo:
+    # TODO(chunxiaozheng): add more worker info in heartbeat
+    instance_id: str
+    worker_id: int
+    ip: str
+    port: int
+    distributed_url: str
+    registration_time: float
+    last_heartbeat_time: float
 
 class RegistrationController:
     def __init__(self):
@@ -40,6 +54,9 @@ class RegistrationController:
 
         # Mapping from `ip` -> `instance_id`
         self.instance_mapping: dict[str, str] = {}
+
+        # Mapping from `(instance_id, worker_id)` -> `WorkerInfo`
+        self.worker_info_mapping: dict[tuple[str, int], WorkerInfo] = {}
 
     def post_init(self, kv_controller, cluster_executor):
         """
@@ -109,6 +126,9 @@ class RegistrationController:
         )
 
         self.socket_mapping[(instance_id, worker_id)] = socket
+        self.worker_info_mapping[(instance_id, worker_id)] = WorkerInfo(
+            instance_id, worker_id, ip, port, distributed_url, time.time(), time.time()
+        )
         if instance_id not in self.worker_mapping:
             self.worker_mapping[instance_id] = []
 
@@ -145,7 +165,12 @@ class RegistrationController:
             self.kv_controller.deregister(instance_id, worker_id)
             logger.info(f"Deregistered instance-worker {(instance_id, worker_id)}")
         else:
-            logger.warning(f"Instance-worker {(instance_id, worker_id)}not registered")
+            logger.warning(f"Instance-worker {(instance_id, worker_id)} not registered")
+
+        if (instance_id, worker_id) in self.worker_info_mapping:
+            self.worker_info_mapping.pop((instance_id, worker_id))
+        else:
+            logger.warning(f"Instance-worker {(instance_id, worker_id)} not registered")
 
     async def health(self, msg: HealthMsg) -> HealthRetMsg:
         """
@@ -155,3 +180,20 @@ class RegistrationController:
             "health",
             msg,
         )
+
+    async def heartbeat(self, msg: HeartbeatMsg) -> None:
+        """
+        Heartbeat from lmcache worker.
+        """
+        instance_id = msg.instance_id
+        worker_id = msg.worker_id
+        worker_key = (instance_id, worker_id)
+        if worker_key not in self.worker_info_mapping:
+            logger.warning(
+                f"{worker_key} has not been registered, re-register the worker."
+            )
+            # re-register the worker
+            await self.register(msg)
+        else:
+            # update worker info
+            self.worker_info_mapping[worker_key].last_heartbeat_time = time.time()

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from dataclasses import dataclass
 from typing import Optional
 import time
 
@@ -19,6 +18,7 @@ from lmcache.v1.cache_controller.message import (
     QueryInstRetMsg,
     RegisterMsg,
 )
+from lmcache.v1.cache_controller.utils import WorkerInfo
 from lmcache.v1.rpc_utils import (
     close_zmq_socket,
     get_zmq_context,
@@ -26,18 +26,6 @@ from lmcache.v1.rpc_utils import (
 )
 
 logger = init_logger(__name__)
-
-
-@dataclass
-class WorkerInfo:
-    # TODO(chunxiaozheng): add more worker info in heartbeat
-    instance_id: str
-    worker_id: int
-    ip: str
-    port: int
-    distributed_url: str
-    registration_time: float
-    last_heartbeat_time: float
 
 
 class RegistrationController:
@@ -182,6 +170,7 @@ class RegistrationController:
             msg,
         )
 
+    # TODO: add more worker info in heartbeat
     async def heartbeat(self, msg: HeartbeatMsg) -> None:
         """
         Heartbeat from lmcache worker.

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -86,6 +86,18 @@ class KVEvictMsg(WorkerMsg):
         return f"kv_evict {self.key} from {self.instance_id}"
 
 
+class HeartbeatMsg(RegisterMsg):
+    """Message for heartbeat, include register info for re-register"""
+
+    # TODO: add more heartbeat info
+
+    def describe(self) -> str:
+        return (
+            f"Heartbeat from instance {self.instance_id}, "
+            f"worker {self.worker_id}"
+        )
+
+
 """Control Message from Controller to LMCache"""
 
 
@@ -525,4 +537,5 @@ Msg = Union[
     ErrorMsg,
     QueryInstMsg,
     QueryInstRetMsg,
+    HeartbeatMsg,
 ]

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -92,10 +92,7 @@ class HeartbeatMsg(RegisterMsg):
     # TODO: add more heartbeat info
 
     def describe(self) -> str:
-        return (
-            f"Heartbeat from instance {self.instance_id}, "
-            f"worker {self.worker_id}"
-        )
+        return f"Heartbeat from instance {self.instance_id}, worker {self.worker_id}"
 
 
 """Control Message from Controller to LMCache"""

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from dataclasses import dataclass
+
+
+@dataclass
+class WorkerInfo:
+    instance_id: str
+    worker_id: int
+    ip: str
+    port: int
+    distributed_url: str
+    registration_time: float
+    last_heartbeat_time: float

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -22,6 +22,7 @@ from lmcache.v1.cache_controller.message import (
     ErrorMsg,
     HealthWorkerMsg,
     HealthWorkerRetMsg,
+    HeartbeatMsg,
     MoveWorkerMsg,
     MoveWorkerRetMsg,
     Msg,
@@ -61,6 +62,7 @@ class LMCacheWorker:
     ):
         # TODO (Jiayi): "instance_id" might not be needed anymore.
         # Please consider removing it.
+        self.config = config
         self.lmcache_instance_id = config.lmcache_instance_id
         assert self.lmcache_instance_id is not None
         self.lmcache_engine = lmcache_engine
@@ -168,6 +170,30 @@ class LMCacheWorker:
             except asyncio.QueueEmpty:
                 break
         return batch
+
+    async def heartbeat(self):
+        enable_heartbeat = (
+            self.config.lmcache_worker_heartbeat_time is not None
+            and self.config.lmcache_worker_heartbeat_time > 0
+        )
+        if enable_heartbeat:
+            logger.info(
+                f"Start heartbeat in {self.lmcache_instance_id} : {self.worker_id}, "
+                f"start delay time: {self.config.lmcache_worker_heartbeat_delay_time}s, "
+                f"heartbeat time: {self.config.lmcache_worker_heartbeat_time}s"
+            )
+            await asyncio.sleep(self.config.lmcache_worker_heartbeat_delay_time)
+            while True:
+                self.put_msg(
+                    HeartbeatMsg(
+                        instance_id=self.lmcache_instance_id,
+                        worker_id=self.worker_id,
+                        ip=self.lmcache_worker_ip,
+                        port=self.lmcache_worker_port,
+                        distributed_url=self.distributed_url
+                    )
+                )
+                await asyncio.sleep(self.config.lmcache_worker_heartbeat_time)
 
     async def push(self):
         while True:
@@ -291,6 +317,7 @@ class LMCacheWorker:
             await asyncio.gather(
                 self.push(),
                 self.handle_request(),
+                self.heartbeat(),
             )
         except Exception as e:
             logger.error(

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -190,7 +190,7 @@ class LMCacheWorker:
                         worker_id=self.worker_id,
                         ip=self.lmcache_worker_ip,
                         port=self.lmcache_worker_port,
-                        distributed_url=self.distributed_url
+                        distributed_url=self.distributed_url,
                     )
                 )
                 await asyncio.sleep(self.config.lmcache_worker_heartbeat_time)

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -179,7 +179,7 @@ class LMCacheWorker:
         if enable_heartbeat:
             logger.info(
                 f"Start heartbeat in {self.lmcache_instance_id} : {self.worker_id}, "
-                f"start delay time: {self.config.lmcache_worker_heartbeat_delay_time}s, "
+                f"delay time: {self.config.lmcache_worker_heartbeat_delay_time}s, "
                 f"heartbeat time: {self.config.lmcache_worker_heartbeat_time}s"
             )
             await asyncio.sleep(self.config.lmcache_worker_heartbeat_delay_time)

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -142,11 +142,16 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": int,
     },
+    # LMCache Worker heartbeat
+    # the lmcache_worker_heartbeat_delay_time means that delay a period of time
+    # before starting, ensures that the heartbeat starts working only after the
+    # service is fully ready(such as, waiting register).
     "lmcache_worker_heartbeat_delay_time": {
         "type": int,
         "default": 10,
         "env_converter": int,
     },
+    # the lmcache_worker_heartbeat_time means that sending heartbeat periodically.
     "lmcache_worker_heartbeat_time": {
         "type": Optional[int],
         "default": None,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -142,6 +142,16 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": int,
     },
+    "lmcache_worker_heartbeat_delay_time": {
+        "type": int,
+        "default": 10,
+        "env_converter": int,
+    },
+    "lmcache_worker_heartbeat_time": {
+        "type": Optional[int],
+        "default": None,
+        "env_converter": int,
+    },
     # Nixl configurations
     "enable_nixl": {
         "type": bool,


### PR DESCRIPTION
Support heartbeat in `LMCacheWoker`,  which will be used for us to collect some information about lmcache workers

TODO:
- Add tests
- Improve more information in `HeartbeatMsg`
- Add a `list` interface to display information about all workers under a certain instance