### PR TITLE
[feat] Introduce a plugin framework

### DIFF
--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,61 @@
+# LMCache Plugin System Documentation
+
+## Overview
+The LMCache plugin system allows users to extend functionality by running custom scripts or programs during cache operations. Plugins can be written in any language (Python, Bash, etc.) and are managed by the `PluginLauncher` class.
+
+## Configuration
+Plugins are configured through the following methods:
+
+1. **Environment Variables**:
+   - `LMCACHE_PLUGIN_ROLE`: The role of the current process (e.g., `SCHEDULER`, `WORKER`)
+   - `LMCACHE_PLUGIN_CONFIG`: JSON string containing the plugin configuration
+
+2. **Configuration File**:
+   Plugins can be specified in the `lmcahce.yaml` file under the `plugin_locs` field:
+   ```yaml
+   plugin_locs: ["/path/to/plugins"]
+   ```
+
+## Plugin Naming Rules
+Plugin filenames determine which roles/worker_id they run on:
+
+**Role-Specific Plugins**:
+   - Format: `<ROLE>[_<WORKER_ID>][_<DESCRIPTION>].<EXTENSION>`
+   - Examples:
+     - `scheduler_foo_plugin.py`: Runs only on `SCHEDULER` role
+     - `worker_0_test.sh`: Runs only on `WORKER` with `worker_id=0`
+     - `all_run_plugin.sh`: Runs on all nodes
+
+Notes:
+- Role names are case-insensitive (e.g., `worker` = `WORKER`)
+- Worker ID must be a numeric value if specified
+
+## Plugin Execution
+Plugins are executed as follows:
+
+1. **Interpreter Detection**:
+   - The first line (shebang) determines the interpreter:
+     ```python
+     #!/opt/venv/bin/python
+     ```
+   - Fallback interpreters:
+     - `.py` files: `python`
+     - `.sh` files: `bash`
+
+2. **Output Capture**:
+   - Plugin stdout/stderr is captured continuously
+   - Output is logged with the plugin name as prefix
+
+3. **Process Management**:
+   - Plugins are launched as subprocesses
+   - All plugins are terminated when the parent process exits
+
+## Example Plugins
+1. Python Plugin (`scheduler_foo_plugin.py`)
+2. Bash Plugin (`all_run_plugin.sh`)
+
+## Best Practices
+1. Keep plugins lightweight
+2. Use descriptive names
+3. Handle errors gracefully
+4. Include shebang for portability

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -11,7 +11,7 @@ Plugins are configured through the following methods:
    - `LMCACHE_PLUGIN_CONFIG`: JSON string containing the plugin configuration
 
 2. **Configuration File**:
-   Plugins can be specified in the `lmcahce.yaml` file under the `plugin_locs` field:
+   Plugins can be specified in the `lmcache.yaml` file under the `plugin_locs` field:
    ```yaml
    plugin_locs: ["/path/to/plugins"]
    ```

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,7 +1,15 @@
 # LMCache Plugin System Documentation
 
 ## Overview
+
 The LMCache plugin system allows users to extend functionality by running custom scripts or programs during cache operations. Plugins can be written in any language (Python, Bash, etc.) and are managed by the `PluginLauncher` class.
+
+Base on this, hope developer of our community can contribute more plugins, e.g.
+- Start metric reporter to centralized metric system.
+- Start log reporter to centralized log collect and query system.
+- Report customized process level metrics to the alert system.
+- Heartbeat to a health monitor system or a service discover system.
+- ...
 
 ## Configuration
 Plugins are configured through the following methods:
@@ -9,12 +17,16 @@ Plugins are configured through the following methods:
 1. **Environment Variables**:
    - `LMCACHE_PLUGIN_ROLE`: The role of the current process (e.g., `SCHEDULER`, `WORKER`)
    - `LMCACHE_PLUGIN_CONFIG`: JSON string containing the plugin configuration
+   - `LMCACHE_PLUGIN_WORKER_ID`: The worker id of current process
+   - `LMCACHE_PLUGIN_WORKER_COUNT`: The total worker count of this cluster
 
 2. **Configuration File**:
    Plugins can be specified in the `lmcache.yaml` file under the `plugin_locs` field:
    ```yaml
    plugin_locs: ["/path/to/plugins"]
    ```
