### PR TITLE
Reduce space cost to 1/TP while using MLA

### DIFF
--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -58,6 +58,7 @@ class RemoteBackend(StorageBackendInterface):
 
         self.loop = loop
         self.config = config
+        self.metadata = metadata
 
         # Re-establish connection only when the connection
         # has been lost for 10 secs
@@ -71,7 +72,19 @@ class RemoteBackend(StorageBackendInterface):
             config.remote_serde, metadata, config
         )
 
-        logger.info(f"Connected to remote storage at {config.remote_url}")
+        # Precompute MLA mode status
+        self._mla_worker_id_as0_mode = (
+            config.extra_config is not None
+            and config.extra_config.get("remote_enable_mla_worker_id_as0", False)
+            and metadata.use_mla
+            and metadata.world_size > 1
+            and metadata.worker_id != 0
+        )
+
+        logger.info(
+            f"Connected to remote storage at {config.remote_url}, "
+            f"remote mla worker id as 0 mode: {self._mla_worker_id_as0_mode}"
+        )
 
         # TODO(Jiayi): If we want to have cache admission policies,
         # we must make decision (whether to send or not) at the local side
@@ -126,6 +139,12 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning("Connection is None in contains, returning False")
             return False
 
+        # For MLA worker id as 0 mode, use worker_id 0
+        if self._mla_worker_id_as0_mode:
+            key = CacheEngineKey(
+                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash
+            )
+
         future = asyncio.run_coroutine_threadsafe(
             self.connection.exists(key), self.loop
         )
@@ -159,6 +178,10 @@ class RemoteBackend(StorageBackendInterface):
     ) -> Optional[Future]:
         if self.connection is None:
             logger.warning("Connection is None in submit_put_task, returning None")
+            return None
+
+        # If MLA worker id as 0 mode is enabled, skip put tasks
+        if self._mla_worker_id_as0_mode:
             return None
 
         memory_obj.ref_count_up()
@@ -197,6 +220,11 @@ class RemoteBackend(StorageBackendInterface):
         if self.connection is None:
             logger.warning("Connection is None in get_blocking, returning None")
             return None
+        # For MLA worker id as 0 mode, use worker_id 0
+        if self._mla_worker_id_as0_mode:
+            key = CacheEngineKey(
+                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash
+            )
         t1 = time.perf_counter()
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -80,10 +80,10 @@ class RemoteBackend(StorageBackendInterface):
             and metadata.world_size > 1
             and metadata.worker_id != 0
         )
-
+        logger.info(f"metadata={metadata}")
         logger.info(
             f"Connected to remote storage at {config.remote_url}, "
-            f"remote mla worker id as 0 mode: {self._mla_worker_id_as0_mode}"
+            f"remote_mla_worker_id_as_0 mode: {self._mla_worker_id_as0_mode}"
         )
 
         # TODO(Jiayi): If we want to have cache admission policies,

