### PR TITLE
[Bugfix] Fix shape mismatch in cacheblend with partial HBM cache (fixes #854)

### DIFF
--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -69,9 +69,15 @@ class LMCBlender:
         layer_id: int,
         attn_output: Optional[torch.Tensor],
         attn_metadata,
+        mask: Optional[torch.Tensor] = None
     ):
         logger.debug(f"Blender is processing KV for layer {layer_id}")
         old_k, old_v = self.gpu_connector.get_kv(layer_id)
+
+        if mask is not None:
+            num_falses = mask.numel() - mask.long().sum().item()
+        else:
+            num_falses = 0
 
         if attn_output is None:
             attn_output = torch.empty(
@@ -90,8 +96,11 @@ class LMCBlender:
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
 
         if layer_id in self.common_metadata.check_layers:
+            assert k[num_falses:].shape[0] == old_k.shape[0], \
+                "Mismatch between number of tokens in k (after skipping falses) and old_k"
+
             diff_k = torch.sum(
-                (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
+                (k[num_falses:].to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
             )
             total_len = diff_k.shape[0]
 
@@ -136,7 +145,7 @@ class LMCBlender:
 
         # TODO(Jiayi): store is currently not included in this function
 
-        layerwise_model_executor = self.layerwise_model.compute_layer(tokens)
+        layerwise_model_executor = self.layerwise_model.compute_layer(tokens, mask)
         layerwise_retriever = self.cache_engine.retrieve_layer(tokens, mask, **kwargs)
 
         next(layerwise_retriever)

--- a/lmcache/v1/compute/models/llama.py
+++ b/lmcache/v1/compute/models/llama.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Third Party
+from typing import Optional
 from torch import nn
 import torch
 
@@ -68,6 +69,7 @@ class LMCLlamaModel(nn.Module):
     def compute_layer(
         self,
         input_ids: torch.Tensor,
+        mask: Optional[torch.Tensor] = None
     ):
         hidden_states = self.vllm_model.get_input_embeddings(input_ids.cuda())
         residual = None
@@ -116,7 +118,7 @@ class LMCLlamaModel(nn.Module):
             )
 
             q, k, v, residual, attn_output, attn_metadata = self.blender.process_qkv(
-                q, k, v, residual, idx, attn_output, attn_metadata
+                q, k, v, residual, idx, attn_output, attn_metadata, mask
             )
 
             num_heads = self.vllm_attn_layers[idx].num_heads


### PR DESCRIPTION
This PR fixes a shape mismatch issue in the cacheblend component when handling partial caches stored in HBM.

The original code assumed that the key tensors `k` and the `old_k` have the same length. However, in cases where a partial cache exists in HBM—enabled by the `APC` mechanism in vLLM—`k` contains tokens from both HBM and storage, while `old_k` only contains tokens from storage. This difference causes a shape mismatch error during comparison.

The fix adjusts the comparison by ignoring the initial tokens corresponding to the partial HBM cache, preventing the mismatch and ensuring correct behavior.

Fixes #854

