### PR TITLE
Remove redundant and incorrect truncation of the last n tokens.

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -521,10 +521,6 @@ class LMCacheConnectorV1Impl:
             )
             token_mask[:masked_token_count] = False
 
-            if self.skip_last_n_tokens > 0:
-                tokens = tokens[: -self.skip_last_n_tokens]
-                token_mask = token_mask[: -self.skip_last_n_tokens]
-
             lmcache_cached_tokens = request.load_spec.lmcache_cached_tokens
             if self.use_layerwise:
                 if idx == last_idx:


### PR DESCRIPTION
It errors if we don't delete these lines.

At line 314 in vllm_v1_adapter.py, we truncate the tokens.

[token_ids = torch.tensor(input_token_ids)[:num_tokens_to_save]](https://github.com/LMCache/LMCache/blob/f62585dea788e8c4f8bc98b7183edbe2afba5701/lmcache/integration/vllm/vllm_v1_adapter.py#L314)

Suppose the input length=300, chunk size=256, skip_last_n_tokens=3. If we discard partial chunks, we will truncate the tokens tensor to 256. Then, if we truncate the last 3 tokens again before retrieving, we will be retrieving 253 tokens, which is incorrect.