### PR TITLE
Fix: Docker Container Running with Dangerous Root User Privileges in docker/Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,10 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && . /opt/venv/bin/activate \
     && python3 --version
 
+# Create non-root user
+RUN groupadd -g 1000 lmcache && \
+    useradd -u 1000 -g lmcache -s /bin/bash -m lmcache
+
 WORKDIR /workspace
 
 # Install and setup nixl
@@ -138,4 +142,20 @@ uv pip install vllm[runai,tensorizer] && \
     uv pip install lmcache --verbose
 
 WORKDIR /workspace
+
+# Change ownership of the working directory to the non-root user
+RUN chown -R lmcache:lmcache /workspace || true
+
+# Switch to non-root user
+USER lmcache
+
+
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -r -u 1000 -g appuser appuser && \
+    chown -R appuser:appuser /workspace
+
+# Switch to non-root user
+USER appuser
+
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
- **Rule ID:** dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
- **Severity:** MEDIUM
- **File:** docker/Dockerfile
- **Lines Affected:** 127 - 127

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker/Dockerfile` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.