### PR TITLE
[fix]: zeroing out separator token positions

### DIFF
--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -356,6 +356,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
 
         self.buffer_mapping = {}
 
+        # track gap positions between blended chunks
+        self.current_gap_positions = None
+
     def get_kv(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Get the KV cache for the given layer ID.
@@ -411,6 +414,15 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
 
         num_all_tokens = ends[-1] - starts[0]
         slot_mapping_full = slot_mapping[starts[0] : ends[-1]]
+
+        # compute gap positions 
+        gap_mask = torch.ones(num_all_tokens, dtype=torch.bool, device=slot_mapping_full.device)
+        buf_offset = starts[0]
+        
+        for start, end in zip(starts, ends):
+            gap_mask[start - buf_offset : end - buf_offset] = False
+        
+        self.current_gap_positions = torch.where(gap_mask)[0]
 
         buf_offset = starts[0]
         if self.cache_positions:
@@ -472,6 +484,10 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                         new_positions_full,
                         compute_gpu_buffer_obj.tensor[0],
                     )
+
+                # gap zeroing after RoPE
+                if self.current_gap_positions.numel():
+                    compute_gpu_buffer_obj.tensor[:, self.current_gap_positions] = 0.0
 
                 self.buffer_mapping[layer_id - 1] = compute_gpu_buffer_obj
 

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -415,13 +415,15 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         num_all_tokens = ends[-1] - starts[0]
         slot_mapping_full = slot_mapping[starts[0] : ends[-1]]
 
-        # compute gap positions 
-        gap_mask = torch.ones(num_all_tokens, dtype=torch.bool, device=slot_mapping_full.device)
+        # compute gap positions
+        gap_mask = torch.ones(
+            num_all_tokens, dtype=torch.bool, device=slot_mapping_full.device
+        )
         buf_offset = starts[0]
-        
-        for start, end in zip(starts, ends):
+
+        for start, end in zip(starts, ends, strict=False):
             gap_mask[start - buf_offset : end - buf_offset] = False
-        
+
         self.current_gap_positions = torch.where(gap_mask)[0]
 
         buf_offset = starts[0]


### PR DESCRIPTION
https://github.com/LMCache/LMCache/issues/1064 @amyluo1106 identifies that the separator tokens are prone to corruption because they are not written to when using buffers from the gpu memory allocator. 

a naive solution would be to always zero out the load and compute buffers (and `.zero_` in torch should be pretty optimized so maybe that might be the way to go?)

this is a proposal to find the gaps and zero them out. it uses a single write operation as well but has some overhead to compute the gaps. On tests with the `blend.py` example, this solution sometimes is 1ms better than the full zero (0.16ms vs 0.15ms). 