### PR TITLE
[Core] Support layerwise in PD disagg

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -173,6 +173,29 @@ class LayerCacheEngineKey(CacheEngineKey):
             f"@{self.worker_id}@{self.chunk_hash}@{self.layer_id}"
         )
 
+    def to_dict(self):
+        # Override parent's to_dict to include layer_id
+        return {
+            "__type__": "LayerCacheEngineKey",
+            "fmt": self.fmt,
+            "model_name": self.model_name,
+            "world_size": self.world_size,
+            "worker_id": self.worker_id,
+            "chunk_hash": self.chunk_hash,
+            "layer_id": self.layer_id,
+        }
+
+    @staticmethod
+    def from_dict(d):
+        return LayerCacheEngineKey(
+            fmt=d["fmt"],
+            model_name=d["model_name"],
+            world_size=d["world_size"],
+            worker_id=d["worker_id"],
+            chunk_hash=d["chunk_hash"],
+            layer_id=d["layer_id"],
+        )
+
     def split_layers(self, num_layers: int) -> List["LayerCacheEngineKey"]:
         """Split the key into multiple keys for each layer"""
         keys = []

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections import defaultdict
+from itertools import chain
 from typing import Dict, Generator, List, Optional, Tuple, Union
 import asyncio
 import gc
@@ -367,7 +368,17 @@ class LMCacheEngine:
             for layer_id in range(self.num_layers):
                 yield
                 next(mem_obj_generator)
-                self.storage_manager.batched_put(keys[layer_id], memory_objs[layer_id])
+                if not self.config.enable_nixl:
+                    self.storage_manager.batched_put(
+                        keys[layer_id], memory_objs[layer_id]
+                    )
+
+            # Note: batched put once for NixlBackend to avoid the duplicate flush.
+            if self.config.enable_nixl:
+                self.storage_manager.batched_put(
+                    list(chain.from_iterable(keys)),
+                    list(chain.from_iterable(memory_objs)),
+                )
         else:
             # If no cache are found, we still need to yield to avoid
             # `StopIteration`
@@ -578,6 +589,7 @@ class LMCacheEngine:
 
             ret_mask[start:end] = True
 
+        mem_obj_consumer = None
         if keys:
             # Transpose the keys into layer major format
             keys_layer_major = [list(row) for row in zip(*keys, strict=False)]
@@ -617,7 +629,8 @@ class LMCacheEngine:
         yield None
 
         # synchronize the last layer
-        next(mem_obj_consumer)
+        if mem_obj_consumer is not None:
+            next(mem_obj_consumer)
 
         retrieved_tokens = torch.sum(ret_mask)
         self.stats_monitor.on_retrieve_finished(monitor_req_id, retrieved_tokens)

--- a/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
+++ b/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
-from typing import Callable, Optional, Union
+from typing import Callable, List, Optional, Union
 import abc
 import threading
 import time
@@ -15,7 +15,7 @@ import zmq
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
+from lmcache.utils import CacheEngineKey, LayerCacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.memory_management import (
     MemoryAllocatorInterface,
     MemoryFormat,
@@ -103,10 +103,67 @@ class NixlBufferAllocator(MemoryAllocatorInterface):
         batch_size: int,
         fmt=MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = "nixl",
-    ):
-        raise NotImplementedError(
-            "Batched allocation is not supported in NIXL buffer allocator"
+    ) -> Optional[List[MemoryObj]]:
+        """
+        Batch allocate memory objects for multiple tensors with the same shape
+        and dtype. Raises an error if the batch size is larger than the NIXL
+        buffer capacity.
+
+        :param torch.Size shape: The shape of each tensor to allocate
+        :param torch.dtype dtype: The dtype of each tensor to allocate
+        :param int batch_size: Number of MemoryObj to allocate
+        :param MemoryFormat fmt: The format of the memory to allocate
+        :param str allocator_type: Type of allocator (unused, kept for
+        interface compatibility)
+
+        :return: List of MemoryObj wrapping the allocated memory
+        :rtype: Optional[List[MemoryObj]]
+        """
+        # Pre-calculate the size once
+        metadata = MemoryObjMetadata(
+            shape=shape,
+            dtype=dtype,
+            address=self.allocated_size,  # Will be updated for each object
+            phy_size=0,
+            ref_count=1,
+            fmt=fmt,
         )
