### PR TITLE
[bugfix] Fix crash caused by raised runtime error due to inconsistent number of hit tokens across tp ranks

### DIFF
--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -126,7 +126,7 @@ class LMCacheLookupClient(LookupClientInterface):
             result = int.from_bytes(resp, "big")
             results.append(result)
 
-        if not all(x == results[0] for x in results):
+        if len(set(results)) > 1:
             logger.error(
                 f"Lookup results (number of hit tokens) differ "
                 f"across tensor parallel ranks: {results}."

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -127,7 +127,7 @@ class LMCacheLookupClient(LookupClientInterface):
             results.append(result)
 
         if len(set(results)) > 1:
-            logger.error(
+            logger.warning(
                 f"Lookup results (number of hit tokens) differ "
                 f"across tensor parallel ranks: {results}."
             )

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -127,11 +127,14 @@ class LMCacheLookupClient(LookupClientInterface):
             results.append(result)
 
         if not all(x == results[0] for x in results):
-            raise RuntimeError(
+            logger.error(
                 f"Lookup results (number of hit tokens) differ "
                 f"across tensor parallel ranks: {results}."
             )
-        return results[0]
+        # NOTE: it is possible that the number of hit tokens is different
+        # across TP ranks, so we can use the minimum value as the
+        # number of hit tokens.
+        return min(results)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports producer kvcache reuse"""


### PR DESCRIPTION
[bugfix] Fix crash caused by raised runtime error due to inconsistent number of hit tokens across tp ranks

It is possible for different TP ranks to have different numbers of hit tokens, for example, when using the Mooncake Store backend. Since the Mooncake Store backend is unaware of the TP information associated with keys, during eviction it may remove the KV cache generated by only a subset of TP ranks. This can lead to inconsistencies in the number of hit tokens observed across ranks.
In previous versions, such inconsistencies would raise a runtime error, which was not properly caught at higher levels, ultimately causing the process to crash.

log
<img width="1798" height="465" alt="image" src="https://github.com/user-attachments/assets/5d47a835-23c0-4db8-bbec-4ac0e5c1caf3" />



To improve robustness, I have removed the raise RuntimeError and replaced it with an error log message. This change prevents crashes while still alerting users to the inconsistency for debugging purposes.

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
