### PR TITLE
[Bugfix] Ensure RequestTracker.update compatibility with vLLM 0.9.0

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -193,7 +193,11 @@ class RequestTracker:
         scheduled again
         """
         self.token_ids.extend(cached_request.new_token_ids)
-        self.allocated_block_ids.extend(cached_request.new_block_ids)
+        if not isinstance(cached_request.new_block_ids[0], list):
+            self.allocated_block_ids.extend(cached_request.new_block_ids)
+        else:
+            for ids in cached_request.new_block_ids:
+                self.allocated_block_ids.extend(ids)
 
 
 @dataclass


### PR DESCRIPTION
Modify `RequestTracker.update` in a similar way to #655 to fix the following error.
```
[2025-05-16 12:35:55,838] LMCache INFO: Reqid: chatcmpl-1d6a155b768f429d8e6266132f9c9658, Total tokens 192, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:670:lmcache.integration.vllm.vllm_v1_adapter)
[2025-05-16 12:35:55,890] LMCache INFO: Storing KV cache for 192 out of 192 tokens for request chatcmpl-1d6a155b768f429d8e6266132f9c9658 (vllm_v1_adapter.py:620:lmcache.integration.vllm.vllm_v1_adapter)
ERROR 05-16 12:35:58 [core.py:491] EngineCore encountered a fatal error.
ERROR 05-16 12:35:58 [core.py:491] Traceback (most recent call last):
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/vllm/vllm/v1/engine/core.py", line 482, in run_engine_core
ERROR 05-16 12:35:58 [core.py:491]     engine_core.run_busy_loop()
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/vllm/vllm/v1/engine/core.py", line 509, in run_busy_loop
ERROR 05-16 12:35:58 [core.py:491]     self._process_engine_step()
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/vllm/vllm/v1/engine/core.py", line 534, in _process_engine_step
ERROR 05-16 12:35:58 [core.py:491]     outputs = self.step_fn()
ERROR 05-16 12:35:58 [core.py:491]               ^^^^^^^^^^^^^^
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/vllm/vllm/v1/engine/core.py", line 221, in step
ERROR 05-16 12:35:58 [core.py:491]     scheduler_output = self.scheduler.schedule()
ERROR 05-16 12:35:58 [core.py:491]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/vllm/vllm/v1/core/sched/scheduler.py", line 540, in schedule
ERROR 05-16 12:35:58 [core.py:491]     meta = self.connector.build_connector_meta(scheduler_output)
ERROR 05-16 12:35:58 [core.py:491]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/vllm/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 133, in build_connector_meta
ERROR 05-16 12:35:58 [core.py:491]     return self._lmcache_engine.build_connector_meta(scheduler_output)
ERROR 05-16 12:35:58 [core.py:491]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 757, in build_connector_meta
ERROR 05-16 12:35:58 [core.py:491]     req_meta = ReqMeta.from_request_tracker(
ERROR 05-16 12:35:58 [core.py:491]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-16 12:35:58 [core.py:491]   File "/workspace/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 267, in from_request_tracker
ERROR 05-16 12:35:58 [core.py:491]     block_ids = torch.tensor(tracker.allocated_block_ids, dtype=torch.long)
ERROR 05-16 12:35:58 [core.py:491]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-16 12:35:58 [core.py:491] TypeError: 'list' object cannot be interpreted as an integer
```

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <a href="https://github.com/LMCache/LMCache/blob/dev/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

To create a new tag for lmcache (Note: `v` prefix is required):
`git tag vx.x.x`
`git push origin vx.x.x` (same version again)

For example:
`git tag v0.3.0`
`git push origin v0.3.0`

In case the workflow fails, delete the tag and try again:
`git tag -d vx.x.x`
`git push origin :refs/tags/vx.x.x`

For example:
`git tag -d v0.3.0`
`git push origin :refs/tags/v0.3.0`

To create a new release and publish `lmcache` Python package to PyPi:
`git remote add upstream git@github.com:LMCache/LMCache.git`
`gh release create vx.x.x --repo LMCache/LMCache --title "vx.x.x" --notes "<Add decsription>"`

For example:
`git remote add upstream git@github.com:LMCache/LMCache.git`
`gh release create v0.3.0 --repo LMCache/LMCache --title "v0.3.0" --notes "LMCache v0.3.0 is a feature realease. Users are encouraged to upgrade for the best experience."`

> [!TIP]
> The creation of a release and subsequent tag generation can be done alternatively from the LMCache [releases](https://github.com/LMCache/LMCache/releases) page.

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
