### PR TITLE
Add metadata context support to eliminate redundant metadata storage

### DIFF
--- a/lmcache/v1/storage_backend/connector/audit_connector.py
+++ b/lmcache/v1/storage_backend/connector/audit_connector.py
@@ -22,7 +22,10 @@ import time
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj
-from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.connector.base_connector import (
+    ConnectorMetadataContext,
+    RemoteConnector,
+)
 
 logger = init_logger(__name__)
 
@@ -39,6 +42,7 @@ class AuditConnector(RemoteConnector):
     """
 
     def __init__(self, real_connector: RemoteConnector, verify_checksum: bool = False):
+        super().__init__()  # Initialize the base class
         self.real_connector = real_connector
 
         self.verify_checksum = verify_checksum
@@ -145,3 +149,12 @@ class AuditConnector(RemoteConnector):
         self.logger.debug("[REMOTE_AUDIT]CLOSE|START")
         await self.real_connector.close()
         self.logger.info("[REMOTE_AUDIT]CLOSE|SUCCESS")
+
+    def set_metadata_context(self, context: ConnectorMetadataContext) -> None:
+        """Delegate metadata context setting to the underlying connector."""
+        # Set on both the wrapper and the underlying connector
+        super().set_metadata_context(context)
+        self.real_connector.set_metadata_context(context)
+        self.logger.info(
+            f"[REMOTE_AUDIT]SET_METADATA_CONTEXT|SUCCESS|Shape:{context.shape}|Dtype:{context.dtype}"
+        )

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -16,18 +16,48 @@
 from typing import List, Optional
 import abc
 
+# Third Party
+import torch
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
-from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 
 logger = init_logger(__name__)
+
+
+class ConnectorMetadataContext:
+    """
+    Metadata context that provides shape, dtype, and format information
+    for KV cache tensors. This eliminates the need to store metadata
+    with each individual key.
+    """
+
+    def __init__(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: MemoryFormat,
+    ):
+        self.shape = shape
+        self.dtype = dtype
+        self.fmt = fmt
 
 
 class RemoteConnector(metaclass=abc.ABCMeta):
     """
     Interface for remote connector
     """
+
+    def __init__(self):
+        self.metadata_context: Optional[ConnectorMetadataContext] = None
+
+    def set_metadata_context(self, context: ConnectorMetadataContext) -> None:
+        """
+        Set the metadata context for this connector.
+        """
+        self.metadata_context = context
 
     @abc.abstractmethod
     async def exists(self, key: CacheEngineKey) -> bool:

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -21,7 +21,10 @@ from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj
-from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.connector.base_connector import (
+    ConnectorMetadataContext,
+    RemoteConnector,
+)
 
 logger = init_logger(__name__)
 
@@ -33,6 +36,7 @@ class InstrumentedRemoteConnector(RemoteConnector):
     """
 
     def __init__(self, connector: RemoteConnector):
+        super().__init__()  # Initialize the base class
         self._connector = connector
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
 
@@ -76,3 +80,9 @@ class InstrumentedRemoteConnector(RemoteConnector):
 
     async def close(self) -> None:
         await self._connector.close()
+
+    def set_metadata_context(self, context: ConnectorMetadataContext) -> None:
+        """Delegate metadata context setting to the underlying connector."""
+        # Set on both the wrapper and the underlying connector
+        super().set_metadata_context(context)
+        self._connector.set_metadata_context(context)

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -29,13 +29,10 @@ from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
-from lmcache.v1.protocol import RemoteMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
-
-METADATA_BYTES_LEN = 28
 
 
 @dataclass
@@ -105,6 +102,7 @@ class MooncakestoreConnector(RemoteConnector):
         local_cpu_backend: LocalCPUBackend,
         lmcache_config: Optional[LMCacheEngineConfig],
     ):
+        super().__init__()
         try:
             # Third Party
             from mooncake.store import MooncakeDistributedStore
