### PR TITLE
Add `caching` to enable_cache for one request

### DIFF
--- a/docs/source/developer_guide/contributing.rst
+++ b/docs/source/developer_guide/contributing.rst
@@ -183,5 +183,5 @@ Serve docs page locally at http://localhost:8000: :code:`python -m http.server -
 Thank You
 ---------
 
-Thank you for your contribution to LMCache and making it a better, and accessible framework for all. 
+Thank you for your contribution to LMCache and making it a better, and accessible framework for all.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ Welcome to LMCache!
 .. raw:: html
 
    <p style="text-align:justify">
-   LMCache lets LLMs prefill each text only once. By storing the KV caches of all reusable texts, LMCache can reuse the KV caches of any reused text (not necessarily prefix) in any serving engine instance. 
+   LMCache lets LLMs prefill each text only once. By storing the KV caches of all reusable texts, LMCache can reuse the KV caches of any reused text (not necessarily prefix) in any serving engine instance.
    It thus reduces prefill delay, i.e., time to first token (TTFT), as well as saves the precious GPU cycles and memory.
 
    By combining LMCache with vLLM, LMCaches achieves 3-10x delay savings and GPU cycle reduction in many LLM use cases, including multi-round QA and RAG.
@@ -76,6 +76,7 @@ Documentation
 
    kv_cache/storage_backends/index
    kv_cache/caching_policies
+   kv_cache/caching_switch
 
 :raw-html:`<br />`
 
@@ -138,7 +139,7 @@ Documentation
    api_reference/storage_backends
    api_reference/dynamic_connector
    api_reference/multimodality
-   
+
 :raw-html:`<br />`
 
 .. toctree::
@@ -149,4 +150,4 @@ Documentation
    community/blogs
 
 raw-html:`<br />`
-   
+

--- a/docs/source/kv_cache/caching_switch.rst
+++ b/docs/source/kv_cache/caching_switch.rst
@@ -6,59 +6,61 @@ LMCache supports caching by request
 For example, if you want to cache some requests and redo prefill for other requests, you can add ``caching`` field to
 ``kv_transfer_params`` to control whether to cache this request.
 
-example.yaml
-```
-chunk_size: 256
-local_device: "cpu"
-local_cpu: True
-max_local_cpu_size: 10
+.. code-block:: yaml
 
-```
+	chunk_size: 256
+	local_device: "cpu"
+	local_cpu: True
+	max_local_cpu_size: 10
+
 
 1. Start the vllm engine at port 8000:
 
-```bash
-VLLM_USE_V1=1 \
-LMCACHE_USE_EXPERIMENTAL=True \
-LMCACHE_TRACK_USAGE=false \
-LMCACHE_CONFIG_FILE=example.yaml \
-vllm serve /disc/f/models/opt-125m/ \
-           --served-model-name "facebook/opt-125m" \
-           --enforce-eager  \
-           --port 8000 \
-           --gpu-memory-utilization 0.8 \
-           --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \
-           --trust-remote-code
-```
+.. code-block:: bash
 
-2. Send a request to vllm engine with `kv_transfer_params: {caching: false}`:
-```bash
-curl -X POST http://localhost:8000/v1/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "facebook/opt-125m",
-    "prompt": "Explain the significance of KV cache in language models." * 100,
-    "max_tokens": 10,
-	"kv_transfer_params": {
-	  "caching": false
-	}
-  }'
-```
+	VLLM_USE_V1=1 \
+	LMCACHE_USE_EXPERIMENTAL=True \
+	LMCACHE_TRACK_USAGE=false \
+	LMCACHE_CONFIG_FILE=example.yaml \
+	vllm serve /disc/f/models/opt-125m/ \
+			   --served-model-name "facebook/opt-125m" \
+			   --enforce-eager  \
+			   --port 8000 \
+			   --gpu-memory-utilization 0.8 \
+			   --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \
+			   --trust-remote-code
+
+2. Send a request to vllm engine with ``kv_transfer_params: {caching: false}``:
+
+.. code-block:: bash
+
+	curl -X POST http://localhost:8000/v1/completions \
+	  -H "Content-Type: application/json" \
+	  -d '{
+		"model": "facebook/opt-125m",
+		"prompt": "Explain the significance of KV cache in language models." * 100,
+		"max_tokens": 10,
+		"kv_transfer_params": {
+		  "caching": false
+		}
+	  }'
 
 This request will not be cached.
 
