### PR TITLE
[Bugfix] check None result in prefetch callback and wait prefetch bef…

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -14,7 +14,7 @@
 
 # Standard
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union, List
 import threading
 
 # Third Party
@@ -965,3 +965,10 @@ class LMCacheConnectorV1Impl:
             }
 
         return 0, return_params
+
+    def prefetch(
+        self,
+        tokens: Union[torch.Tensor, List[int]],
+        mask: Optional[torch.Tensor] = None,
+    ):
+        return self.lmcache_engine.prefetch(tokens, mask)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -388,7 +388,9 @@ class LMCacheEngine:
         reordered_ends = []
         for start, end, key in self.token_database.process_tokens(tokens, mask):
             assert isinstance(key, CacheEngineKey)
-
+            self.storage_manager.wait_prefetch(
+                key, timeout=self.config.prefetch_timeout_secs
+            )
             if key in self.lookup_cache:
                 # TODO(Jiayi): we can reduce the number of `contains` calls
                 # by checking the lookup cache first (should be updated in `lookup`)
@@ -586,7 +588,7 @@ class LMCacheEngine:
     @_lmcache_nvtx_annotate
     def prefetch(
         self,
-        tokens: torch.Tensor,
+        tokens: Union[torch.Tensor, List[int]],
         mask: Optional[torch.Tensor] = None,
     ) -> None:
         """Launch the prefetching process in the storage manager to load the

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -120,6 +120,9 @@ class LMCacheEngineConfig:
     # when calling get_blocking method in remote backend
     blocking_timeout_secs: int = 10
 
+    # Set timeout(seconds) when calling prefetch
+    prefetch_timeout_secs: float = 0.1
+
     @staticmethod
     def from_defaults(
         chunk_size: int = 256,
@@ -157,6 +160,7 @@ class LMCacheEngineConfig:
         extra_config: Optional[dict] = None,
         save_unfull_chunk: bool = True,
         blocking_timeout_secs: int = 10,
+        prefetch_timeout_secs: float = 0.1,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
         return LMCacheEngineConfig(
@@ -195,6 +199,7 @@ class LMCacheEngineConfig:
             extra_config,
             save_unfull_chunk,
             blocking_timeout_secs,
+            prefetch_timeout_secs,
         ).validate()
 
     @staticmethod
@@ -359,6 +364,7 @@ class LMCacheEngineConfig:
         save_unfull_chunk = config.get("save_unfull_chunk", True)
 
         blocking_timeout_secs = config.get("blocking_timeout_secs", 10)
+        prefetch_timeout_secs = config.get("prefetch_timeout_secs", 0.1)
 
         local_disk_path = _parse_local_disk(local_disk)
 
@@ -407,6 +413,7 @@ class LMCacheEngineConfig:
                 extra_config,
                 save_unfull_chunk,
                 blocking_timeout_secs,
+                prefetch_timeout_secs,
             )
             .validate()
             .log_config()
@@ -596,6 +603,11 @@ class LMCacheEngineConfig:
                 get_env_name("blocking_timeout_secs"), config.blocking_timeout_secs
             )
         )
+        config.prefetch_timeout_secs = to_float(
+            parse_env(
+                get_env_name("prefetch_timeout_secs"), config.prefetch_timeout_secs
+            )
+        )
         return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:
@@ -679,6 +691,7 @@ class LMCacheEngineConfig:
             "extra_config": self.extra_config,
             "save_unfull_chunk": self.save_unfull_chunk,
             "blocking_timeout_secs": self.blocking_timeout_secs,
+            "prefetch_timeout_secs": self.prefetch_timeout_secs,
         }
         logger.info(f"LMCache Configuration: {config_dict}")
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -187,10 +187,7 @@ class StorageManager:
         for memory_obj in memory_objs:
             memory_obj.ref_count_down()
 
-    def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        """
-        Blocking function to get the memory object from the storages.
-        """
+    def wait_prefetch(self, key: CacheEngineKey, timeout: float = 0.2):
         # Search in prefetch task
         self.manager_lock.acquire()
         prefetch_task = self.prefetch_tasks.get(key, None)
@@ -206,8 +203,13 @@ class StorageManager:
             # Calling result() twice (already once in callback) will have
             # no effect
             # Tune the timeout for better performance
-            prefetch_task.result(timeout=1)
+            prefetch_task.result(timeout=timeout)
 
+    def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        """
+        Blocking function to get the memory object from the storages.
+        """
+        self.wait_prefetch(key, timeout=self.config.prefetch_timeout_secs)
         # Search all backends for blocking get
         for backend_name, backend in self.storage_backends.items():
             # NOTE(Jiayi): bypass the allocator for now
@@ -286,28 +288,16 @@ class StorageManager:
         except Exception as e:
             logger.error(f"Exception captured from future in prefetch_callback: {e}")
             raise e
-        kv_chunk = buffer_memory_obj.tensor
-        kv_shape = kv_chunk.shape
-        kv_dtype = kv_chunk.dtype
-        memory_obj = self.allocator_backend.allocate(kv_shape, kv_dtype)
-        if memory_obj is None:
-            logger.warning("Memory allocation failed in prefetch_callback")
+        if buffer_memory_obj is None:
             return
+        assert isinstance(buffer_memory_obj, MemoryObj)
+        assert buffer_memory_obj.tensor is not None, "Encounter invalid tensor"
+        assert buffer_memory_obj.tensor.device.type == "cpu"
 
-        assert memory_obj.tensor is not None, "Encounter invalid tensor"
-
-        # TODO(Jiayi): this part should be done in another process if
-        # the cpu->pinned cpu copy is blocking.
-        prefetch_stream = torch.cuda.Stream()
-        with torch.cuda.stream(prefetch_stream):
-            memory_obj.tensor.copy_(kv_chunk, non_blocking=True)
-        prefetch_stream.synchronize()
-
-        # NOTE: no need to ref_count_up here because
-        # the memory_obj's ref_count is already 1
-        self.manager_lock.acquire()
-        self.storage_backends["LocalCPUBackend"].submit_put_task(key, memory_obj)
-        self.manager_lock.release()
+        # the buffer_memory_obj is a cpu backend allocated memory obj
+        self.storage_backends["LocalCPUBackend"].submit_put_task(key, buffer_memory_obj)
+        # prefetched memory should also be evictable
+        buffer_memory_obj.ref_count_down()
 
     def prefetch(self, key: CacheEngineKey) -> None:
         """Launch a prefetch request in the storage backend. Non-blocking"""


### PR DESCRIPTION
Fix bug of https://github.com/LMCache/LMCache/issues/940 by check none results
also optimize:
1, remove redundant alloc and copy, seems unnecessary.
2, decrease ref count to enable evict.
3, wait prefetch before batched_get calling in retrieve.