### PR TITLE
[Bug]: Double Free

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -328,6 +328,14 @@ class TensorMemoryObj(MemoryObj):
     def ref_count_down(self):
         with self.lock:
             self.meta.ref_count -= 1
+            if self.meta.ref_count < 0:
+                logger.warning(
+                    f"Ref count of MemoryObj {self.meta.address}"
+                    f"is negative: {self.meta.ref_count}."
+                    "Double free occurred somewhere."
+                    "Setting ref count back to 0 as a hack but please find the bug."
+                )
+                self.meta.ref_count = 0
             if (
                 self.meta.ref_count == 0
                 and self.parent_allocator is not None

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -246,7 +246,8 @@ class LocalCPUBackend(StorageBackendInterface):
                 old_mem_obj = self.hot_cache[evict_key]
                 # If the ref_count > 1, we cannot evict it as the cpu memory
                 # might be used as buffers by other storage backends
-                if old_mem_obj.get_ref_count() > 1:
+                # Also, don't evict pinned objects
+                if old_mem_obj.get_ref_count() > 1 or old_mem_obj.is_pinned:
                     continue
                 evict_keys.append(evict_key)
 
@@ -310,7 +311,8 @@ class LocalCPUBackend(StorageBackendInterface):
                 old_mem_obj = self.hot_cache[evict_key]
                 # If the ref_count > 1, we cannot evict it as the cpu memory
                 # might be used as buffers by other storage backends
-                if old_mem_obj.get_ref_count() > 1 and not old_mem_obj.is_pinned:
+                # Also, don't evict pinned objects
+                if old_mem_obj.get_ref_count() > 1 or old_mem_obj.is_pinned:
                     continue
                 # HACK: We assume batch_size=num_layers here.
                 # We also assume if the one layer's ref_count > 1 or pinned,

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -256,7 +256,9 @@ class LocalCPUBackend(StorageBackendInterface):
                 if memory_obj is not None:
                     break
         for evict_key in evict_keys:
-            self.remove(evict_key)
+            # already freed above in order to allocate new memory object
+            # this is to remove the key from the hot cache
+            self.remove(evict_key, free_obj=False)
         if self.lookup_server is not None:
             self.lookup_server.batched_remove(evict_keys)
         return memory_obj
@@ -333,6 +335,8 @@ class LocalCPUBackend(StorageBackendInterface):
                     break
                 old_mem_objs = []
         for evict_key in evict_keys:
+            # already freed above in order to allocate new memory objects
+            # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
         if self.lookup_server is not None:
             self.lookup_server.batched_remove(evict_keys)
@@ -420,7 +424,6 @@ class LocalCPUBackend(StorageBackendInterface):
                 if memory_obj.get_ref_count() > 1:
                     continue
                 clear_keys.append(key)
-                memory_obj.ref_count_down()
 
         for key in clear_keys:
             self.remove(key)


### PR DESCRIPTION
Fix https://github.com/LMCache/LMCache/issues/987


This issue identifies issue of LMCache CPU hot cache running out of space. PTAL: @wangqia0309

1. fix double free in allocate() and clear()

2. skip over evicting pinned memory objects from both hot cache and the memory allocator