### PR TITLE
[CI/Build]: Fix Linux CUDA wheel builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,36 +77,9 @@ jobs:
                 NO_CUDA_EXT=1 python -m build --sdist
 
             - name: Build CUDA wheels with cibuildwheel
-              env:
-                # this builds 3.10, 3.11, 3.12, 3.13 right now
-                CIBW_BUILD: "cp3*-manylinux_x86_64"
-                CIBW_SKIP: "pp*"
-                # see https://developer.nvidia.com/cuda-gpus for compute capabilities
-                # "CUDA-Enabled Datacenter Products"
-                # 7.0: V100
-                # 7.5: T4
-                # 8.0: A100, A30
-                # 8.6: A40, A10, A16, A2
-                # 8.9: L4, L40, L40S
-                # 9.0: H100
-                # CIBW_ENVIRONMENT: "TORCH_CUDA_ARCH_LIST='7.0;7.5;8.0;8.6;8.9;9.0'"
-                CIBW_ENVIRONMENT: "TORCH_CUDA_ARCH_LIST='9.0'"
-                CIBW_MANYLINUX_X86_64_IMAGE: "docker.io/pytorch/manylinux2_28-builder:cuda12.8"
-                CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-                    auditwheel repair
-                    --plat manylinux_2_28_x86_64
-                    --exclude libtorch.so
-                    --exclude libtorch_cuda.so
-                    --exclude libtorch_python.so
-                    --exclude libtorch_cpu.so
-                    --exclude libc10.so
-                    --exclude libc10_cuda.so
-                    --exclude libcudart.so.12
-                    -w {dest_dir} {wheel}
-              # continue even if cibuildwheel fails since the wheels are probably
-              # built even if some error messages show up
+              # Configuration is set in pyproject.toml
               run: |
-                python -m cibuildwheel --output-dir dist || true
+                python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,17 +89,19 @@ jobs:
                 # 8.6: A40, A10, A16, A2
                 # 8.9: L4, L40, L40S
                 # 9.0: H100
-                CIBW_ENVIRONMENT: "TORCH_CUDA_ARCH_LIST='7.0;7.5;8.0;8.6;8.9;9.0'"
-                CIBW_MANYLINUX_X86_64_IMAGE: "docker.io/apostab/manylinux-cuda124"
+                # CIBW_ENVIRONMENT: "TORCH_CUDA_ARCH_LIST='7.0;7.5;8.0;8.6;8.9;9.0'"
+                CIBW_ENVIRONMENT: "TORCH_CUDA_ARCH_LIST='9.0'"
+                CIBW_MANYLINUX_X86_64_IMAGE: "docker.io/pytorch/manylinux2_28-builder:cuda12.8"
                 CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
                     auditwheel repair
-                    --plat manylinux_2_17_x86_64
+                    --plat manylinux_2_28_x86_64
                     --exclude libtorch.so
                     --exclude libtorch_cuda.so
                     --exclude libtorch_python.so
                     --exclude libtorch_cpu.so
                     --exclude libc10.so
                     --exclude libc10_cuda.so
+                    --exclude libcudart.so.12
                     -w {dest_dir} {wheel}
               # continue even if cibuildwheel fails since the wheels are probably
               # built even if some error messages show up

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,16 +41,10 @@ jobs:
               with:
                 egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-            - name: Remove toolcache to free space
+            - name: Print disk space before cleanup
               run: |
-                sudo rm -rf /opt/hostedtoolcache || true
                 df -h
-
-            - name: Remove other cruft to free space
-              run: |
-                docker system prune -af || true
-                sudo rm -rf ~/.cache || true
-                df -h
+              shell: bash
 
             - name: Free Disk Space Linux
               if: runner.os == 'Linux'
@@ -65,6 +59,11 @@ jobs:
                 sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
                 sudo apt-get autoremove -y >/dev/null 2>&1
                 sudo apt-get autoclean -y >/dev/null 2>&1
+              shell: bash
+
+            - name: Print disk space after cleanup
+              run: |
+                df -h
               shell: bash
 
             - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,21 @@ jobs:
                 sudo rm -rf ~/.cache || true
                 df -h
 
+            - name: Free Disk Space Linux
+              if: runner.os == 'Linux'
+              run: |
+                sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+                sudo rm -rf \
+                  /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                  /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+                  /usr/lib/jvm || true
+                sudo apt install aptitude -y >/dev/null 2>&1
+                sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+                sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+                sudo apt-get autoremove -y >/dev/null 2>&1
+                sudo apt-get autoclean -y >/dev/null 2>&1
+              shell: bash
+
             - name: Checkout code
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,12 @@ warn_return_any = false
 
 follow_imports = "silent"
 
-# use a custom manylinux image for cibuildwheel that contains CUDA 12.4
+# use a custom manylinux image for cibuildwheel that contains CUDA 12.8
 [tool.cibuildwheel]
-manylinux-x86_64-image = "docker.io/apostab/manylinux-cuda124"
+manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda12.8"
 repair-wheel-command = """
 auditwheel repair \
-  --plat manylinux_2_17_x86_64 \
+  --plat manylinux_2_28_x86_64 \
   --exclude libtorch.so \
   --exclude libtorch_cuda.so \
   --exclude libtorch_python.so \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,25 @@ warn_return_any = false
 
 follow_imports = "silent"
 
-# use a custom manylinux image for cibuildwheel that contains CUDA 12.8
 [tool.cibuildwheel]
+build = "cp3*-manylinux_x86_64"
+skip = "pp*"
+
+# see https://developer.nvidia.com/cuda-gpus for compute capabilities
+# "CUDA-Enabled Datacenter Products"
+# 7.0: V100
+# 7.5: T4
+# 8.0: A100, A30
+# 8.6: A40, A10, A16, A2
+# 8.9: L4, L40, L40S
+# 9.0: H100
+environment = {TORCH_CUDA_ARCH_LIST = "7.0;7.5;8.0;8.6;8.9;9.0"}
+
+# Use the PyTorch manylinux image version '2_28' that contains CUDA 12.8
+# and torch 2.7 supports (https://pypi.org/project/torch/2.7.0/#files)
 manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda12.8"
+
+[tool.cibuildwheel.linux]
 repair-wheel-command = """
 auditwheel repair \
   --plat manylinux_2_28_x86_64 \
@@ -137,5 +153,6 @@ auditwheel repair \
   --exclude libtorch_cpu.so \
   --exclude libc10.so \
   --exclude libc10_cuda.so \
+  --exclude libcudart.so.12 \
   -w {dest_dir} {wheel}
 """


### PR DESCRIPTION
Build is broken because torch 2.7 is not supported by CUDA 12.4 and torch 2.7 does not have distributions for manylinux_2_17_x86_64. See [torch 2.7 supports](https://pypi.org/project/torch/2.7.0/#files).

This PR updates the manylinux cuda image used by [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) to manylinux_2_28_x86_64 which is supported by torch 2.7 and uses the [PyTorch manylinux 2_28 cuda 12.8 container image](https://hub.docker.com/r/pytorch/manylinux2_28-builder/tags) instead of the custom build image.

Fixes #782 

