### PR TITLE
[Core]: CPU backend busy loop + async redis

### DIFF
--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -216,5 +216,26 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    def support_batched_put(self) -> bool:
+        """
+        Check if the connector supports batched put
+
+        Returns:
+            True if batched put is supported, False otherwise
+        """
+        return False
+
+    async def batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        """
+        Batched put the memory_objs with the corresponding keys
+
+        Input:
+            keys: the keys of the corresponding objects
+            memory_objs: the memory_objs of the corresponding keys
+        """
+        raise NotImplementedError
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}>"

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -20,10 +20,6 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 
-# NOTE(Jiayi): `redis-py` supports async operations, but data copy
-# cannot be avoided. `hiredis` is more lower-level but asyncio is
-# not supported.
-
 # Constants for the combined format
 METADATA_HEADER_SIZE = 28  # 7 integers * 4 bytes each from RemoteMetadata.serialize()
 
@@ -42,6 +38,7 @@ class RedisConnector(RemoteConnector):
         self.connection = redis_from_url(url=url, decode_responses=False)
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        # pip install hiredis automatically enables hiredis (asyncio compatible)
         logger.info(
             f"HIREDIS_AVAILABLE: {getattr(redis.connection, 'HIREDIS_AVAILABLE', None)}"
         )
@@ -143,7 +140,6 @@ class RedisConnector(RemoteConnector):
         # degrades async performance
 
         # temporary pipeline
-        logger.info(f"Batched get {len(keys)} keys")
         async with self.connection.pipeline(transaction=False) as pipeline:
             key_strings = [key.to_string() for key in keys]
 

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -2,10 +2,12 @@
 # Standard
 from typing import List, Optional, Tuple, no_type_check
 import asyncio
-import inspect
 import os
+import struct
 
 # Third Party
+from redis.asyncio import from_url as redis_from_url
+from redis.asyncio.sentinel import Sentinel
 import redis
 
 # First Party
@@ -18,10 +20,12 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 
-# TODO(Jiayi): Use `redis.asyncio`
 # NOTE(Jiayi): `redis-py` supports async operations, but data copy
 # cannot be avoided. `hiredis` is more lower-level but asyncio is
 # not supported.
+
+# Constants for the combined format
+METADATA_HEADER_SIZE = 28  # 7 integers * 4 bytes each from RemoteMetadata.serialize()
 
 
 class RedisConnector(RemoteConnector):
@@ -35,26 +39,66 @@ class RedisConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
-        self.connection = redis.from_url(url=url, decode_responses=False)
+        self.connection = redis_from_url(url=url, decode_responses=False)
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        logger.info(
+            f"HIREDIS_AVAILABLE: {getattr(redis.connection, 'HIREDIS_AVAILABLE', None)}"
+        )
+
+    @staticmethod
+    def _pack_metadata_and_data(memory_obj: MemoryObj) -> bytes:
+        """Pack metadata and KV bytes into a single byte array with header format."""
+        kv_bytes = memory_obj.byte_array
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        metadata = RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype, memory_format)
+        metadata_bytes = metadata.serialize()
+
+        # Combine: [metadata_header][kv_data]
+        return metadata_bytes + kv_bytes
+
+    @staticmethod
+    def _unpack_metadata_and_data(
+        combined_bytes: bytes,
+    ) -> Tuple[RemoteMetadata, bytes]:
+        """Unpack metadata and KV bytes from combined format."""
+        if len(combined_bytes) < METADATA_HEADER_SIZE:
+            raise ValueError(
+                "Combined bytes too small:"
+                "{len(combined_bytes)} < {METADATA_HEADER_SIZE}"
+            )
+
+        metadata_bytes = combined_bytes[:METADATA_HEADER_SIZE]
+        kv_bytes = combined_bytes[METADATA_HEADER_SIZE:]
+
+        metadata = RemoteMetadata.deserialize(metadata_bytes)
+        return metadata, kv_bytes
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return bool(self.connection.exists(key.to_string() + "metadata"))
+        return await self.connection.exists(key.to_string())
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
-        return bool(self.connection.exists(key.to_string() + "metadata"))
+        raise NotImplementedError(
+            "exists_sync is not supported", " for RedisConnector yet"
+        )
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        metadata_bytes = self.connection.get(key_str + "metadata")
 