+        required_size = metadata.get_size()
+        batched_required_size = required_size * batch_size
+
+        batch_start_idx = self.allocated_size
+        batch_end_idx = batch_start_idx + batched_required_size
+
+        # Check capacity once for the entire batch
+        assert batch_end_idx <= self.capacity, (
+            "The batch size is larger than the NIXL buffer capacity. "
+            "Consider decreasing `max_batched_tokens` in vllm config "
+            "or increasing `nixl_buffer_size` in lmcache config."
+        )
+
+        batch_buffer = self.buffer[batch_start_idx:batch_end_idx]
+        raw_datas = torch.chunk(batch_buffer, batch_size)
+
+        rets = [
+            TensorMemoryObj(
+                raw_data=raw_data,
+                metadata=MemoryObjMetadata(
+                    shape=shape,
+                    dtype=dtype,
+                    address=batch_start_idx + i * required_size,
+                    phy_size=0,
+                    ref_count=1,
+                    fmt=fmt,
+                ),
+                parent_allocator=self,
+            )
+            for i, raw_data in enumerate(raw_datas)
+        ]
+
+        # Update allocated size once for the entire batch
+        self.allocated_size += batched_required_size
+
+        return rets
 
     def free(self, obj: MemoryObj, allocator_type: Optional[str] = "nixl"):
         """Free the memory object."""
@@ -158,6 +215,8 @@ class NixlRequest:
         t = d["__type__"]
         if t == "CacheEngineKey":
             return CacheEngineKey.from_dict(d)
+        elif t == "LayerCacheEngineKey":
+            return LayerCacheEngineKey.from_dict(d)
         elif t == "MemoryObjMetadata":
             return MemoryObjMetadata.from_dict(d)
         elif t == "NixlRequest":
@@ -390,6 +449,27 @@ class NixlPipe:
         # and may be confusing
         return self._allocator.allocate(shape, dtype, fmt)
 
