### PR TITLE
feat: enhance controller manager to support JSON messages from Mooncake

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -103,7 +103,7 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.device_name = dev_name
             logger.info("Mooncake Configuration loaded. config: %s", self.config)
 
-            self.store.setup(
+            self.store.setup_lmcache(
                 self.config.local_hostname,
                 self.config.metadata_server,
                 self.config.global_segment_size,
@@ -111,6 +111,8 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.protocol,
                 self.config.device_name,
                 self.config.master_server_address,
+                local_cpu_backend.instance_id,
+                str(local_cpu_backend.lmcache_worker.worker_id),
             )
 
         except ValueError as e:


### PR DESCRIPTION
## Summary

This PR enhances the LMCache controller manager to support JSON message format from external systems like Mooncake, while maintaining backward compatibility with existing MessagePack format.


## Integration with Mooncake

This change enables seamless integration with Mooncake events. The controller can now receive and process JSON messages from Mooncake in the following format:

```json
{
  "type": "KVAdmitMsg",
  "instance_id": "lmcache_default_instance",
  "worker_id": 0,
  "key": "vllm@/models/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B@2@0@894ba81fc60e15b15eca144d861408be6851437abc9101c3f4561af8df05c642",
  "location": "mooncake_cpu_ram"
}
```

## Example Log Output

With this enhancement, you'll see logs like:

```
[2025-06-09 14:28:51,858] LMCache INFO: Received msg type: <class 'lmcache.v1.cache_controller.message.KVAdmitMsg'> (controller_manager.py:155:lmcache.v1.cache_controller.controller_manager)
[2025-06-09 14:28:51,868] LMCache INFO: Received message, content is b'{"type":"KVAdmitMsg","instance_id":"lmcache_default_instance","worker_id":0,"key":"vllm@/models/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B@2@0@894ba81fc60e15b15eca144d861408be6851437abc9101c3f4561af8df05c642","location":"mooncake_cpu_ram"}' (controller_manager.py:146:lmcache.v1.cache_controller.controller_manager)
```