### PR TITLE
[FEAT] Couchbase as remote connector

### DIFF
--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -211,6 +211,7 @@ def CreateConnector(
     - lm://host:port
     - infinistore://host:port[?device=device_name]
     - mooncakestore://host:port[?device=device_name]
+    - couchbase://[[username]:[password]@]host[:port][?bucket=bucket_name&scope=scope_name&collection=collection_name]
     - blackhole://[any_text]
     - audit://host:port[?verify=true|false]
     - fs://[host:port]/path
@@ -222,6 +223,7 @@ def CreateConnector(
     - lm://localhost:65432
     - infinistore://127.0.0.1:12345?device=mlx5_0
     - mooncakestore://127.0.0.1:50051
+    - couchbase://username:password@localhost:8091?bucket=lmcache&scope=cache&collection=kv
     - blackhole://
     - audit://localhost:8080?verify=true
     - fs:///tmp/lmcache

--- a/lmcache/v1/storage_backend/connector/couchbase_adapter.py
+++ b/lmcache/v1/storage_backend/connector/couchbase_adapter.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import os
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    parse_remote_url,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+logger = init_logger(__name__)
+
+
+class CouchbaseConnectorAdapter(ConnectorAdapter):
+    """Adapter for Couchbase connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("couchbase://")
+
+    def can_parse(self, url: str) -> bool:
+        """Check if this adapter can parse the given URL."""
+        return url.startswith(self.schema) or url.startswith("couchbases://")
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        """Create a Couchbase connector using the given context."""
+        # Local
+        from .couchbase_connector import CouchbaseConnector
+
+        logger.info(f"Creating Couchbase connector for URL: {context.url}")
+
+        # Parse the URL
+        parsed_url = parse_remote_url(context.url)
+
+        # Extract connection parameters
+        host = parsed_url.host or "localhost"
+        port = parsed_url.port or 8091
+        username = parsed_url.username
+        password = parsed_url.password
+
+        # Extract bucket, scope, and collection from query parameters or use defaults
+        query_params = parsed_url.query_params
+        bucket_name = query_params.get("bucket", ["default"])[0]
+        scope_name = query_params.get("scope", ["_default"])[0]
+        collection_name = query_params.get("collection", ["_default"])[0]
+
+        # Support environment variables as fallback
+        bucket_name = os.environ.get("COUCHBASE_BUCKET", bucket_name)
+        scope_name = os.environ.get("COUCHBASE_SCOPE", scope_name)
+        collection_name = os.environ.get("COUCHBASE_COLLECTION", collection_name)
+
+        logger.info(
+            f"Connecting to Couchbase: {host}:{port}, "
+            f"bucket={bucket_name}, scope={scope_name}, "
+            f"collection={collection_name}"
+        )
+
+        return CouchbaseConnector(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            bucket_name=bucket_name,
+            scope_name=scope_name,
+            collection_name=collection_name,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+        )

--- a/lmcache/v1/storage_backend/connector/couchbase_connector.py
+++ b/lmcache/v1/storage_backend/connector/couchbase_connector.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import List, Optional
+import asyncio
+
+try:
+    # Third Party
+    from couchbase.auth import PasswordAuthenticator
+    from couchbase.cluster import Cluster
+    from couchbase.exceptions import DocumentNotFoundException
+    from couchbase.options import ClusterOptions
+except ImportError:
+    PasswordAuthenticator = None
+    Cluster = None
+    DocumentNotFoundException = None
+    ClusterOptions = None
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.protocol import RemoteMetadata
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+logger = init_logger(__name__)
+
+METADATA_KEY_SUFFIX = "::metadata"
+DATA_KEY_SUFFIX = "::data"
+
+
+class CouchbaseConnector(RemoteConnector):
+    """Couchbase-based connector for remote storage."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: Optional[str],
+        password: Optional[str],
+        bucket_name: str,
+        scope_name: str,
+        collection_name: str,
+        loop: asyncio.AbstractEventLoop,
+        local_cpu_backend: LocalCPUBackend,
+    ):
+        """
+        Initialize Couchbase connector.
+
+        Args:
+            host: Couchbase server hostname
+            port: Couchbase server port
+            username: Authentication username
+            password: Authentication password
+            bucket_name: Couchbase bucket name
+            scope_name: Couchbase scope name
+            collection_name: Couchbase collection name
+            loop: Asyncio event loop
+            local_cpu_backend: Memory allocator interface
+        """
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.bucket_name = bucket_name
+        self.scope_name = scope_name
+        self.collection_name = collection_name
+        self.loop = loop
+        self.local_cpu_backend = local_cpu_backend
+
+        # Initialize Couchbase connection
+        self._initialize_connection()
+
+        logger.info(
+            f"Initialized CouchbaseConnector: {host}:{port}/{bucket_name}"
+            f".{scope_name}.{collection_name}"
+        )
+
+    def _initialize_connection(self):
+        """Initialize connection to Couchbase cluster."""
+        if Cluster is None:
+            raise ImportError(
+                "Couchbase SDK is not installed. Please install it with: "
+                "pip install couchbase"
+            )
+
+        connection_string = f"couchbase://{self.host}:{self.port}"
+
+        if self.username and self.password:
+            auth = PasswordAuthenticator(self.username, self.password)
+            options = ClusterOptions(auth)
+            self.cluster = Cluster(connection_string, options)
+        else:
+            self.cluster = Cluster(connection_string)
+
+        self.bucket = self.cluster.bucket(self.bucket_name)
+        self.scope = self.bucket.scope(self.scope_name)
+        self.collection = self.scope.collection(self.collection_name)
+
+    def _get_key_string(self, key: CacheEngineKey) -> str:
+        """Convert CacheEngineKey to string format."""
+        return key.to_string()
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        """Check if key exists in Couchbase."""
+        key_str = self._get_key_string(key)
+        metadata_key = key_str + METADATA_KEY_SUFFIX
+
+        try:
+            # Run in thread pool since Couchbase SDK is synchronous
+            result = await self.loop.run_in_executor(
+                None, lambda: self.collection.exists(metadata_key)
+            )
+            return result.exists
+        except Exception as e:
+            logger.error(f"Error checking existence for key {key_str}: {str(e)}")
+            return False
+
+    def exists_sync(self, key: CacheEngineKey) -> bool:
+        """Check if key exists in Couchbase (synchronous)."""
+        key_str = self._get_key_string(key)
+        metadata_key = key_str + METADATA_KEY_SUFFIX
+
+        try:
+            result = self.collection.exists(metadata_key)
+            return result.exists
+        except Exception as e:
+            logger.error(f"Error checking existence for key {key_str}: {str(e)}")
+            return False
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        """Retrieve data from Couchbase."""
+        key_str = self._get_key_string(key)
+        metadata_key = key_str + METADATA_KEY_SUFFIX
+        data_key = key_str + DATA_KEY_SUFFIX
+
+        try:
+            if self.save_chunk_meta:
+                # Get metadata first
+                metadata_result = await self.loop.run_in_executor(
+                    None, lambda: self.collection.get(metadata_key)
+                )
+                metadata_bytes = metadata_result.content_as[bytes]
+                metadata = RemoteMetadata.deserialize(metadata_bytes)
+
+                # Allocate memory based on metadata
+                memory_obj = self.local_cpu_backend.allocate(
+                    metadata.shape, metadata.dtype, metadata.fmt
+                )
+            else:
+                # Use pre-configured metadata
+                memory_obj = self.local_cpu_backend.allocate(
+                    self.meta_shape, self.meta_dtype, self.meta_fmt
+                )
+
+            if memory_obj is None:
+                logger.debug("Memory allocation failed during Couchbase load.")
+                return None
+
+            # Get actual data
+            data_result = await self.loop.run_in_executor(
+                None, lambda: self.collection.get(data_key)
+            )
+            data_bytes = data_result.content_as[bytes]
+
+            if self.save_chunk_meta:
+                # Copy data into allocated memory
+                if len(data_bytes) != len(memory_obj.byte_array):
+                    raise RuntimeError(
+                        f"Data size mismatch: expected {len(memory_obj.byte_array)}, "
+                        f"got {len(data_bytes)}"
+                    )
+
+                # Handle memory view casting similar to Redis connector
+                if isinstance(memory_obj.byte_array, memoryview):
+                    view = memory_obj.byte_array
+                    if view.format == "<B":
+                        view = view.cast("B")
+                else:
+                    view = memoryview(memory_obj.byte_array)
+
+                view[: len(data_bytes)] = data_bytes
+            else:
+                # Handle partial chunks
+                if isinstance(memory_obj.byte_array, memoryview):
+                    view = memory_obj.byte_array
+                    if view.format == "<B":
+                        view = view.cast("B")
+                else:
+                    view = memoryview(memory_obj.byte_array)
+
+                view[: len(data_bytes)] = data_bytes
+                memory_obj = self.reshape_partial_chunk(memory_obj, len(data_bytes))
+
+            return memory_obj
+
+        except Exception as e:
+            if DocumentNotFoundException and isinstance(e, DocumentNotFoundException):
+                # Key doesn't exist - this is normal
+                return None
+            else:
+                logger.error(f"Error retrieving key {key_str}: {str(e)}")
+                return None
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        """Store data in Couchbase."""
+        key_str = self._get_key_string(key)
+        metadata_key = key_str + METADATA_KEY_SUFFIX
+        data_key = key_str + DATA_KEY_SUFFIX
+
+        try:
+            # Prepare data
+            kv_bytes = memory_obj.byte_array
+
+            if self.save_chunk_meta:
+                # Store metadata
+                kv_shape = memory_obj.get_shape()
+                kv_dtype = memory_obj.get_dtype()
+                memory_format = memory_obj.get_memory_format()
+
+                metadata_bytes = RemoteMetadata(
+                    len(kv_bytes), kv_shape, kv_dtype, memory_format
+                ).serialize()
+
+                await self.loop.run_in_executor(
+                    None, lambda: self.collection.upsert(metadata_key, metadata_bytes)
+                )
+
+            # Store actual data
+            await self.loop.run_in_executor(
+                None, lambda: self.collection.upsert(data_key, kv_bytes)
+            )
+
+        except Exception as e:
+            logger.error(f"Error storing key {key_str}: {str(e)}")
+            raise
+        finally:
+            # Always decrease reference count
+            memory_obj.ref_count_down()
+
+    async def list(self) -> List[str]:
+        """List all keys in Couchbase collection."""
+        try:
+            # Use N1QL query to get all document keys
+            query = (
+                f"SELECT META().id FROM "
+                f"`{self.bucket_name}`.`{self.scope_name}`.`{self.collection_name}`"
+            )
+
+            result = await self.loop.run_in_executor(
+                None, lambda: self.cluster.query(query)
+            )
+
+            keys = []
+            for row in result:
+                doc_id = row["id"]
+                # Filter out metadata keys and extract base keys
+                if doc_id.endswith(DATA_KEY_SUFFIX):
+                    base_key = doc_id[: -len(DATA_KEY_SUFFIX)]
+                    keys.append(base_key)
+
+            return keys
+
+        except Exception as e:
+            logger.error(f"Error listing keys: {str(e)}")
+            return []
+
+    async def close(self):
+        """Clean up Couchbase connection."""
+        try:
+            await self.loop.run_in_executor(None, lambda: self.cluster.close())
+            logger.info("Closed Couchbase connection")
+        except Exception as e:
+            logger.error(f"Error closing Couchbase connection: {str(e)}")
+
+    def support_ping(self) -> bool:
+        """Couchbase supports health checks."""
+        return True
+
+    async def ping(self) -> int:
+        """Perform health check on Couchbase connection."""
+        try:
+            # Use bucket ping for health check
+            result = await self.loop.run_in_executor(None, lambda: self.bucket.ping())
+            # Return 0 for success, non-zero for failure
+            return 0 if result else 1
+        except Exception:
+            return 1
+
+    def support_batched_get(self) -> bool:
+        """Couchbase supports batch operations."""
+        return True
+
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
+        """Retrieve multiple keys in batch from Couchbase."""
+        # For simplicity, implement as sequential gets
+        # Could be optimized with Couchbase's multi-get operations
+        results = []
+        for key in keys:
+            result = await self.get(key)
+            results.append(result)
+        return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,97 @@ class MockRedisSentinel:
         return self.redis
 
 
+class MockCouchbaseCollection:
+    """Mock Couchbase collection for testing."""
+
+    def __init__(self):
+        self.data = {}
+
+    def exists(self, key):
+        """Mock exists operation."""
+
+        class ExistsResult:
+            def __init__(self, exists):
+                self.exists = exists
+
+        return ExistsResult(key in self.data)
+
+    def get(self, key):
+        """Mock get operation."""
+        if key not in self.data:
+            # Import here to avoid circular imports
+            try:
+                # First Party
+                from lmcache.v1.storage_backend.connector.couchbase_connector import (
+                    DocumentNotFoundException,
+                )
+
+                if DocumentNotFoundException:
+                    raise DocumentNotFoundException()
+            except Exception:
+                pass
+            raise Exception("Document not found")
+
+        class GetResult:
+            def __init__(self, data):
+                self.content_as = {bytes: data, dict: data}
+
+        return GetResult(self.data[key])
+
+    def upsert(self, key, value):
+        """Mock upsert operation."""
+        self.data[key] = value
+
+    def remove(self, key):
+        """Mock remove operation."""
+        if key in self.data:
+            del self.data[key]
+
+
+class MockCouchbaseScope:
+    """Mock Couchbase scope for testing."""
+
+    def __init__(self):
+        self._collection = MockCouchbaseCollection()
+
+    def collection(self, name):
+        return self._collection
+
+
+class MockCouchbaseBucket:
+    """Mock Couchbase bucket for testing."""
+
+    def __init__(self):
+        self._scope = MockCouchbaseScope()
+
+    def scope(self, name):
+        return self._scope
+
+    def ping(self):
+        """Mock ping operation."""
+        return True
+
+
+class MockCouchbaseCluster:
+    """Mock Couchbase cluster for testing."""
+
+    def __init__(self, connection_string, options=None):
+        self.connection_string = connection_string
+        self.options = options
+        self._bucket = MockCouchbaseBucket()
+
+    def bucket(self, name):
+        return self._bucket
+
+    def query(self, query_str):
+        """Mock N1QL query for list operations."""
+        return []
+
+    def close(self):
+        """Mock close operation."""
+        pass
+
+
 @dataclass
 class LMCacheServerProcess:
     server_url: str
@@ -208,6 +299,36 @@ def mock_redis():
 def mock_redis_sentinel():
     with patch("redis.Sentinel", MockRedisSentinel) as mock:
         yield mock
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_couchbase():
+    """Mock the Couchbase SDK components."""
+    with (
+        patch(
+            "lmcache.v1.storage_backend.connector.couchbase_connector.Cluster",
+            MockCouchbaseCluster,
+        ),
+        patch(
+            (
+                "lmcache.v1.storage_backend.connector"
+                ".couchbase_connector.PasswordAuthenticator"
+            ),
+            lambda x, y: None,
+        ),
+        patch(
+            ("lmcache.v1.storage_backend.connector.couchbase_connector.ClusterOptions"),
+            lambda x: None,
+        ),
+        patch(
+            (
+                "lmcache.v1.storage_backend.connector"
+                ".couchbase_connector.DocumentNotFoundException"
+            ),
+            Exception,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture(scope="module")

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -72,6 +72,68 @@ def test_lm_connector(url, autorelease_v1, lmserver_v1_process):
     memory_allocator.close()
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "couchbase://localhost:8091",
+        "couchbase://user:password@localhost:8091?bucket=testbucket",
+        "couchbase://localhost:8091?bucket=lmcache&scope=cache&collection=kv",
+        "couchbases://user:password@secure.example.com:18091?bucket=secure",
+    ],
+)
+def test_couchbase_connector_basic(url, autorelease_v1):
+    """Test Couchbase connector: exists, put, get operations.
+
+    This test uses the MockCouchbaseCluster from conftest.py to simulate
+    Couchbase behavior without requiring an actual Couchbase server.
+    """
+
+    async_loop, async_thread = init_asyncio_loop()
+    memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+
+    random_key = dumb_cache_engine_key()
+
+    # Test 1: Verify key doesn't exist initially
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert not future.result()
+
+    # Test 2: Create and store test data
+    num_tokens = 1000
+    mem_obj_shape = [2, 32, num_tokens, 1024]
+    dtype = torch.bfloat16
+    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj.ref_count_up()
+
+    torch.manual_seed(42)
+    test_tensor = torch.randint(0, 100, memory_obj.raw_data.shape, dtype=torch.int64)
+    memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+    # Test 3: Put data
+    future = asyncio.run_coroutine_threadsafe(
+        connector.put(random_key, memory_obj), async_loop
+    )
+    future.result()
+
+    # Test 4: Verify key exists after putting data
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert future.result()
+    assert memory_obj.get_ref_count() == 1
+
+    # Test 5: Retrieve and verify data
+    future = asyncio.run_coroutine_threadsafe(connector.get(random_key), async_loop)
+    retrieved_memory_obj = future.result()
+
+    check_mem_obj_equal(
+        [retrieved_memory_obj],
+        [memory_obj],
+    )
+
+    close_asyncio_loop(async_loop, async_thread)
+
+    memory_allocator.close()
+
+
 @pytest.mark.parametrize("full_chunk", [True, False])
 @pytest.mark.parametrize("save_chunk_meta", [True, False])
 @pytest.mark.parametrize("use_mla", [True, False])
@@ -238,6 +300,68 @@ def test_redis_connector(url, autorelease_v1):
 @pytest.mark.parametrize(
     "url",
     [
+        "couchbase://localhost:8091",
+        "couchbase://user:password@localhost:8091?bucket=testbucket",
+        "couchbase://localhost:8091?bucket=lmcache&scope=cache&collection=kv",
+        "couchbases://user:password@secure.example.com:18091?bucket=secure",
+    ],
+)
+def test_couchbase_connector_operations(url, autorelease_v1):
+    """Test Couchbase connector: exists, put, get operations.
+
+    This test uses the MockCouchbaseCluster from conftest.py to simulate
+    Couchbase behavior without requiring an actual Couchbase server.
+    """
+
+    async_loop, async_thread = init_asyncio_loop()
+    memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+
+    random_key = dumb_cache_engine_key()
+
+    # Test 1: Verify key doesn't exist initially
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert not future.result()
+
+    # Test 2: Create and store test data
+    num_tokens = 1000
+    mem_obj_shape = [2, 32, num_tokens, 1024]
+    dtype = torch.bfloat16
+    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj.ref_count_up()
+
+    torch.manual_seed(42)
+    test_tensor = torch.randint(0, 100, memory_obj.raw_data.shape, dtype=torch.int64)
+    memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+    # Test 3: Put data
+    future = asyncio.run_coroutine_threadsafe(
+        connector.put(random_key, memory_obj), async_loop
+    )
+    future.result()
+
+    # Test 4: Verify key exists after putting data
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert future.result()
+    assert memory_obj.get_ref_count() == 1
+
+    # Test 5: Retrieve and verify data
+    future = asyncio.run_coroutine_threadsafe(connector.get(random_key), async_loop)
+    retrieved_memory_obj = future.result()
+
+    check_mem_obj_equal(
+        [retrieved_memory_obj],
+        [memory_obj],
+    )
+
+    close_asyncio_loop(async_loop, async_thread)
+
+    memory_allocator.close()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
         "redis-sentinel://localhost:26379,localhost:26380,localhost:26381",
         "redis-sentinel://user:password@localhost:26379,localhost:26380",
         "redis-sentinel://localhost:26379",
@@ -291,6 +415,68 @@ def test_redis_sentinel_connector(url, autorelease_v1):
     # Test 5: Retrieve and verify data
     future = asyncio.run_coroutine_threadsafe(connector.get(random_key), async_loop)
     future.result()
+
+    close_asyncio_loop(async_loop, async_thread)
+
+    memory_allocator.close()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "couchbase://localhost:8091",
+        "couchbase://user:password@localhost:8091?bucket=testbucket",
+        "couchbase://localhost:8091?bucket=lmcache&scope=cache&collection=kv",
+        "couchbases://user:password@secure.example.com:18091?bucket=secure",
+    ],
+)
+def test_couchbase_connector_advanced(url, autorelease_v1):
+    """Test Couchbase connector: exists, put, get operations.
+
+    This test uses the MockCouchbaseCluster from conftest.py to simulate
+    Couchbase behavior without requiring an actual Couchbase server.
+    """
+
+    async_loop, async_thread = init_asyncio_loop()
+    memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+
+    random_key = dumb_cache_engine_key()
+
+    # Test 1: Verify key doesn't exist initially
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert not future.result()
+
+    # Test 2: Create and store test data
+    num_tokens = 1000
+    mem_obj_shape = [2, 32, num_tokens, 1024]
+    dtype = torch.bfloat16
+    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj.ref_count_up()
+
+    torch.manual_seed(42)
+    test_tensor = torch.randint(0, 100, memory_obj.raw_data.shape, dtype=torch.int64)
+    memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+    # Test 3: Put data
+    future = asyncio.run_coroutine_threadsafe(
+        connector.put(random_key, memory_obj), async_loop
+    )
+    future.result()
+
+    # Test 4: Verify key exists after putting data
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert future.result()
+    assert memory_obj.get_ref_count() == 1
+
+    # Test 5: Retrieve and verify data
+    future = asyncio.run_coroutine_threadsafe(connector.get(random_key), async_loop)
+    retrieved_memory_obj = future.result()
+
+    check_mem_obj_equal(
+        [retrieved_memory_obj],
+        [memory_obj],
+    )
 
     close_asyncio_loop(async_loop, async_thread)
 


