### PR TITLE
Introduce a remote monitor thread to monitor remote and support fallback to blackhole

### DIFF
--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -101,7 +101,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         Ping the remote server
 
         Returns:
-            The time taken to ping the remote server in milliseconds
+            The error code, 0 means success
         """
         raise NotImplementedError
 

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -86,3 +86,24 @@ class RemoteConnector(metaclass=abc.ABCMeta):
 
         """
         raise NotImplementedError
+
+    def support_ping(self) -> bool:
+        """
+        Check if the connector supports ping operation
+
+        Returns:
+            True if ping is supported, False otherwise
+        """
+        return False
+
+    async def ping(self) -> int:
+        """
+        Ping the remote server
+
+        Returns:
+            The time taken to ping the remote server in milliseconds
+        """
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}>"

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -35,6 +35,7 @@ class InstrumentedRemoteConnector(RemoteConnector):
     def __init__(self, connector: RemoteConnector):
         self._connector = connector
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
+        self.name = self.__repr__()
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj) -> None:
         obj_size = memory_obj.get_size()
@@ -49,7 +50,7 @@ class InstrumentedRemoteConnector(RemoteConnector):
         self._stats_monitor.update_interval_remote_time_to_put((end - begin) * 1000)
         self._stats_monitor.update_interval_remote_write_metrics(obj_size)
         logger.debug(
-            f"Bytes offloaded: {obj_size / 1e6:.3f} MBytes "
+            f"[{self.name}]Bytes offloaded: {obj_size / 1e6:.3f} MBytes "
             f"in {(end - begin) * 1000:.3f}ms"
         )
 
@@ -62,7 +63,7 @@ class InstrumentedRemoteConnector(RemoteConnector):
             obj_size = memory_obj.get_size()
             self._stats_monitor.update_interval_remote_read_metrics(obj_size)
             logger.debug(
-                f"Bytes loaded: {obj_size / 1e6:.3f} MBytes "
+                f"[{self.name}]Bytes loaded: {obj_size / 1e6:.3f} MBytes "
                 f"in {(end - begin) * 1000:.3f}ms"
             )
         return memory_obj

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -79,3 +79,12 @@ class InstrumentedRemoteConnector(RemoteConnector):
 
     def getWrappedConnector(self) -> RemoteConnector:
         return self._connector
+
+    def support_ping(self) -> bool:
+        return self._connector.support_ping()
+
+    async def ping(self) -> int:
+        return await self._connector.ping()
+
+    def __repr__(self) -> str:
+        return f"InstrumentedRemoteConnector({self._connector})"

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -32,7 +32,6 @@ from lmcache.v1.storage_backend.connector import CreateConnector
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.naive_serde import CreateSerde
-from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
 
 logger = init_logger(__name__)
 
@@ -94,6 +93,10 @@ class RemoteBackend(StorageBackendInterface):
 
         # Create RemoteMonitor instance, which initializes the
         # connection status and active connector
+        # 动态导入RemoteMonitor，避免循环依赖
+        # First Party
+        from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
+
         self.remote_monitor = RemoteMonitor(self)
 
         # Start the remote monitor thread (if ping is supported)

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -14,7 +14,6 @@
 
 # Standard
 from concurrent.futures import Future, TimeoutError
-from functools import wraps
 from typing import List, Optional
 import asyncio
 import threading
@@ -67,7 +66,7 @@ class RemoteBackend(StorageBackendInterface):
         self.connection: Optional[RemoteConnector] = None
         self.min_reconnect_interval = 10
         self.failure_time = -1000000.0