@@ -152,11 +150,29 @@ class MooncakestoreConnector(RemoteConnector):
 
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        self.lmcache_config = lmcache_config
+
+        # Check if save_unfull_chunk is enabled, throw if disabled
+        if lmcache_config is None or lmcache_config.save_unfull_chunk:
+            raise ValueError(
+                "MooncakestoreConnector requires save_unfull_chunk to be disabled. "
+                "Please set save_unfull_chunk=False in your LMCache configuration."
+            )
 
     async def exists(self, key: CacheEngineKey) -> bool:
         return self.store.is_exist(key.to_string())
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        if self.metadata_context is None:
+            logger.error(
+                "Metadata context not set. Cannot retrieve data without metadata."
+            )
+            return None
+
+        metadata_shape = self.metadata_context.shape
+        metadata_dtype = self.metadata_context.dtype
+        metadata_fmt = self.metadata_context.fmt
+
         key_str = key.to_string()
 
         try:
@@ -176,33 +192,32 @@ class MooncakestoreConnector(RemoteConnector):
         if buffer is None:
             return None
 
-        retrieved_view = memoryview(buffer)
-        metadata_bytes = retrieved_view[:METADATA_BYTES_LEN]
-        if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
-            return None
-
-        metadata = RemoteMetadata.deserialize(metadata_bytes)
-
         memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
-            metadata.fmt,
+            metadata_shape,
+            metadata_dtype,
+            metadata_fmt,
         )
-        assert len(retrieved_view) == metadata.length + METADATA_BYTES_LEN
 
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
         if memory_obj.tensor is not None:
-            assert metadata.dtype is not None
-            num_elements = reduce(operator.mul, metadata.shape)
+            assert metadata_dtype is not None
+            num_elements = reduce(operator.mul, metadata_shape)
+            # check size
+            if len(buffer) != num_elements * metadata_dtype.itemsize:
+                expected_size = num_elements * metadata_dtype.itemsize
+                logger.error(
+                    f"Buffer size mismatch. Expected {expected_size}, got {len(buffer)}"
+                )
+                return None
             temp_tensor = torch.frombuffer(
                 buffer,
-                dtype=metadata.dtype,
-                offset=METADATA_BYTES_LEN,
+                dtype=metadata_dtype,
+                offset=0,  # No metadata prefix anymore
                 count=num_elements,
-            ).reshape(metadata.shape)
+            ).reshape(metadata_shape)
 
             memory_obj.tensor.copy_(temp_tensor)
             return memory_obj
@@ -210,23 +225,32 @@ class MooncakestoreConnector(RemoteConnector):
             return None
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # Please use a function like `memory_obj.to_meta()`.
+        # Assert that memory object metadata matches metadata context
+        assert self.metadata_context is not None, (
+            "Metadata context not set. Cannot store data without metadata."
+        )
+        
+        memory_shape = memory_obj.get_shape()
+        memory_dtype = memory_obj.get_dtype()
+        memory_fmt = memory_obj.get_fmt()
+        assert memory_shape == self.metadata_context.shape, (
+            f"Memory object shape {memory_shape} does not match "
+            f"metadata context shape {self.metadata_context.shape}"
+        )
+        assert memory_dtype == self.metadata_context.dtype, (
+            f"Memory object dtype {memory_dtype} does not match "
+            f"metadata context dtype {self.metadata_context.dtype}"
+        )
+        assert memory_fmt == self.metadata_context.fmt, (
+            f"Memory object format {memory_fmt} does not match "
+            f"metadata context format {self.metadata_context.fmt}"
+        )
+
         kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
-        assert len(metadata_bytes) == METADATA_BYTES_LEN
         key_str = key.to_string()
-
         try:
             await asyncio.wait_for(
-                asyncio.to_thread(
-                    self.store.put_parts, key_str, metadata_bytes, kv_bytes
-                ),
+                asyncio.to_thread(self.store.put, key_str, kv_bytes),
                 timeout=self.config.transfer_timeout,
             )
         except asyncio.TimeoutError:
@@ -235,11 +259,7 @@ class MooncakestoreConnector(RemoteConnector):
                 "Decode instance may redo prefill."
             )
         except Exception as e:
-            logger.error(
-                f"Failed to put key {key_str},"
-                f"meta type: {type(metadata_bytes)},"
-                f"data: {type(kv_bytes)}: {e}"
-            )
+            logger.error(f"Failed to put key {key_str},data: {type(kv_bytes)}: {e}")
 
     @no_type_check
     async def list(self) -> List[str]:

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -152,6 +152,32 @@ class MooncakestoreConnector(RemoteConnector):
         self.local_cpu_backend = local_cpu_backend
         self.lmcache_config = lmcache_config
 
