### PR TITLE
Introduce extra config to lmcache config

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -104,6 +104,9 @@ class LMCacheEngineConfig:
     # Size of CuFile Buffer in MiB
     cufile_buffer_size: Optional[int] = None
 
+    # Extra configuration dictionary for custom settings
+    extra_config: dict = None
+
     @staticmethod
     def from_defaults(
         chunk_size: int = 256,
@@ -134,6 +137,7 @@ class LMCacheEngineConfig:
         nixl_buffer_device: Optional[str] = None,
         nixl_enable_gc: Optional[bool] = False,
         audit_actual_remote_url: Optional[str] = None,
+        extra_config: Optional[dict] = None,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
         return LMCacheEngineConfig(
@@ -165,6 +169,7 @@ class LMCacheEngineConfig:
             nixl_buffer_device,
             nixl_enable_gc,
             audit_actual_remote_url,
+            extra_config=extra_config or {},
         ).validate()
 
     @staticmethod
@@ -315,6 +320,9 @@ class LMCacheEngineConfig:
         weka_path = config.get("weka_path", None)
         cufile_buffer_size = config.get("cufile_buffer_size", None)
 
+        # Get extra_config dictionary
+        extra_config = config.get("extra_config", {})
+
         local_disk_path = _parse_local_disk(local_disk)
 
         match remote_url:
@@ -357,6 +365,7 @@ class LMCacheEngineConfig:
                 audit_actual_remote_url,
                 weka_path,
                 cufile_buffer_size,
+                extra_config=extra_config,
             )
             .validate()
             .log_config()
@@ -395,6 +404,26 @@ class LMCacheEngineConfig:
             if value is None:
                 return 0.0
             return float(value)
+
+        def parse_extra_config(value: Optional[str]) -> dict:
+            """Parse extra_config from JSON string"""
+            if not value:
+                return {}
+            try:
+                # Standard
+                import json
+
+                return json.loads(value)
+            except ImportError:
+                # Handle missing json module (unlikely but possible)
+                logger.error("import json module error")
+                return {}
+            except (TypeError, ValueError, json.JSONDecodeError) as e:
+                # Handle all possible parsing errors
+                logger.warning(
+                    f"Failed to parse extra config: {str(e)}, using empty dict"
+                )
+                return {}
 
         config = LMCacheEngineConfig.from_defaults(remote_url=None, remote_serde=None)
         config.chunk_size = to_int(
@@ -519,6 +548,11 @@ class LMCacheEngineConfig:
             get_env_name("cufile_buffer_size"),
             config.cufile_buffer_size,
         )
+
+        # Parse extra_config from environment
+        extra_config_str = parse_env(get_env_name("extra_config"), None)
+        config.extra_config = parse_extra_config(extra_config_str)
+
         return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:
@@ -597,6 +631,7 @@ class LMCacheEngineConfig:
             "nixl_buffer_device": self.nixl_buffer_device,
             "nixl_enable_gc": self.nixl_enable_gc,
             "weka_path": self.weka_path,
+            "extra_config": self.extra_config,
         }
         logger.info(f"LMCache Configuration: {config_dict}")
 

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -181,7 +181,7 @@ def CreateConnector(
                 host, port, device_name, loop, local_cpu_backend
             )
         case "blackhole":
-            connector = BlackholeConnector()
+            connector = BlackholeConnector(config)
         case "fs":
             if num_hosts != 1:
                 raise ValueError(

--- a/lmcache/v1/storage_backend/connector/blackhole_connector.py
+++ b/lmcache/v1/storage_backend/connector/blackhole_connector.py
@@ -18,6 +18,7 @@ from typing import List, Optional, no_type_check
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
 
 # reuse
@@ -27,11 +28,21 @@ logger = init_logger(__name__)
 
 
 class BlackholeConnector(RemoteConnector):
-    def __init__(self):
-        pass
+    def __init__(self, config: Optional[LMCacheEngineConfig] = None):
+        """
+        Initialize the Blackhole connector.
+
+        Args:
+            config: LMCacheEngineConfig instance for accessing extra_config
+        """
+        self.always_exists = False
+        if config and config.extra_config:
+            self.always_exists = config.extra_config.get(
+                "remote_black_hole_always_exists", False
+            )
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return False
+        return self.always_exists
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         return None


### PR DESCRIPTION
# Motivation

For now, developer have to define a new argument and introduce many related glue codes to pass the new defined argument to the inner logic which use that new argument, it is bothering.

So I propose to supply a generic extra key-value pairs config.

Something like kv_connector_extra_config of vllm, we could have a  --extra_config for LMCache.

With this PR, #747 could focus the changes in the `mooncakestore_connector.py`.

# How to test

- ./lmcache-blackhole.yaml
```yaml
chunk_size: 256
local_device: "cpu"
remote_serde: "naive"
remote_url: "blackhole://host:0/"
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 10
extra_config:
  remote_black_hole_always_exists: true
```

- Start vllm
```
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN \
VLLM_USE_V1=0 LMCACHE_CONFIG_FILE=./lmcache-blackhole.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}'
```

- Test by curl
```
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'
```

- Verified from temp log
```
[2025-06-02 08:40:24,408] LMCache INFO: key CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9986f4b448a1f7cfee35e733ce736bec3625062a6bceec46e13fe0961de001c5') exist return True (blackhole_connector.py:46:lmcache.experimental.storage_backend.connector.blackhole_connector)
```

If I set the `remote_black_hole_always_exists` to false

```
[2025-06-02 08:45:40,098] LMCache INFO: key CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9986f4b448a1f7cfee35e733ce736bec3625062a6bceec46e13fe0961de001c5') exist return False (blackhole_connector.py:46:lmcache.experimental.storage_backend.connector.blackhole_connector)
```