+3. **Pass more parameters via lmcache extra_config**
+   You can Pass more parameters via specify extra_config within `lmcache.yaml`.
 
 ## Plugin Naming Rules
 Plugin filenames determine which roles/worker_id they run on:

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -21,9 +21,9 @@ Plugins are configured through the following methods:
    - `LMCACHE_PLUGIN_WORKER_COUNT`: The total worker count of this cluster
 
 2. **Configuration File**:
-   Plugins can be specified in the `lmcache.yaml` file under the `plugin_locs` field:
+   Plugins can be specified in the `lmcache.yaml` file under the `plugin_locations` field:
    ```yaml
-   plugin_locs: ["/path/to/plugins"]
+   plugin_locations: ["/path/to/plugins"]
    ```
 3. **Pass more parameters via lmcache extra_config**
    You can Pass more parameters via specify extra_config within `lmcache.yaml`.

--- a/examples/plugins/all_run_plugin.sh
+++ b/examples/plugins/all_run_plugin.sh
@@ -6,15 +6,16 @@
 trap "echo 'Received termination signal, exiting...'; exit 0" SIGTERM
 
 role="$LMCACHE_PLUGIN_ROLE"
+worker_id="$LMCACHE_PLUGIN_WORKER_ID"
+worker_count="$LMCACHE_PLUGIN_WORKER_COUNT"
 config="$LMCACHE_PLUGIN_CONFIG"
 
-echo "Shell plugin running with role: $role"
-echo "Config: $config"
+echo "All plugin started for role: $role, worker ID: $worker_id, worker count: $worker_count"
+echo "All plugin accept LMCache Config: $config"
 
-# Main loop
+loop_count=0
 while true; do
-    echo "Plugin is running..."
+    echo "All plugin is running for ${role} ${worker_id}...(loop_count: ${loop_count})"
+    loop_count=$((loop_count + 1))
     sleep 10
 done
-
-echo "Shell plugin finished"

--- a/examples/plugins/all_run_plugin.sh
+++ b/examples/plugins/all_run_plugin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Example plugin for LMCache system
+# This plugin runs continuously and exits when parent process terminates
+
+# Handle termination signal
+trap "echo 'Received termination signal, exiting...'; exit 0" SIGTERM
+
+role="$LMCACHE_PLUGIN_ROLE"
+config="$LMCACHE_PLUGIN_CONFIG"
+
+echo "Shell plugin running with role: $role"
+echo "Config: $config"
+
+# Main loop
+while true; do
+    echo "Plugin is running..."
+    sleep 10
+done
+
+echo "Shell plugin finished"

--- a/examples/plugins/scheduler_foo_plugin.py
+++ b/examples/plugins/scheduler_foo_plugin.py
@@ -23,7 +23,8 @@ def handle_exit(signum, frame):
 signal.signal(signal.SIGTERM, handle_exit)
 
 role = os.getenv("LMCACHE_PLUGIN_ROLE")
-
+worker_id = os.getenv("LMCACHE_PLUGIN_WORKER_ID")
+worker_count = os.getenv("LMCACHE_PLUGIN_WORKER_COUNT")
 config_str = os.getenv("LMCACHE_PLUGIN_CONFIG")
 try:
     config = LMCacheEngineConfig.from_json(config_str)
@@ -31,10 +32,15 @@ except json.JSONDecodeError as e:
     print(f"Error parsing LMCACHE_PLUGIN_CONFIG: {e}")
     config = lmcache_get_config()
 
-print(f"Python plugin running with role: {role}")
+print(
+    f"Python plugin running with role: {role}, worker_id: {worker_id}, "
+    f"worker_count: {worker_count}"
+)
 print(f"Config: {config}")
 
 # Main loop
+loop_count = 0
 while True:
-    print("Scheduler plugin is running...")
+    print(f"Scheduler plugin is running... (loop_count: {loop_count})")
+    loop_count += 1
     time.sleep(10)

