### PR TITLE
[optimize] support timeout when get blocking

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -116,6 +116,10 @@ class LMCacheEngineConfig:
     # But in some scenarios, such as reuse, save unfull chunk is unnecessary
     save_unfull_chunk: bool = True
 
+    # Set timeout(seconds) to improve lmcache stability
+    # when calling get_blocking method in remote backend
+    get_blocking_timeout_secs: int = 10
+
     @staticmethod
     def from_defaults(
         chunk_size: int = 256,
@@ -152,6 +156,7 @@ class LMCacheEngineConfig:
         cufile_buffer_size: Optional[int] = None,
         extra_config: Optional[dict] = None,
         save_unfull_chunk: bool = True,
+        get_blocking_timeout_secs: int = 10,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
         return LMCacheEngineConfig(
@@ -189,6 +194,7 @@ class LMCacheEngineConfig:
             cufile_buffer_size,
             extra_config,
             save_unfull_chunk,
+            get_blocking_timeout_secs,
         ).validate()
 
     @staticmethod
@@ -352,6 +358,8 @@ class LMCacheEngineConfig:
 
         save_unfull_chunk = config.get("save_unfull_chunk", True)
 
+        get_blocking_timeout_secs = config.get("get_blocking_timeout_secs", 10)
+
         local_disk_path = _parse_local_disk(local_disk)
 
         match remote_url:
@@ -398,6 +406,7 @@ class LMCacheEngineConfig:
                 cufile_buffer_size,
                 extra_config,
                 save_unfull_chunk,
+                get_blocking_timeout_secs,
             )
             .validate()
             .log_config()
@@ -582,6 +591,9 @@ class LMCacheEngineConfig:
         config.save_unfull_chunk = to_bool(
             parse_env(get_env_name("save_unfull_chunk"), config.save_unfull_chunk)
         )
+        config.get_blocking_timeout_secs = to_int(
+            parse_env(get_env_name("get_blocking_timeout_secs"), config.get_blocking_timeout_secs)
+        )
         return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:
@@ -664,6 +676,7 @@ class LMCacheEngineConfig:
             "gds_path": self.gds_path,
             "extra_config": self.extra_config,
             "save_unfull_chunk": self.save_unfull_chunk,
+            "get_blocking_timeout_secs": self.get_blocking_timeout_secs,
         }
         logger.info(f"LMCache Configuration: {config_dict}")
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -592,7 +592,9 @@ class LMCacheEngineConfig:
             parse_env(get_env_name("save_unfull_chunk"), config.save_unfull_chunk)
         )
         config.blocking_timeout_secs = to_int(
-            parse_env(get_env_name("blocking_timeout_secs"), config.blocking_timeout_secs)
+            parse_env(
+                get_env_name("blocking_timeout_secs"), config.blocking_timeout_secs
+            )
         )
         return config.validate().log_config()
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -118,7 +118,7 @@ class LMCacheEngineConfig:
 
     # Set timeout(seconds) to improve lmcache stability
     # when calling get_blocking method in remote backend
-    get_blocking_timeout_secs: int = 10
+    blocking_timeout_secs: int = 10
 
     @staticmethod
     def from_defaults(
@@ -156,7 +156,7 @@ class LMCacheEngineConfig:
         cufile_buffer_size: Optional[int] = None,
         extra_config: Optional[dict] = None,
         save_unfull_chunk: bool = True,
-        get_blocking_timeout_secs: int = 10,
+        blocking_timeout_secs: int = 10,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
         return LMCacheEngineConfig(
@@ -194,7 +194,7 @@ class LMCacheEngineConfig:
             cufile_buffer_size,
             extra_config,
             save_unfull_chunk,
-            get_blocking_timeout_secs,
+            blocking_timeout_secs,
         ).validate()
 
     @staticmethod
@@ -358,7 +358,7 @@ class LMCacheEngineConfig:
 
         save_unfull_chunk = config.get("save_unfull_chunk", True)
 
-        get_blocking_timeout_secs = config.get("get_blocking_timeout_secs", 10)
+        blocking_timeout_secs = config.get("blocking_timeout_secs", 10)
 
         local_disk_path = _parse_local_disk(local_disk)
 
@@ -406,7 +406,7 @@ class LMCacheEngineConfig:
                 cufile_buffer_size,
                 extra_config,
                 save_unfull_chunk,
-                get_blocking_timeout_secs,
+                blocking_timeout_secs,
             )
             .validate()
             .log_config()
