### PR TITLE
Add structure for pluggable hash libraries

### DIFF
--- a/examples/cache_controller/example.yaml
+++ b/examples/cache_controller/example.yaml
@@ -6,4 +6,4 @@ max_local_cpu_size: 5
 enable_controller: True
 lmcache_instance_id: "lmcache_default_instance"
 controller_url: "localhost:9001"
-lmcache_worker_url: "localhost:8001"
+lmcache_worker_port: 8001

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -61,7 +61,6 @@ class KVController:
 
         # TODO(Jiayi): remove this hardcode
         self.token_database = ChunkedTokenDatabase()
-        self.token_database.chunk_size = 256
 
     def post_init(self, cluster_executor):
         """

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -72,17 +72,12 @@ class KVController:
         """
         Admit a new kv chunk.
         """
-        print("** In KVController::admit() **")
         instance_id = msg.instance_id
         worker_id = msg.worker_id
         key = msg.key
         location = msg.location
         if key not in self.kv_pool:
             self.kv_pool[key] = []
-        print(
-            f"** In KVController::admit(), append - instance_id: {instance_id}, "
-            f"worker_id: {worker_id}, location: {location} **"
-        )
         self.kv_pool[key].append(KVChunkMetadata(instance_id, worker_id, location))
 
     async def evict(self, msg: KVEvictMsg) -> None:
@@ -164,22 +159,14 @@ class KVController:
     # `instance_id` with longest prefix.
     # TODO(Jiayi): Need to get rid of the hash somehow
     async def lookup(self, msg: LookupMsg) -> LookupRetMsg:
-        print("In KVController:lookup()")
         tokens = msg.tokens
         layout_info = {}
         for start, end, key in self.token_database.process_tokens(
             tokens, make_key=False
         ):
-            print(f"In KVController:lookup() - key: {key}, key type: {type(key)}")
-            # assert isinstance(key, str)
             if key not in self.kv_pool:
-                print(
-                    f"In KVController:lookup() - key: {key} "
-                    f"not in kv_pool: {self.kv_pool}"
-                )
                 break
             matched_instance = self.kv_pool[str(key)][0].instance_id
             matched_location = self.kv_pool[str(key)][0].location
             layout_info[matched_instance] = (matched_location, end)
-            print(f"In KVController:lookup() - layout_info: {layout_info}")
         return LookupRetMsg(layout_info=layout_info)

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -72,12 +72,17 @@ class KVController:
         """
         Admit a new kv chunk.
         """
+        print("** In KVController::admit() **")
         instance_id = msg.instance_id
         worker_id = msg.worker_id
         key = msg.key
         location = msg.location
         if key not in self.kv_pool:
             self.kv_pool[key] = []
+        print(
+            f"** In KVController::admit(), append - instance_id: {instance_id}, "
+            f"worker_id: {worker_id}, location: {location} **"
+        )
         self.kv_pool[key].append(KVChunkMetadata(instance_id, worker_id, location))
 
     async def evict(self, msg: KVEvictMsg) -> None:
@@ -159,15 +164,22 @@ class KVController:
     # `instance_id` with longest prefix.
     # TODO(Jiayi): Need to get rid of the hash somehow
     async def lookup(self, msg: LookupMsg) -> LookupRetMsg:
+        print("In KVController:lookup()")
         tokens = msg.tokens
         layout_info = {}
         for start, end, key in self.token_database.process_tokens(
             tokens, make_key=False
         ):
-            assert isinstance(key, str)
+            print(f"In KVController:lookup() - key: {key}, key type: {type(key)}")
+            # assert isinstance(key, str)
             if key not in self.kv_pool:
+                print(
+                    f"In KVController:lookup() - key: {key} "
+                    f"not in kv_pool: {self.kv_pool}"
+                )
                 break
-            matched_instance = self.kv_pool[key][0].instance_id
-            matched_location = self.kv_pool[key][0].location
+            matched_instance = self.kv_pool[str(key)][0].instance_id
+            matched_location = self.kv_pool[str(key)][0].location
             layout_info[matched_instance] = (matched_location, end)
+            print(f"In KVController:lookup() - layout_info: {layout_info}")
         return LookupRetMsg(layout_info=layout_info)

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -93,6 +93,8 @@ class LMCacheEngineConfig:
     # lmcache worker url
     # NOTE: port number will add `worker_id`
     lmcache_worker_port: Optional[int] = None
+    # Algorithm used to hash tokens pre caching
+    pre_caching_hash_algorithm: str = "builtin"
 
     # (Optional) Nixl configurations
     # whether to enable Nixl
@@ -157,6 +159,7 @@ class LMCacheEngineConfig:
         remote_serde: Optional[str] = "naive",
         use_layerwise: bool = False,
         save_decode_cache: bool = False,
+        pre_caching_hash_algorithm: str = "builtin",
         enable_blending: bool = False,
         blend_recompute_ratio: float = 0.15,
         blend_min_tokens: int = 256,
@@ -214,6 +217,7 @@ class LMCacheEngineConfig:
             lmcache_instance_id,
             controller_url,
             lmcache_worker_port,
+            pre_caching_hash_algorithm,
             enable_nixl,
             nixl_role,
             nixl_receiver_host,
@@ -343,6 +347,8 @@ class LMCacheEngineConfig:
 
         save_decode_cache = config.get("save_decode_cache", False)
 
+        pre_caching_hash_algorithm = config.get("pre_caching_hash_algorithm", "builtin")
+
         enable_blending = config.get("enable_blending", False)
         blend_recompute_ratio = config.get("blend_recompute_ratio", 0.15)
         blend_min_tokens = config.get("blend_min_tokens", 256)
@@ -442,6 +448,7 @@ class LMCacheEngineConfig:
                 lmcache_instance_id,
                 controller_url,
                 lmcache_worker_port,
+                pre_caching_hash_algorithm,
                 enable_nixl,
                 nixl_role,
                 nixl_receiver_host,
@@ -537,6 +544,12 @@ class LMCacheEngineConfig:
         config.save_decode_cache = to_bool(
             parse_env(get_env_name("save_decode_cache"), config.save_decode_cache)
         )
+
+        pre_caching_hash_algorithm = parse_env(
+            get_env_name("pre_caching_hash_algorithm"), "builtin"
+        )
+        assert pre_caching_hash_algorithm is not None
+        config.pre_caching_hash_algorithm = pre_caching_hash_algorithm
 
         config.enable_blending = to_bool(
             parse_env(get_env_name("enable_blending"), config.enable_blending)
@@ -737,6 +750,7 @@ class LMCacheEngineConfig:
             "error_handling": self.error_handling,
             "enable_controller": self.enable_controller,
             "lmcache_instance_id": self.lmcache_instance_id,
+            "pre_caching_hash_algorithm": self.pre_caching_hash_algorithm,
             "enable_nixl": self.enable_nixl,
             "nixl_role": self.nixl_role,
             "nixl_receiver_host": self.nixl_receiver_host,

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -35,14 +35,6 @@ except ImportError:
     # Fallback to a default value if vllm is not available
     NONE_HASH = 0
 
-vllm_is_available = True
-try:
-    # Third Party
-    from vllm.utils import sha256, sha256_cbor_64bit
-except ImportError:
-    # vLLM sha256, sha256_cbor_64bit not available if vllm is not available
-    vllm_is_available = False
-
 
 class TokenDatabase(metaclass=abc.ABCMeta):
     """TokenDatabase is used to convert input tokens into list of
