### PR TITLE
[CI/Build]: Addition to Dockerfile for choice of vLLM and LMCache package versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,24 @@
-# The vLLM Dockerfile is used to construct vLLM image that can be directly used
-# to run the OpenAI compatible server.
+# The LMcache Dockerfile is used to build a LMCache image that is integrated
+# to run with vLLM OpenAI server.
+
 # Please update any changes made here to
-# docs/source/dev/dockerfile/dockerfile.rst and
-# docs/source/assets/dev/dockerfile-stages-dependency.png
-ARG CUDA_VERSION=12.8.0
+# docs/source/developer_guide/docker_file.rst
+# docs/source/getting_started/installation.rst
+# docs/production/docker_deployment.rst
+
+ARG CUDA_VERSION=12.8
+ARG UBUNTU_VERSION=24.04
+
 #################### BASE BUILD IMAGE ####################
-# prepare basic build environment
-FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda12.8-devel-ubuntu24.04 AS base
-ARG CUDA_VERSION=12.8.0
+# Prepare basic build environment
+
+FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS base
+
+ARG CUDA_VERSION
 ARG PYTHON_VERSION=3.12
+ARG UBUNTU_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
+
 # Install Python and other dependencies
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
@@ -24,17 +33,15 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && uv venv /opt/venv \
     && . /opt/venv/bin/activate \
     && python3 --version
-# Workaround for https://github.com/openai/triton/issues/2507 and
-# https://github.com/pytorch/pytorch/issues/107960 -- hopefully
-# this won't be needed for future versions of this docker image
-# or future versions of triton.
-RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
+
 WORKDIR /workspace
+
+# Install and setup nixl
 RUN apt-get update -y && \
     apt-get -y install \
     ninja-build \
     pybind11-dev \
-    python3.12-dev \
+    python${PYTHON_VERSION}-dev \
     cmake
 RUN export LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
 RUN export NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
@@ -59,13 +66,14 @@ RUN cd /workspace/nixl/ && \
     . /opt/venv/bin/activate && \
     uv build --wheel --out-dir /tmp/dist && \
     uv pip install /tmp/dist/nixl-0.3.0-cp312-cp312-linux_x86_64.whl
-# install build and runtime dependencies
+
+# Install runtime dependencies
 COPY ./requirements/common.txt common.txt
 COPY ./requirements/cuda.txt cuda.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
-    uv pip install torch==2.7.0 torchvision==0.22.0 && \
     uv pip install -r cuda.txt
+
 # cuda arch list used by torch
 # can be useful for both `dev` and `test`
 # explicitly set the list to avoid issues with torch 2.2
@@ -75,33 +83,57 @@ ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 # Override the arch list for flash-attn to reduce the binary size
 ARG vllm_fa_cmake_gpu_arches='80-real;90-real'
 ENV VLLM_FA_CMAKE_GPU_ARCHES=${vllm_fa_cmake_gpu_arches}
-#################### BASE BUILD IMAGE ####################
-#################### WHEEL BUILD IMAGE ####################
-# FROM base AS build
+
+#################### vLLM IMAGE & LMCache (Build) #######################
+# Integrate vLLM nightly build and LMCache build and 
+# expose vLLM OpenAI API
+
+FROM base AS image-build
+
 # install build dependencies
 COPY ./requirements/build.txt build.txt
-# max jobs used by Ninja to build extensions
+
+# Max jobs used by Ninja to build extensions
 ARG max_jobs=2
 ENV MAX_JOBS=${max_jobs}
-# number of threads used by nvcc
+
+# Number of threads used by nvcc
 ARG nvcc_threads=8
 ENV NVCC_THREADS=$nvcc_threads
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
     uv pip install -r build.txt
+
 ARG LMCACHE_COMMIT_ID=1
+
 COPY . /workspace/LMCache
 WORKDIR /workspace/LMCache
+
+# Build LMCache
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache
+
+# Install LMCache latest build and vLLM nightly build
 RUN . /opt/venv/bin/activate && \
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/nightly && \
     uv pip install /workspace/LMCache/dist_lmcache/*.whl --verbose
+
 WORKDIR /workspace
-# COPY vllm_examples /workspace/examples
-# Create an entrypoint script to activate the virtual environment
-# RUN echo '#!/bin/bash\n . /opt/venv/bin/activate\n vllm serve "$@"' > /entrypoint.sh \
-#     && chmod +x /entrypoint.sh
+ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
+
+#################### vLLM IMAGE & LMCache (Release) #######################
+# Integrate vLLM and LMCache stable releases and expose vLLM 
+# OpenAI API
+
+FROM base AS image-release
+
+# Install LMCache and vLLM stable releases
+RUN . /opt/venv/bin/activate && \
+uv pip install vllm && \
+    uv pip install lmcache --verbose
+
+WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]

--- a/docker/example_build.sh
+++ b/docker/example_build.sh
@@ -1,19 +1,15 @@
 # Example script to build the LMCache container image
 
 # Update the following variables accordingly
-# Note: latest (built from GitHub) images of vLLM are in AWS ECR registry:
-# public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
-# The latest release version of vLLM imnage are on DockerHub: vllm/vllm-openai
-CUDA_VERSION=12.8.1
+CUDA_VERSION=12.8
 DOCKERFILE_NAME='Dockerfile'
 DOCKER_BUILD_PATH='../' # This path should point to the LMCache root for access to 'requirements' directory
-UBUNTU_VERSION=22.04
-VLLM_IMAGE_REPO='vllm/vllm-openai'
-VLLM_TAG='latest'
+UBUNTU_VERSION=24.04
+BUILD_TARGET=image-build # change to 'image-release' for using release package versions of vLLM and LMCache
+IMAGE_TAG='lmcache/vllm-openai:build-latest'
 
 docker build \
     --build-arg CUDA_VERSION=$CUDA_VERSION \
     --build-arg UBUNTU_VERSION=$UBUNTU_VERSION \
-    --build-arg VLLM_IMAGE_REPO=$VLLM_IMAGE_REPO \
-    --build-arg VLLM_TAG=$VLLM_TAG \
-    -f $DOCKERFILE_NAME $DOCKER_BUILD_PATH
+    --target $BUILD_TARGET --file $DOCKERFILE_NAME \
+    --tag $IMAGE_TAG  $DOCKER_BUILD_PATH

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -102,7 +102,7 @@ We provide pre-built Docker images that include vLLM integration:
 
 .. code-block:: bash
 
-    docker pull lmcache/vllm-openai:2025-04-18
+    docker pull lmcache/vllm-openai
 
 .. note::
     Currently, we build and release Docker images manually. An automated Docker build/release GitHub workflow will be set up soon. Contributions to this effort are welcomed!


### PR DESCRIPTION
This PR adds the flexibility to choose:

- Nightly build package of vLLM and to build LMCache package as the base for building the `lmcache/vllm-openai` container image OR
- Latest release packages of vLLM and LMCache as the base for building the `lmcache/vllm-openai` container image

This allows user to build an image with latest code in both repositories and also the ability to build an image with the latest release versions of both projects.

Dockerfile updated as follows:

- Target added which uses vLLM nightly build and LMCache local build
- Target added which uses latest vLLM release and LMCache release
- Refactor of redundant commands

Updated to example docker build file for new arguments and versions. Small updated to online doc for docker run command.

This builds on PR #734 
Partial #733 