### PR TITLE
Support sglang gpu connector SGLangPagedMemGPUConnector

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -230,6 +230,7 @@ __global__ void load_and_reshape_multi_layer_kernel(
   }
 }
 
+<<<<<<< Updated upstream
 template <typename scalar_t, bool DIRECTION>
 __global__ void load_and_reshape_multi_layer_kernel_unilateral(
     scalar_t* __restrict__ key_value,    // [2, num_layer, num_tokens,
@@ -239,17 +240,43 @@ __global__ void load_and_reshape_multi_layer_kernel_unilateral(
     scalar_t** __restrict__ value_ptrs,  // [num_layers] * [PAGE_BUFFER_SIZE,
                                          // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,  // [num_tokens]
+=======
+/**
+ * Quickly load KV cache between sglang MHA paged memory and offloading buffer
+ * sglang K or V format is [token_id, head_dim, head_size]
+ * slot_id = slot_mapping[block.x]
+ * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][block.z,
+ * slot_id, thread.x]
+ * Note: does not support MLA, please use VLLM version
+ */
+template <typename scalar_t, bool DIRECTION>
+__global__ void load_and_reshape_multi_layer_kernel_sglang(
+    scalar_t* __restrict__ key_value,           // [2, num_layer, num_tokens,
+                                                // scalars_per_token]
+    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * [2,
+                                                // PAGE_BUFFER_SIZE,
+                                                // scalars_per_token]
+    const int64_t* __restrict__ slot_mapping,   // [num_tokens]
+>>>>>>> Stashed changes
     const int scalars_per_token, const int num_tokens, const int num_layers,
     const int page_buffer_size) {
   const int token_id = blockIdx.x;
   const int layer_id = blockIdx.y;
+<<<<<<< Updated upstream
   const int k_or_v = blockIdx.z;
+=======
+>>>>>>> Stashed changes
   const int tid = threadIdx.x;
   const int num_threads = blockDim.x;
 
   const int64_t slot_idx = slot_mapping[token_id];
+<<<<<<< Updated upstream
   int64_t* key_ptr = key_ptrs[layer_id];
   int64_t* value_ptr = value_ptrs[layer_id];
+=======
+  int64_t* key_paged_buffer_ptr = paged_buffer_ptrs[layer_id];
+  int64_t* val_paged_buffer_ptr = paged_buffer_ptrs[layer_id + num_layers];
+>>>>>>> Stashed changes
 
   if (slot_idx < 0) {
     return;
@@ -257,6 +284,7 @@ __global__ void load_and_reshape_multi_layer_kernel_unilateral(
 
   /** Copy the data from page buffer to key_value **/
   for (int i = tid; i < scalars_per_token; i += num_threads) {
+<<<<<<< Updated upstream
     const int64_t lmcache_offset =
         key_value_offset(k_or_v, layer_id, token_id, i, scalars_per_token,
                          num_tokens, num_layers);
@@ -274,6 +302,23 @@ __global__ void load_and_reshape_multi_layer_kernel_unilateral(
         key_value[lmcache_offset] = value_ptr[sgl_offset];
       else  // 0 is LMCache to paged buffer
         value_ptr[sgl_offset] = key_value[lmcache_offset];
+=======
+    const int64_t key_lmcache_offset =
+        layer_id * num_tokens * scalars_per_token +
+        token_id * scalars_per_token + i;
+    const int64_t val_lmcache_offset =
+        num_layers * num_tokens * scalars_per_token + key_lmcache_offset;
+    const int64_t sglang_offset = slot_idx * scalars_per_token + i;
+
+    if (DIRECTION) {
+      // DIRECTION 1 is paged buffer to LMCache
+      key_value[key_lmcache_offset] = key_paged_buffer_ptr[sglang_offset];
+      key_value[val_lmcache_offset] = val_paged_buffer_ptr[sglang_offset];
+    } else {
+      // DIRECTION 0 is LMCache to paged buffer
+      key_paged_buffer_ptr[sglang_offset] = key_value[key_lmcache_offset];
+      val_paged_buffer_ptr[sglang_offset] = key_value[val_lmcache_offset];
+>>>>>>> Stashed changes
     }
   }
 }
@@ -334,7 +379,7 @@ void multi_layer_kv_transfer(
     const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
-    const bool direction, const bool use_mla) {
+    const bool direction, const bool use_mla, const bool is_sglang) {
   int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
   int64_t** page_buffer_ptrs =
       get_kernel_ptr<int64_t*, const torch::Tensor>(key_value_ptrs);
@@ -348,7 +393,7 @@ void multi_layer_kv_transfer(
   int num_qwords = num_origin_elements / elements_per_qword;
 
   int k_or_v_size = 2;
-  if (use_mla) {
+  if (use_mla || is_sglang) {
     k_or_v_size = 1;
   }
 
@@ -358,18 +403,34 @@ void multi_layer_kv_transfer(
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  if (not direction) {
-    lmc::load_and_reshape_multi_layer_kernel<int64_t, false>
-        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
-                                     slot_mapping_ptr, num_qwords, num_tokens,
-                                     num_layers, page_buffer_size);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  if ((!is_sglang) || use_mla) {
+    if (not direction) {
+      lmc::load_and_reshape_multi_layer_kernel<int64_t, false>
+          <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+                                       slot_mapping_ptr, num_qwords, num_tokens,
+                                       num_layers, page_buffer_size);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    } else {
+      lmc::load_and_reshape_multi_layer_kernel<int64_t, true>
+          <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+                                       slot_mapping_ptr, num_qwords, num_tokens,
+                                       num_layers, page_buffer_size);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
   } else {
-    lmc::load_and_reshape_multi_layer_kernel<int64_t, true>
-        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
-                                     slot_mapping_ptr, num_qwords, num_tokens,
-                                     num_layers, page_buffer_size);
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    if (not direction) {
+      lmc::load_and_reshape_multi_layer_kernel_sglang<int64_t, false>
+          <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+                                       slot_mapping_ptr, num_qwords, num_tokens,
+                                       num_layers, page_buffer_size);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    } else {
+      lmc::load_and_reshape_multi_layer_kernel_sglang<int64_t, true>
+          <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+                                       slot_mapping_ptr, num_qwords, num_tokens,
+                                       num_layers, page_buffer_size);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+    }
   }
 }
 

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -27,7 +27,7 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& slot_mapping,
                              const torch::Device& paged_memory_device,
                              const int page_buffer_size, const bool direction,
-                             const bool use_mla);
+                             const bool use_mla, const bool is_sglang);
 
 void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_ptrs,

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -414,6 +414,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.page_buffer_size,
             False,
             self.use_mla,
+            False,
         )
 
     @_lmcache_nvtx_annotate
@@ -457,6 +458,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                 self.page_buffer_size,
                 True,
                 self.use_mla,
+                False,
             )
         else:
             # kvcaches -> gpu_buffer -> memobj
@@ -470,6 +472,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                 self.page_buffer_size,
                 True,
                 self.use_mla,
+                False,
             )
             memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 

