### PR TITLE
refactor: ensure tensors are on CPU during token conversion

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -993,7 +993,7 @@ class LMCacheConnectorV1Impl:
         ):
             return 0
 
-        token_ids = torch.tensor(request.prompt_token_ids)
+        token_ids = torch.tensor(request.prompt_token_ids, device="cpu")
 
         # If the request has multimodal hashes, apply them to the token ids
         if request.mm_hashes:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -114,7 +114,11 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         self, tokens: Union[torch.Tensor, List[int]], prefix_hash: Optional[int] = None
     ) -> int:
         if isinstance(tokens, torch.Tensor):
-            tokens_tuple = tuple(tokens.cpu().tolist())
+            # if already on cpu
+            if tokens.device == torch.device("cpu"):
+                tokens_tuple = tuple(tokens.tolist())
+            else:
+                tokens_tuple = tuple(tokens.cpu().tolist())
         elif isinstance(tokens, list):
             tokens_tuple = tuple(tokens)
         else:


### PR DESCRIPTION
The primary reason stems from my observation of long-tail latency in hash computations. Upon further investigation, I discovered that torch.cpu() was the culprit behind this performance bottleneck. After deeper consideration, I realized that this particular tensor doesn't necessarily need to reside on the GPU, which led to these modifications. Following the changes, the long-tail behavior in hash calculations improved significantly.

Perhaps we could explore why torch.cpu() introduces such latency spikes.


local cpu backend with default settings

dev branch
```
============ Serving Benchmark Result ============
Successful requests:                     50        
Benchmark duration (s):                  47.75     
Total input tokens:                      404689    
Total generated tokens:                  6400      
Request throughput (req/s):              1.05      
Output token throughput (tok/s):         134.03    
Total Token throughput (tok/s):          8609.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          22041.18  
Median TTFT (ms):                        21423.00  
P99 TTFT (ms):                           45086.14  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          166.85    
Median TPOT (ms):                        194.69    
P99 TPOT (ms):                           242.35    
---------------Inter-token Latency----------------
Mean ITL (ms):                           166.85    
Median ITL (ms):                         227.59    
P99 ITL (ms):                            318.05    
```

my pr
```
============ Serving Benchmark Result ============
Successful requests:                     50        
Benchmark duration (s):                  5.57      
Total input tokens:                      404689    
Total generated tokens:                  6371      
Request throughput (req/s):              8.97      
Output token throughput (tok/s):         1143.08   
Total Token throughput (tok/s):          73752.05  
---------------Time to First Token----------------
Mean TTFT (ms):                          1528.80   
Median TTFT (ms):                        1530.47   
P99 TTFT (ms):                           1876.80   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.67     
Median TPOT (ms):                        31.66     
P99 TPOT (ms):                           42.11     
---------------Inter-token Latency----------------
Mean ITL (ms):                           31.67     
Median ITL (ms):                         29.05     
P99 ITL (ms):                            42.83     
==================================================
```