### PR TITLE
[Enhancement] Add sparse attention for kv blending

### DIFF
--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -21,10 +21,10 @@ void multi_layer_kv_transfer_unilateral(
     const int page_buffer_size, const bool direction, const bool use_mla);
 
 void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
-                              torch::Tensor& vllm_key_cache,
-                              torch::Tensor& vllm_value_cache,
+                              torch::Tensor& vllm_key_value_cache,
                               torch::Tensor& slot_mapping, const bool direction,
-                              const bool token_major = false);
+                              const bool token_major = false,
+                              const bool vllm_two_major = false);
 
 void load_and_reshape_flash(torch::Tensor& key_value, torch::Tensor& key_cache,
                             torch::Tensor& value_cache,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -562,6 +562,7 @@ class LMCacheConnectorV1Impl:
                     ENGINE_NAME,
                     self.lmcache_engine,
                     self.lmcache_engine.gpu_connector,
+                    config,
                 )
 
             # Create lookup server using factory

--- a/lmcache/v1/compute/attention/abstract.py
+++ b/lmcache/v1/compute/attention/abstract.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from typing import TYPE_CHECKING
 import abc
 
 # Third Party
 import torch
 
-# First Party
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.compute.attention.metadata import LMCAttnMetadata
 
 
 class AttentionInterface(metaclass=abc.ABCMeta):

--- a/lmcache/v1/compute/attention/abstract.py
+++ b/lmcache/v1/compute/attention/abstract.py
@@ -6,7 +6,6 @@ import abc
 import torch
 
 # First Party
-from lmcache.v1.compute.attention.metadata import LMCFlashAttnMetadata
 
 
 class AttentionInterface(metaclass=abc.ABCMeta):
@@ -24,7 +23,7 @@ class AttentionInterface(metaclass=abc.ABCMeta):
         Perform forward pass of the attention mechanism.
         """
         raise NotImplementedError
-    
+
     @abc.abstractmethod
     def init_attn_metadata(
         self,

--- a/lmcache/v1/compute/attention/abstract.py
+++ b/lmcache/v1/compute/attention/abstract.py
@@ -17,10 +17,21 @@ class AttentionInterface(metaclass=abc.ABCMeta):
         key: torch.Tensor,
         value: torch.Tensor,
         output: torch.Tensor,
-        attn_metadata: "LMCFlashAttnMetadata",
+        attn_metadata: "LMCAttnMetadata",
         **kwargs,
     ) -> torch.Tensor:
         """
         Perform forward pass of the attention mechanism.
+        """
+        raise NotImplementedError
+    
+    @abc.abstractmethod
+    def init_attn_metadata(
+        self,
+        input_ids: torch.Tensor,
+        **kwargs,
+    ) -> "LMCAttnMetadata":
+        """
+        Initialize attention metadata.
         """
         raise NotImplementedError

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -103,19 +103,19 @@ class LMCFlashAttnBackend(AttentionInterface):
                 window_size=self.vllm_attn_impl.aot_sliding_window,
             )
         return None
-    
+
     def init_attn_metadata(
         input_ids: torch.tensor,
         **kwargs,
     ):
         return LMCFlashAttnMetadata(
-                query_start_loc=torch.tensor(
-                    [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-                ),
-                seq_lens=torch.tensor([input_ids.shape[0]], device=hidden_states.device),
-                cu_seqlens_k=torch.tensor(
-                    [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-                ),
-                max_query_len=input_ids.shape[0],
-                max_seq_len=input_ids.shape[0],
-            )
+            query_start_loc=torch.tensor(
+                [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
+            ),
+            seq_lens=torch.tensor([input_ids.shape[0]], device=hidden_states.device),
+            cu_seqlens_k=torch.tensor(
+                [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
+            ),
+            max_query_len=input_ids.shape[0],
+            max_seq_len=input_ids.shape[0],
+        )

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -107,7 +107,7 @@ class LMCFlashAttnBackend(AttentionInterface):
     def init_attn_metadata(
         input_ids: torch.tensor,
         **kwargs,
-    ):
+    ) -> LMCFlashAttnMetadata:
         return LMCFlashAttnMetadata(
             query_start_loc=torch.tensor(
                 [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -105,17 +105,18 @@ class LMCFlashAttnBackend(AttentionInterface):
         return None
 
     def init_attn_metadata(
+        self,
         input_ids: torch.tensor,
         **kwargs,
     ) -> LMCFlashAttnMetadata:
+        seq_len = input_ids.shape[0]
+        device = input_ids.device
         return LMCFlashAttnMetadata(
             query_start_loc=torch.tensor(
-                [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
+                [0, seq_len], dtype=torch.int32, device=device
             ),
-            seq_lens=torch.tensor([input_ids.shape[0]], device=hidden_states.device),
-            cu_seqlens_k=torch.tensor(
-                [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-            ),
-            max_query_len=input_ids.shape[0],
-            max_seq_len=input_ids.shape[0],
+            seq_lens=torch.tensor([seq_len], device=device),
+            cu_seqlens_k=torch.tensor([0, seq_len], dtype=torch.int32, device=device),
+            max_query_len=seq_len,
+            max_seq_len=seq_len,
         )

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import TYPE_CHECKING
+
 # Third Party
 from vllm.attention import Attention
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
@@ -8,6 +11,10 @@ import torch
 # First Party
 from lmcache.v1.compute.attention.abstract import AttentionInterface
 from lmcache.v1.compute.attention.metadata import LMCFlashAttnMetadata
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.compute.attention.metadata import LMCAttnMetadata
 
 
 class LMCFlashAttnBackend(AttentionInterface):
@@ -36,10 +43,10 @@ class LMCFlashAttnBackend(AttentionInterface):
         key: torch.Tensor,
         value: torch.Tensor,
         output: torch.Tensor,
-        attn_metadata: LMCFlashAttnMetadata,
+        attn_metadata: "LMCAttnMetadata",
         **kwargs,
     ) -> torch.Tensor:
-        # num_actual_tokens = query.shape[0]
+        assert isinstance(attn_metadata, LMCFlashAttnMetadata)
 
         cu_seqlens_q = attn_metadata.query_start_loc
         seqused_k = attn_metadata.seq_lens

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Optional, Tuple, Union
+import math
+
 # Third Party
 from flashinfer import VariableBlockSparseAttentionWrapper
-import flashinfer
-import math
-from typing import Optional, Tuple, Union
-
-import torch
-
 from flashinfer.page import block_sparse_indices_to_vector_sparse_offsets
 from flashinfer.utils import (
     TensorLayout,
@@ -14,6 +12,10 @@ from flashinfer.utils import (
     _check_shape_dtype_device,
     device_support_pdl,
 )
+from vllm.attention import Attention
+from vllm.v1.attention.backends.flashinfer import FlashInferImpl
+import flashinfer
+import torch
 
 # First Party
 from lmcache.v1.compute.attention.abstract import AttentionInterface
@@ -21,7 +23,6 @@ from lmcache.v1.compute.attention.metadata import LMCFlashInferSparseMetadata
 
 
 class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
-
     def run(
         self,
         q: torch.Tensor,
@@ -48,7 +49,8 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
         out : Optional[torch.Tensor]
             The output tensor, if not provided, will be allocated internally.
         lse : Optional[torch.Tensor]
-            The log-sum-exp of attention logits, if not provided, will be allocated internally.
+            The log-sum-exp of attention logits, if not provided, will be
+            allocated internally.
         return_lse : bool
             Whether to return the log-sum-exp of attention logits
         enable_pdl : bool
@@ -58,7 +60,8 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
         Returns
         -------
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
-            If :attr:`return_lse` is ``False``, the attention output, shape: ``[M, num_qo_heads, head_dim]``.
+            If :attr:`return_lse` is ``False``, the attention output, shape:
+            ``[M, num_qo_heads, head_dim]``.
             If :attr:`return_lse` is ``True``, a tuple of two tensors:
 
             * The attention output, shape: ``[M, num_qo_heads, head_dim]``.
@@ -82,12 +85,10 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
             rope_scale = 1.0
         if rope_theta is None:
             rope_theta = 1e4
-        
+
         # 1 denotes page size
         k = k.reshape(-1, 1, *k.shape[-2:])
         v = v.reshape(-1, 1, *v.shape[-2:])
-
-
 
         stride_block = k.stride(0)
         stride_n = k.stride(1)
@@ -113,7 +114,8 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
                 <= self._paged_kv_indices_buf.numel()
             ):
                 raise ValueError(
-                    "_vector_sparse_indices_buffer is not large enough. Please increase the buffer size."
+                    "_vector_sparse_indices_buffer is not large enough. "
+                    "Please increase the buffer size."
                 )
 
             sparse_indices = block_sparse_indices_to_vector_sparse_offsets(
@@ -130,7 +132,6 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
         else:
             sparse_indices = self._paged_kv_indices_buf
             sparse_indptr = self._paged_kv_indptr_buf
-
 
         self._cached_module.paged_run(
             self._float_workspace_buffer,
@@ -169,6 +170,7 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
 
         return (out, lse) if return_lse else out
 
+
 class LMCFlashInferSparseBackend(AttentionInterface):
     """
     FlashAttention backend for LMCache.