-        if metadata_bytes is None:
+        # Get combined metadata + KV bytes
+        combined_bytes = await self.connection.get(key_str)
+        if combined_bytes is None:
+            logger.warning(f"Key {key_str} does not exist in the cache")
             return None
 
-        assert not inspect.isawaitable(metadata_bytes)
-
-        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+        try:
+            metadata, kv_bytes = self._unpack_metadata_and_data(combined_bytes)
+        except (ValueError, struct.error) as e:
+            logger.error(f"Failed to unpack data for key {key_str}: {e}")
+            return None
 
         memory_obj = self.local_cpu_backend.allocate(
             metadata.shape,
@@ -63,22 +107,6 @@ class RedisConnector(RemoteConnector):
         )
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
-            return None
-
-        # TODO(Jiayi): Find a way to do `get` inplace
-        kv_bytes = self.connection.get(key_str + "kv_bytes")
-        assert not inspect.isawaitable(kv_bytes)
-
-        if kv_bytes is None:
-            # TODO (Jiayi): We might need a way to better handle
-            # consistency issues.
-            # TODO (Jiayi): A better way is to aggregate metadata
-            # and kv cache in one key.
-            logger.warning(
-                "Key exists but KV cache does not exist."
-                "Might happen when the cache is evicted by redis."
-            )
-            self.connection.delete(key_str + "metadata")
             return None
 
         if isinstance(memory_obj.byte_array, memoryview):
@@ -99,21 +127,92 @@ class RedisConnector(RemoteConnector):
 
         return memory_obj
 
+    def support_batched_get(self) -> bool:
+        # TODO: False because currently batching degrades
+        # performance with async redis client
+        # tested with MGET as well as pipeline,
+        # the performance is not improved
+        return False
+
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
+        # TODO: currently batching degrades
+        # performance with async redis client
+        # need to figure out why batching
+        # degrades async performance
+
+        # temporary pipeline
+        logger.info(f"Batched get {len(keys)} keys")
+        async with self.connection.pipeline(transaction=False) as pipeline:
+            key_strings = [key.to_string() for key in keys]
+
+            for key_str in key_strings:
+                pipeline.get(key_str)
+
+            combined_bytes_list = await pipeline.execute()
+            final_memory_objs = []
+
+            for i, combined_bytes in enumerate(combined_bytes_list):
+                if combined_bytes is None:
+                    logger.warning(f"Key {keys[i]} does not exist in the cache")
+                    final_memory_objs.append(None)
+                    continue
+
+                try:
+                    metadata, kv_bytes = self._unpack_metadata_and_data(combined_bytes)
+                except (ValueError, struct.error) as e:
+                    logger.error(f"Failed to unpack data for key {keys[i]}: {e}")
+                    final_memory_objs.append(None)
+                    continue
+
+                memory_obj = self.local_cpu_backend.allocate(
+                    metadata.shape,
+                    metadata.dtype,
+                    metadata.fmt,
+                )
+                if memory_obj is None:
+                    logger.warning("Failed to allocate memory during remote receive")
+                    final_memory_objs.append(None)
+                    continue
+
+                if isinstance(memory_obj.byte_array, memoryview):
+                    view = memory_obj.byte_array
+                    if view.format == "<B":
+                        view = view.cast("B")
+                else:
+                    view = memoryview(memory_obj.byte_array)
+
+                if isinstance(kv_bytes, (bytes, bytearray)):
+                    view[: metadata.length] = kv_bytes
+                elif isinstance(kv_bytes, str):
+                    converted = kv_bytes.encode("utf-8")
+                    view[: metadata.length] = converted
+                else:
+                    converted = bytes(kv_bytes)
+                    view[: metadata.length] = converted
+
+                final_memory_objs.append(memory_obj)
+
+            return final_memory_objs
+
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # TODO(Jiayi): The following code is ugly.
-        # Please use a function like `memory_obj.to_meta()`.
-        kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
-
         key_str = key.to_string()
