### PR TITLE
[Bugfix]: Add `.item()` to convert `torch.sum(...)` to a Python scalar for JSON serialization

### DIFF
--- a/lmcache/cache_engine.py
+++ b/lmcache/cache_engine.py
@@ -321,7 +321,7 @@ class LMCacheEngine:
             "token length does not match mask length"
         )
         # NOTE(Sixian): Now kv_tensors_mask always a suffix mask.
-        num_skip_tok = len(kv_tensors_mask) - torch.sum(kv_tensors_mask)
+        num_skip_tok = len(kv_tensors_mask) - torch.sum(kv_tensors_mask).item()
         assert num_skip_tok == 0 or skip_existing, (
             "When skip_existing is False, the mask must cover all tokens"
         )
@@ -395,7 +395,7 @@ class LMCacheEngine:
         num_skip_tok = 0
         ret_mask = torch.ones_like(tokens, dtype=torch.bool)
         if mask is not None:
-            num_skip_tok = len(mask) - torch.sum(mask)
+            num_skip_tok = len(mask) - torch.sum(mask).item()
             num_skip_chunk = num_skip_tok // self.chunk_size
         ret_mask[:num_skip_tok] = False
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -155,7 +155,7 @@ class LMCacheEngine:
         """
         st = time.perf_counter()
         if mask is not None:
-            num_store_tokens = torch.sum(mask)
+            num_store_tokens = torch.sum(mask).item()
         else:
             num_store_tokens = len(tokens)
         monitor_req_id = self.stats_monitor.on_store_request(num_store_tokens)
@@ -694,7 +694,7 @@ class LayerwiseLMCacheEngine(LMCacheEngine):
         # synchronize the last layer
         next(mem_obj_consumer)
 
-        retrieved_tokens = torch.sum(ret_mask)
+        retrieved_tokens = torch.sum(ret_mask).item()
         self.stats_monitor.on_retrieve_finished(monitor_req_id, retrieved_tokens)
         logger.debug(
             f"Retrieved {retrieved_tokens} "


### PR DESCRIPTION
This PR fixes a serialization error encountered during LMCache-based benchmarking (in the own benchmark) when transmitting cache statistics in JSON format between processes.

As part of a vLLM benchmarking setup, a script was implemented to request cache statistics from `LMCStatsMonitor`. These statistics are sent over IPC in JSON format for analysis.

The `LMCStatsMonitor` stores various cache-related statistics via some methods. These methods are designed to receive **Python scalar (int) values** as input arguments. However, in the current implementation, some of these values are computed using `torch.sum(...)` and passes directly to the monitor **without converting them to Python scalars**. 

For example, `retrieved_tokens` is computed by `torch.sum(...)` and its type is `torch.Tensor`. Then, it is passed into `on_retrieve_finished`.
https://github.com/LMCache/LMCache/blob/2e4c7b95a0784babd6d61313724a801614898e1e/lmcache/v1/cache_engine.py#L356-L357
But, `on_retrieve_finished` receives `retrieved_tokens` as `int`, not `torch.Tensor`.
https://github.com/LMCache/LMCache/blob/2e4c7b95a0784babd6d61313724a801614898e1e/lmcache/observability.py#L155-L157

The results in two issues:
1. Type mismatch: The monitor methods expect `int`, but receive `torch.Tensor`, which makes some properties of the monitor `torch.Tensor` type.
2. Serialization error: When the statistics are later serialized into JSON, the presence of `torch.Tensor` values leads to: `TypeError: Object of type Tensor is not JSON serializable`.

To resolve this, I added `.item()` to convert the tensor into a Python int scalar, ensuring both compatibility with the monitor method signatures and safe JSON serialization.