### PR TITLE
[Bugfix] Fix hash value mismatch between Prefill and Decode

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -137,7 +137,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             raise ValueError(f"Unsupported tokens type: {type(tokens)}")
         
         # NOTE: Using the builtin hash to calculate the None object will give different results each time
-        prefix_hash = prefix_hash or prefix_hash
+        prefix_hash = prefix_hash or 0
         extra_keys_tuple = tuple(extra_keys or [])
 
         # Ignore extra keys for now

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -137,7 +137,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             raise ValueError(f"Unsupported tokens type: {type(tokens)}")
         
         # NOTE: Using the builtin hash to calculate the None object will give different results each time
-        prefix_hash = prefix_hash or 0
+        prefix_hash = () if prefix_hash is None else prefix_hash
         extra_keys_tuple = tuple(extra_keys or [])
 
         # Ignore extra keys for now

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -135,11 +135,15 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             tokens_tuple = tuple(tokens)
         else:
             raise ValueError(f"Unsupported tokens type: {type(tokens)}")
+        
+        # NOTE: Using the builtin hash to calculate the None object will give different results each time
+        prefix_hash = 0 if prefix_hash is None else prefix_hash
+        extra_keys_tuple = tuple(extra_keys) if extra_keys is not None else ()  
 
         # Ignore extra keys for now
         # Extra keys are for multi-modal inputs and
         # request specific metadata (e.g., LoRA ID).
-        return self.hash_func((prefix_hash, tokens_tuple, extra_keys))
+        return self.hash_func((prefix_hash, tokens_tuple, extra_keys_tuple))
 
 
 class ChunkedTokenDatabase(TokenDatabase):

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -137,7 +137,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             raise ValueError(f"Unsupported tokens type: {type(tokens)}")
         
         # NOTE: Using the builtin hash to calculate the None object will give different results each time
-        prefix_hash = 0 if prefix_hash is None else prefix_hash
+        prefix_hash = prefix_hash or prefix_hash
         extra_keys_tuple = tuple(extra_keys or [])
 
         # Ignore extra keys for now

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -138,7 +138,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         
         # NOTE: Using the builtin hash to calculate the None object will give different results each time
         prefix_hash = 0 if prefix_hash is None else prefix_hash
-        extra_keys_tuple = tuple(extra_keys) if extra_keys is not None else ()  
+        extra_keys_tuple = tuple(extra_keys or [])
 
         # Ignore extra keys for now
         # Extra keys are for multi-modal inputs and


### PR DESCRIPTION
Fix hash value mismatch between Prefill and Decode. This error was introduced by #1380 

There are two issues with the current version of the code:

1. Hashing None values yields inconsistent results across different runs, causing mismatches in hash values between the prefill and decode phases.
2. The code attempts to hash a list without first converting it to an immutable type such as a tuple, which leads to a TypeError.

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
