### PR TITLE
[WIP] 1P1D mem leak fix

### DIFF
--- a/examples/disagg_prefill/1p1d_experimental/configs/lmcache-decoder-config.yaml
+++ b/examples/disagg_prefill/1p1d_experimental/configs/lmcache-decoder-config.yaml
@@ -1,5 +1,6 @@
-local_cpu: False
-max_local_cpu_size: 0
+local_cpu: True
+max_local_cpu_size: 10
+max_local_disk_size: 0
 
 enable_nixl: True
 enable_xpyd: True

--- a/examples/disagg_prefill/1p1d_experimental/configs/lmcache-prefiller-config.yaml
+++ b/examples/disagg_prefill/1p1d_experimental/configs/lmcache-prefiller-config.yaml
@@ -1,5 +1,5 @@
 local_cpu: True
-max_local_cpu_size: 5
+max_local_cpu_size: 10
 max_local_disk_size: 0
 
 enable_nixl: True

--- a/examples/disagg_prefill/1p1d_experimental/disagg_proxy_server.py
+++ b/examples/disagg_prefill/1p1d_experimental/disagg_proxy_server.py
@@ -160,6 +160,7 @@ run_proxy = True  # Shutdown flag
 
 
 async def zmq_pull_server():
+    global counter
     socket = zmq_ctx.socket(zmq.PULL)
     proxy_url = f"{global_args.proxy_host}:{global_args.proxy_port}"
     socket.bind(f"tcp://{proxy_url}")
@@ -171,7 +172,7 @@ async def zmq_pull_server():
             msg = msgspec.msgpack.decode(msg_bytes, type=NixlMsg)
             req_id = msg.req_id
             app.state.finished_reqs.add(req_id)
-            logger.debug(f"Prefill of req {req_id} done.")
+            logger.info(f"Prefill of req {req_id} done. Global counter is {counter}")
         except zmq.Again:
             await asyncio.sleep(0.01)  # Avoid busy loop
         except Exception as e:
@@ -221,9 +222,14 @@ async def wait_decode_kv_ready(req_id: str):
     app.state.finished_reqs.remove(req_id)
 
 
+num_requests = 0
+
+
 @app.post("/v1/completions")
 async def handle_completions(request: Request):
-    global counter, stats_calculator
+    global counter, stats_calculator, num_requests
+    num_requests += 1
+    logger.info(f"DEBUG: the {num_requests}'th request is received")
     counter += 1
     req_id = str(counter)  # we use counter as req_id
 
@@ -264,6 +270,9 @@ async def handle_completions(request: Request):
         prefill_client = round_robin_pick_client(app.state.prefill_clients, counter)
         prefill_output = await send_request_to_service(
             prefill_client.client, "/v1/completions", req_data
+        )
+        logger.info(
+            f"DEBUG: the {num_requests}'th request is sent to the prefill service and the response is received"
         )
 
         prefill_output = prefill_output.json()

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -181,6 +181,7 @@ class ReqMeta:
     slot_mapping: torch.Tensor
 
     # Whether is last prefill or not
+    is_first_prefill: bool = True
     is_last_prefill: bool = False
 
     # Skip save or not
@@ -684,23 +685,22 @@ class LMCacheConnectorV1Impl:
             # TODO: have a pre-allocated buffer to hold the slot_mappings
             slot_mapping = slot_mapping.cuda()
 
-            if self.kv_role == "kv_producer":
-                skip_leading_tokens = 0
-            else:
-                skip_leading_tokens = max(
-                    self.lmcache_engine.lookup(token_ids),
-                    save_spec.skip_leading_tokens,
-                )
-                skip_leading_tokens = save_spec.skip_leading_tokens
+            skip_leading_tokens = max(
+                self.lmcache_engine.lookup(token_ids),
+                save_spec.skip_leading_tokens,
+            )
+            skip_leading_tokens = save_spec.skip_leading_tokens
 
-                if skip_leading_tokens == len(token_ids):
-                    continue  # skip this request
-                # Align to lmcache chunk size
-                skip_leading_tokens = (
-                    skip_leading_tokens
-                    // self._lmcache_chunk_size
-                    * self._lmcache_chunk_size
-                )
+            if skip_leading_tokens == len(token_ids) and not (
+                self.kv_role == "kv_producer" and request.is_first_prefill
+            ):
+                continue  # skip this request
+            # Align to lmcache chunk size
+            skip_leading_tokens = (
+                skip_leading_tokens
+                // self._lmcache_chunk_size
+                * self._lmcache_chunk_size
+            )
 
             store_mask = torch.ones_like(token_ids, dtype=torch.bool)
             store_mask[:skip_leading_tokens] = False
