### PR TITLE
[Bug][PD] Avoid doing int16 conversion on hash

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -171,7 +171,7 @@ class CacheEngineKey:
             parts[1],
             int(parts[2]),
             int(parts[3]),
-            int(parts[4], 16),
+            parts[4],
             request_configs,
         )
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -116,7 +116,7 @@ class CacheEngineKey:
     def to_string(self):
         s = (
             f"{self.fmt}@{self.model_name}@{self.world_size}"
-            f"@{self.worker_id}@{self.chunk_hash}"
+            f"@{self.worker_id}@{self.chunk_hash:x}"
         )
         if self.tags is not None and len(self.tags) != 0:
             tags = [f"{k}%{v}" for k, v in self.tags.items()]
@@ -171,7 +171,7 @@ class CacheEngineKey:
             parts[1],
             int(parts[2]),
             int(parts[3]),
-            int(parts[4]),
+            int(parts[4], 16),
             request_configs,
         )
 
@@ -244,7 +244,7 @@ class LayerCacheEngineKey(CacheEngineKey):
     def to_string(self):
         s = (
             f"{self.fmt}@{self.model_name}@{self.world_size}"
-            f"@{self.worker_id}@{self.chunk_hash}@{self.layer_id}"
+            f"@{self.worker_id}@{self.chunk_hash:x}@{self.layer_id}"
         )
         if self.tags is not None and len(self.tags) != 0:
             tags = [f"{k}%{v}" for k, v in self.tags.items()]
@@ -286,7 +286,7 @@ class LayerCacheEngineKey(CacheEngineKey):
             parts[1],
             int(parts[2]),
             int(parts[3]),
-            int(parts[4]),
+            int(parts[4], 16),
             request_configs,
             int(parts[5]),
         )

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -171,7 +171,7 @@ class CacheEngineKey:
             parts[1],
             int(parts[2]),
             int(parts[3]),
-            parts[4],
+            int(parts[4]),
             request_configs,
         )
 
@@ -286,7 +286,7 @@ class LayerCacheEngineKey(CacheEngineKey):
             parts[1],
             int(parts[2]),
             int(parts[3]),
-            int(parts[4], 16),
+            int(parts[4]),
             request_configs,
             int(parts[5]),
         )

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -52,7 +52,7 @@ def create_test_config(disk_path: str, max_disk_size: float = 1.0):
     return config
 
 
-def create_test_key(key_id: str = "test_key") -> CacheEngineKey:
+def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey("vllm", "test_model", 3, 123, key_id)
 
@@ -162,7 +162,7 @@ class TestLocalDiskBackend:
 
     def test_key_to_path(self, local_disk_backend):
         """Test key to path conversion."""
-        key = create_test_key("test_hash")
+        key = create_test_key(1)
         path = local_disk_backend._key_to_path(key)
 
         expected_filename = key.to_string().replace("/", "-") + ".pt"
@@ -172,7 +172,7 @@ class TestLocalDiskBackend:
 
     def test_contains_key_not_exists(self, local_disk_backend):
         """Test contains() when key doesn't exist."""
-        key = create_test_key("nonexistent")
+        key = create_test_key(2)
         assert not local_disk_backend.contains(key)
         assert not local_disk_backend.contains(key, pin=True)
 
@@ -180,7 +180,7 @@ class TestLocalDiskBackend:
 
     def test_contains_key_exists(self, local_disk_backend):
         """Test contains() when key exists."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key first
@@ -193,7 +193,7 @@ class TestLocalDiskBackend:
 
     def test_pin_unpin(self, local_disk_backend):
         """Test pin() and unpin() operations."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
         # Insert key first
         local_disk_backend.insert_key(key, memory_obj)
@@ -205,7 +205,7 @@ class TestLocalDiskBackend:
         assert local_disk_backend.dict[key].pin_count == 0
 
         # Test pin/unpin non-existent key
-        non_existent_key = create_test_key("non_existent")
+        non_existent_key = create_test_key(4)
         assert not local_disk_backend.pin(non_existent_key)
         assert not local_disk_backend.unpin(non_existent_key)
 