--- a/tests/v1/test_remote_backend_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_backend_mla_worker_id_as0.py
@@ -1,0 +1,168 @@
+# Standard
+from typing import List
+
+# Add import for mock
+from unittest import mock
+import asyncio
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.storage_backend.connector import RemoteConnector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+
+
+class MockConnector(RemoteConnector):
+    def __init__(self):
+        self.storage = {}
+
+    async def exists(self, key):
+        return key in self.storage
+
+    async def put(self, key, value):
+        self.storage[key] = value
+
+    async def get(self, key):
+        return self.storage.get(key)
+
+    async def close(self):
+        pass
+
+    async def list(self) -> List[str]:
+        return []
+
+
+# Mock the entire torch.cuda.Stream class
+@mock.patch("torch.cuda.Stream")
+def test_remote_backend_methods(mock_stream):
+    # Create configuration
+    config = LMCacheEngineConfig(
+        chunk_size=256,
+        local_cpu=True,
+        max_local_cpu_size=5.0,
+        local_disk=None,
+        max_local_disk_size=0.0,
+        remote_url="lm://localhost:65432",
+        remote_serde="naive",
+        use_layerwise=False,
+        save_decode_cache=False,
+        enable_blending=False,
+        blend_recompute_ratio=0.15,
+        blend_min_tokens=256,
+        extra_config={"remote_enable_mla_worker_id_as0": True},
+    )
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-model",
+        fmt="vllm",
+        kv_dtype=torch.float16,
+        kv_shape=(2, 32, 1000, 1024, 1),
+        use_mla=True,
+        world_size=4,
+        worker_id=2,
+    )
+    metadata0 = LMCacheEngineMetadata(
+        model_name="test-model",
+        fmt="vllm",
+        kv_dtype=torch.float16,
+        kv_shape=(1, 32, 1, 1024, 1),
+        use_mla=True,
+        world_size=4,
+        worker_id=0,
+    )
+
+    # Create memory allocator and local backend
+    # First Party
+    from lmcache.v1.memory_management import AdHocMemoryAllocator
+
+    pin_allocator = AdHocMemoryAllocator()
+    local_cpu_backend = LocalCPUBackend(config, pin_allocator)
+
+    loop = asyncio.new_event_loop()
+    backend = RemoteBackend(
+        config=config,
+        metadata=metadata,
+        loop=loop,
+        local_cpu_backend=local_cpu_backend,
+        lookup_server=None,
+    )
+    backend.connection = MockConnector()
+
+    # Start the event loop in a separate thread
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+
+    # Create key
+    key = CacheEngineKey(
+        fmt="vllm",
+        model_name="test-model",
+        world_size=4,
+        worker_id=2,
+        chunk_hash="test_hash",
+    )
+
+    backend0 = RemoteBackend(
+        config=config,
+        metadata=metadata0,
+        loop=loop,
+        local_cpu_backend=local_cpu_backend,
+        lookup_server=None,
+    )
+    backend0.connection = backend.connection
+    # Create key
+    key0 = CacheEngineKey(
+        fmt="vllm",
+        model_name="test-model",
+        world_size=4,
+        worker_id=0,
+        chunk_hash="test_hash",
+    )
+
+    # Test not contains before adding data
+    assert not backend.contains(key)
+    assert not backend0.contains(key0)
+
+    # Test submit_put_task
+    memory_obj = local_cpu_backend.allocate(torch.Size([10, 10]), torch.float32)
+    future = backend.submit_put_task(key, memory_obj)
+    # Wait for put task to complete
+    if future is not None:
+        future.result()
+
+    # Test not contains after adding data since worker_id 2 skipped put
+    assert not backend.contains(key)
+
+    future = backend0.submit_put_task(key0, memory_obj)
+    # Wait for put task to complete
+    if future is not None:
+        future.result()
+
+    # Test contains after adding data since worker_id 0 should put
+    assert backend0.contains(key0)
+    # Test contains after adding data since we use worker_id 0 instead
+    assert backend.contains(key)
+
+    # Test get_blocking
+    retrieved = backend.get_blocking(key)
+    assert retrieved is not None
+    assert retrieved.get_shape() == torch.Size([10, 10])
+
+    # Cleanup
+    # Cancel all running tasks
+    tasks = asyncio.all_tasks(loop)
+    for task in tasks:
+        task.cancel()
+    # Wait until all tasks are cancelled
+    loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+    # Stop the event loop
+    loop.call_soon_threadsafe(loop.stop)
+    # Wait for the loop thread to finish
+    loop_thread.join(timeout=1.0)
+    # Then close the loop
+    loop.close()

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -40,7 +40,7 @@ class MockConnector(RemoteConnector):
 
 # Mock the entire torch.cuda.Stream class
 @mock.patch("torch.cuda.Stream")