+        # Register CPU buffer with Mooncake for zero-copy operations
+        self._register_cpu_buffer()
+
+    def _register_cpu_buffer(self):
+        """Register CPU buffer for zero-copy operations."""
+        try:
+            allocator = self.local_cpu_backend.memory_allocator
+            if not hasattr(allocator, "pin_allocator") or not hasattr(
+                allocator.pin_allocator, "buffer"
+            ):
+                logger.warning("Cannot register buffer: incompatible allocator")
+                return
+
+            buffer = allocator.pin_allocator.buffer
+            result = self.store.register_buffer(buffer.data_ptr(), buffer.numel())
+
+            if result == 0:
+                logger.info(
+                    f"Registered CPU buffer: {hex(buffer.data_ptr())}, "
+                    f"{buffer.numel()} bytes"
+                )
+            else:
+                logger.warning(f"Buffer registration failed: error={result}")
+        except Exception as e:
+            logger.error(f"Buffer registration error: {e}")
+
     async def exists(self, key: CacheEngineKey) -> bool:
         return self.store.is_exist(key.to_string())
 
@@ -166,17 +192,28 @@ class MooncakestoreConnector(RemoteConnector):
         metadata_dtype = self.metadata_context.dtype
         metadata_fmt = self.metadata_context.fmt
 
+        # Pre-allocate memory object
         memory_obj = self.local_cpu_backend.allocate(
             metadata_shape,
             metadata_dtype,
             metadata_fmt,
         )
 
+        if memory_obj is None:
+            logger.warning("Failed to allocate memory during remote receive")
+            return None
+
         key_str = key.to_string()
 
         try:
-            buffer = await asyncio.wait_for(
-                asyncio.to_thread(self.store.get_buffer, key_str),
+            # Use get_into for zero-copy reading directly into the allocated buffer
+            buffer_ptr = memory_obj.tensor.data_ptr()
+            buffer_size = memory_obj.tensor.numel() * memory_obj.tensor.element_size()
+
+            bytes_read = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self.store.get_into, key_str, buffer_ptr, buffer_size
+                ),
                 timeout=self.config.transfer_timeout,
             )
         except asyncio.TimeoutError:
@@ -187,25 +224,28 @@ class MooncakestoreConnector(RemoteConnector):
             return None
         except Exception as e:
             logger.error(f"Failed to get key {key_str}. {e}")
-
-        if buffer is None:
             return None
 
-        if memory_obj is None:
-            logger.warning("Failed to allocate memory during remote receive")
+        if bytes_read < 0:
+            logger.error(
+                f"Failed to read data for key {key_str}, error code: {bytes_read}"
+            )
             return None
 
-        if memory_obj.tensor is not None and len(buffer) > 0:
+        if bytes_read == 0:
+            logger.warning(f"No data read for key {key_str}")
+            return None
+
+        if memory_obj.tensor is not None and bytes_read > 0:
             assert metadata_dtype is not None
             expected_data_size = (
                 reduce(operator.mul, metadata_shape) * metadata_dtype.itemsize
             )
-            actual_data_size = len(buffer)
+            actual_data_size = bytes_read
+
             if expected_data_size == actual_data_size:
-                source_tensor = torch.frombuffer(buffer, dtype=metadata_dtype).reshape(
-                    metadata_shape
-                )
-                memory_obj.tensor.copy_(source_tensor)
+                # Data size matches exactly, no need to copy since data is already
+                # in place
                 return memory_obj
             else:
                 # Chunk is not full, need to reshape
@@ -225,12 +265,6 @@ class MooncakestoreConnector(RemoteConnector):
                         f"({expected_elements})"
                     )
                     return None
-                source_tensor = torch.frombuffer(
-                    buffer,
-                    dtype=metadata_dtype,
-                    offset=0,
-                    count=actual_elements,
-                )
 
                 # Calculate actual shape for KV_2LTD format:
                 # [2, num_layers, seq_len, hidden_dim]
@@ -250,9 +284,6 @@ class MooncakestoreConnector(RemoteConnector):
                     )
                     return None
 