@@ -726,6 +726,10 @@ class LMCacheConnectorV1Impl:
                 token_ids = token_ids[:aligned_token_len]
                 store_mask = store_mask[:aligned_token_len]
                 slot_mapping = slot_mapping[:aligned_token_len]
+
+            if self.kv_role == "kv_producer" and request.is_first_prefill:
+                skip_leading_tokens = 0
+                request.is_first_prefill = False
 
             self.lmcache_engine.store(
                 token_ids,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -338,7 +338,6 @@ class LMCacheConnectorV1Impl:
                 vllm_config, config
             )
             self._unfinished_requests: dict[str, Request] = {}
-            self._lookup_requests_in_step: list[str] = []
         else:
             self.lmcache_engine = init_lmcache_engine(
                 vllm_config.model_config,
@@ -368,6 +367,9 @@ class LMCacheConnectorV1Impl:
                 vllm_config,
                 get_tensor_model_parallel_rank(),
             )
+
+        # used by both scheduler and worker
+        self._lookup_requests_in_step: list[str] = []
 
         self.kv_caches: dict[str, torch.Tensor] = {}
 
@@ -519,8 +521,7 @@ class LMCacheConnectorV1Impl:
                         num_retrieved_tokens,
                         num_expected_tokens,
                     )
-
-        self.lmcache_engine.lookup_unpin(metadata.lookup_requests_in_step)
+        self._lookup_requests_in_step = metadata.lookup_requests_in_step
 
     @_lmcache_nvtx_annotate
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -650,6 +651,14 @@ class LMCacheConnectorV1Impl:
     @_lmcache_nvtx_annotate
     def wait_for_save(self):
         """Blocking until the KV cache is saved to the connector buffer."""
+
+        # `vllm/v1/worker/gpu_model_runner.py`
+        # `def execute_model()` always invokes wait_for_save()
+        # so we avoid mem leaks and calling `lookup_unpin()`
+        # here guarantees layerwise retrieval finishes first
+        logger.info("\n\n\nDEBUG: wait_for_save() calling lookup_unpin()")
+        self.lmcache_engine.lookup_unpin(self._lookup_requests_in_step)
+
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
             return

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 import asyncio
 
 # Third Party
@@ -35,6 +35,7 @@ def CreateStorageBackends(
     dst_device: str = "cuda",
     lmcache_worker: Optional["LMCacheWorker"] = None,
     lookup_server: Optional[LookupServerInterface] = None,
+    storage_manager: Any = None,  # noqa: E501
 ) -> OrderedDict[str, StorageBackendInterface]:
     # Replace 'cuda' with 'cuda:<device id>'
     if dst_device == "cuda":
@@ -48,7 +49,7 @@ def CreateStorageBackends(
             from lmcache.v1.storage_backend.nixl_backend_v3 import NixlBackend
 
             storage_backends["NixlBackend"] = NixlBackend.CreateNixlBackend(
-                config, metadata, memory_allocator
+                config, metadata, memory_allocator, storage_manager=storage_manager
             )
         else:
             # First Party

--- a/lmcache/v1/storage_backend/connector/nixl_connector_v3.py
+++ b/lmcache/v1/storage_backend/connector/nixl_connector_v3.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from collections import defaultdict
 from dataclasses import dataclass
 from queue import Queue
 from typing import TYPE_CHECKING, Any, Optional, Union
@@ -53,6 +54,7 @@ class NixlAllocRequest(NixlMsgBase):
     dtype: str
     last_chunk_toks: int
     is_last_prefill: bool
+    req_id: str
 
 
 class NixlAllocResponse(NixlMsgBase):
@@ -140,6 +142,7 @@ class NixlSenderTask:
             dtype=dtype,
             last_chunk_toks=last_chunk_toks,
             is_last_prefill=self.is_last_prefill,
+            req_id=self.req_id,
         )
 
     # TODO (Jiayi): reduce for loop
@@ -551,21 +554,21 @@ class NixlReceiver:
         # from the nixl buffer
         self.storage_manager = storage_manager
 
-        # A list of (cek, mem_obj) tuples that are in the nixl buffer from the previous step
+        # req_id -> (cek, mem_obj) tuples that are in the nixl buffer from the previous step
         # This allows us to continuously offload from the nixl buffer to cpu during chunked prefill
