### PR TITLE
[#771]Support dynamic loading of external remote connector implementations

### DIFF
--- a/examples/kv_cache_reuse/remote_backends/README.md
+++ b/examples/kv_cache_reuse/remote_backends/README.md
@@ -5,3 +5,4 @@ We have examples for the following backends:
 
 - Infinistore: `infinistore/`
 - Mooncake: `mooncakestore/`
+- External: `external/`

--- a/examples/kv_cache_reuse/remote_backends/external/README.md
+++ b/examples/kv_cache_reuse/remote_backends/external/README.md
@@ -36,6 +36,6 @@ vllm serve /disc/f/models/opt-125m/ \
            --enforce-eager  \
            --port 8000 \
            --gpu-memory-utilization 0.8 \
-           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}' \
+           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both"}' \
            --trust-remote-code
 ```

--- a/examples/kv_cache_reuse/remote_backends/external/README.md
+++ b/examples/kv_cache_reuse/remote_backends/external/README.md
@@ -1,0 +1,41 @@
+# External Connector for LMCache
+
+LMCache supports custom external storage backends via Python modules. This connector type allows integrating any key-value store with LMCache.
+
+## Requirements
+
+1. Implement a connector class inheriting from `BaseConnector` (see `base_connector.py`)
+2. Place your module in Python import path
+
+## Configuration
+
+Specify module and class name by `remote_url` in `backend_type.yaml`, and the remote_url should contain
+- **Module Path**: Specify the Python module path (e.g., `adt`)
+- **Connector Name**: Provide the class name of the connector (e.g., `adt_kv_connector`)
+
+## Example YAML Configuration
+
+This example use adt-kv as an example which is an internal lmcache remote connector.
+
+```yaml
+remote_url: "external://host:0/adt.adt_kv_connector/?connector_name=AdtKVConnector"
+extra_config:
+  adt_kv_secret: "---"
+  adt_kv_connections: 4
+  adt_kv_workers: 32
+```
+
+## Start vLLM with the external adt-kv connector
+
+```shell
+VLLM_USE_V1=0 \
+LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
+LMCACHE_CONFIG_FILE=backend_type.yaml \
+vllm serve /disc/f/models/opt-125m/ \
+           --served-model-name "facebook/opt-125m" \
+           --enforce-eager  \
+           --port 8000 \
+           --gpu-memory-utilization 0.8 \
+           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}' \
+           --trust-remote-code
+```

--- a/examples/kv_cache_reuse/remote_backends/external/backend_type.yaml
+++ b/examples/kv_cache_reuse/remote_backends/external/backend_type.yaml
@@ -1,0 +1,11 @@
+chunk_size: 256
+local_device: "cpu"
+local_cpu: False
+max_local_cpu_size: 10
+remote_url: "external://host:0/adt.adt_kv_connector/?connector_name=AdtKVConnector"
+remote_serde: "naive"
+pipelined_backend: False
+extra_config:
+  adt_kv_secret: "---"
+  adt_kv_connections: 4
+  adt_kv_workers: 32

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -210,6 +210,49 @@ def CreateConnector(
             return AuditConnector(
                 real_connector=real_connector, verify_checksum=verify_checksum
             )
+        case "external":
+            if num_hosts != 1:
+                raise ValueError(
+                    f"External connector only supports a single host, "
+                    f"but got url: {url}"
+                )
+
+            # Get the module path and connector name
+            module_path = parsed_url.paths[0].rstrip("/")
+            connector_name = parsed_url.query_params[0].get("connector_name")
+            if not connector_name:
+                raise ValueError(
+                    "External connector requires 'connector_name' in query parameters"
+                )
+
+            # Lazily import the module and get the connector class
+            # Standard
+            import importlib
+
+            try:
+                module = importlib.import_module(module_path)
+                connector_class = getattr(module, connector_name)
+
+                # Verify that it's a subclass of RemoteConnector
+                if not issubclass(connector_class, RemoteConnector):
+                    raise TypeError(
+                        f"{connector_name} must be a subclass of RemoteConnector"
+                    )
+
+                # Create the connector instance
+                connector = connector_class(
+                    loop=loop, local_cpu_backend=local_cpu_backend, config=config
+                )
+                logger.info(
+                    f"Loaded external connector: {module_path}.{connector_name}"
+                )
+
+            except ImportError as e:
+                raise ImportError(f"Could not import module '{module_path}'") from e
+            except AttributeError as e:
+                raise AttributeError(
+                    f"Module '{module_path}' has no class '{connector_name}'"
+                ) from e
         case _:
             raise ValueError(f"Unknown connector type {connector_type} (url is: {url})")
 


### PR DESCRIPTION
#771 

# How to test - use our inner remote connector as an example

```yaml
chunk_size: 256
local_device: "cpu"
local_cpu: False
max_local_cpu_size: 10
remote_url: "external://host:0/adt.adt_kv_connector/?connector_name=AdtKVConnector"
remote_serde: "naive"
pipelined_backend: False
extra_config:
  adt_kv_secret: "---"
  adt_kv_connections: 4
  adt_kv_workers: 32
```

![image](https://github.com/user-attachments/assets/07fbb1cd-44ce-447b-8625-daf3fa259908)
