### PR TITLE
Support show thread info within cache engine internal api server

### DIFF
--- a/lmcache/v1/cache_engine_internal_api_server.py
+++ b/lmcache/v1/cache_engine_internal_api_server.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from typing import Optional
 import asyncio
 import logging
+import sys
 import threading
+import traceback
 
 # Third Party
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from prometheus_client import REGISTRY, generate_latest
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -24,6 +27,54 @@ app = FastAPI()
 async def get_metrics(request: Request):
     metrics_data = generate_latest(REGISTRY)
     return PlainTextResponse(content=metrics_data, media_type="text/plain")
+
+
+@app.get("/threads")
+async def get_threads(
+    request: Request,
+    name: Optional[str] = Query(
+        None, description="Filter by thread name (fuzzy match)"
+    ),
+    thread_id: Optional[int] = Query(None, description="Filter by thread ID"),
+):
+    """Return information about active threads with optional filtering"""
+    threads = threading.enumerate()
+
+    filtered_threads = []
+    for t in threads:
+        # Apply filters
+        if name and name.lower() not in t.name.lower():
+            continue
+        if thread_id and t.ident != thread_id:
+            continue
+        filtered_threads.append(t)
+
+    thread_info = []
+
+    for t in filtered_threads:
+        # Basic thread info with creation time
+        info = f"Thread: {t}\n"
+
+        # Get stack trace if available
+        try:
+            stack_frames = sys._current_frames().get(t.ident)
+            if stack_frames:
+                stack_trace = traceback.format_stack(stack_frames)
+                info += "Stack trace:\n" + "".join(stack_trace)
+            else:
+                info += "No stack trace available\n"
+        except AttributeError:
+            info += "Stack trace unavailable\n"
+
+        thread_info.append(info)
+
+    # Add summary section
+    summary = "\n\n=== Thread Summary ===\n"
+    summary += f"Total threads: {len(filtered_threads)}\n"
+
+    return PlainTextResponse(
+        content="\n\n".join(thread_info) + summary, media_type="text/plain"
+    )
 
 
 @app.get("/loglevel")


### PR DESCRIPTION
# Test

```yaml
chunk_size: 256
remote_serde: "naive"
local_cpu: True
max_local_cpu_size: 5
cache_engine_internal_api_server_enabled: True
cache_engine_internal_api_server_port_start: 8080
```

We can get the thread info by http://localhost:8080/threads if we set `cache_engine_internal_api_server_port_start: 8080`

<img width="2568" height="1980" alt="image" src="https://github.com/user-attachments/assets/e1461933-7538-43e2-b619-26ebe32c6c7b" />

