### PR TITLE
[CI]: Add disk cleanup as a GH action

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,27 @@
+name: 'Free Disk Space'
+description: 'Frees disk space on the runner'
+runs:
+  using: "composite"
+  steps:
+    - name: Print disk space before cleanup
+      run: |
+        df -h
+      shell: bash
+    - name: Free Disk Space Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+        sudo rm -rf \
+          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+          /usr/lib/jvm || true
+        sudo apt install aptitude -y >/dev/null 2>&1
+        sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+        sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+        sudo apt-get autoremove -y >/dev/null 2>&1
+        sudo apt-get autoclean -y >/dev/null 2>&1
+      shell: bash
+    - name: Print disk space after cleanup
+      run: |
+        df -h
+      shell: bash

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -17,17 +17,6 @@ jobs:
         with:
             egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-      - name: Remove toolcache to free space
-        run: |
-          sudo rm -rf /opt/hostedtoolcache || true
-          df -h
-
-      - name: Remove other cruft to free space
-        run: |
-          docker system prune -af || true
-          sudo rm -rf ~/.cache || true
-          df -h
-
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -42,6 +31,9 @@ jobs:
         with:
           # for setuptools-scm
           fetch-depth: 0
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Setup Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,36 +41,14 @@ jobs:
               with:
                 egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-            - name: Print disk space before cleanup
-              run: |
-                df -h
-              shell: bash
-
-            - name: Free Disk Space Linux
-              if: runner.os == 'Linux'
-              run: |
-                sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
-                sudo rm -rf \
-                  /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                  /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-                  /usr/lib/jvm || true
-                sudo apt install aptitude -y >/dev/null 2>&1
-                sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
-                sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
-                sudo apt-get autoremove -y >/dev/null 2>&1
-                sudo apt-get autoclean -y >/dev/null 2>&1
-              shell: bash
-
-            - name: Print disk space after cleanup
-              run: |
-                df -h
-              shell: bash
-
             - name: Checkout code
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                 # for setuptools-scm
                 fetch-depth: 0
+
+            - name: Free disk space
+              uses: ./.github/actions/free-disk-space
 
             - name: Setup Python 3.11
               uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -190,31 +168,6 @@ jobs:
               with:
                 egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-            - name: Print disk space before cleanup
-              run: |
-                df -h
-              shell: bash
-
-            - name: Free Disk Space Linux
-              if: runner.os == 'Linux'
-              run: |
-                sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
-                sudo rm -rf \
-                  /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                  /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-                  /usr/lib/jvm || true
-                sudo apt install aptitude -y >/dev/null 2>&1
-                sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
-                sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
-                sudo apt-get autoremove -y >/dev/null 2>&1
-                sudo apt-get autoclean -y >/dev/null 2>&1
-              shell: bash
-
-            - name: Print disk space after cleanup
-              run: |
-                df -h
-              shell: bash
-
             - name: Login to DockerHub
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
               with:
@@ -229,6 +182,9 @@ jobs:
               with:
                 # for setuptools-scm
                 fetch-depth: 0
+
+            - name: Free disk space
+              uses: ./.github/actions/free-disk-space
 
             - name: Get the latest tag (corresponds to release cut in publish-pypi job)
               run: |


### PR DESCRIPTION
Runner sometimes needs its disk to be cleanup before a workflow can run successfully on it.

This PR moves the cleanup code which is being duplicated across workflows into a GitHub action so that it can be called centrally in a consistent manner.