@@ -190,7 +192,6 @@ class LMCFlashInferSparseBackend(AttentionInterface):
             128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
         )
 
-        # FIXME
         self.num_qo_heads = self.vllm_attn_impl.num_heads
         self.num_kv_heads = self.vllm_attn_impl.num_kv_heads
         self.head_dim = self.vllm_attn_impl.head_size
@@ -199,8 +200,8 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         self.window_left = self.vllm_attn_impl.window_left
         self.logits_soft_cap = self.vllm_attn_impl.logits_soft_cap
 
-        self.k_scale = 0#layer._k_scale_float
-        self.v_scale = 0#layer._v_scale_floa,
+        self.k_scale = vllm_attn._k_scale_float
+        self.v_scale = vllm_attn._v_scale_float
 
     def forward_contiguous(
         self,
@@ -211,34 +212,32 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         attn_metadata: LMCFlashInferSparseMetadata,
         **kwargs,
     ) -> torch.Tensor:
-
         is_causal = attn_metadata.is_causal
         if is_causal:
             output = flashinfer.prefill.single_prefill_with_kv_cache(
                 q=query,
-                k=key, 
+                k=key,
                 v=value,
                 scale_q=None,
                 scale_k=self.k_scale,
                 scale_v=self.v_scale,
                 o_dtype=query.dtype,
-                custom_mask=None, 
-                packed_custom_mask=None, 
-                causal=True, 
+                custom_mask=None,
+                packed_custom_mask=None,
+                causal=True,
                 kv_layout="NHD",
-                pos_encoding_mode="None",
+                pos_encoding_mode="NONE",
                 use_fp16_qk_reduction=False,
                 sm_scale=self.sm_scale,
                 window_left=self.window_left,
                 logits_soft_cap=self.logits_soft_cap,
-                rope_scale=None, 
-                rope_theta=None, 
-                backend="auto", 
-                return_lse=False
+                rope_scale=None,
+                rope_theta=None,
+                backend="auto",
+                return_lse=False,
             )
         else:
-            output = wrapper.run(query, key, value, output)
-
+            output = attn_metadata.wrapper.run(query, key, value, output)
         return output
 
     def init_attn_metadata(
@@ -259,9 +258,10 @@ class LMCFlashInferSparseBackend(AttentionInterface):
 
         num_block_col = seq_len // sparse_blk_col_size
         last_col_len = seq_len % sparse_blk_col_size
-        block_col_sizes = torch.tensor([sparse_blk_col_size] * num_block_col, device=device)
-        block_col_sizes[-1] = last_col_len + sparse_blk_col_size
-
+        block_col_sizes = torch.tensor(
+            [sparse_blk_col_size] * num_block_col, device=self.device
+        )
+        block_col_sizes[-1] += last_col_len
         return LMCFlashInferSparseMetadata(
             wrapper,
             seq_len,

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Third Party
 from vllm.attention import Attention
-from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
+import flashinfer
 from vllm.vllm_flash_attn import flash_attn_varlen_func, get_scheduler_metadata
 import torch
 
 # First Party
 from lmcache.v1.compute.attention.abstract import AttentionInterface
-from lmcache.v1.compute.attention.metadata import LMCFlashAttnMetadata
+from lmcache.v1.compute.attention.metadata import LMCFlashInferSparseMetadata
 
 
-class LMCFlashAttnBackend(AttentionInterface):
+class LMCFlashInferSparseBackend(AttentionInterface):
     """
     FlashAttention backend for LMCache.
     This backend uses the FlashAttention implementation
@@ -24,11 +24,10 @@ class LMCFlashAttnBackend(AttentionInterface):
         self.vllm_attn = vllm_attn
         self.vllm_attn_impl: FlashAttentionImpl = vllm_attn.impl
 
-        # TODO(Jiayi): remove this hardcode
-        self.aot_schedule = False
-
         idx = torch.cuda.current_device()
         self.device = torch.device(f"cuda:{idx}")
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
 
     def forward_contiguous(
         self,
@@ -49,7 +48,6 @@ class LMCFlashAttnBackend(AttentionInterface):
 
         descale_shape = (cu_seqlens_q.shape[0] - 1, key.shape[1])
 
-        # TODO(Jiayi): Figure out how to use aot_schedule.
         scheduler_metadata = self._schedule(
             batch_size=1,  # NOTE(Jiayi): Assuming batch size is 1,
             # since we are processing request by request.
@@ -85,37 +83,14 @@ class LMCFlashAttnBackend(AttentionInterface):
 
         return output
 
-    def _schedule(
-        self, batch_size, cu_query_lens, max_query_len, seqlens, max_seq_len, causal
-    ):
-        if self.aot_schedule:
-            return get_scheduler_metadata(
-                batch_size=batch_size,
-                max_seqlen_q=max_query_len,
-                max_seqlen_k=max_seq_len,
-                cache_seqlens=seqlens,
-                num_heads_q=self.vllm_attn_impl.num_heads_q,
-                num_heads_kv=self.vllm_attn_impl.num_heads_kv,
-                headdim=self.vllm_attn_impl.headdim,
-                page_size=self.vllm_attn_impl.block_size,
-                cu_seqlens_q=cu_query_lens,
-                causal=causal,
-                window_size=self.vllm_attn_impl.aot_sliding_window,
-            )
-        return None
-    
     def init_attn_metadata(
-        input_ids: torch.tensor,
+        self,
+        input_ids: torch.Tensor,
         **kwargs,
-    ):
-        return LMCFlashAttnMetadata(
-                query_start_loc=torch.tensor(
-                    [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-                ),
-                seq_lens=torch.tensor([input_ids.shape[0]], device=hidden_states.device),
-                cu_seqlens_k=torch.tensor(
-                    [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-                ),
-                max_query_len=input_ids.shape[0],
-                max_seq_len=input_ids.shape[0],
-            )
+    ) -> LMCFlashInferSparseMetadata:
+        """
+        Initialize non-sparse attention metadata first.
+        """
+
+        wrapper = flashinfer.VariableBlockSparseAttentionWrapper(workspace_buffer)
+        

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 import math
 
 # Third Party
@@ -20,6 +20,10 @@ import torch
 # First Party
 from lmcache.v1.compute.attention.abstract import AttentionInterface
 from lmcache.v1.compute.attention.metadata import LMCFlashInferSparseMetadata
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.compute.attention.metadata import LMCAttnMetadata
 
 
 class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
@@ -209,9 +213,10 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         key: torch.Tensor,
         value: torch.Tensor,
         output: torch.Tensor,
-        attn_metadata: LMCFlashInferSparseMetadata,
+        attn_metadata: "LMCAttnMetadata",
         **kwargs,
     ) -> torch.Tensor:
+        assert isinstance(attn_metadata, LMCFlashInferSparseMetadata)
         is_causal = attn_metadata.is_causal
         if is_causal:
             output = flashinfer.prefill.single_prefill_with_kv_cache(

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Third Party
 from vllm.attention import Attention
+from vllm.vllm_flash_attn import flash_attn_varlen_func
 import flashinfer
-from vllm.vllm_flash_attn import flash_attn_varlen_func, get_scheduler_metadata
 import torch
 
 # First Party
@@ -27,7 +27,9 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         idx = torch.cuda.current_device()
         self.device = torch.device(f"cuda:{idx}")
 
-        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+        workspace_buffer = torch.empty(
+            128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
+        )
 
     def forward_contiguous(
         self,
@@ -93,4 +95,3 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         """
 
         wrapper = flashinfer.VariableBlockSparseAttentionWrapper(workspace_buffer)
-        

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -1,14 +1,173 @@
 # SPDX-License-Identifier: Apache-2.0
 # Third Party
-from vllm.attention import Attention
-from vllm.vllm_flash_attn import flash_attn_varlen_func
+from flashinfer import VariableBlockSparseAttentionWrapper
 import flashinfer
+import math
+from typing import Optional, Tuple, Union
+
 import torch
+
+from flashinfer.page import block_sparse_indices_to_vector_sparse_offsets
+from flashinfer.utils import (
+    TensorLayout,
+    _check_pos_encoding_mode,
+    _check_shape_dtype_device,
+    device_support_pdl,
+)
 
 # First Party
 from lmcache.v1.compute.attention.abstract import AttentionInterface
 from lmcache.v1.compute.attention.metadata import LMCFlashInferSparseMetadata
 
+
+class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
+
+    def run(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        lse: Optional[torch.Tensor] = None,
+        return_lse: bool = False,
+        enable_pdl: Optional[bool] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        This is adapted from https://github.com/flashinfer-ai/flashinfer/blob/cc5ab77370dd9a489357a47e34315d9a8f3ad5fb/flashinfer/sparse.py#L1073
+
+        Compute block-sparse attention between Q/K/V tensors.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            The query tensor with shape ``(qo_len, num_qo_heads, head_dim)``.
+        k : torch.Tensor
+            The key tensor with shape ``(kv_len, num_kv_heads, head_dim)``.
+        v : torch.Tensor
+            The value tensor with shape ``(kv_len, num_kv_heads, head_dim)``.
+        out : Optional[torch.Tensor]
+            The output tensor, if not provided, will be allocated internally.
+        lse : Optional[torch.Tensor]
+            The log-sum-exp of attention logits, if not provided, will be allocated internally.
+        return_lse : bool
+            Whether to return the log-sum-exp of attention logits
+        enable_pdl : bool
+            Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
+            Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+
+        Returns
+        -------
+        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            If :attr:`return_lse` is ``False``, the attention output, shape: ``[M, num_qo_heads, head_dim]``.
+            If :attr:`return_lse` is ``True``, a tuple of two tensors:
+
+            * The attention output, shape: ``[M, num_qo_heads, head_dim]``.
+            * The logsumexp of attention output, shape: ``[M, num_qo_heads]``.
+        """
+
+        if enable_pdl is None:
+            enable_pdl = device_support_pdl(q.device)
+
+        pos_encoding_mode = self._pos_encoding_mode
+        logits_soft_cap = self._logits_soft_cap
+        sm_scale = self._sm_scale
+        rope_scale = self._rope_scale
+        rope_theta = self._rope_theta
+        _check_pos_encoding_mode(pos_encoding_mode)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
+        if sm_scale is None:
+            sm_scale = 1.0 / math.sqrt(q.size(-1))
+        if rope_scale is None:
+            rope_scale = 1.0
+        if rope_theta is None:
+            rope_theta = 1e4
+        
+        # 1 denotes page size
+        k = k.reshape(-1, 1, *k.shape[-2:])
+        v = v.reshape(-1, 1, *v.shape[-2:])
+
+
+
+        stride_block = k.stride(0)
+        stride_n = k.stride(1)
+
+        if return_lse:
+            if lse is None:
+                lse = torch.empty(
+                    (q.size(0), q.size(1)), dtype=torch.float32, device=q.device
+                )
+            else:
+                _check_shape_dtype_device(
+                    lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
+                )
+
+        if out is None:
+            out = torch.empty_like(q, dtype=self._o_dtype)
+        else:
+            _check_shape_dtype_device(out, q.shape, self._o_dtype, q.device, "out")
+
+        if self._backend == "fa3":
+            if (
+                self._vector_sparse_indices_buffer.numel()
+                <= self._paged_kv_indices_buf.numel()
+            ):
+                raise ValueError(
+                    "_vector_sparse_indices_buffer is not large enough. Please increase the buffer size."
+                )
+
+            sparse_indices = block_sparse_indices_to_vector_sparse_offsets(
+                self._paged_kv_indices_buf,
+                self._paged_kv_indptr_buf,
+                self._vector_sparse_indices_buffer,  # output
+                self._vector_sparse_indptr_buffer,
+                self._kv_lens_buffer,
+                stride_block // stride_n,
+                1,  # stride_n // stride_n
+                1,  # block_size
+            )
+            sparse_indptr = self._vector_sparse_indptr_buffer
+        else:
+            sparse_indices = self._paged_kv_indices_buf
+            sparse_indptr = self._paged_kv_indptr_buf
+
+
+        self._cached_module.paged_run(
+            self._float_workspace_buffer,
+            self._int_workspace_buffer,
+            self._plan_info,
+            q,
+            k,
+            v,
+            self._qo_indptr,
+            sparse_indptr,
+            sparse_indices,
+            self._paged_kv_last_page_len,
+            out,
+            lse,
+            self._mask_mode,
+            TensorLayout[self._kv_layout].value,
+            -1,  # window_left
+            enable_pdl,
+            # ADDITIONAL_FUNC_PARAMS
+            # Not supported yet
+            None,  # packed_mask_buf
+            None,  # mask_indptr_buf
+            None,  # alibi_slopes_buf
+            None,
+            None,
+            None,
+            logits_soft_cap,
+            sm_scale,
+            None,  # scale_q
+            None,  # scale_k
+            None,  # scale_v
+            rope_scale,
+            rope_theta,
+            0,  # token_pos_in_items_len
+        )
+
+        return (out, lse) if return_lse else out
 
 class LMCFlashInferSparseBackend(AttentionInterface):
     """
@@ -22,14 +181,26 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         vllm_attn: Attention,
     ):
         self.vllm_attn = vllm_attn
-        self.vllm_attn_impl: FlashAttentionImpl = vllm_attn.impl
+        self.vllm_attn_impl: FlashInferImpl = vllm_attn.impl
 
         idx = torch.cuda.current_device()
         self.device = torch.device(f"cuda:{idx}")
 
-        workspace_buffer = torch.empty(
+        self.workspace_buffer = torch.empty(
             128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
         )
+
+        # FIXME
+        self.num_qo_heads = self.vllm_attn_impl.num_heads
+        self.num_kv_heads = self.vllm_attn_impl.num_kv_heads
+        self.head_dim = self.vllm_attn_impl.head_size
+
+        self.sm_scale = self.vllm_attn_impl.scale
+        self.window_left = self.vllm_attn_impl.window_left
+        self.logits_soft_cap = self.vllm_attn_impl.logits_soft_cap
+
+        self.k_scale = 0#layer._k_scale_float
+        self.v_scale = 0#layer._v_scale_floa,
 
     def forward_contiguous(
         self,
@@ -37,51 +208,36 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         key: torch.Tensor,
         value: torch.Tensor,
         output: torch.Tensor,
-        attn_metadata: LMCFlashAttnMetadata,
+        attn_metadata: LMCFlashInferSparseMetadata,
         **kwargs,
     ) -> torch.Tensor:
-        # num_actual_tokens = query.shape[0]
 
-        cu_seqlens_q = attn_metadata.query_start_loc
-        seqused_k = attn_metadata.seq_lens
-        cu_seqlens_k = attn_metadata.cu_seqlens_k
-        max_seqlen_q = attn_metadata.max_query_len
-        max_seqlen_k = attn_metadata.max_seq_len
-
-        descale_shape = (cu_seqlens_q.shape[0] - 1, key.shape[1])
-
-        scheduler_metadata = self._schedule(
-            batch_size=1,  # NOTE(Jiayi): Assuming batch size is 1,
-            # since we are processing request by request.
-            cu_query_lens=cu_seqlens_q,
-            max_query_len=max_seqlen_q,
-            seqlens=seqused_k,
-            max_seq_len=max_seqlen_k,
-            causal=True,  # Assuming causal attention
-        )
-
-        flash_attn_varlen_func(
-            q=query,  # contiguous
-            k=key,  # contiguous
-            v=value,  # contiguous
-            out=output,
-            cu_seqlens_q=cu_seqlens_q,
-            max_seqlen_q=max_seqlen_q,
-            cu_seqlens_k=cu_seqlens_k,
-            # seqused_k=seqused_k,
-            max_seqlen_k=max_seqlen_k,
-            softmax_scale=self.vllm_attn_impl.scale,
-            causal=True,
-            alibi_slopes=self.vllm_attn_impl.alibi_slopes,
-            window_size=self.vllm_attn_impl.sliding_window,
-            block_table=None,
-            softcap=self.vllm_attn_impl.logits_soft_cap,
-            scheduler_metadata=scheduler_metadata,
-            fa_version=self.vllm_attn_impl.vllm_flash_attn_version,
-            q_descale=self.vllm_attn._q_scale.expand(descale_shape),
-            k_descale=self.vllm_attn._k_scale.expand(descale_shape),
-            v_descale=self.vllm_attn._v_scale.expand(descale_shape),
-        )
+        is_causal = attn_metadata.is_causal
+        if is_causal:
+            output = flashinfer.prefill.single_prefill_with_kv_cache(
+                q=query,
+                k=key, 
+                v=value,
+                scale_q=None,
+                scale_k=self.k_scale,
+                scale_v=self.v_scale,
+                o_dtype=query.dtype,
+                custom_mask=None, 
+                packed_custom_mask=None, 
+                causal=True, 
+                kv_layout="NHD",
+                pos_encoding_mode="None",
+                use_fp16_qk_reduction=False,
+                sm_scale=self.sm_scale,
+                window_left=self.window_left,
+                logits_soft_cap=self.logits_soft_cap,
+                rope_scale=None, 
+                rope_theta=None, 
+                backend="auto", 
+                return_lse=False
+            )
+        else:
+            output = wrapper.run(query, key, value, output)
 
         return output
 
@@ -94,4 +250,26 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         Initialize non-sparse attention metadata first.
         """
 
-        wrapper = flashinfer.VariableBlockSparseAttentionWrapper(workspace_buffer)
+        wrapper = HackBSAWrapper(self.workspace_buffer)
+        seq_len = len(input_ids)
+
+        # TODO(Jiayi): remove this hardcode
+        sparse_blk_row_size = 32
+        sparse_blk_col_size = 32
+
+        num_block_col = seq_len // sparse_blk_col_size
+        last_col_len = seq_len % sparse_blk_col_size
+        block_col_sizes = torch.tensor([sparse_blk_col_size] * num_block_col, device=device)
+        block_col_sizes[-1] = last_col_len + sparse_blk_col_size
+
+        return LMCFlashInferSparseMetadata(
+            wrapper,
+            seq_len,
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            block_col_sizes,
+            sparse_blk_row_size,
+            sparse_blk_col_size,
+            is_causal=True,
+        )

--- a/lmcache/v1/compute/attention/metadata.py
+++ b/lmcache/v1/compute/attention/metadata.py
@@ -2,11 +2,16 @@
 # Standard
 from abc import abstractmethod
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+import abc
 
 # Third Party
 import torch
 
-from lmcache.v1.compute.attention.flash_infer_sparse import HackBSAWrapper
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.compute.attention.flash_infer_sparse import HackBSAWrapper
+
 
 @dataclass
 class LMCAttnMetadata(metaclass=abc.ABCMeta):
@@ -33,32 +38,48 @@ class LMCFlashAttnMetadata(LMCAttnMetadata):
 
 @dataclass
 class LMCFlashInferSparseMetadata(LMCAttnMetadata):
-    wrapper: Optional[HackBSAWrapper]
+    wrapper: "HackBSAWrapper"
     seq_len: int
     num_qo_heads: int
     num_kv_heads: int
     head_dim: int
     block_col_sizes: torch.Tensor
-    sparse_blk_row_size: int = 32 # TODO(Jiayi): make this tunable
-    sparse_blk_col_size: int = 32 # TODO(Jiayi): make this tunable
+    sparse_blk_row_size: int = 32  # TODO(Jiayi): make this tunable
+    sparse_blk_col_size: int = 32  # TODO(Jiayi): make this tunable
     is_causal: bool = True
+    q_data_dtype: torch.dtype = torch.bfloat16  # TODO(Jiayi): remove hardcode
 
     def update_from_top_indices(self, top_indices: torch.Tensor):
+        # self.is_causal = False
         device = top_indices.device
         top_k_num = len(top_indices)
         num_block_row = top_k_num // self.sparse_blk_row_size
-        block_row_sizes = torch.tensor([sparse_blk_row_size] * num_block_row, device=device)
-        
-        block_mask_map = torch.zeros(top_k_num, seq_len, dtype=torch.bool, device=device)
-        cols = torch.arange(block_mask_map.size(1)).expand(block_mask_map.size(0), -1)
-        mask = cols < top_indices.unsqueeze(1)
-        block_mask_map[mask] = 1
+        block_row_sizes = torch.tensor(
+            [self.sparse_blk_row_size] * num_block_row, device=device
+        )
+        block_row_sizes[-1] += top_k_num % self.sparse_blk_row_size
 
+        block_mask_map = torch.zeros(
+            num_block_row, len(self.block_col_sizes), dtype=torch.bool, device=device
+        )
+        cols = torch.arange(block_mask_map.size(1), device=device).expand(
+            block_mask_map.size(0), -1
+        )
+
+        # NOTE(Jiayi): select every `sparse_blk_row_size`-th index from top_indices
+        # to approximate the attention mask at block level.
+        top_indices_slice = top_indices[
+            self.sparse_blk_row_size - 1 :: self.sparse_blk_row_size
+        ]
+        top_indices_slice //= self.sparse_blk_col_size
+        mask = cols < top_indices_slice.unsqueeze(1)
+        block_mask_map[mask] = 1
         self.wrapper.plan(
-            block_mask_map,
-            block_row_sizes,
-            self.block_col_sizes,
+            block_mask_map.expand(self.num_kv_heads, -1, -1),
+            block_row_sizes.expand(self.num_kv_heads, -1),
+            self.block_col_sizes.expand(self.num_kv_heads, -1),
             self.num_qo_heads,
             self.num_kv_heads,
             self.head_dim,
+            q_data_type=self.q_data_dtype,
         )

--- a/lmcache/v1/compute/attention/metadata.py
+++ b/lmcache/v1/compute/attention/metadata.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from abc import abstractmethod
 from dataclasses import dataclass
-from abc import ABC, abstractmethod
 
 # Third Party
 import torch
@@ -9,11 +9,9 @@ import torch
 
 @dataclass
 class LMCAttnMetadata(metaclass=abc.ABCMeta):
-    
     @abstractmethod
     def update_from_topk(self, top_k: int):
-        raise NotImplementedError(
-            "This method should be implemented in subclasses.")
+        raise NotImplementedError("This method should be implemented in subclasses.")
 
 
 @dataclass
@@ -28,12 +26,10 @@ class LMCFlashAttnMetadata(LMCAttnMetadata):
         self.max_query_len = top_k_num
         device = self.query_start_loc.device
         dtype = self.query_start_loc.dtype
-        self.query_start_loc = torch.tensor(
-            [0, top_k_num], dtype=dtype, device=device
-        )
+        self.query_start_loc = torch.tensor([0, top_k_num], dtype=dtype, device=device)
+
 
 @dataclass
 class LMCFlashInferSparseMetadata(LMCAttnMetadata):
-
     def update_from_topk(self, top_k: int):
         pass

--- a/lmcache/v1/compute/attention/metadata.py
+++ b/lmcache/v1/compute/attention/metadata.py
@@ -1,14 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
+from abc import ABC, abstractmethod
 
 # Third Party
 import torch
 
 
 @dataclass
-class LMCAttnMetadata:
-    pass
+class LMCAttnMetadata(metaclass=abc.ABCMeta):
+    
+    @abstractmethod
+    def update_from_topk(self, top_k: int):
+        raise NotImplementedError(
+            "This method should be implemented in subclasses.")
 
 
 @dataclass
@@ -18,3 +23,17 @@ class LMCFlashAttnMetadata(LMCAttnMetadata):
     cu_seqlens_k: torch.Tensor
     max_query_len: torch.Tensor
     max_seq_len: torch.Tensor
+
+    def update_from_topk(self, top_k_num: int):
+        self.max_query_len = top_k_num
+        device = self.query_start_loc.device
+        dtype = self.query_start_loc.dtype
+        self.query_start_loc = torch.tensor(
+            [0, top_k_num], dtype=dtype, device=device
+        )
+
+@dataclass
+class LMCFlashInferSparseMetadata(LMCAttnMetadata):
+
+    def update_from_topk(self, top_k: int):
+        pass

--- a/lmcache/v1/compute/attention/metadata.py
+++ b/lmcache/v1/compute/attention/metadata.py
@@ -6,11 +6,12 @@ from dataclasses import dataclass
 # Third Party
 import torch
 
+from lmcache.v1.compute.attention.flash_infer_sparse import HackBSAWrapper
 
 @dataclass
 class LMCAttnMetadata(metaclass=abc.ABCMeta):
     @abstractmethod
-    def update_from_topk(self, top_k: int):
+    def update_from_top_indices(self, top_indices: torch.Tensor):
         raise NotImplementedError("This method should be implemented in subclasses.")
 
 
@@ -22,7 +23,8 @@ class LMCFlashAttnMetadata(LMCAttnMetadata):
     max_query_len: torch.Tensor
     max_seq_len: torch.Tensor
 
-    def update_from_topk(self, top_k_num: int):
+    def update_from_top_indices(self, top_indices: torch.Tensor):
+        top_k_num = len(top_indices)
         self.max_query_len = top_k_num
         device = self.query_start_loc.device
         dtype = self.query_start_loc.dtype
@@ -31,5 +33,32 @@ class LMCFlashAttnMetadata(LMCAttnMetadata):
 
 @dataclass
 class LMCFlashInferSparseMetadata(LMCAttnMetadata):
-    def update_from_topk(self, top_k: int):
-        pass
+    wrapper: Optional[HackBSAWrapper]
+    seq_len: int
+    num_qo_heads: int
+    num_kv_heads: int
+    head_dim: int
+    block_col_sizes: torch.Tensor
+    sparse_blk_row_size: int = 32 # TODO(Jiayi): make this tunable
+    sparse_blk_col_size: int = 32 # TODO(Jiayi): make this tunable
+    is_causal: bool = True
+
+    def update_from_top_indices(self, top_indices: torch.Tensor):
+        device = top_indices.device
+        top_k_num = len(top_indices)
+        num_block_row = top_k_num // self.sparse_blk_row_size
+        block_row_sizes = torch.tensor([sparse_blk_row_size] * num_block_row, device=device)
+        
+        block_mask_map = torch.zeros(top_k_num, seq_len, dtype=torch.bool, device=device)
+        cols = torch.arange(block_mask_map.size(1)).expand(block_mask_map.size(0), -1)
+        mask = cols < top_indices.unsqueeze(1)
+        block_mask_map[mask] = 1
+
+        self.wrapper.plan(
+            block_mask_map,
+            block_row_sizes,
+            self.block_col_sizes,
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.head_dim,
+        )

--- a/lmcache/v1/compute/attention/utils.py
+++ b/lmcache/v1/compute/attention/utils.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Local
+from .flash_attn import LMCFlashAttnBackend
+from .flash_infer_sparse import LMCFlashInferSparseBackend
+
+
+def infer_attn_backend_from_vllm(vllm_attn, enable_sparse=False):
+    attn_name = type(vllm_attn.impl).__name__
+    if attn_name == "FlashInferImpl" and enable_sparse:
+        return LMCFlashInferSparseBackend(vllm_attn)
+    elif attn_name == "FlashAttentionImpl" and not enable_sparse:
+        return LMCFlashAttnBackend(vllm_attn)
+    else:
+        raise ValueError(f"Attention backend {attn_name} is not supported in LMCache.")

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -7,6 +7,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.compute.attention.metadata import LMCAttnMetadata
 from lmcache.v1.compute.blend.metadata import LMCBlendCommonMetadata, LMCBlendMetadata
 from lmcache.v1.compute.models.utils import infer_model_from_vllm
 
@@ -55,7 +56,7 @@ class LMCBlender:
         residual: torch.Tensor,
         layer_id: int,
         attn_output: Optional[torch.Tensor],
-        attn_metadata,
+        attn_metadata: LMCAttnMetadata,
     ):
         logger.debug(f"Blender is processing KV for layer {layer_id}")
         old_k, old_v = self.gpu_connector.get_kv(layer_id)
@@ -93,14 +94,12 @@ class LMCBlender:
             residual = residual[top_indices]
 
             logger.debug(f"Number of indices picked: {len(top_indices)}")
+
             self.metadata.imp_indices = top_indices
             self.metadata.positions = self.metadata.positions[top_indices]
             attn_output = attn_output[:topk_num]
 
-            attn_metadata.max_query_len = topk_num
-            attn_metadata.query_start_loc = torch.tensor(
-                [0, topk_num], dtype=torch.int32, device=q.device
-            )
+            attn_metadata.update_from_topk(topk_num)
 
         if self.metadata.imp_indices is not None:
             old_k[self.metadata.imp_indices] = k

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -10,6 +10,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.compute.attention.metadata import LMCAttnMetadata
 from lmcache.v1.compute.blend.metadata import LMCBlendCommonMetadata, LMCBlendMetadata
 from lmcache.v1.compute.models.utils import infer_model_from_vllm
+from lmcache.v1.config import LMCacheEngineConfig
 
 logger = init_logger(__name__)
 
@@ -25,11 +26,16 @@ class LMCBlender:
         cache_engine,
         gpu_connector,
         vllm_model,
+        config: LMCacheEngineConfig,
     ):
         self.cache_engine = cache_engine
         self.gpu_connector = gpu_connector
 
-        self.layerwise_model = infer_model_from_vllm(vllm_model, self)
+        enable_sparse = False
+        if config.extra_config is not None:
+            enable_sparse = config.extra_config.get("enable_sparse", False)
+
+        self.layerwise_model = infer_model_from_vllm(vllm_model, self, enable_sparse)
 
         # TODO: remove this hardcode
         self.num_layers = len(vllm_model.model.layers)
@@ -82,6 +88,8 @@ class LMCBlender:
                 (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
             )
             total_len = diff_k.shape[0]
+
+            assert self.common_metadata.recomp_ratios is not None
 
             # TODO(Jiayi): remove `[0]` hardcode
             topk_num = int(total_len * self.common_metadata.recomp_ratios[0])

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -99,7 +99,7 @@ class LMCBlender:
             self.metadata.positions = self.metadata.positions[top_indices]
             attn_output = attn_output[:topk_num]
 
-            attn_metadata.update_from_topk(topk_num)
+            attn_metadata.update_from_top_indices(top_indices)
 
         if self.metadata.imp_indices is not None:
             old_k[self.metadata.imp_indices] = k

--- a/lmcache/v1/compute/blend/utils.py
+++ b/lmcache/v1/compute/blend/utils.py
@@ -13,6 +13,7 @@ from lmcache.v1.compute.models.utils import VLLMModelTracker
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.cache_engine import LMCacheEngine
+    from lmcache.v1.config import LMCacheEngineConfig
     from lmcache.v1.gpu_connector import GPUConnectorInterface
 
 logger = init_logger(__name__)
@@ -27,6 +28,7 @@ class LMCBlenderBuilder:
         instance_id: str,
         cache_engine: "LMCacheEngine",
         gpu_connector: "GPUConnectorInterface",
+        config: "LMCacheEngineConfig",
     ):
         """
         Get or create a blender for the given instance_id.
@@ -39,6 +41,7 @@ class LMCBlenderBuilder:
                 cache_engine=cache_engine,
                 gpu_connector=gpu_connector,
                 vllm_model=vllm_model,
+                config=config,
             )
             cls._blenders[instance_id] = blender
         else:

--- a/lmcache/v1/compute/models/llama.py
+++ b/lmcache/v1/compute/models/llama.py
@@ -4,7 +4,7 @@ from torch import nn
 import torch
 
 # First Party
-from lmcache.v1.compute.attention.flash_attn import LMCFlashAttnBackend
+from lmcache.v1.compute.attention.utils import infer_attn_backend_from_vllm
 from lmcache.v1.compute.positional_encoding import get_fused_rope
 
 # TODO(Jiayi): A few things need to be tested/supported:
@@ -16,6 +16,7 @@ class LMCLlamaModel(nn.Module):
         self,
         vllm_model,
         blender,
+        enable_sparse: bool = False,
     ):
         super().__init__()
         self.vllm_model = vllm_model
@@ -27,10 +28,10 @@ class LMCLlamaModel(nn.Module):
         for i in range(self.num_layers):
             vllm_attn = vllm_model.model.layers[i].self_attn.attn
             self.vllm_attn_layers.append(vllm_attn)
-            
-            #FIXME
-            import pdb; pdb.set_trace()
-            self.lmc_attn_layers.append(LMCFlashAttnBackend(vllm_attn))
+
+            self.lmc_attn_layers.append(
+                infer_attn_backend_from_vllm(vllm_attn, enable_sparse)
+            )
 
         # NOTE(Jiayi): better not to pass the blender in init
         # if we want to make this LMCModel more general.
@@ -59,7 +60,8 @@ class LMCLlamaModel(nn.Module):
         self,
         input_ids: torch.Tensor,
     ):