-        self.connection.set(key_str + "metadata", metadata_bytes)
-        self.connection.set(key_str + "kv_bytes", kv_bytes)
+        combined_bytes = self._pack_metadata_and_data(memory_obj)
+        await self.connection.set(key_str, combined_bytes)
+
+    def support_batched_put(self) -> bool:
+        return True
+
+    async def batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        async with self.connection.pipeline(transaction=False) as pipeline:
+            for key, memory_obj in zip(keys, memory_objs, strict=False):
+                key_str = key.to_string()
+                combined_bytes = self._pack_metadata_and_data(memory_obj)
+                pipeline.set(key_str, combined_bytes)
+            await pipeline.execute()
 
     # TODO
     @no_type_check
@@ -121,7 +220,7 @@ class RedisConnector(RemoteConnector):
         pass
 
     async def close(self):
-        self.connection.close()
+        await self.connection.aclose()
         logger.info("Closed the redis connection")
 
 
@@ -171,7 +270,7 @@ class RedisSentinelConnector(RemoteConnector):
                 timeout = float(value)
 
         logger.info(f"Host and ports: {hosts_and_ports}")
-        self.sentinel = redis.Sentinel(hosts_and_ports, socket_timeout=timeout)
+        self.sentinel = Sentinel(hosts_and_ports, socket_timeout=timeout)
         self.master = self.sentinel.master_for(
             service_name, socket_timeout=timeout, username=username, password=password
         )
@@ -181,22 +280,60 @@ class RedisSentinelConnector(RemoteConnector):
 
         self.local_cpu_backend = local_cpu_backend
 
+    @staticmethod
+    def _pack_metadata_and_data(memory_obj: MemoryObj) -> bytes:
+        """Pack metadata and KV bytes into a single byte array with header format."""
+        kv_bytes = memory_obj.byte_array
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        metadata = RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype, memory_format)
+        metadata_bytes = metadata.serialize()
+
+        # Combine: [metadata_header][kv_data]
+        return metadata_bytes + kv_bytes
+
+    @staticmethod
+    def _unpack_metadata_and_data(
+        combined_bytes: bytes,
+    ) -> Tuple[RemoteMetadata, bytes]:
+        """Unpack metadata and KV bytes from combined format."""
+        if len(combined_bytes) < METADATA_HEADER_SIZE:
+            raise ValueError(
+                "Combined bytes too small: "
+                "{len(combined_bytes)} < {METADATA_HEADER_SIZE}"
+            )
+
+        metadata_bytes = combined_bytes[:METADATA_HEADER_SIZE]
+        kv_bytes = combined_bytes[METADATA_HEADER_SIZE:]
+
+        metadata = RemoteMetadata.deserialize(metadata_bytes)
+        return metadata, kv_bytes
+
     async def exists(self, key: CacheEngineKey) -> bool:
-        return bool(self.slave.exists(key.to_string() + "metadata"))
+        # Simple Redis key existence check
+        return await self.slave.exists(key.to_string())
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
-        return bool(self.slave.exists(key.to_string() + "metadata"))
+        raise NotImplementedError(
+            "exists_sync is not supported for RedisSentinelConnector yet"
+        )
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        metadata_bytes = self.slave.get(key_str + "metadata")
 
-        if metadata_bytes is None:
+        # Get combined metadata + KV bytes
+        combined_bytes = await self.slave.get(key_str)
+        if combined_bytes is None:
+            logger.warning(f"Key {key_str} does not exist in the cache")
             return None
 
-        assert not inspect.isawaitable(metadata_bytes)
-
-        metadata = RemoteMetadata.deserialize(metadata_bytes)
+        try:
+            metadata, kv_bytes = self._unpack_metadata_and_data(combined_bytes)
+        except (ValueError, struct.error) as e:
+            logger.error(f"Failed to unpack data for key {key_str}: {e}")
+            return None
 
         memory_obj = self.local_cpu_backend.allocate(
             metadata.shape,
@@ -205,23 +342,6 @@ class RedisSentinelConnector(RemoteConnector):
         )
         if memory_obj is None:
             logger.warning("Failed to allocate memory during remote receive")
-            return None
-
-        # TODO(Jiayi): Find a way to do `get` inplace
-        kv_bytes = self.slave.get(key_str + "kv_bytes")
-
-        assert not inspect.isawaitable(kv_bytes)
-
-        if kv_bytes is None:
-            # TODO (Jiayi): We might need a way to better handle
-            # consistency issues.
-            # TODO (Jiayi): A background sweeper might be better
-            # for the sake of performance.
-            logger.warning(
-                "Key exists but KV cache does not exist."
-                "Might happen when the cache is evicted by redis."
-            )
-            self.master.delete(key_str + "metadata")
             return None
 
         if isinstance(memory_obj.byte_array, memoryview):
