### PR TITLE
[Fix] Fix race between test_gds/weka rmtree and asyncio thread loop

### DIFF
--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -107,9 +107,15 @@ def test_gds_backend_sanity():
         assert returned_memory_obj.get_shape() == memory_obj.get_shape()
         assert returned_memory_obj.get_dtype() == memory_obj.get_dtype()
     finally:
-        if os.path.exists(GDS_DIR):
-            shutil.rmtree(GDS_DIR)
         if thread_loop.is_running():
             thread_loop.call_soon_threadsafe(thread_loop.stop)
         if thread.is_alive():
             thread.join()
+        # We rmtree AFTER we ensure that the thread loop is done.
+        # This way we don't hit any race conditions in rmtree()
+        # where temp files are renamed while we try to unlink them.
+        # We also take care of any other errors with ignore_errors=True
+        # so if we want to run tests in parallel in the future they
+        # don't make each other fail.
+        if os.path.exists(GDS_DIR):
+            shutil.rmtree(GDS_DIR)

--- a/tests/v1/test_weka.py
+++ b/tests/v1/test_weka.py
@@ -79,9 +79,15 @@ def test_weka_backend_sanity():
         assert returned_memory_obj.get_shape() == memory_obj.get_shape()
         assert returned_memory_obj.get_dtype() == memory_obj.get_dtype()
     finally:
-        if os.path.exists(WEKA_DIR):
-            shutil.rmtree(WEKA_DIR)
         if thread_loop.is_running():
             thread_loop.call_soon_threadsafe(thread_loop.stop)
         if thread.is_alive():
             thread.join()
+        # We rmtree AFTER we ensure that the thread loop is done.
+        # This way we don't hit any race conditions in rmtree()
+        # where temp files are renamed while we try to unlink them.
+        # We also take care of any other errors with ignore_errors=True
+        # so if we want to run tests in parallel in the future they
+        # don't make each other fail.
+        if os.path.exists(WEKA_DIR):
+            shutil.rmtree(WEKA_DIR)


### PR DESCRIPTION
@YaoJiayi let me know about a failure in the weka test: https://buildkite.com/lmcache/lmcache-unittests/builds/2097#0197659a-e33a-4d15-9072-a0384e616e86

The root cause is that we'd rmtree while the thread loop in the Weka backend can be issuing file operations in the same directory. The fix is to ensure that the thread loop is done before running rmtree. As an extra precaution I also made sure to ignore any errors as this is just cleanup and should not bother other tests in the CI.

Since the generic GDS backend is also susceptible I fixed the bug there too.