-        self._init_connection()
+        self.init_connection()
 
         assert config.remote_serde is not None
         self.serializer, self.deserializer = CreateSerde(
@@ -103,7 +102,7 @@ class RemoteBackend(StorageBackendInterface):
     def __str__(self):
         return self.__class__.__name__
 
-    def _init_connection(self):
+    def init_connection(self):
         # Initialize connection
         if self.connection is not None:
             return
@@ -131,18 +130,6 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning(f"Failed to initialize/re-establish remote connection: {e}")
             self.connection = None
 
-    @staticmethod
-    def _init_connection_wrapper(func):
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            self._init_connection()
-            result = func(self, *args, **kwargs)
-            return result
-
-        return wrapper
-
-    # TODO(Jiayi): handle `pin` semantics
-    @_init_connection_wrapper
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         if self.connection is None:
             logger.warning("Connection is None in contains, returning False")
@@ -161,9 +148,6 @@ class RemoteBackend(StorageBackendInterface):
             res = future.result()
             return res
         except Exception as e:
-            with self.lock:
-                self.connection = None
-                self.failure_time = time.time()
             logger.warning(f"Remote connection failed in contains: {e}")
             logger.warning("Returning False")
             return False
@@ -254,9 +238,6 @@ class RemoteBackend(StorageBackendInterface):
             if isinstance(e, TimeoutError):
                 logger.warning("get blocking timeout, trigger cancel the future task")
                 future.cancel()
-            with self.lock:
-                self.connection = None
-                self.failure_time = time.time()
             logger.warning(f"Error occurred in get_blocking: {e}")
             logger.warning("Returning None")
             return None

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -92,8 +92,7 @@ class RemoteBackend(StorageBackendInterface):
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
 
         # Create RemoteMonitor instance, which initializes the
-        # connection status and active connector
-        # 动态导入RemoteMonitor，避免循环依赖
+        # connection status and active connector dynamically
         # First Party
         from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -33,6 +33,7 @@ from lmcache.v1.storage_backend.connector import CreateConnector
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.naive_serde import CreateSerde
+from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
 
 logger = init_logger(__name__)
 
@@ -91,6 +92,13 @@ class RemoteBackend(StorageBackendInterface):
         # we must make decision (whether to send or not) at the local side
 
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
+
+        # Create RemoteMonitor instance, which initializes the
+        # connection status and active connector
+        self.remote_monitor = RemoteMonitor(self)
+
+        # Start the remote monitor thread (if ping is supported)
+        self.remote_monitor.start()
 
     def __str__(self):
         return self.__class__.__name__

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -1,0 +1,164 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+import asyncio
+import threading
+import time
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import BlackholeConnector
+
+logger = init_logger(__name__)
+
+# Ping error codes
+PING_TIMEOUT_ERROR_CODE = -1
+PING_GENERIC_ERROR_CODE = -2
+
+# Configuration constants
+PING_TIMEOUT_CONFIG_KEY = "ping_timeout"
+PING_INTERVAL_CONFIG_KEY = "ping_interval"
+DEFAULT_PING_TIMEOUT = 5.0
+DEFAULT_PING_INTERVAL = 30.0
+
+
+class RemoteMonitor:
+    """
+    Remote monitor class, encapsulating the monitor logic
+    """
+
+    def __init__(self, backend):
+        self.backend = backend
+
+        # Initialize connection status
+        self.connection_healthy = True
+
+        # Store the original connector
+        self.original_connector = backend.connection
+
+        # Create a blackhole connector for fallback
+        self.blackhole_connector = BlackholeConnector()
+
+    def _should_skip_ping(self) -> bool:
+        """
+        Check if we should skip ping for this connector
+        """
+        if self.original_connector is None:
+            logger.warning("Original connector is None, should retry.")
+            return False
+
+        if not self.original_connector.support_ping():
+            logger.info(
+                f"Connector {type(self.original_connector).__name__} "
+                f"does not support ping, skipping ping loop"
+            )
+            return True
+
+        return False
+
+    def start(self):
+        """
+        Start the monitor thread
+        """
+        # Check if we should skip starting the thread
+        if self._should_skip_ping():
+            return None
+
+        thread = threading.Thread(
+            target=self.run_loop,
+            daemon=True,
+            name=f"{self.original_connector}-monitor-thread",
+        )
+        thread.start()
+        return thread
+
+    def run_loop(self):
+        """
+        Run the monitor loop
+        """
+        # Get configuration from extra_config
+        extra_config = (
+            self.backend.config.extra_config
+            if self.backend.config.extra_config is not None
+            else {}
+        )
+        ping_timeout = extra_config.get(PING_TIMEOUT_CONFIG_KEY, DEFAULT_PING_TIMEOUT)
+        ping_interval = extra_config.get(
+            PING_INTERVAL_CONFIG_KEY, DEFAULT_PING_INTERVAL
+        )
+        logger.info(
+            f"Starting remote monitor thread {threading.current_thread().name} "
+            f"with interval {ping_interval}s and timeout {ping_timeout}s"
+        )
+        while True:
+            time.sleep(ping_interval)
+            # Check if original_connector is still uninitialized
+            if self.original_connector is None:
+                logger.warning(
+                    "original_connector is None, skipping ping. Re-init connection."
+                )
+                self.backend.init_connection()
+                self.original_connector = self.backend.connection
+                if self.original_connector is None:
+                    continue
+                if not self.original_connector.support_ping():
+                    logger.info(
+                        f"Connector {self.original_connector} "
+                        "does not support ping, break RemoteMonitor thread."
+                    )
+                    break
+
+            try:
+                start_time = time.perf_counter()
+                future = asyncio.run_coroutine_threadsafe(
+                    self.original_connector.ping(), self.backend.loop
+                )
+                error_code = future.result(timeout=ping_timeout)
+                latency = (time.perf_counter() - start_time) * 1000
+                # Record ping latency
+                self.backend.stats_monitor.update_remote_ping_latency(latency)
+                self.connection_healthy = error_code == 0
+                # Record error code (0 means success)
+                self.backend.stats_monitor.update_remote_ping_error_code(error_code)
+                if error_code != 0:
+                    logger.warning(f"Ping failed with error code: {error_code}")
+            except asyncio.TimeoutError:
+                self.connection_healthy = False
+                logger.warning("Ping timeout")
+                # Set timeout error code (-1)
+                self.backend.stats_monitor.update_remote_ping_error_code(
+                    PING_TIMEOUT_ERROR_CODE
+                )
+            except Exception as e:
+                self.connection_healthy = False
+                logger.error(f"Ping error: {e}")
+                # Set generic exception error code (-2)
+                self.backend.stats_monitor.update_remote_ping_error_code(
+                    PING_GENERIC_ERROR_CODE
+                )
+
+            # Update connector based on health status
+            if self.connection_healthy:
+                if self.backend.connection != self.original_connector:
+                    logger.info(
+                        "Connection restored, switching back to original connector"
+                    )
+                    self.backend.connection = self.original_connector
+            else:
+                if self.backend.connection != self.blackhole_connector:
+                    logger.warning(
+                        "Connection unhealthy, switching to blackhole connector"
+                    )
+                    self.backend.connection = self.blackhole_connector

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -19,7 +19,10 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.storage_backend.connector import BlackholeConnector
+from lmcache.v1.storage_backend.connector import (
+    BlackholeConnector,
+    InstrumentedRemoteConnector,
+)
 
 logger = init_logger(__name__)
 
@@ -42,14 +45,14 @@ class RemoteMonitor:
     def __init__(self, backend):
         self.backend = backend
 
-        # Initialize connection status
-        self.connection_healthy = True
+        # Lock for connector switching
+        self.connector_lock = threading.RLock()
 
         # Store the original connector
         self.original_connector = backend.connection
 
         # Create a blackhole connector for fallback
-        self.blackhole_connector = BlackholeConnector()
+        self.blackhole_connector = InstrumentedRemoteConnector(BlackholeConnector())
 
     def _should_skip_ping(self) -> bool:
         """
@@ -84,6 +87,12 @@ class RemoteMonitor:
         thread.start()
         return thread
 
+    def _safe_switch_connector(self, new_connector):
+        """Thread-safe connector switching"""
+        with self.connector_lock:
+            if self.backend.connection != new_connector:
+                self.backend.connection = new_connector
+
     def run_loop(self):
         """
         Run the monitor loop
@@ -102,23 +111,28 @@ class RemoteMonitor:
             f"Starting remote monitor thread {threading.current_thread().name} "
             f"with interval {ping_interval}s and timeout {ping_timeout}s"
         )