@@ -242,23 +362,86 @@ class RedisSentinelConnector(RemoteConnector):
 
         return memory_obj
 
+    def support_batched_get(self) -> bool:
+        return False
+
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
+        """Batched get operation for Redis Sentinel."""
+        logger.info(f"Batched get {len(keys)} keys")
+        async with self.slave.pipeline(transaction=False) as pipeline:
+            key_strings = [key.to_string() for key in keys]
+
+            for key_str in key_strings:
+                pipeline.get(key_str)
+
+            combined_bytes_list = await pipeline.execute()
+            final_memory_objs = []
+
+            for i, combined_bytes in enumerate(combined_bytes_list):
+                if combined_bytes is None:
+                    logger.warning(f"Key {keys[i]} does not exist in the cache")
+                    final_memory_objs.append(None)
+                    continue
+
+                try:
+                    metadata, kv_bytes = self._unpack_metadata_and_data(combined_bytes)
+                except (ValueError, struct.error) as e:
+                    logger.error(f"Failed to unpack data for key {keys[i]}: {e}")
+                    final_memory_objs.append(None)
+                    continue
+
+                memory_obj = self.local_cpu_backend.allocate(
+                    metadata.shape,
+                    metadata.dtype,
+                    metadata.fmt,
+                )
+                if memory_obj is None:
+                    logger.warning("Failed to allocate memory during remote receive")
+                    final_memory_objs.append(None)
+                    continue
+
+                if isinstance(memory_obj.byte_array, memoryview):
+                    view = memory_obj.byte_array
+                    if view.format == "<B":
+                        view = view.cast("B")
+                else:
+                    view = memoryview(memory_obj.byte_array)
+
+                if isinstance(kv_bytes, (bytes, bytearray)):
+                    view[0 : metadata.length] = kv_bytes
+                elif isinstance(kv_bytes, str):
+                    converted = kv_bytes.encode("utf-8")
+                    view[0 : metadata.length] = converted
+                else:
+                    converted = bytes(kv_bytes)
+                    view[0 : metadata.length] = converted
+
+                final_memory_objs.append(memory_obj)
+
+            return final_memory_objs
+
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
-        # TODO(Jiayi): The following code is ugly.
-        # Please use a function like `memory_obj.to_meta()`.
-        kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
-        memory_format = memory_obj.get_memory_format()
-
-        metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
-
         key_str = key.to_string()
-        self.master.set(key_str + "metadata", metadata_bytes)
-        self.master.set(key_str + "kv_bytes", kv_bytes)
+        combined_bytes = self._pack_metadata_and_data(memory_obj)
+        await self.master.set(key_str, combined_bytes)
 
         memory_obj.ref_count_down()
+
+    def support_batched_put(self) -> bool:
+        return True
+
+    async def batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        """Batched put operation for Redis Sentinel."""
+        async with self.master.pipeline(transaction=False) as pipeline:
+            for key, memory_obj in zip(keys, memory_objs, strict=False):
+                key_str = key.to_string()
+                combined_bytes = self._pack_metadata_and_data(memory_obj)
+                pipeline.set(key_str, combined_bytes)
+            await pipeline.execute()
 
     # TODO
     @no_type_check
@@ -266,5 +449,6 @@ class RedisSentinelConnector(RemoteConnector):
         pass
 
     async def close(self):
-        self.master.close()
-        self.slave.close()
+        await self.master.aclose()
+        await self.slave.aclose()
+        logger.info("Closed Redis Sentinel clients")

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -64,8 +64,8 @@ class RedisConnector(RemoteConnector):
         """Unpack metadata and KV bytes from combined format."""
         if len(combined_bytes) < METADATA_HEADER_SIZE:
             raise ValueError(
-                "Combined bytes too small:"
-                "{len(combined_bytes)} < {METADATA_HEADER_SIZE}"
+                f"Combined bytes too small: "
+                f"{len(combined_bytes)} < {METADATA_HEADER_SIZE}"
             )
 
         metadata_bytes = combined_bytes[:METADATA_HEADER_SIZE]