-        hidden_states = self.vllm_model.get_input_embeddings(input_ids.cuda())
+        input_ids = input_ids.cuda()
+        hidden_states = self.vllm_model.get_input_embeddings(input_ids)
         residual = None
 
         attn_output = None

--- a/lmcache/v1/compute/models/llama.py
+++ b/lmcache/v1/compute/models/llama.py
@@ -60,22 +60,13 @@ class LMCLlamaModel(nn.Module):
         hidden_states = self.vllm_model.get_input_embeddings(input_ids.cuda())
         residual = None
 
-        # TODO (Jiayi): reduce the number of calls
         attn_output = None
 
         # TODO(Jiayi): Need to build `attn_metadata` more elegantly.
-        attn_metadata = LMCFlashAttnMetadata(
-            query_start_loc=torch.tensor(
-                [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-            ),
-            seq_lens=torch.tensor([input_ids.shape[0]], device=hidden_states.device),
-            cu_seqlens_k=torch.tensor(
-                [0, input_ids.shape[0]], dtype=torch.int32, device=hidden_states.device
-            ),
-            max_query_len=input_ids.shape[0],
-            max_seq_len=input_ids.shape[0],
+        attn_metadata = self.lmc_attn_layers[0].init_attn_metadata(
+            input_ids=input_ids,
         )
-
+        
         for idx, layer in enumerate(
             self.vllm_model.model.layers[
                 self.vllm_model.model.start_layer : self.vllm_model.model.end_layer

--- a/lmcache/v1/compute/models/llama.py
+++ b/lmcache/v1/compute/models/llama.py
@@ -5,7 +5,6 @@ import torch
 
 # First Party
 from lmcache.v1.compute.attention.flash_attn import LMCFlashAttnBackend
-from lmcache.v1.compute.attention.metadata import LMCFlashAttnMetadata
 from lmcache.v1.compute.positional_encoding import get_fused_rope
 
 # FIXME(Jiayi): A few things need to be tested/supported:
@@ -66,7 +65,7 @@ class LMCLlamaModel(nn.Module):
         attn_metadata = self.lmc_attn_layers[0].init_attn_metadata(
             input_ids=input_ids,
         )
-        
+
         for idx, layer in enumerate(
             self.vllm_model.model.layers[
                 self.vllm_model.model.start_layer : self.vllm_model.model.end_layer

--- a/lmcache/v1/compute/models/llama.py
+++ b/lmcache/v1/compute/models/llama.py
@@ -7,8 +7,8 @@ import torch
 from lmcache.v1.compute.attention.flash_attn import LMCFlashAttnBackend
 from lmcache.v1.compute.positional_encoding import get_fused_rope
 
-# FIXME(Jiayi): A few things need to be tested/supported:
-# PP, Multimodal
+# TODO(Jiayi): A few things need to be tested/supported:
+# TP, PP, Multimodal
 
 
 class LMCLlamaModel(nn.Module):
@@ -27,6 +27,9 @@ class LMCLlamaModel(nn.Module):
         for i in range(self.num_layers):
             vllm_attn = vllm_model.model.layers[i].self_attn.attn
             self.vllm_attn_layers.append(vllm_attn)
+            
+            #FIXME
+            import pdb; pdb.set_trace()
             self.lmc_attn_layers.append(LMCFlashAttnBackend(vllm_attn))
 
         # NOTE(Jiayi): better not to pass the blender in init

--- a/lmcache/v1/compute/models/utils.py
+++ b/lmcache/v1/compute/models/utils.py
@@ -11,16 +11,13 @@ from lmcache.logging import init_logger
 logger = init_logger(__name__)
 
 
-# TODO (Jiayi): Need to infer the model type from vllm model
-
-
-def infer_model_from_vllm(vllm_model, blender):
+def infer_model_from_vllm(vllm_model, blender, enable_sparse: bool = False):
     model_name = type(vllm_model).__name__
     if model_name == "LlamaForCausalLM":
         # First Party
         from lmcache.v1.compute.models.llama import LMCLlamaModel
 
-        return LMCLlamaModel(vllm_model, blender)
+        return LMCLlamaModel(vllm_model, blender, enable_sparse)
     else:
         # TODO(Jiayi): Add support for more models
         raise NotImplementedError(

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -440,8 +440,7 @@ def test_single_layer_kernel(num_tokens, token_major):
     for layer_id in range(num_layers):
         lmc_ops.single_layer_kv_transfer(
             tmp_gpu_buffer,
-            kv_cache[layer_id][0],
-            kv_cache[layer_id][1],
+            kv_cache[layer_id],
             slot_mapping,
             True,
             token_major,
@@ -449,8 +448,7 @@ def test_single_layer_kernel(num_tokens, token_major):
         )
         lmc_ops.single_layer_kv_transfer(
             tmp_gpu_buffer,
-            kv_cache_new[layer_id][0],
-            kv_cache_new[layer_id][1],
+            kv_cache_new[layer_id],
             slot_mapping,
             False,
             token_major,

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -445,6 +445,7 @@ def test_single_layer_kernel(num_tokens, token_major):
             slot_mapping,
             True,
             token_major,
+            True,
         )
         lmc_ops.single_layer_kv_transfer(
             tmp_gpu_buffer,
@@ -453,6 +454,7 @@ def test_single_layer_kernel(num_tokens, token_major):
             slot_mapping,
             False,
             token_major,
+            True,
         )
 
     check_paged_kv_cache_equal(


### PR DESCRIPTION
Add sparse attention for kv blending.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
