### PR TITLE
[CD]: nightly build patch

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
         with:
-            disable-sudo-and-containers: true
+            disable-sudo-and-containers: false
             egress-policy: block
             allowed-endpoints: >
               github.com:443


### PR DESCRIPTION
harden builder should not block sudo or else setup docker buildx will fail