### PR TITLE
[Fix] Multiple calls to the `compress` API with the same tokens will result in the second request fail

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -813,20 +813,25 @@ class LMCacheEngine:
         )
 
         compressed_memory_objs = []
+        # new_compress_num_tokens indicate the number of tokens need to compress
+        new_compress_num_tokens = num_tokens
         for memory_obj in memory_objs:
-            compressed_memory_obj = serializer.serialize(memory_obj)
-            memory_obj.unpin()
-            compressed_memory_objs.append(compressed_memory_obj)
+            if isinstance(memory_obj, TensorMemoryObj):
+                compressed_memory_obj = serializer.serialize(memory_obj)
+                compressed_memory_objs.append(compressed_memory_obj)
+                memory_obj.unpin()
+            else:
+                compressed_memory_objs.append(memory_obj)
+                new_compress_num_tokens -= memory_obj.get_num_tokens()
 
-        self.storage_manager.batched_remove(keys, locations=[location])
-
-        self.storage_manager.batched_put(
-            keys=keys,
-            memory_objs=compressed_memory_objs,
-            location=location,
-        )
-
-        return num_tokens
+        if new_compress_num_tokens > 0:
+            self.storage_manager.batched_remove(keys, locations=[location])
+            self.storage_manager.batched_put(
+                keys=keys,
+                memory_objs=compressed_memory_objs,
+                location=location,
+            )
+        return new_compress_num_tokens
 
     @_lmcache_nvtx_annotate
     def decompress(
@@ -864,20 +869,26 @@ class LMCacheEngine:
         )
 
         memory_objs = []
+        # new_decompress_num_tokens indicate the number of tokens need to decompress
+        new_decompress_num_tokens = num_tokens
         for compressed_memory_obj in compressed_memory_objs:
-            memory_obj = deserializer.deserialize(compressed_memory_obj)
-            compressed_memory_obj.unpin()
-            memory_objs.append(memory_obj)
+            if not isinstance(compressed_memory_obj, TensorMemoryObj):
+                memory_obj = deserializer.deserialize(compressed_memory_obj)
+                compressed_memory_obj.unpin()
+                memory_objs.append(memory_obj)
+            else:
+                memory_objs.append(compressed_memory_obj)
+                new_decompress_num_tokens -= compressed_memory_obj.get_num_tokens()
 
-        self.storage_manager.batched_remove(keys, locations=[location])
+        if new_decompress_num_tokens > 0:
+            self.storage_manager.batched_remove(keys, locations=[location])
+            self.storage_manager.batched_put(
+                keys=keys,
+                memory_objs=memory_objs,
+                location=location,
+            )
 
-        self.storage_manager.batched_put(
-            keys=keys,
-            memory_objs=memory_objs,
-            location=location,
-        )
-
-        return num_tokens
+        return new_decompress_num_tokens
 
     @_lmcache_nvtx_annotate
     def lookup_unpin(self, lookup_ids: list[str]) -> None:

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -95,6 +95,9 @@ class MemoryObjMetadata:
     # cache controller pins are persistent
     pin_count: int = 0
 
+    # the number of token before compress
+    num_tokens: int = 0
+
     # The 'logical' format of the tensor
     fmt: MemoryFormat = MemoryFormat.UNDEFINED
 
@@ -492,8 +495,7 @@ class BytesBufferMemoryObj(MemoryObj):
         return 1
 
     def get_num_tokens(self) -> int:
-        # TODO(Jiayi): record the number of tokens somehow
-        return 1
+        return self.metadata.num_tokens
 
     @property
     def metadata(self) -> MemoryObjMetadata:

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -10,7 +10,6 @@ from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
     BytesBufferMemoryObj,
-    MemoryFormat,
     MemoryObj,
     MemoryObjMetadata,
 )
@@ -93,6 +92,6 @@ class CacheGenSerializer(Serializer):
             ref_count=1,
             pin_count=0,
             num_tokens=memory_obj.get_num_tokens(),
-            fmt=MemoryFormat.BINARY_BUFFER,
+            fmt=memory_obj.metadata.fmt,
         )
         return BytesBufferMemoryObj(output_dict.to_bytes(), metadata=meta)

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -8,7 +8,12 @@ from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_encoder import encode_function
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import BytesBufferMemoryObj, MemoryObj
+from lmcache.v1.memory_management import (
+    BytesBufferMemoryObj,
+    MemoryFormat,
+    MemoryObj,
+    MemoryObjMetadata,
+)
 from lmcache.v1.storage_backend.naive_serde.cachegen_basics import CacheGenConfig
 from lmcache.v1.storage_backend.naive_serde.serde import Serializer
 
@@ -80,5 +85,14 @@ class CacheGenSerializer(Serializer):
             self.value_bins,
             ntokens,
         )
-
-        return BytesBufferMemoryObj(output_dict.to_bytes())
+        meta = MemoryObjMetadata(
+            shape=torch.Size([len(output_dict.to_bytes()), 0, 0, 0]),
+            dtype=None,
+            address=0,
+            phy_size=0,
+            ref_count=1,
+            pin_count=0,
+            num_tokens=memory_obj.get_num_tokens(),
+            fmt=MemoryFormat.BINARY_BUFFER,
+        )
+        return BytesBufferMemoryObj(output_dict.to_bytes(), metadata=meta)


### PR DESCRIPTION
Fix the issue https://github.com/LMCache/LMCache/issues/1354
And the `decompress` API has similar problem.
It works according to the following principles:

- if the tokens has not been compressed at all, compress all the tokens.
- if the tokens has been compressed entirely, no compression is required .
- if the tokens has been compressed partly, compress the remaining decompressed tokens.