### PR TITLE
Improve the store log of vllm v1 adapter

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -553,9 +553,10 @@ class LMCacheConnectorV1Impl:
                 store_mask[:skip_leading_tokens] = False
 
                 logger.info(
-                    "Storing KV cache for %d out of %d tokens for request %s",
+                    "Storing KV cache for %d out of %d tokens "
+                    "(skip_leading_tokens=%d) for request %s",
                     len(token_ids) - skip_leading_tokens, len(token_ids),
-                    request.req_id)
+                    skip_leading_tokens, request.req_id)
                 layerwise_storer = self.lmcache_engine.store_layer(
                     token_ids,
                     mask=store_mask,
@@ -618,9 +619,10 @@ class LMCacheConnectorV1Impl:
             store_mask[:skip_leading_tokens] = False
 
             logger.info(
-                "Storing KV cache for %d out of %d tokens for request %s",
+                "Storing KV cache for %d out of %d tokens "
+                "(skip_leading_tokens=%d) for request %s",
                 len(token_ids) - skip_leading_tokens, len(token_ids),
-                request.req_id)
+                skip_leading_tokens, request.req_id)
             self.lmcache_engine.store(token_ids,
                                       mask=store_mask,
                                       kvcaches=kvcaches,


### PR DESCRIPTION
Add the `skip_leading_tokens` into the log to show more information.

After this improvement, the log is like the following
```
(VllmWorker rank=1 pid=9739) [2025-05-16 23:43:45,775] LMCache INFO: Storing KV cache for 149 out of 405 tokens (skip_leading_tokens=256) for request chatcmpl-6ec4b7c3cc854cdea23acf91646b1734 (vllm_v1_adapter.py:621:lmcache.integration.vllm.vllm_v1_adapter)
```