### PR TITLE
[Refactor]: Remove duplicate code from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,30 +9,6 @@ from setuptools import find_packages, setup
 ROOT_DIR = Path(__file__).parent
 
 
-# Taken from https://github.com/vllm-project/vllm/blob/main/setup.py
-def get_requirements() -> list[str]:
-    """Get Python package dependencies from requirements.txt."""
-    requirements_dir = ROOT_DIR / "requirements"
-
-    def _read_requirements(filename: str) -> list[str]:
-        with open(requirements_dir / filename) as f:
-            requirements = f.read().strip().split("\n")
-        resolved_requirements = []
-        for line in requirements:
-            if line.startswith("-r "):
-                resolved_requirements += _read_requirements(line.split()[1])
-            elif (
-                not line.startswith("--")
-                and not line.startswith("#")
-                and line.strip() != ""
-            ):
-                resolved_requirements.append(line)
-        return resolved_requirements
-
-    requirements = _read_requirements("common.txt")
-    return requirements
-
-
 # python -m build --sdist
 # will run python setup.py sdist --dist-dir dist
 BUILDING_SDIST = "sdist" in sys.argv or os.environ.get("NO_CUDA_EXT", "0") == "1"
@@ -68,7 +44,6 @@ else:
 
 setup(
     packages=find_packages(exclude=("csrc")),
-    install_requires=get_requirements(),
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     include_package_data=True,


### PR DESCRIPTION
Project requirements are now loaded now from `pyproject.toml` as `dependencies`. This means that the loading of requirements from `setup.py` are no longer needed. This PR removes the loading from `setup.py`.
