### PR TITLE
[CI/Build][Doc] Remove deprecated pipelined_backend configuration option from testcase, documentation and examples

### DIFF
--- a/docs/source/getting_started/quickstart/share_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/share_kv_cache.rst
@@ -37,9 +37,6 @@ First, create a configuration file named ``lmcache_config.yaml`` with the follow
     local_cpu: true
     remote_url: "lm://localhost:65432"
     remote_serde: "cachegen"
-    
-    # Whether retrieve() is pipelined or not
-    pipelined_backend: false
 
 Run centralized sharing example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/kv_cache/mooncake.rst
+++ b/docs/source/kv_cache/mooncake.rst
@@ -85,7 +85,6 @@ Create your ``mooncake-config.yaml``:
     local_device: "cpu"
     remote_url: "mooncakestore://127.0.0.1:50051/"
     remote_serde: "naive"
-    pipelined_backend: False
     local_cpu: False
     max_local_cpu_size: 5
 

--- a/examples/frontend/example.yaml
+++ b/examples/frontend/example.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_cpu: True
 remote_url: "lm://localhost:65432"
 remote_serde: "cachegen"
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/examples/kv_cache_reuse/remote_backends/external/backend_type.yaml
+++ b/examples/kv_cache_reuse/remote_backends/external/backend_type.yaml
@@ -5,7 +5,6 @@ local_cpu: False
 max_local_cpu_size: 5
 remote_url: "external://host:0/external_log_connector.lmc_external_log_connector/?connector_name=ExternalLogConnector"
 remote_serde: "naive"
-pipelined_backend: False
 extra_config:
   ext_log_connector_support_ping: True
   ext_log_connector_health_interval: 10.0

--- a/examples/kv_cache_reuse/share_across_instances/centralized_sharing/example.yaml
+++ b/examples/kv_cache_reuse/share_across_instances/centralized_sharing/example.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_cpu: True
 remote_url: "lm://localhost:65432"
 remote_serde: "cachegen"
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/examples/online_session/example.yaml
+++ b/examples/online_session/example.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_device: "cpu"
 remote_url: "lm://localhost:65432"
 remote_serde: "cachegen"
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/tests/data/test_creation_from_file/disk.yaml
+++ b/tests/data/test_creation_from_file/disk.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_device: "file:///tmp"
 remote_url: null
 remote_serde: null
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/tests/data/test_creation_from_file/fail.yaml
+++ b/tests/data/test_creation_from_file/fail.yaml
@@ -1,4 +1,1 @@
 chunk_size: 256
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/tests/data/test_creation_from_file/hybrid.yaml
+++ b/tests/data/test_creation_from_file/hybrid.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_device: "cpu"
 remote_url: "lm://localhost:65000"
 remote_serde: "safetensor"
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/tests/data/test_creation_from_file/local.yaml
+++ b/tests/data/test_creation_from_file/local.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_device: "cpu"
 remote_url: null
 remote_serde: null
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/tests/data/test_creation_from_file/remote.yaml
+++ b/tests/data/test_creation_from_file/remote.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_device: null
 remote_url: "lm://localhost:65000"
 remote_serde: "cachegen"
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False


### PR DESCRIPTION
The `pipelined_backend` configuration option was part of the legacy configuration system. This option is no longer supported and was causing confusion in the documentation.
Additionally, `pipelined_backendis` is set to False by default, so this change will not affect any functionality.

This PR removes the deprecated `pipelined_backend` configuration option from all testcases, docs and examples. 
