### PR TITLE
[Refactor] refactor prefetch

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -14,7 +14,7 @@
 
 # Standard
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 # Third Party
 from vllm.config import VllmConfig
@@ -914,3 +914,10 @@ class LMCacheConnectorV1Impl:
             }
 
         return 0, return_params
+
+    def prefetch(
+        self,
+        tokens: Union[torch.Tensor, List[int]],
+        mask: Optional[torch.Tensor] = None,
+    ):
+        return self.lmcache_engine.prefetch(tokens, mask)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -392,7 +392,9 @@ class LMCacheEngine:
         reordered_ends = []
         for start, end, key in self.token_database.process_tokens(tokens, mask):
             assert isinstance(key, CacheEngineKey)
-
+            self.storage_manager.wait_prefetch(
+                key, timeout=self.config.prefetch_timeout_secs
+            )
             if key in self.lookup_cache:
                 # TODO(Jiayi): we can reduce the number of `contains` calls
                 # by checking the lookup cache first (should be updated in `lookup`)
@@ -590,7 +592,7 @@ class LMCacheEngine:
     @_lmcache_nvtx_annotate
     def prefetch(
         self,
-        tokens: torch.Tensor,
+        tokens: Union[torch.Tensor, List[int]],
         mask: Optional[torch.Tensor] = None,
     ) -> None:
         """Launch the prefetching process in the storage manager to load the

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -125,6 +125,9 @@ class LMCacheEngineConfig:
     # When set, uses external lookup client instead of regular lookup server
     external_lookup_client: Optional[str] = None
 
+    # Set timeout(seconds) when calling prefetch
+    prefetch_timeout_secs: float = 0.1
+
     @staticmethod
     def from_defaults(
         chunk_size: int = 256,
@@ -163,6 +166,7 @@ class LMCacheEngineConfig:
         save_unfull_chunk: bool = True,
         blocking_timeout_secs: int = 10,
         external_lookup_client: Optional[str] = None,
+        prefetch_timeout_secs: float = 0.1,
     ) -> "LMCacheEngineConfig":
         # TODO (ApostaC): Add nixl config
         return LMCacheEngineConfig(
@@ -202,6 +206,7 @@ class LMCacheEngineConfig:
             save_unfull_chunk,
             blocking_timeout_secs,
             external_lookup_client,
+            prefetch_timeout_secs,
         ).validate()
 
     @staticmethod
@@ -366,6 +371,7 @@ class LMCacheEngineConfig:
         save_unfull_chunk = config.get("save_unfull_chunk", True)
 
         blocking_timeout_secs = config.get("blocking_timeout_secs", 10)
+        prefetch_timeout_secs = config.get("prefetch_timeout_secs", 0.1)
 
         external_lookup_client = config.get("external_lookup_client", None)
 
@@ -417,6 +423,7 @@ class LMCacheEngineConfig:
                 save_unfull_chunk,
                 blocking_timeout_secs,
                 external_lookup_client,
+                prefetch_timeout_secs,
             )
             .validate()
             .log_config()
@@ -609,6 +616,11 @@ class LMCacheEngineConfig:
         config.external_lookup_client = parse_env(
             get_env_name("external_lookup_client"), config.external_lookup_client
         )
+        config.prefetch_timeout_secs = to_float(
+            parse_env(
+                get_env_name("prefetch_timeout_secs"), config.prefetch_timeout_secs
+            )
+        )
         return config.validate().log_config()
 
     def to_original_config(self) -> orig_config.LMCacheEngineConfig:
@@ -693,6 +705,7 @@ class LMCacheEngineConfig:
             "save_unfull_chunk": self.save_unfull_chunk,
             "blocking_timeout_secs": self.blocking_timeout_secs,
             "external_lookup_client": self.external_lookup_client,
+            "prefetch_timeout_secs": self.prefetch_timeout_secs,
         }
         logger.info(f"LMCache Configuration: {config_dict}")
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -100,6 +100,7 @@ class StorageManager:
         self.worker_id = metadata.worker_id
 
         self.stream = torch.cuda.Stream()
+        self.prefetch_timeout_secs = config.prefetch_timeout_secs
 
     @_lmcache_nvtx_annotate
     def allocate(
@@ -187,14 +188,10 @@ class StorageManager:
         for memory_obj in memory_objs:
             memory_obj.ref_count_down()
 
-    def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        """
-        Blocking function to get the memory object from the storages.
-        """
+    def wait_prefetch(self, key: CacheEngineKey, timeout: float = 0.1):
         # Search in prefetch task
-        self.manager_lock.acquire()
-        prefetch_task = self.prefetch_tasks.get(key, None)
-        self.manager_lock.release()
+        with self.manager_lock:
+            prefetch_task = self.prefetch_tasks.get(key, None)
 
         # Wait until prefetch task finishes
         # Here, it is assumed all prefetch tasks load the memoryobj to
@@ -206,8 +203,16 @@ class StorageManager:
             # Calling result() twice (already once in callback) will have
             # no effect
             # Tune the timeout for better performance
-            prefetch_task.result(timeout=1)
+            try:
+                prefetch_task.result(timeout=timeout)
+            except Exception as e:
+                logger.warning(f"prefetch timeout: {e}, key: {key}")
 
+    def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        """
+        Blocking function to get the memory object from the storages.
+        """
+        self.wait_prefetch(key, timeout=self.prefetch_timeout_secs)
         # Search all backends for blocking get
         for backend_name, backend in self.storage_backends.items():
             # NOTE(Jiayi): bypass the allocator for now
@@ -278,47 +283,32 @@ class StorageManager:
         """
         Update metadata after prefetch.
         """
-        self.manager_lock.acquire()
-        prefetch_task = self.prefetch_tasks.pop(key)
-        self.manager_lock.release()
+        with self.manager_lock:
+            prefetch_task = self.prefetch_tasks.pop(key)
         try:
             buffer_memory_obj = prefetch_task.result()
         except Exception as e:
             logger.error(f"Exception captured from future in prefetch_callback: {e}")
             raise e
-        kv_chunk = buffer_memory_obj.tensor
-        kv_shape = kv_chunk.shape
-        kv_dtype = kv_chunk.dtype
-        memory_obj = self.allocator_backend.allocate(kv_shape, kv_dtype)
-        if memory_obj is None:
-            logger.warning("Memory allocation failed in prefetch_callback")
+        if buffer_memory_obj is None:
             return
+        assert isinstance(buffer_memory_obj, MemoryObj)
+        assert buffer_memory_obj.tensor is not None, "Encounter invalid tensor"
+        assert buffer_memory_obj.tensor.device.type == "cpu"
 
-        assert memory_obj.tensor is not None, "Encounter invalid tensor"
-
-        # TODO(Jiayi): this part should be done in another process if
-        # the cpu->pinned cpu copy is blocking.
-        prefetch_stream = torch.cuda.Stream()
-        with torch.cuda.stream(prefetch_stream):
-            memory_obj.tensor.copy_(kv_chunk, non_blocking=True)
-        prefetch_stream.synchronize()
-
-        # NOTE: no need to ref_count_up here because
-        # the memory_obj's ref_count is already 1
-        self.manager_lock.acquire()
-        self.storage_backends["LocalCPUBackend"].submit_put_task(key, memory_obj)
-        self.manager_lock.release()
+        # the buffer_memory_obj is a cpu backend allocated memory obj
+        self.storage_backends["LocalCPUBackend"].submit_put_task(key, buffer_memory_obj)
+        # prefetched memory should also be evictable
+        buffer_memory_obj.ref_count_down()
 
     def prefetch(self, key: CacheEngineKey) -> None:
         """Launch a prefetch request in the storage backend. Non-blocking"""
 
         if self.storage_backends["LocalCPUBackend"].contains(key):
             return
-        self.manager_lock.acquire()
-        if key in self.prefetch_tasks:
-            self.manager_lock.release()
-            return
-        self.manager_lock.release()
+        with self.manager_lock:
+            if key in self.prefetch_tasks:
+                return
 
         for backend in self.storage_backends.values():
             prefetch_task = backend.submit_prefetch_task(key)
@@ -326,10 +316,9 @@ class StorageManager:
                 continue
             lambda_callback = lambda f: self.prefetch_callback(f, key)
 
-            self.manager_lock.acquire()
-            self.prefetch_tasks[key] = prefetch_task
+            with self.manager_lock:
+                self.prefetch_tasks[key] = prefetch_task
             prefetch_task.add_done_callback(lambda_callback)
-            self.manager_lock.release()
             break
 
     # TODO(Jiayi): Currently, search_range is only used for testing.


### PR DESCRIPTION
This pr refactor prefetch
1, Fix bug of https://github.com/LMCache/LMCache/issues/940 by checking none result.
2, remove redundant alloc and copy, seems unnecessary.
3, decrease prefetched memory ref count to allow eviction.
4, wait prefetch before batched_get calling in retrieve, previously only supported in get calling.
5, add a configurable prefetch time out parameter.
6, add a prefetch interface in VLLM adapter.

Prefetch is very useful for multi level cache. When to call prefetch: in VLLM/sglang, when scheduler add request, the prefetch can be called. Since requests are waiting to be precessed in scheduler waiting queue, when the requests are waiting, they can be prefetched from low speed cache storage, such as disk.