-3. Send a request to vllm engine with `kv_transfer_params: {caching: true}` or not pass the param:
-```bash
-curl -X POST http://localhost:8000/v1/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "facebook/opt-125m",
-    "prompt": "Explain the significance of KV cache in language models." * 100,
-    "max_tokens": 10,
-	"kv_transfer_params": {
-	  "caching": true
-	}
-  }'
-```
+3. Send a request to vllm engine with ``kv_transfer_params: {caching: true}`` or not pass the param:
+
+.. code-block:: bash
+
+	curl -X POST http://localhost:8000/v1/completions \
+	  -H "Content-Type: application/json" \
+	  -d '{
+		"model": "facebook/opt-125m",
+		"prompt": "Explain the significance of KV cache in language models." * 100,
+		"max_tokens": 10,
+		"kv_transfer_params": {
+		  "caching": true
+		}
+	  }'
+
 This request will be cached.
 

--- a/docs/source/kv_cache/caching_switch.rst
+++ b/docs/source/kv_cache/caching_switch.rst
@@ -6,6 +6,8 @@ LMCache supports caching by request
 For example, if you want to cache some requests and redo prefill for other requests, you can add ``caching`` field to
 ``kv_transfer_params`` to control whether to cache this request.
 
+example.yaml
+
 .. code-block:: yaml
 
 	chunk_size: 256

--- a/docs/source/kv_cache/caching_switch.rst
+++ b/docs/source/kv_cache/caching_switch.rst
@@ -1,12 +1,20 @@
-# Cache by request
-This is an example to cache by request, use the `kv_transfer_params.caching` field to control whether to cache this request.
+Caching by request
+===================================
 
-## Prerequisites
-Your server should have at least 1 GPU.
+LMCache supports caching by request
 
-This will use the port 8000 for 1 vllm.
+For example, if you want to cache some requests and redo prefill for other requests, you can add ``caching`` field to
+``kv_transfer_params`` to control whether to cache this request.
 
-## Steps
+example.yaml
+```
+chunk_size: 256
+local_device: "cpu"
+local_cpu: True
+max_local_cpu_size: 10
+
+```
+
 1. Start the vllm engine at port 8000:
 
 ```bash
@@ -53,3 +61,4 @@ curl -X POST http://localhost:8000/v1/completions \
   }'
 ```
 This request will be cached.
+

--- a/examples/caching_switch/README.md
+++ b/examples/caching_switch/README.md
@@ -1,0 +1,55 @@
+# Cache by request
+This is an example to cache by request, use the `kv_transfer_params.caching` field to control whether to cache this request.
+
+## Prerequisites
+Your server should have at least 1 GPU.
+
+This will use the port 8000 for 1 vllm.
+
+## Steps
+1. Start the vllm engine at port 8000:
+
+```bash
+VLLM_USE_V1=1 \
+LMCACHE_USE_EXPERIMENTAL=True \
+LMCACHE_TRACK_USAGE=false \
+LMCACHE_CONFIG_FILE=example.yaml \
+vllm serve /disc/f/models/opt-125m/ \
+           --served-model-name "facebook/opt-125m" \
+           --enforce-eager  \
+           --port 8000 \
+           --gpu-memory-utilization 0.8 \
+           --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \
+           --trust-remote-code
+```
+
+3. Send a request to vllm engine with `kv_transfer_params: {caching: false}`:
+```bash
+curl -X POST http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "facebook/opt-125m",
+    "prompt": "Explain the significance of KV cache in language models." * 100,
+    "max_tokens": 10,
+	"kv_transfer_params": {
+	  "caching": false
+	}
+  }'
+```
+
+This request will not be cached.
+
+4. Send a request to vllm engine with `kv_transfer_params: {caching: true}` or not pass the param:
+```bash
+curl -X POST http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "facebook/opt-125m",
+    "prompt": "Explain the significance of KV cache in language models." * 100,
+    "max_tokens": 10,
+	"kv_transfer_params": {
+	  "caching": true
+	}
+  }'
+```
+This request will be cached.

