### PR TITLE
[#1373][feat]Support dynamical load external backend

### DIFF
--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -1,0 +1,39 @@
+External Storage Backends
+=======================
+
+LMCache supports integrating custom storage backends through dynamic loading. This allows extending cache storage capabilities without modifying core code.
+
+Configuration
+-------------
+Add the following to your ``lmcache.yaml``:
+
+.. code-block:: yaml
+
+    chunk_size: 64
+    local_cpu: False
+    max_local_cpu_size: 5
+    external_backends: "log_external_backend"
+    extra_config:
+      external_backend.log_external_backend.module_path: lmc_external_log_backend.lmc_external_log_backend
+      external_backend.log_external_backend.class_name: ExternalLogBackend
+
+Implementation Example
+----------------------
+A sample backend implementation (e.g., https://github.com/opendataio/lmc_external_log_backend):
+
+Key Requirements
+----------------
+1. Inherit from ``StorageBackendInterface``
+2. Implement all abstract methods
+3. Provide parameterless constructor
+4. Package as installable Python module
+
+Usage Notes
+-----------
+1. Install your backend package in LMCache environment
+2. Add ``external_backends`` configuration and its related ``module_path`` and  ``class_name`` to ``extra_config`` section
+3. Backends are initialized during LMCache startup
+4. Use ``external_backends`` list to enable specific backends
+
+.. note::
+   Backends are loaded in order - earlier backends have higher priority during cache lookups.

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -19,7 +19,7 @@ Add the following to your ``lmcache.yaml``:
 
 Implementation Example
 ----------------------
-A sample backend implementation (e.g., https://github.com/opendataio/lmc_external_log_backend):
+A sample backend implementation (e.g., https://github.com/opendataio/lmc_external_log_backend/ ):
 
 Key Requirements
 ----------------

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -25,7 +25,7 @@ Key Requirements
 ----------------
 1. Inherit from ``StorageBackendInterface``
 2. Implement all abstract methods
-3. Provide parameterless constructor
+3. Provide the constructor as this example
 4. Package as installable Python module
 
 Usage Notes

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -298,6 +298,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": lambda x: x if isinstance(x, list) else [x] if x else [],
     },
+    "external_backends": {
+        "type": Optional[list[str]],
+        "default": None,
+        "env_converter": _to_str_list,
+    },
 }
 
 

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Optional
 import asyncio
+import importlib  # Added for dynamic import
 
 # Third Party
 import torch
@@ -25,6 +26,62 @@ if TYPE_CHECKING:
     from lmcache.v1.cache_controller.worker import LMCacheWorker
 
 logger = init_logger(__name__)
+
+
+def create_dynamic_backends(
+    config: LMCacheEngineConfig,
+    metadata: LMCacheEngineMetadata,
+    loop: asyncio.AbstractEventLoop,
+    memory_allocator: MemoryAllocatorInterface,
+    dst_device: str,
+    lookup_server: Optional[LookupServerInterface],
+    storage_backends: OrderedDict[str, StorageBackendInterface],
+) -> None:
+    """
+    Dynamically create backends based on configuration.
+
+    Looks for backend configurations in config.extra_config and instantiates
+    them using the specified module and class names.
+    """
+    if not config.extra_config or "backends" not in config.extra_config:
+        return
+
+    # Get the list of allowed external backends if configured
+    allowed_backends = (
+        set(config.external_backends) if config.external_backends else None
+    )
+
+    for backend_name in allowed_backends:
+        try:
+            module_path = config.extra_config.get(
+                f"external_backend.{backend_name}.module_path"
+            )
+            class_name = config.extra_config.get(
+                f"external_backend.{backend_name}.class_name"
+            )
+
+            if not module_path or not class_name:
+                logger.warning(
+                    f"Backend {backend_name} missing module_path or class_name"
+                )
+                continue
+
+            # Dynamically import the module
+            module = importlib.import_module(module_path)
+            # Get the class from the module
+            backend_class = getattr(module, class_name)
+
+            # Create the backend instance
+            backend_instance = backend_class(
+                config, metadata, loop, memory_allocator, dst_device, lookup_server
+            )
+
+            # Add to storage backends
+            storage_backends[backend_name] = backend_instance
+            logger.info(f"Created dynamic backend: {backend_name}")
+
+        except Exception as e:
+            logger.error(f"Failed to create backend {backend_name}: {str(e)}")
 
 
 def CreateStorageBackends(
@@ -102,6 +159,17 @@ def CreateStorageBackends(
         )
         backend_name = str(remote_backend)
         storage_backends[backend_name] = remote_backend
+
+    # Create dynamic backends from configuration
+    create_dynamic_backends(
+        config,
+        metadata,
+        loop,
+        memory_allocator,
+        dst_device,
+        lookup_server,
+        storage_backends,
+    )
 
     # Only wrap if audit is enabled in config
     if config.extra_config is not None and config.extra_config.get(

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -33,10 +33,10 @@ def create_dynamic_backends(
     metadata: LMCacheEngineMetadata,
     loop: asyncio.AbstractEventLoop,
     memory_allocator: MemoryAllocatorInterface,
+    local_cpu_backend: LocalCPUBackend,
     dst_device: str,
     lookup_server: Optional[LookupServerInterface],
     storage_backends: OrderedDict[str, StorageBackendInterface],
-    local_cpu_backend: LocalCPUBackend,
 ) -> None:
     """
     Dynamically create backends based on configuration.
@@ -78,9 +78,9 @@ def create_dynamic_backends(
                 metadata,
                 loop,
                 memory_allocator,
+                local_cpu_backend,
                 dst_device,
                 lookup_server,
-                local_cpu_backend,
             )
 
             # Add to storage backends
@@ -173,10 +173,10 @@ def CreateStorageBackends(
         metadata,
         loop,
         memory_allocator,
+        local_cpu_backend,
         dst_device,
         lookup_server,
         storage_backends,
-        local_cpu_backend=local_cpu_backend,
     )
 
     # Only wrap if audit is enabled in config

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -36,6 +36,7 @@ def create_dynamic_backends(
     dst_device: str,
     lookup_server: Optional[LookupServerInterface],
     storage_backends: OrderedDict[str, StorageBackendInterface],
+    local_cpu_backend: LocalCPUBackend,
 ) -> None:
     """
     Dynamically create backends based on configuration.
@@ -73,7 +74,13 @@ def create_dynamic_backends(
 
             # Create the backend instance
             backend_instance = backend_class(
-                config, metadata, loop, memory_allocator, dst_device, lookup_server
+                config,
+                metadata,
+                loop,
+                memory_allocator,
+                dst_device,
+                lookup_server,
+                local_cpu_backend,
             )
 
             # Add to storage backends
@@ -169,6 +176,7 @@ def CreateStorageBackends(
         dst_device,
         lookup_server,
         storage_backends,
+        local_cpu_backend=local_cpu_backend,
     )
 
     # Only wrap if audit is enabled in config

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -43,7 +43,7 @@ def create_dynamic_backends(
     Looks for backend configurations in config.extra_config and instantiates
     them using the specified module and class names.
     """
-    if not config.extra_config or "backends" not in config.extra_config:
+    if not config.extra_config:
         return
 
     # Get the list of allowed external backends if configured


### PR DESCRIPTION
Fix #1373

lmcache.yaml

```yaml
chunk_size: 64
local_cpu: False
max_local_cpu_size: 5
external_backends: "log_external_backend"
extra_config:
  external_backend.log_external_backend.module_path: lmc_external_log_backend.lmc_external_log_backend
  external_backend.log_external_backend.class_name: ExternalLogBackend
```

The demonstrate external backend implementation located in https://github.com/opendataio/lmc_external_log_backend 

# Test

vLLM.log shown that lmc_external_log_backend is imported corrected.

```
(VllmWorker rank=0 pid=1748919) [2025-08-27 01:18:20,946] LMCache INFO: ExternalLogBackend Checking contains for key: CacheEngineKey(fmt='vllm', model_name='/data1/DeepSeek-V2-Lite-Chat', world_size=2, worker_id=0, chunk_hash=4048403367038317870, request_configs=None) (lmc_external_log_backend.py:36:lmc_external_log_backend.lmc_external_log_backend)
(VllmWorker rank=0 pid=1748919) [2025-08-27 01:18:21,103] LMCache INFO: ExternalLogBackend Put task for key: CacheEngineKey(fmt='vllm', model_name='/data1/DeepSeek-V2-Lite-Chat', world_size=2, worker_id=0, chunk_hash=4048403367038317870, request_configs=None), size: torch.Size([1, 27, 64, 576]) (lmc_external_log_backend.py:50:lmc_external_log_backend.lmc_external_log_backend)
(VllmWorker rank=0 pid=1748919) [2025-08-27 01:18:21,104] LMCache INFO: ExternalLogBackend Put task for key: CacheEngineKey(fmt='vllm', model_name='/data1/DeepSeek-V2-Lite-Chat', world_size=2, worker_id=0, chunk_hash=-5434902526263666758, request_configs=None), size: torch.Size([1, 27, 64, 576]) (lmc_external_log_backend.py:50:lmc_external_log_backend.lmc_external_log_backend)
(VllmWorker rank=0 pid=1748919) [2025-08-27 01:18:21,104] LMCache INFO: ExternalLogBackend Put task for key: CacheEngineKey(fmt='vllm', model_name='/data1/DeepSeek-V2-Lite-Chat', world_size=2, worker_id=0, chunk_hash=-3637723106345021972, request_configs=None), size: torch.Size([1, 27, 64, 576]) (lmc_external_log_backend.py:50:lmc_external_log_backend.lmc_external_log_backend)
```