### PR TITLE
[refact] use request_configs replace tags

### DIFF
--- a/examples/cache_with_configs/README.md
+++ b/examples/cache_with_configs/README.md
@@ -1,5 +1,8 @@
-# Cache by tags
-This is an example to cache by tags, use the `kv_transfer_params.user` field to pass the `user` tag, which is enable for user-isolated caching.
+# Cache with configs
+This is an example to cache with configs, includes tags and the other configs.
+- tags will be used to generate the key
+- configs will be used to interact with the backends, such as set the ttl
+
 ## Prerequisites
 Your server should have at least 1 GPU.
 
@@ -22,7 +25,7 @@ vllm serve /disc/f/models/opt-125m/ \
            --trust-remote-code
 ```
 
-3. Send a request to vllm engine with `kv_transfer_params: {user: example_user_1}`:
+2. Send a request to vllm engine with tags and configs by `kv_transfer_params: {}`:
 ```bash
 curl -X POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
@@ -31,14 +34,10 @@ curl -X POST http://localhost:8000/v1/completions \
     "prompt": "Explain the significance of KV cache in language models." * 100,
     "max_tokens": 10,
 	"kv_transfer_params": {
-	  "user": "example_user_1"
+	  "lmcache.tag.user": "example_user_1",
+	  "lmcache.ttl": 60
 	}
   }'
 ```
-
-You should be able to see logs `Retrieved xxx out of xxx out of total xxx tokens` at the second time use the same input,
-but if you change the `user` field, the first time will not hit the cache.
-
-```plaintext
-LMCache INFO: Retrieved 512 out of 512 out of total 512 tokens
-```
+- set tags: use `lmcache.tag.xxx`
+- set configs: use `lmcache.xxx`

--- a/examples/cache_with_configs/example.yaml
+++ b/examples/cache_with_configs/example.yaml
@@ -2,6 +2,3 @@ chunk_size: 256
 local_device: "cpu"
 local_cpu: True
 max_local_cpu_size: 10
-extra_config:
-  tag_keys: ["user"]
-

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -88,16 +88,16 @@ class DisaggSpec:
 tmp_disagg_tracker: dict[str, DisaggSpec] = {}
 
 
-def extract_request_extra_configs(sampling_params: SamplingParams) -> Optional[dict]:
-    extra_configs = None
+def extract_request_configs(sampling_params: SamplingParams) -> Optional[dict]:
+    request_configs = None
     if sampling_params.extra_args is not None:
         if kv_transfer_params := sampling_params.extra_args.get("kv_transfer_params"):
             for k, v in kv_transfer_params.items():
                 if k.startswith("lmcache."):
-                    if extra_configs is None:
-                        extra_configs = {}
-                    extra_configs[k] = v
-    return extra_configs
+                    if request_configs is None:
+                        request_configs = {}
+                    request_configs[k] = v
+    return request_configs
 
 
 @dataclass
@@ -127,8 +127,8 @@ class RequestTracker:
     mm_hashes: Optional[list[str]] = None
     mm_positions: Optional[list["PlaceholderRange"]] = None
 
-    # The extra configs of the request, includes tags and other configs
-    extra_configs: Optional[dict] = None
+    # The configs of the request, includes tags and other configs
+    request_configs: Optional[dict] = None
 
     # Whether the request is in decode phase
     is_decode_phase = False
@@ -173,7 +173,7 @@ class RequestTracker:
         # NOTE: Initialized in `update_state_after_alloc`
         disagg_spec = tmp_disagg_tracker.pop(new_request.req_id, None)
 
-        extra_configs = extract_request_extra_configs(new_request.sampling_params)
+        request_configs = extract_request_configs(new_request.sampling_params)
 
         return RequestTracker(
             req_id=new_request.req_id,
@@ -184,7 +184,7 @@ class RequestTracker:
             disagg_spec=disagg_spec,
             mm_hashes=new_request.mm_hashes.copy(),
             mm_positions=new_request.mm_positions.copy(),
-            extra_configs=extra_configs,
+            request_configs=request_configs,
         )
 
     def update(
@@ -233,8 +233,8 @@ class ReqMeta:
     load_spec: Optional[LoadSpec] = None
     # disagg spec
     disagg_spec: Optional[DisaggSpec] = None
-    # the extra configs
-    extra_configs: Optional[dict] = None
+    # the configs of the request
+    request_configs: Optional[dict] = None
 
     @staticmethod
     def from_request_tracker(
@@ -360,7 +360,7 @@ class ReqMeta:
             save_spec=save_spec,
             load_spec=load_spec,
             disagg_spec=tracker.disagg_spec,
-            extra_configs=tracker.extra_configs,
+            request_configs=tracker.request_configs,
         )
 
 
@@ -720,7 +720,7 @@ class LMCacheConnectorV1Impl:
                     token_mask[:lmcache_cached_tokens],
                     kvcaches=kvcaches,
                     slot_mapping=slot_mapping[:lmcache_cached_tokens],
-                    extra_configs=request.extra_configs,
+                    request_configs=request.request_configs,
                 )
 
                 # Check the result
@@ -949,7 +949,7 @@ class LMCacheConnectorV1Impl:
                 slot_mapping=slot_mapping,
                 offset=skip_leading_tokens,
                 transfer_spec=request.disagg_spec,
-                extra_configs=request.extra_configs,
+                request_configs=request.request_configs,
             )
 
             # NOTE(Jiayi): We assume all tokens are saved
@@ -1001,18 +1001,18 @@ class LMCacheConnectorV1Impl:
         lookup_id = str(uuid.uuid4())
         self._lookup_requests_in_step.append(lookup_id)
 
-        extra_configs = extract_request_extra_configs(request.sampling_params)
+        request_configs = extract_request_configs(request.sampling_params)
         if self.skip_last_n_tokens > 0:
             num_external_hit_tokens = self.lookup_client.lookup(
                 token_ids[: -self.skip_last_n_tokens],
                 lookup_id=lookup_id,
-                extra_configs=extra_configs,
+                request_configs=request_configs,
             )
         else:
             num_external_hit_tokens = self.lookup_client.lookup(
                 token_ids,
                 lookup_id=lookup_id,
-                extra_configs=extra_configs,
+                request_configs=request_configs,
             )
 
         # When prompt length is divisible by the block size and all

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -88,21 +88,16 @@ class DisaggSpec:
 tmp_disagg_tracker: dict[str, DisaggSpec] = {}
 
 
-def extract_tags(
-    config: LMCacheEngineConfig, sampling_params: SamplingParams
-) -> OrderedDict:
-    tags = None
-    tag_keys = None
-    if config.extra_config is not None and isinstance(config.extra_config, dict):
-        tag_keys = config.extra_config.get("tag_keys")
-    if sampling_params.extra_args is not None and tag_keys is not None:
+def extract_request_extra_configs(sampling_params: SamplingParams) -> Optional[dict]:
+    extra_configs = None
+    if sampling_params.extra_args is not None:
         if kv_transfer_params := sampling_params.extra_args.get("kv_transfer_params"):
-            for k in tag_keys:
-                if v := kv_transfer_params.get(k):
-                    if tags is None:
-                        tags = OrderedDict()
-                    tags[k] = v
-    return tags
+            for k, v in kv_transfer_params.items():
+                if k.startswith("lmcache."):
+                    if extra_configs is None:
+                        extra_configs = {}
+                    extra_configs[k] = v
+    return extra_configs
 
 
 @dataclass
@@ -131,8 +126,9 @@ class RequestTracker:
     # Multimodal hashes and positions
     mm_hashes: Optional[list[str]] = None
     mm_positions: Optional[list["PlaceholderRange"]] = None
-    # The request tags
-    tags: Optional[OrderedDict] = None
+
+    # The extra configs of the request, includes tags and other configs
+    extra_configs: Optional[dict] = None
 
     # Whether the request is in decode phase
     is_decode_phase = False
@@ -177,7 +173,7 @@ class RequestTracker:
         # NOTE: Initialized in `update_state_after_alloc`
         disagg_spec = tmp_disagg_tracker.pop(new_request.req_id, None)
 
-        tags = extract_tags(lmcache_config, new_request.sampling_params)
+        extra_configs = extract_request_extra_configs(new_request.sampling_params)
 
         return RequestTracker(
             req_id=new_request.req_id,
@@ -188,7 +184,7 @@ class RequestTracker:
             disagg_spec=disagg_spec,
             mm_hashes=new_request.mm_hashes.copy(),
             mm_positions=new_request.mm_positions.copy(),
-            tags=tags,
+            extra_configs=extra_configs,
         )
 
     def update(
@@ -237,8 +233,8 @@ class ReqMeta:
     load_spec: Optional[LoadSpec] = None
     # disagg spec
     disagg_spec: Optional[DisaggSpec] = None
-    # tags
-    tags: Optional[OrderedDict] = None
+    # the extra configs
+    extra_configs: Optional[dict] = None
 
     @staticmethod
     def from_request_tracker(
@@ -364,7 +360,7 @@ class ReqMeta:
             save_spec=save_spec,
             load_spec=load_spec,
             disagg_spec=tracker.disagg_spec,
-            tags=tracker.tags,
+            extra_configs=tracker.extra_configs,
         )
 
 
@@ -724,7 +720,7 @@ class LMCacheConnectorV1Impl:
                     token_mask[:lmcache_cached_tokens],
                     kvcaches=kvcaches,
                     slot_mapping=slot_mapping[:lmcache_cached_tokens],
-                    tags=request.tags,
+                    extra_configs=request.extra_configs,
                 )
 
                 # Check the result
@@ -953,7 +949,7 @@ class LMCacheConnectorV1Impl:
                 slot_mapping=slot_mapping,
                 offset=skip_leading_tokens,
                 transfer_spec=request.disagg_spec,
-                tags=request.tags,
+                extra_configs=request.extra_configs,
             )
 
             # NOTE(Jiayi): We assume all tokens are saved
@@ -1005,18 +1001,18 @@ class LMCacheConnectorV1Impl:
         lookup_id = str(uuid.uuid4())
         self._lookup_requests_in_step.append(lookup_id)
 
-        tags = extract_tags(self.config, request.sampling_params)
+        extra_configs = extract_request_extra_configs(request.sampling_params)
         if self.skip_last_n_tokens > 0:
             num_external_hit_tokens = self.lookup_client.lookup(
                 token_ids[: -self.skip_last_n_tokens],
                 lookup_id=lookup_id,
-                tags=tags,
+                extra_configs=extra_configs,
             )
         else:
             num_external_hit_tokens = self.lookup_client.lookup(
                 token_ids,
                 lookup_id=lookup_id,
-                tags=tags,
+                extra_configs=extra_configs,
             )
 
         # When prompt length is divisible by the block size and all

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional, OrderedDict, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 import os
 import uuid
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -88,7 +88,7 @@ class CacheEngineKey:
                 if k.startswith("lmcache.tag."):
                     if tags is None:
                         tags = {}
-                    tags[k[len("lmcache.tag."):]] = v
+                    tags[k[len("lmcache.tag.") :]] = v
         self.tags = tags
 
     def __hash__(self):
@@ -167,7 +167,12 @@ class CacheEngineKey:
                     raise ValueError(f"Invalid key string: {s}")
                 extra_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
-            parts[0], parts[1], int(parts[2]), int(parts[3]), int(parts[4], 16), extra_configs
+            parts[0],
+            parts[1],
+            int(parts[2]),
+            int(parts[3]),
+            int(parts[4], 16),
+            extra_configs,
         )
 
     def to_dict(self):

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -79,12 +79,12 @@ class CacheEngineKey:
     world_size: int
     worker_id: int
     chunk_hash: int
-    extra_configs: Optional[dict] = None
+    request_configs: Optional[dict] = None
 
     def __post_init__(self):
         tags = None
-        if self.extra_configs is not None:
-            for k, v in self.extra_configs.items():
+        if self.request_configs is not None:
+            for k, v in self.request_configs.items():
                 if k.startswith("lmcache.tag."):
                     if tags is None:
                         tags = {}
@@ -134,7 +134,7 @@ class CacheEngineKey:
                     self.world_size,
                     self.worker_id,
                     self.chunk_hash,
-                    self.extra_configs,
+                    self.request_configs,
                     layer_id,
                 )
             )
@@ -148,7 +148,7 @@ class CacheEngineKey:
             self.world_size,
             self.worker_id,
             self.chunk_hash,
-            self.extra_configs,
+            self.request_configs,
             0,
         )
         return key
@@ -158,21 +158,21 @@ class CacheEngineKey:
         parts = s.split("@")
         if len(parts) < 5:
             raise ValueError(f"Invalid key string: {s}")
-        extra_configs = None
+        request_configs = None
         if len(parts) >= 6:
-            extra_configs = {}
+            request_configs = {}
             for kv in parts[5:]:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
-                extra_configs[kvs[0]] = kvs[1]
+                request_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
             parts[0],
             parts[1],
             int(parts[2]),
             int(parts[3]),
             int(parts[4], 16),
-            extra_configs,
+            request_configs,
         )
 
     def to_dict(self):
@@ -185,27 +185,27 @@ class CacheEngineKey:
             "worker_id": self.worker_id,
             "chunk_hash": self.chunk_hash,
         }
-        if self.extra_configs is not None and len(self.extra_configs) != 0:
-            msg["extra_configs"] = [f"{k}%{v}" for k, v in self.extra_configs.items()]
+        if self.request_configs is not None and len(self.request_configs) != 0:
+            msg["request_configs"] = [f"{k}%{v}" for k, v in self.request_configs.items()]
         return msg
 
     @staticmethod
     def from_dict(d):
-        extra_configs = None
-        if extra_configs_list := d.get("extra_configs"):
-            extra_configs = {}
-            for kv in extra_configs_list:
+        request_configs = None
+        if request_configs_list := d.get("request_configs"):
+            request_configs = {}
+            for kv in request_configs_list:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key dict: {d}")
-                extra_configs[kvs[0]] = kvs[1]
+                request_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
             fmt=d["fmt"],
             model_name=d["model_name"],
             world_size=d["world_size"],
             worker_id=d["worker_id"],
             chunk_hash=d["chunk_hash"],
-            extra_configs=extra_configs,
+            request_configs=request_configs,
         )
 
 
@@ -260,7 +260,7 @@ class LayerCacheEngineKey(CacheEngineKey):
                     self.world_size,
                     self.worker_id,
                     self.chunk_hash,
-                    self.extra_configs,
+                    self.request_configs,
                     layer_id,
                 )
             )
@@ -271,21 +271,21 @@ class LayerCacheEngineKey(CacheEngineKey):
         parts = s.split("@")
         if len(parts) < 6:
             raise ValueError(f"Invalid key string: {s}")
-        extra_configs = None
+        request_configs = None
         if len(parts) >= 7:
-            extra_configs = {}
+            request_configs = {}
             for kv in parts[6:]:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
-                extra_configs[kvs[0]] = kvs[1]
+                request_configs[kvs[0]] = kvs[1]
         return LayerCacheEngineKey(
             parts[0],
             parts[1],
             int(parts[2]),
             int(parts[3]),
             int(parts[4], 16),
-            extra_configs,
+            request_configs,
             int(parts[5]),
         )
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 # Standard
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, OrderedDict, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 import asyncio
 import hashlib
 import threading
@@ -79,7 +79,17 @@ class CacheEngineKey:
     world_size: int
     worker_id: int
     chunk_hash: int
-    tags: Optional[OrderedDict] = None
+    extra_configs: Optional[dict] = None
+
+    def __post_init__(self):
+        tags = None
+        if self.extra_configs is not None:
+            for k, v in self.extra_configs.items():
+                if k.startswith("lmcache.tag."):
+                    if tags is None:
+                        tags = {}
+                    tags[k[len("lmcache.tag."):]] = v
+        self.tags = tags
 
     def __hash__(self):
         if self.tags is None:
@@ -124,7 +134,7 @@ class CacheEngineKey:
                     self.world_size,
                     self.worker_id,
                     self.chunk_hash,
-                    self.tags,
+                    self.extra_configs,
                     layer_id,
                 )
             )
@@ -138,7 +148,7 @@ class CacheEngineKey:
             self.world_size,
             self.worker_id,
             self.chunk_hash,
-            self.tags,
+            self.extra_configs,
             0,
         )
         return key
@@ -148,16 +158,16 @@ class CacheEngineKey:
         parts = s.split("@")
         if len(parts) < 5:
             raise ValueError(f"Invalid key string: {s}")
-        tags = None
+        extra_configs = None
         if len(parts) >= 6:
-            tags = OrderedDict()
+            extra_configs = {}
             for kv in parts[5:]:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
-                tags[kvs[0]] = kvs[1]
+                extra_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
-            parts[0], parts[1], int(parts[2]), int(parts[3]), int(parts[4], 16), tags
+            parts[0], parts[1], int(parts[2]), int(parts[3]), int(parts[4], 16), extra_configs
         )
 
     def to_dict(self):
@@ -170,27 +180,27 @@ class CacheEngineKey:
             "worker_id": self.worker_id,
             "chunk_hash": self.chunk_hash,
         }
-        if self.tags is not None and len(self.tags) != 0:
-            msg["tags"] = [f"{k}%{v}" for k, v in self.tags.items()]
+        if self.extra_configs is not None and len(self.extra_configs) != 0:
+            msg["extra_configs"] = [f"{k}%{v}" for k, v in self.extra_configs.items()]
         return msg
 
     @staticmethod
     def from_dict(d):
-        tags = None
-        if tag_list := d.get("tags"):
-            tags = OrderedDict()
-            for kv in tag_list:
+        extra_configs = None
+        if extra_configs_list := d.get("extra_configs"):
+            extra_configs = {}
+            for kv in extra_configs_list:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key dict: {d}")
-                tags[kvs[0]] = kvs[1]
+                extra_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
             fmt=d["fmt"],
             model_name=d["model_name"],
             world_size=d["world_size"],
             worker_id=d["worker_id"],
             chunk_hash=d["chunk_hash"],
-            tags=tags,
+            extra_configs=extra_configs,
         )
 
 
@@ -245,7 +255,7 @@ class LayerCacheEngineKey(CacheEngineKey):
                     self.world_size,
                     self.worker_id,
                     self.chunk_hash,
-                    self.tags,
+                    self.extra_configs,
                     layer_id,
                 )
             )
@@ -256,21 +266,21 @@ class LayerCacheEngineKey(CacheEngineKey):
         parts = s.split("@")
         if len(parts) < 6:
             raise ValueError(f"Invalid key string: {s}")
-        tags = None
+        extra_configs = None
         if len(parts) >= 7:
-            tags = OrderedDict()
+            extra_configs = {}
             for kv in parts[6:]:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
-                tags[kvs[0]] = kvs[1]
+                extra_configs[kvs[0]] = kvs[1]
         return LayerCacheEngineKey(
             parts[0],
             parts[1],
             int(parts[2]),
             int(parts[3]),
             int(parts[4], 16),
-            tags,
+            extra_configs,
             int(parts[5]),
         )
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -186,7 +186,9 @@ class CacheEngineKey:
             "chunk_hash": self.chunk_hash,
         }
         if self.request_configs is not None and len(self.request_configs) != 0:
-            msg["request_configs"] = [f"{k}%{v}" for k, v in self.request_configs.items()]
+            msg["request_configs"] = [
+                f"{k}%{v}" for k, v in self.request_configs.items()
+            ]
         return msg
 
     @staticmethod

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -238,16 +238,16 @@ class LMCacheEngine:
         tot_token_num = 0
         t = time.perf_counter()
 
-        extra_configs = kwargs.get("extra_configs")
-        if extra_configs is not None and len(extra_configs) != 0:
-            assert isinstance(extra_configs, dict)
+        request_configs = kwargs.get("request_configs")
+        if request_configs is not None and len(request_configs) != 0:
+            assert isinstance(request_configs, dict)
 
         for start, end, key in self.token_database.process_tokens(
             tokens,
             hashes,
             offsets,
             mask,
-            extra_configs=extra_configs,
+            request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)
             # Allocate the memory object
@@ -343,12 +343,12 @@ class LMCacheEngine:
         memory_objs = []
         tot_token_num = 0
         kv_dtype = self.metadata.kv_dtype
-        extra_configs = kwargs.get("extra_configs")
-        if extra_configs is not None and len(extra_configs) != 0:
-            assert isinstance(extra_configs, dict)
+        request_configs = kwargs.get("request_configs")
+        if request_configs is not None and len(request_configs) != 0:
+            assert isinstance(request_configs, dict)
 
         for start, end, key in self.token_database.process_tokens(
-            tokens=tokens, mask=mask, extra_configs=extra_configs
+            tokens=tokens, mask=mask, request_configs=request_configs
         ):
             assert isinstance(key, CacheEngineKey)
 
@@ -535,13 +535,13 @@ class LMCacheEngine:
         ends = []
         keys = []
 
-        extra_configs = kwargs.get("extra_configs")
-        if extra_configs is not None and len(extra_configs) != 0:
-            assert isinstance(extra_configs, dict)
+        request_configs = kwargs.get("request_configs")
+        if request_configs is not None and len(request_configs) != 0:
+            assert isinstance(request_configs, dict)
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
-            extra_configs=extra_configs,
+            request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)
 
@@ -613,7 +613,7 @@ class LMCacheEngine:
         self,
         tokens: Union[torch.Tensor, List[int]],
         mask: Optional[torch.Tensor] = None,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> None:
         """Launch the prefetching process in the storage manager to load the
         KV to the local CPU memory
@@ -621,7 +621,7 @@ class LMCacheEngine:
         if self._is_passive():
             return
         for start, end, key in self.token_database.process_tokens(
-            tokens=tokens, mask=mask, extra_configs=extra_configs
+            tokens=tokens, mask=mask, request_configs=request_configs
         ):
             assert isinstance(key, CacheEngineKey)
             self.storage_manager.prefetch(key)
@@ -633,7 +633,7 @@ class LMCacheEngine:
         search_range: Optional[List[str]] = None,
         lookup_id: Optional[str] = None,
         pin: bool = False,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
@@ -650,7 +650,7 @@ class LMCacheEngine:
 
         :param bool pin: If True, pin the KV cache in the storage.
 
-        :param Optional[dict] extra_configs: the extra configs of the request
+        :param Optional[dict] request_configs: the configs of the request.
 
         :return: An int indicating how many prefix tokens are cached.
         """
@@ -668,7 +668,7 @@ class LMCacheEngine:
             )
 
             for start, end, key in self.token_database.process_tokens(
-                tokens=tokens, extra_configs=extra_configs
+                tokens=tokens, request_configs=request_configs
             ):
                 assert isinstance(key, CacheEngineKey)
 
@@ -892,23 +892,23 @@ class LMCacheEngine:
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
         locations: Optional[List[str]] = None,
-        extra_configs: Optional[dict] = None,  # TODO: need to clean by extra_configs
+        request_configs: Optional[dict] = None,  # TODO: need to clean by request_configs
     ) -> int:
         if self.save_only_first_rank:
             if self.metadata.is_first_rank():
-                num_removed = self._clear(tokens, locations, extra_configs)
+                num_removed = self._clear(tokens, locations, request_configs)
                 self.broadcast_object_fn(num_removed, self.metadata.first_rank)
                 return num_removed
             else:
                 num_removed = self.broadcast_object_fn(None, self.metadata.first_rank)
                 return int(num_removed)
-        return self._clear(tokens, locations, extra_configs)
+        return self._clear(tokens, locations, request_configs)
 
     def _clear(
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
         locations: Optional[List[str]] = None,
-        extra_configs: Optional[dict] = None,  # TODO: need to clean by extra_configs
+        request_configs: Optional[dict] = None,  # TODO: need to clean by request_configs
     ) -> int:
         assert isinstance(self.storage_manager, StorageManager)
         # Clear all caches if tokens is None
@@ -919,7 +919,7 @@ class LMCacheEngine:
         num_removed = 0
         # Only remove the caches for the given tokens
         for start, end, key in self.token_database.process_tokens(
-            tokens=tokens, extra_configs=extra_configs
+            tokens=tokens, request_configs=request_configs
         ):
             assert isinstance(key, CacheEngineKey)
             removed = self.storage_manager.remove(key, locations)
@@ -975,13 +975,13 @@ class LMCacheEngine:
         # [(CacheEngineKey, MemoryObj, start, end)]
         reordered_chunks: List[Tuple[CacheEngineKey, MemoryObj, int, int]] = []
 
-        extra_configs = kwargs.get("extra_configs")
-        if extra_configs is not None and len(extra_configs) != 0:
-            assert isinstance(extra_configs, dict)
+        request_configs = kwargs.get("request_configs")
+        if request_configs is not None and len(request_configs) != 0:
+            assert isinstance(request_configs, dict)
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
-            extra_configs=extra_configs,
+            request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -892,8 +892,9 @@ class LMCacheEngine:
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
         locations: Optional[List[str]] = None,
-        request_configs: Optional[dict] = None,  # TODO: need to clean by request_configs
+        request_configs: Optional[dict] = None,
     ) -> int:
+        # TODO: need to clear by request_configs
         if self.save_only_first_rank:
             if self.metadata.is_first_rank():
                 num_removed = self._clear(tokens, locations, request_configs)
@@ -908,7 +909,7 @@ class LMCacheEngine:
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
         locations: Optional[List[str]] = None,
-        request_configs: Optional[dict] = None,  # TODO: need to clean by request_configs
+        request_configs: Optional[dict] = None,
     ) -> int:
         assert isinstance(self.storage_manager, StorageManager)
         # Clear all caches if tokens is None

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -8,7 +8,6 @@ from typing import (
     Generator,
     List,
     Optional,
-    OrderedDict,
     Tuple,
     Union,
 )
@@ -239,16 +238,16 @@ class LMCacheEngine:
         tot_token_num = 0
         t = time.perf_counter()
 
-        tags = kwargs.get("tags")
-        if tags is not None and len(tags) != 0:
-            assert isinstance(tags, OrderedDict)
+        extra_configs = kwargs.get("extra_configs")
+        if extra_configs is not None and len(extra_configs) != 0:
+            assert isinstance(extra_configs, dict)
 
         for start, end, key in self.token_database.process_tokens(
             tokens,
             hashes,
             offsets,
             mask,
-            tags=tags,
+            extra_configs=extra_configs,
         ):
             assert isinstance(key, CacheEngineKey)
             # Allocate the memory object
@@ -344,12 +343,12 @@ class LMCacheEngine:
         memory_objs = []
         tot_token_num = 0
         kv_dtype = self.metadata.kv_dtype
-        tags = kwargs.get("tags")
-        if tags is not None and len(tags) != 0:
-            assert isinstance(tags, OrderedDict)
+        extra_configs = kwargs.get("extra_configs")
+        if extra_configs is not None and len(extra_configs) != 0:
+            assert isinstance(extra_configs, dict)
 
         for start, end, key in self.token_database.process_tokens(
-            tokens=tokens, mask=mask, tags=tags
+            tokens=tokens, mask=mask, extra_configs=extra_configs
         ):
             assert isinstance(key, CacheEngineKey)
 
@@ -536,13 +535,13 @@ class LMCacheEngine:
         ends = []
         keys = []
 
-        tags = kwargs.get("tags")
-        if tags is not None and len(tags) != 0:
-            assert isinstance(tags, OrderedDict)
+        extra_configs = kwargs.get("extra_configs")
+        if extra_configs is not None and len(extra_configs) != 0:
+            assert isinstance(extra_configs, dict)
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
-            tags=tags,
+            extra_configs=extra_configs,
         ):
             assert isinstance(key, CacheEngineKey)
 
@@ -614,7 +613,7 @@ class LMCacheEngine:
         self,
         tokens: Union[torch.Tensor, List[int]],
         mask: Optional[torch.Tensor] = None,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> None:
         """Launch the prefetching process in the storage manager to load the
         KV to the local CPU memory
@@ -622,7 +621,7 @@ class LMCacheEngine:
         if self._is_passive():
             return
         for start, end, key in self.token_database.process_tokens(
-            tokens=tokens, mask=mask, tags=tags
+            tokens=tokens, mask=mask, extra_configs=extra_configs
         ):
             assert isinstance(key, CacheEngineKey)
             self.storage_manager.prefetch(key)
@@ -634,7 +633,7 @@ class LMCacheEngine:
         search_range: Optional[List[str]] = None,
         lookup_id: Optional[str] = None,
         pin: bool = False,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
@@ -650,6 +649,8 @@ class LMCacheEngine:
         associate with the lookup
 
         :param bool pin: If True, pin the KV cache in the storage.
+
+        :param Optional[dict] extra_configs: the extra configs of the request
 
         :return: An int indicating how many prefix tokens are cached.
         """
@@ -667,7 +668,7 @@ class LMCacheEngine:
             )
 
             for start, end, key in self.token_database.process_tokens(
-                tokens=tokens, tags=tags
+                tokens=tokens, extra_configs=extra_configs
             ):
                 assert isinstance(key, CacheEngineKey)
 
@@ -891,23 +892,23 @@ class LMCacheEngine:
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
         locations: Optional[List[str]] = None,
-        tags: OrderedDict = None,  # TODO: need to clean by tags
+        extra_configs: Optional[dict] = None,  # TODO: need to clean by extra_configs
     ) -> int:
         if self.save_only_first_rank:
             if self.metadata.is_first_rank():
-                num_removed = self._clear(tokens, locations)
+                num_removed = self._clear(tokens, locations, extra_configs)
                 self.broadcast_object_fn(num_removed, self.metadata.first_rank)
                 return num_removed
             else:
                 num_removed = self.broadcast_object_fn(None, self.metadata.first_rank)
                 return int(num_removed)
-        return self._clear(tokens, locations)
+        return self._clear(tokens, locations, extra_configs)
 
     def _clear(
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
         locations: Optional[List[str]] = None,
-        tags: OrderedDict = None,  # TODO: need to clean by tags
+        extra_configs: Optional[dict] = None,  # TODO: need to clean by extra_configs
     ) -> int:
         assert isinstance(self.storage_manager, StorageManager)
         # Clear all caches if tokens is None
@@ -918,7 +919,7 @@ class LMCacheEngine:
         num_removed = 0
         # Only remove the caches for the given tokens
         for start, end, key in self.token_database.process_tokens(
-            tokens=tokens, tags=tags
+            tokens=tokens, extra_configs=extra_configs
         ):
             assert isinstance(key, CacheEngineKey)
             removed = self.storage_manager.remove(key, locations)
@@ -974,13 +975,13 @@ class LMCacheEngine:
         # [(CacheEngineKey, MemoryObj, start, end)]
         reordered_chunks: List[Tuple[CacheEngineKey, MemoryObj, int, int]] = []
 
-        tags = kwargs.get("tags")
-        if tags is not None and len(tags) != 0:
-            assert isinstance(tags, OrderedDict)
+        extra_configs = kwargs.get("extra_configs")
+        if extra_configs is not None and len(extra_configs) != 0:
+            assert isinstance(extra_configs, dict)
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
-            tags=tags,
+            extra_configs=extra_configs,
         ):
             assert isinstance(key, CacheEngineKey)
 

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Optional, OrderedDict
+from typing import TYPE_CHECKING, Optional
 import abc
 
 # Third Party
@@ -19,7 +19,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
         self,
         token_ids: torch.Tensor,
         lookup_id: Optional[str] = None,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> int:
         """
         Perform lookup for the given token IDs.
@@ -28,6 +28,9 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
             token_ids: The token IDs to lookup
 
             lookup_id: The lookup ID to associate with the lookup
+
+            extra_configs: The extra configs of the request,
+            includes tags and the other configs
 
         Returns:
             The number of tokens that can be loaded from cache

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -19,7 +19,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
         self,
         token_ids: torch.Tensor,
         lookup_id: Optional[str] = None,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> int:
         """
         Perform lookup for the given token IDs.
@@ -29,7 +29,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
 
             lookup_id: The lookup ID to associate with the lookup
 
-            extra_configs: The extra configs of the request,
+            request_configs: The configs of the request,
             includes tags and the other configs
 
         Returns:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -72,7 +72,9 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:
-            request_configs_str = "@".join([f"{k}%{v}" for k, v in request_configs.items()])
+            request_configs_str = "@".join(
+                [f"{k}%{v}" for k, v in request_configs.items()]
+            )
         request_configs_buf = request_configs_str.encode("utf-8")
         ranks = self.tensor_parallel_size
         if self.create_lookup_server_only_on_worker_0_for_mla:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Optional, OrderedDict
+from typing import TYPE_CHECKING, Optional
 import threading
 
 # Third Party
@@ -66,19 +66,19 @@ class LMCacheLookupClient(LookupClientInterface):
         self,
         token_ids: torch.Tensor,
         lookup_id: Optional[str] = None,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> int:
         token_bufs = self.encoder.encode(token_ids)
         lookup_id_buf = lookup_id.encode("utf-8")
-        tags_str = ""
-        if tags is not None and len(tags) != 0:
-            tags_str = "@".join([f"{k}%{v}" for k, v in tags.items()])
-        tags_buf = tags_str.encode("utf-8")
+        extra_configs_str = ""
+        if extra_configs is not None and len(extra_configs) != 0:
+            extra_configs_str = "@".join([f"{k}%{v}" for k, v in extra_configs.items()])
+        extra_configs_buf = extra_configs_str.encode("utf-8")
         ranks = self.tensor_parallel_size
         if self.create_lookup_server_only_on_worker_0_for_mla:
             ranks = 1
         results = []
-        msg_buf = token_bufs + [lookup_id_buf, tags_buf]
+        msg_buf = token_bufs + [lookup_id_buf, extra_configs_buf]
         for i in range(ranks):
             self.sockets[i].send_multipart(msg_buf, copy=False)
 
@@ -132,23 +132,23 @@ class LMCacheLookupServer:
                 frames = self.socket.recv_multipart(copy=False)
                 token_frames = frames[:-2]
                 lookup_id = frames[-2].bytes.decode("utf-8")
-                tags_str = frames[-1].bytes.decode("utf-8")
-                tags = None
-                if tags_str != "":
-                    tags = OrderedDict()
-                    tags_list = tags_str.split("@")
-                    for kv in tags_list:
+                extra_configs_str = frames[-1].bytes.decode("utf-8")
+                extra_configs = None
+                if extra_configs_str != "":
+                    extra_configs = {}
+                    extra_configs_list = extra_configs_str.split("@")
+                    for kv in extra_configs_list:
                         kvs = kv.split("%", 1)
                         if len(kvs) != 2:
                             raise ValueError("Unexpected tags_str: {tags_str}")
-                        tags[kvs[0]] = kvs[1]
+                        extra_configs[kvs[0]] = kvs[1]
 
                 token_ids = self.decoder.decode(token_frames)
                 result = self.lmcache_engine.lookup(
                     token_ids,
                     lookup_id=lookup_id,
                     pin=True,
-                    tags=tags,
+                    extra_configs=extra_configs,
                 )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -66,19 +66,19 @@ class LMCacheLookupClient(LookupClientInterface):
         self,
         token_ids: torch.Tensor,
         lookup_id: Optional[str] = None,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> int:
         token_bufs = self.encoder.encode(token_ids)
         lookup_id_buf = lookup_id.encode("utf-8")
-        extra_configs_str = ""
-        if extra_configs is not None and len(extra_configs) != 0:
-            extra_configs_str = "@".join([f"{k}%{v}" for k, v in extra_configs.items()])
-        extra_configs_buf = extra_configs_str.encode("utf-8")
+        request_configs_str = ""
+        if request_configs is not None and len(request_configs) != 0:
+            request_configs_str = "@".join([f"{k}%{v}" for k, v in request_configs.items()])
+        request_configs_buf = request_configs_str.encode("utf-8")
         ranks = self.tensor_parallel_size
         if self.create_lookup_server_only_on_worker_0_for_mla:
             ranks = 1
         results = []
-        msg_buf = token_bufs + [lookup_id_buf, extra_configs_buf]
+        msg_buf = token_bufs + [lookup_id_buf, request_configs_buf]
         for i in range(ranks):
             self.sockets[i].send_multipart(msg_buf, copy=False)
 
@@ -132,23 +132,23 @@ class LMCacheLookupServer:
                 frames = self.socket.recv_multipart(copy=False)
                 token_frames = frames[:-2]
                 lookup_id = frames[-2].bytes.decode("utf-8")
-                extra_configs_str = frames[-1].bytes.decode("utf-8")
-                extra_configs = None
-                if extra_configs_str != "":
-                    extra_configs = {}
-                    extra_configs_list = extra_configs_str.split("@")
-                    for kv in extra_configs_list:
+                request_configs_str = frames[-1].bytes.decode("utf-8")
+                request_configs = None
+                if request_configs_str != "":
+                    request_configs = {}
+                    request_configs_list = request_configs_str.split("@")
+                    for kv in request_configs_list:
                         kvs = kv.split("%", 1)
                         if len(kvs) != 2:
                             raise ValueError("Unexpected tags_str: {tags_str}")
-                        extra_configs[kvs[0]] = kvs[1]
+                        request_configs[kvs[0]] = kvs[1]
 
                 token_ids = self.decoder.decode(token_frames)
                 result = self.lmcache_engine.lookup(
                     token_ids,
                     lookup_id=lookup_id,
                     pin=True,
-                    extra_configs=extra_configs,
+                    request_configs=request_configs,
                 )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Optional, OrderedDict
+from typing import TYPE_CHECKING, Optional
 
 # Third Party
 import torch
@@ -60,7 +60,7 @@ class MooncakeLookupClient(LookupClientInterface):
         self,
         token_ids: torch.Tensor,
         lookup_id: Optional[str] = None,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> int:
         # process token_ids to cacheengine keys
         keys = []

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -60,7 +60,7 @@ class MooncakeLookupClient(LookupClientInterface):
         self,
         token_ids: torch.Tensor,
         lookup_id: Optional[str] = None,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> int:
         # process token_ids to cacheengine keys
         keys = []

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -128,7 +128,7 @@ class RemoteBackend(StorageBackendInterface):
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
             key = CacheEngineKey(
-                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.tags
+                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.extra_configs,
             )
 
         try:
@@ -225,7 +225,7 @@ class RemoteBackend(StorageBackendInterface):
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
             key = CacheEngineKey(
-                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.tags
+                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.extra_configs
             )
         t1 = time.perf_counter()
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
@@ -270,7 +270,7 @@ class RemoteBackend(StorageBackendInterface):
         if self._mla_worker_id_as0_mode:
             new_keys = [
                 CacheEngineKey(
-                    key.fmt, key.model_name, key.world_size, 0, key.chunk_hash
+                    key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.extra_configs,
                 )
                 for key in keys
             ]

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -128,7 +128,12 @@ class RemoteBackend(StorageBackendInterface):
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
             key = CacheEngineKey(
-                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.extra_configs,
+                key.fmt,
+                key.model_name,
+                key.world_size,
+                0,
+                key.chunk_hash,
+                key.extra_configs,
             )
 
         try:
@@ -225,7 +230,12 @@ class RemoteBackend(StorageBackendInterface):
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
             key = CacheEngineKey(
-                key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.extra_configs
+                key.fmt,
+                key.model_name,
+                key.world_size,
+                0,
+                key.chunk_hash,
+                key.extra_configs,
             )
         t1 = time.perf_counter()
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
@@ -270,7 +280,12 @@ class RemoteBackend(StorageBackendInterface):
         if self._mla_worker_id_as0_mode:
             new_keys = [
                 CacheEngineKey(
-                    key.fmt, key.model_name, key.world_size, 0, key.chunk_hash, key.extra_configs,
+                    key.fmt,
+                    key.model_name,
+                    key.world_size,
+                    0,
+                    key.chunk_hash,
+                    key.extra_configs,
                 )
                 for key in keys
             ]

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -133,7 +133,7 @@ class RemoteBackend(StorageBackendInterface):
                 key.world_size,
                 0,
                 key.chunk_hash,
-                key.extra_configs,
+                key.request_configs,
             )
 
         try:
@@ -235,7 +235,7 @@ class RemoteBackend(StorageBackendInterface):
                 key.world_size,
                 0,
                 key.chunk_hash,
-                key.extra_configs,
+                key.request_configs,
             )
         t1 = time.perf_counter()
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
@@ -285,7 +285,7 @@ class RemoteBackend(StorageBackendInterface):
                     key.world_size,
                     0,
                     key.chunk_hash,
-                    key.extra_configs,
+                    key.request_configs,
                 )
                 for key in keys
             ]

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -81,7 +81,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> Iterable[Tuple[int, int, Union[CacheEngineKey, int]]]:
         """Process the tokens and return the corresponding cache engine keys.
 
@@ -100,7 +100,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         :param bool make_key: Whether to make the cache engine key or not.
             If False, the hash value will be returned instead.
 
-        :param Optional[dict] extra_configs: The extra configs of the request.
+        :param Optional[dict] request_configs: The configs of the request.
 
         :returns: A iterable of tuples with three elements. The first element
             is the start index of the tokens for the key. The second element
@@ -110,7 +110,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    def _make_key_by_hash(self, chunk_hash: int, extra_configs: Optional[dict] = None):
+    def _make_key_by_hash(self, chunk_hash: int, request_configs: Optional[dict] = None):
         assert self.metadata is not None
         return CacheEngineKey(
             self.metadata.fmt,
@@ -118,7 +118,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             self.metadata.world_size,
             self.metadata.worker_id,
             chunk_hash,
-            extra_configs,
+            request_configs,
         )
 
     def _hash_tokens(
@@ -217,7 +217,7 @@ class ChunkedTokenDatabase(TokenDatabase):
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> Iterable[Tuple[int, int, Union[CacheEngineKey, int]]]:
         """Process the tokens/hashes and return the corresponding cache engine keys.
 
@@ -236,7 +236,7 @@ class ChunkedTokenDatabase(TokenDatabase):
         :param bool make_key: Whether to make the cache engine key or not.
             If False, the hash value will be returned instead.
 
-        :param Optional[dict] extra_configs: The extra configs of the request.
+        :param Optional[dict] request_configs: The configs of the request.
 
         :returns: A iterable of tuples with three elements. The first element
             is the start index of the tokens for the key. The second element
@@ -270,7 +270,7 @@ class ChunkedTokenDatabase(TokenDatabase):
                         yield (
                             start_idx,
                             end_idx,
-                            self._make_key_by_hash(hash_val, extra_configs),
+                            self._make_key_by_hash(hash_val, request_configs),
                         )
                     else:
                         yield start_idx, end_idx, hash_val
@@ -285,7 +285,7 @@ class ChunkedTokenDatabase(TokenDatabase):
                     yield (
                         start_idx,
                         end_idx,
-                        self._make_key_by_hash(hash_val, extra_configs),
+                        self._make_key_by_hash(hash_val, request_configs),
                     )
                 else:
                     yield start_idx, end_idx, hash_val
@@ -342,7 +342,7 @@ class SegmentTokenDatabase(TokenDatabase):
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
-        extra_configs: Optional[dict] = None,
+        request_configs: Optional[dict] = None,
     ) -> Iterable[Tuple[int, int, Union[CacheEngineKey, int]]]:
         """Process the tokens and return the corresponding cache engine keys.
 
@@ -361,7 +361,7 @@ class SegmentTokenDatabase(TokenDatabase):
         :param bool make_key: Whether to make the cache engine key or not.
             If False, the hash value will be returned instead.
 
-        :param Optional[dict] extra_configs: The extra configs of the request.
+        :param Optional[dict] request_configs: The configs of the request.
 
         :returns: A iterable of tuples with three elements. The first element
             is the start index of the tokens for the key. The second element
@@ -397,7 +397,7 @@ class SegmentTokenDatabase(TokenDatabase):
                         start_idx,
                         end_idx,
                         self._make_key_by_hash(
-                            self._hash_tokens(token_chunk), extra_configs
+                            self._hash_tokens(token_chunk), request_configs
                         ),
                     )
                 else:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Any, Iterable, List, Optional, OrderedDict, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union
 import abc
 
 # Third Party
@@ -81,7 +81,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> Iterable[Tuple[int, int, Union[CacheEngineKey, int]]]:
         """Process the tokens and return the corresponding cache engine keys.
 
@@ -97,6 +97,11 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             FFFFFTTTTTTT, where True means the tokens needs to be matched,
             and the Falses will ALWAYS be at the PREFIX of the tensor.
 
+        :param bool make_key: Whether to make the cache engine key or not.
+            If False, the hash value will be returned instead.
+
+        :param Optional[dict] extra_configs: The extra configs of the request.
+
         :returns: A iterable of tuples with three elements. The first element
             is the start index of the tokens for the key. The second element
             is the end index of the tokens for the key. The third element is
@@ -105,7 +110,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    def _make_key_by_hash(self, chunk_hash: int, tags: OrderedDict = None):
+    def _make_key_by_hash(self, chunk_hash: int, extra_configs: Optional[dict] = None):
         assert self.metadata is not None
         return CacheEngineKey(
             self.metadata.fmt,
@@ -113,7 +118,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             self.metadata.world_size,
             self.metadata.worker_id,
             chunk_hash,
-            tags,
+            extra_configs,
         )
 
     def _hash_tokens(
@@ -212,7 +217,7 @@ class ChunkedTokenDatabase(TokenDatabase):
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> Iterable[Tuple[int, int, Union[CacheEngineKey, int]]]:
         """Process the tokens/hashes and return the corresponding cache engine keys.
 
@@ -230,6 +235,8 @@ class ChunkedTokenDatabase(TokenDatabase):
 
         :param bool make_key: Whether to make the cache engine key or not.
             If False, the hash value will be returned instead.
+
+        :param Optional[dict] extra_configs: The extra configs of the request.
 
         :returns: A iterable of tuples with three elements. The first element
             is the start index of the tokens for the key. The second element
@@ -260,7 +267,7 @@ class ChunkedTokenDatabase(TokenDatabase):
                     continue
                 else:
                     if make_key:
-                        yield start_idx, end_idx, self._make_key_by_hash(hash_val, tags)
+                        yield start_idx, end_idx, self._make_key_by_hash(hash_val, extra_configs)
                     else:
                         yield start_idx, end_idx, hash_val
         elif hashes is not None:
@@ -271,7 +278,7 @@ class ChunkedTokenDatabase(TokenDatabase):
             for hash_val, offset in zip(hashes, offsets, strict=False):
                 end_idx = start_idx + offset
                 if make_key:
-                    yield start_idx, end_idx, self._make_key_by_hash(hash_val, tags)
+                    yield start_idx, end_idx, self._make_key_by_hash(hash_val, extra_configs)
                 else:
                     yield start_idx, end_idx, hash_val
                 start_idx = end_idx
@@ -327,16 +334,26 @@ class SegmentTokenDatabase(TokenDatabase):
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
-        tags: OrderedDict = None,
+        extra_configs: Optional[dict] = None,
     ) -> Iterable[Tuple[int, int, Union[CacheEngineKey, int]]]:
         """Process the tokens and return the corresponding cache engine keys.
 
         :param Union[torch.Tensor, List[int]] tokens: The tokens to process.
 
+        :param Optional[List[int]] hashes: The hashes to process. If provided,
+            it will be used instead of tokens to generate cache engine keys.
+
+        :param Optional[List[int]] offsets: The number of tokens in each chunk.
+
         :param Optional[torch.Tensor] mask: The mask for the tokens. Should
             have the same length as tokens. And the mask should ALWAYS be like
             FFFFFTTTTTTT, where True means the tokens needs to be matched,
             and the Falses will ALWAYS be at the PREFIX of the tensor.
+
+        :param bool make_key: Whether to make the cache engine key or not.
+            If False, the hash value will be returned instead.
+
+        :param Optional[dict] extra_configs: The extra configs of the request.
 
         :returns: A iterable of tuples with three elements. The first element
             is the start index of the tokens for the key. The second element
@@ -372,7 +389,7 @@ class SegmentTokenDatabase(TokenDatabase):
                         start_idx,
                         end_idx,
                         self._make_key_by_hash(
-                            self._hash_tokens(token_chunk), tags=tags
+                            self._hash_tokens(token_chunk), extra_configs
                         ),
                     )
                 else:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -267,7 +267,11 @@ class ChunkedTokenDatabase(TokenDatabase):
                     continue
                 else:
                     if make_key:
-                        yield start_idx, end_idx, self._make_key_by_hash(hash_val, extra_configs)
+                        yield (
+                            start_idx,
+                            end_idx,
+                            self._make_key_by_hash(hash_val, extra_configs),
+                        )
                     else:
                         yield start_idx, end_idx, hash_val
         elif hashes is not None:
@@ -278,7 +282,11 @@ class ChunkedTokenDatabase(TokenDatabase):
             for hash_val, offset in zip(hashes, offsets, strict=False):
                 end_idx = start_idx + offset
                 if make_key:
-                    yield start_idx, end_idx, self._make_key_by_hash(hash_val, extra_configs)
+                    yield (
+                        start_idx,
+                        end_idx,
+                        self._make_key_by_hash(hash_val, extra_configs),
+                    )
                 else:
                     yield start_idx, end_idx, hash_val
                 start_idx = end_idx

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -110,7 +110,9 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
         raise NotImplementedError
 
-    def _make_key_by_hash(self, chunk_hash: int, request_configs: Optional[dict] = None):
+    def _make_key_by_hash(
+        self, chunk_hash: int, request_configs: Optional[dict] = None
+    ):
         assert self.metadata is not None
         return CacheEngineKey(
             self.metadata.fmt,


### PR DESCRIPTION
# DESCRIPTIOIN
This PR refact https://github.com/LMCache/LMCache/pull/1200, use `request_configs` to replace tags. By `request_configs`, we can set tags and the other configs.

# WHY DO THIS
In our scenario, we not only need to set tags to separate different requests, but also need to support setting different configs for different requests, such as setting ttl when puting the key, etc. This PR use `request_configs` to replace `tags`, if the key starts with `lmcache.tag.`, such as `lmcache.tag.tag1`, the `tag1` will be treated as the tag, if the key starts with `lmcache.`, such as `lmcache.config1`, the `configs1` will be treated as the config.

Besides, for the convenience of review, most of the changes is renaming `tags` to `request_configs`. The change is that add a `__post_init__` method in `CacheEngineKey` to extract `tags` from the `request_configs`.