### PR TITLE
[Bugfix] Fix Prefill returns before all kv store operations complete

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -861,6 +861,7 @@ class LMCacheConnectorV1Impl:
 
         connector_metadata = self._parent._get_connector_metadata()
         assert isinstance(connector_metadata, LMCacheConnectorMetadata)
+        assert self.lmcache_engine is not None
 
         self.lmcache_engine.lookup_unpin(connector_metadata.lookup_requests_in_step)
 
@@ -871,12 +872,12 @@ class LMCacheConnectorV1Impl:
         if self.use_layerwise:
             for layerwise_storer in self.layerwise_storers:
                 next(layerwise_storer)
+            self.lmcache_engine.wait_for_store(timeout=None)
             return
 
         assert len(self.kv_caches) > 0
         kvcaches = list(self.kv_caches.values())
 
-        assert self.lmcache_engine is not None
 
         for request in connector_metadata.requests:
             save_spec = request.save_spec
@@ -945,6 +946,7 @@ class LMCacheConnectorV1Impl:
                 transfer_spec=request.disagg_spec,
                 request_configs=request.request_configs,
             )
+            self.lmcache_engine.wait_for_store(timeout=None)
 
             # NOTE(Jiayi): We assume all tokens are saved
             save_spec.skip_leading_tokens = len(token_ids)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections import defaultdict
+from concurrent.futures import Future
 from typing import (
     Any,
     Callable,
@@ -102,6 +103,9 @@ class LMCacheEngine:
             self.config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
             and metadata.use_mla
         )
+
+        self.store_futures: List[Future] = []
+
         self.enable_p2p = config.enable_p2p
 
         self.enable_controller = config.enable_controller
@@ -277,7 +281,10 @@ class LMCacheEngine:
         t = time.perf_counter()
 
         transfer_spec = kwargs.get("transfer_spec", None)
-        self.storage_manager.batched_put(keys, memory_objs, transfer_spec=transfer_spec)
+
+        futures = self.storage_manager.batched_put(keys, memory_objs, transfer_spec=transfer_spec)
+        self.store_futures.extend(futures)
+
         put_time += time.perf_counter() - t
 
         tot_time = offload_time + put_time
@@ -402,7 +409,9 @@ class LMCacheEngine:
             for layer_id in range(self.num_layers):
                 yield
                 next(mem_obj_generator)
-                self.storage_manager.batched_put(keys[layer_id], memory_objs[layer_id])
+                futures = self.storage_manager.batched_put(keys[layer_id], memory_objs[layer_id])
+                self.store_futures.extend(futures)
+
         else:
             # If no cache are found, we still need to yield to avoid
             # `StopIteration`
@@ -412,6 +421,36 @@ class LMCacheEngine:
         self.stats_monitor.on_store_finished(monitor_req_id, tot_token_num)
         logger.debug(f"Stored {tot_token_num} out of total {len(tokens)} tokens")
         yield
+
+    @_lmcache_nvtx_annotate
+    @torch.inference_mode()
+    def wait_for_store(
+        self, 
+        timeout: Optional[int] = 20
+    ) -> None:
+        """
+        Block until all asynchronous store operations are completed
+        """
+        try:
+            logger.debug("Waiting for store operations to complete")
+            start_time = time.time()
+            for future in self.store_futures:
+                if timeout is not None:
+                    elapsed = time.time() - start_time
+                    remaining = max(0, timeout - elapsed)
+                    if elapsed >= timeout:
+                        raise asyncio.TimeoutError("Timeout waiting for store operations to complete")
+                    future.result(timeout=remaining)
+                else:
+                    future.result()
+            logger.debug("Finished all store operations, Used {:.3f}ms".format((time.time() - start_time)*1000))
+        except asyncio.TimeoutError:
+            logger.error("Timeout waiting for store operations to complete")
+        except Exception as e:
+            logger.error(f"Error waiting for store: {e}")
+        finally:
+            self.store_futures.clear()
+        return
 
     @_lmcache_nvtx_annotate
     @torch.inference_mode()

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -439,18 +439,17 @@ class LMCacheEngine:
                     elapsed = time.time() - start_time
                     remaining = max(0, timeout - elapsed)
                     if elapsed >= timeout:
-                        raise asyncio.TimeoutError("Timeout waiting for store operations to complete")
+                        raise concurrent.futures.TimeoutError("Timeout waiting for store operations to complete")
                     future.result(timeout=remaining)
                 else:
                     future.result()
             logger.debug("Finished all store operations, Used {:.3f}ms".format((time.time() - start_time)*1000))
