### PR TITLE
[security]: Tighten runner security by specifying endpoints

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -34,7 +34,13 @@ jobs:
       - name: "Harden Runner"
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo-and-containers: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry-1.docker.io:443
+            production.cloudflare.docker.com:443
+            auth.docker.io:443
 
       - name: "Checkout"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: "Harden Runner"
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
-          disable-sudo-and-containers: true
+          disable-sudo-and-containers: false
           egress-policy: block
           allowed-endpoints: >
             github.com:443

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -16,7 +16,12 @@ jobs:
         - name: Harden Runner
           uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
           with:
-            egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+            disable-sudo-and-containers: true
+            egress-policy: block
+            allowed-endpoints: >
+              github.com:443
+              pypi.org:443
+              files.pythonhosted.org:443
 
         - name: Checkout code
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,11 @@ jobs:
     - name: "Harden Runner"
       uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        disable-sudo-and-containers: true
+        egress-policy: block
+        allowed-endpoints: >
+          github.com:443
+          api.github.com:443
 
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -15,7 +15,24 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
-            egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+            disable-sudo-and-containers: true
+            egress-policy: block
+            allowed-endpoints: >
+              github.com:443
+              registry-1.docker.io:443
+              production.cloudflare.docker.com:443
+              auth.docker.io:443
+              azure.archive.ubuntu.com:80
+              pypi.org:443
+              files.pythonhosted.org:443
+              wheels.vllm.ai:443
+              release-assets.githubusercontent.com:443
+              wrapdb.mesonbuild.com:443
+              nvcr.io:443
+              layers.nvcr.io:443
+              archive.ubuntu.com:80
+              security.ubuntu.com:80
+              astral.sh:443
 
       - name: Login to DockerHub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
             - name: "Harden Runner"
               uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
               with:
-                disable-sudo-and-containers: true
+                disable-sudo-and-containers: false
                 egress-policy: block
                 allowed-endpoints: >
                   github.com:443

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,15 @@ jobs:
             - name: Harden Runner
               uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
               with:
-                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+                disable-sudo-and-containers: true
+                egress-policy: block
+                allowed-endpoints: >
+                  ghcr.io:443
+                  pkg-containers.githubusercontent.com:443
+                  test.pypi.org:443
+                  tuf-repo-cdn.sigstore.dev:443
+                  fulcio.sigstore.dev:443
+                  rekor.sigstore.dev:443
 
             - name: Fetch release artifacts
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -142,7 +150,17 @@ jobs:
             - name: Harden Runner
               uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
               with:
-                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+                  disable-sudo-and-containers: true
+                  egress-policy: block
+                  allowed-endpoints: >
+                    api.github.com:443
+                    uploads.github.com:443
+                    ghcr.io:443
+                    pkg-containers.githubusercontent.com:443
+                    upload.pypi.org:443
+                    tuf-repo-cdn.sigstore.dev:443
+                    fulcio.sigstore.dev:443
+                    rekor.sigstore.dev:443
 
             - name: Fetch release artifacts
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -175,7 +193,24 @@ jobs:
             - name: "Harden Runner"
               uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
               with:
-                egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+                disable-sudo-and-containers: false
+                egress-policy: block
+                allowed-endpoints: >
+                  github.com:443
+                  registry-1.docker.io:443
+                  production.cloudflare.docker.com:443
+                  auth.docker.io:443
+                  azure.archive.ubuntu.com:80
+                  archive.ubuntu.com:80
+                  security.ubuntu.com:80
+                  astral.sh:443
+                  objects.githubusercontent.com:443
+                  pypi.org:443
+                  files.pythonhosted.org:443
+                  release-assets.githubusercontent.com:443
+                  wrapdb.mesonbuild.com:443
+                  nvcr.io:443
+                  layers.nvcr.io:443
 
             - name: Login to DockerHub
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,16 @@ jobs:
             - name: "Harden Runner"
               uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
               with:
-                egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+                disable-sudo-and-containers: true
+                egress-policy: block
+                allowed-endpoints: >
+                  github.com:443
+                  registry-1.docker.io:443
+                  production.cloudflare.docker.com:443
+                  auth.docker.io:443
+                  azure.archive.ubuntu.com:80
+                  pypi.org:443
+                  files.pythonhosted.org:443
 
             - name: Checkout code
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,21 @@ jobs:
       - name: "Harden Runner"
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo-and-containers: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            index.docker.io:443
+            www.bestpractices.dev:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            api.osv.dev:443
+            api.deps.dev:443
+            fulcio.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            rekor.sigstore.dev:443
+            auth.docker.io:443
+            api.scorecard.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -24,7 +24,10 @@ jobs:
       - name: "Harden Runner"
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo-and-containers: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: "Stale Action"
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0


### PR DESCRIPTION
Tighten the runner security by specifying allowed endpoints only.

This is a follow up task to feedback from @sammshen in https://github.com/LMCache/LMCache/pull/611#issuecomment-2867858300.
