### PR TITLE
[CD]: Dynamic Torch Versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,15 +64,23 @@ jobs:
               with:
                 python-version: "3.11"
 
-            - name: Install dependencies
+            - name: Install uv
               run: |
-                python -m pip install --upgrade pip
-                # this will build lmcache with the latest torch version
-                # however, lmcache does not pin its torch version so other 
-                # dependencies can easily override the torch version installed
-                # if these torch versions differ across major versions (ABI compatibility)
-                # lmcache will break and so the wheels cannot be directly used
-                pip install build cibuildwheel
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+                echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            
+            - name: Cache uv cache
+              uses: actions/cache@v4
+              with:
+                path: ~/.cache/uv
+                key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml') }}
+                restore-keys: |
+                  ${{ runner.os }}-uv-
+
+            - name: Install build tooling
+              run: |
+                uv pip install --system --upgrade pip
+                uv pip install --system build cibuildwheel
 
             - name: Clean up release artifacts
               run: |
@@ -84,7 +92,12 @@ jobs:
 
             - name: Build CUDA wheels with cibuildwheel
               # Configuration is set in pyproject.toml
+              # this will build lmcache with the latest version that vllm uses to 
+              # keep torch versions compatible. It is important to keep other dependencies
+              # non-collisional with the torch version that vllm uses. 
+              # the installation is the same as the image-release in docker/Dockerfile
               run: |
+                CIBW_BEFORE_BUILD="uv pip install --prerelease=allow vllm[runai,tensorizer]" \
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,12 +83,10 @@ jobs:
 
             - name: Build CUDA wheels with cibuildwheel
               # Configuration is set in pyproject.toml
-              # this will build lmcache with the latest version that vllm uses to 
-              # keep torch versions compatible. It is important to keep other dependencies
-              # non-collisional with the torch version that vllm uses. 
-              # the installation is the same as the image-release in docker/Dockerfile
+              # this will build lmcache with the latest version of torch
+              # building from source will be required if a serving engine uses
+              # an early non-ABI compatible version of torch
               run: |
-                pip install vllm
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
                 disable-sudo-and-containers: false
                 egress-policy: block
                 allowed-endpoints: >
+                  api.github.com:443
                   github.com:443
                   registry-1.docker.io:443
                   production.cloudflare.docker.com:443

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,11 @@ jobs:
             - name: Install dependencies
               run: |
                 python -m pip install --upgrade pip
+                # this will build lmcache with the latest torch version
+                # however, lmcache does not pin its torch version so other 
+                # dependencies can easily override the torch version installed
+                # if these torch versions differ across major versions (ABI compatibility)
+                # lmcache will break and so the wheels cannot be directly used
                 pip install build cibuildwheel
 
             - name: Clean up release artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
 
             - name: Install build tooling
               run: |
-                pip install --upgrade pip
+                python -m pip install --upgrade pip
                 pip install build cibuildwheel
 
             - name: Clean up release artifacts
@@ -88,7 +88,7 @@ jobs:
               # non-collisional with the torch version that vllm uses. 
               # the installation is the same as the image-release in docker/Dockerfile
               run: |
-                pip install --prerelease=allow "vllm[runai,tensorizer]"
+                pip install vllm
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,8 @@ jobs:
                   azure.archive.ubuntu.com:80
                   pypi.org:443
                   files.pythonhosted.org:443
+                  codeload.github.com:443
+                  objects.githubusercontent.com:443
 
             - name: Checkout code
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
                   files.pythonhosted.org:443
                   codeload.github.com:443
                   objects.githubusercontent.com:443
+                  releases.githubusercontent.com:443
 
             - name: Checkout code
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -69,6 +70,8 @@ jobs:
 
             - name: Install the latest version of uv
               uses: astral-sh/setup-uv@v6
+              with:
+                version: "0.8.11"
             
             - name: Cache uv cache
               uses: actions/cache@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,8 +70,8 @@ jobs:
 
             - name: Install build tooling
               run: |
