### PR TITLE
[Bugfix] remove duplicate loop code

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -473,10 +473,6 @@ class LMCacheConnectorV1Impl:
 
         self.lmcache_engine.post_init(kvcaches=kvcaches)
 
-        for idx, request in enumerate(metadata.requests):
-            if request.load_spec is None:
-                continue
-
         self.layerwise_retrievers = []
         for idx, request in enumerate(metadata.requests):
             if request.load_spec is None:


### PR DESCRIPTION
In the code, there are two identical loop operations: `for idx, request in enumerate(metadata.requests)`.
It’s possible that the first loop is redundant.

https://github.com/LMCache/LMCache/blob/6ae211ed8c07d02a70ce74f01a7493162ad35ce3/lmcache/integration/vllm/vllm_v1_adapter.py#L476-L486