+
+        connection_healthy = True
         while True:
             time.sleep(ping_interval)
             # Check if original_connector is still uninitialized
             if self.original_connector is None:
-                logger.warning(
-                    "original_connector is None, skipping ping. Re-init connection."
-                )
-                self.backend.init_connection()
-                self.original_connector = self.backend.connection
-                if self.original_connector is None:
-                    continue
-                if not self.original_connector.support_ping():
-                    logger.info(
-                        f"Connector {self.original_connector} "
-                        "does not support ping, break RemoteMonitor thread."
-                    )
-                    break
+                # Double-checked locking for initialization
+                with self.connector_lock:
+                    if self.original_connector is None:
+                        logger.warning(
+                            "original_connector is None, re-initializing connection."
+                        )
+                        self.backend.init_connection()
+                        self.original_connector = self.backend.connection
+                        if self.original_connector is None:
+                            continue
+                        if not self.original_connector.support_ping():
+                            logger.info(
+                                f"Connector {self.original_connector} "
+                                "does not support ping, break RemoteMonitor thread."
+                            )
+                            break
 
             try:
                 start_time = time.perf_counter()
@@ -129,20 +143,20 @@ class RemoteMonitor:
                 latency = (time.perf_counter() - start_time) * 1000
                 # Record ping latency
                 self.backend.stats_monitor.update_remote_ping_latency(latency)
