### PR TITLE
[Bugfix] fix package error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lmcache"
 authors = [{name = "LMCache Team", email = "lmcacheteam@gmail.com"}]
-license = "Apache-2.0"
-license-files = ["LICENSE"]
+license = {file = "LICENSE"}
 readme = "README.md"
 description = "A LLM serving engine extension to reduce TTFT and increase throughput, especially under long-context scenarios."
 classifiers = [


### PR DESCRIPTION
With https://github.com/LMCache/LMCache/pull/592, When I use the `python3 setup.py bdist_wheel --dist-dir=dist_lmcache` command to package, two error occurs:
```
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```

```
ValueError: invalid pyproject.toml config: `project`.
configuration error: `project` must not contain {'license-files'} properties
```
With using the modifications in current PR, we can package successfully.
