### PR TITLE
Refactor remote connector to make it easy to extends

### DIFF
--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -230,6 +230,7 @@ def CreateConnector(
     - blackhole://
     - audit://localhost:8080?verify=true
     - fs:///tmp/lmcache
+    - external://host:0/external_log_connector.lmc_external_log_connector/?connector_name=ExternalLogConnector
 
     Args:
         url: The remote URL

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -15,28 +15,21 @@
 # Standard
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
 import asyncio
+import importlib
+import inspect
+import pkgutil
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
-from lmcache.v1.storage_backend.connector.lm_connector import LMCServerConnector
-from lmcache.v1.storage_backend.connector.redis_connector import (
-    RedisConnector,
-    RedisSentinelConnector,
+from lmcache.v1.storage_backend.connector.instrumented_connector import (
+    InstrumentedRemoteConnector,
 )
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
-
-# Local
-from .audit_connector import AuditConnector
-from .blackhole_connector import BlackholeConnector
-from .fs_connector import FSConnector
-from .infinistore_connector import InfinistoreConnector
-from .instrumented_connector import InstrumentedRemoteConnector
-from .mooncakestore_connector import MooncakestoreConnector
 
 logger = init_logger(__name__)
 
@@ -139,305 +132,6 @@ class ConnectorAdapter(ABC):
         pass
 
 
-class RedisConnectorAdapter(ConnectorAdapter):
-    """Adapter for Redis connectors."""
-
-    def __init__(self) -> None:
-        super().__init__("redis://")
-
-    def can_parse(self, url: str) -> bool:
-        # The Redis adaptor is also applicable to the URL format of rediss.
-        return url.startswith((self.schema, "rediss://", "unix://"))
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create a Redis connector.
-
-        URL formats:
-        - redis://[[username]:[password]@]host[:port][/database][?option=value]
-        - rediss://[[username]:[password]@]host[:port][/database][?option=value] (SSL)
-        - unix://[username@]/path/to/socket.sock?db=0[&password=password]
-
-        Examples:
-        - redis://localhost:6379
-        - redis://user:password@redis.example.com:6380/0
-        - redis://:password@localhost:6379/1
-        - rediss://user:password@redis.example.com:6379?ssl_cert_reqs=CERT_REQUIRED
-        """
-        logger.info(f"Creating Redis connector for URL: {context.url}")
-
-        return RedisConnector(
-            url=context.url,
-            loop=context.loop,
-            local_cpu_backend=context.local_cpu_backend,
-        )
-
-
-class RedisSentinelConnectorAdapter(ConnectorAdapter):
-    """Adapter for Redis Sentinel connectors."""
-
-    def __init__(self) -> None:
-        super().__init__("redis-sentinel://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create a Redis Sentinel connector.
-
-        URL format:
-        - redis-sentinel://[username:password@]host1:port1[,host2:port2,...]/service_name
-        """
-        logger.info(f"Creating Redis connector for URL: {context.url}")
-        url = context.url[len(self.schema) :]
-
-        # parse username and password from url.
-        username: str = ""
-        password: str = ""
-        if "@" in url:
-            auth, url = url.split("@", 1)
-            if ":" in auth:
-                username, password = auth.split(":", 1)
-            else:
-                username = auth
-
-        # parse host and port from url.
-        hosts_and_ports: List[Tuple[str, int]] = []
-        for sub_url in url.split(","):
-            # add a schema to parse the url correctly.
-            if not sub_url.startswith(self.schema):
-                sub_url = self.schema + sub_url
-
-            parsed_url = parse_remote_url(sub_url)
-            hosts_and_ports.append((parsed_url.host, parsed_url.port))
-
-        return RedisSentinelConnector(
-            hosts_and_ports=hosts_and_ports,
-            username=username,
-            password=password,
-            loop=context.loop,
-            local_cpu_backend=context.local_cpu_backend,
-        )
-
-
-class LMServerConnectorAdapter(ConnectorAdapter):
-    """Adapter for LM Server connectors."""
-
-    def __init__(self) -> None:
-        super().__init__("lm://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create an LM Server connector.
-        URL format:
-        - lm://host:port
-        """
-        logger.info(f"Creating LM Server connector for URL: {context.url}")
-        hosts = context.url.split(",")
-        if len(hosts) > 1:
-            raise ValueError(
-                f"Only one host is supported for lm server, but got {hosts}"
-            )
-
-        parse_url = parse_remote_url(context.url)
-        return LMCServerConnector(
-            host=parse_url.host,
-            port=parse_url.port,
-            loop=context.loop,
-            local_cpu_backend=context.local_cpu_backend,
-        )
-
-
-class InfinistoreConnectorAdapter(ConnectorAdapter):
-    """Adapter for Infinistore connectors."""
-
-    def __init__(self) -> None:
-        super().__init__("infinistore://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create an Infinistore connector.
-
-        URL format:
-        - infinistore://host:port[?device=device_name]
-
-        Examples:
-        - infinistore://127.0.0.1:12345
-        - infinistore://infinistore-server.example.com:12345?device=mlx5_0
-        - infinistore://10.0.0.1:12345?device=custom_device
-        """
-        logger.info(f"Creating Infinistore connector for URL: {context.url}")
-        hosts = context.url.split(",")
-        if len(hosts) > 1:
-            raise ValueError(
-                f"Only one host is supported for infinistore, but got {hosts}"
-            )
-
-        parse_url = parse_remote_url(context.url)
-        device_name = parse_url.query_params.get("device", ["mlx5_0"])[0]
-        return InfinistoreConnector(
-            host=parse_url.host,
-            port=parse_url.port,
-            dev_name=device_name,
-            loop=context.loop,
-            memory_allocator=context.local_cpu_backend,
-        )
-
-
-class MooncakestoreConnectorAdapter(ConnectorAdapter):
-    """Adapter for Mooncakestore connectors."""
-
-    def __init__(self) -> None:
-        super().__init__("mooncakestore://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create a Mooncakestore connector.
-
-        URL format:
-        - mooncakestore://host:port[?device=device_name]
-
-        Examples:
-        - mooncakestore://127.0.0.1:50051
-        - mooncakestore://mooncake-server.example.com:50051?device=custom_device
-        """
-        logger.info(f"Creating Mooncakestore connector for URL: {context.url}")
-        hosts = context.url.split(",")
-        if len(hosts) > 1:
-            raise ValueError(
-                f"Only one host is supported for mooncakestore, but got {hosts}"
-            )
-
-        parse_url = parse_remote_url(context.url)
-        device_name = parse_url.query_params.get("device", [""])[0]
-        return MooncakestoreConnector(
-            host=parse_url.host,
-            port=parse_url.port,
-            dev_name=device_name,
-            loop=context.loop,
-            local_cpu_backend=context.local_cpu_backend,
-            lmcache_config=context.config,
-        )
-
-
-class BlackholeConnectorAdapter(ConnectorAdapter):
-    """Adapter for Blackhole connectors (for testing)."""
-
-    def __init__(self) -> None:
-        super().__init__("blackhole://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create a Blackhole connector. This connector is used for testing
-        and discards all data.
-
-        URL format:
-        - blackhole://[any_text]
-
-        Examples:
-        - blackhole://127.0.0.1:8080
-        """
-        logger.info(f"Creating Blackhole connector for URL: {context.url}")
-        return BlackholeConnector()
-
-
-class AuditConnectorAdapter(ConnectorAdapter):
-    """Adapter for Audit connectors (for debugging and verification)."""
-
-    def __init__(self) -> None:
-        super().__init__("audit://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create an Audit connector. This connector wraps another connector
-        and audits all operations.
-
-        URL format:
-        - audit://host:port[?verify=true|false]
-
-        Examples:
-        - audit://localhost:8080
-        - audit://audit-server.example.com:8080?verify=true
-        - audit://127.0.0.1:8080?verify=false
-        """
-        logger.info(f"Creating Audit connector for URL: {context.url}")
-        hosts = context.url.split(",")
-        if len(hosts) > 1:
-            raise ValueError(
-                f"Only one host is supported for audit connector, but got {hosts}"
-            )
-
-        if not context.config or not context.config.audit_actual_remote_url:
-            raise ValueError("audit_actual_remote_url is not set in the config")
-
-        parse_url = parse_remote_url(context.url)
-        verify_param = parse_url.query_params.get("verify", ["false"])[0]
-        verify_checksum = verify_param.lower() in ("true", "1", "yes")
-        real_url = context.config.audit_actual_remote_url
-        connector = CreateConnector(
-            real_url, context.loop, context.local_cpu_backend, context.config
-        )
-        # As the real connector is wrapped, we need to get the wrapped connector
-        return AuditConnector(connector.getWrappedConnector(), verify_checksum)
-
-
-class FsConnectorAdapter(ConnectorAdapter):
-    """Adapter for Filesystem connectors."""
-
-    def __init__(self) -> None:
-        super().__init__("fs://")
-
-    def can_parse(self, url: str) -> bool:
-        return url.startswith(self.schema)
-
-    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
-        """
-        Create a Filesystem connector. This connector stores data
-        in the local filesystem.
-
-        URL format:
-        fs://[host:port]/path
-
-        Examples:
-        - fs:///tmp/lmcache
-        - fs://localhost:0/var/lib/lmcache
-        - fs://127.0.0.1:0/home/user/lmcache_data
-
-        Note: The host:port part is optional and ignored. The path is
-        the important part.
-        """
-        logger.info(f"Creating FS connector for URL: {context.url}")
-        hosts = context.url.split(",")
-        if len(hosts) > 1:
-            raise ValueError(
-                f"Only one host is supported for fs connector, but got {hosts}"
-            )
-
-        parse_url = parse_remote_url(context.url)
-        assert parse_url.path, "Path is required for fs connector"
-
-        if not parse_url.path.startswith("/"):
-            parse_url.path = "/" + parse_url.path
-
-        return FSConnector(parse_url.path, context.loop, context.local_cpu_backend)
-
-
 class ConnectorManager:
     """
     Manager for creating connectors based on URL.
@@ -460,19 +154,43 @@ class ConnectorManager:
             config=config,
         )
         self.adapters: List[ConnectorAdapter] = []
-        self._register_adapters()
+        self._discover_adapters()
 
-    def _register_adapters(self) -> None:
-        """Register all available connector adapters."""
+    def _discover_adapters(self) -> None:
+        """Automatically discover and register all ConnectorAdapter subclasses."""
+        # Import current package to ensure all modules are loaded
+        # First Party
+        import lmcache.v1.storage_backend.connector as connector_pkg
 
-        self.adapters.append(RedisConnectorAdapter())
-        self.adapters.append(RedisSentinelConnectorAdapter())
-        self.adapters.append(LMServerConnectorAdapter())
-        self.adapters.append(InfinistoreConnectorAdapter())
-        self.adapters.append(MooncakestoreConnectorAdapter())
-        self.adapters.append(BlackholeConnectorAdapter())
-        self.adapters.append(AuditConnectorAdapter())
-        self.adapters.append(FsConnectorAdapter())
+        # Discover all modules in the connector package
+        for _, module_name, _ in pkgutil.iter_modules(connector_pkg.__path__):
+            # Skip private modules and non-adapter modules
+            if module_name.startswith("_") or not module_name.endswith("_adapter"):
+                continue
+
+            try:
+                module = importlib.import_module(
+                    f"{connector_pkg.__name__}.{module_name}"
+                )
+
+                # Find all ConnectorAdapter subclasses in the module
+                for _, obj in inspect.getmembers(module):
+                    if (
+                        inspect.isclass(obj)
+                        and issubclass(obj, ConnectorAdapter)
+                        and obj != ConnectorAdapter
+                    ):
+                        try:
+                            adapter_instance = obj()
+                            self.adapters.append(adapter_instance)
+                            logger.info(f"Discovered adapter: {obj.__name__}")
+                        except Exception as e:
+                            logger.error(
+                                "Failed to instantiate adapter "
+                                f"{obj.__name__}: {str(e)}"
+                            )
+            except ImportError as e:
+                logger.warning(f"Failed to import module {module_name}: {e}")
 
     def create_connector(self) -> RemoteConnector:
         for adapter in self.adapters:

--- a/lmcache/v1/storage_backend/connector/audit_adapter.py
+++ b/lmcache/v1/storage_backend/connector/audit_adapter.py
@@ -1,0 +1,70 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    CreateConnector,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class AuditConnectorAdapter(ConnectorAdapter):
+    """Adapter for Audit connectors (for debugging and verification)."""
+
+    def __init__(self) -> None:
+        super().__init__("audit://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .audit_connector import AuditConnector
+
+        """
+        Create an Audit connector. This connector wraps another connector
+        and audits all operations.
+
+        URL format:
+        - audit://host:port[?verify=true|false]
+
+        Examples:
+        - audit://localhost:8080
+        - audit://audit-server.example.com:8080?verify=true
+        - audit://127.0.0.1:8080?verify=false
+        """
+        logger.info(f"Creating Audit connector for URL: {context.url}")
+        hosts = context.url.split(",")
+        if len(hosts) > 1:
+            raise ValueError(
+                f"Only one host is supported for audit connector, but got {hosts}"
+            )
+
+        if not context.config or not context.config.audit_actual_remote_url:
+            raise ValueError("audit_actual_remote_url is not set in the config")
+
+        parse_url = parse_remote_url(context.url)
+        verify_param = parse_url.query_params.get("verify", ["false"])[0]
+        verify_checksum = verify_param.lower() in ("true", "1", "yes")
+        real_url = context.config.audit_actual_remote_url
+        connector = CreateConnector(
+            real_url, context.loop, context.local_cpu_backend, context.config
+        )
+        return AuditConnector(connector, verify_checksum)

--- a/lmcache/v1/storage_backend/connector/blackhole_adapter.py
+++ b/lmcache/v1/storage_backend/connector/blackhole_adapter.py
@@ -1,0 +1,37 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import ConnectorAdapter, ConnectorContext
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class BlackholeConnectorAdapter(ConnectorAdapter):
+    """Adapter for Blackhole connectors (for testing)."""
+
+    def __init__(self) -> None:
+        super().__init__("blackhole://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .blackhole_connector import BlackholeConnector
+
+        logger.info(f"Creating Blackhole connector for URL: {context.url}")
+        return BlackholeConnector()

--- a/lmcache/v1/storage_backend/connector/external_adapter.py
+++ b/lmcache/v1/storage_backend/connector/external_adapter.py
@@ -1,0 +1,89 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class ExternalConnectorAdapter(ConnectorAdapter):
+    """Adapter for External connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("external://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        """
+        Create an External connector. This connector stores data
+        in the key-value store.
+        URL format:
+        - external://host:port/module_path/?connector_name=ConnectorName
+        Examples:
+        - external://host:0/external_log_connector.lmc_external_log_connector/?connector_name=ExternalLogConnector
+        """
+        logger.info(f"Creating External connector for URL: {context.url}")
+        hosts = context.url.split(",")
+        if len(hosts) > 1:
+            raise ValueError(
+                f"Only one host is supported for external connector, but got {hosts}"
+            )
+
+        parse_url = parse_remote_url(context.url)
+
+        # Get the module path and connector name
+        module_path = parse_url.path.strip("/")
+        connector_name = parse_url.query_params.get("connector_name", [""])[0]
+        if not connector_name:
+            raise ValueError(
+                "External connector requires 'connector_name' in query parameters"
+            )
+
+        # Lazily import the module and get the connector class
+        # Standard
+        import importlib
+
+        try:
+            module = importlib.import_module(module_path)
+            connector_class = getattr(module, connector_name)
+
+            # Verify that it's a subclass of RemoteConnector
+            if not issubclass(connector_class, RemoteConnector):
+                raise TypeError(
+                    f"{connector_name} must be a subclass of RemoteConnector"
+                )
+
+            # Create the connector instance
+            connector = connector_class(
+                loop=context.loop,
+                local_cpu_backend=context.local_cpu_backend,
+                config=context.config,
+            )
+            logger.info(f"Loaded external connector: {module_path}.{connector_name}")
+            return connector
+        except ImportError as e:
+            raise ImportError(f"Could not import module '{module_path}'") from e
+        except AttributeError as e:
+            raise AttributeError(
+                f"Module '{module_path}' has no class '{connector_name}'"
+            ) from e

--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -1,0 +1,42 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class FsConnectorAdapter(ConnectorAdapter):
+    """Adapter for Filesystem connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("fs://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .fs_connector import FSConnector
+
+        logger.info(f"Creating FS connector for URL: {context.url}")
+        parse_url = parse_remote_url(context.url)
+        return FSConnector(parse_url.path, context.loop, context.local_cpu_backend)

--- a/lmcache/v1/storage_backend/connector/infinistore_adapter.py
+++ b/lmcache/v1/storage_backend/connector/infinistore_adapter.py
@@ -1,0 +1,55 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class InfinistoreConnectorAdapter(ConnectorAdapter):
+    """Adapter for Infinistore connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("infinistore://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .infinistore_connector import InfinistoreConnector
+
+        logger.info(f"Creating Infinistore connector for URL: {context.url}")
+        hosts = context.url.split(",")
+        if len(hosts) > 1:
+            raise ValueError(
+                f"Only one host is supported for infinistore, but got {hosts}"
+            )
+
+        parse_url = parse_remote_url(context.url)
+        device_name = parse_url.query_params.get("device", ["mlx5_0"])[0]
+        return InfinistoreConnector(
+            host=parse_url.host,
+            port=parse_url.port,
+            dev_name=device_name,
+            loop=context.loop,
+            memory_allocator=context.local_cpu_backend,
+        )

--- a/lmcache/v1/storage_backend/connector/lm_adapter.py
+++ b/lmcache/v1/storage_backend/connector/lm_adapter.py
@@ -1,0 +1,47 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class LMServerConnectorAdapter(ConnectorAdapter):
+    """Adapter for LM Server connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("lm://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .lm_connector import LMCServerConnector
+
+        logger.info(f"Creating LM Server connector for URL: {context.url}")
+        parse_url = parse_remote_url(context.url)
+        return LMCServerConnector(
+            host=parse_url.host,
+            port=parse_url.port,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+        )

--- a/lmcache/v1/storage_backend/connector/mooncakestore_adapter.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_adapter.py
@@ -1,0 +1,56 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class MooncakestoreConnectorAdapter(ConnectorAdapter):
+    """Adapter for Mooncakestore connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("mooncakestore://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .mooncakestore_connector import MooncakestoreConnector
+
+        logger.info(f"Creating Mooncakestore connector for URL: {context.url}")
+        hosts = context.url.split(",")
+        if len(hosts) > 1:
+            raise ValueError(
+                f"Only one host is supported for mooncakestore, but got {hosts}"
+            )
+
+        parse_url = parse_remote_url(context.url)
+        device_name = parse_url.query_params.get("device", [""])[0]
+        return MooncakestoreConnector(
+            host=parse_url.host,
+            port=parse_url.port,
+            dev_name=device_name,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+            config=context.config,
+        )

--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -1,0 +1,91 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Standard
+from typing import List, Tuple
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class RedisConnectorAdapter(ConnectorAdapter):
+    """Adapter for Redis connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("redis://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith((self.schema, "rediss://", "unix://"))
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .redis_connector import RedisConnector
+
+        logger.info(f"Creating Redis connector for URL: {context.url}")
+        return RedisConnector(
+            url=context.url,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+        )
+
+
+class RedisSentinelConnectorAdapter(ConnectorAdapter):
+    """Adapter for Redis Sentinel connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("redis-sentinel://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .redis_connector import RedisSentinelConnector
+
+        logger.info(f"Creating Redis Sentinel connector for URL: {context.url}")
+        url = context.url[len(self.schema) :]
+
+        # Parse username and password
+        username: str = ""
+        password: str = ""
+        if "@" in url:
+            auth, url = url.split("@", 1)
+            if ":" in auth:
+                username, password = auth.split(":", 1)
+            else:
+                username = auth
+
+        # Parse host and port
+        hosts_and_ports: List[Tuple[str, int]] = []
+        for sub_url in url.split(","):
+            if not sub_url.startswith(self.schema):
+                sub_url = self.schema + sub_url
+
+            parsed_url = parse_remote_url(sub_url)
+            hosts_and_ports.append((parsed_url.host, parsed_url.port))
+
+        return RedisSentinelConnector(
+            hosts_and_ports=hosts_and_ports,
+            username=username,
+            password=password,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+        )


### PR DESCRIPTION
# Motivation

Inspired by https://github.com/LMCache/LMCache/pull/737 , and did a small further step to make new remote connector developer never need to modify the source file out of the new connector, base on this, new built-in connector PR should never conflict with others.

# Core changes
- Use `_discover_adapters` to discover all `connectorAdapter` and append to `adapters` automatically.
- Move all `connectorAdapter` to a single individual files for two purpose
    - Reduce conflict. Keep individual for each connector related.
    - Lazy import. We do not need to install all dependences of `all remote connectors`, but we need to discover all the `connectorAdapter` implementation, so we need to import the real remote connector implementation only while create connector.