@@ -54,6 +46,37 @@ class TokenDatabase(metaclass=abc.ABCMeta):
     - SegmentTokenDatabase: It processes tokens into segments based on
     special separators and convert each segment into a cache engine key.
     """
+
+    @abc.abstractmethod
+    def __init__(
+        self,
+        config: Optional[LMCacheEngineConfig] = None,
+        metadata: Optional[LMCacheEngineMetadata] = None,
+    ):
+        vllm_is_available = True
+        try:
+            # Third Party
+            from vllm.utils import sha256, sha256_cbor_64bit
+        except ImportError:
+            # sha256, sha256_cbor_64bit are available through vLLM only
+            vllm_is_available = False
+
+        hash_algorithm: str
+        if config is not None:
+            hash_algorithm = config.pre_caching_hash_algorithm
+        else:  # Default value
+            hash_algorithm = "builtin"  # fallback to builtin hash
+
+        # Need to support vLLM hashing functions at a minimum
+        self.hash_func = (
+            sha256_cbor_64bit
+            if hash_algorithm == "sha256_cbor_64bit" and vllm_is_available
+            else sha256
+            if hash_algorithm == "sha256" and vllm_is_available
+            else hash
+        )
+
+        self.metadata = metadata
 
     @abc.abstractmethod
     def process_tokens(
@@ -93,26 +116,14 @@ class ChunkedTokenDatabase(TokenDatabase):
         config: Optional[LMCacheEngineConfig] = None,
         metadata: Optional[LMCacheEngineMetadata] = None,
     ):
-        hash_algorithm: str
+        super(ChunkedTokenDatabase, self).__init__(config, metadata)
+
         if config is not None:
             self.chunk_size = config.chunk_size
             self.save_unfull_chunk = config.save_unfull_chunk
-            hash_algorithm = config.pre_caching_hash_algorithm
         else:  # Default values
             self.chunk_size = 256
             self.save_unfull_chunk = True
-            hash_algorithm = "builtin"  # hash
-
-        # Need to support vLLM hashing functions at a minimum
-        self.hash_func = (
-            sha256_cbor_64bit
-            if hash_algorithm == "sha256_cbor_64bit" and vllm_is_available
-            else sha256
-            if hash_algorithm == "sha256" and vllm_is_available
-            else hash
-        )
-
-        self.metadata = metadata
 
     def _make_key_by_hash(self, chunk_hash: int):
         assert self.metadata is not None
@@ -249,15 +260,9 @@ class SegmentTokenDatabase(TokenDatabase):
     """
 
     def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