--- a/lmcache/v1/gpu_connector_sglang.py
+++ b/lmcache/v1/gpu_connector_sglang.py
@@ -1,0 +1,253 @@
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+from typing import List, Optional, Tuple, Union
+import abc
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.integration.vllm.utils import ENGINE_NAME
+from lmcache.logging import init_logger
+from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.v1.compute.blend.utils import LMCBlenderBuilder
+from lmcache.v1.memory_management import GPUMemoryAllocator  # noqa: E501
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.gpu_connector import GPUConnectorInterface
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+
+
+class SGLangPagedMemGPUConnector(GPUConnectorInterface):
+    """
+    The GPU KV cache should be a nested tuple of K and V tensors.
+    More specifically, we have:
+    - GPUTensor = Tuple[KVLayer, ...]
+    - KVLayer = Tuple[Tensor, Tensor]
+    - Tensor: [num_blocks, block_size, num_heads, head_size]
+
+    It will produce / consume memory object with KV_2LTD format
+    """
+
+    def __init__(
+        self,
+        hidden_dim_size: int,
+        num_layers: int,
+        use_gpu: bool = False,
+        **kwargs,
+    ):
+        """
+        If use_gpu is true, it will create a gpu intermediate buffer. In this
+        case, it requires the following kwargs:
+        - chunk_size: The MAX size of the chunk to be copied to GPU.
+        - dtype: The data type of the intermediate buffer.
+        """
+        self.hidden_dim_size = hidden_dim_size
+        self.num_layers = num_layers
+
+        # Not sure we need a dict here. Maybe a single GPU connector always
+        # works with a single device?
+        self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
+        self.page_buffer_size = 0
+
+        self.gpu_buffer: Optional[torch.Tensor] = None
+        self.use_mla = "use_mla" in kwargs and kwargs["use_mla"]
+
+        if self.use_mla:
+            self.kv_cache_pointers = torch.empty(
+                num_layers, dtype=torch.int64, device="cpu"
+            )
+        else:
+            self.kv_cache_pointers = torch.empty(
+                num_layers * 2, dtype=torch.int64, device="cpu"
+            )
+
+        if use_gpu:
+            assert "chunk_size" in kwargs, (
+                "chunk_size should be provided to create a GPU buffer."
+            )
+            assert "dtype" in kwargs, "dtype should be provided to create a GPU buffer."
+            assert "device" in kwargs, (
+                "device should be provided to create a GPU buffer."
+            )
+            shape = self.get_shape(kwargs["chunk_size"])
+            self.gpu_buffer = torch.empty(
+                shape, dtype=kwargs["dtype"], device=kwargs["device"]
+            )
+
+    def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
+        """
+        - kv_caches: sglang k_buffer + v_buffer for MHA and kv_buffer for MLA
+        """
+        if self.use_mla:
+            assert len(kv_caches) == self.num_layers
+        else:
+            assert len(kv_caches) == self.num_layers * 2
+        self.kv_cache_pointers.numpy()[:] = [t.data_ptr() for t in kv_caches]
+        device = kv_caches[0].device
+        assert device.type == "cuda", "The device should be CUDA."
+        idx = device.index
+        if idx not in self.kv_cache_pointers_on_gpu:
+            self.kv_cache_pointers_on_gpu[idx] = torch.empty(
+                len(kv_caches), dtype=torch.int64, device=device
+            )
+        self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
+        if self.use_mla:
+            # VLLM MLA kv_caches[0].shape: [num_pages, page_size, head_size]
+            # sglang MLA kv_caches[0].shape: [num_pages * page_size, 1, head_size]
+            assert kv_caches[0].dim() == 3
+            assert kv_caches[0].shape[1] == 1
+            self.page_buffer_size = kv_caches[0].shape[0]
+        else:
+            # VLLM MHA kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size]
+            # sglang MHA kv_caches[0].shape: [num_pages * page_size, num_heads, head_size]
+            assert kv_caches[0].dim() == 3
+            self.page_buffer_size = kv_caches[0].shape[0]
+        return self.kv_cache_pointers_on_gpu[idx]
+
+    @_lmcache_nvtx_annotate
+    def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
+        The kvcaches should correspond to the "WHOLE token sequence".
+
+        Note:
+          1. This function expects the 'slot_mapping' is a "full slot mapping"
+             where it's length is the same as the whole token sequence.
+          2. In the case that there is prefix caching, slot_mapping will starts
+             with -1s until the end of the matched prefix. The start and end
+             should NEVER overlap with the prefix caching (which means the
+             underlying CUDA kernel will never see -1 in slot_mapping)
+
+
+        :raises ValueError: If 'kvcaches' is not provided in kwargs.
+        :raises AssertionError: If the memory object does not have a tensor.
+        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        slot_mapping is what is stored in req_to_token_pool
+        """
+        assert memory_obj.tensor is not None
+
+        if self.use_mla:
+            if memory_obj.metadata.fmt != MemoryFormat.KV_MLA_FMT:
+                raise ValueError(
+                    "The memory object should be in KV_MLA_FMT format in"
+                    f" order to be processed by {self.__class__.__name__}"
+                )
+        else:
+            if memory_obj.metadata.fmt != MemoryFormat.KV_2LTD:
+                raise ValueError(
+                    "The memory object should be in KV_2LTD format in"
+                    f" order to be processed by {self.__class__.__name__}"
+                )
+
+        if "kvcaches" not in kwargs:
+            raise ValueError("'kvcaches' should be provided in kwargs.")
+
+        if "slot_mapping" not in kwargs:
+            raise ValueError("'slot_mapping' should be provided in kwargs.")
+
+        kvcaches: List[torch.Tensor] = kwargs["kvcaches"]
+        slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+
+        kv_cache_pointers = self._initialize_pointers(kvcaches)
+
+        lmc_ops.multi_layer_kv_transfer(
+            memory_obj.tensor,
+            kv_cache_pointers,
+            slot_mapping[start:end],
+            kvcaches[0].device,
+            self.page_buffer_size,
+            False,
+            self.use_mla,
+            True,
+        )
+
+    @_lmcache_nvtx_annotate
+    def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
+        The kvcaches should correspond to the "WHOLE token sequence".
+
+        Will set the memory_obj.metadata.fmt to MemoryFormat.KV_2LTD.
+
+        Note:
+          1. This function expects the 'slot_mapping' is a "full slot mapping"
+             where it's length is the same as the whole token sequence.
+          2. In the case that there is prefix caching, slot_mapping will starts
+             with -1s until the end of the matched prefix. The start and end
+             should NEVER overlap with the prefix caching (which means the
+             underlying CUDA kernel will never see -1 in slot_mapping)
+
+        :raises ValueError: If 'kvcaches' is not provided in kwargs,
+        :raises AssertionError: If the memory object does not have a tensor.
+        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        """
+        assert memory_obj.tensor is not None
+
+        if "kvcaches" not in kwargs:
+            raise ValueError("'kvcaches' should be provided in kwargs.")
+
+        if "slot_mapping" not in kwargs:
+            raise ValueError("'slot_mapping' should be provided in kwargs.")
+
+        kvcaches: List[torch.Tensor] = kwargs["kvcaches"]
+        slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+
+        kv_cache_pointers = self._initialize_pointers(kvcaches)
+
+        if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
+            lmc_ops.multi_layer_kv_transfer(
+                memory_obj.tensor,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                kvcaches[0].device,
+                self.page_buffer_size,
+                True,
+                self.use_mla,
+                True,
+            )
+        else:
+            # kvcaches -> gpu_buffer -> memobj
+            assert self.gpu_buffer.device == kvcaches[0].device
+            tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
+            lmc_ops.multi_layer_kv_transfer(
+                tmp_gpu_buffer,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                kvcaches[0].device,
+                self.page_buffer_size,
+                True,
+                self.use_mla,
+                True,
+            )
+            memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
+
+        if not memory_obj.tensor.is_cuda:
+            # Force a synchronize if the target buffer is NOT CUDA device
+            # NOTE: for better performance, we may not want to sync for every
+            # memory object
+            torch.cuda.synchronize()
+
+        if self.use_mla:
+            memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
+
+    # TODO(Jiayi): need to optimize to enable real batching
+    def batched_from_gpu(self, memory_objs, starts, ends, **kwargs):
+        for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
+            self.from_gpu(memory_obj, start, end, **kwargs)
+
+    def get_shape(self, num_tokens: int) -> torch.Size:
+        kv_size = 1 if self.use_mla else 2
+        return torch.Size([kv_size, self.num_layers, num_tokens, self.hidden_dim_size])

