### PR TITLE
Fix the config logic of `create_lookup_server_only_on_worker_0`

### DIFF
--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -72,8 +72,8 @@ class LookupClientFactory:
         # Only create the KV lookup API server on worker rank 0
         # when there are multiple workers and when not using external lookup client
         create_lookup_server_only_on_worker_0 = (
-            config.extra_config
-            and config.extra_config.get("create_lookup_server_only_on_worker_0", True)
+            not config.extra_config
+            or config.extra_config.get("create_lookup_server_only_on_worker_0", True)
         )
         if config.external_lookup_client is None and (
             not create_lookup_server_only_on_worker_0

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -71,12 +71,14 @@ class LookupClientFactory:
 
         # Only create the KV lookup API server on worker rank 0
         # when there are multiple workers and when not using external lookup client
-        create_lookup_server_only_on_worker_0 = (
-            not config.extra_config
-            or config.extra_config.get("create_lookup_server_only_on_worker_0", True)
+        create_lookup_server_only_on_worker_0_for_mla = (
+            config.extra_config
+            and config.extra_config.get(
+                "create_lookup_server_only_on_worker_0_for_mla", False
+            )
         )
         if config.external_lookup_client is None and (
-            not create_lookup_server_only_on_worker_0
+            not create_lookup_server_only_on_worker_0_for_mla
             or lmcache_engine.metadata.worker_id == 0
         ):
             # First Party

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -28,7 +28,7 @@ class LMCacheLookupClient(LookupClientInterface):
     ZMQ-based lookup client that communicates with a lookup server.
 
     Related extra_config:
-    - create_lookup_server_only_on_worker_0:
+    - create_lookup_server_only_on_worker_0_for_mla:
         is a flag to control whether to create lookup server only on worker 0.
     """
 
@@ -39,12 +39,14 @@ class LMCacheLookupClient(LookupClientInterface):
             "lmcache_rpc_port", 0
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
-        self.create_lookup_server_only_on_worker_0 = (
-            not config.extra_config
-            or config.extra_config.get("create_lookup_server_only_on_worker_0", True)
+        self.create_lookup_server_only_on_worker_0_for_mla = (
+            config.extra_config
+            and config.extra_config.get(
+                "create_lookup_server_only_on_worker_0_for_mla", False
+            )
         )
         ranks = self.tensor_parallel_size
-        if self.create_lookup_server_only_on_worker_0:
+        if self.create_lookup_server_only_on_worker_0_for_mla:
             ranks = 1
         for tp_rank in range(ranks):
             socket_path = get_zmq_rpc_path_lmcache(
@@ -64,7 +66,7 @@ class LMCacheLookupClient(LookupClientInterface):
         token_bufs = self.encoder.encode(token_ids)
         request_id_buf = request_id.encode("utf-8")
         ranks = self.tensor_parallel_size
-        if self.create_lookup_server_only_on_worker_0:
+        if self.create_lookup_server_only_on_worker_0_for_mla:
             ranks = 1
         results = []
         for i in range(ranks):

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -40,8 +40,8 @@ class LMCacheLookupClient(LookupClientInterface):
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
         self.create_lookup_server_only_on_worker_0 = (
-            config.extra_config
-            and config.extra_config.get("create_lookup_server_only_on_worker_0", True)
+            not config.extra_config
+            or config.extra_config.get("create_lookup_server_only_on_worker_0", True)
         )
         ranks = self.tensor_parallel_size
         if self.create_lookup_server_only_on_worker_0:


### PR DESCRIPTION
The bug this PR will fix is introduced by #1144

As we intend to set the default value of `create_lookup_server_only_on_worker_0` to `true`, so we need to fix by this PR.