### PR TITLE
Lmcache internal api server for metrics export

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -151,13 +151,10 @@ class LMCacheEngine:
             gc.disable()
 
         # Start api server
-        if config.cache_engine_internal_api_server_enabled:
+        if config.cache_engine_internal_api_server_enabled and metadata.worker_id == 0:
             # TODO(baoloongmao): support create api servers for each worker.
-            api_port = config.cache_engine_internal_api_server_port_start
-            logger.info(f"Starting cache engine internal API server on port {api_port}")
-            self.api_server = CacheEngineInternalAPIServer(api_port)
+            self.api_server = CacheEngineInternalAPIServer(config)
             self.api_server.start()
-            logger.info(f"Started cache engine internal API server on port {api_port}")
 
     def post_init(self, **kwargs) -> None:
         if not self.post_inited:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -144,17 +144,18 @@ class LMCacheEngine:
         InitializeUsageContext(config.to_original_config(), metadata)
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
 
+        if config.cache_engine_internal_api_server_enabled and metadata.worker_id == 0:
+            # TODO(baoloongmao): support create api servers for each worker.
+            self.api_server = CacheEngineInternalAPIServer(config)
+            self.api_server.start()
+        else:
+            self.api_server = None
+
         self.post_inited = False
 
         gc.collect()
         if not config.py_enable_gc:
             gc.disable()
-
-        # Start api server
-        if config.cache_engine_internal_api_server_enabled and metadata.worker_id == 0:
-            # TODO(baoloongmao): support create api servers for each worker.
-            self.api_server = CacheEngineInternalAPIServer(config)
-            self.api_server.start()
 
     def post_init(self, **kwargs) -> None:
         if not self.post_inited:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -16,6 +16,7 @@ from lmcache.logging import init_logger
 from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