--- a/tests/v1/test_gpu_connector_sglang.py
+++ b/tests/v1/test_gpu_connector_sglang.py
@@ -1,0 +1,118 @@
+# Standard
+import random
+
+# Third Party
+from utils import (
+    check_sglang_paged_kv_cache_equal,
+    check_paged_kv_cache_equal_with_mla,
+    generate_sglang_kv_cache_paged_list_tensors,
+)
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.gpu_connector_sglang import SGLangPagedMemGPUConnector
+from lmcache.v1.memory_management import (
+    GPUMemoryAllocator,
+    HostMemoryAllocator,
+    MemoryFormat,
+    PinMemoryAllocator,
+)
+
+
+@pytest.mark.parametrize("use_gpu", [True, False])
+@pytest.mark.parametrize("use_mla", [True, False])
+def test_sglang_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
+    num_blocks = 100
+    block_size = 16
+    num_layers = 32
+    num_heads = 1 if use_mla else 8
+    head_size = 128
+    device = "cuda"
+    hidden_dim = num_heads * head_size
+
+    num_tokens = num_blocks * block_size // 2
+    chunk_size = 256
+
+    allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+
+    gpu_kv_src = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers, num_blocks=num_blocks, block_size=block_size,
+        num_heads=num_heads, head_size=head_size, use_mla=use_mla,
+        device=device,
+    )
+    gpu_kv_dst = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers, num_blocks=num_blocks, block_size=block_size,
+        num_heads=num_heads, head_size=head_size, use_mla=use_mla,
+        device=device,
+    )
+
+    slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
+
+    # Check the gpu_kv is not the same before copying
+    with pytest.raises(AssertionError):
+        if use_mla:
+            check_paged_kv_cache_equal_with_mla(
+                gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, head_size
+            )
+        else:
+            check_sglang_paged_kv_cache_equal(
+                gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
+            )
+
+    connector = SGLangPagedMemGPUConnector(
+        hidden_dim,
+        num_layers,
+        use_gpu=use_gpu,
+        chunk_size=chunk_size,
+        dtype=gpu_kv_src[0].dtype,
+        device=device,
+        use_mla=use_mla,
+    )
+    connector2 = SGLangPagedMemGPUConnector(
+        hidden_dim,
+        num_layers,
+        use_gpu=use_gpu,
+        chunk_size=chunk_size,
+        dtype=gpu_kv_src[0].dtype,
+        device=device,
+        use_mla=use_mla,
+    )
+    assert connector.use_mla == use_mla
+    assert connector2.use_mla == use_mla
+    for start in range(0, num_tokens, chunk_size):
+        end = min(start + chunk_size, num_tokens)
+        shape = connector.get_shape(end - start)
+        memory_obj = allocator.allocate(shape, gpu_kv_src[0][0].dtype)
+        connector.from_gpu(
+            memory_obj,
+            start,
+            end,
+            kvcaches=gpu_kv_src,
+            slot_mapping=slot_mapping,
+            offset=0,
+        )
+        if use_mla:
+            assert memory_obj.metadata.fmt == MemoryFormat.KV_MLA_FMT
+        else:
+            assert memory_obj.metadata.fmt == MemoryFormat.KV_2LTD
+        connector2.to_gpu(
+            memory_obj,
+            start,
+            end,
+            kvcaches=gpu_kv_dst,
+            slot_mapping=slot_mapping,
+            offset=0,
+        )
+        allocator.free(memory_obj)
+        assert allocator.memcheck()
+
+    if use_mla:
+        check_paged_kv_cache_equal_with_mla(
+            gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, head_size
+        )
+    else:
+        check_sglang_paged_kv_cache_equal(
+            gpu_kv_src, gpu_kv_dst, num_tokens, slot_mapping, num_heads, head_size
+        )

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -114,6 +114,28 @@ def generate_kv_cache_paged_list_tensors(
     return ret
 
 
+def generate_sglang_kv_cache_paged_list_tensors(
+    num_layers, num_blocks, block_size, num_heads, head_size, use_mla=False,
+    device="cuda", dtype=torch.bfloat16
+):
+    """
+    Instead of Tuple[Tuple[Tensor, Tensor]], return List[Tensor]
+    where KV are in the same tensor
+    """
+    shape = (
+        [num_blocks * block_size, 1, head_size]
+        if use_mla
+        else [num_blocks * block_size, num_heads, head_size]
+    )
+    if use_mla:
+        kv_cache = [torch.rand(shape, dtype=dtype, device=device) for i in range(num_layers)]
+    else:
+        k_cache = [torch.rand(shape, dtype=dtype, device=device) for i in range(num_layers)]
+        v_cache = [torch.rand(shape, dtype=dtype, device=device) for i in range(num_layers)]
+        kv_cache = k_cache + v_cache
+    return kv_cache
+
+
 def generate_mla_kv_cache_paged_list_tensors(
     num_blocks, device, block_size=64, dtype=torch.bfloat16, num_layers=32
 ):
@@ -227,6 +249,26 @@ def check_paged_kv_cache_equal(
 
         assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
         assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
+
+
+def check_sglang_paged_kv_cache_equal(
+    left, right, num_tokens, slot_mapping, num_heads=8, head_size=128
+):
+    """
+    check whether two paged kv caches are the same at slot_mapping
+    """
+    token_dim = 0
+    for left_kv, right_kv in zip(left, right, strict=False):
+        _left_kv = left_kv.reshape(-1, num_heads, head_size)
+        _right_kv = right_kv.reshape(-1, num_heads, head_size)
+
+        assert len(_left_kv.shape) == 3
+        assert len(_right_kv.shape) == 3
+
+        assert _left_kv.shape[token_dim] >= num_tokens
+        assert _right_kv.shape[token_dim] >= num_tokens
+
+        assert (_left_kv[slot_mapping, :, :] == _right_kv[slot_mapping, :, :]).all()
 
 
 def check_paged_kv_cache_equal_with_mla(


### PR DESCRIPTION
Support SGLangPagedMemGPUConnector gpu connector for sglang.
Since sglang create independent key and value cache tensor, thus I implemented a new cuda kernel to copy kv cache between GPU and lmcache chunk tensor.
Support both MHA and MLA, and MLA reuse VLLM cuda kernel.