### PR TITLE
[CI/Build]: Build container image when a new release is published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -232,7 +232,7 @@ jobs:
 
             - name: Get the latest tag (corresponds to release cut in publish-pypi job)
               run: |
-                echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+                echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
 
             - name: Build lmcache/vllm-openai container image with latest releases
               run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,3 +173,84 @@ jobs:
               uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
               with:
                 verbose: true
+
+    # Build container image and push to DockerHub when:
+    # - a new GitHub release is created
+    publish-image:
+        name: Publish image to DockerHub
+        # Uncomment once prove job is working
+        # if: |
+        #     github.repository_owner == 'LMCache' && github.event.action == 'published'
+        # Remove once ready to merge .. only runs when release cut
+
+        runs-on: ubuntu-latest
+        # Uncomment once prove job is working
+        # needs: publish-pypi
+        # Remove once ready to merge .. only runs when release cut
+        needs: build-artifacts
+
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+              with:
+                egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+            - name: Print disk space before cleanup
+              run: |
+                df -h
+              shell: bash
+
+            - name: Free Disk Space Linux
+              if: runner.os == 'Linux'
+              run: |
+                sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+                sudo rm -rf \
+                  /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                  /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+                  /usr/lib/jvm || true
+                sudo apt install aptitude -y >/dev/null 2>&1
+                sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+                sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+                sudo apt-get autoremove -y >/dev/null 2>&1
+                sudo apt-get autoclean -y >/dev/null 2>&1
+              shell: bash
+
+            - name: Print disk space after cleanup
+              run: |
+                df -h
+              shell: bash
+
+            - name: Login to DockerHub
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              with:
+                username: ${{ vars.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+            - name: Checkout code
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                # for setuptools-scm
+                fetch-depth: 0
+
+            - name: Get the latest tag (corresponds to release cut in publish-pypi job)
+              run: |
+                echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+            - name: Build lmcache/vllm-openai container image with latest releases
+              run: |
+                docker build \
+                --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+                --target image-release \
+                --tag lmcache/vllm-openai:latest --tag lmcache/vllm-openai:${{ env.LATEST_TAG }} \
+                --file docker/Dockerfile .
+
+            - name: Push lmcache/vllm-openai container image to DockerHub
+              # Uncomment and use when ready to merge as its overrides the latest tag
+              # run: |
+              #   docker push lmcache/vllm-openai:latest
+              #   docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}
+              run: |
+                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,16 +178,11 @@ jobs:
     # - a new GitHub release is created
     publish-image:
         name: Publish image to DockerHub
-        # Uncomment once prove job is working
-        # if: |
-        #     github.repository_owner == 'LMCache' && github.event.action == 'published'
-        # Remove once ready to merge .. only runs when release cut
+        if: |
+            github.repository_owner == 'LMCache' && github.event.action == 'published'
 
         runs-on: ubuntu-latest
-        # Uncomment once prove job is working
-        # needs: publish-pypi
-        # Remove once ready to merge .. only runs when release cut
-        needs: build-artifacts
+        needs: publish-pypi
 
         steps:
             - name: "Harden Runner"
@@ -248,9 +243,6 @@ jobs:
                 --file docker/Dockerfile .
 
             - name: Push lmcache/vllm-openai container image to DockerHub
-              # Uncomment and use when ready to merge as its overrides the latest tag
-              # run: |
-              #   docker push lmcache/vllm-openai:latest
-              #   docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}
               run: |
+                docker push lmcache/vllm-openai:latest
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}

--- a/docker/example_build.sh
+++ b/docker/example_build.sh
@@ -1,12 +1,16 @@
-# Example script to build the LMCache container image
+# Example script to build the LMCache integrated with vLLM container image
 
 # Update the following variables accordingly
 CUDA_VERSION=12.8
 DOCKERFILE_NAME='Dockerfile'
 DOCKER_BUILD_PATH='../' # This path should point to the LMCache root for access to 'requirements' directory
 UBUNTU_VERSION=24.04
-BUILD_TARGET=image-build # change to 'image-release' for using release package versions of vLLM and LMCache
-IMAGE_TAG='lmcache/vllm-openai:build-latest'
+
+# `image-build` target will use the latest LMCache and vLLM code
+# Change to 'image-release' target for using release package versions of vLLM and LMCache
+BUILD_TARGET=image-build 
+
+IMAGE_TAG='lmcache/vllm-openai:build-latest' # Name of container image to build
 
 docker build \
     --build-arg CUDA_VERSION=$CUDA_VERSION \

--- a/docs/source/developer_guide/docker_file.rst
+++ b/docs/source/developer_guide/docker_file.rst
@@ -1,45 +1,23 @@
 Dockerfile
 ==========
 
-We provide a Dockerfile to help you build a Docker image for LMCache. More information about deploying LMCache with Docker can be 
-found here - :ref:`Docker deployment guide <docker_deployment>`.
+We provide a Dockerfile to help you build a container image for LMCache integrated with vLLM.
+More information about deploying LMCache image using Docker can be found here - :ref:`Docker deployment guide <docker_deployment>`.
 
-Example run command
--------------------
+Building the container image
+----------------------------
 
-.. code-block:: bash
+You can build the LMCache (integrated with vLLM) image using Docker from source via the provided Dockerfile.
+The Dockerfile is located at `docker <https://github.com/LMCache/LMCache/tree/dev/docker>`_.
 
-    IMAGE=<IMAGE_NAME>:<TAG>
-    docker run --runtime nvidia --gpus all \
-        --env "HF_TOKEN=<YOUR_HUGGINGFACE_TOKEN>" \
-        --env "LMCACHE_USE_EXPERIMENTAL=True" \
-        --env "LMCACHE_CHUNK_SIZE=256" \
-        --env "LMCACHE_LOCAL_CPU=True" \
-        --env "LMCACHE_MAX_LOCAL_CPU_SIZE=5" \
-        -v ~/.cache/huggingface:/root/.cache/huggingface \
-        --network host \
-        --entrypoint "/usr/local/bin/vllm" \
-        $IMAGE \
-        serve mistralai/Mistral-7B-Instruct-v0.2 --kv-transfer-config \
-        '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
-
-
-The Image Name and Tag can be found on Docker Hub - `LMCache <https://hub.docker.com/r/lmcache/vllm-openai>`_.
-
-Building the Docker image
--------------------------
-
-You can build and run LMCache with Docker from source via the provided Dockerfile.
-The Dockerfile is located in at `Dockerfile <https://github.com/LMCache/LMCache/tree/dev/docker>`_.
-
-To build the Docker image, run the following command from the root directory of the LMCache repository:
+To build the container image, run the following command from the root directory of the LMCache repository:
 
 .. code-block:: bash
 
-    docker build -t <IMAGE_NAME>:<TAG> -f docker/Dockerfile .
+    docker build --tag <IMAGE_NAME>:<TAG> --target image-build --file docker/Dockerfile .
 
-Replace `<IMAGE_NAME>` and `<TAG>` with your desired image name and tag.
-
+Replace `<IMAGE_NAME>` and `<TAG>` with your desired image name and tag. See example build file in `docker <https://github.com/LMCache/LMCache/tree/dev/docker>`_
+for explanation of all arguments.
 
 
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -3,14 +3,14 @@
 Installation
 ============
 
-Prerequisites
--------------
-
-- Python 3.10+
-- CUDA 12.4+
-
 Setup using Python
 ------------------
+
+Prerequisites
+~~~~~~~~~~~~~
+
+- Python 3.10+
+- CUDA 12.8+
 
 Install Stable LMCache from PyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,14 +95,24 @@ LMCache with vLLM v0
 Setup using Docker
 ------------------
 
-Pre-built vLLM + LMCache Images
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prerequisites
+~~~~~~~~~~~~~
 
-We provide pre-built Docker images that include vLLM integration:
+- Docker Engine 27.0+
+
+Pre-built LMCache integrated with vLLM Images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We provide pre-built container images of LMCache integrated with vLLM.
+
+You can get the latest stable image as follows:
 
 .. code-block:: bash
 
     docker pull lmcache/vllm-openai
 
-.. note::
-    Currently, we build and release Docker images manually. An automated Docker build/release GitHub workflow will be set up soon. Contributions to this effort are welcomed!
+You can get the nightly build of latest code of LMcache and vLLM as follows:
+
+.. code-block:: bash
+
+    docker pull lmcache/vllm-openai:latest-nightly

--- a/docs/source/production/docker_deployment.rst
+++ b/docs/source/production/docker_deployment.rst
@@ -3,4 +3,30 @@
 Docker deployment
 =================
 
-Coming soon... 
+Running the container image
+---------------------------
+
+You can run the LMCache integrated with vLLM image using Docker as follows:
+
+.. code-block:: bash
+
+    IMAGE=<IMAGE_NAME>:<TAG>
+    docker run --runtime nvidia --gpus all \
+        --env "HF_TOKEN=<REPLACE_WITH_YOUR_HF_TOKEN>" \
+        --env "LMCACHE_CHUNK_SIZE=256" \
+        --env "LMCACHE_LOCAL_CPU=True" \
+        --env "LMCACHE_MAX_LOCAL_CPU_SIZE=5" \
+        --volume ~/.cache/huggingface:/root/.cache/huggingface \
+        --network host \
+        $IMAGE \
+        meta-llama/Llama-3.1-8B-Instruct --kv-transfer-config \
+        '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+
+
+The image name and tag can be found on DockerHub - `LMCache/vllm-openai <https://hub.docker.com/r/lmcache/vllm-openai>`_.
+See example run file in `docker <https://github.com/LMCache/LMCache/tree/dev/docker>`_ for more details.
+
+.. note::
+    DockerHub contains the following image types:
+    - Nightly build images of LMCache and vLLM latest code
+    - Images of stable releases of LMCache and vLLM


### PR DESCRIPTION
Adds job to publish workflow to build container image when a new release is published. It also sets the `latest` tag to the image.

At the moment, this is being done manually. It will be more consistent and efficient to add it as a job to the publish workflow after package is published to PyPi.

Summary of the container image ([LMCache integrated with vLLM](https://hub.docker.com/r/lmcache/vllm-openai)) build workflow:

- Scheduled nightly build which pushes two tags 1. nightly-{date} and 2. `latest-nightly`
- Automated build when release is cut with two tags 1. Release tag (e.g. `v0.x.y`) and 2. `latest`

~TODO: Update the documentation on container image.~ Updated.

Fixes #686 
Partial: #594

~**Note to reviewers:** Update `publish.yml` to only run image publish when release is cut, when happy with workflow and ready for merging.~ Pushed [commit](https://github.com/LMCache/LMCache/pull/784/commits/a5467f8302c37d7370ab626d179fc923acf782d7) to remove the events for testing. Ready to merge.