@@ -78,9 +78,7 @@ class RedisConnector(RemoteConnector):
         return await self.connection.exists(key.to_string())
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError(
-            "exists_sync is not supported", " for RedisConnector yet"
-        )
+        raise NotImplementedError("exists_sync is not supported for RedisConnector yet")
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
@@ -297,8 +295,8 @@ class RedisSentinelConnector(RemoteConnector):
         """Unpack metadata and KV bytes from combined format."""
         if len(combined_bytes) < METADATA_HEADER_SIZE:
             raise ValueError(
-                "Combined bytes too small: "
-                "{len(combined_bytes)} < {METADATA_HEADER_SIZE}"
+                f"Combined bytes too small: "
+                f"{len(combined_bytes)} < {METADATA_HEADER_SIZE}"
             )
 
         metadata_bytes = combined_bytes[:METADATA_HEADER_SIZE]

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -3,6 +3,7 @@
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, List, Optional
 import threading
+import time
 
 # Third Party
 import torch
@@ -195,6 +196,14 @@ class LocalCPUBackend(StorageBackendInterface):
             memory_obj.unpin()
             return True
 
+    def batched_remove(self, keys: List[CacheEngineKey], force: bool = True) -> int:
+        num_removed = 0
+        for key in keys:
+            num_removed += self.remove(key, force=force)
+        if self.lookup_server is not None:
+            self.lookup_server.batched_remove(keys)
+        return num_removed
+
     def remove(self, key: CacheEngineKey, force: bool = True) -> bool:
         if force:
             self.cpu_lock.acquire()
@@ -222,6 +231,15 @@ class LocalCPUBackend(StorageBackendInterface):
         # other backends might still (temporarily) hold the memory object.
         return True
 
+    # TODO
+    # local cpu backend and nixl backend allocators both have a race condition
+    # on allocate where if many requests enter but cannot be finished, we will
+    # infinitely spin. the probable solution is preemption.
+    # this is more likely to occur when concurrency is high and
+    # with longer inputs and more chunked prefills
+    # the most difficult part is to detect when this has occurred because we
+    # do not know how many more chunked prefills are coming for any given
+    # request
     @_lmcache_nvtx_annotate
     def allocate(
         self,
@@ -253,34 +271,52 @@ class LocalCPUBackend(StorageBackendInterface):
             self.memory_allocator, NixlCPUMemoryAllocator
         )
 
-        with self.cpu_lock:
-            while True:
-                # TODO(Jiayi): optimize `num_cacndidates` with estimation.
-                # Accurate estimation is hard due to fragmentation.
-                evict_keys = self.cache_policy.get_evict_candidates(
-                    self.hot_cache, num_candidates=1
-                )
-
-                if not evict_keys:
-                    logger.warning(
-                        "No eviction candidates found in local cpu backend. "
-                        "Local cpu memory is under pressure."
+        while True:
+            # whether or not this request needs to wait for other requests
+            wait_other_requests = True
+            if self.use_hot:
+                with self.cpu_lock:
+                    # TODO(Jiayi): optimize `num_candidates` with estimation.
+                    # Accurate estimation is hard due to fragmentation.
+                    evict_keys = self.cache_policy.get_evict_candidates(
+                        self.hot_cache, num_candidates=1
                     )
-                    break
+                    if evict_keys:
+                        # we can continue trying to evict from the hot_cache
+                        # and don't need to wait for other requests yet
+                        wait_other_requests = False
+                        logger.debug(
+                            f"Evicting {len(evict_keys)} chunk from cpu memory"
+                        )
+                        self.batched_remove(evict_keys, force=False)
 
-                self.batched_remove(evict_keys, force=False)
+            if wait_other_requests:
+                # TODO: make time_to_wait a config
+                time_to_wait = 0.1
+                logger.warning(
+                    "No eviction candidates found in local cpu backend. "
+                    "Local cpu memory is under pressure. "
+                    f"Waiting for {time_to_wait} second before retrying."
+                )
+                self.memory_allocator.memcheck()
+                # do not hold the lock during sleep
+                time.sleep(time_to_wait)
 
-                # TODO(Jiayi): Move this inside `batched_remove`
-                if self.lookup_server is not None:
-                    self.lookup_server.batched_remove(evict_keys)
-
-                memory_obj = self.memory_allocator.allocate(shape, dtype, fmt)
-                logger.debug(f"Evicting {len(evict_keys)} chunk from cpu memory")
-                if memory_obj is not None:
-                    break
+            memory_obj = self.memory_allocator.allocate(shape, dtype, fmt)
+            if memory_obj is not None:
+                break
 
         return memory_obj
 
+    # TODO
+    # local cpu backend and nixl backend allocators both have a race condition
+    # on allocate where if many requests enter but cannot be finished, we will
+    # infinitely spin. the probable solution is preemption.
+    # this is more likely to occur when concurrency is high and
+    # with longer inputs and more chunked prefills
+    # the most difficult part is to detect when this has occurred because we
+    # do not know how many more chunked prefills are coming for any given
+    # request
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
@@ -316,49 +352,62 @@ class LocalCPUBackend(StorageBackendInterface):
             self.memory_allocator, NixlCPUMemoryAllocator
         )
 