-        self.prev_step_chunks: list[tuple[CacheEngineKey, MemoryObj]] = []
+        self.prev_step_chunks: dict[str, list[tuple[CacheEngineKey, MemoryObj]]] = defaultdict(list)
         self.offload_stream = torch.cuda.Stream()
 
     def _allocate_and_put(self, alloc_request: NixlAllocRequest) -> NixlAllocResponse:
         total_allocs = len(alloc_request.keys)
         fmt = MemoryFormat(alloc_request.fmt)
         dtype = STR_DTYPE_TO_TORCH_DTYPE[alloc_request.dtype]
-        shape = alloc_request.shape
+        original_shape = alloc_request.shape
         is_last_prefill = alloc_request.is_last_prefill
 
         total_size_in_bytes = (
             total_allocs
-            * math.prod(shape)
+            * math.prod(original_shape)
             * torch.empty((), dtype=dtype).element_size()
         )
         logger.info(
@@ -583,7 +586,7 @@ class NixlReceiver:
             cpu_keys = []
             cpu_memory_objs = []
             # TODO(apostaB): Optimize this with batched_allocate
-            for cek, mem_obj in self.prev_step_chunks:
+            for cek, mem_obj in self.prev_step_chunks[alloc_request.req_id]:
                 cpu_memory_object = self.memory_allocator.allocate(
                     mem_obj.meta.shape,
                     mem_obj.meta.dtype,
@@ -606,15 +609,16 @@ class NixlReceiver:
                     continue
                 backend.batched_submit_put_task(cpu_keys, cpu_memory_objs)
 
-        self.prev_step_chunks = []
+        self.prev_step_chunks[alloc_request.req_id] = []
         alloc_indexes = []
         already_send_indexes = []
         for idx, key in enumerate(alloc_request.keys):
             if self._backend.contains(key, pin=True, i=self.i - 1):
-                self.prev_step_chunks.append((key, self._backend.get(key)))
+                self.prev_step_chunks[alloc_request.req_id].append((key, self._backend.get(key)))
                 already_send_indexes.append(idx)
                 continue
-
+            
+            shape = list(original_shape)
             if idx == total_allocs - 1:
                 num_alloc_tokens = alloc_request.last_chunk_toks
                 token_dim = fmt.token_dim()
@@ -639,13 +643,13 @@ class NixlReceiver:
 
             alloc_indexes.append(mem_obj.meta.address)
             cek = CacheEngineKey.from_string(key)
-            self.prev_step_chunks.append((cek, mem_obj))
+            self.prev_step_chunks[alloc_request.req_id].append((cek, mem_obj))
 
             self._backend.put(cek, mem_obj)
 
         if is_last_prefill:
             # the chunks in the nixl buffer will be cleared after prefill is done and decode begins
-            self.prev_step_chunks = []
+            self.prev_step_chunks[alloc_request.req_id] = []
 
         logger.info(
             f"DEBUG: the {self.i}'th time of _allocate_and_put() is done and returning the NixlAllocResponse"

--- a/lmcache/v1/storage_backend/connector/nixl_connector_v3.py
+++ b/lmcache/v1/storage_backend/connector/nixl_connector_v3.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from queue import Queue
 from typing import TYPE_CHECKING, Any, Optional, Union
 import copy
+import math
 import threading
 import time
 import uuid
@@ -28,6 +29,7 @@ from lmcache.v1.memory_management import (
 )
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.connector.nixl_utils import NixlConfigXpYd, NixlRole
+from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 if TYPE_CHECKING:
     # Third Party
@@ -50,6 +52,7 @@ class NixlAllocRequest(NixlMsgBase):
     shape: list[int]  # The shape of the memory objects
     dtype: str
     last_chunk_toks: int
+    is_last_prefill: bool
 
 
 class NixlAllocResponse(NixlMsgBase):
@@ -105,6 +108,7 @@ class NixlReceiverInfo:
 class NixlSenderTask:
     req_id: str
     receiver_info: NixlReceiverInfo
+    is_last_prefill: bool
     keys: list[CacheEngineKey]  # The keys to send
     mem_objs: list[MemoryObj]  # The memory objects to send
 
@@ -135,6 +139,7 @@ class NixlSenderTask:
             shape=list(shape),
             dtype=dtype,
             last_chunk_toks=last_chunk_toks,
+            is_last_prefill=self.is_last_prefill,
         )
 
     # TODO (Jiayi): reduce for loop
@@ -230,8 +235,11 @@ class NixlSender:
             receiver_info.receiver_init_port
         )
 
+        is_last_prefill = transfer_spec.is_last_prefill
+
         sender_task = NixlSenderTask(
             req_id=transfer_spec.req_id,
+            is_last_prefill=is_last_prefill,
             receiver_info=receiver_info,
             keys=keys,
             mem_objs=mem_objs,
@@ -475,10 +483,12 @@ class NixlReceiver:
         config: LMCacheEngineConfig,
         backend: StorageBackendInterface,
         tp_rank: int,
+        storage_manager: Optional["StorageManager"] = None,
     ):
         assert nixl_config.role == NixlRole.RECEIVER, (
             "NixlReceiver should only be initialized with NixlRole.RECEIVER"
         )
+        self.i = 1
 
         self._backend = backend
         self.memory_allocator = backend.memory_allocator
@@ -537,17 +547,71 @@ class NixlReceiver:
         self._init_thread.start()
         self._running_threads.append(self._init_thread)
 
+        # The decoder should continuously offload chunked prefill memory objects to cpu
+        # from the nixl buffer
+        self.storage_manager = storage_manager
+
+        # A list of (cek, mem_obj) tuples that are in the nixl buffer from the previous step
+        # This allows us to continuously offload from the nixl buffer to cpu during chunked prefill
+        self.prev_step_chunks: list[tuple[CacheEngineKey, MemoryObj]] = []
+        self.offload_stream = torch.cuda.Stream()
+
     def _allocate_and_put(self, alloc_request: NixlAllocRequest) -> NixlAllocResponse:
         total_allocs = len(alloc_request.keys)
         fmt = MemoryFormat(alloc_request.fmt)
         dtype = STR_DTYPE_TO_TORCH_DTYPE[alloc_request.dtype]
         shape = alloc_request.shape
+        is_last_prefill = alloc_request.is_last_prefill
 
+        total_size_in_bytes = (
+            total_allocs
+            * math.prod(shape)
+            * torch.empty((), dtype=dtype).element_size()
+        )
+        logger.info(
+            f"DEBUG: _allocate_and_put() called for the {self.i}'th time on len(alloc_request.keys) = {total_allocs} with total_size_in_bytes = {total_size_in_bytes}"
+        )
+        self.memory_allocator.nixl_allocator.memcheck()
+        self.i += 1
+        if total_size_in_bytes > self.memory_allocator.nixl_allocator.buffer_size:
+            raise RuntimeError(
+                f"Not enough memory in Nixl Buffer to allocate {total_size_in_bytes} bytes in a single step for the decoder"
+            )
+
+        # offload all the nixl buffer memory objects to cpu from the previous step
+        if hasattr(self.memory_allocator, "cpu_allocator"):
+            cpu_keys = []
+            cpu_memory_objs = []
+            # TODO(apostaB): Optimize this with batched_allocate
+            for cek, mem_obj in self.prev_step_chunks:
+                cpu_memory_object = self.memory_allocator.allocate(
+                    mem_obj.meta.shape,
+                    mem_obj.meta.dtype,
+                    mem_obj.meta.fmt,
+                    allocator_type="cpu",
+                )
+                with torch.cuda.stream(self.offload_stream):
+                    cpu_memory_object.tensor.copy_(mem_obj.tensor, non_blocking=True)
+                    cpu_keys.append(cek)
+                    cpu_memory_objs.append(cpu_memory_object)
+                    # TODO(apostaB): need to pin the cpu memory object and unpin it when the prefill is done
+                    mem_obj.ref_count_down()
+                    if self._backend.contains(cek):
+                        mem_obj.unpin()
+
+            self.offload_stream.synchronize()
+
+            for backend_name, backend in self.storage_manager.storage_backends.items():
+                if backend_name == "NixlBackend":
+                    continue
+                backend.batched_submit_put_task(cpu_keys, cpu_memory_objs)
+
+        self.prev_step_chunks = []
         alloc_indexes = []
         already_send_indexes = []
-
         for idx, key in enumerate(alloc_request.keys):
-            if self._backend.contains(key, pin=True):
+            if self._backend.contains(key, pin=True, i=self.i - 1):
+                self.prev_step_chunks.append((key, self._backend.get(key)))
                 already_send_indexes.append(idx)
                 continue
 
@@ -565,16 +629,27 @@ class NixlReceiver:
             decay = 1.1
             while mem_obj is None:
                 logger.warning(
-                    "Failed to allocate memory object, retrying...",
+                    f"Failed to allocate memory object of size {math.prod(shape) * torch.empty((), dtype=dtype).element_size()} bytes, retrying...",
                 )
                 time.sleep(wait_time)
                 wait_time /= decay
                 mem_obj = self._backend.allocate(torch.Size(shape), dtype, fmt)
+                self.memory_allocator.nixl_allocator.memcheck()
+                time.sleep(1)
 
             alloc_indexes.append(mem_obj.meta.address)
+            cek = CacheEngineKey.from_string(key)
+            self.prev_step_chunks.append((cek, mem_obj))
 
-            self._backend.put(CacheEngineKey.from_string(key), mem_obj)
+            self._backend.put(cek, mem_obj)
 
+        if is_last_prefill:
+            # the chunks in the nixl buffer will be cleared after prefill is done and decode begins
+            self.prev_step_chunks = []
+
+        logger.info(
+            f"DEBUG: the {self.i}'th time of _allocate_and_put() is done and returning the NixlAllocResponse"
+        )
         return NixlAllocResponse(
             already_sent_indexes=already_send_indexes, remote_indexes=alloc_indexes
         )
@@ -696,6 +771,7 @@ class NixlChannel:
         nixl_config: NixlConfigXpYd,
         config: LMCacheEngineConfig,
         backend: StorageBackendInterface,
+        storage_manager: Optional["StorageManager"] = None,
     ):
         self.nixl_config = nixl_config
         self.role = nixl_config.role
