### PR TITLE
 perf(mooncakestore connector): optimize get/put with zero-copy operations

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -12,6 +12,7 @@ import os
 import torch
 
 # First Party
+from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
@@ -36,6 +37,7 @@ class MooncakeStoreConfig:
     master_server_address: str
     transfer_timeout: int
     storage_root_dir: str
+    prefer_local_alloc: bool = False
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
@@ -52,6 +54,7 @@ class MooncakeStoreConfig:
             master_server_address=config.get("master_server_address"),
             transfer_timeout=config.get("transfer_timeout", 1),
             storage_root_dir=config.get("storage_root_dir", ""),
+            prefer_local_alloc=config.get("prefer_local_alloc", False),
         )
 
     @staticmethod
@@ -82,6 +85,7 @@ class MooncakeStoreConfig:
             master_server_address=extra_config["master_server_address"],
             transfer_timeout=extra_config.get("transfer_timeout", 1),
             storage_root_dir=extra_config.get("storage_root_dir", ""),
+            prefer_local_alloc=extra_config.get("prefer_local_alloc", False),
         )
 
 
@@ -97,7 +101,7 @@ class MooncakestoreConnector(RemoteConnector):
     ):
         try:
             # Third Party
-            from mooncake.store import MooncakeDistributedStore
+            from mooncake.store import MooncakeDistributedStore, ReplicateConfig
         except ImportError as e:
             raise ImportError(
                 "Please install mooncake by following the instructions at "
@@ -133,6 +137,15 @@ class MooncakestoreConnector(RemoteConnector):
                     "Set MOONCAKE_STORAGE_ROOT_DIR to: %s", self.config.storage_root_dir
                 )
 
+            logger.info("Setting up Mooncake store with parameters:")
+            logger.info(f"  local_hostname: {self.config.local_hostname}")
+            logger.info(f"  metadata_server: {self.config.metadata_server}")
+            logger.info(f"  global_segment_size: {self.config.global_segment_size}")
+            logger.info(f"  local_buffer_size: {self.config.local_buffer_size}")
+            logger.info(f"  protocol: {self.config.protocol}")
+            logger.info(f"  device_name: {self.config.device_name}")
+            logger.info(f"  master_server_address: {self.config.master_server_address}")
+
             self.store.setup(
                 self.config.local_hostname,
                 self.config.metadata_server,
@@ -142,6 +155,7 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.device_name,
                 self.config.master_server_address,
             )
