### PR TITLE
[Opt]: Speed up V1 token hashing

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -16,11 +16,11 @@
 from typing import Iterable, List, Optional, Tuple, Union
 import abc
 import array
-import hashlib
 
 # Third Party
 from transformers import AutoTokenizer
 import torch
+import xxhash
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
@@ -85,20 +85,21 @@ class ChunkedTokenDatabase(TokenDatabase):
             chunk_hash,
         )
 
-    def _get_init_hash(self) -> str:
-        return ""
+    def _get_init_hasher(self) -> xxhash.xxh64:
+        # seed defaults to 0
+        return xxhash.xxh64()
 
-    def _hash(
+    def _hash_incremental(
         self,
         tokens: Union[torch.Tensor, List[int]],
-        prefix_hash: str,
+        hasher: xxhash.xxh64,
     ) -> str:
-        # TODO: change it to a more efficient hash function
         if isinstance(tokens, torch.Tensor):
             tokens_bytes = tokens.cpu().to(torch.uint32).numpy().tobytes()
         elif isinstance(tokens, list):
             tokens_bytes = array.array("I", tokens).tobytes()
-        return hashlib.sha256(prefix_hash.encode("ascii") + tokens_bytes).hexdigest()
+        hasher.update(tokens_bytes)
+        return hasher.hexdigest()
 
     def _chunk_tokens(
         self,
@@ -125,10 +126,10 @@ class ChunkedTokenDatabase(TokenDatabase):
         self,
         token_chunks: Iterable[Union[torch.Tensor, List[int]]],
     ) -> Iterable[str]:
-        prefix_hash = self._get_init_hash()
+        hasher = self._get_init_hasher()
         for token_chunk in token_chunks:
-            prefix_hash = self._hash(token_chunk, prefix_hash)
-            yield prefix_hash
+            hash_val = self._hash_incremental(token_chunk, hasher)
+            yield hash_val
 
     @_lmcache_nvtx_annotate
     def process_tokens(
@@ -180,7 +181,7 @@ class ChunkedTokenDatabase(TokenDatabase):
                 if make_key:
                     yield start_idx, end_idx, self._make_key_by_hash(hash_val)
                 else:
-                    yield start_idx, end_idx, hash_val
+                    yield start_idx, end_idx, str(hash_val)
 
 
 class SegmentTokenDatabase(TokenDatabase):
@@ -213,12 +214,11 @@ class SegmentTokenDatabase(TokenDatabase):
         self,
         tokens: Union[torch.Tensor, List[int]],
     ) -> str:
-        # TODO: change it to a more efficient hash function
         if isinstance(tokens, torch.Tensor):
             tokens_bytes = tokens.cpu().to(torch.uint32).numpy().tobytes()
         elif isinstance(tokens, list):
             tokens_bytes = array.array("I", tokens).tobytes()
-        return hashlib.sha256(tokens_bytes).hexdigest()
+        return xxhash.xxh64(tokens_bytes).hexdigest()
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
         """Match the `sep_tokens` with sliding windows"""

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -181,7 +181,7 @@ class ChunkedTokenDatabase(TokenDatabase):
                 if make_key:
                     yield start_idx, end_idx, self._make_key_by_hash(hash_val)
                 else:
-                    yield start_idx, end_idx, str(hash_val)
+                    yield start_idx, end_idx, hash_val
 
 
 class SegmentTokenDatabase(TokenDatabase):

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -1,10 +1,8 @@
-# Standard
-import hashlib
-
 # Third Party
 from utils import dumb_metadata, dumb_metadata_with_model_name, generate_tokens
 import pytest
 import torch
+import xxhash
 
 # First Party
 from lmcache.v1.config import LMCacheEngineConfig
@@ -69,14 +67,14 @@ def test_segment_token_database(prefix_length, chunk_lengths):
     starts = [0]
     ends = [sys_length]
     sys_bytes = sys_tokens.cpu().to(torch.uint32).numpy().tobytes()
-    sys_hash = hashlib.sha256(sys_bytes).hexdigest()
+    sys_hash = xxhash.xxh64(sys_bytes).hexdigest()
     hashes = [sys_hash]
     start = sys_length + len(sep_tokens)
     for idx, chunk_length in enumerate(chunk_lengths):
         token_chunk = generate_tokens(chunk_length, "cpu", fixed=True)
 
         token_bytes = token_chunk.cpu().to(torch.uint32).numpy().tobytes()
-        token_hash = hashlib.sha256(token_bytes).hexdigest()
+        token_hash = xxhash.xxh64(token_bytes).hexdigest()
         hashes.append(token_hash)
 
         token_chunk = torch.cat([sep_tokens, token_chunk])
@@ -86,7 +84,7 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         start += chunk_length + len(sep_tokens)
 
     query_bytes = query_tokens.cpu().to(torch.uint32).numpy().tobytes()
-    query_hash = hashlib.sha256(query_bytes).hexdigest()
+    query_hash = xxhash.xxh64(query_bytes).hexdigest()
     hashes.append(query_hash)
     starts.append(start)
     ends.append(start + query_length)


### PR DESCRIPTION
https://github.com/LMCache/LMCache/commit/b9e8b81a6c61147a15e7a3f60ccb38ff8e180654 by @zhouwfang updated teh V0 codepath. This PR updates V1 codepath with xx64 hasher as well (thanks @Siddhant-Ray!)

Some analysis:

With the rolling hasher we hash each byte exactly once.
The old scheme concatenated the entire cumulative prefix into a new buffer every chunk; total bytes processed grows like  n^2

xxh64 is less collision resistant but we need to store 30M chunks to reach 0.027% collision rate, which is 80k GB of KV cache even on a Qwen 4B with int8 quantization so we should still be safe. 
