### PR TITLE
[bugfix]: unpin by unique lookup id instead of request id

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional, Union
 import os
+import random
+import string
 
 # Third Party
 from vllm.config import VllmConfig
@@ -780,14 +782,18 @@ class LMCacheConnectorV1Impl:
                 token_ids, request.mm_hashes, request.mm_positions
             )
 
-        self._lookup_requests_in_step.append(request.request_id)
+        # since the vllm scheduler may look up the same request
+        # multiple times before the worker runs even a single forward pass,
+        # we need to use a unique lookup id for each lookup request
+        lookup_id = "".join(random.choices(string.ascii_letters + string.digits, k=10))
+        self._lookup_requests_in_step.append(lookup_id)
         if self.skip_last_n_tokens > 0:
             num_external_hit_tokens = self.lookup_client.lookup(
-                token_ids[: -self.skip_last_n_tokens], request_id=request.request_id
+                token_ids[: -self.skip_last_n_tokens], lookup_id=lookup_id
             )
         else:
             num_external_hit_tokens = self.lookup_client.lookup(
-                token_ids, request_id=request.request_id
+                token_ids, lookup_id=lookup_id
             )
 
         # When prompt length is divisible by the block size and all

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -135,7 +135,7 @@ class LMCacheEngine:
                 self.fmt = MemoryFormat.KV_T2D
 
         self.lookup_cache = {}
-        # request_id -> [pinned keys]
+        # lookup_id -> [pinned keys]
         self.lookup_pins = defaultdict(list)
 
         InitializeUsageContext(config.to_original_config(), metadata)
@@ -635,7 +635,7 @@ class LMCacheEngine:
         self,
         tokens: Union[torch.Tensor, List[int]],
         search_range: Optional[List[str]] = None,
-        request_id: Optional[str] = None,
+        lookup_id: Optional[str] = None,
         pin: bool = False,
     ) -> int:
         """
@@ -648,7 +648,7 @@ class LMCacheEngine:
         ["LocalCPUBackend", "LocalDiskBackend"] for now.
         If None, search in all backends.
 
-        :param str request_id: The request ID to associate with the lookup
+        :param str lookup_id: The lookup ID to associate with the lookup
 
         :param bool pin: If True, pin the KV cache in the storage.
 
@@ -659,7 +659,7 @@ class LMCacheEngine:
             prev_end = 0
 
             if pin:
-                assert request_id is not None, "request_id is required when pin is True"
+                assert lookup_id is not None, "lookup_id is required when pin is True"
 
             # secondary lookup on p2p (via lookup_server) if enabled
             search_p2p = self.enable_p2p and (
@@ -686,14 +686,14 @@ class LMCacheEngine:
                                 found = True
                     if found:
                         if pin:
-                            self.lookup_pins[request_id].extend(key_all_layers)
+                            self.lookup_pins[lookup_id].extend(key_all_layers)
                         prev_end = end
                         continue
                     return prev_end
                 else:
                     if self.storage_manager.contains(key, search_range, pin):
                         if pin:
-                            self.lookup_pins[request_id].append(key)
+                            self.lookup_pins[lookup_id].append(key)
                         prev_end = end
                         continue
 
@@ -728,7 +728,7 @@ class LMCacheEngine:
         num_tokens = self.lookup(
             tokens,
             search_range=old_position,
-            request_id=event_id,
+            lookup_id=event_id,
             pin=True,
         )
 
@@ -792,7 +792,7 @@ class LMCacheEngine:
         num_tokens = self.lookup(
             tokens,
             search_range=[location],
-            request_id=event_id,
+            lookup_id=event_id,
             pin=True,
         )
 
@@ -823,11 +823,11 @@ class LMCacheEngine:
         return num_tokens
 
     @_lmcache_nvtx_annotate
-    def lookup_unpin(self, request_ids: list[str]) -> None:
-        for request_id in request_ids:
-            if request_id in self.lookup_pins:
-                self.storage_manager.batched_unpin(self.lookup_pins[request_id])
-                del self.lookup_pins[request_id]
+    def lookup_unpin(self, lookup_ids: list[str]) -> None:
+        for lookup_id in lookup_ids:
+            if lookup_id in self.lookup_pins:
+                self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
+                del self.lookup_pins[lookup_id]
 
     @_lmcache_nvtx_annotate
     def clear(

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -15,7 +15,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
     """Abstract interface for lookup clients."""
 
     @abc.abstractmethod
-    def lookup(self, token_ids: torch.Tensor, request_id: Optional[str] = None) -> int:
+    def lookup(self, token_ids: torch.Tensor, lookup_id: Optional[str] = None) -> int:
         """
         Perform lookup for the given token IDs.
 

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -56,7 +56,7 @@ class MooncakeLookupClient(LookupClientInterface):
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
 
-    def lookup(self, token_ids: torch.Tensor, request_id: Optional[str] = None) -> int:
+    def lookup(self, token_ids: torch.Tensor, lookup_id: Optional[str] = None) -> int:
         # process token_ids to cacheengine keys
         keys = []
         ends = []


### PR DESCRIPTION
Tested with on only 5 GB cpu offload size and then:
 send tons of the same long context at once to try to get it to get permanently pinned (memory leak)