+    def batched_allocate_for_write(
+        self,
+        shape: torch.Size,
+        dtype: Optional[torch.dtype],
+        batch_size: int,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+    ) -> Optional[List[MemoryObj]]:
+        """
+        Batch allocate the memory for write.
+
+        :param torch.Size shape: The shape of each tensor to allocate
+        :param torch.dtype dtype: The dtype of each tensor to allocate
+        :param int batch_size: Number of MemoryObj to allocate
+        :param MemoryFormat fmt: The format of the memory to allocate
+        :param str allocator_type: Type of allocator (unused, kept
+        for interface compatibility)
+
+        :return: A list of MemoryObj if allocation is successful
+        """
+        return self._allocator.batched_allocate(shape, dtype, batch_size, fmt)
+
     @_lmcache_nvtx_annotate
     def flush(self):
         """Flush the buffer to the receiver side.
@@ -561,6 +641,19 @@ class NixlSender:
 
         self._added_payload_count += 1
         return self._pipe.allocate_for_write(shape, dtype, fmt)
+
+    def batched_allocate_for_send(
+        self,
+        shape: torch.Size,
+        dtype: Optional[torch.dtype],
+        batch_size: int,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+    ) -> Optional[List[MemoryObj]]:
+        """
+        Batch allocate the memory for send.
+        """
+        self._added_payload_count += batch_size
+        return self._pipe.batched_allocate_for_write(shape, dtype, batch_size, fmt)
 
     def _flush_send(self):
         """Flush the underlying pipe"""
@@ -884,6 +977,19 @@ class NixlChannel:
         """Allocate the memory for send."""
         sender = self._check_sender()
         return sender.allocate_for_send(shape, dtype, fmt)
+
+    def batched_allocate_for_send(
+        self,
+        shape: torch.Size,
+        dtype: Optional[torch.dtype],
+        batch_size: int,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+    ) -> Optional[List[MemoryObj]]:
+        """
+        Batch allocate the memory for send.
+        """
+        sender = self._check_sender()
+        return sender.batched_allocate_for_send(shape, dtype, batch_size, fmt)
 
     def finish_send(self):
         """Finish the send transaction by flushing the buffer."""

--- a/lmcache/v1/storage_backend/nixl_backend.py
+++ b/lmcache/v1/storage_backend/nixl_backend.py
@@ -171,10 +171,10 @@ class RecvObjPool:
             return ret
 
     def pin(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError
+        return True
 
     def unpin(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError
+        return True
 
 
 class BasicNixlObserver(NixlObserverInterface):
@@ -316,6 +316,25 @@ class NixlBackend(StorageBackendInterface):
         assert ret is not None, "Failed to allocate zero-copy buffer from nixl_channel"
         return ret
 
+    def batched_allocate(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        batch_size: int,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        eviction: bool = False,
+    ) -> Optional[List[MemoryObj]]:
+        """
+        Batched allocate a zero-copy write object for the given shape and dtype.
+        """
+        self._num_payload_added += batch_size
+
+        rets = self._nixl_channel.batched_allocate_for_send(
+            shape=shape, dtype=dtype, batch_size=batch_size, fmt=fmt
+        )
+        assert rets is not None, "Failed to allocate zero-copy buffer from nixl_channel"
+        return rets
+
     def flush_put_tasks(self) -> None:
         """
         Flush the registered tasks
@@ -367,7 +386,19 @@ class NixlBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
     ) -> Optional[Future]:
