### PR TITLE
[CI/Build] Reduce pinned memory size in unit tests

### DIFF
--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -14,7 +14,6 @@ from lmcache.v1.memory_management import (
     AdHocMemoryAllocator,
     MemoryFormat,
     MemoryObj,
-    MixedMemoryAllocator,
 )
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
@@ -63,30 +62,6 @@ def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> Memor
     allocator = AdHocMemoryAllocator(device="cpu")
     memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
     return memory_obj
-
-
-@pytest.fixture(scope="session")
-def memory_allocator():
-    """One MixedMemoryAllocator (1GB) for the whole test session;
-    .close() is a no-op per-test."""
-    _real = MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
-
-    class _NoCloseWrapper:
-        def __init__(self, real):
-            self._real = real
-
-        def __getattr__(self, name):
-            return getattr(self._real, name)
-
-        def close(self):
-            # No-op so per-test close() calls don't shut down the shared allocator
-            pass
-
-    try:
-        yield _NoCloseWrapper(_real)
-    finally:
-        # Actually close once when the session ends
-        _real.close()
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -65,10 +65,28 @@ def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> Memor
     return memory_obj
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def memory_allocator():
-    """Create a memory allocator for testing."""
-    return MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
+    """One MixedMemoryAllocator (1GB) for the whole test session;
+    .close() is a no-op per-test."""
+    _real = MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
+
+    class _NoCloseWrapper:
+        def __init__(self, real):
+            self._real = real
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def close(self):
+            # No-op so per-test close() calls don't shut down the shared allocator
+            pass
+
+    try:
+        yield _NoCloseWrapper(_real)
+    finally:
+        # Actually close once when the session ends
+        _real.close()
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -87,11 +87,36 @@ def async_loop():
     loop.close()
 
 
+# ---- ADDED: shared session-scoped allocator (close() is a no-op per-test) ----
+@pytest.fixture(scope="session")
+def shared_allocator():
+    _real = MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
+
+    class _NoCloseWrapper:
+        def __init__(self, real):
+            self._real = real
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def close(self):
+            # no-op during individual tests
+            pass
+
+    try:
+        yield _NoCloseWrapper(_real)
+    finally:
+        _real.close()
+
+
+# ----------------------------------------------------------------------------
+
+
 @pytest.fixture
-def local_cpu_backend():
+def local_cpu_backend(shared_allocator):
     """Create a LocalCPUBackend for testing."""
     config = LMCacheEngineConfig.from_legacy(chunk_size=256)
-    memory_allocator = MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
+    memory_allocator = shared_allocator  # was: MixedMemoryAllocator(1GB)
     return LocalCPUBackend(config, memory_allocator)
 
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -16,7 +16,6 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
-    MixedMemoryAllocator,
 )
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -87,36 +86,13 @@ def async_loop():
     loop.close()
 
 
-# ---- ADDED: shared session-scoped allocator (close() is a no-op per-test) ----
-@pytest.fixture(scope="session")
-def shared_allocator():
-    _real = MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
-
-    class _NoCloseWrapper:
-        def __init__(self, real):
-            self._real = real
-
-        def __getattr__(self, name):
-            return getattr(self._real, name)
-
-        def close(self):
-            # no-op during individual tests
-            pass
-
-    try:
-        yield _NoCloseWrapper(_real)
-    finally:
-        _real.close()
-
-
 # ----------------------------------------------------------------------------
 
 
 @pytest.fixture
-def local_cpu_backend(shared_allocator):
+def local_cpu_backend(memory_allocator):
     """Create a LocalCPUBackend for testing."""
     config = LMCacheEngineConfig.from_legacy(chunk_size=256)
-    memory_allocator = shared_allocator  # was: MixedMemoryAllocator(1GB)
     return LocalCPUBackend(config, memory_allocator)
 
 


### PR DESCRIPTION
Previously, in `local_cpu_test`, we pin 29GB memory and in `local_disk_test` we pin 24GB memory. This is because we create a memory allocator in each test case. This PR changes to use a single memory allocator for all the test cases in a python script. Thus it reduces to 1GB pinned memory per test script.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