-        with self.cpu_lock:
-            while True:
-                evict_keys = self.cache_policy.get_evict_candidates(
-                    self.hot_cache, num_candidates=1
-                )
-
-                # HACK: We assume batch_size=num_layers here.
-                # FIXME: We also assume if the one layer's ref_count > 1 or pinned,
-                # then the other layers are also ref_count > 1 or
-                # pinned in the cpu memory. This might not be true.
-
-                if not evict_keys:
-                    logger.warning(
-                        "No eviction candidates found in local cpu backend. "
-                        "Local cpu memory is under pressure."
+        while True:
+            # whether or not this request needs to wait for other requests
+            wait_other_requests = True
+            if self.use_hot:
+                with self.cpu_lock:
+                    evict_keys = self.cache_policy.get_evict_candidates(
+                        self.hot_cache, num_candidates=1
                     )
-                    break
 
-                for evict_key in evict_keys:
-                    evict_key_all_layer = evict_key.split_layers(batch_size)
+                    # HACK: We assume batch_size=num_layers here.
+                    # FIXME: We also assume if the one layer's ref_count > 1 or pinned,
+                    # then the other layers are also ref_count > 1 or
+                    # pinned in the cpu memory. This might not be true.
 
-                    # TODO(Jiayi): batched allocate is not supported through
-                    # `batched_remove`. Therefore, features like usage tracking
-                    # is not supported.
-                    old_mem_objs = []
-                    for key in evict_key_all_layer:
-                        old_mem_objs.append(self.hot_cache[key])
-                        self.cache_policy.update_on_force_evict(key)
+                    if evict_keys:
+                        wait_other_requests = False
+                        for evict_key in evict_keys:
+                            evict_key_all_layer = evict_key.split_layers(batch_size)
 
-                    self.memory_allocator.batched_free(old_mem_objs)
-                    self.hot_cache.pop(evict_key, None)
+                            # TODO(Jiayi): batched allocate is not supported through
+                            # `batched_remove`. Therefore, features like usage tracking
+                            # is not supported.
+                            old_mem_objs = []
+                            for key in evict_key_all_layer:
+                                old_mem_objs.append(self.hot_cache[key])
+                                self.cache_policy.update_on_force_evict(key)
 
-                    if self.lookup_server is not None:
-                        self.lookup_server.batched_remove(evict_key_all_layer)
+                            self.memory_allocator.batched_free(old_mem_objs)
+                            self.hot_cache.pop(evict_key, None)
 
-                    logger.debug(f"Evicting {len(old_mem_objs)} chunks from cpu memory")
+                            if self.lookup_server is not None:
+                                self.lookup_server.batched_remove(evict_key_all_layer)
 
-                memory_objs = self.memory_allocator.batched_allocate(
-                    shape, dtype, batch_size, fmt
+                            logger.debug(
+                                f"Evicting {len(old_mem_objs)} chunks from cpu memory"
+                            )
+
+            if wait_other_requests:
+                # TODO: make time_to_wait a config
+                time_to_wait = 0.1
+                logger.warning(
+                    "No eviction candidates found in local cpu backend. "
+                    "Local cpu memory is under pressure. "
+                    f"Waiting for {time_to_wait} second before retrying."
                 )
+                self.memory_allocator.memcheck()
+                # do not hold the lock during sleep
+                time.sleep(time_to_wait)
 
-                if memory_objs:
-                    break
+            memory_objs = self.memory_allocator.batched_allocate(
+                shape, dtype, batch_size, fmt
+            )
+
+            if memory_objs:
+                break
+
         return memory_objs
 
     def get_keys(self) -> List[CacheEngineKey]:

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -298,7 +298,7 @@ class LocalCPUBackend(StorageBackendInterface):
                     "Local cpu memory is under pressure. "
                     f"Waiting for {time_to_wait} second before retrying."
                 )
-                self.memory_allocator.memcheck()
+                # self.memory_allocator.memcheck()
                 # do not hold the lock during sleep
                 time.sleep(time_to_wait)
 
@@ -397,7 +397,7 @@ class LocalCPUBackend(StorageBackendInterface):
                     "Local cpu memory is under pressure. "
                     f"Waiting for {time_to_wait} second before retrying."
                 )
