### PR TITLE
[Core] Fix hash mismatch between LMCache and vLLM

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -64,13 +64,12 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         # set consistently across all processes (e.g., export PYTHONHASHSEED=0).
         try:
             # Third Party
-            from vllm.v1.core.kv_cache_utils import NONE_HASH
-        except ImportError:
-            # Third Party
             from vllm.v1.core import kv_cache_utils
 
             kv_cache_utils.init_none_hash(self.hash_func)
             NONE_HASH = kv_cache_utils.NONE_HASH
+        except (ImportError, AttributeError):
+            NONE_HASH = 0
 
         self.metadata = metadata
 

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Iterable, List, Optional, OrderedDict, Tuple, Union
+from typing import Any, Iterable, List, Optional, OrderedDict, Tuple, Union
 import abc
 
 # Third Party
@@ -117,7 +117,10 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         )
 
     def _hash_tokens(
-        self, tokens: Union[torch.Tensor, List[int]], prefix_hash: Optional[int] = None
+        self,
+        tokens: Union[torch.Tensor, List[int]],
+        prefix_hash: Optional[int] = None,
+        extra_keys: Optional[list[Any]] = None,
     ) -> int:
         if isinstance(tokens, torch.Tensor):
             tokens_tuple = tuple(tokens.cpu().tolist())
@@ -126,13 +129,10 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         else:
             raise ValueError(f"Unsupported tokens type: {type(tokens)}")
 
-        if prefix_hash is not None:
-            # Ignore extra keys for now
-            # Extra keys are for multi-modal inputs and
-            # request specific metadata (e.g., LoRA ID).
-            extra_keys = None
-            return self.hash_func((prefix_hash, tokens_tuple, extra_keys))
-        return self.hash_func(tokens_tuple)
+        # Ignore extra keys for now
+        # Extra keys are for multi-modal inputs and
+        # request specific metadata (e.g., LoRA ID).
+        return self.hash_func((prefix_hash, tokens_tuple, extra_keys))
 
 
 class ChunkedTokenDatabase(TokenDatabase):

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -15,14 +15,7 @@ from lmcache.v1.config import LMCacheEngineConfig
 
 logger = init_logger(__name__)
 
-# NOTE: For centralized cache sharing, ensure PYTHONHASHSEED is
-# set consistently across all processes (e.g., export PYTHONHASHSEED=0).
-try:
-    # Third Party
-    from vllm.v1.core.kv_cache_utils import NONE_HASH
-except ImportError:
-    # Fallback to a default value if vllm is not available
-    NONE_HASH = 0
+NONE_HASH: int
 
 
 class TokenDatabase(metaclass=abc.ABCMeta):
@@ -42,6 +35,8 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         config: Optional[LMCacheEngineConfig] = None,
         metadata: Optional[LMCacheEngineMetadata] = None,
     ):
+        global NONE_HASH
+
         vllm_is_available = True
         try:
             # Third Party
@@ -64,6 +59,18 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             if hash_algorithm == "sha256" and vllm_is_available
             else hash
         )
+
+        # NOTE: For centralized cache sharing, ensure PYTHONHASHSEED is
+        # set consistently across all processes (e.g., export PYTHONHASHSEED=0).
+        try:
+            # Third Party
+            from vllm.v1.core.kv_cache_utils import NONE_HASH
+        except ImportError:
+            # Third Party
+            from vllm.v1.core import kv_cache_utils
+
+            kv_cache_utils.init_none_hash(self.hash_func)
+            NONE_HASH = kv_cache_utils.NONE_HASH
 
         self.metadata = metadata
 
@@ -121,7 +128,11 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             raise ValueError(f"Unsupported tokens type: {type(tokens)}")
 
         if prefix_hash is not None:
-            return self.hash_func((prefix_hash, tokens_tuple))
+            # Ignore extra keys for now
+            # Extra keys are for multi-modal inputs and
+            # request specific metadata (e.g., LoRA ID).
+            extra_keys = None
+            return self.hash_func((prefix_hash, tokens_tuple, extra_keys))
         return self.hash_func(tokens_tuple)
 
 

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -67,14 +67,14 @@ def test_segment_token_database(prefix_length, chunk_lengths):
     starts = [0]
     ends = [sys_length]
     sys_tuple = tuple(sys_tokens.cpu().tolist())
-    sys_hash = hash(sys_tuple)
+    sys_hash = hash((None, sys_tuple, None))
     hashes = [sys_hash]
     start = sys_length + len(sep_tokens)
     for idx, chunk_length in enumerate(chunk_lengths):
         token_chunk = generate_tokens(chunk_length, "cpu", fixed=True)
 
         token_tuple = tuple(token_chunk.cpu().tolist())
-        token_hash = hash(token_tuple)
+        token_hash = hash((None, token_tuple, None))
         hashes.append(token_hash)
 
         token_chunk = torch.cat([sep_tokens, token_chunk])
@@ -84,7 +84,7 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         start += chunk_length + len(sep_tokens)
 
     query_tuple = tuple(query_tokens.cpu().tolist())
-    query_hash = hash(query_tuple)
+    query_hash = hash((None, query_tuple, None))
     hashes.append(query_hash)
     starts.append(start)
     ends.append(start + query_length)


### PR DESCRIPTION
1. Add `extra_keys`
2. Correctly initialize `NONE_HASH`

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
