### PR TITLE
[Fix]: Pin torch version again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
 # Requirements for package build
 # Should be mirrored in requirements/build.txt (for builds external to setuptools)
+# the torch version in requirements/common.txt MUST match
 requires = [
     "ninja",
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch",
+    "torch==2.7.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch==2.7.0",
+    "torch==2.7.1",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,7 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
-# don't pin torch version to avoid breaking vllm dockerfile (contains lmcache wheels)
-torch
+# please update ASAP when vllm torch updates
+torch==2.7.1
 wheel
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,6 +15,7 @@ safetensors
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
 sortedcontainers
-# don't pin torch version to avoid breaking vllm dockerfile (contains lmcache wheels)
-torch
+# please update ASAP when vllm torch updates
+# MUST match the [build-system].requires in pyproject.toml
+torch==2.7.1
 transformers >= 4.51.1

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -5,8 +5,8 @@
 ray >= 2.9
 nvidia-ml-py # for pynvml package
 
-# These dependencies also exist in vLLM (so we don't pin the version, even though this may cause some hard-to-debug issues)
-torch
+# please update ASAP when vllm torch updates
+torch==2.7.1
 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 torchvision
 # platform_system == 'Linux' and platform_machine == 'x86_64' 


### PR DESCRIPTION
FIX https://github.com/LMCache/LMCache/issues/1273

The issue arose when torch 2.8.0 was released. This caused the build stage torch from the runtime torch versions ABI to diverge and cause linking issues. 

The cause of unpinning torch version was: https://github.com/LMCache/LMCache/issues/1184

This means we need to quickly watch for when torch versions change in vllm and update lmcache quickly

WIP: looking for a way to insert torch version dynamically @maobaolong 