### PR TITLE
[CI]: isolate versioning fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch==2.7.0",
+    "torch",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,6 +4,7 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
-torch==2.7.0 # Corresponds to the version used by vLLM main branch
+# don't pin torch version to avoid breaking vllm dockerfile (contains lmcache wheels)
+torch
 wheel
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,6 +15,7 @@ safetensors
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
 sortedcontainers
-torch==2.7.0  # Should correspond to the version used by vLLM main branch
+# don't pin torch version to avoid breaking vllm dockerfile (contains lmcache wheels)
+torch
 transformers >= 4.51.1
 xxhash==3.5.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -5,7 +5,9 @@
 ray >= 2.9
 nvidia-ml-py # for pynvml package
 
-# These must be updated alongside torch to correspond to vLLM versions
-torch == 2.7.0
-torchvision == 0.22.0   # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-xformers == 0.0.30; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.7.0
+# These dependencies also exist in vLLM (so we don't pin the version, even though this may cause some hard-to-debug issues)
+torch
+# Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+torchvision
+# platform_system == 'Linux' and platform_machine == 'x86_64' 
+xformer 

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -10,4 +10,4 @@ torch
 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 torchvision
 # platform_system == 'Linux' and platform_machine == 'x86_64' 
-xformer 
+xformers


### PR DESCRIPTION
FIX https://github.com/LMCache/LMCache/issues/1184

SOLUTION: as long as lmcache does not pin a torch version, when the vllm dockerfile does pip install lmcache, it will reuse vllm's own torch version.

Downside: since torch version is no longer deterministic, it may be harder to debug some issues in the future but prioritization is compatibility with vllm first

TODO (asap): create a new LMCache release after this PR is merged