### PR TITLE
[optimize] boost local_disk_backend submit_put_task performance

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, List, Optional
 import asyncio
 import os
 import threading
+import time
 
 # Third Party
 import aiofiles
@@ -71,12 +72,16 @@ class LocalDiskBackend(StorageBackendInterface):
         self.evictor = LRUEvictor(max_cache_size=config.max_local_disk_size)
 
         self.loop = loop
-        self.put_tasks: List[CacheEngineKey] = []
+        self.put_tasks: OrderedDict[CacheEngineKey, MemoryObj] = OrderedDict()
 
         self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.usage = 0
+        self.closed = False
+
+        self.put_thread = threading.Thread(target=self._put_task_worker)
+        self.put_thread.start()
 
     def __str__(self):
         return self.__class__.__name__
@@ -162,35 +167,62 @@ class LocalDiskBackend(StorageBackendInterface):
                 KVAdmitMsg(self.instance_id, key.worker_id, key.chunk_hash, "disk")
             )
 
+    def _put_task_worker(self):
+        while not self.closed:
+            if len(self.put_tasks) == 0:
+                time.sleep(0.001)
+                continue
+
+            with self.disk_lock:
+                key, memory_obj = next(iter(self.put_tasks.items()))
+                del self.put_tasks[key]
+
+            # Update cache recency
+            evict_keys, put_status = self.evictor.update_on_put(
+                self.dict, memory_obj.get_physical_size()
+            )
+            if put_status != PutStatus.ILLEGAL:
+                # evict caches
+                for evict_key in evict_keys:
+                    self.remove(evict_key)
+                if self.lookup_server is not None:
+                    self.lookup_server.batched_remove(evict_keys)
+            else:
+                memory_obj_size = memory_obj.get_physical_size()
+                logger.error(
+                    f"evictor update_on_put failed, memory_obj size: {memory_obj_size}"
+                )
+
+            self.save_bytes_to_disk(key, memory_obj)
+            self.insert_key(key, memory_obj)
+            memory_obj.ref_count_down()
+
+        # clean up after close
+        self.clear_put_tasks()
+
+    def clear_put_tasks(self, num=-1):
+        with self.disk_lock:
+            if num == -1:
+                num = len(self.put_tasks)
+            while self.put_tasks and num > 0:
+                key, memory_obj = next(iter(self.put_tasks.items()))
+                del self.put_tasks[key]
+                memory_obj.ref_count_down()
+                num -= 1
+
     def submit_put_task(
         self,
         key: CacheEngineKey,
         memory_obj: MemoryObj,
     ) -> Optional[Future]:
         assert memory_obj.tensor is not None
-
-        # Update cache recency
-        evict_keys, put_status = self.evictor.update_on_put(
-            self.dict, memory_obj.get_physical_size()
-        )
-        if put_status == PutStatus.ILLEGAL:
+        if not self.put_thread.is_alive():
+            logger.warning("put_thread is not alive")
             return None
-        # evict caches
-        for evict_key in evict_keys:
-            self.remove(evict_key)
-        if self.lookup_server is not None:
-            self.lookup_server.batched_remove(evict_keys)
-
         memory_obj.ref_count_up()
