### PR TITLE
Fix old vllm compatible issue by update LMCacheConnectorV1Impl

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -219,7 +219,9 @@ class RequestTracker:
         self.token_ids.extend(cached_request.new_token_ids)
         new_block_ids: list[int]
 
-        if not isinstance(cached_request.new_block_ids[0], list):
+        if len(cached_request.new_block_ids) == 0:
+            new_block_ids = []
+        elif not isinstance(cached_request.new_block_ids[0], list):
             new_block_ids = cached_request.new_block_ids
         else:
             new_block_ids = cached_request.new_block_ids[0]

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -370,7 +370,7 @@ class LMCacheConnectorV1Impl:
         is_tp = vllm_config.parallel_config.tensor_parallel_size > 1
 
         config = lmcache_get_config()
-
+        self.layerwise_retrievers = []
         if role == KVConnectorRole.SCHEDULER:
             self.lookup_client = LMCacheLookupClient(role, is_tp, vllm_config)
         else:


### PR DESCRIPTION
A simple bug fix.

```
(VllmWorker rank=0 engine_index=0 pid=1677)   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1123, in __call__
(VllmWorker rank=0 engine_index=0 pid=1677)     return self._op(*args, **(kwargs or {}))
(VllmWorker rank=0 engine_index=0 pid=1677)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=0 engine_index=0 pid=1677)   File "/usr/local/lib/python3.12/dist-packages/vllm/attention/layer.py", line 410, in unified_attention_with_output
(VllmWorker rank=0 engine_index=0 pid=1677)     wait_for_kv_layer_from_connector(layer_name)
(VllmWorker rank=0 engine_index=0 pid=1677)   File "/usr/local/lib/python3.12/dist-packages/vllm/attention/layer.py", line 346, in wait_for_kv_layer_from_connector
(VllmWorker rank=0 engine_index=0 pid=1677)     connector.wait_for_layer_load(layer_name)
(VllmWorker rank=0 engine_index=0 pid=1677)   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 59, in wait_for_layer_load
(VllmWorker rank=0 engine_index=0 pid=1677)     self._lmcache_engine.wait_for_layer_load(layer_name)
(VllmWorker rank=0 engine_index=0 pid=1677)   File "/usr/local/lib/python3.12/dist-packages/lmcache/integration/vllm/vllm_v1_adapter.py", line 569, in wait_for_layer_load
(VllmWorker rank=0 engine_index=0 pid=1677)     if self.layerwise_retrievers:
(VllmWorker rank=0 engine_index=0 pid=1677)        ^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorker rank=0 engine_index=0 pid=1677) AttributeError: 'LMCacheConnectorV1Impl' object has no attribute 'layerwise_retrievers'
```

```
st chatcmpl-fb3bbdbab1d44e509c9917b5dcff3161 (vllm_v1_adapter.py:634:lmcache.integration.vllm.vllm_v1_adapter)
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 422, in run_engine_core
    engine_core.run_busy_loop()
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 446, in run_busy_loop
    self._process_engine_step()
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 475, in _process_engine_step
    outputs = self.step_fn()
              ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 220, in step
    scheduler_output = self.scheduler.schedule()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py", line 531, in schedule
    meta = self.connector.build_connector_meta(scheduler_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 132, in build_connector_meta
    return self._lmcache_engine.build_connector_meta(scheduler_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/lmcache/integration/vllm/vllm_v1_adapter.py", line 769, in build_connector_meta
    request_tracker.update(request)
  File "/usr/local/lib/python3.12/dist-packages/lmcache/integration/vllm/vllm_v1_adapter.py", line 206, in update
    if not isinstance(cached_request.new_block_ids[0], list):
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```