### PR TITLE
Support get config and metadata api of LMCache internal api server

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -319,6 +319,9 @@ def _create_config_class():
             "from_legacy": classmethod(_from_legacy),
             "from_file": classmethod(_from_file),
             "from_env": classmethod(_from_env),
+            "__str__": lambda self: str(
+                {name: getattr(self, name) for name in _CONFIG_DEFINITIONS}
+            ),
         },
     )
     return cls

--- a/lmcache/v1/internal_api_server/conf_api.py
+++ b/lmcache/v1/internal_api_server/conf_api.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Any, Dict, List, Optional
+import json
+
+# Third Party
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+import torch
+
+# First Party
+from lmcache.v1.config import _CONFIG_DEFINITIONS, LMCacheEngineConfig
+
+router = APIRouter()
+
+
+def _get_config_dict(
+    config: LMCacheEngineConfig, keys: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """Get the config dict filtered by keys"""
+    if keys is None:
+        keys = _CONFIG_DEFINITIONS
+    return {key: getattr(config, key) for key in keys if hasattr(config, key)}
+
+
+@router.get("/conf")
+async def get_config(request: Request, names: Optional[str] = None):
+    config = request.app.state.lmcache_adapter.config
+    # Parse query parameter names (comma-separated list of config names)
+    keys = names.split(",") if names else None
+    config_dict = _get_config_dict(config, keys)
+    return PlainTextResponse(
+        content=json.dumps(config_dict, indent=2), media_type="text/plain"
+    )
+
+
+@router.get("/meta")
+async def get_metadata(request: Request, names: Optional[str] = None):
+    """
+    Get metadata of the cache engine
+    """
+    lmcache_engine = request.app.state.lmcache_adapter.lmcache_engine
+    if not lmcache_engine:
+        return PlainTextResponse(
+            content="/meta api only work for lmcache_engine", status_code=500
+        )
+    metadata = lmcache_engine.metadata
+
+    if names:
+        attr_list = names.split(",")
+        metadata_dict = {}
+        for attr in attr_list:
+            if (
+                hasattr(metadata, attr)
+                and not attr.startswith("__")
+                and not callable(getattr(metadata, attr))
+            ):
+                value = getattr(metadata, attr)
+                if isinstance(value, (torch.dtype, torch.Size)):
+                    value = str(value)
+                metadata_dict[attr] = value
+    else:
+        metadata_dict = {
+            attr: getattr(metadata, attr)
+            for attr in dir(metadata)
+            if not attr.startswith("__") and not callable(getattr(metadata, attr))
+        }
+        for key, value in metadata_dict.items():
+            if isinstance(value, (torch.dtype, torch.Size)):
+                metadata_dict[key] = str(value)
+
+    return PlainTextResponse(
+        content=json.dumps(metadata_dict, indent=2, default=str),
+        media_type="text/plain",
+    )


### PR DESCRIPTION
# Descriptiion

Add config, metadata api to lmcache internal api server.

# How to use

```Shell

# Get specified key metadata
curl "http://localhost:8080/meta?names=worker_id,model_name"
{
  "worker_id": 0,
  "model_name": "/data1/DeepSeek-V2-Lite-Chat"
}

# Get all keys metadata

curl http://localhost:8080/meta
{
  "first_rank": 0,
  "fmt": "vllm",
  "kv_dtype": "torch.bfloat16",
  "kv_shape": [
    27,
    1,
    64,
    1,
    576
  ],
  "model_name": "/data1/DeepSeek-V2-Lite-Chat",
  "use_mla": true,
  "worker_id": 0,
  "world_size": 2
}

# Get specified keys conf

curl "http://localhost:8080/conf?names=max_local_cpu_size,enable_p2p"
{
  "max_local_cpu_size": 0.1,
  "enable_p2p": false
}

# get all conf
curl http://localhost:8080/conf
{
  "chunk_size": 64,
  "local_cpu": true,
  "max_local_cpu_size": 0.1,
  "local_disk": null,
  "max_local_disk_size": 0.0,
  "remote_url": null,
  "remote_serde": "naive",
  "use_layerwise": false,
  "save_decode_cache": false,
  "pre_caching_hash_algorithm": "builtin",
  "enable_blending": false,
  "blend_recompute_ratio": 0.15,
  "blend_min_tokens": 256,
  "blend_special_str": " # # ",
  "enable_p2p": false,
  "lookup_url": null,
  "distributed_url": null,
  "error_handling": false,
  "enable_controller": false,
  "lmcache_instance_id": "lmcache_default_instance",
  "controller_url": null,
  "lmcache_worker_port": null,
  "enable_nixl": false,
  "nixl_role": null,
  "nixl_receiver_host": null,
  "nixl_receiver_port": null,
  "nixl_buffer_size": null,
  "nixl_buffer_device": null,
  "nixl_enable_gc": false,
  "enable_xpyd": false,
  "nixl_peer_host": null,
  "nixl_peer_init_port": null,
  "nixl_peer_alloc_port": null,
  "nixl_proxy_host": null,
  "nixl_proxy_port": null,
  "weka_path": null,
  "gds_path": null,
  "cufile_buffer_size": null,
  "audit_actual_remote_url": null,
  "extra_config": {
    "save_only_first_rank": true,
    "create_lookup_server_only_on_worker_0_for_mla": true,
    "audit_exclude_cmds": "exists,get",
    "tag_keys": [
      "user"
    ]
  },
  "save_unfull_chunk": true,
  "blocking_timeout_secs": 10,
  "external_lookup_client": null,
  "py_enable_gc": true,
  "cache_policy": "LRU",
  "cache_engine_internal_api_server_enabled": true,
  "cache_engine_internal_api_server_port_start": 8080
}
```