-                pip install --system --upgrade pip
-                pip install --system build cibuildwheel
+                pip install --upgrade pip
+                pip install build cibuildwheel
 
             - name: Clean up release artifacts
               run: |
@@ -88,7 +88,7 @@ jobs:
               # non-collisional with the torch version that vllm uses. 
               # the installation is the same as the image-release in docker/Dockerfile
               run: |
-                pip install --prerelease=allow vllm[runai,tensorizer]
+                pip install --prerelease=allow "vllm[runai,tensorizer]"
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
               # Configuration is set in pyproject.toml
               # this will build lmcache with the latest version of torch
               # building from source will be required if a serving engine uses
-              # an early non-ABI compatible version of torch
+              # an earlier non-ABI compatible version of torch
               run: |
                 python -m cibuildwheel --output-dir dist
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,23 +68,10 @@ jobs:
               with:
                 python-version: "3.11"
 
-            - name: Install the latest version of uv
-              uses: astral-sh/setup-uv@v6
-              with:
-                version: "0.8.11"
-            
-            - name: Cache uv cache
-              uses: actions/cache@v4
-              with:
-                path: ~/.cache/uv
-                key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml') }}
-                restore-keys: |
-                  ${{ runner.os }}-uv-
-
             - name: Install build tooling
               run: |
-                uv pip install --system --upgrade pip
-                uv pip install --system build cibuildwheel
+                pip install --system --upgrade pip
+                pip install --system build cibuildwheel
 
             - name: Clean up release artifacts
               run: |
@@ -101,7 +88,7 @@ jobs:
               # non-collisional with the torch version that vllm uses. 
               # the installation is the same as the image-release in docker/Dockerfile
               run: |
-                CIBW_BEFORE_BUILD="uv pip install --prerelease=allow vllm[runai,tensorizer]" \
+                pip install --prerelease=allow vllm[runai,tensorizer]
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,10 +64,8 @@ jobs:
               with:
                 python-version: "3.11"
 
-            - name: Install uv
-              run: |
-                curl -LsSf https://astral.sh/uv/install.sh | sh
-                echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            - name: Install the latest version of uv
+              uses: astral-sh/setup-uv@v6
             
             - name: Cache uv cache
               uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip install lmcache
 
 Works on Linux NVIDIA GPU platform.
 
