### PR TITLE
[feature] support batched_get_blocking in remote backend

### DIFF
--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -120,9 +120,9 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
     def batched_get_blocking(
         self,
         keys: List[CacheEngineKey],
-    ) -> List[MemoryObj]:
+    ) -> List[Optional[MemoryObj]]:
         """
-        A blcocking function to get the kv cache from the storage backend.
+        A blocking function to get the kv cache from the storage backend.
 
         :param List[CacheEngineKey] keys: The keys of the MemoryObjs.
 

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -188,8 +188,9 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         """
         return False
 
-    @abc.abstractmethod
-    async def batched_get(self, keys: List[CacheEngineKey]) -> List[Optional[MemoryObj]]:
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
         """
         Batched get the memory_objs of the corresponding keys
 

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -179,5 +179,28 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    def support_batched_get(self) -> bool:
+        """
+        Check if the connector supports batched get
+
+        Returns:
+            True if batched get is supported, False otherwise
+        """
+        return False
+
+    @abc.abstractmethod
+    async def batched_get(self, keys: List[CacheEngineKey]) -> List[Optional[MemoryObj]]:
+        """
+        Batched get the memory_objs of the corresponding keys
+
+        Input:
+            keys: the keys of the corresponding objects
+
+        Returns:
+            The memory_objs of the corresponding keys
+            Return None if the key does not exist
+        """
+        raise NotImplementedError
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}>"

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -74,5 +74,11 @@ class InstrumentedRemoteConnector(RemoteConnector):
     async def ping(self) -> int:
         return await self._connector.ping()
 
+    def support_batched_get(self) -> bool:
+        return self._connector.support_batched_get()
+
+    async def batched_get(self, keys: List[CacheEngineKey]) -> List[Optional[MemoryObj]]:
+        return await self._connector.batched_get(keys)
+
     def __repr__(self) -> str:
         return f"InstrumentedRemoteConnector({self._connector})"

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -77,7 +77,9 @@ class InstrumentedRemoteConnector(RemoteConnector):
     def support_batched_get(self) -> bool:
         return self._connector.support_batched_get()
 
-    async def batched_get(self, keys: List[CacheEngineKey]) -> List[Optional[MemoryObj]]:
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
         return await self._connector.batched_get(keys)
 
     def __repr__(self) -> str:

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -271,7 +271,7 @@ class RemoteBackend(StorageBackendInterface):
 
         t1 = time.perf_counter()
         # batched get
-        if hasattr(self.connection, "batched_get"):
+        if self.connection.support_batched_get():
             future = asyncio.run_coroutine_threadsafe(
                 self.connection.batched_get(new_keys), self.loop
             )

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -260,32 +260,41 @@ class RemoteBackend(StorageBackendInterface):
 
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            new_keys = []
-            for key in keys:
-                new_key = CacheEngineKey(
+            new_keys = [
+                CacheEngineKey(
                     key.fmt, key.model_name, key.world_size, 0, key.chunk_hash
                 )
-                new_keys.append(new_key)
+                for key in keys
+            ]
         else:
             new_keys = keys
 
         t1 = time.perf_counter()
         # batched get
         if hasattr(self.connection, "batched_get"):
-            future = asyncio.run_coroutine_threadsafe(self.connection.batched_get(new_keys), self.loop)
+            future = asyncio.run_coroutine_threadsafe(
+                self.connection.batched_get(new_keys), self.loop
+            )
             try:
                 memory_objs = future.result(self.blocking_timeout_secs)
             except Exception as e:
                 if isinstance(e, TimeoutError):
-                    logger.warning("batched get blocking timeout, trigger cancel the future task")
+                    logger.warning(
+                        "batched get blocking timeout, trigger cancel the future task"
+                    )
                     future.cancel()
                 with self.lock:
                     self.connection = None
                     self.failure_time = time.time()
-                logger.warning(f"Error occurred in batched_get_blocking: {e}, returning None list")
+                logger.warning(
+                    f"Error occurred in batched_get_blocking: {e}, returning None list"
+                )
                 return [None] * len(keys)
         else:
-            futures = [asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop) for key in new_keys]
+            futures = [
+                asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
+                for key in new_keys
+            ]
             memory_objs = []
             failed = False
             for future in futures:
@@ -295,12 +304,16 @@ class RemoteBackend(StorageBackendInterface):
                     except Exception as e:
                         failed = True
                         if isinstance(e, TimeoutError):
-                            logger.warning("get blocking timeout, trigger cancel the future task")
+                            logger.warning(
+                                "get blocking timeout, trigger cancel the future task"
+                            )
                             future.cancel()
                         with self.lock:
                             self.connection = None
                             self.failure_time = time.time()
-                        logger.warning(f"Error occurred in get_blocking: {e}, returning None")
+                        logger.warning(
+                            f"Error occurred in get_blocking: {e}, returning None"
+                        )
                         memory_obj = None
                     memory_objs.append(memory_obj)
                 else:
@@ -314,9 +327,14 @@ class RemoteBackend(StorageBackendInterface):
             if memory_obj is None:
                 decompressed_memory_objs.append(None)
             else:
-                decompressed_memory_objs.append(self.deserializer.deserialize(memory_obj))
+                decompressed_memory_objs.append(
+                    self.deserializer.deserialize(memory_obj)
+                )
 
-        assert len(decompressed_memory_objs) == len(keys), f"keys length: {len(keys)}, decompressed memory objs length: {len(decompressed_memory_objs)}"
+        assert len(decompressed_memory_objs) == len(keys), (
+            f"keys length: {len(keys)}, "
+            f"decompressed memory objs length: {len(decompressed_memory_objs)}"
+        )
         return decompressed_memory_objs
 
     def pin(self, key: CacheEngineKey) -> bool:

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -250,6 +250,75 @@ class RemoteBackend(StorageBackendInterface):
     ) -> Optional[Future]:
         raise NotImplementedError
 
+    def batched_get_blocking(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> List[Optional[MemoryObj]]:
+        if self.connection is None:
+            logger.warning("Connection is None in batched_get_blocking, returning None")
+            return [None] * len(keys)
+
+        # For MLA worker id as 0 mode, use worker_id 0
+        if self._mla_worker_id_as0_mode:
+            new_keys = []
+            for key in keys:
+                new_key = CacheEngineKey(
+                    key.fmt, key.model_name, key.world_size, 0, key.chunk_hash
+                )
+                new_keys.append(new_key)
+        else:
+            new_keys = keys
+
+        t1 = time.perf_counter()
+        # batched get
+        if hasattr(self.connection, "batched_get"):
+            future = asyncio.run_coroutine_threadsafe(self.connection.batched_get(new_keys), self.loop)
+            try:
+                memory_objs = future.result(self.blocking_timeout_secs)
+            except Exception as e:
+                if isinstance(e, TimeoutError):
+                    logger.warning("batched get blocking timeout, trigger cancel the future task")
+                    future.cancel()
+                with self.lock:
+                    self.connection = None
+                    self.failure_time = time.time()
+                logger.warning(f"Error occurred in batched_get_blocking: {e}, returning None list")
+                return [None] * len(keys)
+        else:
+            futures = [asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop) for key in new_keys]
+            memory_objs = []
+            failed = False
+            for future in futures:
+                if not failed:
+                    try:
+                        memory_obj = future.result(self.blocking_timeout_secs)
+                    except Exception as e:
+                        failed = True
+                        if isinstance(e, TimeoutError):
+                            logger.warning("get blocking timeout, trigger cancel the future task")
+                            future.cancel()
+                        with self.lock:
+                            self.connection = None
+                            self.failure_time = time.time()
+                        logger.warning(f"Error occurred in get_blocking: {e}, returning None")
+                        memory_obj = None
+                    memory_objs.append(memory_obj)
+                else:
+                    memory_objs.append(None)
+                    future.cancel()
+
+        t2 = time.perf_counter()
+        self.stats_monitor.update_interval_remote_time_to_get_sync((t2 - t1) * 1000)
+        decompressed_memory_objs = []
+        for memory_obj in memory_objs:
+            if memory_obj is None:
+                decompressed_memory_objs.append(None)
+            else:
+                decompressed_memory_objs.append(self.deserializer.deserialize(memory_obj))
+
+        assert len(decompressed_memory_objs) == len(keys), f"keys length: {len(keys)}, decompressed memory objs length: {len(decompressed_memory_objs)}"
+        return decompressed_memory_objs
+
     def pin(self, key: CacheEngineKey) -> bool:
         logger.debug(
             "Remote backend does not support pin. "


### PR DESCRIPTION
support `batched_get_blocking` in remote backend to improve get-blocking performance.

In my test, I deployed with `1p1d`, use `FSConnector`, in our internal test system, run 1000s for every test, the result is as follows:
| | TTFT | QPM | The average length of input tokens | Number of runs |
| ------ | ------ | ------ | ------ | ------|
| baseline(not use lmcache) | 20.57s | 25.56 | 1.55w | 460 |
| use lmcache without this PR | 20.06s | 22.28 | 1.38w | 401 |
| use lmcache with this PR | 2.76s | 28.61 | 1.68w | 515 |

The results indicate that `batched_get_blocking` is highly effective in improving TTFT.