### PR TITLE
[RemoteBackend] Improve the auditconnector to help insight traffic of remote

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -186,6 +186,8 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": int,
     },
     # Other configurations
+    # (Deprecated) The url of the actual remote lmcache instance for auditing.
+    # Please use extra_config['audit_actual_remote_url'] instead.
     "audit_actual_remote_url": {
         "type": Optional[str],
         "default": None,

--- a/lmcache/v1/storage_backend/connector/audit_connector.py
+++ b/lmcache/v1/storage_backend/connector/audit_connector.py
@@ -8,6 +8,7 @@ import time
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 
@@ -25,14 +26,28 @@ class AuditConnector(RemoteConnector):
     - Optional checksum validation for put/get operations
     """
 
-    def __init__(self, real_connector: RemoteConnector, verify_checksum: bool = False):
+    def __init__(
+        self, real_connector: RemoteConnector, lmcache_config: LMCacheEngineConfig
+    ):
         self.real_connector = real_connector
-
-        self.verify_checksum = verify_checksum
+        self.verify_checksum = (
+            lmcache_config.extra_config is not None
+            and "audit_verify_checksum" in lmcache_config.extra_config
+            and lmcache_config.extra_config["audit_verify_checksum"]
+        )
+        self.calc_checksum = (
+            lmcache_config.extra_config is not None
+            and "audit_calc_checksum" in lmcache_config.extra_config
+            and lmcache_config.extra_config["audit_calc_checksum"]
+        )
         self.checksum_registry: Dict[CacheEngineKey, str] = {}
-        self.registry_lock = Lock() if verify_checksum else None
+        self.registry_lock = Lock() if self.verify_checksum else None
         self.logger = logger.getChild("audit")
-        logger.info(f"[REMOTE_AUDIT]INITIALIZED|Verify Checksum: {verify_checksum}")
+        logger.info(
+            f"[REMOTE_AUDIT][{self.real_connector}]:INITIALIZED|"
+            f"Calc Checksum:{self.calc_checksum}｜"
+            f"Verify Checksum: {self.verify_checksum}"
+        )
 
     def _calculate_checksum(self, data: bytes) -> str:
         """Calculate SHA-256 checksum for data validation"""
@@ -41,10 +56,10 @@ class AuditConnector(RemoteConnector):
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """Store data with optional checksum tracking"""
         data = memory_obj.byte_array
-        checksum = self._calculate_checksum(data)
+        checksum = self._calculate_checksum(data) if self.calc_checksum else "N/A"
         data_size = len(data)
         self.logger.debug(
-            f"[REMOTE_AUDIT]:PUT|START|Size:{data_size}|"
+            f"[REMOTE_AUDIT][{self.real_connector}]:PUT|START|Size:{data_size}|"
             f"Checksum:{checksum[:8]}|Saved:{len(self.checksum_registry)}|Key:{key}"
         )
 
@@ -57,21 +72,23 @@ class AuditConnector(RemoteConnector):
                 with self.registry_lock:
                     self.checksum_registry[key] = checksum
             self.logger.info(
-                f"[REMOTE_AUDIT]PUT|SUCCESS|Size:{data_size}|"
+                f"[REMOTE_AUDIT][{self.real_connector}]:PUT|SUCCESS|Size:{data_size}|"
                 f"Checksum:{checksum[:8]}|Cost:{cost:.6f}ms|Saved:"
                 f"{len(self.checksum_registry)}|Key:{key}"
             )
 
         except Exception as e:
             self.logger.error(
-                f"[REMOTE_AUDIT]PUT|FAILED|Size:{data_size}|Key:{key}|Error: {str(e)}"
+                f"[REMOTE_AUDIT][{self.real_connector}]:PUT|FAILED|Size:{data_size}|"
+                f"Key:{key}|Error: {str(e)}"
             )
             raise
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Retrieve data with optional integrity check"""
         self.logger.debug(
-            f"[REMOTE_AUDIT]GET|START|Saved:{len(self.checksum_registry)}|Key:{key}"
+            f"[REMOTE_AUDIT][{self.real_connector}]:GET|START|"
+            f"Saved:{len(self.checksum_registry)}|Key:{key}"
         )
 
         try:
@@ -80,13 +97,15 @@ class AuditConnector(RemoteConnector):
             t2 = time.perf_counter()
             if result is None:
                 self.logger.info(
-                    f"[REMOTE_AUDIT]GET|MISS|Key:{key}|"
+                    f"[REMOTE_AUDIT][{self.real_connector}]:GET|MISS|Key:{key}|"
                     f"Saved: {len(self.checksum_registry)}"
                 )
                 return None
 
             current_data = result.byte_array
-            current_checksum = self._calculate_checksum(current_data)
+            current_checksum = (
+                self._calculate_checksum(current_data) if self.calc_checksum else "N/A"
+            )
             data_size = len(current_data)
 
             if self.registry_lock:
@@ -95,7 +114,8 @@ class AuditConnector(RemoteConnector):
 
                 if expected_checksum and current_checksum != expected_checksum:
                     self.logger.error(
-                        f"[REMOTE_AUDIT]GET|MISMATCH|Size:{data_size}|"
+                        f"[REMOTE_AUDIT][{self.real_connector}]:"
+                        f"GET|MISMATCH|Size:{data_size}|"
                         f"Expected:<{expected_checksum[:8]}>|"
                         f"Actual:<{current_checksum[:8]}>|Key:{key}"
                     )
@@ -103,32 +123,70 @@ class AuditConnector(RemoteConnector):
 
             cost = (t2 - t1) * 1000
             self.logger.info(
-                f"[REMOTE_AUDIT]GET|SUCCESS|"
+                f"[REMOTE_AUDIT][{self.real_connector}]:GET|SUCCESS|"
                 f"Checksum:{current_checksum[:8]}|"
                 f"Cost:{cost:.6f}ms|Saved:{len(self.checksum_registry)}|Key:{key}"
             )
             return result
 
         except Exception as e:
-            self.logger.error(f"[REMOTE_AUDIT]GET|FAILED|Key:{key}|Error: {str(e)}")
+            self.logger.error(
+                f"[REMOTE_AUDIT][{self.real_connector}]:GET|"
+                f"FAILED|Key:{key}|Error: {str(e)}"
+            )
             raise
 
     async def exists(self, key: CacheEngineKey) -> bool:
         """Check key existence with audit log"""
-        self.logger.debug(f"[REMOTE_AUDIT]EXISTS|START|Key:{key}")
+        self.logger.debug(
+            f"[REMOTE_AUDIT][{self.real_connector}]:EXISTS|START|Key:{key}"
+        )
+        t1 = time.perf_counter()
         result = await self.real_connector.exists(key)
-        self.logger.info(f"[REMOTE_AUDIT]EXISTS|{result}|Key: {key}")
+        t2 = time.perf_counter()
+        cost = (t2 - t1) * 1000
+        self.logger.info(
+            f"[REMOTE_AUDIT][{self.real_connector}]:EXISTS|{result}|"
+            f"Cost:{cost:.6f}ms|"
+            f"Key:{key}"
+        )
         return result
 
     async def list(self) -> List[str]:
         """List keys with audit log"""
-        self.logger.debug("[REMOTE_AUDIT]LIST|START")
+        self.logger.debug("[REMOTE_AUDIT][{self.real_connector}]:LIST|START")
+        t1 = time.perf_counter()
         result = await self.real_connector.list()
-        self.logger.info(f"[REMOTE_AUDIT]LIST|SUCCESS|Size:{len(result)}")
+        t2 = time.perf_counter()
+        cost = (t2 - t1) * 1000
+        self.logger.info(
+            f"[REMOTE_AUDIT][{self.real_connector}]:LIST|SUCCESS|"
+            f"Count:{len(result)}|Cost:{cost:.6f}ms"
+        )
         return result
 
     async def close(self):
         """Cleanup resources with audit log"""
-        self.logger.debug("[REMOTE_AUDIT]CLOSE|START")
+        self.logger.debug(f"[REMOTE_AUDIT][{self.real_connector}]:CLOSE|START")
         await self.real_connector.close()
-        self.logger.info("[REMOTE_AUDIT]CLOSE|SUCCESS")
+        self.logger.info(f"[REMOTE_AUDIT][{self.real_connector}]:CLOSE|SUCCESS")
+
+    def support_ping(self) -> bool:
+        self.logger.debug(f"[REMOTE_AUDIT][{self.real_connector}]:SUPPORT_PING|START")
+        support = self.real_connector.support_ping()
+        self.logger.info(
+            f"[REMOTE_AUDIT][{self.real_connector}]:SUPPORT_PING|{support}"
+        )
+        return support
+
+    async def ping(self) -> int:
+        self.logger.debug(f"[REMOTE_AUDIT][{self.real_connector}]:PING|START")
+        t1 = time.perf_counter()
+        error_code = await self.real_connector.ping()
+        t2 = time.perf_counter()
+        cost = (t2 - t1) * 1000
+        self.logger.debug(
+            f"[REMOTE_AUDIT][{self.real_connector}]:PING|{error_code}｜"
+            f"Cost:{cost:.6f}ms"
+        )
+        return error_code


### PR DESCRIPTION
# Main changes
- Fix the audit connector ref_count underflow issue
- Add missed two apis
- Use extra_config instead of params of url(do not remove old code to keep consistency)
- Add audit_verify_checksum extra config to specify whether to calc the checksum
- Add class docs for all extra_config of audit connector

# Test
- lmcache.yaml
```yaml
chunk_size: 64
local_device: "cpu"
remote_url: "audit://host:0/"
remote_serde: "naive"
pipelined_backend: False
local_cpu: False
max_local_cpu_size: 2
extra_config:
  audit_actual_remote_url: "fs://host:0/disc/data1/baoloongmao/fs_data_20250731/"
```

- vllm.log
```
(VllmWorker rank=0 engine_index=0 pid=70521) [2025-08-03 13:17:40,754] LMCache INFO: [REMOTE_AUDIT][<FSConnector>]:EXISTS|True|Cost:0.567039ms|Key:CacheEngineKey(fmt='vllm', model_name='/disc/data1/quantification_model/DeepSeek-R1-Int4_Fp8_MoE_Int8_Linear_global_step0/', world_size=8, worker_id=0, chunk_hash=-1441814254093697323) (audit_connector.py:148:lmcache.v1.storage_backend.connector.audit_connector.audit)
```