+            logger.info("Mooncake store setup completed successfully")
 
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
@@ -152,6 +166,82 @@ class MooncakestoreConnector(RemoteConnector):
 
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        self.registered_buffer_ptr = None
+
+        # Initialize ReplicateConfig
+        self.replica_config = ReplicateConfig()
+        self.replica_config.replica_num = 1
+
+        # Set preferred_segment based on configuration
+        if self.config.prefer_local_alloc:
+            self.replica_config.preferred_segment = self.store.get_hostname()
+
+        # Register CPU buffer for zero-copy operations
+        self._register_cpu_buffer()
+
+        logger.info("MooncakeConnector initialized successfully.")
+
+    def init_chunk_meta(
+        self,
+        config: Optional[LMCacheEngineConfig],
+        metadata: Optional[LMCacheEngineMetadata],
+    ) -> None:
+        """Initialize chunk metadata and log the configuration."""
+        super().init_chunk_meta(config, metadata)
+
+        # Log metadata information after initialization
+        if self.meta_shape and self.meta_dtype and self.meta_fmt:
+            logger.info(
+                f"MooncakeConnector metadata initialized: "
+                f"Format: {self.meta_fmt}, "
+                f"Shape: {self.meta_shape}, "
+                f"Dtype: {self.meta_dtype}, "
+                f"Save chunk meta: {not self.save_chunk_meta}"
+            )
+        else:
+            logger.warning("MooncakeConnector using legacy mode")
+
+    def _register_cpu_buffer(self):
+        """Register CPU buffer for zero-copy operations."""
+        try:
+            allocator = self.local_cpu_backend.memory_allocator
+            if hasattr(allocator, "pin_allocator") and hasattr(
+                allocator.pin_allocator, "buffer"
+            ):
+                buffer = allocator.pin_allocator.buffer
+                self.registered_buffer_ptr = buffer.data_ptr()
+                result = self.store.register_buffer(buffer.data_ptr(), buffer.numel())
+                if result == 0:
+                    logger.info(
+                        f"Registered: {hex(buffer.data_ptr())}, {buffer.numel()} bytes"
+                    )
+                else:
+                    logger.warning(f"Buffer registration failed: error={result}")
+                    self.registered_buffer_ptr = None
+            else:
+                self.registered_buffer_ptr = None
+        except Exception as e:
+            logger.error(f"Buffer registration error: {e}")
+            self.registered_buffer_ptr = None
+
+    def _unregister_cpu_buffer(self):
+        """Unregister CPU buffer."""
+        if self.registered_buffer_ptr is not None:
+            result = self.store.unregister_buffer(self.registered_buffer_ptr)
+            if result == 0:
+                logger.info(f"Unregistered buffer: {hex(self.registered_buffer_ptr)}")
+            else:
+                logger.warning(f"Buffer unregistration failed: error={result}")
+            self.registered_buffer_ptr = None
+
+    def support_batched_get(self) -> bool:
+        """
+        Check if the connector supports batched get
+
+        Returns:
+            True if batched get is supported, False otherwise
+        """
+        return True
 
     async def exists(self, key: CacheEngineKey) -> bool:
         return self.store.is_exist(key.to_string())
@@ -159,26 +249,149 @@ class MooncakestoreConnector(RemoteConnector):
     def exists_sync(self, key: CacheEngineKey) -> bool:
         return self.store.is_exist(key.to_string())
 
