### PR TITLE
[optimize] simplify the implementation of MLA

### DIFF
--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -61,67 +61,13 @@ def test_vllm_nested_gpu_connector():
     check_kv_cache_equal(gpu_kv_src, gpu_kv_dst, 512, "vllm")
 
 
-def test_vllm_paged_connector_v2():
-    num_blocks = 100
-    block_size = 16
-    num_layers = 32
-    num_heads = 8
-    head_size = 128
-    device = "cuda"
-    hidden_dim = num_heads * head_size
-
-    num_tokens = 800
-    chunk_size = 256
-
-    allocator = PinMemoryAllocator(1024 * 1024 * 1024)
-
-    gpu_kv_src = generate_kv_cache_paged_list_tensors(num_blocks, device, block_size)
-    gpu_kv_dst = generate_kv_cache_paged_list_tensors(num_blocks, device, block_size)
-
-    slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
-    slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
-
-    # Check the gpu_kv is not the same before copying
-    with pytest.raises(AssertionError):
-        check_kv_cache_equal(gpu_kv_src, gpu_kv_dst, num_tokens, "vllm")
-
-    connector = VLLMPagedMemGPUConnectorV2(hidden_dim, num_layers)
-    connector2 = VLLMPagedMemGPUConnectorV2(hidden_dim, num_layers)
-    for start in range(0, num_tokens, chunk_size):
-        end = min(start + chunk_size, num_tokens)
-        shape = connector.get_shape(end - start)
-        memory_obj = allocator.allocate(shape, gpu_kv_src[0][0].dtype)
-        connector.from_gpu(
-            memory_obj,
-            start,
-            end,
-            kvcaches=gpu_kv_src,
-            slot_mapping=slot_mapping,
-            offset=0,
-        )
-        assert memory_obj.metadata.fmt == MemoryFormat.KV_2LTD
-        connector2.to_gpu(
-            memory_obj,
-            start,
-            end,
-            kvcaches=gpu_kv_dst,
-            slot_mapping=slot_mapping,
-            offset=0,
-        )
-        allocator.free(memory_obj)
-        assert allocator.memcheck()
-
-    check_paged_kv_cache_equal(
-        gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
-    )
-
-
 @pytest.mark.parametrize("use_gpu", [True, False])
-def test_vllm_paged_connector_v2_with_gpu(use_gpu):
+@pytest.mark.parametrize("use_mla", [True, False])
+def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
     num_blocks = 100
     block_size = 16
     num_layers = 32
-    num_heads = 8
+    num_heads = 1 if use_mla else 8
     head_size = 128
     device = "cuda"
     hidden_dim = num_heads * head_size
@@ -131,8 +77,12 @@ def test_vllm_paged_connector_v2_with_gpu(use_gpu):
 
     allocator = PinMemoryAllocator(1024 * 1024 * 1024)
 
-    gpu_kv_src = generate_kv_cache_paged_list_tensors(num_blocks, device, block_size)
-    gpu_kv_dst = generate_kv_cache_paged_list_tensors(num_blocks, device, block_size)
+    gpu_kv_src = generate_kv_cache_paged_list_tensors(
+        num_blocks=num_blocks, device=device, block_size=block_size, use_mla=use_mla
+    )
+    gpu_kv_dst = generate_kv_cache_paged_list_tensors(
+        num_blocks=num_blocks, device=device, block_size=block_size, use_mla=use_mla
+    )
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
@@ -148,6 +98,7 @@ def test_vllm_paged_connector_v2_with_gpu(use_gpu):
         chunk_size=chunk_size,
         dtype=gpu_kv_src[0].dtype,
         device=device,
+        use_mla=use_mla,
     )
     connector2 = VLLMPagedMemGPUConnectorV2(
         hidden_dim,
@@ -156,7 +107,10 @@ def test_vllm_paged_connector_v2_with_gpu(use_gpu):
         chunk_size=chunk_size,
         dtype=gpu_kv_src[0].dtype,
         device=device,
+        use_mla=use_mla,
     )
+    assert connector.use_mla == use_mla
+    assert connector2.use_mla == use_mla
     for start in range(0, num_tokens, chunk_size):
         end = min(start + chunk_size, num_tokens)
         shape = connector.get_shape(end - start)
@@ -169,7 +123,10 @@ def test_vllm_paged_connector_v2_with_gpu(use_gpu):
             slot_mapping=slot_mapping,
             offset=0,
         )
