### PR TITLE
[bugfix] fix skip_leading_tokens always 0

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -640,11 +640,10 @@ class LMCacheConnectorV1Impl:
                 # return 0 if there is no local storage configured.
                 # In this case, we should rely on the slip_leading_tokens in
                 # save_spec to avoid transmit the already saved tokens again.
-                # skip_leading_tokens = max(
-                #    self.lmcache_engine.lookup(token_ids),
-                #    save_spec.skip_leading_tokens,
-                # )
-                skip_leading_tokens = save_spec.skip_leading_tokens
+                skip_leading_tokens = max(
+                    self.lmcache_engine.lookup(token_ids),
+                    save_spec.skip_leading_tokens,
+                )
 
                 if skip_leading_tokens == len(token_ids):
                     continue  # skip this request
@@ -725,11 +724,10 @@ class LMCacheConnectorV1Impl:
             # 0 if there is no local storage configured. In this case, we
             # should rely on the slip_leading_tokens in save_spec to avoid
             # transmit the already saved tokens again.
-            # skip_leading_tokens = max(
-            #    self.lmcache_engine.lookup(token_ids),
-            #    save_spec.skip_leading_tokens,
-            # )
-            skip_leading_tokens = save_spec.skip_leading_tokens
+            skip_leading_tokens = max(
+                self.lmcache_engine.lookup(token_ids),
+                save_spec.skip_leading_tokens,
+            )
 
             if skip_leading_tokens == len(token_ids):
                 continue  # skip this request


### PR DESCRIPTION
# Description
In out internal test, we found that there is hits in lmcache, but `skip_leading_tokens` is always 0.

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/b90bbd27-9cb2-4a3f-93e4-43416399e554" />
<img width="1445" alt="image" src="https://github.com/user-attachments/assets/d3215138-5266-4754-a6ce-ec6082fd5028" />

By learning code,  `from_new_request` always return `RequestTracker` with `num_saved_tokens=0`,  which result in that no matter if there is token hit or not, `skip_leading_tokens` is always 0.

With this PR, the number of calls to `lookup` will increase(Actually, it's calling `contains`), but with `store_mask[:skip_leading_tokens] = False`,  when processing keys through `process_token`, the previous keys will also be filtered out, which will decrease the number of calls to `contains`. Therefore, I understand that this will have almost no impact on performance.

In addition, with `store_mask[:skip_leading_tokens] = False`, the existing keys have been skipped. Do we still need to call `self.storage_manager.contains(key)` in `store` or `store_layer` of `cache_engine`?