### PR TITLE
[bugfix] adapt old vllm version

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1131,6 +1131,10 @@ class LMCacheConnectorV1Impl:
 
         meta = LMCacheConnectorMetadata()
 
+        # set and update lookup requests for unpin
+        meta.lookup_requests_in_step = self._lookup_requests_in_step
+        self._lookup_requests_in_step = []
+
         for finished_req_id in scheduler_output.finished_req_ids:
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)
@@ -1216,8 +1220,6 @@ class LMCacheConnectorV1Impl:
             if req_meta is not None:
                 meta.add_request(req_meta)
 
-        meta.lookup_requests_in_step = self._lookup_requests_in_step
-        self._lookup_requests_in_step = []
         return meta
 
     @_lmcache_nvtx_annotate


### PR DESCRIPTION
set lookup requests when use old vllm version

our vllm version is old, the lookup requests will not set without this PR, which will result in memory leak.

our grafana can clearly show that pinned memory objects not released, and will rusult in allocate failed in `local_cpu_backend`.
<img width="898" height="262" alt="image" src="https://github.com/user-attachments/assets/0a60288e-a19d-4c5b-89e0-8de69b53a3ca" />