-                self.memory_allocator.memcheck()
+                # self.memory_allocator.memcheck()
                 # do not hold the lock during sleep
                 time.sleep(time_to_wait)
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from concurrent.futures import Future, TimeoutError
-from typing import List, Optional
+from typing import List, Optional, Set
 import asyncio
 import threading
 import time
@@ -33,7 +33,7 @@ class RemoteBackend(StorageBackendInterface):
         dst_device: str = "cuda",
         lookup_server: Optional[LookupServerInterface] = None,
     ):
-        self.put_tasks: List[CacheEngineKey] = []
+        self.put_tasks: Set[CacheEngineKey] = set()
         self.lock = threading.Lock()
 
         assert config.remote_url is not None
@@ -155,9 +155,8 @@ class RemoteBackend(StorageBackendInterface):
         """
         Callback function for put tasks.
         """
-        self.lock.acquire()
-        self.put_tasks.remove(key)
-        self.lock.release()
+        with self.lock:
+            self.put_tasks.discard(key)
 
     def submit_put_task(
         self,
@@ -174,9 +173,8 @@ class RemoteBackend(StorageBackendInterface):
 
         memory_obj.ref_count_up()
 
-        self.lock.acquire()
-        self.put_tasks.append(key)
-        self.lock.release()
+        with self.lock:
+            self.put_tasks.add(key)
 
         compressed_memory_obj = self.serializer.serialize(memory_obj)
         memory_obj.ref_count_down()
@@ -190,16 +188,46 @@ class RemoteBackend(StorageBackendInterface):
         future.add_done_callback(lambda_callback)
         return future
 
+    def batched_put_callback(self, future: Future, keys: List[CacheEngineKey]):
+        """
+        Callback function for batched put tasks.
+        """
+        with self.lock:
+            self.put_tasks.difference_update(keys)
+
     def batched_submit_put_task(
         self,
         keys: List[CacheEngineKey],
         memory_objs: List[MemoryObj],
         transfer_spec=None,
     ) -> Optional[List[Future]]:
-        return [
-            self.submit_put_task(key, memory_obj)
-            for key, memory_obj in zip(keys, memory_objs, strict=False)
-        ]
+        if self.connection.support_batched_put():
+            if self.connection is None:
+                logger.warning(
+                    "Connection is None in batched_submit_put_task, returning None"
+                )
+                return None
+            if self._mla_worker_id_as0_mode:
+                return None
+
+            compressed_memory_objs = []
+
+            for memory_obj in memory_objs:
+                memory_obj.ref_count_up()
+                compressed_memory_objs.append(self.serializer.serialize(memory_obj))
+                memory_obj.ref_count_down()
+
+            future = asyncio.run_coroutine_threadsafe(
+                self.connection.batched_put(keys, compressed_memory_objs), self.loop
+            )
+            lambda_callback = lambda f: self.batched_put_callback(f, keys)
+            future.add_done_callback(lambda_callback)
+            return future
+        else:
+            return [
+                self.submit_put_task(key, memory_obj)
+                for key, memory_obj in zip(keys, memory_objs, strict=False)
+            ]
 
     def submit_prefetch_task(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,6 +238,8 @@ def mock_redis():
         patch("redis.Redis", MockRedis) as mock_redis_class,
         patch("redis.from_url", MockRedis.from_url),
         patch("redis.asyncio.from_url", MockRedis.from_url),
+        patch("redis.asyncio.Redis", MockRedis),
+        patch("redis.asyncio.client.Redis", MockRedis),
     ):
         yield mock_redis_class
 
@@ -247,6 +249,7 @@ def mock_redis_sentinel():
     with (
         patch("redis.Sentinel", MockRedisSentinel) as mock,
         patch("redis.asyncio.sentinel.Sentinel", MockRedisSentinel),
+        patch("redis.asyncio.Sentinel", MockRedisSentinel),
     ):
         yield mock
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,37 @@ def patch_pin_allocator():
         yield
 
 
+class MockRedisPipeline:
+    def __init__(self, store):
+        self.store = store
+        self.commands = []
+
+    def set(self, key, value):
+        self.commands.append(("set", key, value))
+        return self
+
+    def get(self, key):
+        self.commands.append(("get", key))
+        return self
+
+    async def execute(self):
+        results = []
+        for cmd in self.commands:
+            if cmd[0] == "set":
+                self.store[cmd[1]] = cmd[2]
+                results.append(True)
+            elif cmd[0] == "get":
+                results.append(self.store.get(cmd[1], None))
+        self.commands.clear()
+        return results
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
 class MockRedis:
     def __init__(
         self, host=None, port=None, url=None, decode_responses=False, **kwargs
@@ -149,19 +180,25 @@ class MockRedis:
         self.url = url
         self.decode_responses = decode_responses
 
-    def set(self, key, value):
+    async def set(self, key, value):
         self.store[key] = value
         return True
 
-    def get(self, key):
+    async def get(self, key):
         return self.store.get(key, None)
 
-    def exists(self, key):
+    async def exists(self, key):
         return key in self.store
+
+    def pipeline(self, transaction=False):
+        return MockRedisPipeline(self.store)
 
     def scan(self, cursor=0, match=None):
         keys = [s.encode("utf-8") for s in self.store.keys()]
         return (0, keys)
+
+    async def aclose(self):
+        pass
 
     def close(self):
         pass
@@ -200,13 +237,17 @@ def mock_redis():
     with (
         patch("redis.Redis", MockRedis) as mock_redis_class,
         patch("redis.from_url", MockRedis.from_url),
+        patch("redis.asyncio.from_url", MockRedis.from_url),
     ):
         yield mock_redis_class
 
 
 @pytest.fixture(scope="function", autouse=True)
 def mock_redis_sentinel():
-    with patch("redis.Sentinel", MockRedisSentinel) as mock:
+    with (
+        patch("redis.Sentinel", MockRedisSentinel) as mock,
+        patch("redis.asyncio.sentinel.Sentinel", MockRedisSentinel),
+    ):
         yield mock
 
 


### PR DESCRIPTION
## Items: 

1. have the local cpu backend do a busy loop while waiting for memory to free up
2. do memory allocation after redis has gotten the kv bytes, not before
3. merge the metadata and the kv bytes into a single bytes array and store in redis (fixes consistency)
4. async redis client
5. trying out hiredis
6. redis batched put + batched get (tried pipelining and MSET / MGET)

Vanilla vllm: 
```text
=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 1.493s
Warmup round time: 36.355s
Warmup round prompt count: 50
Query round mean TTFT: 1.033s
Query round time: 34.067s
Query round prompt count: 50
```

Redis before refactor: 
```text
=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 4.707s
Warmup round time: 101.584s
Warmup round prompt count: 50
Query round mean TTFT: 38.690s
Query round time: 515.408s
Query round prompt count: 50
```

Redis after refactor: 
```text
=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 4.760s
Warmup round time: 115.488s
Warmup round prompt count: 50
Query round mean TTFT: 14.881s
Query round time: 239.532s
Query round prompt count: 50
```


## Deployment: 
```yaml
chunk_size: 256
local_cpu: false
max_local_cpu_size: 10.0
remote_url: "redis://localhost:6379"
remote_serde: "naive"
blocking_timeout_secs: 120
```
```bash
LMCACHE_CONFIG_FILE="redis.yaml" \
vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --max-model-len 32000 \
  --port 8000 \
  --kv-transfer-config \
  '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' \
  --disable-log-requests
```

## Benchmark
```bash
python benchmarks/long-doc-qa/long-doc-qa.py \
  --num-documents 50 \
  --document-length 20000 \
  --output-len 100 \
  --repeat-count 1 \
  --repeat-mode random \
  --shuffle-seed 0 \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --max-inflight-requests 5
  --port 8000
```