### PR TITLE
optimize lock usage and scope

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -107,15 +107,15 @@ class LocalCPUBackend(StorageBackendInterface):
             self.hot_cache[key] = memory_obj
             memory_obj.ref_count_up()
 
-            self.usage += memory_obj.get_size()
-            self.stats_monitor.update_local_cache_usage(self.usage)
+        self.usage += memory_obj.get_size()
+        self.stats_monitor.update_local_cache_usage(self.usage)
 
-            # TODO(Jiayi): optimize this with batching?
-            # push kv admit msg
-            if self.lmcache_worker is not None:
-                self.lmcache_worker.put_msg(
-                    KVAdmitMsg(self.instance_id, key.worker_id, key.chunk_hash, "cpu")
-                )
+        # TODO(Jiayi): optimize this with batching?
+        # push kv admit msg
+        if self.lmcache_worker is not None:
+            self.lmcache_worker.put_msg(
+                KVAdmitMsg(self.instance_id, key.worker_id, key.chunk_hash, "cpu")
+            )
         return None
 
     def batched_submit_put_task(
@@ -197,20 +197,20 @@ class LocalCPUBackend(StorageBackendInterface):
             if key not in self.hot_cache:
                 return False
             memory_obj = self.hot_cache.pop(key)
-            if free_obj:
-                memory_obj.ref_count_down()
+        if free_obj:
+            memory_obj.ref_count_down()
 
-            self.usage -= memory_obj.get_size()
-            self.stats_monitor.update_local_cache_usage(self.usage)
+        self.usage -= memory_obj.get_size()
+        self.stats_monitor.update_local_cache_usage(self.usage)
 
-            if self.lmcache_worker is not None:
-                self.lmcache_worker.put_msg(
-                    KVEvictMsg(self.instance_id, key.worker_id, key.chunk_hash, "cpu")
-                )
-            # NOTE (Jiayi): This `return True` might not accurately reflect
-            # whether the key is removed from the actual memory because
-            # other backends might still (temporarily) hold the memory object.
-            return True
+        if self.lmcache_worker is not None:
+            self.lmcache_worker.put_msg(
+                KVEvictMsg(self.instance_id, key.worker_id, key.chunk_hash, "cpu")
+            )
+        # NOTE (Jiayi): This `return True` might not accurately reflect
+        # whether the key is removed from the actual memory because
+        # other backends might still (temporarily) hold the memory object.
+        return True
 
     @_lmcache_nvtx_annotate
     def allocate(
@@ -350,11 +350,9 @@ class LocalCPUBackend(StorageBackendInterface):
             return
 
         if memory_obj.tensor is not None and memory_obj.tensor.is_cuda:
-            self.cpu_lock.acquire()
-            if key in self.hot_cache:
-                self.cpu_lock.release()
-                return
-            self.cpu_lock.release()
+            with self.cpu_lock:
+                if key in self.hot_cache:
+                    return
 
             # Allocate a cpu memory object
             cpu_memory_obj = self.memory_allocator.allocate(
@@ -375,10 +373,9 @@ class LocalCPUBackend(StorageBackendInterface):
             memory_obj.tensor.record_stream(self.stream)
 
             # Update the hot cache
-            self.cpu_lock.acquire()
-            self.hot_cache[key] = cpu_memory_obj
+            with self.cpu_lock:
+                self.hot_cache[key] = cpu_memory_obj
             cpu_memory_obj.ref_count_up()
-            self.cpu_lock.release()
 
             # Push kv msg
             if self.lmcache_worker is not None:
@@ -388,24 +385,21 @@ class LocalCPUBackend(StorageBackendInterface):
 
             logger.debug("Updated hot cache!")
         else:
-            self.cpu_lock.acquire()
-            if self.use_hot and key not in self.hot_cache:
-                self.hot_cache[key] = memory_obj
-                memory_obj.ref_count_up()
-                self.cpu_lock.release()
+            with self.cpu_lock:
+                if self.use_hot and key not in self.hot_cache:
+                    self.hot_cache[key] = memory_obj
+                    memory_obj.ref_count_up()
 
-                # Push kv msg
-                if self.lmcache_worker is not None:
-                    self.lmcache_worker.put_msg(
-                        KVAdmitMsg(
-                            self.instance_id,
-                            key.worker_id,
-                            key.chunk_hash,
-                            "cpu",
+                    # Push kv msg
+                    if self.lmcache_worker is not None:
+                        self.lmcache_worker.put_msg(
+                            KVAdmitMsg(
+                                self.instance_id,
+                                key.worker_id,
+                                key.chunk_hash,
+                                "cpu",
+                            )
                         )
-                    )
-            else:
-                self.cpu_lock.release()
 
     def get_keys(self) -> List[CacheEngineKey]:
         """

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -126,9 +126,8 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
     ) -> None:
         path = self.dict[key].path
-        self.disk_lock.acquire()
-        self.dict.pop(key)
-        self.disk_lock.release()
+        with self.disk_lock:
+            self.dict.pop(key)
         size = os.path.getsize(path)
         self.usage -= size
         self.stats_monitor.update_local_storage_usage(self.usage)
@@ -183,9 +182,8 @@ class LocalDiskBackend(StorageBackendInterface):
 
         memory_obj.ref_count_up()
 
-        self.disk_lock.acquire()
-        self.put_tasks.append(key)
-        self.disk_lock.release()
+        with self.disk_lock:
+            self.put_tasks.append(key)
 
         future = asyncio.run_coroutine_threadsafe(
             self.async_save_bytes_to_disk(key, memory_obj), self.loop
@@ -207,23 +205,20 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
     ) -> Optional[Future]:
-        self.disk_lock.acquire()
-        if key not in self.dict:
-            self.disk_lock.release()
-            return None
+        with self.disk_lock:
+            if key not in self.dict:
+                return None
+            # Update cache recency
+            self.evictor.update_on_hit(key, self.dict)
 
-        # Update cache recency
-        self.evictor.update_on_hit(key, self.dict)
+            path = self.dict[key].path
+            dtype = self.dict[key].dtype
+            shape = self.dict[key].shape
+            fmt = self.dict[key].fmt
+            logger.info(f"Prefetching {key} from disk.")
+            assert dtype is not None
+            assert shape is not None
 
-        path = self.dict[key].path
-        dtype = self.dict[key].dtype
-        shape = self.dict[key].shape
-        fmt = self.dict[key].fmt
-        self.disk_lock.release()
-        logger.info(f"Prefetching {key} from disk.")
-
-        assert dtype is not None
-        assert shape is not None
         future = asyncio.run_coroutine_threadsafe(
             self.async_load_bytes_from_disk(path, dtype, shape, fmt), self.loop
         )
@@ -236,22 +231,20 @@ class LocalDiskBackend(StorageBackendInterface):
         """
         Blocking get function.
         """
-        self.disk_lock.acquire()
-        if key not in self.dict:
-            self.disk_lock.release()
-            return None
+        with self.disk_lock:
+            if key not in self.dict:
+                return None
+            # Update cache recency
+            self.evictor.update_on_hit(key, self.dict)
 
-        # Update cache recency
-        self.evictor.update_on_hit(key, self.dict)
+            path = self.dict[key].path
+            dtype = self.dict[key].dtype
+            shape = self.dict[key].shape
+            fmt = self.dict[key].fmt
+            assert dtype is not None
+            assert shape is not None
 
-        path = self.dict[key].path
-        dtype = self.dict[key].dtype
-        shape = self.dict[key].shape
-        fmt = self.dict[key].fmt
-        assert dtype is not None
-        assert shape is not None
         memory_obj = self.load_bytes_from_disk(path, dtype=dtype, shape=shape, fmt=fmt)
-        self.disk_lock.release()
         return memory_obj
 
     def get_non_blocking(
@@ -291,9 +284,8 @@ class LocalDiskBackend(StorageBackendInterface):
 
         memory_obj.ref_count_down()
 
-        self.disk_lock.acquire()
-        self.put_tasks.remove(key)
-        self.disk_lock.release()
+        with self.disk_lock:
+            self.put_tasks.remove(key)
 
     # TODO(Jiayi): use `bytes_read = await f.readinto(buffer)`
     # for better performance (i.e., fewer copy)
@@ -353,6 +345,5 @@ class LocalDiskBackend(StorageBackendInterface):
 
     def close(self) -> None:
         if self.lookup_server is not None:
-            self.disk_lock.acquire()
-            self.lookup_server.batched_remove(list(self.dict.keys()))
-            self.disk_lock.release()
+            with self.disk_lock:
+                self.lookup_server.batched_remove(list(self.dict.keys()))

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -162,9 +162,8 @@ class RemoteBackend(StorageBackendInterface):
         """
         Callback function for put tasks.
         """
-        self.lock.acquire()
-        self.put_tasks.remove(key)
-        self.lock.release()
+        with self.lock:
+            self.put_tasks.remove(key)
 
     def submit_put_task(
         self,
@@ -181,9 +180,8 @@ class RemoteBackend(StorageBackendInterface):
 
         memory_obj.ref_count_up()
 
-        self.lock.acquire()
-        self.put_tasks.append(key)
-        self.lock.release()
+        with self.lock:
+            self.put_tasks.append(key)
 
         compressed_memory_obj = self.serializer.serialize(memory_obj)
         memory_obj.ref_count_down()

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -195,9 +195,8 @@ class StorageManager:
         Blocking function to get the memory object from the storages.
         """
         # Search in prefetch task
-        self.manager_lock.acquire()
-        prefetch_task = self.prefetch_tasks.get(key, None)
-        self.manager_lock.release()
+        with self.manager_lock:
+            prefetch_task = self.prefetch_tasks.get(key, None)
 
         # Wait until prefetch task finishes
         # Here, it is assumed all prefetch tasks load the memoryobj to
@@ -281,9 +280,8 @@ class StorageManager:
         """
         Update metadata after prefetch.
         """
-        self.manager_lock.acquire()
-        prefetch_task = self.prefetch_tasks.pop(key)
-        self.manager_lock.release()
+        with self.manager_lock:
+            prefetch_task = self.prefetch_tasks.pop(key)
         try:
             buffer_memory_obj = prefetch_task.result()
         except Exception as e:
@@ -308,20 +306,16 @@ class StorageManager:
 
         # NOTE: no need to ref_count_up here because
         # the memory_obj's ref_count is already 1
-        self.manager_lock.acquire()
         self.storage_backends["LocalCPUBackend"].submit_put_task(key, memory_obj)
-        self.manager_lock.release()
 
     def prefetch(self, key: CacheEngineKey) -> None:
         """Launch a prefetch request in the storage backend. Non-blocking"""
 
         if self.storage_backends["LocalCPUBackend"].contains(key):
             return
-        self.manager_lock.acquire()
-        if key in self.prefetch_tasks:
-            self.manager_lock.release()
-            return
-        self.manager_lock.release()
+        with self.manager_lock:
+            if key in self.prefetch_tasks:
+                return
 
         for backend in self.storage_backends.values():
             prefetch_task = backend.submit_prefetch_task(key)
@@ -329,10 +323,9 @@ class StorageManager:
                 continue
             lambda_callback = lambda f: self.prefetch_callback(f, key)
 
-            self.manager_lock.acquire()
-            self.prefetch_tasks[key] = prefetch_task
+            with self.manager_lock:
+                self.prefetch_tasks[key] = prefetch_task
             prefetch_task.add_done_callback(lambda_callback)
-            self.manager_lock.release()
             break
 
     # TODO(Jiayi): Currently, search_range is only used for testing.


### PR DESCRIPTION
This PR optimizes lock usage and scope:
1, use "with lock" to replace explicit lock acquire and release calling.
2, only keep minumum lock scope to avoid bug and reduce risk of dead lock. For example, lock useage in StorageManager can cause dead lock, since prefetch callback also use manager_lock:
```
            self.manager_lock.acquire()
            self.prefetch_tasks[key] = prefetch_task
            prefetch_task.add_done_callback(lambda_callback)
            self.manager_lock.release()
```