-        raise NotImplementedError
+        """
+        Non-blocking get function. Return the dummy future object.
+
+        :param key: The key of the MemoryObj.
+
+        :return: MemoryObj. None if the key does not exist.
+        """
+        memory_obj = self._obj_pool.get(key)
+        if memory_obj is None:
+            return None
+        f: Future = Future()
+        f.set_result(memory_obj)
+        return f
 
     def remove(self, key: CacheEngineKey, force=True) -> bool:
         """
@@ -390,10 +421,22 @@ class NixlBackend(StorageBackendInterface):
         return self._nixl_channel.get_allocator()
 
     def pin(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError
+        """Pin the key in the storage backend.
+
+        :param key: The key to pin.
+
+        :return: True if the key is pinned, False otherwise.
+        """
+        return self._obj_pool.pin(key)
 
     def unpin(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError
+        """Unpin the key in the storage backend.
+
+        :param key: The key to unpin.
+
+        :return: True if the key is unpinned, False otherwise.
+        """
+        return self._obj_pool.unpin(key)
 
     @staticmethod
     def CreateNixlBackend(

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,5 @@ pytest-benchmark
 pytest-benchmark[histogram]
 pytest-cov
 pytest-html>=3.2,<5.0  # 4.x requires external assets; 3.2 is stable
-jinja2<3.2     
+jinja2<3.2
+msgpack==1.1.1

--- a/tests/v1/storage_backend/connector/test_nixl_connector_v2.py
+++ b/tests/v1/storage_backend/connector/test_nixl_connector_v2.py
@@ -135,7 +135,6 @@ class TestNixlPipeBatchedAllocateForWrite:
 
     def test_batched_allocate_for_write_success(self, mock_nixl_pipe):
         """Test successful batch allocation for write."""
-        # Arrange
         shape = torch.Size([2, 16, 8, 128])
         dtype = torch.bfloat16
         batch_size = 4

--- a/tests/v1/storage_backend/connector/test_nixl_connector_v2.py
+++ b/tests/v1/storage_backend/connector/test_nixl_connector_v2.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Optional
+from unittest.mock import MagicMock, patch
+import types
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+
+
+class MockNixlAgent:
+    """Mock NIXL agent for testing."""
+
+    def __init__(self):
+        self.registered_memory = []
+        self.remote_agents = {}
+        self.dlist_handles = {}
+        self.xfer_handles = {}
+        self.notifications = []
+
+    def register_memory(
+        self,
+        reg_list,
+        mem_type: Optional[str] = None,
+        is_sorted: bool = False,
+        backends: Optional[list[str]] = None,
+    ):
+        """Register memory with the NIXL agent."""
+        self.registered_memory.append(reg_list)
+        mock_desc = MagicMock()
+        mock_desc.trim.return_value = MagicMock()
+        return mock_desc
+
+    def deregister_memory(self, dereg_list, backends: Optional[list[str]] = None):
+        """Deregister memory from the NIXL agent."""
+        if dereg_list in self.registered_memory:
+            self.registered_memory.remove(dereg_list)
+
+    def get_serialized_descs(self, descs) -> bytes:
+        """Get serialized descriptors."""
+        return b"mock_serialized_descs"
+
+    def get_agent_metadata(self):
+        """Get agent metadata."""
+        return b"mock_agent_metadata"
+
+    def add_remote_agent(self, metadata: bytes) -> bytes:
+        """Add a remote agent."""
+        peer_name = "mock_peer_name"
+        self.remote_agents[peer_name] = metadata
+        return peer_name.encode("utf-8")
+
+    def remove_remote_agent(self, peer_name):
+        """Remove a remote agent."""
+        if peer_name in self.remote_agents:
+            del self.remote_agents[peer_name]
+
+
+class MockSideChannel:
+    """Mock side channel for testing."""
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        """Close the side channel."""
+        self.closed = True
+
+    def send(self, data: bytes):
+        """Send data to the specific sender."""
+        pass
+
+
+@pytest.fixture
+def mock_nixl_config():
+    """Create a mock NixlConfig for testing."""
+    nixl_pkg = types.ModuleType("nixl")
+    nixl_pkg.__path__ = []
+    nixl_api_mod = types.ModuleType("nixl._api")
+    nixl_api_mod.nixl_agent = MagicMock(return_value=MockNixlAgent())
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "nixl": nixl_pkg,
+            "nixl._api": nixl_api_mod,
+        },
+    ):
+        # First Party
+        from lmcache.v1.storage_backend.connector.nixl_connector_v2 import NixlConfig
+
+        config = NixlConfig(
+            role="sender",
+            receiver_host="127.0.0.1",
+            receiver_port=12346,
+            buffer_size=1024 * 1024,
+            buffer_device="cuda:0",
+            enable_gc=True,
+        )
+        return config
+
+
+@pytest.fixture
+def mock_nixl_pipe(mock_nixl_config):
+    """Create a mock NixlPipe for testing."""
+    nixl_pkg = types.ModuleType("nixl")
+    nixl_pkg.__path__ = []
+    nixl_api_mod = types.ModuleType("nixl._api")
+    nixl_api_mod.nixl_agent = MagicMock(return_value=MockNixlAgent())
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "nixl": nixl_pkg,
+            "nixl._api": nixl_api_mod,
+        },
+    ):
+        # First Party
+        from lmcache.v1.storage_backend.connector.nixl_connector_v2 import NixlPipe
+
+        pipe = NixlPipe(
+            nixl_config=mock_nixl_config,
+            side_channel=MockSideChannel(),
+            sender_meta=b"mock_sender_meta",
+        )
+        return pipe
+
+
+class TestNixlPipeBatchedAllocateForWrite:
+    """Test cases for NixlPipe.batched_allocate_for_write method."""
+
+    def test_batched_allocate_for_write_success(self, mock_nixl_pipe):
+        """Test successful batch allocation for write."""
+        # Arrange
+        shape = torch.Size([2, 16, 8, 128])
+        dtype = torch.bfloat16
+        batch_size = 4
+        fmt = MemoryFormat.KV_2LTD
+
+        result = mock_nixl_pipe.batched_allocate_for_write(
+            shape=shape, dtype=dtype, batch_size=batch_size, fmt=fmt
+        )
+
+        assert result is not None
+        assert len(result) == batch_size
+        for obj in result:
+            assert isinstance(obj, MemoryObj)
+            assert obj.metadata.shape == shape
+            assert obj.metadata.dtype == dtype
+            assert obj.metadata.fmt == fmt
+
+    def test_batched_allocate_for_write_allocator_arise_assertion_error(
+        self, mock_nixl_pipe
+    ):
+        """Test when allocator raises assertion error (buffer full scenario)."""
+        shape = torch.Size([2, 16, 8, 128])
+        dtype = torch.bfloat16
+        batch_size = 1000
+        fmt = MemoryFormat.KV_2LTD
+
+        with pytest.raises(AssertionError):
+            mock_nixl_pipe.batched_allocate_for_write(
+                shape=shape, dtype=dtype, batch_size=batch_size, fmt=fmt
+            )
+
+    def test_batched_allocate_for_write_different_formats(self, mock_nixl_pipe):
+        """Test batch allocation with different memory formats."""
+        shape = torch.Size([2, 16, 8, 128])
+        dtype = torch.bfloat16
+        batch_size = 2
+
+        formats = [
+            MemoryFormat.KV_2LTD,
+            MemoryFormat.KV_2TD,
+            MemoryFormat.KV_T2D,
+            MemoryFormat.KV_MLA_FMT,
+        ]
+
+        for fmt in formats:
+            result = mock_nixl_pipe.batched_allocate_for_write(
+                shape=shape, dtype=dtype, batch_size=batch_size, fmt=fmt
+            )
+
+            assert result is not None
+            assert len(result) == batch_size
+            for obj in result:
+                assert isinstance(obj, MemoryObj)
+                assert obj.metadata.shape == shape
+                assert obj.metadata.dtype == dtype
+                assert obj.metadata.fmt == fmt
+
+    def test_batched_allocate_for_write_different_batch_sizes(self, mock_nixl_pipe):
+        """Test batch allocation with different batch sizes."""
+        shape = torch.Size([2, 16, 8, 128])
+        dtype = torch.bfloat16
+        fmt = MemoryFormat.KV_2LTD
+
+        batch_sizes = [1, 2, 4, 8]
+
+        for batch_size in batch_sizes:
+            result = mock_nixl_pipe.batched_allocate_for_write(
+                shape=shape, dtype=dtype, batch_size=batch_size, fmt=fmt
+            )
+
+            assert result is not None
+            assert len(result) == batch_size
+            for obj in result:
+                assert isinstance(obj, MemoryObj)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR addresses issue  #1174 by adding `layerwise` compatibility for PD.
Since storage and retrieval must remain consistent, both the prefiller and decoder need to have `use_layerwise: True`.

Changes
-  Support `batched_allocate` and `get_non_blocking` in `NixlBackend`
-  Add layer_id field to `NixlRequest`

Example config:

```yaml
local_cpu: False
max_local_cpu_size: 0
max_local_disk_size: 0
remote_serde: NULL

enable_nixl: True
nixl_role: "sender"
nixl_receiver_host: "localhost"
nixl_receiver_port: 55555
nixl_buffer_size: 1073741824 # 1GB
nixl_buffer_device: "cuda"
nixl_enable_gc: True

use_layerwise: True
```

```yaml
local_cpu: False
max_local_cpu_size: 0
max_local_disk_size: 0
remote_serde: NULL

enable_nixl: True
nixl_role: "receiver"
nixl_receiver_host: "localhost"
nixl_receiver_port: 55555
nixl_buffer_size: 1073741824 # 1GB
nixl_buffer_device: "cuda"
nixl_enable_gc: True

use_layerwise: True
```
resolve #1174 ，Please let me know if there’s anything that needs to be adjusted.