### PR TITLE
[fix]: Enable container access for score card and PyPI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
             - name: Harden Runner
               uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
               with:
-                disable-sudo-and-containers: true
+                disable-sudo-and-containers: false
                 egress-policy: block
                 allowed-endpoints: >
                   ghcr.io:443
@@ -150,7 +150,7 @@ jobs:
             - name: Harden Runner
               uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
               with:
-                  disable-sudo-and-containers: true
+                  disable-sudo-and-containers: false
                   egress-policy: block
                   allowed-endpoints: >
                     api.github.com:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Harden Runner"
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
-          disable-sudo-and-containers: true
+          disable-sudo-and-containers: false
           egress-policy: block
           allowed-endpoints: >
             github.com:443


### PR DESCRIPTION
Score card and PyPI workflow requiress docker access. This is a fix to new changes in hardening security in the workflow.