@@ -213,7 +213,7 @@ class TestLocalDiskBackend:
 
     def test_insert_key(self, local_disk_backend):
         """Test insert_key()."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
         local_disk_backend.insert_key(key, memory_obj)
         assert key in local_disk_backend.dict
@@ -227,7 +227,7 @@ class TestLocalDiskBackend:
 
     def test_insert_key_reinsert(self, local_disk_backend):
         """Test insert_key() with reinsertion."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj1 = create_test_memory_obj(shape=(2, 16, 8, 128))
         memory_obj2 = create_test_memory_obj(shape=(2, 32, 8, 128))
 
@@ -246,7 +246,7 @@ class TestLocalDiskBackend:
 
     def test_remove(self, local_disk_backend):
         """Test remove()."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key first
@@ -281,7 +281,7 @@ class TestLocalDiskBackend:
             dst_device="cuda",
             lmcache_worker=lmcache_worker,
         )
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
         # Insert key first
         backend.insert_key(key, memory_obj)
@@ -303,7 +303,7 @@ class TestLocalDiskBackend:
 
     def test_submit_put_task(self, local_disk_backend):
         """Test submit_put_task() synchronous"""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Test that the key is not in put_tasks initially
@@ -334,7 +334,7 @@ class TestLocalDiskBackend:
 
     def test_submit_prefetch_task_key_not_exists(self, local_disk_backend):
         """Test submit_prefetch_task() when key doesn't exist."""
-        key = create_test_key("nonexistent")
+        key = create_test_key(2)
         res = local_disk_backend.submit_prefetch_task(key)
 
         assert not res
@@ -343,7 +343,7 @@ class TestLocalDiskBackend:
 
     def test_submit_prefetch_task_key_exists(self, local_disk_backend):
         """Test submit_prefetch_task() when key exists."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key first
@@ -363,7 +363,7 @@ class TestLocalDiskBackend:
 
     def test_get_blocking_key_not_exists(self, local_disk_backend):
         """Test get_blocking() when key doesn't exist."""
-        key = create_test_key("nonexistent")
+        key = create_test_key(2)
         result = local_disk_backend.get_blocking(key)
 
         assert result is None
@@ -372,7 +372,7 @@ class TestLocalDiskBackend:
 
     def test_get_blocking_key_exists(self, local_disk_backend):
         """Test get_blocking() when key exists."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key first
@@ -394,7 +394,7 @@ class TestLocalDiskBackend:
 
     def test_async_save_bytes_to_disk(self, local_disk_backend, async_loop):
         """Test async_save_bytes_to_disk()."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         local_disk_backend.insert_key(key, memory_obj)
@@ -410,7 +410,7 @@ class TestLocalDiskBackend:
 
     def test_async_load_bytes_from_disk(self, local_disk_backend):
         """Test async_load_bytes_from_disk()"""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Create the file first
@@ -435,7 +435,7 @@ class TestLocalDiskBackend:
 
     def test_load_bytes_from_disk(self, local_disk_backend):
         """Test load_bytes_from_disk()."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Create the file first
@@ -473,7 +473,7 @@ class TestLocalDiskBackend:
 
         # Add some keys
         for i in range(3):
-            key = create_test_key(f"key_{i}")
+            key = create_test_key(i + 5)
             memory_obj = create_test_memory_obj()
             backend.insert_key(key, memory_obj)
 
@@ -487,7 +487,7 @@ class TestLocalDiskBackend:
 
     def test_concurrent_access(self, local_disk_backend):
         """Test concurrent access to the backend."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key
@@ -509,7 +509,7 @@ class TestLocalDiskBackend:
     def test_file_operations_error_handling(self, local_disk_backend):
         """Test error handling in file operations."""
         # Test with non-existent file
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         non_existent_path = "/non/existent/path/file.pt"
 
         memory_obj = local_disk_backend.load_bytes_from_disk(
@@ -524,7 +524,7 @@ class TestLocalDiskBackend:
 
     def test_cleanup_on_remove(self, local_disk_backend):
         """Test that resources are properly cleaned up on remove."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key
@@ -550,7 +550,7 @@ class TestLocalDiskBackend:
 
     def test_thread_safety(self, local_disk_backend):
         """Test thread safety of the backend."""
-        key = create_test_key("test_key")
+        key = create_test_key(3)
         memory_obj = create_test_memory_obj()
 
         # Insert key


### PR DESCRIPTION
This will break the PD chunk hash consistency.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