-        self.tokenizer = AutoTokenizer.from_pretrained(metadata.model_name)
+        super(SegmentTokenDatabase, self).__init__(config, metadata)
 
-        self.hash_func = (
-            sha256_cbor_64bit
-            if config.pre_caching_hash_algorithm == "sha256_cbor_64bit"
-            else sha256
-            if config.pre_caching_hash_algorithm == "sha256"
-            else hash
-        )
+        self.tokenizer = AutoTokenizer.from_pretrained(metadata.model_name)
 
         # TODO (Jiayi): figure out how to decide when
         # to use `1:` (whether there's a special starting token
@@ -265,7 +270,6 @@ class SegmentTokenDatabase(TokenDatabase):
         self.sep_tokens = self.tokenizer.encode(config.blend_special_str)[1:]
         self.sep_tokens = torch.tensor(self.sep_tokens, device="cpu")
         self.sep_len = len(self.sep_tokens)
-        self.metadata = metadata
 
     def _make_key_by_hash(self, chunk_hash: str):
         return CacheEngineKey(

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -15,10 +15,12 @@
 # Standard
 from typing import Iterable, List, Optional, Tuple, Union
 import abc
+import array
 
 # Third Party
 from transformers import AutoTokenizer
 import torch
+import xxhash
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
@@ -86,11 +88,14 @@ class ChunkedTokenDatabase(TokenDatabase):
         metadata: Optional[LMCacheEngineMetadata] = None,
     ):
         # FIXME(Jiayi): cache_config.prefix_caching_hash_algo
-        self.hash_func = hash
+        self.hash_func = xxhash.xxh64()
 
         if config is not None:
             self.chunk_size = config.chunk_size
             self.save_unfull_chunk = config.save_unfull_chunk
