### PR TITLE
[Bugfix] ref_count problem in remote_backend

### DIFF
--- a/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
@@ -145,9 +145,10 @@ class CacheGenDeserializer(Deserializer):
                 dtype=kv_chunk.dtype,
                 address=-1,
                 phy_size=kv_chunk.numel() * kv_chunk.element_size(),
-                ref_count=-1,  # HACK: avoid mis-free
+                ref_count=1,  # Use normal ref_count
                 fmt=MemoryFormat.KV_2LTD,
             ),
+            # The parent_allocator is None by default
         )
 
         return memory_obj

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -260,6 +260,13 @@ class RemoteBackend(StorageBackendInterface):
             f"Get takes {(t2 - t1) * 1000:.6f} msec, "
             f"deserialization takes {(t3 - t2) * 1000:.6f} msec"
         )
+
+        # ref count up for caller to avoid situation where the memory_obj
+        # is evicted before the caller calls ref count down themselves
+        # This maintains consistency with LocalCPUBackend behavior
+        if decompressed_memory_obj is not None:
+            decompressed_memory_obj.ref_count_up()
+
         return decompressed_memory_obj
 
     def get_non_blocking(


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE
## Bug description
When using the `RemoteBackend` as the storage backend(e.g., `examples/kv_cache_reuse/share_across_instances/centralized_sharing`), in the `retrieve()` process, the `ref_count` of retrieved `memory_obj` will be count down unexpectedly.

```python
for key, memory_obj in zip(reordered_keys, reordered_memory_objs, strict=False):
    memory_obj.ref_count_down()
```
As far as I'm concerned, the `memory_obj.ref_count_down()` here is to balance the`ref_count_up()` in `get_blocking()` when retrieving the memory object(like in `LocalCPUBackend`), while it is not the case in `RemoteBackend`. Currently, the default `ref_count` for the memory object retrieved from `RemoteBackend` is -1 to avoid mis-free. This causes the `ref_count` to be -2.

```bash
[2025-07-15 15:20:37,208] LMCache WARNING: Ref count of MemoryObj -1is negative: -2.Double free occurred somewhere.Setting ref count back to 0 as a hack but please find the bug. (memory_management.py:332:lmcache.v1.memory_management)
```
## Fix
I think setting the retrieved  memory object `ref_count` to -1 to avoid mis-free is meaningless since the default `parent_allocator` is None and there is no way that this object will be freed when its `ref_count` comes to 0. So we can treat it like in `LocalCPUBackend`.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

To create a new tag for lmcache (Note: `v` prefix is required):
`git tag vx.x.x`
`git push origin vx.x.x` (same version again)

For example:
`git tag v0.3.0`
`git push origin v0.3.0`

In case the workflow fails, delete the tag and try again:
`git tag -d vx.x.x`
`git push origin :refs/tags/vx.x.x`

For example:
`git tag -d v0.3.0`
`git push origin :refs/tags/v0.3.0`

To create a new release and publish `lmcache` Python package to PyPi:
`git remote add upstream git@github.com:LMCache/LMCache.git`
`gh release create vx.x.x --repo LMCache/LMCache --title "vx.x.x" --notes "<Add description>"`

For example:
`git remote add upstream git@github.com:LMCache/LMCache.git`
`gh release create v0.3.0 --repo LMCache/LMCache --title "v0.3.0" --notes "LMCache v0.3.0 is a feature release. Users are encouraged to upgrade for the best experience."`

> [!TIP]
> The creation of a release and subsequent tag generation can be done alternatively from the LMCache [releases](https://github.com/LMCache/LMCache/releases) page.

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
