### PR TITLE
[Test]: Make the unit test coverage report available

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,3 +36,9 @@ steps:
       - "durations/test.html"
       - "coverage-test.xml"
       - "coverage-test/**/*"
+
+  - label: "Upload Coverage Report"
+    command: |
+      cat << EOF | buildkite-agent annotate --style "info"
+        Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>
+      EOF


### PR DESCRIPTION
This PR is a follow on to #823. @YaoJiayi asked in https://github.com/LMCache/LMCache/pull/823#issuecomment-3001202183 if the results could be accessed easily in addition to them being output to the terminal during the pipeline run.

They can now be accessed from the buildkite dashboard as shown below:
 
![Screenshot 2025-07-01 at 16 11 49](https://github.com/user-attachments/assets/f90109f7-2fbe-4a1b-9619-f59b5c105a6f)

When you click on `Read the uploaded coverage report`, you will see output as follows:

![Screenshot 2025-07-01 at 16 12 26](https://github.com/user-attachments/assets/68947e71-0e47-4f5f-9b1a-4a8ed041b7a2)

[...]