--- a/examples/plugins/scheduler_foo_plugin.py
+++ b/examples/plugins/scheduler_foo_plugin.py
@@ -1,0 +1,40 @@
+#!/opt/venv/bin/python
+# SPDX-License-Identifier: Apache-2.0
+"""Example plugin for LMCache system
+This plugin runs continuously and exits when parent process terminates"""
+
+# Standard
+import json
+import os
+import signal
+import time
+
+# First Party
+from lmcache.integration.vllm.utils import lmcache_get_config
+from lmcache.v1.config import LMCacheEngineConfig
+
+
+# Graceful exit handler
+def handle_exit(signum, frame):
+    print("Received termination signal, exiting...")
+    exit(0)
+
+
+signal.signal(signal.SIGTERM, handle_exit)
+
+role = os.getenv("LMCACHE_PLUGIN_ROLE")
+
+config_str = os.getenv("LMCACHE_PLUGIN_CONFIG")
+try:
+    config = LMCacheEngineConfig.from_json(config_str)
+except json.JSONDecodeError as e:
+    print(f"Error parsing LMCACHE_PLUGIN_CONFIG: {e}")
+    config = lmcache_get_config()
+
+print(f"Python plugin running with role: {role}")
+print(f"Config: {config}")
+
+# Main loop
+while True:
+    print("Scheduler plugin is running...")
+    time.sleep(10)

--- a/examples/plugins/worker_0_test.sh
+++ b/examples/plugins/worker_0_test.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
+# Example plugin for LMCache system
+# This plugin runs continuously and exits when parent process terminates
+
+# Handle termination signal
+trap "echo 'Received termination signal, exiting...'; exit 0" SIGTERM
 
 role="$LMCACHE_PLUGIN_ROLE"
-worker_id="$LMCACHE_PLUGIN_WORKER_ID"  # Assuming WORKER_ID is passed as an environment variable
+worker_id="$LMCACHE_PLUGIN_WORKER_ID"
+worker_count="$LMCACHE_PLUGIN_WORKER_COUNT"
+config="$LMCACHE_PLUGIN_CONFIG"
 
-echo "Worker plugin started for role: $role, worker ID: $worker_id"
+echo "Worker plugin started for role: $role, worker ID: $worker_id, worker count: $worker_count"
+echo "Config: $config"
 
+loop_count=0
 while true; do
-    echo "Worker plugin is running..."
-    sleep 5
+    echo "Worker plugin is running for worker ${worker_id}...(loop_count: ${loop_count})"
+    loop_count=$((loop_count + 1))
+    sleep 10
 done

--- a/examples/plugins/worker_0_test.sh
+++ b/examples/plugins/worker_0_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+role="$LMCACHE_PLUGIN_ROLE"
+worker_id="$LMCACHE_PLUGIN_WORKER_ID"  # Assuming WORKER_ID is passed as an environment variable
+
+echo "Worker plugin started for role: $role, worker ID: $worker_id"
+
+while true; do
+    echo "Worker plugin is running..."
+    sleep 5
+done

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -539,7 +539,7 @@ class LMCacheConnectorV1Impl:
     ):
         self._parent = parent
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-
+        self.worker_count = vllm_config.parallel_config.tensor_parallel_size
         config = lmcache_get_config()
         self.config = config
         self.layerwise_retrievers = []
