### PR TITLE
FSConnector#get should not output error log for FileNotFoundError 

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -107,6 +107,9 @@ class FSConnector(RemoteConnector):
 
             return memory_obj
 
+        except FileNotFoundError:
+            # Key does not exist is normal case
+            return None
         except Exception as e:
             logger.error(f"Failed to read from file {file_path}: {str(e)}")
             return None


### PR DESCRIPTION
# Description
FileNotFoundError while `get` for FSConnector is a normal case, so we need to keep silent for this case.

# How to test

Run vllm with lmcache

**_Notice:  --no-enable-prefix-caching --no-enable-chunked-prefill are necessary parameters_**

```
LMCACHE_CONFIG_FILE=./lmcache_audit.yaml \
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
          --trust-remote-code \
          --served-model-name vllm_cpu_offload \
          --max-model-len 12000 \
          --max-seq-len-to-capture 12000 \
          --gpu-memory-utilization 0.9  \
          --disable-log-requests \
          -tp 1 \
          --no-enable-prefix-caching --no-enable-chunked-prefill \
          --max-num-batched-tokens 12000 --enforce-eager \
--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_parallel_size":2}'
```

- lmcache_audit.yaml
```yaml
chunk_size: 256
local_device: "cpu"
remote_url: "audit://host:0/"
audit_actual_remote_url: "fs://host:0/disc/data1/baoloongmao/fs_data/"
remote_serde: "naive"
# Whether retrieve() is pipelined or not
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 10
```

Curl two request, first request contains over 1 chunk, second request contains over 2 chunk.

```shell
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'


    curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'
```

- vllm.log
```console
[2025-06-19 15:52:49,684] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:49,684] LMCache INFO: Reqid: chatcmpl-a8a5d44cdd3e45e7a81ab49737eaa596, Total tokens 265, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:769:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-19 15:52:49,717] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:49,717] LMCache INFO: Storing KV cache for 265 out of 265 tokens (skip_leading_tokens=0) for request chatcmpl-a8a5d44cdd3e45e7a81ab49737eaa596 (vllm_v1_adapter.py:712:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-19 15:52:49,717] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:49,723] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9708277a7b6572932de251a248aeb8b24978af85e21d53ea1311faefd82de298') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:49,725] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Size:279936|Checksum:92ff83a4|Cost:1.517672ms|Saved:0|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='9708277a7b6572932de251a248aeb8b24978af85e21d53ea1311faefd82de298') (audit_connector.py:72:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:49,727] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Size:7962624|Checksum:09fb0b96|Cost:4.166560ms|Saved:0|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:72:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:49,974] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:468:lmcache.integration.vllm.vllm_v1_adapter)
INFO:     127.0.0.1:43062 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO 06-19 15:52:51 [loggers.py:118] Engine 000: Avg prompt throughput: 26.5 tokens/s, Avg generation throughput: 1.2 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%




[2025-06-19 15:52:59,882] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,883] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,883] LMCache INFO: Reqid: chatcmpl-08990936f73342d488e8fbcf654f8cb0, Total tokens 529, LMCache hit tokens: 256, need to load: 256 (vllm_v1_adapter.py:769:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-19 15:52:59,892] LMCache INFO: [REMOTE_AUDIT]GET|SUCCESS|Checksum:09fb0b96|Cost:2.271328ms|Saved:0|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:118:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,893] LMCache ERROR: Failed to read from file /disc/data1/baoloongmao/fs_data/vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@1@0@fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e.data: [Errno 2] No such file or directory: '/disc/data1/baoloongmao/fs_data/vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@1@0@fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e.data' (fs_connector.py:111:lmcache.v1.storage_backend.connector.fs_connector)
[2025-06-19 15:52:59,893] LMCache INFO: [REMOTE_AUDIT]GET|MISS|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e')|Saved: 0 (audit_connector.py:95:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,939] LMCache INFO: [REMOTE_AUDIT]EXISTS|True|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='b415471b3f5989b8752093a51601c86a5ddda74b1096999c476c5885c7e0b1f1') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,940] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,940] LMCache INFO: Storing KV cache for 273 out of 529 tokens (skip_leading_tokens=256) for request chatcmpl-08990936f73342d488e8fbcf654f8cb0 (vllm_v1_adapter.py:712:lmcache.integration.vllm.vllm_v1_adapter)
[2025-06-19 15:52:59,940] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,946] LMCache INFO: [REMOTE_AUDIT]EXISTS|False|Key: CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='29f0e6b10b573d547bd94297fe15b595214094c2c922e83ea7fd2b80009e8a58') (audit_connector.py:133:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,948] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Size:528768|Checksum:90eb3dd6|Cost:1.564812ms|Saved:0|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='29f0e6b10b573d547bd94297fe15b595214094c2c922e83ea7fd2b80009e8a58') (audit_connector.py:72:lmcache.v1.storage_backend.connector.audit_connector.audit)
[2025-06-19 15:52:59,949] LMCache INFO: [REMOTE_AUDIT]PUT|SUCCESS|Size:7962624|Checksum:8e725e68|Cost:3.519252ms|Saved:0|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/', world_size=1, worker_id=0, chunk_hash='fa49f485c0af48824a3f490089766f080a5447e5c11392c1370179bf87621d7e') (audit_connector.py:72:lmcache.v1.storage_backend.connector.audit_connector.audit)
```