### PR TITLE
[Misc] GdsBackend: add internal fallback to POSIX APIs

### DIFF
--- a/docs/source/kv_cache/gds.rst
+++ b/docs/source/kv_cache/gds.rst
@@ -52,6 +52,7 @@ Example ``config.yaml``:
     # CuFile Buffer Size in MiB
     cufile_buffer_size: 8192
 
+
 CuFile Buffer Size Explanation
 ------------------------------
 
@@ -131,3 +132,19 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
         --kv-transfer-config \
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
 
+
+POSIX fallback
+--------------
+
+In some cases, libcufile implements its own internal POSIX fallback without `GdsBackend` being aware.
+In others, an error such as `RuntimeError: cuFileHandleRegister failed (cuFile err=5030, cuda_err=0)` may be throwned.
+Thus, backend can be configured to fallback to its own POSIX implementation when the usage of the libcufile APIs is not successful.
+
+To force `GdsBackend` not use libcufile APIs for any reason, you can override its behavior via `extra_config`,
+e.g:
+
+.. code-block:: yaml
+
+    LMCACHE_EXTRA_CONFIG='{"use_cufile": false}'
+
+Note that under this mode it would still use CUDA APIs to map and do operations the pre-registered GPU memory.

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -199,14 +199,16 @@ class GdsBackend(StorageBackendInterface):
         if config.extra_config is not None:
             use_cufile = config.extra_config.get("use_cufile", None)
             if use_cufile is not None:
-                if use_cufile in [False, True]:
-                    logger.info("Getting use_cufile from config")
+                logger.info("Getting use_cufile from config")
+                if isinstance(use_cufile, str):
+                    self.use_cufile = use_cufile.lower() == "true"
+                elif use_cufile in [False, True]:
                     self.use_cufile = use_cufile
-                    use_cufile_from_config = True
                 else:
                     raise RuntimeError(
                         f"Invalid value `{use_cufile}` for use_cufile in extra_config"
                     )
+                use_cufile_from_config = True
 
         if self.fstype in ["tmpfs", "overlayfs"]:
             # TODO: we can replace the auto-detection of unsupported cufile

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -20,6 +20,7 @@ from typing import Optional, Tuple
 import asyncio
 import ctypes
 import json
+import mmap
 import os
 import random
 import string
@@ -29,6 +30,7 @@ import time
 
 # Third Party
 import aiofile
+import numpy as np
 import torch
 
 # First Party
@@ -173,13 +175,6 @@ class GdsBackend(StorageBackendInterface):
         memory_allocator: MemoryAllocatorInterface,
         dst_device: str = "cuda",
     ):
-        # HACK(Jiayi): cufile import is buggy on some hardware
-        # (e.g., without GPUDirect), so it's temporarily put here.
-        # Third Party
-        import cufile
-
-        self.cufile = cufile
-
         assert dst_device.startswith("cuda")
         super().__init__(dst_device)
 
@@ -198,6 +193,46 @@ class GdsBackend(StorageBackendInterface):
             f"GDS backend using fstype '{self.fstype}' on path '{self.gds_path}'"
         )
 
+        self.use_cufile = True
+        use_cufile_from_config = False
+
+        if config.extra_config is not None:
+            use_cufile = config.extra_config.get("use_cufile", None)
+            if use_cufile is not None:
+                if use_cufile in [False, True]:
+                    logger.info("Getting use_cufile from config")
+                    self.use_cufile = use_cufile
+                    use_cufile_from_config = True
+                else:
+                    raise RuntimeError(
+                        f"Invalid value `{use_cufile}` for use_cufile in extra_config"
+                    )
+
+        if self.fstype in ["tmpfs", "overlayfs"]:
+            # TODO: we can replace the auto-detection of unsupported cufile
+            # file systems by doing a small cufile API test on them. If as
+            # read/write test fails, we can fallback to not using cufile APIs.
+            if use_cufile_from_config:
+                logger.warning("No automatic disabling of cufile usage due to fstype")
+            else:
+                logger.info("Automatic disabling of cufile usage due to fstype")
+                self.use_cufile = False
+
+        if self.use_cufile:
+            logger.info("Using cufile")
+            # HACK(Jiayi): cufile import is buggy on some hardware
+            # (e.g., without GPUDirect), so it's temporarily put here.
+            # Third Party
+            import cufile
+
+            self.cudart = None
+            self.cufile = cufile
+            self._cufile_driver = self.cufile.CuFileDriver()
+        else:
+            logger.info("Not using cufile")
+            self.cufile = None
+            self.cudart = ctypes.CDLL("libcudart.so")
+
         if not os.path.exists(self.gds_path):
             os.makedirs(self.gds_path, exist_ok=True)
 
@@ -212,7 +247,6 @@ class GdsBackend(StorageBackendInterface):
 
         self.rand = random.Random(self.dst_device)
 
-        self._cufile_driver = self.cufile.CuFileDriver()
         if hasattr(self.memory_allocator, "base_pointer"):
             logger.debug(f"Using base pointer {self.memory_allocator.base_pointer}")
             self.cufile_base_pointer = self.memory_allocator.base_pointer
