### PR TITLE
[minor enhancement] Skip unnecessary storage store if hit cache or file exist already

### DIFF
--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -389,10 +389,26 @@ class GdsBackend(StorageBackendInterface):
         self, key: CacheEngineKey, memory_obj: MemoryObj
     ) -> Optional[Future]:
         assert memory_obj.tensor is not None
-        memory_obj.ref_count_up()
+
+        # Check if key is already being processed
+        with self.put_lock:
+            if key in self.put_tasks:
+                logger.debug(f"[GDS_BACKEND] Key already in put tasks, skipping: {key}")
+                return None
+
+        # Check if key already exists in cache
+        if self.contains(key):
+            logger.debug(f"[GDS_BACKEND] Key already exists, skipping put: {key}")
+            return None
 
         with self.put_lock:
             self.put_tasks.add(key)
+
+        memory_obj.ref_count_up()
+        logger.debug(
+            f"[GDS_BACKEND] Starting put task for key {key},"
+            f"size: {memory_obj.get_size() / 1024**3:.4f} GB"
+        )
 
         future = asyncio.run_coroutine_threadsafe(
             self._async_save_bytes_to_disk(key, memory_obj), self.loop

--- a/lmcache/v1/storage_backend/weka_gds_backend.py
+++ b/lmcache/v1/storage_backend/weka_gds_backend.py
@@ -289,10 +289,23 @@ class WekaGdsBackend(StorageBackendInterface):
         self, key: CacheEngineKey, memory_obj: MemoryObj
     ) -> Optional[Future]:
         assert memory_obj.tensor is not None
-        memory_obj.ref_count_up()
+
+        # Check if key is already in put_tasks
+        if self.exists_in_put_tasks(key):
+            logger.debug(
+                f"[WEKA_GDS_BACKEND] Key already in put_tasks, skipping put: {key}"
+            )
+            return None
+
+        # Check if key already exists in cache
+        if self.contains(key):
+            logger.debug(f"[WEKA_GDS_BACKEND] Key already exists, skipping put: {key}")
+            return None
 
         with self.put_lock:
             self.put_tasks.add(key)
+
+        memory_obj.ref_count_up()
 
         future = asyncio.run_coroutine_threadsafe(
             self._async_save_bytes_to_disk(key, memory_obj), self.loop


### PR DESCRIPTION
# Why this PR

Previous , you will see log, even CPU Backend already has the key in hot cache, but the GDS Backend still try to put the key into write task( when the cache was hit in RAM , or the keyfile already exist in disk, the GDS put task should be skipped )

note the 
`[CPU_BACKEND] Key already exists in hot cache:` 
and 
`[GDS_BACKEND] Starting put task for key ` 
lines

```
[2025-08-13 06:06:36,085] LMCache DEBUG: [CPU_BACKEND] Starting put operation for key: vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354, size: 0.0029 GB (local_cpu_backend.py:105:lmcache.v1.storage_backend.local_cpu_backend)
[2025-08-13 06:06:36,085] LMCache DEBUG: [CPU_BACKEND] Key already exists in hot cache: vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354 (local_cpu_backend.py:109:lmcache.v1.storage_backend.local_cpu_backend)
[2025-08-13 06:06:36,085] LMCache DEBUG: [GDS_BACKEND] Starting put task for key vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354, size: 0.0029 GB (gds_backend.py:396:lmcache.v1.storage_backend.gds_backend)
[2025-08-13 06:06:36,085] LMCache INFO: Stored 256 out of total 256 tokens. size: 0.0029 gb, cost 0.3450 ms, throughput: 8.4914 GB/s; offload_time: 0.2087 ms, put_time: 0.1363 ms (cache_engine.py:251:lmcache.v1.cache_engine)
[2025-08-13 06:06:36,090] LMCache INFO: [GDS_BACKEND] Wrote 0.0029 GB to disk in 4.90 ms, throughput: 0.60 GB/s, key: vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354 (gds_backend.py:452:lmcache.v1.storage_backend.gds_backend)
[2025-08-13 06:06:36,090] LMCache DEBUG: [GDS_BACKEND] Total async save operation completed in 5.02 ms, key: vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354 (gds_backend.py:470:lmcache.v1.storage_backend.gds_backend)

```


After my fix, you will see `[GDS_BACKEND] Key already exists, skipping put` as below:

```
[2025-08-13 07:33:06,865] LMCache INFO: Storing KV cache for 256 out of 768 tokens (skip_leading_tokens=512) for request cmpl-d1c7d981112f412587518049efa8ae4d-0 (vllm_v1_adapter.py:709:lmcache.integration.vllm.vllm_v1_adapter)
[2025-08-13 07:33:06,865] LMCache DEBUG: [CPU_BACKEND] Starting put operation for key: vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354, size: 0.0029 GB (local_cpu_backend.py:105:lmcache.v1.storage_backend.local_cpu_backend)
[2025-08-13 07:33:06,865] LMCache DEBUG: [CPU_BACKEND] Key already exists in hot cache: vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354 (local_cpu_backend.py:109:lmcache.v1.storage_backend.local_cpu_backend)
[2025-08-13 07:33:06,865] LMCache DEBUG: [GDS_BACKEND] Starting put task for key vllm@/models/Qwen-2.5-0.5B/@1@0@-1727581306308489354, size: 0.0029 GB (gds_backend.py:396:lmcache.v1.storage_backend.gds_backend)
[2025-08-13 07:33:06,865] LMCache DEBUG: [GDS_BACKEND] Key already exists, skipping put: CacheEngineKey(fmt='vllm', model_name='/models/Qwen-2.5-0.5B/', world_size=1, worker_id=0, chunk_hash=-1727581306308489354) (gds_backend.py:399:lmcache.v1.storage_backend.gds_backend)
[2025-08-13 07:33:06,865] LMCache INFO: Stored 256 out of total 256 tokens. size: 0.0029 gb, cost 0.4264 ms, throughput: 6.8708 GB/s; offload_time: 0.2514 ms, put_time: 0.1750 ms (cache_engine.py:251:lmcache.v1.cache_engine)
[
```



NOTE : the logging depends on https://github.com/LMCache/LMCache/pull/1325 



# Reproduce step:

```
       LMCACHE_GDS_PATH="/mnt/afs/cache/Qwen-2.5-0.5B"\
        LMCACHE_CUFILE_BUFFER_SIZE=500 \
        LMCACHE_LOCAL_CPU=True \
	LMCACHE_MAX_LOCAL_CPU_SIZE=0.03 \
        VLLM_ENABLE_V1_MULTIPROCESSING=1 \
        VLLM_LOGGING_LEVEL=DEBUG   LMCACHE_LOG_LEVEL=DEBUG  \
        vllm serve /models/Qwen-2.5-0.5B/ \
       --gpu-memory-utilization 0.05 \
        --port 9100 \
       --max_model_len 1000 \
        --disable-log-requests \
        --enforce-eager \
        --no-enable-prefix-caching \
        --kv-transfer-config \
        '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'

```


```
python benchmark_serving.py --port 9100 --model "/models/Qwen-2.5-0.5B/"  --dataset-path  /models/ShareGPT_V3_unfiltered_cleaned_split.json     --dataset-name sharegpt   --num-prompts 100 --max-concurrency 10  --sharegpt-output-len 5  #--sonnet-input-len  10000

```