### PR TITLE
[RFC] Parallel get to improve TTFT a bit

### DIFF
--- a/docs/source/kv_cache/storage_backends/gds.rst
+++ b/docs/source/kv_cache/storage_backends/gds.rst
@@ -133,18 +133,17 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
 
 
-POSIX fallback
---------------
+Further settings
+-----------------
 
-In some cases, libcufile implements its own internal POSIX fallback without `GdsBackend` being aware.
-In others, an error such as `RuntimeError: cuFileHandleRegister failed (cuFile err=5030, cuda_err=0)` may be throwned.
-Thus, backend can be configured to fallback to its own POSIX implementation when the usage of the libcufile APIs is not successful.
+The `extra_config` configuration variable can support the following:
 
-To force `GdsBackend` not use libcufile APIs for any reason, you can override its behavior via `extra_config`,
-e.g:
+- ``use_cufile`` (type: boolean): POSIX fallback. In some cases, NVIDIA `libcufile` implements its own internal POSIX fallback without `GdsBackend` being aware. In others, an error such as `RuntimeError: cuFileHandleRegister failed (cuFile err=5030, cuda_err=0)` may be throwned. Thus, backend can be configured to fallback to its own POSIX implementation when the usage of the libcufile APIs is not successful. Pass `false` here to enable the fallback. Note that under this mode it would still use CUDA APIs to map and do operations the pre-registered GPU memory. **Default**: true
+
+- ``batched_get_threads`` (type: integer): This is the number of threads that will be spawned for a dedicated blocking call threadpool to service backend ``blocking_get`` requests. This can improve latency on some cases. **Default:** none.
+
+Example config (via environment variable):
 
 .. code-block:: yaml
 
-    LMCACHE_EXTRA_CONFIG='{"use_cufile": false}'
-
-Note that under this mode it would still use CUDA APIs to map and do operations the pre-registered GPU memory.
+    LMCACHE_EXTRA_CONFIG='{"batched_get_threads": 16, "use_cufile": false}'

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -35,6 +35,18 @@ _METADATA_MAX_SIZE = 4096  # reserve 4K for metadata.
 # TODO: It is possible to read this 4KB block without triggering read-ahead by
 # various means.
 
+THREAD_POOL = None
+
+
+def get_thread_pool(max_workers):
+    # Standard
+    from concurrent.futures import ThreadPoolExecutor
+
+    global THREAD_POOL
+    if not THREAD_POOL:
+        THREAD_POOL = ThreadPoolExecutor(max_workers=max_workers)
+    return THREAD_POOL
+
 
 class UnsupportedMetadataVersion(Exception):
     pass
@@ -154,6 +166,20 @@ def get_extra_config_bool(key, config: LMCacheEngineConfig) -> bool | None:
     return bool_value
 
 
+def get_extra_config_int(key, config: LMCacheEngineConfig) -> int | None:
+    value = config.extra_config.get(key, None)
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        int_value = int(value)
+    else:
+        raise RuntimeError(f"Invalid value `{value}` for `{key}` in extra_config")
+
+    logger.info(f"Getting {key} = {int_value} from extra_config")
+    return int_value
+
+
 class GdsBackend(StorageBackendInterface):
     """
     Originally based on the open sourced WekaGdsBackend, this is a backend that
@@ -198,11 +224,19 @@ class GdsBackend(StorageBackendInterface):
         self.use_cufile = True
         use_cufile_from_config = False
 
+        # Whether to enable parallel blocking 'get' and and the amount of background
+        # threads that will be serving `get` calls on the backend in parallel
+        self.batched_get_threads = None
+
         if config.extra_config is not None:
             use_cufile = get_extra_config_bool("use_cufile", config)
             if use_cufile is not None:
                 self.use_cufile = use_cufile
                 use_cufile_from_config = True
+
+            self.batched_get_threads = get_extra_config_int(
+                "batched_get_threads", config
+            )
 
         if self.fstype in ["tmpfs", "overlayfs"]:
             # TODO: we can replace the auto-detection of unsupported cufile
@@ -503,6 +537,26 @@ class GdsBackend(StorageBackendInterface):
         assert dtype is not None
         assert shape is not None
         return self._load_bytes_from_disk(key, path, dtype=dtype, shape=shape)
+
+    def batched_get_blocking(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj | None]:
+        if self.batched_get_threads is not None:
+            futures = []
+            for key in keys:
+                futures.append(
+                    get_thread_pool(self.batched_get_threads).submit(
+                        self.get_blocking, key
+                    )
+                )
+            mem_objs = [f.result() for f in futures]
+        else:
+            mem_objs = []
+            for key in keys:
+                mem_objs.append(self.get_blocking(key))
+
+        return mem_objs
 
     def _load_bytes_from_disk(
         self,


### PR DESCRIPTION
We saw a 10% improvement in TTFT by allowing `blocking_get` to be served from threadpool.

This adds the ability to enable this threadpool and to specify the size of the threadpool in the amount of threads.

I'm not expecting this to be merged as-is... I am putting this here more to open a discussion. 

Some points:

- I am aware there's the `LayerwiseLMCacheEngine` which is using the async APIs for fetching KV cache, so adding a thread pool may seem somewhat redundant. However after some experimentation I see it is either not fully stable or does not improve latency over original `LMCacheEngine`. Even after `LayerwiseLMCacheEngine` would work well, I think this change still has value, because it would allow to do a more robust comparison of the performance difference of the the two engines.
- We likely need to find a better name than the too long `parallel_blocking_get_thread_count`. Please suggest.