### PR TITLE
[FSConnector] improve performance with asyncio and direct read to memory object

### DIFF
--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -48,7 +48,10 @@ class InstrumentedRemoteConnector(RemoteConnector):
         end = time.perf_counter()
         self._stats_monitor.update_interval_remote_time_to_put((end - begin) * 1000)
         self._stats_monitor.update_interval_remote_write_metrics(obj_size)
-        logger.debug(f"Bytes offloaded: {obj_size / 1e6:.4f} MBytes")
+        logger.debug(
+            f"Bytes offloaded: {obj_size / 1e6:.3f} MBytes "
+            f"in {(end - begin) * 1000:.3f}ms"
+        )
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         begin = time.perf_counter()
@@ -58,7 +61,10 @@ class InstrumentedRemoteConnector(RemoteConnector):
         if memory_obj is not None:
             obj_size = memory_obj.get_size()
             self._stats_monitor.update_interval_remote_read_metrics(obj_size)
-            logger.debug(f"Bytes loaded: {obj_size / 1e6:.4f} MBytes")
+            logger.debug(
+                f"Bytes loaded: {obj_size / 1e6:.3f} MBytes "
+                f"in {(end - begin) * 1000:.3f}ms"
+            )
         return memory_obj
 
     # Delegate all other methods to the underlying connector


### PR DESCRIPTION
It was observed that fs_connector get() took ~200ms for a 130MB file while the actual filesystem speed is 30ms (with dd).

This PR implements fs_connector get() to use aiofiles (like in local_disk_backend), and also use file.readinto() to read the data directly into allocated memory. To allocate the memory it needs to first read the meta-data section from the beginning of the file, then parse the shape, dtype, fmt, so it can allocate the right amount of memory, and finally read directly into it. The 2 reads are worth it because with these changes get latency decreased from 200ms to 30ms (Python 3.12.3).

In addition, also changed fs_connector's put() and exists() to use aiofiles.

See small test output with time breakdowns of put and get:

```
$ LMCACHE_LOG_LEVEL=debug pytest -s tests/v1/test_connector.py
...
tests/v1/test_connector.py::test_fs_connector[cpu] [2025-05-30 02:05:05,060] LMCache INFO: Initialized FSConnector with base path /tmp/tmph8aximvi/ (fs_connector.py:62:lmcache.v1.storage_backend.connector.fs_connector)
[2025-05-30 02:05:05,061] LMCache INFO: Created connector <lmcache.v1.storage_backend.connector.fs_connector.FSConnector object at 0x71916d5bcd40> for fs (__init__.py:216:lmcache.v1.storage_backend.connector)
[2025-05-30 02:05:07,128] LMCache DEBUG: FSConnector put /tmp/tmph8aximvi/vllm@test_model@3@123@hash.data took 70.739375ms - open=0.462161ms md=0.122279ms write=69.588883ms replace=0.566052ms (fs_connector.py:149:lmcache.v1.storage_backend.connector.fs_connector)
[2025-05-30 02:05:07,129] LMCache DEBUG: Bytes offloaded: 131.0720 MBytes (instrumented_connector.py:51:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-05-30 02:05:07,161] LMCache DEBUG: FSConnector get /tmp/tmph8aximvi/vllm@test_model@3@123@hash.data took 30.869987ms - open=0.251681ms md=0.186751ms allocate=0.396347ms read=30.035209ms (fs_connector.py:109:lmcache.v1.storage_backend.connector.fs_connector)
[2025-05-30 02:05:07,161] LMCache DEBUG: Bytes loaded: 131.0720 MBytes (instrumented_connector.py:61:lmcache.v1.storage_backend.connector.instrumented_connector)
PASSED
```