### PR TITLE
[Bugfix] Close file descriptor when using use_odirect feature

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -467,6 +467,7 @@ class LocalDiskBackend(StorageBackendInterface):
         else:
             fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_DIRECT, 0o644)
             os.write(fd, byte_array)
+            os.close(fd)
 
         disk_write_time = time.time() - start_time
         logger.debug(
@@ -512,8 +513,8 @@ class LocalDiskBackend(StorageBackendInterface):
                 f.readinto(buffer)
         else:
             fd = os.open(path, os.O_RDONLY | os.O_DIRECT)
-            fdo = os.fdopen(fd, "rb", buffering=0)
-            fdo.readinto(buffer)
+            with os.fdopen(fd, "rb", buffering=0) as fdo:
+                fdo.readinto(buffer)
         disk_read_time = time.time() - start_time
         logger.debug(
             f"Disk read size: {size} bytes, "
@@ -561,8 +562,8 @@ class LocalDiskBackend(StorageBackendInterface):
                 f.readinto(buffer)
         else:
             fd = os.open(path, os.O_RDONLY | os.O_DIRECT)
-            fdo = os.fdopen(fd, "rb", buffering=0)
-            fdo.readinto(buffer)
+            with os.fdopen(fd, "rb", buffering=0) as fdo:
+                fdo.readinto(buffer)
         disk_read_time = time.time() - start_time
         logger.debug(
             f"Disk read size: {size} bytes, "


### PR DESCRIPTION
Hi, @YaoJiayi!

This PR includes a small patch that ensures a file descriptor is properly closed after use, as requested in https://github.com/LMCache/LMCache/pull/1172#discussion_r2240317529

I've verified that the address alignment issue and file permission problem I mentioned in the link were resolved in your recent PR #1233