### PR TITLE
[Add] Lookup observability metrics

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -25,6 +25,9 @@ class LMCacheStats:
     interval_store_requests: int
     interval_requested_tokens: int
     interval_hit_tokens: int
+    interval_lookup_requested_tokens: int
+    interval_lookup_hits: int
+    interval_lookup_requests: int
 
     interval_remote_read_requests: int
     interval_remote_read_bytes: int
@@ -76,6 +79,12 @@ class RetrieveRequestStats:
 
 
 @dataclass
+class LookupRequestStats:
+    num_tokens: int
+    hits: int
+
+
+@dataclass
 class StoreRequestStats:
     num_tokens: int
     start_time: float
@@ -100,6 +109,9 @@ class LMCStatsMonitor:
         self.interval_store_requests = 0
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
+        self.interval_lookup_requests = 0
+        self.interval_lookup_requested_tokens = 0
+        self.interval_lookup_hits = 0
 
         # remote backends read/write metrics
         self.interval_remote_read_requests = 0
@@ -125,9 +137,11 @@ class LMCStatsMonitor:
 
         self.retrieve_requests: Dict[int, RetrieveRequestStats] = {}
         self.store_requests: Dict[int, StoreRequestStats] = {}
+        self.lookup_requests: Dict[int, LookupRequestStats] = {}
 
         self.retrieve_request_id = 0
         self.store_request_id = 0
+        self.lookup_request_id = 0
 
     @thread_safe
     def on_retrieve_request(self, num_tokens: int) -> int:
@@ -157,6 +171,29 @@ class LMCStatsMonitor:
         retrieve_stats.local_hit_tokens = retrieved_tokens
         retrieve_stats.end_time = curr_time
         self.interval_hit_tokens += retrieved_tokens
+
+    @thread_safe
+    def on_lookup_request(self, num_tokens: int) -> int:
+        """
+        Returns the internal "request id" that will be used in
+        on_lookup_finished
+        """
+        lookup_stats = LookupRequestStats(
+            num_tokens=num_tokens,
+            hits=0,
+        )
+        self.interval_lookup_requests += 1
+        self.interval_lookup_requested_tokens += num_tokens
+        self.lookup_requests[self.lookup_request_id] = lookup_stats
+        self.lookup_request_id += 1
+        return self.lookup_request_id - 1
+
+    @thread_safe
+    def on_lookup_finished(self, request_id: int, hits: int):
+        assert request_id in self.lookup_requests
+        lookup_stats = self.lookup_requests[request_id]
+        lookup_stats.hits = hits
+        self.interval_lookup_hits += hits
 
     @thread_safe
     def on_store_request(self, num_tokens: int) -> int:
@@ -237,6 +274,9 @@ class LMCStatsMonitor:
 
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
+        self.interval_lookup_requests = 0
+        self.interval_lookup_requested_tokens = 0
+        self.interval_lookup_hits = 0
 
         self.interval_remote_read_requests = 0
         self.interval_remote_read_bytes = 0
@@ -302,6 +342,9 @@ class LMCStatsMonitor:
             interval_store_requests=self.interval_store_requests,
             interval_requested_tokens=self.interval_requested_tokens,
             interval_hit_tokens=self.interval_hit_tokens,
+            interval_lookup_requests=self.interval_lookup_requests,
+            interval_lookup_requested_tokens=self.interval_lookup_requested_tokens,
+            interval_lookup_hits=self.interval_lookup_hits,
             interval_remote_read_requests=self.interval_remote_read_requests,
             interval_remote_read_bytes=self.interval_remote_read_bytes,
             interval_remote_write_requests=self.interval_remote_write_requests,
@@ -377,6 +420,24 @@ class PrometheusLogger:
         self.counter_num_hit_tokens = self._counter_cls(
             name="lmcache:num_hit_tokens",
             documentation="Total number of tokens hit in lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_lookup_requests = self._counter_cls(
+            name="lmcache:num_lookup_requests",
+            documentation="Total number of lookup requests sent to lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_lookup_requested_tokens = self._counter_cls(
+            name="lmcache:num_lookup_requested_tokens",
+            documentation="Total number of tokens requested during lookup from lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_lookup_hits = self._counter_cls(
+            name="lmcache:num_lookup_hits",
+            documentation="Total number of tokens hit during lookup from lmcache",
             labelnames=labelnames,
         )
 
