### PR TITLE
[CI/Build] Reduce pinned memory in testing cache engine

### DIFF
--- a/lmcache/v1/storage_backend/nixl_backend_v3.py
+++ b/lmcache/v1/storage_backend/nixl_backend_v3.py
@@ -108,6 +108,7 @@ class NixlBackend(StorageBackendInterface):
         dtype: Optional[torch.dtype],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = False,
+        busy_loop: bool = False,
     ) -> MemoryObj:
         """
         Allocate a zero-copy write object for the given shape and dtype.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ import subprocess
 import time
 
 # Third Party
-from _pytest.monkeypatch import MonkeyPatch
 import pytest
 
 # First Party
@@ -388,24 +387,19 @@ def memory_allocator():
 
 
 @pytest.fixture(autouse=True)  # function-scoped by default
-def use_shared_allocator(request, memory_allocator):
+def use_shared_allocator(request, monkeypatch, memory_allocator):
     """Default: patch. Opt out with @pytest.mark.no_shared_allocator."""
     if request.node.get_closest_marker("no_shared_allocator"):
         # do NOT patch for this test
         yield
         return
 
-    mp = MonkeyPatch()
-
-    def _create_shared_allocator(cls, config, metadata, numa_mapping):
+    def _create_shared_allocator(config, metadata, numa_mapping):
         return memory_allocator
 
-    mp.setattr(
+    monkeypatch.setattr(
         LMCacheEngineBuilder,
         "_Create_memory_allocator",
-        classmethod(_create_shared_allocator),
+        _create_shared_allocator,
     )
-    try:
-        yield
-    finally:
-        mp.undo()
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,12 @@ import subprocess
 import time
 
 # Third Party
+from _pytest.monkeypatch import MonkeyPatch
 import pytest
 
 # First Party
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.memory_management import MixedMemoryAllocator
-from _pytest.monkeypatch import MonkeyPatch
 
 # This is to mock the constructor and destructor of
 # MixedMemoryAllocator and PinMemoryAllocator to
@@ -385,6 +385,7 @@ def memory_allocator():
     finally:
         # Actually close once when the session ends
         _real.close()
+
 
 @pytest.fixture(autouse=True)  # function-scoped by default
 def use_shared_allocator(request, memory_allocator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 # First Party
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.memory_management import MixedMemoryAllocator
+from _pytest.monkeypatch import MonkeyPatch
 
 # This is to mock the constructor and destructor of
 # MixedMemoryAllocator and PinMemoryAllocator to
@@ -364,9 +365,9 @@ def autorelease_v1(request):
 
 @pytest.fixture(scope="session")
 def memory_allocator():
-    """One MixedMemoryAllocator (1GB) for the whole test session;
+    """One MixedMemoryAllocator (5GB) for the whole test session;
     .close() is a no-op per-test."""
-    _real = MixedMemoryAllocator(1024 * 1024 * 1024)  # 1GB
+    _real = MixedMemoryAllocator(5 * 1024 * 1024 * 1024)  # 5GB
 
     class _NoCloseWrapper:
         def __init__(self, real):
@@ -384,3 +385,26 @@ def memory_allocator():
     finally:
         # Actually close once when the session ends
         _real.close()
+
+@pytest.fixture(autouse=True)  # function-scoped by default
+def use_shared_allocator(request, memory_allocator):
+    """Default: patch. Opt out with @pytest.mark.no_shared_allocator."""
+    if request.node.get_closest_marker("no_shared_allocator"):
+        # do NOT patch for this test
+        yield
+        return
+
+    mp = MonkeyPatch()
+
+    def _create_shared_allocator(cls, config, metadata, numa_mapping):
+        return memory_allocator
+
+    mp.setattr(
+        LMCacheEngineBuilder,
+        "_Create_memory_allocator",
+        classmethod(_create_shared_allocator),
+    )
+    try:
+        yield
+    finally:
+        mp.undo()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 log_cli = true
 log_cli_level = INFO
+markers =
+    no_shared_allocator: Disable the shared-allocator monkeypatch for this test

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -794,6 +794,7 @@ def test_paged_prefetch_retrieve(backend, prefetch_from, autorelease_v1):
         "local_cpu_disk_remote",
     ],
 )
+@pytest.mark.no_shared_allocator
 @pytest.mark.parametrize("lmserver_v1_process", ["cpu"], indirect=True)
 def test_paged_mem_leak(fmt, chunk_size, backend, lmserver_v1_process, autorelease_v1):
     url = None


### PR DESCRIPTION
Continue reducing pinned memory in the unit test. The cache engine test used to pin more than 20GB memory but right now it reuses a single 5GB memory allocator. Only creating new memory allocators when testing memory leak.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
