### PR TITLE
[optimize] support don't save unfull chunk

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -72,6 +72,7 @@ class ChunkedTokenDatabase(TokenDatabase):
     ):
         if config is not None:
             self.chunk_size = config.chunk_size
+            self.save_unfull_chunk = config.save_unfull_chunk
         self.metadata = metadata
 
     def _make_key_by_hash(self, chunk_hash: str, layer_id: Optional[int] = None):
@@ -112,7 +113,12 @@ class ChunkedTokenDatabase(TokenDatabase):
         :return: a generator of chunks of tokens, each with
                 shape [chunk_size]
         """
-        for i in range(0, len(tokens), self.chunk_size):
+        end = (
+            len(tokens)
+            if self.save_unfull_chunk
+            else (len(tokens) - len(tokens) % self.chunk_size)
+        )
+        for i in range(0, end, self.chunk_size):
             yield tokens[i : i + self.chunk_size]
 
     def _prefix_hash(
@@ -164,7 +170,6 @@ class ChunkedTokenDatabase(TokenDatabase):
         token_chunks = self._chunk_tokens(tokens)
         prefix_hashes = self._prefix_hash(token_chunks)
 
-        start_idx = 0
         for chunk_id, hash_val in enumerate(prefix_hashes):
             start_idx = chunk_id * self.chunk_size
             end_idx = min(start_idx + self.chunk_size, total_len)


### PR DESCRIPTION
When dividing tokens into chunks, the last chunk is likely to be unfull. By default, all chunks are saved, the last unfull chunk is useful in PD disaggregation scenarios, but in some scenarios, such as reuse, the unfull chunk is useless.  

In reuse case, wo don't need to save the last unfull chunk, which can help us save space and time.