+        else:  # Default values
+            self.chunk_size = 256
+            self.save_unfull_chunk = True
         self.metadata = metadata
 
     def _make_key_by_hash(self, chunk_hash: int):
@@ -103,19 +108,21 @@ class ChunkedTokenDatabase(TokenDatabase):
             chunk_hash,
         )
 
-    def _get_init_hash(self) -> int:
-        return NONE_HASH
+    def _get_init_hash(self) -> str:
+        return ""
 
     def _hash(
         self,
         tokens: Union[torch.Tensor, List[int]],
         prefix_hash: int,
-    ) -> int:
+    ) -> Union[int, str]:
         if isinstance(tokens, torch.Tensor):
-            tokens_tuple = tuple(tokens.cpu().tolist())
+            tokens_bytes = tokens.cpu().to(torch.uint32).numpy().tobytes()
         elif isinstance(tokens, list):
-            tokens_tuple = tuple(tokens)
-        return self.hash_func((prefix_hash, tokens_tuple, None))
+            tokens_bytes = array.array("I", tokens).tobytes()
+        self.hash_func.update(prefix_hash.encode("ascii"))
+        self.hash_func.update(tokens_bytes)
+        return self.hash_func.hexdigest()
 
     def _chunk_tokens(
         self,
@@ -231,7 +238,7 @@ class SegmentTokenDatabase(TokenDatabase):
         self.tokenizer = AutoTokenizer.from_pretrained(metadata.model_name)
 
         # FIXME(Jiayi): cache_config.prefix_caching_hash_algo
-        self.hash_func = hash
+        self.hash_func = xxhash.xxh64()
 
         # TODO (Jiayi): figure out how to decide when
         # to use `1:` (whether there's a special starting token
@@ -253,12 +260,9 @@ class SegmentTokenDatabase(TokenDatabase):
     def _hash(
         self,
         tokens: Union[torch.Tensor, List[int]],
-    ) -> int:
-        if isinstance(tokens, torch.Tensor):
-            tokens_tuple = tuple(tokens.cpu().tolist())
-        elif isinstance(tokens, list):
-            tokens_tuple = tuple(tokens)
-        return self.hash_func(tokens_tuple)
+    ) -> Union[int, str]:
+        self.hash_func.update(tokens.numpy().tobytes())
+        return self.hash_func.hexdigest()
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
         """Match the `sep_tokens` with sliding windows"""

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -136,10 +136,6 @@ class ChunkedTokenDatabase(TokenDatabase):
             tokens_tuple = tuple(tokens.cpu().tolist())
         elif isinstance(tokens, list):
             tokens_tuple = tuple(tokens)
-        print(
-            f"In ChunkedTokenDB:_hash() - hash func type: {type(self.hash_func)}, "
-            f"prefix_hash: {prefix_hash}, tokens_tuple: {tokens_tuple}"
-        )
         return self.hash_func((prefix_hash, tokens_tuple, None))
 
     def _chunk_tokens(
@@ -167,15 +163,9 @@ class ChunkedTokenDatabase(TokenDatabase):
         self,
         token_chunks: Iterable[Union[torch.Tensor, List[int]]],
     ) -> Iterable[int]:
-        print("In ChunkedTokenDB:_prefix_hash()")
         prefix_hash = self._get_init_hash()
-        print(f"In ChunkedTokenDB:_prefix_hash(), prefix_hash: {prefix_hash}")
         for token_chunk in token_chunks:
             prefix_hash = self._hash(token_chunk, prefix_hash)
-            print(
-                f"In ChunkedTokenDB:_prefix_hash(), "
-                f"prefix_hash: {prefix_hash} for token_chunk: {token_chunk}"
-            )
             yield prefix_hash
 
     @_lmcache_nvtx_annotate