-                # Reshape source tensor to match actual data
-                source_tensor = source_tensor.reshape(actual_shape)
-
                 # Update the raw_data buffer to only include the actual elements
                 # This is necessary because the tensor property uses
                 # raw_data.view(dtype).view(shape)
@@ -262,32 +293,48 @@ class MooncakestoreConnector(RemoteConnector):
                 # Update metadata shape to match actual data
                 memory_obj.meta.shape = actual_shape
 
-                # Now copy the data to the correctly sized tensor
-                target_tensor = memory_obj.tensor
-                if target_tensor is not None:
-                    target_tensor.copy_(source_tensor)
-                else:
-                    logger.error("Failed to get tensor view from memory object")
-                    return None
+                # Data is already in the correct location due to get_into
                 return memory_obj
         else:
             return None
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        kv_bytes = memory_obj.byte_array
         key_str = key.to_string()
         try:
-            await asyncio.wait_for(
-                asyncio.to_thread(self.store.put, key_str, kv_bytes),
-                timeout=self.config.transfer_timeout,
-            )
+            # Check if we can use zero-copy put_from
+            if hasattr(memory_obj, "tensor") and memory_obj.tensor is not None:
+                # Use put_from for zero-copy writing directly from the tensor buffer
+                buffer_ptr = memory_obj.tensor.data_ptr()
+                buffer_size = (
+                    memory_obj.tensor.numel() * memory_obj.tensor.element_size()
+                )
+
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        self.store.put_from, key_str, buffer_ptr, buffer_size
+                    ),
+                    timeout=self.config.transfer_timeout,
+                )
+
+                if result != 0:
+                    logger.error(
+                        f"Failed to put key {key_str} using put_from, "
+                        f"error code: {result}"
+                    )
+            else:
+                # Fallback to regular put method
+                kv_bytes = memory_obj.byte_array
+                await asyncio.wait_for(
+                    asyncio.to_thread(self.store.put, key_str, kv_bytes),
+                    timeout=self.config.transfer_timeout,
+                )
         except asyncio.TimeoutError:
             logger.warning(
                 f"Timeout when putting key {key_str} from mooncake store."
                 "Decode instance may redo prefill."
             )
         except Exception as e:
-            logger.error(f"Failed to put key {key_str},data: {type(kv_bytes)}: {e}")
+            logger.error(f"Failed to put key {key_str},data: {type(memory_obj)}: {e}")
 
     @no_type_check
     async def list(self) -> List[str]:

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -195,14 +195,17 @@ class MooncakestoreConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        if memory_obj.tensor is not None:
+        if memory_obj.tensor is not None and len(buffer) > 0:
             assert metadata_dtype is not None
             expected_data_size = (
                 reduce(operator.mul, metadata_shape) * metadata_dtype.itemsize
             )
             actual_data_size = len(buffer)
             if expected_data_size == actual_data_size:
-                memory_obj.tensor.copy_(torch.frombuffer(buffer, dtype=metadata_dtype))
+                source_tensor = torch.frombuffer(buffer, dtype=metadata_dtype).reshape(
+                    metadata_shape
+                )
+                memory_obj.tensor.copy_(source_tensor)
                 return memory_obj
             else:
                 # Chunk is not full, need to reshape
@@ -222,7 +225,6 @@ class MooncakestoreConnector(RemoteConnector):
                         f"({expected_elements})"
                     )
                     return None
-
                 source_tensor = torch.frombuffer(
                     buffer,
                     dtype=metadata_dtype,
@@ -248,40 +250,30 @@ class MooncakestoreConnector(RemoteConnector):
                     )
                     return None
 
-                # Reshape source tensor and copy to memory object
+                # Reshape source tensor to match actual data
                 source_tensor = source_tensor.reshape(actual_shape)
 
-                # Reshape memory object tensor to match actual data
-                memory_obj.tensor = memory_obj.tensor.view(-1)[:actual_elements].view(
-                    actual_shape
-                )
-                memory_obj.tensor.copy_(source_tensor)
+                # Update the raw_data buffer to only include the actual elements
+                # This is necessary because the tensor property uses
+                # raw_data.view(dtype).view(shape)
+                actual_bytes = actual_elements * metadata_dtype.itemsize
+                memory_obj.raw_data = memory_obj.raw_data[:actual_bytes]
+
+                # Update metadata shape to match actual data
                 memory_obj.meta.shape = actual_shape
