### PR TITLE
Introduce run scripts api to cache engine api server

### DIFF
--- a/lmcache/v1/internal_api_server/run_script_api.py
+++ b/lmcache/v1/internal_api_server/run_script_api.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+
+# Third Party
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+router = APIRouter()
+
+
+@router.post("/run_script")
+async def run_script(request: Request):
+    form_data = await request.form()
+    script_file = form_data.get("script")
+
+    if not script_file or not hasattr(script_file, "file"):
+        return PlainTextResponse("No script file provided", status_code=400)
+
+    script_content = await script_file.read()
+
+    try:
+        restricted_globals = {
+            "__builtins__": {
+                "print": print,
+                "str": str,
+                "int": int,
+                "float": float,
+                "list": list,
+                "dict": dict,
+                "tuple": tuple,
+                "set": set,
+            },
+            "app": request.app,
+        }
+        restricted_locals = {}
+
+        exec(script_content, restricted_globals, restricted_locals)
+
+        result = restricted_locals.get("result", "Script executed successfully")
+        return PlainTextResponse(str(result), media_type="text/plain")
+
+    except Exception as e:
+        return PlainTextResponse(f"Error executing script: {str(e)}", status_code=500)


### PR DESCRIPTION
# Description

This feature is developed for the developer or maintainer of LMCache, I believe you will like it since It can get or set the value of internal object dynamically, especially while you solving a bug or puzzling and guessing the value of a variable, you can try this feature.

# Hot to use

- Write the content to a python file, e.g. `scratch.py`

```python
# Get cache_engine from app.state
lmcache_engine = app.state.lmcache_adapter.lmcache_engine

# Print the worker ID and model name
print(f"Worker ID: {lmcache_engine.metadata.worker_id}")
print(f"Model name: {lmcache_engine.metadata.model_name}")

# Set LocalCPUBackend.use_hot to False or True
lmcache_engine.storage_manager.storage_backends["LocalCPUBackend"].use_hot = False
# return the output contents
result = {
    "is_first_rank": lmcache_engine.metadata.is_first_rank(),
    "model_version": lmcache_engine.metadata.kv_shape,
    "LocalCPUBackend.use_hot": lmcache_engine.storage_manager.storage_backends["LocalCPUBackend"].use_hot
}


```

- Start vLLM + LMCache with the following lmcache.yaml
```yaml
chunk_size: 256
local_cpu: True
max_local_cpu_size: 0.1

cache_engine_internal_api_server_enabled: True
cache_engine_internal_api_server_port_start: 8080
```

- Send request by curl for testing
```shell
curl -X POST http://localhost:8080/run_script \       
  -F "script=@/Users/msy/Library/Application Support/JetBrains/PyCharm2024.3/scratches/scratch.py"

{'is_first_rank': True, 'model_version': (27, 1, 64, 1, 576), 'LocalCPUBackend.use_hot': False}% 
```