### PR TITLE
hotfix: revert mooncake setup function for compatibility

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -133,7 +133,7 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.device_name = dev_name
             logger.info("Mooncake Configuration loaded. config: %s", self.config)
 
-            self.store.setup_lmcache(
+            self.store.setup(
                 self.config.local_hostname,
                 self.config.metadata_server,
                 self.config.global_segment_size,
@@ -141,8 +141,6 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.protocol,
                 self.config.device_name,
                 self.config.master_server_address,
-                local_cpu_backend.instance_id,
-                str(local_cpu_backend.lmcache_worker.worker_id),
             )
 
         except ValueError as e:


### PR DESCRIPTION
## Summary

This is a hotfix to revert the mooncake setup function for compatibility. Fix #839 

## Changes

- Reverted `setup_lmcache()` back to `setup()` in MooncakestoreConnector
- Removed additional parameters that were causing compatibility issues

## Reason

Waiting for mooncake to stabilize the new feature version before updating the initialization function. This rollback ensures compatibility with current mooncake versions.