### PR TITLE
[Misc] Allow passing nixl backends when creating nixl_agent in nixl_connector_v3

### DIFF
--- a/docs/source/disaggregated_prefill/nixl/1p1d.rst
+++ b/docs/source/disaggregated_prefill/nixl/1p1d.rst
@@ -126,6 +126,7 @@ The decoder is configured via ``configs/lmcache-decoder-config.yaml``:
    nixl_peer_alloc_port: 7400
    nixl_buffer_size: 2147483648 # 2GB
    nixl_buffer_device: "cuda"
+   nixl_backends: "UCX"
 
 Key settings:
 

--- a/docs/source/disaggregated_prefill/nixl/1p1d.rst
+++ b/docs/source/disaggregated_prefill/nixl/1p1d.rst
@@ -126,7 +126,7 @@ The decoder is configured via ``configs/lmcache-decoder-config.yaml``:
    nixl_peer_alloc_port: 7400
    nixl_buffer_size: 2147483648 # 2GB
    nixl_buffer_device: "cuda"
-   nixl_backends: "UCX"
+   nixl_backends: [UCX]
 
 Key settings:
 

--- a/docs/source/disaggregated_prefill/nixl/xpyd.rst
+++ b/docs/source/disaggregated_prefill/nixl/xpyd.rst
@@ -135,6 +135,7 @@ The decoder(s) are configured via ``configs/lmcache-decoder-x-config.yaml``:
    nixl_peer_alloc_port: 740x
    nixl_buffer_size: 2147483648 # 2GB
    nixl_buffer_device: "cuda"
+   nixl_backends: "UCX"
 
 Key settings:
 

--- a/docs/source/disaggregated_prefill/nixl/xpyd.rst
+++ b/docs/source/disaggregated_prefill/nixl/xpyd.rst
@@ -135,7 +135,7 @@ The decoder(s) are configured via ``configs/lmcache-decoder-x-config.yaml``:
    nixl_peer_alloc_port: 740x
    nixl_buffer_size: 2147483648 # 2GB
    nixl_buffer_device: "cuda"
-   nixl_backends: "UCX"
+   nixl_backends: [UCX]
 
 Key settings:
 

--- a/examples/disagg_prefill/1p1d/configs/lmcache-decoder-config.yaml
+++ b/examples/disagg_prefill/1p1d/configs/lmcache-decoder-config.yaml
@@ -10,3 +10,4 @@ nixl_receiver_port: 55555
 nixl_buffer_size: 1073741824 # 1GB
 nixl_buffer_device: "cuda"
 nixl_enable_gc: True
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/1p1d/configs/lmcache-prefiller-config.yaml
+++ b/examples/disagg_prefill/1p1d/configs/lmcache-prefiller-config.yaml
@@ -10,3 +10,4 @@ nixl_receiver_port: 55555
 nixl_buffer_size: 1073741824 # 1GB
 nixl_buffer_device: "cuda"
 nixl_enable_gc: True
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/1p1d_experimental/configs/lmcache-decoder-config.yaml
+++ b/examples/disagg_prefill/1p1d_experimental/configs/lmcache-decoder-config.yaml
@@ -9,3 +9,4 @@ nixl_peer_init_port: 7300
 nixl_peer_alloc_port: 7400
 nixl_buffer_size: 2147483648 # 2GB
 nixl_buffer_device: "cuda"
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/1p1d_experimental/configs/lmcache-prefiller-config.yaml
+++ b/examples/disagg_prefill/1p1d_experimental/configs/lmcache-prefiller-config.yaml
@@ -9,3 +9,4 @@ nixl_proxy_host: "localhost"
 nixl_proxy_port: 7500
 nixl_buffer_size: 1073741824 # 1GB
 nixl_buffer_device: "cuda"
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/xp1d/configs/lmcache-decoder-config.yaml
+++ b/examples/disagg_prefill/xp1d/configs/lmcache-decoder-config.yaml
@@ -10,3 +10,4 @@ nixl_receiver_port: 55555
 nixl_buffer_size: 1073741824 # 1GB
 nixl_buffer_device: "cuda"
 nixl_enable_gc: True
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/xp1d/configs/lmcache-prefiller-config.yaml
+++ b/examples/disagg_prefill/xp1d/configs/lmcache-prefiller-config.yaml
@@ -10,3 +10,4 @@ nixl_receiver_port: 55555
 nixl_buffer_size: 1073741824 # 1GB
 nixl_buffer_device: "cuda"
 nixl_enable_gc: True
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/xpyd_experimental/configs/lmcache-decoder-1-config.yaml
+++ b/examples/disagg_prefill/xpyd_experimental/configs/lmcache-decoder-1-config.yaml
@@ -9,3 +9,4 @@ nixl_peer_init_port: 7300
 nixl_peer_alloc_port: 7400
 nixl_buffer_size: 2147483648 # 2GB
 nixl_buffer_device: "cuda"
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/xpyd_experimental/configs/lmcache-decoder-2-config.yaml
+++ b/examples/disagg_prefill/xpyd_experimental/configs/lmcache-decoder-2-config.yaml
@@ -9,3 +9,4 @@ nixl_peer_init_port: 7301
 nixl_peer_alloc_port: 7401
 nixl_buffer_size: 2147483648 # 2GB
 nixl_buffer_device: "cuda"
+nixl_backends: [UCX]

--- a/examples/disagg_prefill/xpyd_experimental/configs/lmcache-prefiller-config.yaml
+++ b/examples/disagg_prefill/xpyd_experimental/configs/lmcache-prefiller-config.yaml
@@ -9,3 +9,4 @@ nixl_proxy_host: "localhost"
 nixl_proxy_port: 7500
 nixl_buffer_size: 1073741824 # 1GB
 nixl_buffer_device: "cuda"
