### PR TITLE
[bugfix] delete duplicate header files

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -15,7 +15,6 @@
  */
 
 #include <torch/all.h>
-#include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include "mem_kernels.cuh"
 #include <ATen/ATen.h>


### PR DESCRIPTION
delete duplicate header files in mem_kernels.cu
Previously,` #include <ATen/cuda/CUDAContext.h>` was included twice redundantly.