@@ -212,7 +202,6 @@ class ChunkedTokenDatabase(TokenDatabase):
         :raises: ValueError if the number of Falses in the mask is not a
             multiple of the chunk size.
         """
-        print("In ChunkedTokenDatabase::process_tokens()")
         if mask is not None:
             num_falses = mask.numel() - mask.long().sum().item()
         else:
@@ -226,47 +215,18 @@ class ChunkedTokenDatabase(TokenDatabase):
         if tokens is not None:
             total_len = len(tokens)
             token_chunks = self._chunk_tokens(tokens)
-            print(
-                f"ChunkedTokenDatabase::process_tokens(), token_chunks: {token_chunks}"
-            )
             prefix_hashes = self._prefix_hash(token_chunks)
-            print(
-                f"ChunkedTokenDatabase::process_tokens(), "
-                f"prefix_hashes: {prefix_hashes}"
-            )
             for chunk_id, hash_val in enumerate(prefix_hashes):
-                print(
-                    f"ChunkedTokenDatabase::process_tokens(), "
-                    f"chunk_id: {chunk_id}, hash_val: {hash_val}"
-                )
                 start_idx = chunk_id * self.chunk_size
                 end_idx = min(start_idx + self.chunk_size, total_len)
-                print(
-                    f"ChunkedTokenDatabase::process_tokens(), "
-                    f"start_idx: {start_idx}, end_idx: {end_idx}"
-                )
                 if start_idx < num_falses:
-                    print(
-                        f"In ChunkedTokenDB:process_tokens() - "
-                        f"start_idx: {start_idx}, num_falses: {num_falses}"
-                    )
                     continue
                 else:
                     if make_key:
-                        make_key_hash = self._make_key_by_hash(hash_val)
-                        print(
-                            f"ChunkedTokenDatabase::process_tokens(), "
-                            f"make_key_hash: {make_key_hash}"
-                        )
                         yield start_idx, end_idx, self._make_key_by_hash(hash_val)
                     else:
-                        print(
-                            f"ChunkedTokenDatabase::process_tokens(), "
-                            f"hash_val: {hash_val}"
-                        )
                         yield start_idx, end_idx, hash_val
         elif hashes is not None:
-            print(f"In ChunkedTokenDB:process_tokens() - offsets: {offsets}")
             assert offsets is not None, (
                 "If hashes are provided, offsets must also be provided."
             )
@@ -274,16 +234,8 @@ class ChunkedTokenDatabase(TokenDatabase):
             for hash_val, offset in zip(hashes, offsets, strict=False):
                 end_idx = start_idx + offset
                 if make_key:
-                    make_key_hash = self._make_key_by_hash(hash_val)
-                    print(
-                        f"ChunkedTokenDatabase::process_tokens(), "
-                        f"make_key_hash: {make_key_hash}"
-                    )
                     yield start_idx, end_idx, self._make_key_by_hash(hash_val)
                 else:
-                    print(
-                        f"ChunkedTokenDatabase::process_tokens(), hash_val: {hash_val}"
-                    )
                     yield start_idx, end_idx, hash_val
                 start_idx = end_idx
         else:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -302,9 +302,8 @@ class SegmentTokenDatabase(TokenDatabase):
         self.hash_func = (
             sha256_cbor_64bit
             if config.pre_caching_hash_algorithm == "sha256_cbor_64bit"
-            and vllm_is_available
             else sha256
-            if config.pre_caching_hash_algorithm == "sha256" and vllm_is_available
+            if config.pre_caching_hash_algorithm == "sha256"
             else hash
         )
 

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -15,12 +15,10 @@
 # Standard
 from typing import Iterable, List, Optional, Tuple, Union
 import abc
-import array
 
 # Third Party
 from transformers import AutoTokenizer
 import torch
-import xxhash
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
@@ -36,6 +34,14 @@ try:
 except ImportError:
     # Fallback to a default value if vllm is not available
     NONE_HASH = 0
+
+vllm_is_available = True
+try:
+    # Third Party
+    from vllm.utils import sha256, sha256_cbor_64bit
+except ImportError:
+    # vLLM sha256, sha256_cbor_64bit not available if vllm is not available
+    vllm_is_available = False
 
 
 class TokenDatabase(metaclass=abc.ABCMeta):
@@ -87,15 +93,25 @@ class ChunkedTokenDatabase(TokenDatabase):
         config: Optional[LMCacheEngineConfig] = None,
         metadata: Optional[LMCacheEngineMetadata] = None,
     ):
-        # FIXME(Jiayi): cache_config.prefix_caching_hash_algo
-        self.hash_func = xxhash.xxh64()
-
+        hash_algorithm: str
         if config is not None:
             self.chunk_size = config.chunk_size
             self.save_unfull_chunk = config.save_unfull_chunk
+            hash_algorithm = config.pre_caching_hash_algorithm
         else:  # Default values
             self.chunk_size = 256
             self.save_unfull_chunk = True
+            hash_algorithm = "builtin"  # hash
+
+        # Need to support vLLM hashing functions at a minimum
+        self.hash_func = (
+            sha256_cbor_64bit
+            if hash_algorithm == "sha256_cbor_64bit" and vllm_is_available
+            else sha256
+            if hash_algorithm == "sha256" and vllm_is_available
+            else hash
+        )
+
         self.metadata = metadata
 
     def _make_key_by_hash(self, chunk_hash: int):
@@ -108,21 +124,23 @@ class ChunkedTokenDatabase(TokenDatabase):
             chunk_hash,
         )
 
-    def _get_init_hash(self) -> str:
-        return ""
+    def _get_init_hash(self) -> int:
+        return NONE_HASH
 
     def _hash(
         self,
         tokens: Union[torch.Tensor, List[int]],
         prefix_hash: int,
-    ) -> Union[int, str]:
+    ) -> int:
         if isinstance(tokens, torch.Tensor):
-            tokens_bytes = tokens.cpu().to(torch.uint32).numpy().tobytes()
+            tokens_tuple = tuple(tokens.cpu().tolist())
         elif isinstance(tokens, list):
-            tokens_bytes = array.array("I", tokens).tobytes()
-        self.hash_func.update(prefix_hash.encode("ascii"))
-        self.hash_func.update(tokens_bytes)
-        return self.hash_func.hexdigest()
+            tokens_tuple = tuple(tokens)
+        print(
+            f"In ChunkedTokenDB:_hash() - hash func type: {type(self.hash_func)}, "
+            f"prefix_hash: {prefix_hash}, tokens_tuple: {tokens_tuple}"
+        )
+        return self.hash_func((prefix_hash, tokens_tuple, None))
 
     def _chunk_tokens(
         self,
@@ -149,9 +167,15 @@ class ChunkedTokenDatabase(TokenDatabase):
         self,
         token_chunks: Iterable[Union[torch.Tensor, List[int]]],
     ) -> Iterable[int]:
+        print("In ChunkedTokenDB:_prefix_hash()")
         prefix_hash = self._get_init_hash()
+        print(f"In ChunkedTokenDB:_prefix_hash(), prefix_hash: {prefix_hash}")
         for token_chunk in token_chunks:
             prefix_hash = self._hash(token_chunk, prefix_hash)
+            print(
+                f"In ChunkedTokenDB:_prefix_hash(), "
+                f"prefix_hash: {prefix_hash} for token_chunk: {token_chunk}"
+            )
             yield prefix_hash
 
     @_lmcache_nvtx_annotate
@@ -188,6 +212,7 @@ class ChunkedTokenDatabase(TokenDatabase):
         :raises: ValueError if the number of Falses in the mask is not a
             multiple of the chunk size.
         """