+from lmcache.v1.cache_engine_internal_api_server import CacheEngineInternalAPIServer
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.distributed_server import (
     DistributedServerInterface,
@@ -148,6 +149,15 @@ class LMCacheEngine:
         gc.collect()
         if not config.py_enable_gc:
             gc.disable()
+
+        # Start api server
+        if config.cache_engine_internal_api_server_enabled:
+            # TODO(baoloongmao): support create api servers for each worker.
+            api_port = config.cache_engine_internal_api_server_port_start
+            logger.info(f"Starting cache engine internal API server on port {api_port}")
+            self.api_server = CacheEngineInternalAPIServer(api_port)
+            self.api_server.start()
+            logger.info(f"Started cache engine internal API server on port {api_port}")
 
     def post_init(self, **kwargs) -> None:
         if not self.post_inited:
@@ -876,6 +886,11 @@ class LMCacheEngine:
         self.storage_manager.close()
 
         self.memory_allocator.close()
+
+        # Stop the API server
+        if self.api_server is not None:
+            self.api_server.stop()
+            logger.info("LMCache API server stopped")
 
         logger.info("LMCacheEngine closed.")
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -887,7 +887,6 @@ class LMCacheEngine:
         # Stop the API server
         if self.api_server is not None:
             self.api_server.stop()
-            logger.info("LMCache API server stopped")
 
         logger.info("LMCacheEngine closed.")
 

--- a/lmcache/v1/cache_engine_internal_api_server.py
+++ b/lmcache/v1/cache_engine_internal_api_server.py
@@ -40,10 +40,10 @@ class CacheEngineInternalAPIServer:
         await self.server.serve()
 
     def start(self):
-        logger.info(f"Starting API server on port {self.port}")
+        logger.info(f"Starting lmcache internal API server on port {self.port}")
         threading.Thread(target=asyncio.run, args=(self.run(),), daemon=True).start()
 
     def stop(self):
-        logger.info("Stopping LMCache API server")
+        logger.info("Stopping LMCache internal API server")
         if self.server:
             self.server.should_exit = True

--- a/lmcache/v1/cache_engine_internal_api_server.py
+++ b/lmcache/v1/cache_engine_internal_api_server.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+
+# Third Party
+from prometheus_client import REGISTRY, Gauge, generate_latest
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    def do_get(self):
+        if self.path == "/metrics":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(generate_latest(REGISTRY))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+class CacheEngineInternalAPIServer:
+    def __init__(self, port: int):
+        self.port = port
+        self.server = HTTPServer(("0.0.0.0", self.port), MetricsHandler)
+        self.thread = threading.Thread(target=self.run, daemon=True)
+
+        self.cache_hit_rate = Gauge(
+            "lmcache_internal_cache_hit_rate", "Current cache hit rate"
+        )
+        self.local_cache_usage = Gauge(
+            "lmcache_internal_local_cache_usage_bytes", "Local cache usage in bytes"
+        )
+
+        self.cache_hit_rate.set(0.85)
+        self.local_cache_usage.set(1024 * 1024)
+
+    def run(self):
+        logger.info(f"Starting LMCache API server on port {self.port}")
+        self.server.serve_forever()
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        self.server.shutdown()

--- a/lmcache/v1/cache_engine_internal_api_server.py
+++ b/lmcache/v1/cache_engine_internal_api_server.py
@@ -1,51 +1,112 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from http.server import BaseHTTPRequestHandler, HTTPServer
 import threading
+import time
 
 # Third Party
-from prometheus_client import REGISTRY, Gauge, generate_latest
+from fastapi import FastAPI
+from prometheus_client import REGISTRY, generate_latest, make_asgi_app
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.routing import Mount
+from starlette.types import ASGIApp, Receive, Scope, Send
+import prometheus_client
+import regex as re
+import uvicorn
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.config import LMCacheEngineConfig
 
 logger = init_logger(__name__)
 
+app = FastAPI()
 
-class MetricsHandler(BaseHTTPRequestHandler):
-    def do_get(self):
-        if self.path == "/metrics":
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.end_headers()
-            self.wfile.write(generate_latest(REGISTRY))
-        else:
-            self.send_response(404)
-            self.end_headers()
+
+class PrometheusResponse(Response):
+    media_type = prometheus_client.CONTENT_TYPE_LATEST
+
+
+def mount_metrics(app: FastAPI, ttl: int = 0):
+    """Mount prometheus metrics to a FastAPI app."""
+
+    class MetricsCacheMiddleware:
+        def __init__(self, app: ASGIApp):
+            self.app = app
+            self.cached_data = None
+            self.last_update = 0
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send):
+            if scope["path"] == "/metrics":
+                current_time = time.time()
+                if current_time - self.last_update >= ttl:
+                    gen_start = time.perf_counter()
+                    # filter registry to only include lmcache metrics
+                    filtered_registry = REGISTRY.restricted_registry(
+                        [
+                            name
+                            for name in REGISTRY._names_to_collectors
+                            if name.startswith("lmcache")
+                        ]
+                    )
+                    self.cached_data = generate_latest(filtered_registry)
+                    gen_time = (time.perf_counter() - gen_start) * 1000
+                    logger.debug(f"Metrics generation time: {gen_time:.2f}ms")
+
+                    self.last_update = current_time
+                else:
+                    logger.info("Using cached metrics")
+                response = PlainTextResponse(
+                    content=self.cached_data,
+                    media_type=prometheus_client.CONTENT_TYPE_LATEST,
+                )
+                await response(scope, receive, send)
+            else:
+                await self.app(scope, receive, send)
+
+    app.add_middleware(MetricsCacheMiddleware)
+    metrics_route = Mount("/metrics", make_asgi_app())
+
+    # Workaround for 307 Redirect for /metrics
+    metrics_route.path_regex = re.compile("^/metrics(?P<path>.*)$")
+    app.routes.append(metrics_route)
+
+
+@app.get("/test")
+async def get_metrics(request: Request):
+    logger.info(f"Test request {request}")
+    return PlainTextResponse(content="Success", media_type="text/plain")
 
 
 class CacheEngineInternalAPIServer:
-    def __init__(self, port: int):
-        self.port = port
-        self.server = HTTPServer(("0.0.0.0", self.port), MetricsHandler)
+    def __init__(self, config: LMCacheEngineConfig):
         self.thread = threading.Thread(target=self.run, daemon=True)
