### PR TITLE
[Connector] Support config multiply base dir for fs remote connector

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -44,29 +44,45 @@ class FSConnector(RemoteConnector):
 
     def __init__(
         self,
-        base_path: str,
+        base_paths_str: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
         """
         Args:
-            base_path: Root directory to store all cache files
+            base_paths_str: Comma separated storage paths
             loop: Asyncio event loop
-            memory_allocator: Memory allocator interface
+            local_cpu_backend: Memory allocator interface
         """
-        self.base_path = Path(base_path)
+        # Parse comma separated paths
+        self.base_paths = (
+            [Path(p.strip()) for p in base_paths_str.split(",")]
+            if "," in base_paths_str
+            else [Path(base_paths_str)]
+        )
+
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
-        logger.info(f"Initialized FSConnector with base path {base_path}")
-        # Create base directory if not exists
-        self.base_path.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Initialized FSConnector with base paths {self.base_paths}")
+        # Create directories for all paths
+        for path in self.base_paths:
+            path.mkdir(parents=True, exist_ok=True)
 
     def _get_file_path(self, key: CacheEngineKey) -> Path:
         """Get file path for the given key"""
+        # If there's only one path, use it directly
+        if len(self.base_paths) == 1:
+            base_path = self.base_paths[0]
+        else:
+            # Calculate hash value and modulo to select path
+            hex_str = key.chunk_hash[:16]
+            hash_val = int(hex_str, 16)
+            idx = hash_val % len(self.base_paths)
+            base_path = self.base_paths[idx]
+
         key_path = key.to_string().replace("/", "-") + ".data"
-        # Use key's string representation as filename
-        return self.base_path / key_path
+        return base_path / key_path
 
     async def exists(self, key: CacheEngineKey) -> bool:
         """Check if key exists in file system"""
@@ -146,7 +162,10 @@ class FSConnector(RemoteConnector):
     @no_type_check
     async def list(self) -> List[str]:
         """List all keys in file system"""
-        return [f.stem for f in self.base_path.glob("*.data")]
+        keys = []
+        for base_path in self.base_paths:
+            keys.extend([f.stem for f in base_path.glob("*.data")])
+        return keys
 
     async def close(self):
         """Clean up resources"""

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -76,8 +76,7 @@ class FSConnector(RemoteConnector):
             base_path = self.base_paths[0]
         else:
             # Calculate hash value and modulo to select path
-            hex_str = key.chunk_hash[:16]
-            hash_val = int(hex_str, 16)
+            hash_val = abs(key.chunk_hash)
             idx = hash_val % len(self.base_paths)
             base_path = self.base_paths[idx]
 


### PR DESCRIPTION
# Motivation

In our use case of `FSConnector`, we mounted a fuse client to access a distributed filesystem as a remote kvstore, and we found the `fuse client` become the bottleneck. 

So I propose to support config multiply base dirs for FSConnector, and treat each base dir as a `shard` placed by `hash%len(dir)` for each key.

# Test

- test env

Tested with in docker image built 20250701 by ci.

- lmcache.yaml
```yaml
chunk_size: 64
local_device: "cpu"
remote_url: "fs://host:0/disc/data1/baoloongmao/fs_data/,/disc/data1/baoloongmao/fs_data2/,/disc/data1/baoloongmao/fs_data3/"
remote_serde: "naive"
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 10
extra_config:
  remote_enable_mla_worker_id_as0: True
```

- start vllm

```
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=1 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 1 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_parallel_size":2}'
```

- Key log of vllm
```
[2025-07-15 10:51:41,296] LMCache INFO: Initialized FSConnector with base paths [PosixPath('/disc/data1/baoloongmao/fs_data'), PosixPath('/disc/data1/baoloongmao/fs_data2'), PosixPath('/disc/data1/baoloongmao/fs_data3')] (fs_connector.py:67:lmcache.v1.storage_backend.connector.fs_connector)
```

- Tested by curl
```shell
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
    }'
{"id":"chatcmpl-f88767e02bfd40f59571a61d871a5760","object":"chat.completion","created":1752576812,"model":"vllm_cpu_offload","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":" Hello! As an AI, I don't","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":235,"total_tokens":245,"completion_tokens":10,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null
```

- Check the stored chunk file.
```
root@TENCENT64:/vllm-workspace# ll -h /disc/data1/baoloongmao/fs_data*
/disc/data1/baoloongmao/fs_data:
total 1.3Mdrwxr-xr-x  2 root root  144 Jul 15 18:53  ./drwxr-xr-x 37 root root 4.0K Jul 15 18:53  ../-rw-r--r--  1 root root 1.3M Jul 15 18:53 'vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@1@0@9fa7cc51d176461d43b41797d203d496e3661b7595fbd52bad33e8bb024a1a45.data'

/disc/data1/baoloongmao/fs_data2:
total 2.0M
drwxr-xr-x  2 root root  144 Jul 15 18:53  ./
drwxr-xr-x 37 root root 4.0K Jul 15 18:53  ../
-rw-r--r--  1 root root 1.9M Jul 15 18:53 'vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@1@0@49c3eb1e3111a1d996bdc5d1229a21e1c3d0986cb4f2bf72b9b72f13f2636b3a.data'

/disc/data1/baoloongmao/fs_data3:
total 3.9M
drwxr-xr-x  2 root root  278 Jul 15 18:53  ./
drwxr-xr-x 37 root root 4.0K Jul 15 18:53  ../
-rw-r--r--  1 root root 1.9M Jul 15 18:53 'vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@1@0@5f8610142994973a7a14cdb1d45459bfd6d0541ecb7e2efbd107fba4487d6d4f.data'
-rw-r--r--  1 root root 1.9M Jul 15 18:53 'vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@1@0@83d62078d6365387cb16387f221edc059d3e44575ef6f075a9094b723db9e8f9.data'
```