### PR TITLE
[Doc] fix config file name consistency in KV cache sharing example

### DIFF
--- a/docs/source/getting_started/quickstart/share_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/share_kv_cache.rst
@@ -54,7 +54,7 @@ Run centralized sharing example
 
 .. code-block:: bash
 
-    LMCACHE_CONFIG_FILE=example.yaml \
+    LMCACHE_CONFIG_FILE=lmcache_config.yaml \
     CUDA_VISIBLE_DEVICES=0 \
     vllm serve mistralai/Mistral-7B-Instruct-v0.2 \
         --gpu-memory-utilization 0.8 \
@@ -65,7 +65,7 @@ In another terminal,
 
 .. code-block:: bash
 
-    LMCACHE_CONFIG_FILE=example.yaml \
+    LMCACHE_CONFIG_FILE=lmcache_config.yaml \
     CUDA_VISIBLE_DEVICES=1 \
     vllm serve mistralai/Mistral-7B-Instruct-v0.2 \
         --gpu-memory-utilization 0.8 \


### PR DESCRIPTION
Problem: The documentation at https://docs.lmcache.ai/getting_started/quickstart/share_kv_cache.html causes a FileNotFoundError when following the tutorial.

Fix: Standardize all references to use lmcache_config.yaml to resolve the issue.