### PR TITLE
[doc] explain the limitation of proxy_..first_token_from_prefiller.py

### DIFF
--- a/examples/disagg_prefill/xp1d/README.md
+++ b/examples/disagg_prefill/xp1d/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to run LMCache with disaggregated prefill using NIXL on a single node.
 
+### Important Limitations
+
+**⚠️ Prefix Caching Compatibility**: Currently, With example disagg_proxy_server_first_token_from_prefiller.py, prefix caching and disaggregated prefill are not compatible. The prefiller just save KV-Cache with the original prompt, but the decoder tries to look up the entire new prompt (original prompt + first token). Due to strict mapping of Prefix Caching, this causes decoder's lookup failures and prevents KV cache reuse from prefillers to decoders.
+
 ### Prerequisites
 
 - Install [LMCache](https://github.com/LMCache/LMCache). You can simply run `pip install lmcache`.


### PR DESCRIPTION
You can test with another `disagg_proxy_server_first_token_from_decoder.py` first
and see ` Total tokens N, LMCache hit tokens: X, need to load: Y` log from decoder

 
and if you are using  `disagg_proxy_server_first_token_from_prefiller.py` , you will see log of decoder
`Total tokens N, LMCache hit tokens: 0, need to load: 0`


The prefill behaviour is to save kv-cache of "N" tokens (denote prompt is N)
to make transitional P/D disaggregation workable (just like `disagg_proxy_server_first_token_from_decoder.py`)

But for new P/D disaggregation method showing in  `disagg_proxy_server_first_token_from_prefiller.py`,  the prefill should perform another behaviour to save kv-cache of "N+1" tokens (denote prompt is N, 1 is the 1st token generated)

there's no way to switch between two modes for prefiller so far (even set `save_decode_cache=true` in `configs/lmcache-prefiller-config.yaml`)