+nixl_backends: [UCX]

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -39,6 +39,17 @@ def _to_int_list(
     return [int(p) for p in parts]
 
 
+def _to_str_list(
+    value: Optional[Union[str, list[str]]],
+) -> Optional[list[str]]:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    return [p for p in parts]
+
+
 # Configuration aliases and deprecated mappings
 _CONFIG_ALIASES = {
     # Maps deprecated names to current names
@@ -173,6 +184,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": lambda x: x
         if isinstance(x, bool)
         else str(x).lower() in ["true", "1"],
+    },
+    "nixl_backends": {
+        "type": Optional[list[str]],
+        "default": None,
+        "env_converter": _to_str_list,
     },
     # Experimental Nixl configurations
     "enable_xpyd": {

--- a/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
+++ b/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
@@ -238,7 +238,8 @@ class NixlPipe:
         self._agent = nixl_agent(
             str(nixl_config.role) + str(nixl_config.buffer_device),
             nixl_agent_config(backends=nixl_config.backends)
-            if nixl_config.backends else None,
+            if nixl_config.backends
+            else None,
         )
         self._reg_descs = self._agent.register_memory(self._transfer_buffers)
         self._local_xfer_descs = self._reg_descs.trim()

--- a/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
+++ b/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
@@ -235,11 +235,11 @@ class NixlPipe:
         # allocator (should be initialized after self._buffer)
         self._allocator = NixlBufferAllocator(self)
 
+        # Handle None backends by setting default to ["UCX"]
+        backends = nixl_config.backends if nixl_config.backends is not None else ["UCX"]
         self._agent = nixl_agent(
             str(nixl_config.role) + str(nixl_config.buffer_device),
-            nixl_agent_config(backends=nixl_config.backends)
-            if nixl_config.backends
-            else None,
+            nixl_agent_config(backends=backends),
         )
         self._reg_descs = self._agent.register_memory(self._transfer_buffers)
         self._local_xfer_descs = self._reg_descs.trim()

--- a/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
+++ b/lmcache/v1/storage_backend/connector/nixl_connector_v2.py
@@ -8,7 +8,7 @@ import time
 import uuid
 
 # Third Party
-from nixl._api import nixl_agent
+from nixl._api import nixl_agent, nixl_agent_config
 import msgpack
 import torch
 import zmq
@@ -235,7 +235,11 @@ class NixlPipe:
         # allocator (should be initialized after self._buffer)
         self._allocator = NixlBufferAllocator(self)
 
-        self._agent = nixl_agent(str(nixl_config.role) + str(nixl_config.buffer_device))
+        self._agent = nixl_agent(
+            str(nixl_config.role) + str(nixl_config.buffer_device),
+            nixl_agent_config(backends=nixl_config.backends)
+            if nixl_config.backends else None,
+        )
         self._reg_descs = self._agent.register_memory(self._transfer_buffers)
         self._local_xfer_descs = self._reg_descs.trim()
         self._remote_xfer_descs = None

--- a/lmcache/v1/storage_backend/connector/nixl_utils.py
+++ b/lmcache/v1/storage_backend/connector/nixl_utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 import enum
 
 # First Party
@@ -45,7 +45,7 @@ class NixlConfig:
     buffer_size: int
     buffer_device: str
     enable_gc: bool
-    backends: list[str]
+    backends: Optional[list[str]]
 
     @staticmethod
     def from_cache_engine_config(
@@ -85,7 +85,7 @@ class NixlConfig:
             buffer_size=config.nixl_buffer_size,
             buffer_device=corrected_device,
             enable_gc=config.nixl_enable_gc,
-            backends=config.backends,
+            backends=config.nixl_backends,
         )
 
 
@@ -102,6 +102,8 @@ class NixlConfigXpYd:
 
     buffer_size: int
     buffer_device: str
+
+    backends: Optional[list[str]]
 
     @staticmethod
     def from_cache_engine_config(
@@ -148,5 +150,6 @@ class NixlConfigXpYd:
             proxy_host=config.nixl_proxy_host,
             proxy_port=config.nixl_proxy_port,
             buffer_size=config.nixl_buffer_size,
+            backends=config.nixl_backends,
             buffer_device=corrected_device,
         )

--- a/lmcache/v1/storage_backend/connector/nixl_utils.py
+++ b/lmcache/v1/storage_backend/connector/nixl_utils.py
@@ -45,6 +45,7 @@ class NixlConfig:
     buffer_size: int
     buffer_device: str
     enable_gc: bool
+    backends: list[str]
 
     @staticmethod
     def from_cache_engine_config(
@@ -84,6 +85,7 @@ class NixlConfig:
             buffer_size=config.nixl_buffer_size,
             buffer_device=corrected_device,
             enable_gc=config.nixl_enable_gc,
+            backends=config.backends,
         )
 
 

--- a/tests/v1/data/test_config.yaml
+++ b/tests/v1/data/test_config.yaml
@@ -3,3 +3,13 @@ local_cpu: False
 extra_config:
   key1: value1
   key2: value2
+
+enable_nixl: True
+enable_xpyd: True
+nixl_role: "receiver"
+nixl_peer_host: "localhost"
+nixl_peer_init_port: 7300
+nixl_peer_alloc_port: 7400
+nixl_buffer_size: 2147483648
+nixl_buffer_device: "cuda"
+nixl_backends: [UCX, GDS]


### PR DESCRIPTION
Adds support for specifying `nixl_backends` during `nixl_agent` initialization, enabling users to choose/customize communication backends (e.g., UCX, GDS, etc.)  instead of relying on defaults.