### PR TITLE
[Bugfix]: dont pin on second lookup

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -649,14 +649,14 @@ class LMCacheConnectorV1Impl:
     def wait_for_save(self):
         """Blocking until the KV cache is saved to the connector buffer."""
 
-        if self.kv_role == "kv_consumer":
-            # Don't do save if the role is kv_consumer
-            return
-
         connector_metadata = self._parent._get_connector_metadata()
         assert isinstance(connector_metadata, LMCacheConnectorMetadata)
 
         self.lmcache_engine.lookup_unpin(connector_metadata.lookup_requests_in_step)
+
+        if self.kv_role == "kv_consumer":
+            # Don't do save if the role is kv_consumer
+            return
 
         if self.use_layerwise:
             for layerwise_storer in self.layerwise_storers:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -520,8 +520,6 @@ class LMCacheConnectorV1Impl:
                         num_expected_tokens,
                     )
 
-        self.lmcache_engine.lookup_unpin(metadata.lookup_requests_in_step)
-
     @_lmcache_nvtx_annotate
     def wait_for_layer_load(self, layer_name: str) -> None:
         """Blocking until the KV for a specific layer is loaded into vLLM's
@@ -650,17 +648,20 @@ class LMCacheConnectorV1Impl:
     @_lmcache_nvtx_annotate
     def wait_for_save(self):
         """Blocking until the KV cache is saved to the connector buffer."""
+
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
             return
+
+        connector_metadata = self._parent._get_connector_metadata()
+        assert isinstance(connector_metadata, LMCacheConnectorMetadata)
+
+        self.lmcache_engine.lookup_unpin(connector_metadata.lookup_requests_in_step)
 
         if self.use_layerwise:
             for layerwise_storer in self.layerwise_storers:
                 next(layerwise_storer)
             return
-
-        connector_metadata = self._parent._get_connector_metadata()
-        assert isinstance(connector_metadata, LMCacheConnectorMetadata)
 
         assert len(self.kv_caches) > 0
         kvcaches = list(self.kv_caches.values())

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -685,14 +685,14 @@ class LMCacheEngine:
                             if self.lookup_server.lookup(key_single_layer):
                                 found = True
                     if found:
-                        if pin:
+                        if pin and request_id not in self.lookup_pins:
                             self.lookup_pins[request_id].extend(key_all_layers)
                         prev_end = end
                         continue
                     return prev_end
                 else:
                     if self.storage_manager.contains(key, search_range, pin):
-                        if pin:
+                        if pin and request_id not in self.lookup_pins:
                             self.lookup_pins[request_id].append(key)
                         prev_end = end
                         continue


### PR DESCRIPTION
1. avoid memory leak when lookup happens twice in a single vllm schedule step for a single request

2. move unpin to wait_for_save instead of start_load_kv to avoid race conditions with layerwise (some deeper layers getting evicted because cache_engine.retriee() only gets the first layer on first call)

long document qa brief benchmark:
```text
=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 1.213s
Warmup round time: 3.094s
Warmup round prompt count: 24
Query round mean TTFT: 0.957s
Query round time: 3.027s
Query round prompt count: 24
```