### PR TITLE
[Bugfix]Add none check to request.disagg_spec to run disaggregated_prefill example

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -900,7 +900,7 @@ class LMCacheConnectorV1Impl:
             slot_mapping = slot_mapping.cuda()
 
             skip_leading_tokens = save_spec.skip_leading_tokens
-            if self.kv_role == "kv_producer":
+            if self.kv_role == "kv_producer" and request.disagg_spec:
                 skip_leading_tokens = min(
                     skip_leading_tokens, request.disagg_spec.num_transferred_tokens
                 )

--- a/lmcache/v1/storage_backend/nixl_backend.py
+++ b/lmcache/v1/storage_backend/nixl_backend.py
@@ -390,10 +390,10 @@ class NixlBackend(StorageBackendInterface):
         return self._nixl_channel.get_allocator()
 
     def pin(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError
+        return True
 
     def unpin(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError
+        return True
 
     @staticmethod
     def CreateNixlBackend(


### PR DESCRIPTION
#1162 fix the memory leak, but it breaks the example [disaggregated_prefill](https://docs.lmcache.ai/getting_started/quickstart/disaggregated_prefill.html#).

Added the extra check if request.disagg_spec is not None.

I'm still looking for the root cause of why request.disagg_spec is None, and to see if there will be a better solution. Welcome any feedback about how to do this.

```
ERROR 08-20 02:23:43 [core.py:634] EngineCore encountered a fatal error.
ERROR 08-20 02:23:43 [core.py:634] Traceback (most recent call last):
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 625, in run_engine_core
ERROR 08-20 02:23:43 [core.py:634]     engine_core.run_busy_loop()
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 652, in run_busy_loop
ERROR 08-20 02:23:43 [core.py:634]     self._process_engine_step()
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 677, in _process_engine_step
ERROR 08-20 02:23:43 [core.py:634]     outputs, model_executed = self.step_fn()
ERROR 08-20 02:23:43 [core.py:634]                               ^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 267, in step
ERROR 08-20 02:23:43 [core.py:634]     model_output = self.execute_model_with_error_logging(
ERROR 08-20 02:23:43 [core.py:634]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 253, in execute_model_with_error_logging
ERROR 08-20 02:23:43 [core.py:634]     raise err
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 244, in execute_model_with_error_logging
ERROR 08-20 02:23:43 [core.py:634]     return model_fn(scheduler_output)
ERROR 08-20 02:23:43 [core.py:634]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/executor/abstract.py", line 87, in execute_model
ERROR 08-20 02:23:43 [core.py:634]     output = self.collective_rpc("execute_model",
ERROR 08-20 02:23:43 [core.py:634]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
ERROR 08-20 02:23:43 [core.py:634]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 08-20 02:23:43 [core.py:634]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/utils/__init__.py", line 2985, in run_method
ERROR 08-20 02:23:43 [core.py:634]     return func(*args, **kwargs)
ERROR 08-20 02:23:43 [core.py:634]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 08-20 02:23:43 [core.py:634]     return func(*args, **kwargs)
ERROR 08-20 02:23:43 [core.py:634]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 337, in execute_model
ERROR 08-20 02:23:43 [core.py:634]     output = self.model_runner.execute_model(scheduler_output,
ERROR 08-20 02:23:43 [core.py:634]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 08-20 02:23:43 [core.py:634]     return func(*args, **kwargs)
ERROR 08-20 02:23:43 [core.py:634]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1461, in execute_model
ERROR 08-20 02:23:43 [core.py:634]     self.maybe_wait_for_kv_save()
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1767, in maybe_wait_for_kv_save
ERROR 08-20 02:23:43 [core.py:634]     get_kv_transfer_group().wait_for_save()
ERROR 08-20 02:23:43 [core.py:634]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 88, in wait_for_save
ERROR 08-20 02:23:43 [core.py:634]     self._lmcache_engine.wait_for_save()
ERROR 08-20 02:23:43 [core.py:634]   File "/root/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 909, in wait_for_save
ERROR 08-20 02:23:43 [core.py:634]     skip_leading_tokens, request.disagg_spec.num_transferred_tokens
ERROR 08-20 02:23:43 [core.py:634]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [core.py:634] AttributeError: 'NoneType' object has no attribute 'num_transferred_tokens'
Process EngineCore_0:
Traceback (most recent call last):
ERROR 08-20 02:23:43 [async_llm.py:416] AsyncLLM output_handler failed.
ERROR 08-20 02:23:43 [async_llm.py:416] Traceback (most recent call last):
ERROR 08-20 02:23:43 [async_llm.py:416]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 375, in output_handler
ERROR 08-20 02:23:43 [async_llm.py:416]     outputs = await engine_core.get_output_async()
ERROR 08-20 02:23:43 [async_llm.py:416]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 08-20 02:23:43 [async_llm.py:416]   File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 751, in get_output_async
ERROR 08-20 02:23:43 [async_llm.py:416]     raise self._format_exception(outputs) from None
ERROR 08-20 02:23:43 [async_llm.py:416] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
  File "/root/miniconda3/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/root/miniconda3/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 636, in run_engine_core
    raise e
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 625, in run_engine_core
    engine_core.run_busy_loop()
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 652, in run_busy_loop
    self._process_engine_step()
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 677, in _process_engine_step
    outputs, model_executed = self.step_fn()
                              ^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 267, in step
    model_output = self.execute_model_with_error_logging(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 253, in execute_model_with_error_logging
    raise err
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 244, in execute_model_with_error_logging
    return model_fn(scheduler_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/executor/abstract.py", line 87, in execute_model
    output = self.collective_rpc("execute_model",
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
    answer = run_method(self.driver_worker, method, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/utils/__init__.py", line 2985, in run_method
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 337, in execute_model
    output = self.model_runner.execute_model(scheduler_output,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1461, in execute_model
    self.maybe_wait_for_kv_save()
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1767, in maybe_wait_for_kv_save
    get_kv_transfer_group().wait_for_save()
  File "/root/miniconda3/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 88, in wait_for_save
    self._lmcache_engine.wait_for_save()
  File "/root/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 909, in wait_for_save
    skip_leading_tokens, request.disagg_spec.num_transferred_tokens
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'num_transferred_tokens'
```


*

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