-        assert memory_obj.metadata.fmt == MemoryFormat.KV_2LTD
+        if use_mla:
+            assert memory_obj.metadata.fmt == MemoryFormat.KV_MLA_FMT
+        else:
+            assert memory_obj.metadata.fmt == MemoryFormat.KV_2LTD
         connector2.to_gpu(
             memory_obj,
             start,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -5,6 +5,7 @@ import random
 from utils import (
     check_kv_cache_equal,
     check_paged_kv_cache_equal,
+    check_paged_kv_cache_equal_with_mla,
     generate_kv_cache,
     generate_kv_cache_paged_list_tensors,
 )
@@ -89,7 +90,14 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
 
     # Check the gpu_kv is not the same before copying
     with pytest.raises(AssertionError):
-        check_kv_cache_equal(gpu_kv_src, gpu_kv_dst, num_tokens, "vllm")
+        if use_mla:
+            check_paged_kv_cache_equal_with_mla(
+                gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, head_size
+            )
+        else:
+            check_paged_kv_cache_equal(
+                gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
+            )
 
     connector = VLLMPagedMemGPUConnectorV2(
         hidden_dim,
@@ -138,9 +146,14 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
         allocator.free(memory_obj)
         assert allocator.memcheck()
 
-    check_paged_kv_cache_equal(
-        gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
-    )
+    if use_mla:
+        check_paged_kv_cache_equal_with_mla(
+            gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, head_size
+        )
+    else:
+        check_paged_kv_cache_equal(
+            gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
+        )
 
 
 @pytest.mark.parametrize("use_gpu", [True])
@@ -167,7 +180,9 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu):
 
     # Check the gpu_kv is not the same before copying
     with pytest.raises(AssertionError):
-        check_kv_cache_equal(gpu_kv_src, gpu_kv_dst, num_tokens, "vllm")
+        check_paged_kv_cache_equal(
+            gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
+        )
 
     connector = VLLMPagedMemLayerwiseGPUConnector(
         hidden_dim,
@@ -425,7 +440,9 @@ def test_layerwise_vllm_buffer_connector_with_gpu(use_gpu):
 
     # Check the gpu_kv is not the same before copying
     with pytest.raises(AssertionError):
-        check_kv_cache_equal(gpu_kv_src, gpu_kv_dst, num_tokens, "vllm")
+        check_paged_kv_cache_equal(
+            gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
+        )
 
     connector = VLLMBufferLayerwiseGPUConnector(
         hidden_dim,

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -229,6 +229,26 @@ def check_paged_kv_cache_equal(
         assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
 
 
+def check_paged_kv_cache_equal_with_mla(
+    left, right, num_tokens, slot_mapping, head_size=128
+):
+    """
+    check whether two paged kv caches are the same at slot_mapping when use mla
+    """
+    token_dim = 0
+    for left_kv, right_kv in zip(left, right, strict=False):
+        new_left_kv = left_kv.reshape(-1, head_size)
+        new_right_kv = right_kv.reshape(-1, head_size)
+
+        assert len(new_left_kv.shape) == 2
+        assert len(new_right_kv.shape) == 2
+
+        assert new_left_kv.shape[token_dim] >= num_tokens
+        assert new_right_kv.shape[token_dim] >= num_tokens
+
+        assert (new_left_kv[slot_mapping, :] == new_right_kv[slot_mapping, :]).all()
+
+
 def check_kv_cache_device(kvs, device):
     for kv in kvs:
         k, v = kv

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -91,7 +91,7 @@ def generate_kv_cache_paged(
 
 
 def generate_kv_cache_paged_list_tensors(
-    num_blocks, device, block_size=16, dtype=torch.bfloat16
+    num_blocks, device, block_size=16, dtype=torch.bfloat16, use_mla=False
 ):
     """
     Instead of Tuple[Tuple[Tensor, Tensor]], return List[Tensor]
@@ -99,9 +99,13 @@ def generate_kv_cache_paged_list_tensors(
     """
     ret = []
     num_layers = 32
-    num_heads = 8
+    num_heads = 1 if use_mla else 8
     head_size = 128
-    shape = [2, num_blocks, block_size, num_heads, head_size]
+    shape = (
+        [num_blocks, block_size, head_size]
+        if use_mla
+        else [2, num_blocks, block_size, num_heads, head_size]
+    )
 
     for i in range(num_layers):
         kv = torch.rand(shape, dtype=dtype, device=device)


### PR DESCRIPTION
# INTRODUCE
Thiis PR simplify the Implementation of MLA.

The old implementation is basically similar to `VLLMPagedMemGPUConnectorV2`, only with some differences in parameters. In addition, some optimized PRs, such as https://github.com/LMCache/LMCache/pull/678, https://github.com/LMCache/LMCache/pull/522, only modified `VLLMPagedMemGPUConnectorV2` without modifying `VLLMPagedMemGPUConnectorMLA`.

Therefore, I simplified the implementation of mla through this PR and enabled mla in `VLLMPagedMemGPUConnectorV2` through parameter control.

# TODO
After this pr, `VLLMPagedMemGPUConnectorV2` has supported MLA, while the other gpu connectors still need to support mla.

The support status of MLA is as follows:
- [x] `VLLMPagedMemGPUConnectorV2` 
- [ ] `VLLMPagedMemLayerwiseGPUConnector`
- [ ] `VLLMBufferLayerwiseGPUConnector`