-
-        self.cache_hit_rate = Gauge(
-            "lmcache_internal_cache_hit_rate", "Current cache hit rate"
+        self.port = config.cache_engine_internal_api_server_port_start
+        ttl = config.cache_engine_internal_api_server_metrics_ttl
+        mount_metrics(app, ttl)
+        logger.info(
+            f"Starting cache engine internal API server on port {self.port}, ttl {ttl}"
         )
-        self.local_cache_usage = Gauge(
-            "lmcache_internal_local_cache_usage_bytes", "Local cache usage in bytes"
-        )
-
-        self.cache_hit_rate.set(0.85)
-        self.local_cache_usage.set(1024 * 1024)
 
     def run(self):
         logger.info(f"Starting LMCache API server on port {self.port}")
-        self.server.serve_forever()
+        config = uvicorn.Config(
+            app,
+            host="0.0.0.0",
+            port=self.port,
+            log_config=None,
+            access_log=False,
+            timeout_keep_alive=60,
+            workers=10,
+            loop="uvloop",
+            http="httptools",
+            limit_concurrency=100,
+        )
+        server = uvicorn.Server(config)
+        server.run()
 
     def start(self):
         self.thread.start()
 
     def stop(self):
-        self.server.shutdown()
+        logger.info("LMCache API server stopped")

--- a/lmcache/v1/cache_engine_internal_api_server.py
+++ b/lmcache/v1/cache_engine_internal_api_server.py
@@ -1,17 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import asyncio
 import threading
-import time
 
 # Third Party
 from fastapi import FastAPI
-from prometheus_client import REGISTRY, generate_latest, make_asgi_app
+from prometheus_client import REGISTRY, generate_latest
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response
-from starlette.routing import Mount
-from starlette.types import ASGIApp, Receive, Scope, Send
-import prometheus_client
-import regex as re
+from starlette.responses import PlainTextResponse
 import uvicorn
 
 # First Party
@@ -23,90 +19,31 @@ logger = init_logger(__name__)
 app = FastAPI()
 
 
-class PrometheusResponse(Response):
-    media_type = prometheus_client.CONTENT_TYPE_LATEST
-
-
-def mount_metrics(app: FastAPI, ttl: int = 0):
-    """Mount prometheus metrics to a FastAPI app."""
-
-    class MetricsCacheMiddleware:
-        def __init__(self, app: ASGIApp):
-            self.app = app
-            self.cached_data = None
-            self.last_update = 0
-
-        async def __call__(self, scope: Scope, receive: Receive, send: Send):
-            if scope["path"] == "/metrics":
-                current_time = time.time()
-                if current_time - self.last_update >= ttl:
-                    gen_start = time.perf_counter()
-                    # filter registry to only include lmcache metrics
-                    filtered_registry = REGISTRY.restricted_registry(
-                        [
-                            name
-                            for name in REGISTRY._names_to_collectors
-                            if name.startswith("lmcache")
-                        ]
-                    )
-                    self.cached_data = generate_latest(filtered_registry)
-                    gen_time = (time.perf_counter() - gen_start) * 1000
-                    logger.debug(f"Metrics generation time: {gen_time:.2f}ms")
-
-                    self.last_update = current_time
-                else:
-                    logger.info("Using cached metrics")
-                response = PlainTextResponse(
-                    content=self.cached_data,
-                    media_type=prometheus_client.CONTENT_TYPE_LATEST,
-                )
-                await response(scope, receive, send)
-            else:
-                await self.app(scope, receive, send)
-
-    app.add_middleware(MetricsCacheMiddleware)
-    metrics_route = Mount("/metrics", make_asgi_app())
-
-    # Workaround for 307 Redirect for /metrics
-    metrics_route.path_regex = re.compile("^/metrics(?P<path>.*)$")
-    app.routes.append(metrics_route)
-
-
-@app.get("/test")
+@app.get("/metrics")
 async def get_metrics(request: Request):
-    logger.info(f"Test request {request}")
-    return PlainTextResponse(content="Success", media_type="text/plain")
+    metrics_data = generate_latest(REGISTRY)
+    return PlainTextResponse(content=metrics_data, media_type="text/plain")
 
 
 class CacheEngineInternalAPIServer:
     def __init__(self, config: LMCacheEngineConfig):
-        self.thread = threading.Thread(target=self.run, daemon=True)
         self.port = config.cache_engine_internal_api_server_port_start
-        ttl = config.cache_engine_internal_api_server_metrics_ttl
-        mount_metrics(app, ttl)
-        logger.info(
-            f"Starting cache engine internal API server on port {self.port}, ttl {ttl}"
-        )
-
-    def run(self):
-        logger.info(f"Starting LMCache API server on port {self.port}")
+        logger.info(f"Init cache engine internal API server on port {self.port}")
         config = uvicorn.Config(
-            app,
-            host="0.0.0.0",
-            port=self.port,
-            log_config=None,
-            access_log=False,
-            timeout_keep_alive=60,
-            workers=10,
-            loop="uvloop",
-            http="httptools",
-            limit_concurrency=100,
+            app, host="0.0.0.0", port=self.port, loop="uvloop", http="httptools"
         )
         server = uvicorn.Server(config)
-        server.run()
+        self.server = server
+
+    async def run(self):
+        logger.info(f"Running LMCache API server on port {self.port}")
+        await self.server.serve()
 
     def start(self):
-        self.thread.start()
+        logger.info(f"Starting API server on port {self.port}")
+        threading.Thread(target=asyncio.run, args=(self.run(),), daemon=True).start()
 
     def stop(self):
-        logger.info("LMCache API server stopped")
+        logger.info("Stopping LMCache API server")
+        if self.server:
+            self.server.should_exit = True

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -217,6 +217,16 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": "LRU",
         "env_converter": str,
     },