@@ -716,7 +792,9 @@ class NixlChannel:
         if nixl_config.role == NixlRole.SENDER:
             self._sender = NixlSender(nixl_config, config, backend, tp_rank)
         else:
-            self._receiver = NixlReceiver(nixl_config, config, backend, tp_rank)
+            self._receiver = NixlReceiver(
+                nixl_config, config, backend, tp_rank, storage_manager
+            )
 
     def _check_sender(self):
         """Check if this channel is configured as a sender."""

--- a/lmcache/v1/storage_backend/nixl_backend_v3.py
+++ b/lmcache/v1/storage_backend/nixl_backend_v3.py
@@ -3,6 +3,7 @@
 from concurrent.futures import Future
 from typing import List, Optional
 import threading
+import time
 
 # Third Party
 import torch
@@ -22,6 +23,7 @@ from lmcache.v1.storage_backend.connector.nixl_connector_v3 import (
     NixlChannel,
 )
 from lmcache.v1.storage_backend.connector.nixl_utils import NixlConfigXpYd, NixlRole
+from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 logger = init_logger(__name__)
 
@@ -42,6 +44,7 @@ class NixlBackend(StorageBackendInterface):
         nixl_config: NixlConfigXpYd,
         config: LMCacheEngineConfig,
         memory_allocator: MemoryAllocatorInterface,