--- a/examples/caching_switch/example.yaml
+++ b/examples/caching_switch/example.yaml
@@ -1,0 +1,5 @@
+chunk_size: 256
+local_device: "cpu"
+local_cpu: True
+max_local_cpu_size: 10
+

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -107,6 +107,11 @@ def extract_tags(
                     tags[k] = v
     return tags
 
+def should_enable_cache(sampling_params: SamplingParams) -> bool:
+    if sampling_params.extra_args is not None:
+        if kv_transfer_params := sampling_params.extra_args.get("kv_transfer_params"):
+            return kv_transfer_params.get("caching", True)
+    return True
 
 @dataclass
 class RequestTracker:
@@ -136,6 +141,8 @@ class RequestTracker:
     mm_positions: Optional[list["PlaceholderRange"]] = None
     # The request tags
     tags: Optional[OrderedDict] = None
+    # enable_cache
+    enable_cache: Optional[bool] = True
 
     # Whether the request is in decode phase
     is_decode_phase = False
@@ -181,6 +188,7 @@ class RequestTracker:
         disagg_spec = tmp_disagg_tracker.pop(new_request.req_id, None)
 
         tags = extract_tags(lmcache_config, new_request.sampling_params)
+        enable_cache = should_enable_cache(new_request.sampling_params)
 
         return RequestTracker(
             req_id=new_request.req_id,
@@ -192,6 +200,7 @@ class RequestTracker:
             mm_hashes=new_request.mm_hashes.copy(),
             mm_positions=new_request.mm_positions.copy(),
             tags=tags,
+            enable_cache=enable_cache,
         )
 
     def update(
@@ -242,6 +251,8 @@ class ReqMeta:
     disagg_spec: Optional[DisaggSpec] = None
     # tags
     tags: Optional[OrderedDict] = None
+    # enable_cache
+    enable_cache: Optional[bool] = True
 
     @staticmethod
     def from_request_tracker(
@@ -368,6 +379,7 @@ class ReqMeta:
             load_spec=load_spec,
             disagg_spec=tracker.disagg_spec,
             tags=tracker.tags,
+            enable_cache=tracker.enable_cache,
         )
 
 
@@ -674,6 +686,8 @@ class LMCacheConnectorV1Impl:
         for idx, request in enumerate(metadata.requests):
             if request.load_spec is None:
                 continue
+            if not request.enable_cache:
+                continue
 
             tokens = request.token_ids
             # TODO: have a pre-allocated buffer to hold the slot_mappings
@@ -892,6 +906,9 @@ class LMCacheConnectorV1Impl:
             ) and self.kv_role != "kv_producer":
                 continue
 
+            if not request.enable_cache:
+                continue
+
             token_ids = request.token_ids
             assert isinstance(token_ids, torch.Tensor)
             assert token_ids.is_cpu
@@ -989,6 +1006,9 @@ class LMCacheConnectorV1Impl:
         if self.kv_role == "kv_producer" and not hasattr(
             self.lookup_client, "supports_producer_reuse"
         ):
+            return 0
+
+        if not should_enable_cache(request.sampling_params):
             return 0
 
         token_ids = torch.tensor(request.prompt_token_ids)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -107,11 +107,13 @@ def extract_tags(
                     tags[k] = v
     return tags
 
+
 def should_enable_cache(sampling_params: SamplingParams) -> bool:
     if sampling_params.extra_args is not None:
         if kv_transfer_params := sampling_params.extra_args.get("kv_transfer_params"):
             return kv_transfer_params.get("caching", True)
     return True
+
 
 @dataclass
 class RequestTracker:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -688,8 +688,6 @@ class LMCacheConnectorV1Impl:
         for idx, request in enumerate(metadata.requests):
             if request.load_spec is None:
                 continue
-            if not request.enable_cache:
-                continue
 
             tokens = request.token_ids
             # TODO: have a pre-allocated buffer to hold the slot_mappings


### PR DESCRIPTION
When we want to enable cache by request, we can set `kv_transfer_params.caching` field to control whether to cache this request.

How to use:
add caching field to `kv_transfer_params`
```
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "model": "deepseek-r1",
    "messages": [
        {
            "role": "user",
            "content": "Hello, how are you?"
        }
    ],
    "max_tokens": 1000,
    "temperature": 0,
    "top_p": 0.95,
    "stream": true,
    "stream_options": {
         "include_usage": true
    },
    "kv_transfer_params":{
            "caching": false
        }
    }'
```