### PR TITLE
[VLLM|CacheEngine]support only save on rank 0 for DS MLA

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -33,6 +33,13 @@ class LMCacheEngineMetadata:
     kv_shape: tuple[int, int, int, int, int]
     """ whether use MLA"""
     use_mla: bool = False
+    """ the first rank of the distributed setting """
+    # TODO(baoloongmao): first_rank should be configurable
+    first_rank = 0
+
+    def is_first_rank(self) -> bool:
+        """Check if the current worker is the first rank"""
+        return self.worker_id == self.first_rank
 
 
 @dataclass

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -20,6 +20,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
+    get_tp_group,
 )
 from vllm.sampling_params import SamplingParams
 from vllm.utils import cdiv, get_kv_cache_torch_dtype
@@ -500,8 +501,14 @@ def init_lmcache_engine(
             device=device,
             use_mla=use_mla,
         )
+    tpg = get_tp_group()
     engine = LMCacheEngineBuilder.get_or_create(
-        ENGINE_NAME, config, metadata, vllm_gpu_connector
+        ENGINE_NAME,
+        config,
+        metadata,
+        vllm_gpu_connector,
+        tpg.broadcast,
+        tpg.broadcast_object,
     )
 
     return engine


### PR DESCRIPTION
# Highlight

This feature is credit to @xshwu-ai, I help to do a refactor and submit this PR.

Please add the following great co-author of the following before merge.
- xshwu <xshwu@tencent.com>
- Yihua Cheng <yihua98@uchicago.edu

# Motivation

This is an enhance compare to #803 , it not only work for remote connector but also work to any other backend.

For deepseek MLA, this improvement can reduce transfer data from backend, instead, it transfer data between worker0 to workerN. 

# Description

This make the retrieve function broadcast data from the first rank to other ranks in distributed setups when "save_only_first_rank" is set, ensuring only one rank does the heavy lifting and others stay in sync via efficient communication. This design helps reduce storage and IO redundancy across multiple processes.

We added a "save_only_first_rank" mode to the LMCacheEngine, which changes how the retrieve function works in distributed environments:

- Conditional Retrieval and Broadcasting

When "save_only_first_rank" is enabled, only the first rank performs the actual retrieval and broadcasts the relevant metadata and tensors to other ranks.
Other ranks receive the starts/ends, metadata, and tensors via the broadcast functions instead of retrieving from storage themselves.

- Broadcast Logic

On the first rank:
After collecting the needed segments, it broadcasts the starts/ends list and then, for each segment, broadcasts metadata and tensor data to other ranks.
There are safety checks for list length consistency and warnings if mismatches occur.
On non-first ranks:
They receive the starts/ends, then in a loop, receive metadata and tensor data for each segment, reconstructing the memory objects accordingly.

- Removal and Prefetch Consistency

Removal of data after retrieval and prefetching now only happen on the first rank when "save_only_first_rank" is enabled, preventing redundant operations on other ranks since other rank have no data at all.

# How to test

- lmcache.yaml
```yaml
chunk_size: 256
local_cpu: False
max_local_cpu_size: 5
remote_serde: "naive"
pipelined_backend: False
remote_url: "fs://host:0/disc/data1/baoloongmao/fs_data/"
save_unfull_chunk: False
extra_config:
  save_only_first_rank: True
  first_rank_max_local_cpu_size: 50
```

It can be found from `top` that the used memory for the two worker process is different, this is expected.

<img width="1684" height="104" alt="image" src="https://github.com/user-attachments/assets/7bb1570c-1bdf-43fa-9e23-288ea158d99d" />

- Start vllm
```bash
export PROMETHEUS_MULTIPROC_DIR="/tmp/lmcache_prometheus" 
CUDA_VISIBLE_DEVICES=6,7 \
LMCACHE_USE_EXPERIMENTAL=True LMCACHE_TRACK_USAGE=false \
VLLM_MLA_DISABLE=0 VLLM_USE_V1=1 LMCACHE_CONFIG_FILE=./lmcache.yaml \
vllm serve /disc/data1/deepseek/DeepSeek-V2-Lite-Chat/ \
           --trust-remote-code \
           --served-model-name vllm_cpu_offload \
           --max-model-len 32768 \
           --no-enable-prefix-caching \
           --max-seq-len-to-capture 10000 \
           --max-num-seqs 64 \
           --gpu-memory-utilization 0.9 \
           --host 0.0.0.0 \
           -tp 2 \
           --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_parallel_size":2}'
```

- test 
Run the following command twice, one for trigger store, the other for trigger load.
```
curl http://localhost:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
    "model": "vllm_cpu_offload",
    "messages": [{"role": "user", "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"}],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95
}'
{"id":"chatcmpl-f3a4870c42254680918a8c3844df230b","object":"chat.completion","created":1753340706,"model":"vllm_cpu_offload","choices":[{"index":0,"message":{"role":"assistant","content":" Hello! As an AI, I don't","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":null},"logprobs":null,"finish_reason":"length","stop_reason":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":307,"total_tokens":317,"completion_tokens":10,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}
```

- check chunk file
There is only 1 file belong to tp 0, without any chunk file belong to other tp, that is expected.
```
[root@TENCENT64 cpu]# ll -h  ../fs_data/
total 7.6M-rw-r--r-- 1 root root 7.6M Jul 24 15:05 vllm@-disc-data1-deepseek-DeepSeek-V2-Lite-Chat-@2@0@6888939885391290423.data
```

- check from metrics
```
[root@TENCENT64 cpu]# curl -s http://localhost:8000/metrics/ |grep -v \# | grep lmcache | grep num_remote_read_bytes_total
lmcache:num_remote_read_bytes_total{model_name="/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/",worker_id="1"} 0.0
lmcache:num_remote_read_bytes_total{model_name="/disc/data1/deepseek/DeepSeek-V2-Lite-Chat/",worker_id="0"} 7.962624e+06
```