+    "cache_engine_internal_api_server_enabled": {
+        "type": bool,
+        "default": False,
+        "env_converter": lambda x: x.lower() in ["true", "1"],
+    },
+    "cache_engine_internal_api_server_port_start": {
+        "type": int,
+        "default": 7000,
+        "env_converter": int,
+    },
 }
 
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -227,6 +227,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": 7000,
         "env_converter": int,
     },
+    "cache_engine_internal_api_server_metrics_ttl": {
+        "type": int,
+        "default": 30,
+        "env_converter": int,
+    },
 }
 
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -227,11 +227,6 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": 7000,
         "env_converter": int,
     },
-    "cache_engine_internal_api_server_metrics_ttl": {
-        "type": int,
-        "default": 30,
-        "env_converter": int,
-    },
 }
 
 


### PR DESCRIPTION
# Description

Fix https://github.com/LMCache/LMCache/issues/1212

This PR introduce a lmcache internal api server. It exports lmcache metrics by `http://localhost:7000/metrics` by default.

The first step of this PR takes effect on worker 0 first, I can support start lmcache internal apiserver for each worker as a followup task of this.

# Motivation

- Set env variable `PROMETHEUS_MULTIPROC_DIR` may encountered  issue of `No such file or directory: ""/tmp/lmcache_prometheus"/gauge all xxx.db`
<img width="1109" height="746" alt="bbbc190bafaa79b5207fe9ad616b99ce" src="https://github.com/user-attachments/assets/ab54b791-315b-4f70-a719-b7983eff6fd2" />
And we have no idea about how to solve this issue.
- We have a lot of metrics want to add to insight the state of lmcache, but we worry about affect the performance.
- Yet another way to solve https://github.com/LMCache/LMCache/issues/621
- Supply a way to interact with lmcache worker directly.

# Test

- lmcache.yaml
```yaml
cache_engine_internal_api_server_enabled: True
cache_engine_internal_api_server_port_start: 12345
cache_engine_internal_api_server_metrics_ttl: 30
```