+        storage_manager: Optional["StorageManager"] = None,
     ):
         """
         Initialize the Nixl storage backend.
@@ -62,12 +65,18 @@ class NixlBackend(StorageBackendInterface):
             NixlRole.RECEIVER,
         ], "Nixl role must be either SENDER or RECEIVER."
 
+        self.storage_manager = storage_manager
         self.memory_allocator = memory_allocator
 
-        self._nixl_channel = NixlChannel(nixl_config, config, self)
+        # since contains and put is not called from the cache engine,
+        # we need to separately handle pin and unpin logic
+        self.lookup_pins: list[CacheEngineKey] = []
 
-    # TODO(Jiayi): handle `pin` smantics
-    def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
+        self._nixl_channel = NixlChannel(nixl_config, config, self, storage_manager)
+
+    def contains(
+        self, key: CacheEngineKey, pin: bool = False, i: Optional[int] = None
+    ) -> bool:
         """
         Check whether key is in the storage backend.
 
@@ -76,10 +85,19 @@ class NixlBackend(StorageBackendInterface):
 
         :return: True if the key exists, False otherwise
         """
+        logger.info(
+            f"DEBUG: nixl_backend.contains() called during the {i}'th time of _allocate_and_put()"
+        )
         with self._data_lock:
             if mem_obj := self._data.get(key, None):
                 if pin:
-                    mem_obj.ref_count_up()
+                    logger.info("DEBUG: nixl_backend.contains() calling mem_obj.pin()")
+                    if i:
+                        logger.info(
+                            f"this call belongs to the {i}'th time of _allocate_and_put()"
+                        )
+                    mem_obj.pin()
+                    self.lookup_pins.append(key)
                 return True
             return False
 
@@ -192,8 +210,10 @@ class NixlBackend(StorageBackendInterface):
         """
         with self._data_lock:
             if mem_obj := self._data.get(key, None):