-        except asyncio.TimeoutError:
+        except concurrent.futures.TimeoutError:
             logger.error("Timeout waiting for store operations to complete")
         except Exception as e:
             logger.error(f"Error waiting for store: {e}")
         finally:
             self.store_futures.clear()
-        return
 
     @_lmcache_nvtx_annotate
     @torch.inference_mode()

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -136,19 +136,23 @@ class StorageManager:
         key: CacheEngineKey,
         memory_obj: MemoryObj,
         location: Optional[str] = None,
-    ) -> None:
+    ) -> List[Future]:
         """
         Non-blocking function to put the memory object into the storages.
         Do not store if the same object is being stored (handled here by
         storage manager) or has been stored (handled by storage backend).
         """
-
+        put_futures: List[Future] = []
         for backend_name, backend in self.storage_backends.items():
             if location and backend_name != location:
                 continue
-            backend.submit_put_task(key, memory_obj)
+            future = backend.submit_put_task(key, memory_obj)
+            if future is not None:
+                put_futures.append(future)
 
         memory_obj.ref_count_down()
+
+        return put_futures
 
     # TODO(Jiayi): location and transfer_spec might be redundant
     def batched_put(
@@ -157,14 +161,14 @@ class StorageManager:
         memory_objs: List[MemoryObj],
         transfer_spec=None,  # TODO(Jiayi): add type check
         location: Optional[str] = None,
-    ) -> None:
+    ) -> List[Future]:
         """
         Non-blocking function to batched put the memory objects into the
         storage backends.
         Do not store if the same object is being stored (handled here by
         storage manager) or has been stored (handled by storage backend).
         """
