### PR TITLE
[ADAPTER|vLLM] fix: Handle the prefix cache hit >= num_external_hit_tokens case avoid storing invoked

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -822,14 +822,15 @@ class LMCacheConnectorV1Impl:
             num_external_hit_tokens,
             need_to_allocate,
         )
-        if need_to_allocate <= 0:
-            return 0
 
         self.load_specs[request.request_id] = LoadSpec(
             vllm_cached_tokens=num_computed_tokens,
             lmcache_cached_tokens=num_external_hit_tokens,
             can_load=False,
         )
+
+        if need_to_allocate <= 0:
+            return 0
 
         # TODO: Align to vLLM block size. Should test whether it can be removed
         # need_to_allocate = need_to_allocate // self._block_size * \


### PR DESCRIPTION
# Issue description

Without this PR, while enable prefix-cache of vllm together with lmcache connector, `lmcache_engine.store` can avoid to be invoked, since we have detected the `num_external_hit_tokens` during `get_num_new_matched_tokens`.

<img width="2192" height="544" alt="企业微信截图_d4863cf5-1f4c-4c08-9314-5b2c4675ff0b" src="https://github.com/user-attachments/assets/ecc67e35-a52f-4f99-acb6-8320bc97ff66" />


# Fix approach

Keep assign `self.load_specs` to remember the `lmcache_cached_tokens`, so that the following  `wait_for_save` can avoid store kvcache invoked.

# Test
Execute the following curl test more than twice, which is tested in `DeepSeek-V2-Lite`.

```
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 1,
    "temperature": 0,
    "top_p": 0.95
    }'
```

<img width="2056" height="630" alt="image" src="https://github.com/user-attachments/assets/2d034e25-d2fd-4795-b992-75c4677a33c1" />