+
+                # Now copy the data to the correctly sized tensor
+                target_tensor = memory_obj.tensor
+                if target_tensor is not None:
+                    target_tensor.copy_(source_tensor)
+                else:
+                    logger.error("Failed to get tensor view from memory object")
+                    return None
                 return memory_obj
         else:
             return None
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # Assert that memory object metadata matches metadata context
-        assert self.metadata_context is not None, (
-            "Metadata context not set. Cannot store data without metadata."
-        )
-        memory_shape = memory_obj.get_shape()
-        memory_dtype = memory_obj.get_dtype()
-        memory_fmt = memory_obj.get_fmt()
-        assert memory_shape == self.metadata_context.shape, (
-            f"Memory object shape {memory_shape} does not match "
-            f"metadata context shape {self.metadata_context.shape}"
-        )
-        assert memory_dtype == self.metadata_context.dtype, (
-            f"Memory object dtype {memory_dtype} does not match "
-            f"metadata context dtype {self.metadata_context.dtype}"
-        )
-        assert memory_fmt == self.metadata_context.fmt, (
-            f"Memory object format {memory_fmt} does not match "
-            f"metadata context format {self.metadata_context.fmt}"
-        )
-
         kv_bytes = memory_obj.byte_array
         key_str = key.to_string()
         try:

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -229,7 +229,6 @@ class MooncakestoreConnector(RemoteConnector):
         assert self.metadata_context is not None, (
             "Metadata context not set. Cannot store data without metadata."
         )
-        
         memory_shape = memory_obj.get_shape()
         memory_dtype = memory_obj.get_dtype()
         memory_fmt = memory_obj.get_fmt()

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -152,13 +152,6 @@ class MooncakestoreConnector(RemoteConnector):
         self.local_cpu_backend = local_cpu_backend
         self.lmcache_config = lmcache_config
 
-        # Check if save_unfull_chunk is enabled, throw if disabled
-        if lmcache_config is None or lmcache_config.save_unfull_chunk:
-            raise ValueError(
-                "MooncakestoreConnector requires save_unfull_chunk to be disabled. "
-                "Please set save_unfull_chunk=False in your LMCache configuration."
-            )
-
     async def exists(self, key: CacheEngineKey) -> bool:
         return self.store.is_exist(key.to_string())
 
@@ -172,6 +165,12 @@ class MooncakestoreConnector(RemoteConnector):
         metadata_shape = self.metadata_context.shape
         metadata_dtype = self.metadata_context.dtype
         metadata_fmt = self.metadata_context.fmt
+
+        memory_obj = self.local_cpu_backend.allocate(
+            metadata_shape,
+            metadata_dtype,
+            metadata_fmt,
+        )
 
         key_str = key.to_string()
 
@@ -192,35 +191,73 @@ class MooncakestoreConnector(RemoteConnector):
         if buffer is None:
             return None
 
-        memory_obj = self.local_cpu_backend.allocate(
-            metadata_shape,
-            metadata_dtype,
-            metadata_fmt,
-        )
-
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
         if memory_obj.tensor is not None:
             assert metadata_dtype is not None
-            num_elements = reduce(operator.mul, metadata_shape)
-            # check size
-            if len(buffer) != num_elements * metadata_dtype.itemsize:
-                expected_size = num_elements * metadata_dtype.itemsize
-                logger.error(
-                    f"Buffer size mismatch. Expected {expected_size}, got {len(buffer)}"
-                )
-                return None
-            temp_tensor = torch.frombuffer(
-                buffer,
-                dtype=metadata_dtype,
-                offset=0,  # No metadata prefix anymore
-                count=num_elements,
-            ).reshape(metadata_shape)
+            expected_data_size = (
+                reduce(operator.mul, metadata_shape) * metadata_dtype.itemsize
+            )
+            actual_data_size = len(buffer)
+            if expected_data_size == actual_data_size:
+                memory_obj.tensor.copy_(torch.frombuffer(buffer, dtype=metadata_dtype))
+                return memory_obj
+            else:
+                # Chunk is not full, need to reshape
+                if actual_data_size % metadata_dtype.itemsize != 0:
+                    logger.error(
+                        f"Buffer size {actual_data_size} not aligned to dtype size "
+                        f"{metadata_dtype.itemsize}"
+                    )
+                    return None
 