-                self.connection_healthy = error_code == 0
+                connection_healthy = error_code == 0
                 # Record error code (0 means success)
                 self.backend.stats_monitor.update_remote_ping_error_code(error_code)
                 if error_code != 0:
                     logger.warning(f"Ping failed with error code: {error_code}")
             except asyncio.TimeoutError:
-                self.connection_healthy = False
+                connection_healthy = False
                 logger.warning("Ping timeout")
                 # Set timeout error code (-1)
                 self.backend.stats_monitor.update_remote_ping_error_code(
                     PING_TIMEOUT_ERROR_CODE
                 )
             except Exception as e:
-                self.connection_healthy = False
+                connection_healthy = False
                 logger.error(f"Ping error: {e}")
                 # Set generic exception error code (-2)
                 self.backend.stats_monitor.update_remote_ping_error_code(
@@ -150,15 +164,7 @@ class RemoteMonitor:
                 )
 
             # Update connector based on health status
-            if self.connection_healthy:
-                if self.backend.connection != self.original_connector:
-                    logger.info(
-                        "Connection restored, switching back to original connector"
-                    )
-                    self.backend.connection = self.original_connector
+            if connection_healthy:
+                self._safe_switch_connector(self.original_connector)
             else:
-                if self.backend.connection != self.blackhole_connector:
-                    logger.warning(
-                        "Connection unhealthy, switching to blackhole connector"
-                    )
-                    self.backend.connection = self.blackhole_connector
+                self._safe_switch_connector(self.blackhole_connector)

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -43,7 +43,7 @@ class RemoteMonitor:
     Remote monitor class, encapsulating the monitor logic
     """
 
-    def __init__(self, backend: "RemoteBackend"):  # 修改为字符串类型提示
+    def __init__(self, backend: "RemoteBackend"):
         self.backend = backend
 
         # Lock for connector switching

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -19,10 +19,11 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.storage_backend.connector import (
-    BlackholeConnector,
+from lmcache.v1.storage_backend.connector.blackhole_connector import BlackholeConnector
+from lmcache.v1.storage_backend.connector.instrumented_connector import (
     InstrumentedRemoteConnector,
 )
+from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 
 logger = init_logger(__name__)
 
@@ -42,7 +43,7 @@ class RemoteMonitor:
     Remote monitor class, encapsulating the monitor logic
     """
 