@@ -380,7 +414,7 @@ class GdsBackend(StorageBackendInterface):
             self.metadata_dirs.add(subdir_key)
         tmp = ".tmp" + rand_suffix(self.rand, 8)
         metadata = await asyncio.to_thread(
-            self._save_gds_cufile,
+            self._save_gds,
             path,
             tmp,
             kv_chunk,
@@ -475,9 +509,7 @@ class GdsBackend(StorageBackendInterface):
         else:
             addr = ctypes.c_void_p(self.cufile_base_pointer)
             dev_offset = memory_obj.metadata.address
-        ret = self._load_gds_cufile(
-            path, offset, addr, memory_obj.get_size(), dev_offset
-        )
+        ret = self._load_gds(path, offset, addr, memory_obj.get_size(), dev_offset)
         if ret != memory_obj.get_size():
             if ret < 0:
                 logger.error(
@@ -505,7 +537,7 @@ class GdsBackend(StorageBackendInterface):
 
     @_lmcache_nvtx_annotate
     @torch.inference_mode()
-    def _save_gds_cufile(
+    def _save_gds(
         self,
         path: str,
         tmp: str,
@@ -527,17 +559,43 @@ class GdsBackend(StorageBackendInterface):
         try:
             with open(tmp_path, "wb") as f:
                 f.write(metadata)
-            with self.cufile.CuFile(tmp_path, "r+") as f:
-                f.write(
-                    addr, kv_chunk.nbytes, file_offset=offset, dev_offset=dev_offset
+            if self.cufile:
+                with self.cufile.CuFile(tmp_path, "r+") as f:
+                    f.write(
+                        addr, kv_chunk.nbytes, file_offset=offset, dev_offset=dev_offset
+                    )
+            else:
+                # mmap the file
+                fd = os.open(tmp_path, os.O_RDWR)
+                nbytes = kv_chunk.nbytes
+                os.ftruncate(fd, nbytes + offset)
+                mm = mmap.mmap(
+                    fd, nbytes + offset, prot=mmap.PROT_WRITE, flags=mmap.MAP_SHARED
                 )
+                os.close(fd)
+
+                # get mapped file address
+                arr = np.frombuffer(mm, dtype=np.uint8)
+                buf_addr = arr.__array_interface__["data"][0]
+
+                res = self.cudart.cudaMemcpy(
+                    ctypes.c_void_p(buf_addr + offset),
+                    ctypes.c_void_p(int(addr.value) + device_offset),
+                    ctypes.c_size_t(nbytes),
+                    ctypes.c_int(2),
+                )
+                if res:
+                    raise RuntimeError(f"cudaMemcpy failed {res}")
+                del arr
+                mm.close()
+
         except Exception as e:
             logger.error(f"Error saving {tmp_path}: {e}", exc_info=True)
             raise e
         os.rename(tmp_path, path)
         return metadata
 
-    def _load_gds_cufile(
+    def _load_gds(
         self,
         gds_path: str,
         file_offset: int,
@@ -546,13 +604,40 @@ class GdsBackend(StorageBackendInterface):
         dev_offset: int,
     ) -> int:
         # Read data from disk into a GPU buffer
-        with self.cufile.CuFile(gds_path, "r") as f:
-            return f.read(
-                gpu_pointer,
-                size_in_bytes,
-                file_offset=file_offset,
-                dev_offset=dev_offset,
+        if self.cufile:
+            with self.cufile.CuFile(gds_path, "r") as f:
+                return f.read(
+                    gpu_pointer,
+                    size_in_bytes,
+                    file_offset=file_offset,
+                    dev_offset=dev_offset,
+                )
+        else:
+            fd = os.open(gds_path, os.O_RDONLY)
+            file_size = os.fstat(fd).st_size
+            mm = mmap.mmap(
+                fd,
+                file_size,
+                prot=mmap.PROT_READ,
+                flags=mmap.MAP_PRIVATE | mmap.MAP_POPULATE,
             )
+            os.close(fd)
+
+            arr = np.frombuffer(mm, dtype=np.uint8)
+            addr = arr.__array_interface__["data"][0]
+
+            res = self.cudart.cudaMemcpy(
+                ctypes.c_void_p(int(gpu_pointer.value) + dev_offset),
+                ctypes.c_void_p(addr + file_offset),
+                ctypes.c_size_t(size_in_bytes),
+                ctypes.c_int(1),
+            )
+
+            if res != 0:
+                raise RuntimeError(f"cudaMemcpy failed with code {res}")
+            del arr
+            mm.close()
+            return size_in_bytes
 
     def pin(self, key: CacheEngineKey) -> bool:
         # TODO: Implement this


### PR DESCRIPTION
In this change a `use_cufile` extra config variable is added to control whether cuFile APIs will be used by GdsBackend. In addition, based on fstype we can control the default vault of this variable and can turn cuFile usage off.

The libcufile APIs are not always successful in implementing the POSIX compatibility fallback. when either the cuFile own POSIX implementation is triggered, or when GdsBackend's own POSIX implementation is used, there expected to be at least one copy of data from main memory to GPU buffers.

Fixes: #795