### PR TITLE
[metrics] add memory related metrics

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -263,6 +263,7 @@ class LocalCPUBackend(StorageBackendInterface):
                 )
 
                 if not evict_keys:
+                    self.stats_monitor.update_local_cpu_evict_failed_count(1)
                     logger.warning(
                         "No eviction candidates found in local cpu backend. "
                         "Local cpu memory is under pressure."
@@ -332,6 +333,7 @@ class LocalCPUBackend(StorageBackendInterface):
                 # pinned in the cpu memory. This might not be true.
 
                 if not evict_keys:
+                    self.stats_monitor.update_local_cpu_evict_failed_count(1)
                     logger.warning(
                         "No eviction candidates found in local cpu backend. "
                         "Local cpu memory is under pressure."


### PR DESCRIPTION
add metrics, includes
- local_cpu_evict_failed_count
- active_memory_objs_count
- pinned_memory_objs_count

which can help us locate the problem.

our grafana display the metrics as follows:
<img width="901" height="260" alt="image" src="https://github.com/user-attachments/assets/72af1ea2-1b30-4a76-ab28-ec2a1672624c" />


<img width="904" height="269" alt="image" src="https://github.com/user-attachments/assets/ac981061-3670-4187-b31b-b30753403959" />

<img width="908" height="267" alt="image" src="https://github.com/user-attachments/assets/fdfbfcfe-f70f-4214-9d17-f045fbc1fe96" />