-    def __init__(self, backend):
+    def __init__(self, backend: RemoteBackend):
         self.backend = backend
 
         # Lock for connector switching

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -43,7 +43,7 @@ class RemoteMonitor:
     Remote monitor class, encapsulating the monitor logic
     """
 
-    def __init__(self, backend: RemoteBackend):
+    def __init__(self, backend: "RemoteBackend"):  # 修改为字符串类型提示
         self.backend = backend
 
         # Lock for connector switching

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -64,7 +64,7 @@ class RemoteMonitor:
 
         if not self.original_connector.support_ping():
             logger.info(
-                f"Connector {type(self.original_connector).__name__} "
+                f"Connector {self.original_connector} "
                 f"does not support ping, skipping ping loop"
             )
             return True


### PR DESCRIPTION
# Motivation

This PR aimed to supply a way to support fallback ability while there are something wrong with remote connection or remote service.

Without this PR, if remote shutdown or network error, it would cause each request to remote fail and cost too much time for retry.


# Remote Monitor Feature Design

## Overview
The Remote Monitor is a health monitoring system for remote storage connections. It periodically checks connection status and automatically switches between operational and fallback modes based on ping results.

## Key Components

### 1. Monitor Thread
- Runs as a daemon thread (`_remote_monitor_loop`)
- Execution interval configurable via `ping_interval` (default: 30s)
- Performs non-blocking ping checks

### 2. Health Check Mechanism
```mermaid
sequenceDiagram
    participant MonitorThread
    participant RemoteConnector
    participant RemoteStorage
    
    MonitorThread->>RemoteConnector: ping()
    activate RemoteConnector
    RemoteConnector->>RemoteStorage: Ping Request
    activate RemoteStorage
    RemoteStorage-->>RemoteConnector: Response (error_code)
    deactivate RemoteStorage
    RemoteConnector-->>MonitorThread: Return error_code
    deactivate RemoteConnector
    Note right of MonitorThread: Update health status
```

### 3. Connection States
| State | Condition | Action |
|-------|-----------|--------|
| Healthy | error_code == 0 | Use original connector |
| Unhealthy | error_code != 0 | Switch to blackhole connector, Mark as unhealthy  |
| Timeout | No response in ping_timeout | Switch to blackhole connector, Mark as unhealthy  |

### 4. Failover Handling
```mermaid
flowchart TD
    A[Start Monitor] --> B{Sleep ping_interval}
    B --> E[Send Ping]
    E --> F{Response OK?}
    F -->|Yes| G[Use Original Connector]
    F -->|No| H[Use Blackhole Connector]
    G & H --> B
```

### 5. Metrics Collection
- Ping latency (ms)
- Error codes:
  - `0`: Success
  - `-1`: Timeout
  - `-2`: Generic error
  - `>0`: Remote-defined errors

### 6. Configuration Parameters
| Parameter | Default | Description |
|-----------|---------|-------------|
| `ping_interval` | 30.0 | Seconds between health checks |
| `ping_timeout` | 5.0 | Maximum wait time for ping response |

## Sequence of Operations
1. Initialize `RemoteBackend` with configuration
2. Start monitor thread if connector supports ping
3. Thread enters infinite loop:
   - Sleep for `ping_interval`
   - Execute asynchronous ping
   - Handle response/timeout/exception
   - Update connection status
   - Switch connectors if needed
4. Record metrics for observability

## Failure Modes
1. **Transient Failures**: Automatic recovery when connection restores
2. **Persistent Failures**: Continuous use of blackhole connector
3. **Remote Unavailability**: Timeout handling prevents system hangs

## Observability
- Latency histograms
- Error code counters
- Connection state transitions logged


# How to test

I tested this feature leveraged by introduced another light-weight test purpose external log connector, it will simulate unhealthy and healthy by a specified interval.

##  Start vllm + lmcache + external log connector
- lmcache.yaml
```yaml
chunk_size: 256
local_device: "cpu"
local_cpu: False
max_local_cpu_size: 5
remote_url: "external://host:0/external_log_connector.lmc_external_log_connector/?connector_name=ExternalLogConnector"
remote_serde: "naive"
pipelined_backend: False
extra_config:
  ext_log_connector_support_ping: True
  ext_log_connector_health_interval: 10.0
  ext_log_connector_stuck_time: 6.0
```
 
- install external log connector
```shell
pip install external_log_connector
```
Reference to https://github.com/opendataio/lmc_exernal_log_connector

- run vllm
```shell
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=1 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_parallel_size":2}'
```

- Tested by curl
```shell
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'
```

The following is the vllm log, we can found that the request handled by lmc_external_log_connector while healthy, but fallback to blackhole after turn to unhealthy by return value or ping timeout. Whatever, we can get a correct output by vllm even the tested remote backend unhealthy.
```
[2025-06-13 09:15:44,762] LMCache WARNING: [ExternalLogConnector] State changed: healthy (lmc_external_log_connector.py:113:external_log_connector.lmc_external_log_connector)
INFO 06-13 09:15:52 [chat_utils.py:420] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
INFO 06-13 09:15:52 [logger.py:43] Received request chatcmpl-759add15e5b34b68a38914be95691b6a: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.
INFO 06-13 09:15:52 [async_llm.py:271] Added request chatcmpl-759add15e5b34b68a38914be95691b6a.
[2025-06-13 09:15:52,978] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:15:52,978] LMCache INFO: Reqid: chatcmpl-759add15e5b34b68a38914be95691b6a, Total tokens 265, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:773:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:15:53,004] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:15:53,004] LMCache INFO: Storing KV cache for 265 out of 265 tokens (skip_leading_tokens=0) for request chatcmpl-759add15e5b34b68a38914be95691b6a (vllm_v1_adapter.py:716:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:15:53,004] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:15:53,005] LMCache INFO: [ExternalLogConnector] Storing key-value: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1'), memory_obj=<lmcache.v1.memory_management.TensorMemoryObj object at 0x7f30d93aad50> (lmc_external_log_connector.py:82:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:15:53,005] LMCache INFO: [InstrumentedRemoteConnector(<ExternalLogConnector>)]Bytes offloaded: 7.963 MBytes in 0.094ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:15:53,006] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9708277a7b6572932de251a248aeb8b24978af85e21d53ea1311faefd82de298') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:15:53,006] LMCache INFO: [ExternalLogConnector] Storing key-value: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9708277a7b6572932de251a248aeb8b24978af85e21d53ea1311faefd82de298'), memory_obj=<lmcache.v1.memory_management.TensorMemoryObj object at 0x7f334c14b770> (lmc_external_log_connector.py:82:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:15:53,006] LMCache INFO: [InstrumentedRemoteConnector(<ExternalLogConnector>)]Bytes offloaded: 0.280 MBytes in 0.055ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:15:53,067] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)
INFO:     127.0.0.1:36848 - "POST /v1/chat/completions HTTP/1.1" 200 OK



INFO 06-13 09:16:01 [loggers.py:118] Engine 000: Avg prompt throughput: 26.5 tokens/s, Avg generation throughput: 1.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
INFO 06-13 09:16:11 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
[2025-06-13 09:16:14,763] LMCache WARNING: [ExternalLogConnector] State changed: unhealthy (lmc_external_log_connector.py:113:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:14,763] LMCache WARNING: Ping failed with error code: 1000 (remote_monitor.py:150:lmcache.v1.storage_backend.remote_monitor)
INFO 06-13 09:16:22 [logger.py:43] Received request chatcmpl-bad53d31e5a448d8aeff98e43658e01b: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.
INFO 06-13 09:16:22 [async_llm.py:271] Added request chatcmpl-bad53d31e5a448d8aeff98e43658e01b.
[2025-06-13 09:16:22,235] LMCache INFO: Reqid: chatcmpl-bad53d31e5a448d8aeff98e43658e01b, Total tokens 265, LMCache hit tokens: 0, need to load: -256 (vllm_v1_adapter.py:773:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:16:22,250] LMCache INFO: Storing KV cache for 265 out of 265 tokens (skip_leading_tokens=0) for request chatcmpl-bad53d31e5a448d8aeff98e43658e01b (vllm_v1_adapter.py:716:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:16:22,251] LMCache INFO: [InstrumentedRemoteConnector(<BlackholeConnector>)]Bytes offloaded: 7.963 MBytes in 0.032ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:16:22,252] LMCache INFO: [InstrumentedRemoteConnector(<BlackholeConnector>)]Bytes offloaded: 0.280 MBytes in 0.016ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:16:22,305] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)
INFO:     127.0.0.1:50790 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO 06-13 09:16:31 [loggers.py:118] Engine 000: Avg prompt throughput: 26.5 tokens/s, Avg generation throughput: 1.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 48.3%




INFO 06-13 09:16:41 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 48.3%
[2025-06-13 09:16:44,763] LMCache WARNING: [ExternalLogConnector] State changed: healthy (lmc_external_log_connector.py:113:external_log_connector.lmc_external_log_connector)
INFO 06-13 09:16:51 [logger.py:43] Received request chatcmpl-35215e9211754b10918867a053ba1073: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.
INFO 06-13 09:16:51 [async_llm.py:271] Added request chatcmpl-35215e9211754b10918867a053ba1073.
[2025-06-13 09:16:51,821] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:51,821] LMCache INFO: Reqid: chatcmpl-35215e9211754b10918867a053ba1073, Total tokens 265, LMCache hit tokens: 0, need to load: -256 (vllm_v1_adapter.py:773:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:16:51,835] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:51,835] LMCache INFO: Storing KV cache for 265 out of 265 tokens (skip_leading_tokens=0) for request chatcmpl-35215e9211754b10918867a053ba1073 (vllm_v1_adapter.py:716:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:16:51,835] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:51,836] LMCache INFO: [ExternalLogConnector] Storing key-value: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1'), memory_obj=<lmcache.v1.memory_management.TensorMemoryObj object at 0x7f334421cd40> (lmc_external_log_connector.py:82:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:51,836] LMCache INFO: [InstrumentedRemoteConnector(<ExternalLogConnector>)]Bytes offloaded: 7.963 MBytes in 0.076ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:16:51,836] LMCache INFO: [ExternalLogConnector] Checking key existence: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9708277a7b6572932de251a248aeb8b24978af85e21d53ea1311faefd82de298') (lmc_external_log_connector.py:70:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:51,836] LMCache INFO: [ExternalLogConnector] Storing key-value: key=CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9708277a7b6572932de251a248aeb8b24978af85e21d53ea1311faefd82de298'), memory_obj=<lmcache.v1.memory_management.TensorMemoryObj object at 0x7f30d82cb860> (lmc_external_log_connector.py:82:external_log_connector.lmc_external_log_connector)
[2025-06-13 09:16:51,836] LMCache INFO: [InstrumentedRemoteConnector(<ExternalLogConnector>)]Bytes offloaded: 0.280 MBytes in 0.047ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:16:51,890] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)
INFO:     127.0.0.1:38312 - "POST /v1/chat/completions HTTP/1.1" 200 OK



INFO 06-13 09:17:01 [loggers.py:118] Engine 000: Avg prompt throughput: 26.5 tokens/s, Avg generation throughput: 1.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 64.4%
INFO 06-13 09:17:11 [loggers.py:118] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 64.4%
[2025-06-13 09:17:19,764] LMCache WARNING: Ping timeout (remote_monitor.py:153:lmcache.v1.storage_backend.remote_monitor)
[2025-06-13 09:17:20,770] LMCache WARNING: [ExternalLogConnector] State changed: stuck (lmc_external_log_connector.py:113:external_log_connector.lmc_external_log_connector)
INFO 06-13 09:17:23 [logger.py:43] Received request chatcmpl-a024f7f21fc94532be797faffa2e1b92: prompt: '<｜begin▁of▁sentence｜>User: Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?\n\nAssistant:', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: None, prompt_embeds shape: None, lora_request: None, prompt_adapter_request: None.
INFO 06-13 09:17:23 [async_llm.py:271] Added request chatcmpl-a024f7f21fc94532be797faffa2e1b92.
[2025-06-13 09:17:23,911] LMCache INFO: Reqid: chatcmpl-a024f7f21fc94532be797faffa2e1b92, Total tokens 265, LMCache hit tokens: 0, need to load: -256 (vllm_v1_adapter.py:773:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:17:23,924] LMCache INFO: Storing KV cache for 265 out of 265 tokens (skip_leading_tokens=0) for request chatcmpl-a024f7f21fc94532be797faffa2e1b92 (vllm_v1_adapter.py:716:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-13 09:17:23,925] LMCache INFO: [InstrumentedRemoteConnector(<BlackholeConnector>)]Bytes offloaded: 7.963 MBytes in 0.032ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
[2025-06-13 09:17:23,926] LMCache INFO: [InstrumentedRemoteConnector(<BlackholeConnector>)]Bytes offloaded: 0.280 MBytes in 0.015ms (instrumented_connector.py:52:lmcache.v1.storage_backend.connector.instrumented_connector)
```