### PR TITLE
[bugfix] fix AttributeError in LMCacheConnectorMetadata

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Standard
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional, Union
 import os
 
@@ -320,11 +320,8 @@ class ReqMeta:
 
 @dataclass
 class LMCacheConnectorMetadata(KVConnectorMetadata):
-    requests: list[ReqMeta]
-    lookup_requests_in_step: list[str]
-
-    def __init__(self):
-        self.requests = []
+    requests: list[ReqMeta] = field(default_factory=list)
+    lookup_requests_in_step: list[str] = field(default_factory=list)
 
     def add_request(self, req_meta: ReqMeta) -> None:
         """Add a request to the metadata.


### PR DESCRIPTION
When i use the latest `LMCache`, the following error happens:
```
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=2401)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/lmcache/integration/vllm/vllm_v1_adapter.py", line 555, in start_load_kv^M
^[[1;36m(VllmWorker rank=5 engine_index=0 pid=2452)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]     self.lmcache_engine.lookup_unpin(metadata.lookup_requests_in_step)^M
^[[1;36m(VllmWorker rank=4 engine_index=0 pid=2435)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]     self.lmcache_engine.lookup_unpin(metadata.lookup_requests_in_step)^M
^[[1;36m(VllmWorker rank=1 engine_index=0 pid=2388)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=6 engine_index=0 pid=2469)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^Mlm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 46, in start_load_kv^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=2401)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]     self.lmcache_engine.lookup_unpin(metadata.lookup_requests_in_step)^M
^[[1;36m(VllmWorker rank=5 engine_index=0 pid=2452)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=4 engine_index=0 pid=2435)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=1 engine_index=0 pid=2388)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]   File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__^M
^[[1;36m(VllmWorker rank=6 engine_index=0 pid=2469)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146] AttributeError: 'LMCacheConnectorMetadata' object has no attribute 'lookup_requests_in_step'^M
^[[1;36m(VllmWorker rank=7 engine_index=0 pid=2486)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]     self._lmcache_engine.start_load_kv(forward_context, **kwargs)^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=2401)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^M
^[[1;36m(VllmWorker rank=5 engine_index=0 pid=2452)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146] AttributeError: 'LMCacheConnectorMetadata' object has no attribute 'lookup_requests_in_step'^M
^[[1;36m(VllmWorker rank=4 engine_index=0 pid=2435)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146] AttributeError: 'LMCacheConnectorMetadata' object ^[[1;36m(VllmWorker rank=4 engine_index=0 pid=2435)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146] AttributeError: 'LMCacheConnectorMetadata' object has no attribute 'lookup_requests_in_step'^M
^[[1;36m(VllmWorker rank=1 engine_index=0 pid=2388)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]     return next(self.gen)^M
^[[1;36m(VllmWorker rank=6 engine_index=0 pid=2469)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]
^[[1;36m(VllmWorker rank=7 engine_index=0 pid=2486)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146]   File "/usr/local/lib/python3.12/dist-packages/lmcache/integration/vllm/vllm_v1_adapter.py", line 555, in start_load_kv^M
^[[1;36m(VllmWorker rank=2 engine_index=0 pid=2401)^[[0;0m ERROR 07-22 11:46:01 [logger.py:146] AttributeError: 'LMCacheConnectorMetadata' object has no attribute 'lookup_requests_in_step'^M
```

With this PR, my test can run successfully.