### PR TITLE
[gds] make assert for cufile_buffer_size eariler

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -385,6 +385,11 @@ def _validate_config(self):
         )
         assert self.enable_p2p is False, "Nixl only supports enable_p2p=False"
 
+    if self.weka_path is not None or self.gds_path is not None:
+        assert self.cufile_buffer_size is not None, (
+            "cufile_buffer_size must be set when using weka_path or gds_path"
+        )
+
     return self
 
 

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -19,7 +19,10 @@ from lmcache.v1.storage_backend.gds_backend import GdsBackend
 
 def create_test_config(gds_path: str):
     config = LMCacheEngineConfig.from_defaults(
-        chunk_size=256, gds_path=gds_path, lmcache_instance_id="test_instance"
+        chunk_size=256,
+        gds_path=gds_path,
+        lmcache_instance_id="test_instance",
+        cufile_buffer_size=32,
     )
     return config
 


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

FIX #1433



the assertion is too late https://github.com/LMCache/LMCache/blob/dev/lmcache/v1/cache_engine.py#L1208

make it earlier and clear