@@ -591,11 +591,8 @@ class LMCacheEngineConfig:
         config.save_unfull_chunk = to_bool(
             parse_env(get_env_name("save_unfull_chunk"), config.save_unfull_chunk)
         )
-        config.get_blocking_timeout_secs = to_int(
-            parse_env(
-                get_env_name("get_blocking_timeout_secs"),
-                config.get_blocking_timeout_secs,
-            )
+        config.blocking_timeout_secs = to_int(
+            parse_env(get_env_name("blocking_timeout_secs"), config.blocking_timeout_secs)
         )
         return config.validate().log_config()
 
@@ -679,7 +676,7 @@ class LMCacheEngineConfig:
             "gds_path": self.gds_path,
             "extra_config": self.extra_config,
             "save_unfull_chunk": self.save_unfull_chunk,
-            "get_blocking_timeout_secs": self.get_blocking_timeout_secs,
+            "blocking_timeout_secs": self.blocking_timeout_secs,
         }
         logger.info(f"LMCache Configuration: {config_dict}")
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -592,7 +592,10 @@ class LMCacheEngineConfig:
             parse_env(get_env_name("save_unfull_chunk"), config.save_unfull_chunk)
         )
         config.get_blocking_timeout_secs = to_int(
-            parse_env(get_env_name("get_blocking_timeout_secs"), config.get_blocking_timeout_secs)
+            parse_env(
+                get_env_name("get_blocking_timeout_secs"),
+                config.get_blocking_timeout_secs,
+            )
         )
         return config.validate().log_config()
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -53,6 +53,7 @@ class RemoteBackend(StorageBackendInterface):
         assert config.remote_url is not None
 
         self.remote_url = config.remote_url
+        self.get_blocking_timeout_secs = config.get_blocking_timeout_secs
 
         self.local_cpu_backend = local_cpu_backend
 
@@ -237,7 +238,7 @@ class RemoteBackend(StorageBackendInterface):
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
 
         try:
-            memory_obj = future.result()
+            memory_obj = future.result(self.get_blocking_timeout_secs)
         except Exception as e:
             with self.lock:
                 self.connection = None

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -53,7 +53,7 @@ class RemoteBackend(StorageBackendInterface):
         assert config.remote_url is not None
 
         self.remote_url = config.remote_url
-        self.get_blocking_timeout_secs = config.get_blocking_timeout_secs
+        self.blocking_timeout_secs = config.blocking_timeout_secs
 
         self.local_cpu_backend = local_cpu_backend
 
@@ -238,7 +238,7 @@ class RemoteBackend(StorageBackendInterface):
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
 
         try:
-            memory_obj = future.result(self.get_blocking_timeout_secs)
+            memory_obj = future.result(self.blocking_timeout_secs)
         except Exception as e:
             with self.lock:
                 self.connection = None

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Standard
-from concurrent.futures import Future
+from concurrent.futures import Future, TimeoutError
 from functools import wraps
 from typing import List, Optional
 import asyncio
@@ -240,6 +240,9 @@ class RemoteBackend(StorageBackendInterface):
         try:
             memory_obj = future.result(self.blocking_timeout_secs)
         except Exception as e:
+            if isinstance(e, TimeoutError):
+                logger.warning("get blocking timeout, trigger cancel the future task")
+                future.cancel()
             with self.lock:
                 self.connection = None
                 self.failure_time = time.time()


### PR DESCRIPTION
This PR  support setting timeout when `get_blocking` is called, to improve `LMCache` stability.