### PR TITLE
[bugfix][#1357] Unified the default value if use mla

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -12,6 +12,7 @@ import torch
 # First Party
 from lmcache.config import LMCacheEngineConfig as Config  # type: ignore[assignment]
 from lmcache.logging import init_logger
+from lmcache.utils import mla_enabled
 from lmcache.v1.config import (
     LMCacheEngineConfig as V1Config,  # type: ignore[assignment]
 )
@@ -126,13 +127,7 @@ def create_lmcache_metadata(
     kv_dtype = get_kv_cache_torch_dtype(cache_cfg.cache_dtype, model_cfg.dtype)
 
     # Check if MLA is enabled
-    use_mla = False
-    if (
-        hasattr(model_cfg, "use_mla")
-        and isinstance(model_cfg.use_mla, bool)
-        and model_cfg.use_mla
-    ):
-        use_mla = True
+    use_mla = mla_enabled(model_cfg)
 
     # Construct KV shape (for memory pool)
     num_layer = model_cfg.get_num_layers(parallel_cfg)

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Union
 import os
 
 if TYPE_CHECKING:
+    from vllm.config import ModelConfig
     from vllm.multimodal.inputs import PlaceholderRange
 
 # Third Party
@@ -12,7 +13,6 @@ import torch
 # First Party
 from lmcache.config import LMCacheEngineConfig as Config  # type: ignore[assignment]
 from lmcache.logging import init_logger
-from lmcache.utils import mla_enabled
 from lmcache.v1.config import (
     LMCacheEngineConfig as V1Config,  # type: ignore[assignment]
 )
@@ -85,6 +85,14 @@ def apply_mm_hashes_to_token_ids(
         end = min(start + length, n)
         token_ids[start:end] = hex_hash_to_int16(hash_str)
     return token_ids
+
+
+def mla_enabled(model_config: "ModelConfig") -> bool:
+    return (
+        hasattr(model_config, "use_mla")
+        and isinstance(model_config.use_mla, bool)
+        and model_config.use_mla
+    )
 
 
 def create_lmcache_metadata(

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -29,9 +29,10 @@ from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
     lmcache_get_config,
+    mla_enabled,
 )
 from lmcache.logging import init_logger
-from lmcache.utils import _lmcache_nvtx_annotate, mla_enabled
+from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -31,7 +31,7 @@ from lmcache.integration.vllm.utils import (
     lmcache_get_config,
 )
 from lmcache.logging import init_logger
-from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.utils import _lmcache_nvtx_annotate, mla_enabled
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig
@@ -418,14 +418,7 @@ def _init_lmcache_engine(
 
     kv_dtype = get_kv_cache_torch_dtype(cache_config.cache_dtype, model_config.dtype)
 
-    use_mla = False
-    if (
-        hasattr(model_config, "use_mla")
-        and isinstance(model_config.use_mla, bool)
-        and model_config.use_mla
-    ):
-        use_mla = True
-
+    use_mla = mla_enabled(model_config)
     if use_mla and (
         lmcache_config.remote_serde != "naive"
         and lmcache_config.remote_serde is not None

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -339,4 +339,3 @@ def mla_enabled(model_config: "ModelConfig") -> bool:
         and isinstance(model_config.use_mla, bool)
         and model_config.use_mla
     )
-

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -12,6 +12,7 @@ import traceback
 
 # Third Party
 from nvtx import annotate  # type: ignore
+from vllm.config import ModelConfig
 import torch
 
 # First Party
@@ -330,3 +331,12 @@ def start_loop_in_thread_with_exceptions(loop: asyncio.AbstractEventLoop):
 
     loop.set_exception_handler(loop_excepthook)
     loop.run_forever()
+
+
+def mla_enabled(model_config: "ModelConfig") -> bool:
+    return (
+        hasattr(model_config, "use_mla")
+        and isinstance(model_config.use_mla, bool)
+        and model_config.use_mla
+    )
+

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -12,7 +12,6 @@ import traceback
 
 # Third Party
 from nvtx import annotate  # type: ignore
-from vllm.config import ModelConfig
 import torch
 
 # First Party
@@ -331,11 +330,3 @@ def start_loop_in_thread_with_exceptions(loop: asyncio.AbstractEventLoop):
 
     loop.set_exception_handler(loop_excepthook)
     loop.run_forever()
-
-
-def mla_enabled(model_config: "ModelConfig") -> bool:
-    return (
-        hasattr(model_config, "use_mla")
-        and isinstance(model_config.use_mla, bool)
-        and model_config.use_mla
-    )

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -97,14 +97,16 @@ class LMCacheEngine:
         self.gpu_connector = gpu_connector
         self.broadcast_fn = broadcast_fn
         self.broadcast_object_fn = broadcast_object_fn
-        save_only_first_rank_default = True if metadata.use_mla else False
+        # if save_only_first_rank not set in config.extra_config, the default value
+        # is related to use_mla, if use_mla, default value is True, else False,
+        # and save_only_first_rank only works when use mla
         self.save_only_first_rank = (
             self.config.extra_config.get(
-                "save_only_first_rank", save_only_first_rank_default
+                "save_only_first_rank", metadata.use_mla
             )
             if self.config.extra_config
-            else save_only_first_rank_default
-        )
+            else metadata.use_mla
+        ) and metadata.use_mla
 
         self.enable_p2p = config.enable_p2p
 
@@ -1189,14 +1191,16 @@ class LMCacheEngineBuilder:
             return CuFileMemoryAllocator(config.cufile_buffer_size * 1024**2)
 
         max_local_cpu_size = config.max_local_cpu_size
-        save_only_first_rank_default = True if metadata.use_mla else False
+        # if save_only_first_rank not set in config.extra_config, the default value
+        # is related to use_mla, if use_mla, default value is True, else False,
+        # and save_only_first_rank only works when use mla
         save_only_first_rank = (
             config.extra_config.get(
-                "save_only_first_rank", save_only_first_rank_default
+                "save_only_first_rank", metadata.use_mla
             )
             if config.extra_config
-            else save_only_first_rank_default
-        )
+            else metadata.use_mla
+        ) and metadata.use_mla
         if save_only_first_rank and metadata.is_first_rank():
             # Only the first rank will save the cache,
             # so we need to set it lager than other ranks

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -98,10 +98,10 @@ class LMCacheEngine:
         self.broadcast_fn = broadcast_fn
         self.broadcast_object_fn = broadcast_object_fn
         # save_only_first_rank only works when use mla
-        self.save_only_first_rank = self.config.get_extra_config_value(
-            "save_only_first_rank", metadata.use_mla
-        ) and metadata.use_mla
-
+        self.save_only_first_rank = (
+            self.config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
+            and metadata.use_mla
+        )
         self.enable_p2p = config.enable_p2p
 
         self.enable_controller = config.enable_controller
@@ -1186,9 +1186,10 @@ class LMCacheEngineBuilder:
 
         max_local_cpu_size = config.max_local_cpu_size
         # save_only_first_rank only works when use mla
-        save_only_first_rank = config.get_extra_config_value(
-            "save_only_first_rank", metadata.use_mla
-        ) and metadata.use_mla
+        save_only_first_rank = (
+            config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
+            and metadata.use_mla
+        )
         if save_only_first_rank and metadata.is_first_rank():
             # Only the first rank will save the cache,
             # so we need to set it lager than other ranks

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -97,13 +97,9 @@ class LMCacheEngine:
         self.gpu_connector = gpu_connector
         self.broadcast_fn = broadcast_fn
         self.broadcast_object_fn = broadcast_object_fn
-        # if save_only_first_rank not set in config.extra_config, the default value
-        # is related to use_mla, if use_mla, default value is True, else False,
-        # and save_only_first_rank only works when use mla
-        self.save_only_first_rank = (
-            self.config.extra_config.get("save_only_first_rank", metadata.use_mla)
-            if self.config.extra_config
-            else metadata.use_mla
+        # save_only_first_rank only works when use mla
+        self.save_only_first_rank = self.config.get_extra_config_value(
+            "save_only_first_rank", metadata.use_mla
         ) and metadata.use_mla
 
         self.enable_p2p = config.enable_p2p
@@ -1189,13 +1185,9 @@ class LMCacheEngineBuilder:
             return CuFileMemoryAllocator(config.cufile_buffer_size * 1024**2)
 
         max_local_cpu_size = config.max_local_cpu_size
-        # if save_only_first_rank not set in config.extra_config, the default value
-        # is related to use_mla, if use_mla, default value is True, else False,
-        # and save_only_first_rank only works when use mla
-        save_only_first_rank = (
-            config.extra_config.get("save_only_first_rank", metadata.use_mla)
-            if config.extra_config
-            else metadata.use_mla
+        # save_only_first_rank only works when use mla
+        save_only_first_rank = config.get_extra_config_value(
+            "save_only_first_rank", metadata.use_mla
         ) and metadata.use_mla
         if save_only_first_rank and metadata.is_first_rank():
             # Only the first rank will save the cache,

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -101,9 +101,7 @@ class LMCacheEngine:
         # is related to use_mla, if use_mla, default value is True, else False,
         # and save_only_first_rank only works when use mla
         self.save_only_first_rank = (
-            self.config.extra_config.get(
-                "save_only_first_rank", metadata.use_mla
-            )
+            self.config.extra_config.get("save_only_first_rank", metadata.use_mla)
             if self.config.extra_config
             else metadata.use_mla
         ) and metadata.use_mla
@@ -1195,9 +1193,7 @@ class LMCacheEngineBuilder:
         # is related to use_mla, if use_mla, default value is True, else False,
         # and save_only_first_rank only works when use mla
         save_only_first_rank = (
-            config.extra_config.get(
-                "save_only_first_rank", metadata.use_mla
-            )
+            config.extra_config.get("save_only_first_rank", metadata.use_mla)
             if config.extra_config
             else metadata.use_mla
         ) and metadata.use_mla

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -376,7 +376,7 @@ def _to_original_config(self):
     )
 
 
-def _get_extra_config_value(self, key, default_value = None):
+def _get_extra_config_value(self, key, default_value=None):
     if hasattr(self, "extra_config") and self.extra_config is not None:
         return self.extra_config.get(key, default_value)
     else:

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -315,6 +315,7 @@ def _create_config_class():
             "validate": _validate_config,
             "log_config": _log_config,
             "to_original_config": _to_original_config,
+            "get_extra_config_value": _get_extra_config_value,
             "from_defaults": classmethod(_from_defaults),
             "from_legacy": classmethod(_from_legacy),
             "from_file": classmethod(_from_file),
@@ -373,6 +374,13 @@ def _to_original_config(self):
         blend_separator="[BLEND_SEP]",
         blend_add_special_in_precomp=False,
     )
+
+
+def _get_extra_config_value(self, key, default_value = None):
+    if hasattr(self, "extra_config") and self.extra_config is not None:
+        return self.extra_config.get(key, default_value)
+    else:
+        return default_value
 
 
 def _from_defaults(cls, **kwargs):

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -71,13 +71,9 @@ class LookupClientFactory:
 
         # Only create the KV lookup API server on worker rank 0
         # when there are multiple workers and when not using external lookup client
-        create_lookup_server_only_on_worker_0_for_mla = (
-            config.extra_config.get(
-                "create_lookup_server_only_on_worker_0_for_mla",
-                lmcache_engine.metadata.use_mla,
-            )
-            if config.extra_config
-            else lmcache_engine.metadata.use_mla
+        create_lookup_server_only_on_worker_0_for_mla = config.get_extra_config_value(
+            "create_lookup_server_only_on_worker_0_for_mla",
+            lmcache_engine.metadata.use_mla,
         )
 
         if config.external_lookup_client is None and (

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -72,11 +72,14 @@ class LookupClientFactory:
         # Only create the KV lookup API server on worker rank 0
         # when there are multiple workers and when not using external lookup client
         create_lookup_server_only_on_worker_0_for_mla = (
-            config.extra_config
-            and config.extra_config.get(
-                "create_lookup_server_only_on_worker_0_for_mla", False
+            config.extra_config.get(
+                "create_lookup_server_only_on_worker_0_for_mla",
+                lmcache_engine.metadata.use_mla
             )
+            if config.extra_config
+            else lmcache_engine.metadata.use_mla
         )
+
         if config.external_lookup_client is None and (
             not create_lookup_server_only_on_worker_0_for_mla
             or lmcache_engine.metadata.worker_id == 0

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -74,7 +74,7 @@ class LookupClientFactory:
         create_lookup_server_only_on_worker_0_for_mla = (
             config.extra_config.get(
                 "create_lookup_server_only_on_worker_0_for_mla",
-                lmcache_engine.metadata.use_mla
+                lmcache_engine.metadata.use_mla,
             )
             if config.extra_config
             else lmcache_engine.metadata.use_mla

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -10,8 +10,8 @@ import torch
 import zmq
 
 # First Party
+from lmcache.integration.vllm.utils import mla_enabled
 from lmcache.logging import init_logger
-from lmcache.utils import mla_enabled
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -39,11 +39,15 @@ class LMCacheLookupClient(LookupClientInterface):
             "lmcache_rpc_port", 0
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
+        use_mla = (hasattr(vllm_config.model_config, "use_mla")
+                   and isinstance(vllm_config.model_config.use_mla, bool)
+                   and vllm_config.model_config.use_mla)
         self.create_lookup_server_only_on_worker_0_for_mla = (
-            config.extra_config
-            and config.extra_config.get(
-                "create_lookup_server_only_on_worker_0_for_mla", False
+            config.extra_config.get(
+                "create_lookup_server_only_on_worker_0_for_mla", use_mla
             )
+            if config.extra_config
+            else use_mla
         )
         ranks = self.tensor_parallel_size
         self.sockets = []
@@ -53,6 +57,8 @@ class LMCacheLookupClient(LookupClientInterface):
             socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup", rpc_port, tp_rank
             )
+            logger.info(f"lmcache lookup client connect to tp_rank {tp_rank} "
+                        f"with socket path {socket_path}")
             socket = self.socket = make_zmq_socket(
                 self.ctx,
                 socket_path,
@@ -157,6 +163,7 @@ class LMCacheLookupServer:
                 #    break
                 # continue
 
+        logger.info(f"lmcache lookup server start on {socket_path}")
         self.thread = threading.Thread(target=process_request, daemon=True)
         self.thread.start()
 

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -11,6 +11,7 @@ import zmq
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.utils import mla_enabled
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
@@ -39,11 +40,7 @@ class LMCacheLookupClient(LookupClientInterface):
             "lmcache_rpc_port", 0
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
-        use_mla = (
-            hasattr(vllm_config.model_config, "use_mla")
-            and isinstance(vllm_config.model_config.use_mla, bool)
-            and vllm_config.model_config.use_mla
-        )
+        use_mla = mla_enabled(vllm_config.model_config)
         self.create_lookup_server_only_on_worker_0_for_mla = (
             config.extra_config.get(
                 "create_lookup_server_only_on_worker_0_for_mla", use_mla

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -41,12 +41,8 @@ class LMCacheLookupClient(LookupClientInterface):
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
         use_mla = mla_enabled(vllm_config.model_config)
-        self.create_lookup_server_only_on_worker_0_for_mla = (
-            config.extra_config.get(
-                "create_lookup_server_only_on_worker_0_for_mla", use_mla
-            )
-            if config.extra_config
-            else use_mla
+        self.create_lookup_server_only_on_worker_0_for_mla = config.get_extra_config_value(
+            "create_lookup_server_only_on_worker_0_for_mla", use_mla
         )
         ranks = self.tensor_parallel_size
         self.sockets = []

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -39,9 +39,11 @@ class LMCacheLookupClient(LookupClientInterface):
             "lmcache_rpc_port", 0
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
-        use_mla = (hasattr(vllm_config.model_config, "use_mla")
-                   and isinstance(vllm_config.model_config.use_mla, bool)
-                   and vllm_config.model_config.use_mla)
+        use_mla = (
+            hasattr(vllm_config.model_config, "use_mla")
+            and isinstance(vllm_config.model_config.use_mla, bool)
+            and vllm_config.model_config.use_mla
+        )
         self.create_lookup_server_only_on_worker_0_for_mla = (
             config.extra_config.get(
                 "create_lookup_server_only_on_worker_0_for_mla", use_mla
@@ -57,8 +59,10 @@ class LMCacheLookupClient(LookupClientInterface):
             socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup", rpc_port, tp_rank
             )
-            logger.info(f"lmcache lookup client connect to tp_rank {tp_rank} "
-                        f"with socket path {socket_path}")
+            logger.info(
+                f"lmcache lookup client connect to tp_rank {tp_rank} "
+                f"with socket path {socket_path}"
+            )
             socket = self.socket = make_zmq_socket(
                 self.ctx,
                 socket_path,

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -41,8 +41,10 @@ class LMCacheLookupClient(LookupClientInterface):
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
         use_mla = mla_enabled(vllm_config.model_config)
-        self.create_lookup_server_only_on_worker_0_for_mla = config.get_extra_config_value(
-            "create_lookup_server_only_on_worker_0_for_mla", use_mla
+        self.create_lookup_server_only_on_worker_0_for_mla = (
+            config.get_extra_config_value(
+                "create_lookup_server_only_on_worker_0_for_mla", use_mla
+            )
         )
         ranks = self.tensor_parallel_size
         self.sockets = []

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -59,10 +59,20 @@ class RemoteBackend(StorageBackendInterface):
             config.remote_serde, metadata, config
         )
 
+        # if remote_enable_mla_worker_id_as0 not set in config.extra_config,
+        # the default value is related to use_mla, if use_mla, default value
+        # is True, else False
+        remote_enable_mla_worker_id_as0 = (
+            config.extra_config.get(
+                "remote_enable_mla_worker_id_as0", metadata.use_mla
+            )
+            if config.extra_config
+            else metadata.use_mla
+        )
+
         # Precompute MLA mode status
         self._mla_worker_id_as0_mode = (
-            config.extra_config is not None
-            and config.extra_config.get("remote_enable_mla_worker_id_as0", False)
+            remote_enable_mla_worker_id_as0
             and metadata.use_mla
             and metadata.world_size > 1
             and metadata.worker_id != 0

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -59,18 +59,11 @@ class RemoteBackend(StorageBackendInterface):
             config.remote_serde, metadata, config
         )
 
-        # if remote_enable_mla_worker_id_as0 not set in config.extra_config,
-        # the default value is related to use_mla, if use_mla, default value
-        # is True, else False
-        remote_enable_mla_worker_id_as0 = (
-            config.extra_config.get("remote_enable_mla_worker_id_as0", metadata.use_mla)
-            if config.extra_config
-            else metadata.use_mla
-        )
-
         # Precompute MLA mode status
         self._mla_worker_id_as0_mode = (
-            remote_enable_mla_worker_id_as0
+            config.get_extra_config_value(
+                "remote_enable_mla_worker_id_as0", metadata.use_mla
+            )
             and metadata.use_mla
             and metadata.world_size > 1
             and metadata.worker_id != 0

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -63,9 +63,7 @@ class RemoteBackend(StorageBackendInterface):
         # the default value is related to use_mla, if use_mla, default value
         # is True, else False
         remote_enable_mla_worker_id_as0 = (
-            config.extra_config.get(
-                "remote_enable_mla_worker_id_as0", metadata.use_mla
-            )
+            config.extra_config.get("remote_enable_mla_worker_id_as0", metadata.use_mla)
             if config.extra_config
             else metadata.use_mla
         )


### PR DESCRIPTION
Fix: https://github.com/LMCache/LMCache/issues/1357

the default value of some configs can be related to mla, if use mla, the default value is `True`, else `False`, includes the following configs:
- create_lookup_server_only_on_worker_0_for_mla
- remote_enable_mla_worker_id_as0
- save_only_first_rank