-
-        self.disk_lock.acquire()
-        self.put_tasks.append(key)
-        self.disk_lock.release()
-
-        future = asyncio.run_coroutine_threadsafe(
-            self.async_save_bytes_to_disk(key, memory_obj), self.loop
-        )
-        return future
+        with self.disk_lock:
+            self.put_tasks[key] = memory_obj
+        return None
 
     def batched_submit_put_task(
         self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
@@ -288,12 +320,34 @@ class LocalDiskBackend(StorageBackendInterface):
 
         memory_obj.ref_count_down()
 
-        self.disk_lock.acquire()
-        self.put_tasks.remove(key)
-        self.disk_lock.release()
+        with self.disk_lock:
+            del self.put_tasks[key]
+
+    @_lmcache_nvtx_annotate
+    @torch.inference_mode()
+    def save_bytes_to_disk(
+        self,
+        key: CacheEngineKey,
+        memory_obj: MemoryObj,
+    ) -> None:
+        """
+        Convert KV to bytes and async store bytes to disk.
+        """
+        kv_chunk = memory_obj.tensor
+        assert kv_chunk is not None
+        byte_array = memory_obj.byte_array
+        path = self._key_to_path(key)
+
+        size = len(byte_array)
+        self.usage += size
+        self.stats_monitor.update_local_storage_usage(self.usage)
+
+        with open(path, "wb") as f:
+            f.write(byte_array)
 
     # TODO(Jiayi): use `bytes_read = await f.readinto(buffer)`
     # for better performance (i.e., fewer copy)
+
     async def async_load_bytes_from_disk(
         self, path: str, dtype: torch.dtype, shape: torch.Size, fmt: MemoryFormat
     ) -> Optional[MemoryObj]:
@@ -353,3 +407,6 @@ class LocalDiskBackend(StorageBackendInterface):
             self.disk_lock.acquire()
             self.lookup_server.batched_remove(list(self.dict.keys()))
             self.disk_lock.release()
+        self.closed = True
+        if self.put_thread.is_alive():
+            self.put_thread.join()

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -185,9 +185,9 @@ def test_paged_retrieve_prefix(
             torch.cat([slot_mapping, new_slot_mapping])[:expected_length],
         )
 
+    LMCacheEngineBuilder.destroy("test")
     if backend in ["local_disk"]:
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
-    LMCacheEngineBuilder.destroy("test")
 
 
 @pytest.mark.parametrize("fmt", ["vllm"])
@@ -280,9 +280,9 @@ def test_paged_store_offset(
         slot_mapping[:expected_length],
     )
 
+    LMCacheEngineBuilder.destroy("test")
     if backend in ["local_disk"]:
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
-    LMCacheEngineBuilder.destroy("test")
 
 
 @pytest.mark.parametrize("fmt", ["vllm"])
@@ -411,12 +411,12 @@ def test_paged_mixed_retrieve(fmt, chunk_size, backend, autorelease_v1):
         kv_cache,
         slot_mapping=torch.cat([slot_mapping, new_slot_mapping]),
     )
+    # engine.close()
+    LMCacheEngineBuilder.destroy("test")
+
     """destroy local disk path"""
     if backend in ["local_disk"]:
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
-
-    # engine.close()
-    LMCacheEngineBuilder.destroy("test")
 
 
 @pytest.mark.parametrize("fmt", ["vllm"])
@@ -785,9 +785,9 @@ def test_paged_prefetch_retrieve(backend, prefetch_from, autorelease_v1):
         torch.cat([slot_mapping, new_slot_mapping])[:expected_length],
     )
 
+    LMCacheEngineBuilder.destroy("test")
     if backend in ["local_cpu_disk"]:
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
-    LMCacheEngineBuilder.destroy("test")
 
 
 @pytest.mark.parametrize("fmt", ["vllm"])
@@ -866,9 +866,9 @@ def test_paged_mem_leak(fmt, chunk_size, backend, lmserver_v1_process, autorelea
     else:
         assert tensor_memory_allocator.total_allocated_size > 0
 
+    LMCacheEngineBuilder.destroy("test")
     if "disk" in backend:
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
-    LMCacheEngineBuilder.destroy("test")
 
 
 def test_builder(autorelease_v1):


### PR DESCRIPTION
The cache store execution time mainly contains three parts: alloc, cpu-gpu copy, submit_put_task.
Existing local_disk_backend submit_put_task do a lot works that typically take more than 1ms execution time, which reduce throughput much. For vllm serving benchmark, cpu+local disk offload benchmark duration is typically longer than cpu offload only.
This PR using a thread to do the put task, enable submit_put_task return immediately, results in similar vllm serving benchmark duration between cpu+local disk offload and cpu offload only.
Note submit_put_task does not return future, but this is actually not used, thus return None is ok.