- Tested by curl
```shell
curl http://localhost:12345/metrics
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="12",patchlevel="3",version="3.12.3"} 1.0
# HELP lmcache:num_retrieve_requests_total Total number of retrieve requests sent to lmcache
# TYPE lmcache:num_retrieve_requests_total counter
lmcache:num_retrieve_requests_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_retrieve_requests_created Total number of retrieve requests sent to lmcache
# TYPE lmcache:num_retrieve_requests_created gauge
lmcache:num_retrieve_requests_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.754997400236777e+09
# HELP lmcache:num_store_requests_total Total number of store requests sent to lmcache
# TYPE lmcache:num_store_requests_total counter
lmcache:num_store_requests_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_store_requests_created Total number of store requests sent to lmcache
# TYPE lmcache:num_store_requests_created gauge
lmcache:num_store_requests_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.7549974002368026e+09
# HELP lmcache:num_requested_tokens_total Total number of tokens requested from lmcache
# TYPE lmcache:num_requested_tokens_total counter
lmcache:num_requested_tokens_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_requested_tokens_created Total number of tokens requested from lmcache
# TYPE lmcache:num_requested_tokens_created gauge
lmcache:num_requested_tokens_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.7549974002368128e+09
# HELP lmcache:num_hit_tokens_total Total number of tokens hit in lmcache
# TYPE lmcache:num_hit_tokens_total counter
lmcache:num_hit_tokens_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_hit_tokens_created Total number of tokens hit in lmcache
# TYPE lmcache:num_hit_tokens_created gauge
lmcache:num_hit_tokens_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.7549974002368212e+09
# HELP lmcache:num_remote_read_requests_total Total number of requests read from remote backends in lmcache
# TYPE lmcache:num_remote_read_requests_total counter
lmcache:num_remote_read_requests_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_remote_read_requests_created Total number of requests read from remote backends in lmcache
# TYPE lmcache:num_remote_read_requests_created gauge
lmcache:num_remote_read_requests_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.754997400236829e+09
# HELP lmcache:num_remote_read_bytes_total Total number of bytes read from remote backends in lmcache
# TYPE lmcache:num_remote_read_bytes_total counter
lmcache:num_remote_read_bytes_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_remote_read_bytes_created Total number of bytes read from remote backends in lmcache
# TYPE lmcache:num_remote_read_bytes_created gauge
lmcache:num_remote_read_bytes_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.754997400236836e+09
# HELP lmcache:num_remote_write_requests_total Total number of requests write to remote backends in lmcache
# TYPE lmcache:num_remote_write_requests_total counter
lmcache:num_remote_write_requests_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_remote_write_requests_created Total number of requests write to remote backends in lmcache
# TYPE lmcache:num_remote_write_requests_created gauge
lmcache:num_remote_write_requests_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.754997400236843e+09
# HELP lmcache:num_remote_write_bytes_total Total number of bytes write to remote backends in lmcache
# TYPE lmcache:num_remote_write_bytes_total counter
lmcache:num_remote_write_bytes_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:num_remote_write_bytes_created Total number of bytes write to remote backends in lmcache
# TYPE lmcache:num_remote_write_bytes_created gauge
lmcache:num_remote_write_bytes_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.75499740023685e+09
# HELP lmcache:cache_hit_rate Cache hit rate of lmcache since last log
# TYPE lmcache:cache_hit_rate gauge
lmcache:cache_hit_rate{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:local_cache_usage Local cache usage (bytes) of lmcache
# TYPE lmcache:local_cache_usage gauge
lmcache:local_cache_usage{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:remote_cache_usage Remote cache usage (bytes) of lmcache
# TYPE lmcache:remote_cache_usage gauge
lmcache:remote_cache_usage{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:local_storage_usage Local storage usage (bytes) of lmcache
# TYPE lmcache:local_storage_usage gauge
lmcache:local_storage_usage{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:time_to_retrieve Time to retrieve from lmcache (seconds)
# TYPE lmcache:time_to_retrieve histogram
# HELP lmcache:time_to_store Time to store to lmcache (seconds)
# TYPE lmcache:time_to_store histogram
# HELP lmcache:retrieve_speed Retrieve speed of lmcache (tokens per second)
# TYPE lmcache:retrieve_speed histogram
# HELP lmcache:store_speed Store speed of lmcache (tokens per second)
# TYPE lmcache:store_speed histogram
# HELP lmcache:remote_time_to_get Time to get from remote backends (ms)
# TYPE lmcache:remote_time_to_get histogram
# HELP lmcache:remote_time_to_put Time to put to remote backends (ms)
# TYPE lmcache:remote_time_to_put histogram
# HELP lmcache:remote_time_to_get_sync Time to get from remote backends synchronously(ms)
# TYPE lmcache:remote_time_to_get_sync histogram
# HELP lmcache:remote_ping_latency Latest ping latency to remote backends (ms)
# TYPE lmcache:remote_ping_latency gauge
lmcache:remote_ping_latency{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:remote_ping_errors_total Number of ping errors to remote backends
# TYPE lmcache:remote_ping_errors_total counter
lmcache:remote_ping_errors_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:remote_ping_errors_created Number of ping errors to remote backends
# TYPE lmcache:remote_ping_errors_created gauge
lmcache:remote_ping_errors_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.754997400236923e+09
# HELP lmcache:remote_ping_successes_total Number of ping successes to remote backends
# TYPE lmcache:remote_ping_successes_total counter
lmcache:remote_ping_successes_total{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
# HELP lmcache:remote_ping_successes_created Number of ping successes to remote backends
# TYPE lmcache:remote_ping_successes_created gauge
lmcache:remote_ping_successes_created{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 1.7549974002369285e+09
# HELP lmcache:remote_ping_error_code Latest ping error code to remote backends
# TYPE lmcache:remote_ping_error_code gauge
lmcache:remote_ping_error_code{model_name="/data1/DeepSeek-V2-Lite-Chat",worker_id="0"} 0.0
```