### PR TITLE
[kv-cache-caculator] Add support  for openai/gpt-oss-20b,casperhansen/llama-3.3-70b-instruct-awq,Qwen/Qwen3-30B-A3B-Instruct-2507,janhq/Jan-v1-4B

### DIFF
--- a/examples/kv_cache_calculator/generate_config.py
+++ b/examples/kv_cache_calculator/generate_config.py
@@ -38,8 +38,9 @@ def main():
             config_data["kv_lora_rank"] = getattr(config, "kv_lora_rank", None)
             config_data["qk_rope_head_dim"] = getattr(config, "qk_rope_head_dim", None)
 
-        # Check for Qwen3 models (fuzzy matching)
-        if "qwen/qwen3-" in args.model.lower():
+        # Check for models that require head_dim
+        model_prefixes = ["qwen/qwen3-", "janhq/jan-", "casperhansen/llama-", "openai/gpt-"]
+        if any(prefix in args.model.lower() for prefix in model_prefixes):
             config_data["head_dim"] = getattr(config, "head_dim", None)
 
         # Convert to JSON and print

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -180,10 +180,13 @@
 
             // Check for Qwen3 models (fuzzy matching)
             const isQwen3Model = model.toLowerCase().includes("qwen/qwen3-");
+            const isJanModel = model.toLowerCase().includes("janhq/jan-");
+            const isLlama3Model = model.toLowerCase().includes("casperhansen/llama-");
+            const isGPTModel = model.toLowerCase().includes("openai/gpt-");
 
             if (isDeepSeekModel) {
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, kv_lora_rank, qk_rope_head_dim } = config);
-            } else if (isQwen3Model) {
+            } else if (isQwen3Model || isJanModel || isLlama3Model || isGPTModel) {
                 // The Qwen3 series use GQA, and `head_dim` needs to be read from config file.
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, head_dim } = config);
                 console.log(config);
@@ -210,7 +213,7 @@
             let total_elements;
             if (isDeepSeekModel) {
                 total_elements = num_hidden_layers * tokens * (kv_lora_rank + qk_rope_head_dim);
-            } else if (isQwen3Model) {
+            } else if (isQwen3Model || isJanModel || isLlama3Model || isGPTModel) {
                 total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_dim;
             } else {
                 total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_size;
@@ -235,7 +238,7 @@
                 <b>Total Bytes:</b> ${total_elements} × ${dtype_size} = ${total_bytes} bytes<br>
                 <b>KV Cache Size:</b> ${total_bytes} / (1024³) ≈ ${kvCacheSizeGB.toFixed(4)} GB
                 `;
-            } else if (isQwen3Model) {
+            } else if (isQwen3Model || isJanModel || isLlama3Model || isGPTModel) {
                 steps = `
                 <strong>Calculation Details:</strong><br><br>
                 <b>Selected Model:</b> ${model}<br>

--- a/examples/kv_cache_calculator/modelconfig.json
+++ b/examples/kv_cache_calculator/modelconfig.json
@@ -127,5 +127,33 @@
         "num_attention_heads": 32,
         "num_hidden_layers": 32,
         "num_key_value_heads": 32
+    },
+    "janhq/Jan-v1-4B": {
+        "hidden_size": 2560,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 36,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
+    "Qwen/Qwen3-30B-A3B-Instruct-2507": {
+    "hidden_size": 2048,
+    "num_attention_heads": 32,
+    "num_hidden_layers": 48,
+    "num_key_value_heads": 4,
+    "head_dim": 128
+    },
+    "casperhansen/llama-3.3-70b-instruct-awq": {
+    "hidden_size": 8192,
+    "num_attention_heads": 64,
+    "num_hidden_layers": 80,
+    "num_key_value_heads": 8,
+    "head_dim": 128
+    },
+    "openai/gpt-oss-20b": {
+    "hidden_size": 2880,
+    "num_attention_heads": 64,
+    "num_hidden_layers": 24,
+    "num_key_value_heads": 8,
+    "head_dim": 64
     }
 }


### PR DESCRIPTION
This PR adds support for the following models in kv-cache-calculator:
- `casperhansen/llama-3.3-70b-instruct-awq`
- `openai/gpt-oss-20b`
- 'Qwen/Qwen3-30B-A3B-Instruct-2507'
-'janhq/Jan-v1-4'



