### PR TITLE
[FIX] Add type checking and conversion for rpc path generation

### DIFF
--- a/lmcache/v1/rpc_utils.py
+++ b/lmcache/v1/rpc_utils.py
@@ -96,7 +96,15 @@ def get_zmq_rpc_path_lmcache(
 
     base_url = envs.VLLM_RPC_BASE_PATH
 
-    rpc_port += tp_rank
+    if isinstance(rpc_port, int):
+        rpc_port += tp_rank
+    elif isinstance(rpc_port, str):
+        if rpc_port.isdigit():
+            rpc_port = int(rpc_port) + tp_rank
+        else:
+            raise ValueError(f"rpc_port '{rpc_port}' is not a valid integer and cannot add tp_rank {tp_rank}, please check the config lmcache_rpc_port")
+    else:
+        raise TypeError(f"rpc_port type {type(rpc_port)} not supported, please check the config lmcache_rpc_port")
 
     logger.debug("Base URL: %s, RPC Port: %s", base_url, rpc_port)
     return f"ipc://{base_url}/lmcache_rpc_port_{rpc_port}"


### PR DESCRIPTION
Hi, @YaoJiayi 
I find for some existing examples, like vllm LMCache example (https://github.com/vllm-project/vllm/blob/main/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_vllm_launcher.sh#L34), the rpc port `lmcache_rpc_port` will be specified as a str variable instead of int, so the `rpc_port += tp_rank` could lead to the type error.
I add type checking and conversion for above situation. Could you help review?
Thank you.