### PR TITLE
[Doc] Refine logging when memory location fails

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -256,7 +256,8 @@ class LMCacheEngine:
             memory_obj = self.storage_manager.allocate(kv_shape, kv_dtype)
             if memory_obj is None:
                 logger.warning(
-                    "Failed to allocate memory for the KV cache.\n"
+                    "Failed to allocate memory for the KV cache due to "
+                    "allocation failure\n"
                     "The KV cache will not be stored."
                 )
                 break
@@ -368,7 +369,8 @@ class LMCacheEngine:
 
             if memory_objs_multi_layer is None:
                 logger.warning(
-                    "Failed to allocate memory for the KV cache.\n"
+                    "Failed to allocate memory for the KV cache since "
+                    "memory_objs_multi_layer is None.\n"
                     "The KV cache will not be stored."
                 )
                 break


### PR DESCRIPTION
[Doc] Refine logging when memory location fails

I hit following error, but there are two places that print the same logs, this PR could make these two lines of logs different, easier for troubleshooting:

```
(APIServer pid=3022) (EngineCore_0 pid=3173) [2025-08-25 08:43:36,399] LMCache WARNING: Failed to allocate memory for the KV cache since memory_obj is None.
(APIServer pid=3022) (EngineCore_0 pid=3173) The KV cache will not be stored. (cache_engine.py:221:lmcache.v1.cache_engine)
```

FIX #xxxx (*link existing issues this PR will resolve*)

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