-def test_remote_backend_methods(mock_stream):
+def test_remote_mla_worker_id_as0(mock_stream):
     # Create configuration
     config = LMCacheEngineConfig(
         chunk_size=256,
@@ -154,15 +154,24 @@ def test_remote_backend_methods(mock_stream):
     assert retrieved.get_shape() == torch.Size([10, 10])
 
     # Cleanup
-    # Cancel all running tasks
-    tasks = asyncio.all_tasks(loop)
-    for task in tasks:
-        task.cancel()
-    # Wait until all tasks are cancelled
-    loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
-    # Stop the event loop
-    loop.call_soon_threadsafe(loop.stop)
-    # Wait for the loop thread to finish
-    loop_thread.join(timeout=1.0)
-    # Then close the loop
-    loop.close()
+    async def shutdown():
+        # Get all tasks
+        tasks = [t for t in asyncio.all_tasks(loop) if t is not asyncio.current_task()]
+        for task in tasks:
+            task.cancel()
+        # Wait for all tasks to be cancelled (or completed)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        # Then stop the loop
+        loop.stop()
+
+    # Schedule the shutdown coroutine in the event loop thread
+    future = asyncio.run_coroutine_threadsafe(shutdown(), loop)
+    try:
+        # Wait for the shutdown to complete, but with a timeout
+        future.result(timeout=10)
+    except Exception as e:
+        print(f"Error during shutdown: {e}")
+    finally:
+        # Wait for the loop thread to finish
+        loop_thread.join(timeout=1.0)
+        loop.close()


### PR DESCRIPTION
# Background

This PR do the improvement under the result while vLLM using MLA for TP > 0, we found that the kvcache for each TP are all the same for the same token list, so I submit this PR, aimed to reduced the space cost to 1/TP.

# How to test

- start vLLM + LMCache + FSConnector v0

Check the generated files and generated output by vLLM.

```shell
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=0 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 2 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnector","kv_role":"kv_both","kv_parallel_size":2}'
```

- start vLLM + LMCache + FSConnector v0
```shell
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=1 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 2 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_parallel_size":2}'
```

- lmcache.yaml

```yaml
chunk_size: 256
local_device: "cpu"
remote_url: "fs://host:0/disc/data1/baoloongmao/fs_data/"
#remote_serde: "cachegen"
remote_serde: "naive"
# Whether retrieve() is pipelined or not
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 10
extra_config:
  remote_enable_mla_worker_id_as0: True
```

- Without this PR
```
root@TENCENT64: fs]# md5sum *
2c9640350fc9b5f87d198b24ec9abfdb  vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@0@93da5fd4ba09a8fa6bec17e7ecc16c67a9e877fa1a6333440bbe3f06ca093b48.data
2c9640350fc9b5f87d198b24ec9abfdb  vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@1@93da5fd4ba09a8fa6bec17e7ecc16c67a9e877fa1a6333440bbe3f06ca093b48.data
```

- With this PR
```
[root@TENCENT64 fs]# ll ../fs_data
total 7140
-rw-r--r-- 1 root root 7309468 Jun 11 10:46 vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@0@93da5fd4ba09a8fa6bec17e7ecc16c67a9e877fa1a6333440bbe3f06ca093b48.data
[root@TENCENT64 fs]# md5sum ../fs_data/*
2c9640350fc9b5f87d198b24ec9abfdb  ../fs_data/vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@0@93da5fd4ba09a8fa6bec17e7ecc16c67a9e877fa1a6333440bbe3f06ca093b48.data
```

- vllm log
```
[2025-06-11 10:46:20,482] LMCache INFO: Connected to remote storage at fs://host:0/disc/data1/baoloongmao/fs_data/, remote mla worker id as 0 mode: False (remote_backend.py:84:lmcache.v1.storage_backend.remote_backend)
(VllmWorkerProcess pid=24892) [2025-06-11 10:46:20,483] LMCache INFO: Connected to remote storage at fs://host:0/disc/data1/baoloongmao/fs_data/, remote mla worker id as 0 mode: True (remote_backend.py:84:lmcache.v1.storage_backend.remote_backend)
```