### PR TITLE
[Misc] Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+import importlib.metadata
 import os
 import platform
 import subprocess
@@ -10,7 +11,6 @@ import threading
 
 # Third Party
 import cpuinfo
-import pkg_resources
 import psutil
 import requests
 import torch
@@ -233,9 +233,9 @@ class UsageContext:
                     if "docker" in line:
                         return "DOCKER"
         try:
-            _ = pkg_resources.get_distribution("LMCache")
+            _ = importlib.metadata.distribution("LMCache")
             return "PIP"
-        except pkg_resources.DistributionNotFound:
+        except importlib.metadata.PackageNotFoundError:
             pass
         try:
             result = subprocess.run(


### PR DESCRIPTION
## Summary
See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. 
This PR replaces the deprecated `pkg_resources` module with the modern `importlib.metadata` standard library module in the usage context tracking functionality.
 
## Motivation
The `pkg_resources` module from setuptools has been deprecated and is being phased out in favor of the standard library `importlib.metadata` module.

When I run pytest, it shows warning
```
(LMCache) root@gpu-3090:~/oss/LMCache# python -m pytest tests/v1/test_gds.py

===================================== warnings summary =====================================
lmcache/usage_context.py:13
  /root/oss/LMCache/lmcache/usage_context.py:13: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
````