-    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        key_str = key.to_string()
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
+        """
+        Batch get operation - the only supported get method.
+        Uses batch_get_into (with metadata) or batch_get_buffer (without metadata).
+        """
+        if not keys:
+            return []
+
+        # Check if we have metadata for zero-copy operations
+        if self.save_chunk_meta:
+            # Use legacy mode with metadata stored in remote
+            return await self._batch_get_buffer(keys)
+        else:
+            # Use optimized mode with local metadata
+            return await self._batch_get_into(keys)
+
+    async def _batch_get_into(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
+        """
+        Zero-copy batch get using batch_get_into when metadata is available locally.
+        This is used when save_chunk_meta=False (metadata not stored remotely).
+        """
+        if not self.meta_shape or not self.meta_dtype or not self.meta_fmt:
+            logger.error(
+                f"Metadata required for batch_get_into but not available: "
+                f"meta_shape={self.meta_shape}, "
+                f"meta_dtype={self.meta_dtype}, "
+                f"meta_fmt={self.meta_fmt}"
+            )
+            return [None] * len(keys)
+
+        logger.debug(f"Using batch_get_into for {len(keys)} keys (zero-copy mode)")
+
+        # Reserve a buffer for every requested chunk
+        memory_objs: list[Optional[MemoryObj]] = []
+        valid_idx: list[int] = []
+
+        for i, _ in enumerate(keys):
+            buf = self.local_cpu_backend.allocate(
+                self.meta_shape, self.meta_dtype, self.meta_fmt
+            )
+            memory_objs.append(buf)
+            if buf is not None:
+                valid_idx.append(i)
+
+        if not valid_idx:
+            logger.warning("Batch-get aborted: unable to allocate any buffers.")
+            return [None] * len(keys)
+
+        # Build the argument lists for the C++ call
+        key_strs = [keys[i].to_string() for i in valid_idx]
+        buffer_ptrs = [memory_objs[i].tensor.data_ptr() for i in valid_idx]
+        buffer_sizes = [
+            memory_objs[i].tensor.numel() * memory_objs[i].tensor.element_size()
+            for i in valid_idx
+        ]
 
         try:
-            buffer = await asyncio.wait_for(
-                asyncio.to_thread(self.store.get_buffer, key_str),
-                timeout=self.config.transfer_timeout,
+            # Single RPC call for multiple chunks
+            logger.debug(f"Calling batch_get_into with {len(key_strs)} keys")
+            bytes_read_list = await asyncio.to_thread(
+                self.store.batch_get_into, key_strs, buffer_ptrs, buffer_sizes
             )
-        except asyncio.TimeoutError:
-            logger.warning(
-                f"Timeout when getting key {key_str} from mooncake store."
-                "The output may be incorrect."
-            )
-            return None
+            logger.debug(f"batch_get_into returned: {bytes_read_list}")
+
+            # Assemble the final result list
+            results: list[Optional[MemoryObj]] = [None] * len(keys)
+
+            for i, n_read in zip(valid_idx, bytes_read_list, strict=False):
+                if n_read <= 0:
+                    logger.warning(
+                        f"batch_get_into failed for key {keys[i]} (code={n_read})"
+                    )
+                    memory_objs[i].ref_count_down()
+                    continue
+
+                try:
+                    results[i] = self.reshape_partial_chunk(
+                        memory_objs[i],
+                        n_read,
+                    )
+                except Exception as exc:
+                    logger.error(f"Reshape failed for key {keys[i]}: {exc}")
+                    memory_objs[i].ref_count_down()
+
+            return results
+
+        except Exception as exc:
+            logger.error(f"batch_get_into threw exception: {str(exc)}")
+            # Release any buffers we successfully allocated
+            for i in valid_idx:
+                memory_objs[i].ref_count_down()
+            return [None] * len(keys)
+
+    async def _batch_get_buffer(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
+        """
+        Batch get using batch_get_buffer when metadata is stored remotely.
+        This is used when save_chunk_meta=True (metadata stored with data).
+        """
+        key_strs = [key.to_string() for key in keys]
+
+        try:
+            buffers = await asyncio.to_thread(self.store.batch_get_buffer, key_strs)
         except Exception as e:
-            logger.error(f"Failed to get key {key_str}. {e}")
+            logger.error(f"batch_get_buffer failed: {str(e)}")
+            return [None] * len(keys)
 
-        if buffer is None:
-            return None
+        results = []
+        for i, buffer in enumerate(buffers):
+            if buffer is None:
+                logger.warning(f"Buffer {i} is None for key {key_strs[i]}")
+                results.append(None)
+                continue
+            try:
+                memory_obj = self._process_buffer_with_metadata(buffer)
+                results.append(memory_obj)
+            except Exception as e:
+                logger.error(
+                    f"Failed to process buffer {i} for key {key_strs[i]}: {str(e)}"
+                )
+                results.append(None)
+        return results
 
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        """
+        Single get method - NOT SUPPORTED.
+        Use batched_get instead for all operations.
+        """
+        logger.error("Single get operation is not supported. Use batched_get instead.")
+        raise NotImplementedError(
+            "Single get is not supported. Use batched_get([key]) instead."
+        )
+
+    def _process_buffer_with_metadata(self, buffer: bytes) -> Optional[MemoryObj]:
+        """
+        Process buffer that contains metadata + data.
+        Used when save_chunk_meta=True (metadata stored remotely).
+        """
         retrieved_view = memoryview(buffer)
         metadata_bytes = retrieved_view[:METADATA_BYTES_LEN]
         if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
@@ -213,19 +426,69 @@ class MooncakestoreConnector(RemoteConnector):
             return None
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # Please use a function like `memory_obj.to_meta()`.
-        kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
-        assert len(metadata_bytes) == METADATA_BYTES_LEN
+        """
+        Put operation with metadata-consistent handling.
+        Uses put_from (without metadata) or
+        put_parts (with metadata) to match get behavior.
+        """
         key_str = key.to_string()
 
+        # Check metadata handling mode to match get behavior
+        if self.save_chunk_meta:
+            # Use put_parts with metadata stored remotely
+            await self._put_with_metadata(key_str, memory_obj)
+        else:
+            # Use put_from without metadata (zero-copy)
+            await self._put_without_metadata(key_str, memory_obj)
+
+    async def _put_without_metadata(self, key_str: str, memory_obj: MemoryObj):
+        """
+        Zero-copy put using put_from when metadata is not stored remotely.
+        This is used when save_chunk_meta=False (matches _batch_get_into).
+        """
         try:
+            buffer_ptr = memory_obj.tensor.data_ptr()
+            buffer_size = memory_obj.tensor.numel() * memory_obj.tensor.element_size()
+
+            await asyncio.wait_for(
+                asyncio.to_thread(
+                    self.store.put_from,
+                    key_str,
+                    buffer_ptr,
+                    buffer_size,
+                    self.replica_config,
+                ),
+                timeout=self.config.transfer_timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Timeout when putting key {key_str} using put_from. "
+                "Decode instance may redo prefill."
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to put key {key_str} using put_from: "
+                f"{type(e).__name__}: {str(e)}"
+            )
+            raise
+
+    async def _put_with_metadata(self, key_str: str, memory_obj: MemoryObj):
+        """
+        Put using put_parts when metadata is stored remotely.
+        This is used when save_chunk_meta=True (matches _batch_get_buffer).
+        """
+        try:
+            # Serialize data and metadata
+            kv_bytes = memory_obj.byte_array
+            kv_shape = memory_obj.get_shape()
+            kv_dtype = memory_obj.get_dtype()
+            memory_format = memory_obj.get_memory_format()
+
+            metadata_bytes = RemoteMetadata(
+                len(kv_bytes), kv_shape, kv_dtype, memory_format
+            ).serialize()
+            assert len(metadata_bytes) == METADATA_BYTES_LEN
+
             await asyncio.wait_for(
                 asyncio.to_thread(
                     self.store.put_parts, key_str, metadata_bytes, kv_bytes
@@ -234,20 +497,23 @@ class MooncakestoreConnector(RemoteConnector):
             )
         except asyncio.TimeoutError:
             logger.warning(
-                f"Timeout when putting key {key_str} from mooncake store."
+                f"Timeout when putting key {key_str} using put_parts. "
                 "Decode instance may redo prefill."
             )
         except Exception as e:
             logger.error(
-                f"Failed to put key {key_str},"
-                f"meta type: {type(metadata_bytes)},"
-                f"data: {type(kv_bytes)}: {e}"
+                f"Failed to put key {key_str} using put_parts: "
+                f"{type(e).__name__}: {str(e)}"
             )
+            raise
 
     @no_type_check
     async def list(self) -> List[str]:
         pass
 
     async def close(self):
+        # Unregister buffer before closing the store
+        self._unregister_cpu_buffer()
+
         self.store.close()
         logger.info("Closed the mooncake store connection")


### PR DESCRIPTION
another version of #988 

Although I've run multiple benchmark, the performance doesn't match that of PR #988. This might be because the remote connector requires additional code paths to handle operations. However, it still provides significant performance improvements.

optimized connector
```
============ Serving Benchmark Result ============
Successful requests:                     50        
Benchmark duration (s):                  5.72      
Total input tokens:                      404689    
Total generated tokens:                  6400      
Request throughput (req/s):              8.74      
Output token throughput (tok/s):         1118.59   
Total Token throughput (tok/s):          71849.95  
---------------Time to First Token----------------
Mean TTFT (ms):                          1540.05   
Median TTFT (ms):                        1477.40   
P99 TTFT (ms):                           2029.28   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.74     
Median TPOT (ms):                        33.24     
P99 TPOT (ms):                           43.12     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.74     
Median ITL (ms):                         29.06     
P99 ITL (ms):                            42.61     
==================================================
```

compare to result in #988, throuput 77494 tok/s, mean ttft: 925ms, media ttft: 947ms