@@ -659,6 +720,14 @@ class PrometheusLogger:
             self.counter_num_requested_tokens, stats.interval_requested_tokens
         )
         self._log_counter(self.counter_num_hit_tokens, stats.interval_hit_tokens)
+        self._log_counter(
+            self.counter_num_lookup_requests, stats.interval_lookup_requests
+        )
+        self._log_counter(
+            self.counter_num_lookup_requested_tokens,
+            stats.interval_lookup_requested_tokens,
+        )
+        self._log_counter(self.counter_num_lookup_hits, stats.interval_lookup_hits)
 
         self._log_counter(
             self.counter_num_remote_read_requests,

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -670,6 +670,8 @@ class LMCacheEngine:
         :return: An int indicating how many prefix tokens are cached.
         """
         try:
+            monitor_req_id = self.stats_monitor.on_lookup_request(len(tokens))
+
             end = 0
             prev_end = 0
 
@@ -704,6 +706,7 @@ class LMCacheEngine:
                             self.lookup_pins[lookup_id].extend(key_all_layers)
                         prev_end = end
                         continue
+                    self.stats_monitor.on_lookup_finished(monitor_req_id, prev_end)
                     return prev_end
                 else:
                     if self.storage_manager.contains(key, search_range, pin):
@@ -718,9 +721,11 @@ class LMCacheEngine:
                         if self.lookup_server.lookup(key):
                             prev_end = end
                             continue
+                    self.stats_monitor.on_lookup_finished(monitor_req_id, prev_end)
                     return prev_end
 
             # all tokens where found, return the maximal end
+            self.stats_monitor.on_lookup_finished(monitor_req_id, end)
             return end
         finally:
             # vllm lookup sets pin to True


### PR DESCRIPTION
Decided to open a PR for this in case upstream folks interested.

I tested this with Prometheus (e.g. /metrics in vLLM) and the logs from LMCache.

E.g. here are some example logs
```
[2025-08-11 18:05:16,056] LMCache INFO: Reqid: chatcmpl-91595f912aef4fcdb4540c97ffcfcd15, Total tokens 15066, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:985:lmcache.integration.vllm.vllm_v1_adapter)
...
[2025-08-11 18:05:19,610] LMCache INFO: Reqid: chatcmpl-0b011a0d914d46539c52bdbd9ed451b1, Total tokens 15066, LMCache hit tokens: 15066, need to load: 15065 (vllm_v1_adapter.py:985:lmcache.integration.vllm.vllm_v1_adapter)
```

The metrics afterwards in a brand new instance:
```
# HELP lmcache:num_lookup_requests_total Total number of lookup requests sent to lmcache
# TYPE lmcache:num_lookup_requests_total counter
lmcache:num_lookup_requests_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="1"} 2.0
lmcache:num_lookup_requests_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="2"} 2.0
lmcache:num_lookup_requests_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="0"} 2.0
lmcache:num_lookup_requests_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="3"} 2.0
# HELP lmcache:num_lookup_requested_tokens_total Total number of tokens requested during lookup from lmcache
# TYPE lmcache:num_lookup_requested_tokens_total counter
lmcache:num_lookup_requested_tokens_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="1"} 30132.0
lmcache:num_lookup_requested_tokens_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="2"} 30132.0
lmcache:num_lookup_requested_tokens_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="0"} 30132.0
lmcache:num_lookup_requested_tokens_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="3"} 30132.0
# HELP lmcache:num_lookup_hits_total Total number of tokens hit during lookup from lmcache
# TYPE lmcache:num_lookup_hits_total counter
lmcache:num_lookup_hits_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="1"} 15066.0
lmcache:num_lookup_hits_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="2"} 15066.0
lmcache:num_lookup_hits_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="0"} 15066.0
lmcache:num_lookup_hits_total{model_name="meta-llama/Llama-3.1-70B-Instruct",worker_id="3"} 15066.0
```