-More [detailed installation instructions](https://docs.lmcache.ai/getting_started/installation) are available in the docs.
+More [detailed installation instructions](https://docs.lmcache.ai/getting_started/installation) are available in the docs, particularly if you are not using the latest stable version of vllm or using another serving engine with different dependencies. Any "undefined symbol" or torch mismatch versions can be resolved in the documentation. 
 
 ## Getting started
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# The LMcache Dockerfile is used to build a LMCache image that is integrated
+# The LMCache Dockerfile is used to build a LMCache image that is integrated
 # to run with vLLM OpenAI server.
 
 # Please update any changes made here to
@@ -90,6 +90,8 @@ ENV VLLM_FA_CMAKE_GPU_ARCHES=${vllm_fa_cmake_gpu_arches}
 # Integrate vLLM nightly build and LMCache build and
 # expose vLLM OpenAI API
 
+# Will trigger from `.github/workflows/nightly_build.yml`
+
 FROM base AS image-build
 
 # install build dependencies
@@ -113,6 +115,8 @@ COPY . /workspace/LMCache
 WORKDIR /workspace/LMCache
 
 # Build LMCache
+# since we are installing vllm before lmcache, we will implicitly use
+# the same torch version as the vllm nightly when running setup.py bdist_wheel
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
@@ -130,9 +134,14 @@ ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 # Integrate vLLM and LMCache stable releases and expose vLLM
 # OpenAI API
 
+# Will trigger from `.github/workflows/publish.yml`
+
 FROM base AS image-release
 
 # Install LMCache and vLLM stable releases
+# this happens right after we build and publish lmcache wheels in the release pipeline
+# this means that we should publish lmcache wheels that use the same torch version 
+# as vllm when building the wheels
 RUN . /opt/venv/bin/activate && \
     uv pip install --prerelease=allow vllm[runai,tensorizer] && \
     uv pip install lmcache --verbose

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,11 +117,13 @@ WORKDIR /workspace/LMCache
 # Build LMCache
 # since we are installing vllm before lmcache, we will implicitly use
 # the same torch version as the vllm nightly when running setup.py bdist_wheel
+# fall back to stable vllm if nightly is not available
 RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
     uv pip install --prerelease=allow 'vllm[runai,tensorizer]' \
-        --extra-index-url https://wheels.vllm.ai/nightly && \
+        --extra-index-url https://wheels.vllm.ai/nightly \
+        --index-strategy unsafe-best-match && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
     uv pip install ./dist_lmcache/*.whl --verbose

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,15 +117,14 @@ WORKDIR /workspace/LMCache
 # Build LMCache
 # since we are installing vllm before lmcache, we will implicitly use
 # the same torch version as the vllm nightly when running setup.py bdist_wheel
-RUN --mount=type=cache,target=/root/.cache/ccache \
-    --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
+    --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
-    python3 setup.py bdist_wheel --dist-dir=dist_lmcache
-
-# Install LMCache latest build and vLLM nightly build
-RUN . /opt/venv/bin/activate && \
-    uv pip install --prerelease=allow vllm[runai,tensorizer] --extra-index-url https://wheels.vllm.ai/nightly && \
-    uv pip install /workspace/LMCache/dist_lmcache/*.whl --verbose
+    uv pip install --prerelease=allow 'vllm[runai,tensorizer]' \
+        --extra-index-url https://wheels.vllm.ai/nightly && \
+    python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
+    python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
+    uv pip install ./dist_lmcache/*.whl --verbose
 
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -52,18 +52,41 @@ Confirm that you have the latest pre-release:
 Install Latest LMCache from Source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To install from source, clone the repository and install in editable mode:
+To install from source, clone the repository and install in editable mode. 
+
+The reason that torch installation is separated is:
+- different serving engines and different versions of those serving engines 
+have different torch dependencies and we want to maintain compatibility. 
+- no build isolation bypasses `PEP 517 <https://peps.python.org/pep-0517/>`_ / `PEP 518 <https://peps.python.org/pep-0518/>`_
+avoiding a separate build environment where LMCache GPU kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
+inside of `setup.py` with one torch version and the runtime dependencies export another torch version causing undefined symbol references. 
 
 .. code-block:: bash
 
     git clone https://github.com/LMCache/LMCache.git
     cd LMCache
-    pip install -e .
+
+    # we need to install these packages because we are avoiding build isolation
+    pip install -U pip setuptools wheel ninja
+
+    # Option 1. 
+    # select the torch version that matches the dependency of your serving engine
+    # 2.7.1 is an example for vllm 0.10.0
+    pip install torch==2.7.1
+
+    # Option 2. 
+    # install your serving engine with its required torch version declared already
+    # example: vllm 0.10.0 will install torch 2.7.1
+    pip install vllm==0.10.0
+
+    # requires torch to already be installed
+    # with your desired version
+    pip install -e . --no-build-isolation
 
 Install LMCache with uv
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-We recommend developers to use `uv` for a better package management:
+We recommend developers to use `uv` for faster package management:
 
 .. code-block:: bash
 
@@ -72,7 +95,23 @@ We recommend developers to use `uv` for a better package management:
 
     uv venv --python 3.12
     source .venv/bin/activate
-    uv pip install -e .
+
+    # we need to install these packages because we are avoiding build isolation
+    uv pip install -U pip setuptools wheel ninja
+    
+    # Option 1. 
+    # select the torch version that matches the dependency of your serving engine
+    # 2.7.1 is an example for vllm 0.10.0
+    uv pip install torch==2.7.1
+
+    # Option 2. 
+    # install your serving engine with its required torch version declared already
+    # example: vllm 0.10.0 will install torch 2.7.1
+    pip install vllm==0.10.0
+
+    # requires torch to already be installed
+    # with your desired version
+    uv pip install -e . --no-build-isolation
 
 
 LMCache with vLLM v1

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -22,13 +22,13 @@ Install Stable LMCache from PyPI
 
 The simplest way to install the latest stable release of LMCache is through PyPI. If other dependencies
 demand a version of torch that differs across major versions (e.g. 2.7.1 versus 2.8.0), LMCache stays compatible
-through installation from source (see below). The LMCache torch version always matches the latest stable version
-of vllm. Installing from source allows torch version flexibility. 
+through installation from source (see below). The LMCache is always build with the latest version of torch. 
+Installing from source allows torch version flexibility. 
 
 .. code-block:: bash
     
-    # by default, this will port the version of torch of the latest *STABLE* vllm wheel
-    # if your serving engine demands a different version of torch, it will 
+    # LMCache wheels are built with the latest version of torch.
+    # If your serving engine pins a different version of torch, it will 
     # override the torch version installed by lmcache
     # if these torch versions differ across major versions, ABI compatibility
     # may break so please install from source (see below)
@@ -77,7 +77,7 @@ have different torch dependencies and we want to maintain flexibility
 2. no build isolation bypasses `PEP 517 <https://peps.python.org/pep-0517/>`_ / `PEP 518 <https://peps.python.org/pep-0518/>`_
 avoiding the case where LMCache GPU kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
 inside of `setup.py` with one torch version while runtime dependencies (unpinned torch version in `requirements/common.txt`)
-are overriden, causing undefined symbol references. This forces LMCache to be built with the torch version already in your
+are overridden, causing undefined symbol references. This forces LMCache to be built with the torch version already in your
 environment.
 
 .. code-block:: bash

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -22,8 +22,8 @@ Install Stable LMCache from PyPI
 
 The simplest way to install the latest stable release of LMCache is through PyPI. If other dependencies
 demand a version of torch that differs across major versions (e.g. 2.7.1 versus 2.8.0), LMCache stays compatible
-through installation from source (see below). The LMCache torch version is always the latest and unpinned
-so it will be overridden by other dependencies (e.g. vllm). 
+through installation from source (see below). The LMCache torch version always matches the latest stable version
+of vllm. Installing from source allows torch version flexibility. 
 
 .. code-block:: bash
     
@@ -39,8 +39,8 @@ Install Latest LMCache from TestPyPI
 
 These wheels are continually built from the latest LMCache source code (not officially stable release). 
 If other dependencies demand a version of torch that differs across major versions (e.g. 2.7.1 versus 2.8.0), 
-LMCache stays compatible through installation from source (see below). The LMCache torch version is always the 
-latest and unpinned so it will be overridden by other dependencies (e.g. vllm).
+LMCache stays compatible through installation from source (see below). The LMCache torch version always 
+matches the latest nightly version of vllm. Installing from source allows torch version flexibility. 
 
 .. code-block:: bash
 
@@ -63,7 +63,7 @@ Confirm that you have the latest pre-release:
     >>> import lmcache
     >>> from importlib.metadata import version
     >>> print(version("lmcache"))
-    0.2.2.dev57 # should be the latest pre-release version you installed
+    0.3.4.dev61 # should be the latest pre-release version you installed
 
 Install Latest LMCache from Source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -27,7 +27,7 @@ so it will be overridden by other dependencies (e.g. vllm).
 
 .. code-block:: bash
     
-    # by default, this will port the latest version of torch (at the time of the latest lmcache release)
+    # by default, this will port the version of torch of the latest *STABLE* vllm wheel
     # if your serving engine demands a different version of torch, it will 
     # override the torch version installed by lmcache
     # if these torch versions differ across major versions, ABI compatibility
@@ -44,7 +44,7 @@ latest and unpinned so it will be overridden by other dependencies (e.g. vllm).
 
 .. code-block:: bash
 
-    # by default, this will port the latest version of torch (at the time of the latest lmcache github commit)
+    # by default, this will port the version of torch of the latest *NIGHTLY* vllm wheel
     # if your serving engine demands a different version of torch, it will 
     # override the torch version installed by lmcache
     # if these torch versions differ across major versions, ABI compatibility
@@ -84,7 +84,7 @@ inside of `setup.py` with one torch version, the runtime dependencies export ano
     cd LMCache
 
     # we need to install these packages because we are avoiding build isolation
-    pip install -U pip setuptools wheel ninja
+    pip install -r requirements/build.txt
 
     # Option 1. 
     # select the torch version that matches the dependency of your serving engine
@@ -96,7 +96,7 @@ inside of `setup.py` with one torch version, the runtime dependencies export ano
     # example: vllm 0.10.0 will install torch 2.7.1
     pip install vllm==0.10.0
 
-    # requires torch to already be installed
+    # no build isolation requires torch to already be installed
     # with your desired version
     pip install -e . --no-build-isolation
 
@@ -114,7 +114,7 @@ We recommend developers to use `uv` for faster package management:
     source .venv/bin/activate
 
     # we need to install these packages because we are avoiding build isolation
-    uv pip install -U pip setuptools wheel ninja
+    uv pip install -r requirements/build.txt
 
     # Option 1. 
     # select the torch version that matches the dependency of your serving engine
@@ -126,7 +126,7 @@ We recommend developers to use `uv` for faster package management:
     # example: vllm 0.10.0 will install torch 2.7.1
     pip install vllm==0.10.0
 
-    # requires torch to already be installed
+    # no build isolation requires torch to already be installed
     # with your desired version
     uv pip install -e . --no-build-isolation
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -75,8 +75,10 @@ The reason that torch installation is separated is:
 have different torch dependencies and we want to maintain flexibility 
 (torch versions only break across major versions where the ABI may change e.g. 2.7.1 -> 2.8.0). 
 2. no build isolation bypasses `PEP 517 <https://peps.python.org/pep-0517/>`_ / `PEP 518 <https://peps.python.org/pep-0518/>`_
-so that when LMCache GPU kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
-inside of `setup.py` with one torch version, the runtime dependencies export another torch version causing undefined symbol references. 
+avoiding the case where LMCache GPU kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
+inside of `setup.py` with one torch version while runtime dependencies (unpinned torch version in `requirements/common.txt`)
+are overriden, causing undefined symbol references. This forces LMCache to be built with the torch version already in your
+environment.
 
 .. code-block:: bash
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -126,7 +126,7 @@ We recommend developers to use `uv` for faster package management:
     # Option 2. 
     # install your serving engine with its required torch version declared already
     # example: vllm 0.10.0 will install torch 2.7.1
-    pip install vllm==0.10.0
+    uv pip install vllm==0.10.0
 
     # no build isolation requires torch to already be installed
     # with your desired version

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -20,22 +20,38 @@ Prerequisites
 Install Stable LMCache from PyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The simplest way to install the latest stable release of LMCache is through PyPI:
+The simplest way to install the latest stable release of LMCache is through PyPI. If other dependencies
+demand a version of torch that differs across major versions (e.g. 2.7.1 versus 2.8.0), LMCache stays compatible
+through installation from source (see below). The LMCache torch version is always the latest and unpinned
+so it will be overridden by other dependencies (e.g. vllm). 
 
 .. code-block:: bash
-
+    
+    # by default, this will port the latest version of torch (at the time of the latest lmcache release)
+    # if your serving engine demands a different version of torch, it will 
+    # override the torch version installed by lmcache
+    # if these torch versions differ across major versions, ABI compatibility
+    # may break so please install from source (see below)
     pip install lmcache
 
 Install Latest LMCache from TestPyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These wheels are continually built from the latest LMCache source code (not officially stable release).
+These wheels are continually built from the latest LMCache source code (not officially stable release). 
+If other dependencies demand a version of torch that differs across major versions (e.g. 2.7.1 versus 2.8.0), 
+LMCache stays compatible through installation from source (see below). The LMCache torch version is always the 
+latest and unpinned so it will be overridden by other dependencies (e.g. vllm).
 
 .. code-block:: bash
 
-    pip install --index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple lmcache==0.2.2.dev57
+    # by default, this will port the latest version of torch (at the time of the latest lmcache github commit)
+    # if your serving engine demands a different version of torch, it will 
+    # override the torch version installed by lmcache
+    # if these torch versions differ across major versions, ABI compatibility
+    # may break so please install from source (see below)
+    pip install --index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple lmcache==0.3.4.dev61
 
-See the latest pre-release of LMCache: `latest LMCache pre-releases <https://test.pypi.org/project/lmcache/#history>`__ and replace `0.2.2.dev57` with the latest pre-release version.
+See the latest pre-release of LMCache: `latest LMCache pre-releases <https://test.pypi.org/project/lmcache/#history>`__ and replace `0.3.4.dev61` with the latest pre-release version.
 
 This will install all dependencies from the real PyPI and only LMCache itself from TestPyPI.
 
@@ -55,11 +71,12 @@ Install Latest LMCache from Source
 To install from source, clone the repository and install in editable mode. 
 
 The reason that torch installation is separated is:
-- different serving engines and different versions of those serving engines 
-have different torch dependencies and we want to maintain compatibility. 
-- no build isolation bypasses `PEP 517 <https://peps.python.org/pep-0517/>`_ / `PEP 518 <https://peps.python.org/pep-0518/>`_
-avoiding a separate build environment where LMCache GPU kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
-inside of `setup.py` with one torch version and the runtime dependencies export another torch version causing undefined symbol references. 
+1. different serving engines and different versions of those serving engines 
+have different torch dependencies and we want to maintain flexibility 
+(torch versions only break across major versions where the ABI may change e.g. 2.7.1 -> 2.8.0). 
+2. no build isolation bypasses `PEP 517 <https://peps.python.org/pep-0517/>`_ / `PEP 518 <https://peps.python.org/pep-0518/>`_
+so that when LMCache GPU kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
+inside of `setup.py` with one torch version, the runtime dependencies export another torch version causing undefined symbol references. 
 
 .. code-block:: bash
 
@@ -98,7 +115,7 @@ We recommend developers to use `uv` for faster package management:
 
     # we need to install these packages because we are avoiding build isolation
     uv pip install -U pip setuptools wheel ninja
-    
+
     # Option 1. 
     # select the torch version that matches the dependency of your serving engine
     # 2.7.1 is an example for vllm 0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,15 @@
 [build-system]
 # Requirements for package build
 # Should be mirrored in requirements/build.txt (for builds external to setuptools)
-# the torch version in requirements/common.txt MUST match
+# The recommended installation from source will avoid the requirements here in order
+# to stay flexible for the torch version with `--no-build-isolation`. Thus, these packages
+# should be installed before `pip install -e . --no-build-isolation`. 
 requires = [
     "ninja",
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch==2.7.1",
+    "torch",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@
 # The recommended installation from source will avoid the requirements here in order
 # to stay flexible for the torch version with `--no-build-isolation`. Thus, these packages
 # should be installed before `pip install -e . --no-build-isolation`. 
+# However, build isolation is still used for the cibuildwheel releases
 requires = [
     "ninja",
     "packaging>=24.2",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,8 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
-# please update ASAP when vllm torch updates
-torch==2.7.1
+# torch is not here because vllm installation will implicitly install it for the dockerfile
+# and users should be deliberate about choosing their torch version (or letting their serving
+# engine be deliberate for them)
 wheel
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,5 +25,6 @@ sortedcontainers
 # 3. the extra benefit of not pinning is so that when vllm releases their docker
 # image (which has lmcache as a dependency), we will never forcefully collide with
 # whatever torch version that they have
+# 4. this torch version may also be overridden inside of LMCache/docker/Dockerfile
 torch
 transformers >= 4.51.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,7 +15,12 @@ safetensors
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
 sortedcontainers
-# please update ASAP when vllm torch updates
-# MUST match the [build-system].requires in pyproject.toml
-torch==2.7.1
+# avoid pinning torch version in the runtime dependencies so that 
+# installing lmcache (from source or from pypi) will not override
+# the user's preexisting torch version 
+# this keeps lmcache torch version flexible for many serving engines
+# and versions of those serving engines
+# if NO pre-existing torch version is installed, `pip install lmcache` or 
+# `pip install -e . --no-build-isolation` will install the latest torch version
+torch
 transformers >= 4.51.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,12 +15,15 @@ safetensors
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
 sortedcontainers
-# avoid pinning torch version in the runtime dependencies so that 
+# 1. avoid pinning torch version in the runtime dependencies so that 
 # installing lmcache (from source or from pypi) will not override
 # the user's preexisting torch version 
-# this keeps lmcache torch version flexible for many serving engines
+# 2. this keeps lmcache torch version flexible for many serving engines
 # and versions of those serving engines
 # if NO pre-existing torch version is installed, `pip install lmcache` or 
 # `pip install -e . --no-build-isolation` will install the latest torch version
+# 3. the extra benefit of not pinning is so that when vllm releases their docker
+# image (which has lmcache as a dependency), we will never forcefully collide with
+# whatever torch version that they have
 torch
 transformers >= 4.51.1

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -5,8 +5,9 @@
 ray >= 2.9
 nvidia-ml-py # for pynvml package
 
-# please update ASAP when vllm torch updates
-torch==2.7.1
+
+# do not pin version because the dockerfile requires cuda.txt
+torch
 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 torchvision
 # platform_system == 'Linux' and platform_machine == 'x86_64' 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from contextlib import nullcontext
 from dataclasses import dataclass
 from unittest.mock import patch
 import random
 import shlex
 import socket
 import subprocess
-import threading
 import time
 
 # Third Party
 import pytest
-import torch
 
 # First Party
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
-from lmcache.v1.memory_management import (
-    BufferAllocator,
-    PagedTensorMemoryAllocator,
-    TensorMemoryAllocator,
-)
 
 # This is to mock the constructor and destructor of
 # MixedMemoryAllocator and PinMemoryAllocator to
@@ -34,13 +26,10 @@ from lmcache.v1.memory_management import (
 # In production, using the cuda C++ API gives us a larger pinned buffer
 # but for the tests, we do not need this so this mock leaves the unit tests
 # functionally the same
+"""
 @pytest.fixture(autouse=True, scope="session")
 def patch_mixed_allocator():
     def fake_mixed_init(self, size: int, use_paging: bool = False, **kwargs):
-        """
-        :param int size: The size of the pinned memory in bytes.
-        """
-
         # self.buffer = torch.empty(size, dtype=torch.uint8)
         # ptr = self.buffer.data_ptr()
         # err = torch.cuda.cudart().cudaHostRegister(ptr, size, 0)
@@ -92,9 +81,6 @@ def patch_mixed_allocator():
 @pytest.fixture(autouse=True, scope="session")
 def patch_pin_allocator():
     def fake_pin_init(self, size: int, use_paging: bool = False, **kwargs):
-        """
-        :param int size: The size of the pinned memory in bytes.
-        """
 
         # self.buffer = torch.empty(size, dtype=torch.uint8)
         # ptr = self.buffer.data_ptr()
@@ -137,6 +123,7 @@ def patch_pin_allocator():
         patch("lmcache.v1.memory_management.PinMemoryAllocator.close", fake_pin_close),
     ):
         yield
+"""
 
 
 class MockRedis:


### PR DESCRIPTION
1. make installation from source torch version agnostic and force users / serving engine dependencies to specify instead. 
2. fix the wheel installation instructions
3. make the docker image always compatible with lmcache and vllm

All of this was exposed when pytorch upgraded to 2.8.0, which changed the ABI compatibiltiy with 2.7.1. 


This is the proposed solution after https://github.com/LMCache/LMCache/pull/1274