-                if mem_obj.get_ref_count() == 1:
-                    del self._data[key]
+                del self._data[key]
+                while mem_obj.get_ref_count() > 0:
+                    mem_obj.ref_count_down()
+                    time.sleep(0.1)
                 return True
             return False
 
@@ -209,12 +229,30 @@ class NixlBackend(StorageBackendInterface):
     def unpin(self, key: CacheEngineKey) -> bool:
         return True
 
+    def lookup_unpin(self) -> None:
+        """
+        Control Flow:
+        1. vllm gpu model runner finishes forward execution,
+            including potential retrieval from lmcache so we
+            can safely unpin
+        2. calls `vllm_v1_adapter.py` `wait_for_save()`
+        3. calls `lmcache_engine.lookup_unpin()`
+        4. calls `storage_manager.batched_unpin()`
+        5. calls `nixl_backend.lookup_unpin()`
+        """
+        logger.info("DEBUG: nixl_backend.lookup_unpin() calling unpin()")
+        for key in self.lookup_pins:
+            if key in self._data:
+                self._data[key].unpin()
+        self.lookup_pins = []
+
     # TODO (Jiayi): put this in _init__.py later
     @staticmethod
     def CreateNixlBackend(
         config: LMCacheEngineConfig,
         metadata: LMCacheEngineMetadata,
         memory_allocator: MemoryAllocatorInterface,
+        storage_manager: Optional["StorageManager"] = None,
     ) -> "NixlBackend":
         """
         Create a Nixl backend with the given configuration.
@@ -227,5 +265,5 @@ class NixlBackend(StorageBackendInterface):
         # Create the Nixl config
         nixl_config = NixlConfigXpYd.from_cache_engine_config(config, metadata)
         # Create the Nixl backend
-        backend = NixlBackend(nixl_config, config, memory_allocator)
+        backend = NixlBackend(nixl_config, config, memory_allocator, storage_manager)
         return backend

--- a/lmcache/v1/storage_backend/nixl_backend_v3.py
+++ b/lmcache/v1/storage_backend/nixl_backend_v3.py
@@ -3,7 +3,6 @@
 from concurrent.futures import Future
 from typing import List, Optional
 import threading
-import time
 
 # Third Party
 import torch
@@ -211,9 +210,7 @@ class NixlBackend(StorageBackendInterface):
         with self._data_lock:
             if mem_obj := self._data.get(key, None):
                 del self._data[key]
-                while mem_obj.get_ref_count() > 0:
-                    mem_obj.ref_count_down()
-                    time.sleep(0.1)
+                mem_obj.ref_count_down()
                 return True
             return False
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -65,6 +65,7 @@ class StorageManager:
                 dst_device,
                 lmcache_worker,
                 lookup_server,
+                storage_manager=self,
             )
         )
 
@@ -411,6 +412,10 @@ class StorageManager:
         """
         for backend_name, backend in self.storage_backends.items():
             if locations is None or backend_name in locations:
+                if backend_name == "NixlBackend":
+                    # Nixl backend internally remembers keys per vllm step
+                    # we only call batched_unpin() on nixl in this context
+                    backend.lookup_unpin()
                 for key in keys:
                     backend.unpin(key)
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 buildkite-test-collector
-pytest>=7.0
+pytest>=7.0,<8.2  # avoid some plugins breaking in 8.x
 pytest-benchmark
 pytest-benchmark[histogram]
 pytest-cov
-pytest-html
-
+pytest-html>=3.2,<4.0  # 4.x requires external assets; 3.2 is stable
+jinja2<3.1     


### PR DESCRIPTION
The issue is with chunked prefill, because there is a dependency where the prefiller allocates more and more during the chunked prefill on the decoder's nixl buffer. however, the prefiller does not report back to teh proxy untill the entire prefill is finished. and only then can the proxy feed the request to the decoder. Thus, the issue is that if the decoder's buffer fills before chunked prefill finishes on the prefiller side, nobody can progress anymore since:
1. the prefiller is blocked by the decoder to respond that it allocated on its buffer
2. the decoder is blocked by the proxy not allowing it to free its buffer by sending a request
3. the proxy is blocked by the prefiller not having finished the request at hand and reporting to the proxy


This creates a three-way deadlock between prefiller, decoder, and proxy.


# Proposed Fix:

make decoder use cpu buffer during chunked prefill to offload nixl buffer