-
+        put_futures: List[Future] = []
         if self.enable_nixl or (location and location == "NixlBackend"):
             self.allocator_backend.batched_submit_put_task(
                 keys, memory_objs, transfer_spec=transfer_spec
@@ -206,10 +210,14 @@ class StorageManager:
                 continue
             # NOTE: the handling of exists_in_put_tasks
             # is done in the backend
-            backend.batched_submit_put_task(keys, memory_objs)
+            futures = backend.batched_submit_put_task(keys, memory_objs)
+            if futures is not None:
+                put_futures.extend(futures)
 
         for memory_obj in memory_objs:
             memory_obj.ref_count_down()
+        
+        return put_futures
 
     def get(
         self,


### PR DESCRIPTION
FIX Prefill returns before all kv store operations complete (#1350 )

I fixed LMCacheConnectorV1Impl::wait_for_save so it waits for all asynchronous kv store operations to complete before returning. Previously prefill could return before kv cache writes finished, causing decode to read incomplete kv data and trigger errors. 

The change should support both layerwise and non-layerwise stores. Non-layerwise tests pass; layerwise tests currently fail with a kv shape error that I believe is unrelated to this change — I'll investigate and address that separately."

Prefill log
```
(APIServer pid=8812) INFO:     Started server process [8812]
(APIServer pid=8812) INFO:     Waiting for application startup.
(APIServer pid=8812) INFO:     Application startup complete.
(EngineCore_0 pid=9077) [2025-08-21 21:08:22,054] LMCache INFO: Reqid: cmpl-942fda250d02439a841bd04faad52c7a-0, Total tokens 7219, LMCache hit tokens: 0, need to load: 0 (vllm_v1_adapter.py:1024:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP1 pid=9213) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,067] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP3 pid=9215) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP0 pid=9212) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP6 pid=9218) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,069] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=9219) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,069] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,069] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=9217) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,069] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=9214) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,069] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,069] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP4 pid=9216) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,070] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,219] LMCache INFO: Storing KV cache for 7219 out of 7219 tokens (skip_leading_tokens=0) for request cmpl-942fda250d02439a841bd04faad52c7a-0 (vllm_v1_adapter.py:918:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,225] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 5.9674 ms, throughput: 18.4591 GB/s; offload_time: 5.5389 ms, put_time: 0.4285 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,225] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 5.9886 ms, throughput: 18.3939 GB/s; offload_time: 5.3894 ms, put_time: 0.5992 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,225] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 6.0590 ms, throughput: 18.1801 GB/s; offload_time: 5.5153 ms, put_time: 0.5437 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,225] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 5.9910 ms, throughput: 18.3865 GB/s; offload_time: 5.5781 ms, put_time: 0.4129 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,225] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,225] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,225] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,225] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,225] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 6.2353 ms, throughput: 17.6660 GB/s; offload_time: 5.7393 ms, put_time: 0.4960 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,225] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 6.4335 ms, throughput: 17.1217 GB/s; offload_time: 5.5504 ms, put_time: 0.8831 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,226] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 6.5298 ms, throughput: 16.8693 GB/s; offload_time: 5.9535 ms, put_time: 0.5763 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,226] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,226] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,226] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,226] LMCache INFO: Stored 7219 out of total 7219 tokens. size: 0.1102 gb, cost 6.9147 ms, throughput: 15.9303 GB/s; offload_time: 5.5468 ms, put_time: 1.3679 ms (cache_engine.py:295:lmcache.v1.cache_engine)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,226] LMCache DEBUG: Waiting for store operations to complete (cache_engine.py:435:lmcache.v1.cache_engine)
I0821 21:08:22.287154 11342 rdma_endpoint.cpp:116] Connection has been established
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,421] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 195.652ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,421] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 195.724ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,421] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 195.845ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,421] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 196.054ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,421] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 196.010ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,421] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 196.022ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,422] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 196.378ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,422] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 196.131ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,428] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 202.449ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,428] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 202.648ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,433] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 207.029ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,434] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 198.344ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,434] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 208.060ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,434] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 207.766ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,434] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 207.945ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,434] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 207.879ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,434] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 207.916ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,436] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 210.965ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,436] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 200.756ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,445] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 209.215ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,445] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 219.780ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,451] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 224.452ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,451] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 224.720ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,451] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 215.701ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,451] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 215.813ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,453] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 227.723ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP1 pid=9213) [2025-08-21 21:08:22,453] LMCache DEBUG: Finished all store operations, Used 227.546ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,463] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 237.132ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,464] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 237.608ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,464] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 228.793ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,464] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 228.647ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP0 pid=9212) [2025-08-21 21:08:22,464] LMCache DEBUG: Finished all store operations, Used 236.335ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,468] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.619ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,468] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.437ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,468] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.810ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,469] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.938ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,469] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.889ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,469] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.983ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,469] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 242.985ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,477] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 251.645ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,478] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 251.925ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,485] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 258.915ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,492] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 266.789ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.564ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 267.933ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.618ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.055ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.062ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.801ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.217ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.922ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.895ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.321ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 260.682ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.244ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.402ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,494] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.313ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,495] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.525ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,495] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.442ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,495] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 268.424ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,495] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 268.564ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,496] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 261.855ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,496] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 262.075ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,496] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 270.661ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,499] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 273.904ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,500] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 273.797ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,500] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 274.070ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,505] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 279.664ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,509] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 282.717ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,509] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 283.018ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP6 pid=9218) [2025-08-21 21:08:22,509] LMCache DEBUG: Finished all store operations, Used 282.684ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,509] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 283.500ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,511] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 285.493ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,518] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 283.964ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,518] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 284.252ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,519] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 292.532ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,519] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 292.660ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP3 pid=9215) [2025-08-21 21:08:22,519] LMCache DEBUG: Finished all store operations, Used 291.754ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,527] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 301.587ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,528] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 302.756ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,528] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 299.790ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,528] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 299.843ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.285ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 303.691ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.414ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 300.283ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.450ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.586ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.427ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.590ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.902ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 304.161ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.859ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 300.968ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP4 pid=9216) [2025-08-21 21:08:22,529] LMCache DEBUG: Finished all store operations, Used 303.176ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,531] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 305.309ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP5 pid=9217) [2025-08-21 21:08:22,531] LMCache DEBUG: Finished all store operations, Used 305.015ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,538] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 312.271ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.034ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 305.783ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.266ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.179ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 305.875ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.307ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,539] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 305.882ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.511ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 306.104ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 306.374ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.645ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 306.177ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 313.771ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 306.308ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP2 pid=9214) [2025-08-21 21:08:22,540] LMCache DEBUG: Finished all store operations, Used 312.939ms (cache_engine.py:446:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,551] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 325.158ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.117ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.289ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.277ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.257ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.462ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.467ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.441ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.901ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.669ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.592ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.601ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 8.389 MBytes in 326.620ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,552] LMCache DEBUG: [InstrumentedRemoteConnector(<MooncakestoreConnector>)]Bytes offloaded: 0.836 MBytes in 326.646ms (instrumented_connector.py:39:lmcache.v1.storage_backend.connector.instrumented_connector)
(VllmWorker TP7 pid=9219) [2025-08-21 21:08:22,553] LMCache DEBUG: Finished all store operations, Used 326.484ms (cache_engine.py:446:lmcache.v1.cache_engine)
(APIServer pid=8812) INFO:     200.10.0.22:51502 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=8812) INFO:     200.10.0.22:51502 - "POST /tokenize HTTP/1.1" 200 OK
```

Decode log
```
(APIServer pid=7343) INFO:     Started server process [7343]
(APIServer pid=7343) INFO:     Waiting for application startup.
(APIServer pid=7343) INFO:     Application startup complete.
(APIServer pid=7343) INFO:     200.10.0.22:49432 - "POST /tokenize HTTP/1.1" 200 OK
(APIServer pid=7343) INFO:     200.10.0.22:49432 - "POST /v1/completions HTTP/1.1" 200 OK
(EngineCore_0 pid=7608) [2025-08-21 21:08:22,628] LMCache INFO: Reqid: cmpl-8eb2bfa0c87e4d66aabdec96d39298b4-0, Total tokens 7220, LMCache hit tokens: 7219, need to load: 7219 (vllm_v1_adapter.py:1024:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_0 pid=7608) [2025-08-21 21:08:22,630] LMCache DEBUG: Scheduled to load 7219 tokens for request cmpl-8eb2bfa0c87e4d66aabdec96d39298b4-0 (vllm_v1_adapter.py:347:lmcache.integration.vllm.vllm_v1_adapter)
(VllmWorker TP5 pid=7748) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP0 pid=7743) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP7 pid=7750) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP1 pid=7744) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP3 pid=7746) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP5 pid=7748) [2025-08-21 21:08:22,633] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=7750) [2025-08-21 21:08:22,633] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP0 pid=7743) [2025-08-21 21:08:22,633] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP1 pid=7744) [2025-08-21 21:08:22,633] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP3 pid=7746) [2025-08-21 21:08:22,633] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=7745) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP2 pid=7745) [2025-08-21 21:08:22,634] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP6 pid=7749) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP6 pid=7749) [2025-08-21 21:08:22,634] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
(VllmWorker TP4 pid=7747) WARNING 08-21 21:08:22 [cudagraph_dispatcher.py:101] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(VllmWorker TP4 pid=7747) [2025-08-21 21:08:22,636] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:178:lmcache.v1.cache_engine)
I0821 21:08:22.722558  9888 rdma_endpoint.cpp:116] Connection has been established
W0821 21:08:22.726472  9829 worker_pool.cpp:411] Worker: Received context async event communication established for context mlx5_bond_2
I0821 21:08:22.737411  9896 rdma_endpoint.cpp:116] Connection has been established
I0821 21:08:22.739327  8782 rdma_endpoint.cpp:116] Connection has been established
I0821 21:08:22.749563  9973 rdma_endpoint.cpp:116] Connection has been established
W0821 21:08:22.806021  8787 worker_pool.cpp:411] Worker: Received context async event communication established for context mlx5_bond_3
I0821 21:08:22.808272  9857 rdma_endpoint.cpp:116] Connection has been established
(VllmWorker TP4 pid=7747) [2025-08-21 21:08:22,825] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP4 pid=7747) [2025-08-21 21:08:22,825] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 188.4044 ms, throughput: 0.5847 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP0 pid=7743) [2025-08-21 21:08:22,846] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP0 pid=7743) [2025-08-21 21:08:22,846] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 212.1585 ms, throughput: 0.5192 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=7745) [2025-08-21 21:08:22,858] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP2 pid=7745) [2025-08-21 21:08:22,858] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 223.5784 ms, throughput: 0.4927 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP3 pid=7746) [2025-08-21 21:08:22,868] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP1 pid=7744) [2025-08-21 21:08:22,868] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP3 pid=7746) [2025-08-21 21:08:22,868] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 234.6114 ms, throughput: 0.4695 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP1 pid=7744) [2025-08-21 21:08:22,868] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 234.6746 ms, throughput: 0.4694 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP6 pid=7749) [2025-08-21 21:08:22,873] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP6 pid=7749) [2025-08-21 21:08:22,873] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 238.3034 ms, throughput: 0.4622 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=7750) [2025-08-21 21:08:22,874] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP7 pid=7750) [2025-08-21 21:08:22,874] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 240.9075 ms, throughput: 0.4572 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=7748) [2025-08-21 21:08:22,882] LMCache INFO: Retrieved 7219 out of 7219 out of total 7219 tokens (cache_engine.py:529:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=7748) [2025-08-21 21:08:22,882] LMCache DEBUG: Retrieved 7219 out of total 7219 out of total 7219 tokens. size: 0.1102 gb, cost 248.5781 ms, throughput: 0.4431 GB/s; (cache_engine.py:534:lmcache.v1.cache_engine)
(VllmWorker TP5 pid=7748) [2025-08-21 21:08:22,953] LMCache DEBUG: Remote backend does not support unpin. This method is a no-op and will return True. (remote_backend.py:372:lmcache.v1.storage_backend.remote_backend)
(APIServer pid=7343) INFO 08-21 21:08:23 [loggers.py:123] Engine 000: Avg prompt throughput: 722.0 tokens/s, Avg generation throughput: 0.9 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=7343) INFO:     200.10.0.22:49432 - "POST /v1/completions HTTP/1.1" 200 OK
```

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
