### PR TITLE
Fix double invoke ref_count_down issue while using audit connector

### DIFF
--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -393,7 +393,8 @@ class AuditConnectorAdapter(ConnectorAdapter):
         connector = CreateConnector(
             real_url, context.loop, context.local_cpu_backend, context.config
         )
-        return AuditConnector(connector, verify_checksum)
+        # As the real connector is wrapped, we need to get the wrapped connector
+        return AuditConnector(connector.getWrappedConnector(), verify_checksum)
 
 
 class FsConnectorAdapter(ConnectorAdapter):
@@ -486,7 +487,7 @@ def CreateConnector(
     loop: asyncio.AbstractEventLoop,
     local_cpu_backend: LocalCPUBackend,
     config: Optional[LMCacheEngineConfig] = None,
-) -> Optional[RemoteConnector]:
+) -> Optional[InstrumentedRemoteConnector]:
     """
     Create a remote connector from the given URL.
 

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -76,3 +76,6 @@ class InstrumentedRemoteConnector(RemoteConnector):
 
     async def close(self) -> None:
         await self._connector.close()
+
+    def getWrappedConnector(self) -> RemoteConnector:
+        return self._connector


### PR DESCRIPTION
This is a quick fix.

As audit connector is wrapped by `InstrumentedRemoteConnector`, but the `_connector` of `auditConnector` is wrapped by `InstrumentedRemoteConnector` too, so after a `put` operation called, the `ref_count_down ` invoked twice.