### PR DESCRIPTION
## Summary
- Add Couchbase adapter and connector implementation for storage backend
- Implement CouchbaseAdapter with get/put/contains operations 
- Add CouchbaseConnector with connection management and configuration
- Add comprehensive tests for both adapter and connector functionality
- Update connector __init__.py to expose new Couchbase classes

## Changes
- **New file**: `lmcache/v1/storage_backend/connector/couchbase_adapter.py` - Core Couchbase operations adapter
- **New file**: `lmcache/v1/storage_backend/connector/couchbase_connector.py` - Couchbase connection management
- **Modified**: `lmcache/v1/storage_backend/connector/__init__.py` - Export new Couchbase classes
- **Modified**: `tests/conftest.py` - Add Couchbase test fixtures and configuration
- **Modified**: `tests/v1/test_connector.py` - Add comprehensive Couchbase connector tests

## Test plan
- [x] Unit tests for CouchbaseAdapter operations (get, put, contains)
- [x] Unit tests for CouchbaseConnector connection management
- [x] Integration tests with mocked Couchbase cluster
- [x] Error handling and edge case testing
- [x] Configuration validation testing

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

To create a new tag for lmcache (Note: `v` prefix is required):
`git tag vx.x.x`
`git push origin vx.x.x` (same version again)

For example:
`git tag v0.3.0`
`git push origin v0.3.0`

In case the workflow fails, delete the tag and try again:
`git tag -d vx.x.x`
`git push origin :refs/tags/vx.x.x`

For example:
`git tag -d v0.3.0`
`git push origin :refs/tags/v0.3.0`

To create a new release and publish `lmcache` Python package to PyPi:
`git remote add upstream git@github.com:LMCache/LMCache.git`
`gh release create vx.x.x --repo LMCache/LMCache --title "vx.x.x" --notes "<Add description>"`

For example:
`git remote add upstream git@github.com:LMCache/LMCache.git`
`gh release create v0.3.0 --repo LMCache/LMCache --title "v0.3.0" --notes "LMCache v0.3.0 is a feature release. Users are encouraged to upgrade for the best experience."`

> [!TIP]
> The creation of a release and subsequent tag generation can be done alternatively from the LMCache [releases](https://github.com/LMCache/LMCache/releases) page.

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