-            memory_obj.tensor.copy_(temp_tensor)
-            return memory_obj
+                actual_elements = actual_data_size // metadata_dtype.itemsize
+                expected_elements = reduce(operator.mul, metadata_shape)
+
+                if actual_elements > expected_elements:
+                    logger.error(
+                        f"Buffer has more elements ({actual_elements}) than expected "
+                        f"({expected_elements})"
+                    )
+                    return None
+
+                source_tensor = torch.frombuffer(
+                    buffer,
+                    dtype=metadata_dtype,
+                    offset=0,
+                    count=actual_elements,
+                )
+
+                # Calculate actual shape for KV_2LTD format:
+                # [2, num_layers, seq_len, hidden_dim]
+                # Only sequence dimension (index 2) changes for unfull chunks
+                actual_shape = list(metadata_shape)
+                other_dims_product = actual_shape[0] * actual_shape[1] * actual_shape[3]
+                actual_seq_len = actual_elements // other_dims_product
+                actual_shape[2] = actual_seq_len
+
+                actual_shape = torch.Size(actual_shape)
+
+                # Validate the calculated shape
+                if reduce(operator.mul, actual_shape) != actual_elements:
+                    logger.error(
+                        f"Cannot reshape {actual_elements} elements to shape "
+                        f"{actual_shape}"
+                    )
+                    return None
+
+                # Reshape source tensor and copy to memory object
+                source_tensor = source_tensor.reshape(actual_shape)
+
+                # Reshape memory object tensor to match actual data
+                memory_obj.tensor = memory_obj.tensor.view(-1)[:actual_elements].view(
+                    actual_shape
+                )
+                memory_obj.tensor.copy_(source_tensor)
+                memory_obj.meta.shape = actual_shape
+                return memory_obj
         else:
             return None
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -20,6 +20,9 @@ import asyncio
 import threading
 import time
 
+# Third Party
+import torch
+
 # First Party
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
@@ -27,10 +30,13 @@ from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_server import LookupServerInterface
-from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.connector import CreateConnector
-from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.connector.base_connector import (
+    ConnectorMetadataContext,
+    RemoteConnector,
+)
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.naive_serde import CreateSerde
 
@@ -91,6 +97,29 @@ class RemoteBackend(StorageBackendInterface):
         # we must make decision (whether to send or not) at the local side
 
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
+
+        # Set up metadata context for the connector
+        self._setup_metadata_context()
+
+    def _setup_metadata_context(self) -> None:
+        """Set up metadata context based on engine metadata."""
+        chunk_size = self.metadata.kv_shape[2]
+        num_kv_head = self.metadata.kv_shape[3]
+        head_size = self.metadata.kv_shape[4]
+        hidden_dim = num_kv_head * head_size
+        chunk_shape = torch.Size([2, self.metadata.kv_shape[0], chunk_size, hidden_dim])
+        memory_format = MemoryFormat.KV_2LTD
+
+        context = ConnectorMetadataContext(
+            shape=chunk_shape,
+            dtype=self.metadata.kv_dtype,
+            fmt=memory_format,
+        )
+
+        if self.connection is not None:
+            self.connection.set_metadata_context(context)
+        else:
+            logger.warning("Remote connection is None, cannot set metadata context")
 
     def __str__(self):
         return self.__class__.__name__


### PR DESCRIPTION
## Summary

This PR introduces metadata context support to connectors, eliminating the need to store redundant metadata with each key in remote storage and simplifying the data flow.

## Changes

- **Add ConnectorMetadataContext class**: Provides shape, dtype, and format information for KV cache tensors
- **Update MooncakeStore connector**: Remove metadata serialization/deserialization, use context-provided metadata instead
- **Add metadata context delegation**: Ensure wrapper connectors (audit, instrumented) properly delegate metadata context to underlying connectors
- **Set up metadata context in RemoteBackend**: Automatically configure metadata context based on engine metadata

## Benefits

- **Reduced storage overhead**: No longer store identical metadata with each key
- **Simplified data flow**: Remove metadata serialization/deserialization steps
- **Better performance**: Eliminate redundant metadata operations