### PR TITLE
[Doc] update doc for nixl storage backend

### DIFF
--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -32,7 +32,6 @@ Example ``lmcache-config.yaml``:
 .. code-block:: yaml
 
     chunk_size: 256
-    enable_nixl: true
     nixl_buffer_size: 1073741824 # 1GB
     nixl_buffer_device: cpu
     extra_config: {enable_nixl_storage: true, nixl_backend: POSIX, \


### PR DESCRIPTION
remove enabel_nixl because nixl storage backend does not need this option

see issue: https://github.com/LMCache/LMCache/issues/1449