### PR TITLE
[Bugfix] make cache clean works

### DIFF
--- a/lmcache/storage_backend/local_backend.py
+++ b/lmcache/storage_backend/local_backend.py
@@ -403,7 +403,7 @@ class LMCLocalDiskBackend(LMCBackendInterface):
         """
         Sweep the future pool to free up memory.
         """
-        while not self.stop_event:
+        while not self.stop_event.is_set():
             logger.debug("Sweeping memory buffer")
             self.update_lock.acquire()
             for key in list(self.future_pool.keys()):


### PR DESCRIPTION
LMCache the cache is not cleaned correctly.

In thread buffer_sweeper the clean cache's code does not run, stop_event should be stop_event.is_set().

Thanks.