+        print("In ChunkedTokenDatabase::process_tokens()")
         if mask is not None:
             num_falses = mask.numel() - mask.long().sum().item()
         else:
@@ -201,18 +226,47 @@ class ChunkedTokenDatabase(TokenDatabase):
         if tokens is not None:
             total_len = len(tokens)
             token_chunks = self._chunk_tokens(tokens)
+            print(
+                f"ChunkedTokenDatabase::process_tokens(), token_chunks: {token_chunks}"
+            )
             prefix_hashes = self._prefix_hash(token_chunks)
+            print(
+                f"ChunkedTokenDatabase::process_tokens(), "
+                f"prefix_hashes: {prefix_hashes}"
+            )
             for chunk_id, hash_val in enumerate(prefix_hashes):
+                print(
+                    f"ChunkedTokenDatabase::process_tokens(), "
+                    f"chunk_id: {chunk_id}, hash_val: {hash_val}"
+                )
                 start_idx = chunk_id * self.chunk_size
                 end_idx = min(start_idx + self.chunk_size, total_len)
+                print(
+                    f"ChunkedTokenDatabase::process_tokens(), "
+                    f"start_idx: {start_idx}, end_idx: {end_idx}"
+                )
                 if start_idx < num_falses:
+                    print(
+                        f"In ChunkedTokenDB:process_tokens() - "
+                        f"start_idx: {start_idx}, num_falses: {num_falses}"
+                    )
                     continue
                 else:
                     if make_key:
+                        make_key_hash = self._make_key_by_hash(hash_val)
+                        print(
+                            f"ChunkedTokenDatabase::process_tokens(), "
+                            f"make_key_hash: {make_key_hash}"
+                        )
                         yield start_idx, end_idx, self._make_key_by_hash(hash_val)
                     else:
+                        print(
+                            f"ChunkedTokenDatabase::process_tokens(), "
+                            f"hash_val: {hash_val}"
+                        )
                         yield start_idx, end_idx, hash_val
         elif hashes is not None:
+            print(f"In ChunkedTokenDB:process_tokens() - offsets: {offsets}")
             assert offsets is not None, (
                 "If hashes are provided, offsets must also be provided."
             )
@@ -220,8 +274,16 @@ class ChunkedTokenDatabase(TokenDatabase):
             for hash_val, offset in zip(hashes, offsets, strict=False):
                 end_idx = start_idx + offset
                 if make_key:
+                    make_key_hash = self._make_key_by_hash(hash_val)
+                    print(
+                        f"ChunkedTokenDatabase::process_tokens(), "
+                        f"make_key_hash: {make_key_hash}"
+                    )
                     yield start_idx, end_idx, self._make_key_by_hash(hash_val)
                 else:
+                    print(
+                        f"ChunkedTokenDatabase::process_tokens(), hash_val: {hash_val}"
+                    )
                     yield start_idx, end_idx, hash_val
                 start_idx = end_idx
         else:
@@ -237,8 +299,14 @@ class SegmentTokenDatabase(TokenDatabase):
     def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
         self.tokenizer = AutoTokenizer.from_pretrained(metadata.model_name)
 
-        # FIXME(Jiayi): cache_config.prefix_caching_hash_algo
-        self.hash_func = xxhash.xxh64()
+        self.hash_func = (
+            sha256_cbor_64bit
+            if config.pre_caching_hash_algorithm == "sha256_cbor_64bit"
+            and vllm_is_available
+            else sha256
+            if config.pre_caching_hash_algorithm == "sha256" and vllm_is_available
+            else hash
+        )
 
         # TODO (Jiayi): figure out how to decide when
         # to use `1:` (whether there's a special starting token
@@ -260,9 +328,12 @@ class SegmentTokenDatabase(TokenDatabase):
     def _hash(
         self,
         tokens: Union[torch.Tensor, List[int]],
-    ) -> Union[int, str]:
-        self.hash_func.update(tokens.numpy().tobytes())
-        return self.hash_func.hexdigest()
+    ) -> int:
+        if isinstance(tokens, torch.Tensor):
+            tokens_tuple = tuple(tokens.cpu().tolist())
+        elif isinstance(tokens, list):
+            tokens_tuple = tuple(tokens)
+        return self.hash_func(tokens_tuple)
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
         """Match the `sep_tokens` with sliding windows"""


### PR DESCRIPTION
Needs to handle vLLM hash algorithm support because vLLM  allows hashes in addition to tokens for querying LMCache.

Fix #1079 