@@ -622,6 +622,7 @@ class LMCacheConnectorV1Impl:
         self.plugin_launcher = PluginLauncher(
             self.config,
             role,
+            self.worker_count,
             -1
             if role == KVConnectorRole.SCHEDULER
             else self.lmcache_engine.metadata.worker_id,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -43,6 +43,7 @@ from lmcache.v1.gpu_connector import (
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.lookup_client import LookupClientFactory
 from lmcache.v1.offload_server.zmq_server import ZMQOffloadServer
+from lmcache.v1.plugin.plugin_launcher import PluginLauncher
 from lmcache.v1.storage_backend.connector.nixl_connector_v3 import (
     NixlReceiverInfo,
 )
@@ -616,6 +617,16 @@ class LMCacheConnectorV1Impl:
         # The enabled check is in the InternalAPIServer constructor
         self.api_server = InternalAPIServer(self)
         self.api_server.start()
+
+        # Launch plugins
+        self.plugin_launcher = PluginLauncher(
+            self.config,
+            role,
+            -1
+            if role == KVConnectorRole.SCHEDULER
+            else self.lmcache_engine.metadata.worker_id,
+        )
+        self.plugin_launcher.launch_plugins()
 
     @_lmcache_nvtx_annotate
     def _init_kv_caches_from_forward_context(self, forward_context: "ForwardContext"):

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -312,23 +312,6 @@ def _create_config_class():
     def _post_init(self):
         self.validate()
 
-    def _to_dict(self):
-        """Convert the configuration object into a dictionary."""
-        return {name: getattr(self, name) for name in _CONFIG_DEFINITIONS}
-
-    def _to_json(self):
-        """Serialize the configuration object to a JSON string."""
-        return json.dumps(self.to_dict(), indent=2)
-
-    def _from_json(cls, json_str: str):
-        """Deserialize a JSON string into a configuration object."""
-        try:
-            config_dict = json.loads(json_str)
-            return cls.from_dict(config_dict)
-        except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON input: {e}")
-            raise
-
     cls = make_dataclass(
         "LMCacheEngineConfig",
         [(name, type_, default) for name, (type_, default) in fields_dict.items()],
@@ -560,6 +543,26 @@ def _from_dict(cls, config_dict: dict):
         config_values[name] = value
     instance = cls(**config_values)
     return instance.log_config()
+
+
+def _to_dict(self):
+    """Convert the configuration object into a dictionary."""
+    return {name: getattr(self, name) for name in _CONFIG_DEFINITIONS}
+
+
+def _to_json(self):
+    """Serialize the configuration object to a JSON string."""
+    return json.dumps(self.to_dict(), indent=2)
+
+
+def _from_json(cls, json_str: str):
+    """Deserialize a JSON string into a configuration object."""
+    try:
+        config_dict = json.loads(json_str)
+        return cls.from_dict(config_dict)
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON input: {e}")
+        raise
 
 
 # Create configuration class

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -262,7 +262,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": _to_int_list,
     },
-    "plugin_locs": {
+    "plugin_locations": {
         "type": Optional[list[str]],
         "default": None,
         "env_converter": lambda x: x if isinstance(x, list) else [x] if x else [],

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -263,7 +263,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": _to_int_list,
     },
     "plugin_locs": {
-        "type": Optional[list[int]],
+        "type": Optional[list[str]],
         "default": None,
         "env_converter": lambda x: x if isinstance(x, list) else [x] if x else [],
     },

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -262,6 +262,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": _to_int_list,
     },
+    "plugin_locs": {
+        "type": Optional[list[int]],
+        "default": None,
+        "env_converter": lambda x: x if isinstance(x, list) else [x] if x else [],
+    },
 }
 
 
@@ -307,6 +312,23 @@ def _create_config_class():
     def _post_init(self):
         self.validate()
 
+    def _to_dict(self):
+        """Convert the configuration object into a dictionary."""
+        return {name: getattr(self, name) for name in _CONFIG_DEFINITIONS}
+
+    def _to_json(self):
+        """Serialize the configuration object to a JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def _from_json(cls, json_str: str):
+        """Deserialize a JSON string into a configuration object."""
+        try:
+            config_dict = json.loads(json_str)
+            return cls.from_dict(config_dict)
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON input: {e}")
+            raise
+
     cls = make_dataclass(
         "LMCacheEngineConfig",
         [(name, type_, default) for name, (type_, default) in fields_dict.items()],
@@ -322,6 +344,10 @@ def _create_config_class():
             "__str__": lambda self: str(
                 {name: getattr(self, name) for name in _CONFIG_DEFINITIONS}
             ),
+            "from_dict": classmethod(_from_dict),
+            "to_dict": _to_dict,
+            "to_json": _to_json,
+            "from_json": classmethod(_from_json),
         },
     )
     return cls
@@ -519,6 +545,19 @@ def _from_env(cls):
 
         config_values[name] = value
 
+    instance = cls(**config_values)
+    return instance.log_config()
+
+
+def _from_dict(cls, config_dict: dict):
+    """Create configuration from a dictionary."""
+    resolved_config = _resolve_config_aliases(config_dict, "dictionary input")
+    config_values = {}
+    for name, config in _CONFIG_DEFINITIONS.items():
+        value = resolved_config.get(name, config["default"])
+        if value is not None:
+            value = config["env_converter"](value)
+        config_values[name] = value
     instance = cls(**config_values)
     return instance.log_config()
 

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -63,7 +63,10 @@ class PluginLauncher:
         if len(parts) > 2 and parts[1].isdigit():
             plugin_worker_id = int(parts[1])
             if plugin_worker_id != self.worker_id:
-                logger.info(f"Skipping {file}: requires worker ID {plugin_worker_id}")
+                logger.info(
+                    f"worker {self.worker_id} is skipping plugin {file}, "
+                    f"which is only for worker ID {plugin_worker_id}"
+                )
                 return True
 
         return False

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -24,10 +24,10 @@ class PluginLauncher:
 
     def launch_plugins(self):
         """Launch all configured plugins"""
-        if not self.config.plugin_locs:
+        if not self.config.plugin_locations:
             return
 
-        for loc in self.config.plugin_locs:
+        for loc in self.config.plugin_locations:
             self._launch_plugins(loc)
 
     def _launch_plugins(self, loc: str):

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -47,34 +47,34 @@ class PluginLauncher:
         for file in files:
             self._launch_plugin(file)
 
+    def _should_skip_plugin(self, file: Path, parts: list[str]) -> bool:
+        """Determine if plugin should be skipped based on role/worker ID"""
+        if len(parts) < 2:
+            return False
+
+        # Check role match
+        plugin_role = parts[0].upper()
+        if plugin_role != "ALL" and plugin_role != self.role.name:
+            logger.info(f"Skipping {file}: requires role {plugin_role}")
+            return True
+
+        # Check worker ID match
+        if len(parts) > 2 and parts[1].isdigit():
+            plugin_worker_id = int(parts[1])
+            if plugin_worker_id != self.worker_id:
+                logger.info(f"Skipping {file}: requires worker ID {plugin_worker_id}")
+                return True
+
+        return False
+
     def _launch_plugin(self, file: Path):
         """Launch a plugin"""
         try:
-            # Parse role and worker ID from filename
             filename = file.stem.lower()
             parts = filename.split("_")
 
-            # Skip if role is specified and does not match
-            if len(parts) > 1 and parts[0] != "":
-                plugin_role = parts[0].upper()
-                if plugin_role == "ALL" or plugin_role == self.role.name == "SCHEDULER":
-                    pass
-                elif plugin_role != self.role.name:
-                    logger.info(
-                        f"Skipping plugin {file}: role mismatch "
-                        f"(expected {plugin_role}, current {self.role})"
-                    )
-                    return
-
-                # Skip if worker ID is specified and does not match
-                if len(parts) > 2 and parts[1].isdigit():
-                    plugin_worker_id = int(parts[1])
-                    if plugin_worker_id != self.worker_id:
-                        logger.info(
-                            f"Skipping plugin {file}: worker ID mismatch "
-                            f"(expected {plugin_worker_id}, current {self.worker_id})"
-                        )
-                        return
+            if self._should_skip_plugin(file, parts):
+                return
 
             # Get interpreter from first line (shebang)
             interpreter = self._get_interpreter(file)
@@ -105,7 +105,7 @@ class PluginLauncher:
     def _get_interpreter(self, file: Path) -> str:
         """Get interpreter from first line comment"""
         try:
-            with open(file, "r") as f:
+            with open(file, "r", encoding="utf-8") as f:
                 first_line = f.readline().strip()
                 if first_line.startswith("#!"):
                     # Extract interpreter path from shebang

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from pathlib import Path
+import atexit
+import os
+import subprocess
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+class PluginLauncher:
+    def __init__(self, config, role, worker_id):
+        self.config = config
+        self.role = role
+        self.worker_id = worker_id
+        self.plugin_processes = []
+        # Register cleanup handler
+        atexit.register(self.stop_plugins)
+
+    def launch_plugins(self):
+        """Launch all configured plugins"""
+        if not self.config.plugin_locs:
+            return
+
+        for loc in self.config.plugin_locs:
+            self._launch_plugins(loc)
+
+    def _launch_plugins(self, loc: str):
+        """Launch plugins from specified location"""
+        path = Path(loc)
+        if not path.exists():
+            logger.warning(f"Plugin location {loc} does not exist")
+            return
+
+        files = []
+        if path.is_file():
+            files = [path]
+        elif path.is_dir():
+            # Recursively find all .py and .sh files
+            for ext in ["*.py", "*.sh"]:
+                files.extend(path.rglob(ext))
+
+        for file in files:
+            self._launch_plugin(file)
+
+    def _launch_plugin(self, file: Path):
+        """Launch a plugin"""
+        try:
+            # Parse role and worker ID from filename
+            filename = file.stem.lower()
+            parts = filename.split("_")
+
+            # Skip if role is specified and does not match
+            if len(parts) > 1 and parts[0] != "":
+                plugin_role = parts[0].upper()
+                if plugin_role == "ALL" or plugin_role == self.role.name == "SCHEDULER":
+                    pass
+                elif plugin_role != self.role.name:
+                    logger.info(
+                        f"Skipping plugin {file}: role mismatch "
+                        f"(expected {plugin_role}, current {self.role})"
+                    )
+                    return
+
+                # Skip if worker ID is specified and does not match
+                if len(parts) > 2 and parts[1].isdigit():
+                    plugin_worker_id = int(parts[1])
+                    if plugin_worker_id != self.worker_id:
+                        logger.info(
+                            f"Skipping plugin {file}: worker ID mismatch "
+                            f"(expected {plugin_worker_id}, current {self.worker_id})"
+                        )
+                        return
+
+            # Get interpreter from first line (shebang)
+            interpreter = self._get_interpreter(file)
+
+            # Pass role and config as environment variables
+            env = os.environ.copy()
+            env["LMCACHE_PLUGIN_ROLE"] = str(self.role)
+            env["LMCACHE_PLUGIN_CONFIG"] = self.config.to_json()
+            env["LMCACHE_PLUGIN_WORKER_ID"] = str(self.worker_id)
+
+            proc = subprocess.Popen(
+                [interpreter, str(file)],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self.plugin_processes.append(proc)
+            logger.info(f"Launched plugin: {file} with {interpreter}")
+
+            # Start thread to capture output continuously
+            threading.Thread(
+                target=self._capture_plugin_output, args=(proc, str(file)), daemon=True
+            ).start()
+        except Exception as e:
+            logger.error(f"Failed to launch plugin {file}: {e}")
+
+    def _get_interpreter(self, file: Path) -> str:
+        """Get interpreter from first line comment"""
+        try:
+            with open(file, "r") as f:
+                first_line = f.readline().strip()
+                if first_line.startswith("#!"):
+                    # Extract interpreter path from shebang
+                    return first_line[2:].strip()
+        except Exception:
+            pass
+
+        # Fallback to default interpreters
+        if file.suffix == ".py":
+            return "python"
+        elif file.suffix == ".sh":
+            return "bash"
+        else:
+            raise ValueError(f"Unsupported plugin type: {file.suffix}")
+
+    def _capture_plugin_output(self, proc: subprocess.Popen, plugin_name: str):
+        """Continuously capture and log plugin output"""
+        try:
+            while True:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                logger.info(f"[{plugin_name}] {line.strip()}")
+
+            proc.wait()
+            logger.info(f"Plugin {plugin_name} exited with code {proc.returncode}")
+        except Exception as e:
+            logger.error(f"Error capturing output for {plugin_name}: {e}")
+
+    def stop_plugins(self):
+        """Terminate all plugin processes"""
+        for proc in self.plugin_processes:
+            try:
+                if proc.poll() is None:
+                    proc.terminate()
+                    logger.info(f"Terminated plugin process: {proc.pid}")
+            except Exception as e:
+                logger.error(f"Error terminating plugin process: {e}")

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -13,9 +13,10 @@ logger = init_logger(__name__)
 
 
 class PluginLauncher:
-    def __init__(self, config, role, worker_id):
+    def __init__(self, config, role, worker_count, worker_id):
         self.config = config
         self.role = role
+        self.worker_count = worker_count
         self.worker_id = worker_id
         self.plugin_processes = []
         # Register cleanup handler
@@ -83,6 +84,7 @@ class PluginLauncher:
             env = os.environ.copy()
             env["LMCACHE_PLUGIN_ROLE"] = str(self.role)
             env["LMCACHE_PLUGIN_CONFIG"] = self.config.to_json()
+            env["LMCACHE_PLUGIN_WORKER_COUNT"] = str(self.worker_count)
             env["LMCACHE_PLUGIN_WORKER_ID"] = str(self.worker_id)
 
             proc = subprocess.Popen(


### PR DESCRIPTION
# Description

The LMCache plugin system allows users to extend functionality by running custom scripts or programs during cache operations. Plugins can be written in any language (Python, Bash, etc.) and are managed by the `PluginLauncher` class.

# How to use

examples/plugins/README.md

# Test

- lmcache.yaml
```yaml
chunk_size: 256
local_cpu: True
max_local_cpu_size: 5
plugin_locs: ["/apdcephfs_szgm/share_303468461/baoloongmao/remote_dev/lmcache_new/LMCache/examples/plugins"]

```

<img width="1488" height="1016" alt="image" src="https://github.com/user-attachments/assets/ea2613e9-0b78-42de-ae36-ad9559dbd2b3" />
