### PR TITLE
[Doc] Fix broken link

### DIFF
--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -122,11 +122,11 @@ Step-by-Step Setup
 
    c. Launch a proxy server to coordinate between prefiller and decoder:
 
-      The code for the proxy server is available `in vLLM repo <https://github.com/vllm-project/vllm/blob/main/examples/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py>`_.
+      The code for the proxy server is available `in vLLM repo <https://github.com/vllm-project/vllm/blob/main/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py>`_.
 
       .. code-block:: bash
 
-          wget https://raw.githubusercontent.com/vllm-project/vllm/main/examples/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py
+          wget https://raw.githubusercontent.com/vllm-project/vllm/main/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py
 
           python3 disagg_proxy_server.py \
               --host localhost \


### PR DESCRIPTION
```
(base) ➜  /tmp wget https://raw.githubusercontent.com/vllm-project/vllm/main/examples/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py
--2025-07-07 11:52:48--  https://raw.githubusercontent.com/vllm-project/vllm/main/examples/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.109.133, 185.199.108.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-07-07 11:52:49 ERROR 404: Not Found.
```