### PR TITLE
support start lookup server on other rank

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -390,6 +390,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": float,
     },
+    "mla_lookup_server_worker_id": {
+        "type": int,
+        "default": -1,
+        "env_converter": int,
+    },
 }
 
 
@@ -447,6 +452,7 @@ def _create_config_class():
             "log_config": _log_config,
             "to_original_config": _to_original_config,
             "get_extra_config_value": _get_extra_config_value,
+            "get_mla_lookup_server_worker_id": _get_mla_lookup_server_worker_id,
             "from_defaults": classmethod(_from_defaults),
             "from_legacy": classmethod(_from_legacy),
             "from_file": classmethod(_from_file),
@@ -545,6 +551,16 @@ def _get_extra_config_value(self, key, default_value=None):
         return self.extra_config.get(key, default_value)
     else:
         return default_value
+
+def _get_mla_lookup_server_worker_id(self, use_mla):
+    if not use_mla:
+        # if mla is not enabled, start lookup server on all worker
+        return -1
+    else:
+        # if mla is enabled, start lookup server on worker 0 as default
+        if self.mla_lookup_server_worker_id == -1:
+            return 0
+        return self.mla_lookup_server_worker_id
 
 
 def _from_defaults(cls, **kwargs):

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -391,8 +391,8 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": float,
     },
     "mla_lookup_server_worker_id": {
-        "type": int,
-        "default": -1,
+        "type": Optional[int],
+        "default": None,
         "env_converter": int,
     },
 }
@@ -553,15 +553,13 @@ def _get_extra_config_value(self, key, default_value=None):
         return default_value
 
 def _get_mla_lookup_server_worker_id(self, use_mla):
-    if not use_mla:
-        # if mla is not enabled, start lookup server on all worker
-        return -1
-    else:
-        # if mla is enabled, start lookup server on worker 0 as default
-        if self.mla_lookup_server_worker_id == -1:
-            return 0
-        return self.mla_lookup_server_worker_id
-
+    if self.mla_lookup_server_worker_id is None:
+        # if mla is not enabled, return -1, which means start
+        # lookup server on all worker as default
+        # if mla is enabled, return 0, which means start lookup
+        # server on worker 0 as default
+        return 0 if use_mla else -1
+    return self.mla_lookup_server_worker_id
 
 def _from_defaults(cls, **kwargs):
     """Create configuration from defaults"""

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -552,6 +552,7 @@ def _get_extra_config_value(self, key, default_value=None):
     else:
         return default_value
 
+
 def _get_mla_lookup_server_worker_id(self, use_mla):
     if self.mla_lookup_server_worker_id is None:
         # if mla is not enabled, return -1, which means start
@@ -560,6 +561,7 @@ def _get_mla_lookup_server_worker_id(self, use_mla):
         # server on worker 0 as default
         return 0 if use_mla else -1
     return self.mla_lookup_server_worker_id
+
 
 def _from_defaults(cls, **kwargs):
     """Create configuration from defaults"""

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -89,22 +89,14 @@ class LookupClientFactory:
             "LMCache v1 config is expected for lookup server and client"
         )
 
-        # Only create the KV lookup API server on one worker
-        # when there are multiple workers and when not using external lookup client
-        create_lookup_server_only_on_one_worker_for_mla = config.get_extra_config_value(
-            "create_lookup_server_only_on_one_worker_for_mla",
-            lmcache_engine.metadata.use_mla,
+        mla_lookup_server_worker_id = config.get_mla_lookup_server_worker_id(
+            lmcache_engine.metadata.use_mla
         )
-
-        # if create lookup server only on one worker, get the worker rank,
-        # default is 0
-        if create_lookup_server_only_on_one_worker_for_mla:
-            lookup_server_rank = config.get_extra_config_value("lookup_server_rank", 0)
-            assert lookup_server_rank < lmcache_engine.metadata.world_size
+        assert mla_lookup_server_worker_id < lmcache_engine.metadata.world_size
 
         if config.external_lookup_client is None and (
-            not create_lookup_server_only_on_one_worker_for_mla
-            or lmcache_engine.metadata.worker_id == lookup_server_rank
+            mla_lookup_server_worker_id < 0
+            or lmcache_engine.metadata.worker_id == mla_lookup_server_worker_id
         ):
             # First Party
             from lmcache.v1.lookup_client.lmcache_async_lookup_client import (

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -89,16 +89,22 @@ class LookupClientFactory:
             "LMCache v1 config is expected for lookup server and client"
         )
 
-        # Only create the KV lookup API server on worker rank 0
+        # Only create the KV lookup API server on one worker
         # when there are multiple workers and when not using external lookup client
-        create_lookup_server_only_on_worker_0_for_mla = config.get_extra_config_value(
-            "create_lookup_server_only_on_worker_0_for_mla",
+        create_lookup_server_only_on_one_worker_for_mla = config.get_extra_config_value(
+            "create_lookup_server_only_on_one_worker_for_mla",
             lmcache_engine.metadata.use_mla,
         )
 
+        # if create lookup server only on one worker, get the worker rank,
+        # default is 0
+        if create_lookup_server_only_on_one_worker_for_mla:
+            lookup_server_rank = config.get_extra_config_value("lookup_server_rank", 0)
+            assert lookup_server_rank < lmcache_engine.metadata.world_size
+
         if config.external_lookup_client is None and (
-            not create_lookup_server_only_on_worker_0_for_mla
-            or lmcache_engine.metadata.worker_id == 0
+            not create_lookup_server_only_on_one_worker_for_mla
+            or lmcache_engine.metadata.worker_id == lookup_server_rank
         ):
             # First Party
             from lmcache.v1.lookup_client.lmcache_async_lookup_client import (

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -36,12 +36,10 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
     Related extra_config:
     - mla_lookup_server_worker_id:
         is a flag to control whether to create lookup server only on one worker.
-        if mla is not enabled(return -1):
-            start lookup server on all workers
-        if mla is enabled(default is 0):
-            - if mla_lookup_server_worker_id < 0, start lookup server on all workers
-            - if mla_lookup server_worker_id >= 0, start lookup server on the given
-              worker
+        if mla is not enabled, default is -1;
+        if mla is enabled, default is 0;
+        - if mla_lookup_server_worker_id < 0, start lookup server on all workers
+        - if mla_lookup server_worker_id >= 0, start lookup server on the given worker
     """
 
     def __init__(

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -58,13 +58,14 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             metadata.use_mla
         )
         assert self.mla_lookup_server_worker_id < metadata.world_size
-        ranks = self.tensor_parallel_size
+
         self.push_sockets = []
         if self.mla_lookup_server_worker_id >= 0:
-            ranks = 1
-        for tp_rank in range(ranks):
-            if self.mla_lookup_server_worker_id >= 0:
-                tp_rank = self.mla_lookup_server_worker_id
+            ranks = [self.mla_lookup_server_worker_id]
+        else:
+            ranks = [i for i in range(self.tensor_parallel_size)]
+
+        for tp_rank in ranks:
             worker_socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup_worker", rpc_port, tp_rank
             )

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -40,7 +40,8 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             start lookup server on all workers
         if mla is enabled(default is 0):
             - if mla_lookup_server_worker_id < 0, start lookup server on all workers
-            - if mla_lookup server_worker_id >= 0, start lookup server on the given worker
+            - if mla_lookup server_worker_id >= 0, start lookup server on the given
+              worker
     """
 
     def __init__(
@@ -206,8 +207,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 all_res = self.res_for_each_worker[lookup_id]
 
                 if len(all_res) == self.tensor_parallel_size or (
-                    self.mla_lookup_server_worker_id >= 0
-                    and len(all_res) == 1
+                    self.mla_lookup_server_worker_id >= 0 and len(all_res) == 1
                 ):
                     self.res_for_each_worker.pop(lookup_id)
 

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -10,7 +10,7 @@ import torch
 import zmq
 
 # First Party
-from lmcache.integration.vllm.utils import create_lmcache_metadata, mla_enabled
+from lmcache.integration.vllm.utils import create_lmcache_metadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
@@ -34,8 +34,13 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
     ZMQ-based lookup client that communicates with a lookup server.
 
     Related extra_config:
-    - create_lookup_server_only_on_worker_0_for_mla:
-        is a flag to control whether to create lookup server only on worker 0.
+    - mla_lookup_server_worker_id:
+        is a flag to control whether to create lookup server only on one worker.
+        if mla is not enabled(return -1):
+            start lookup server on all workers
+        if mla is enabled(default is 0):
+            - if mla_lookup_server_worker_id < 0, start lookup server on all workers
+            - if mla_lookup server_worker_id >= 0, start lookup server on the given worker
     """
 
     def __init__(
@@ -50,17 +55,17 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             "lmcache_rpc_port", 0
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
-        use_mla = mla_enabled(vllm_config.model_config)
-        self.create_lookup_server_only_on_worker_0_for_mla = (
-            config.get_extra_config_value(
-                "create_lookup_server_only_on_worker_0_for_mla", use_mla
-            )
+        self.mla_lookup_server_worker_id = config.get_mla_lookup_server_worker_id(
+            metadata.use_mla
         )
+        assert self.mla_lookup_server_worker_id < metadata.world_size
         ranks = self.tensor_parallel_size
         self.push_sockets = []
-        if self.create_lookup_server_only_on_worker_0_for_mla:
+        if self.mla_lookup_server_worker_id >= 0:
             ranks = 1
         for tp_rank in range(ranks):
+            if self.mla_lookup_server_worker_id >= 0:
+                tp_rank = self.mla_lookup_server_worker_id
             worker_socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup_worker", rpc_port, tp_rank
             )
@@ -179,7 +184,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         ]
 
         ranks = self.tensor_parallel_size
-        if self.create_lookup_server_only_on_worker_0_for_mla:
+        if self.mla_lookup_server_worker_id >= 0:
             ranks = 1
         for i in range(ranks):
             self.push_sockets[i].send_multipart(msg_buf, copy=False)
@@ -201,7 +206,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 all_res = self.res_for_each_worker[lookup_id]
 
                 if len(all_res) == self.tensor_parallel_size or (
-                    self.create_lookup_server_only_on_worker_0_for_mla
+                    self.mla_lookup_server_worker_id >= 0
                     and len(all_res) == 1
                 ):
                     self.res_for_each_worker.pop(lookup_id)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -57,10 +57,12 @@ class LMCacheLookupClient(LookupClientInterface):
             metadata.use_mla
         )
         assert self.mla_lookup_server_worker_id < metadata.world_size
-        ranks = self.tensor_parallel_size
+
         self.sockets = []
         if self.mla_lookup_server_worker_id >= 0:
-            ranks = 1
+            ranks = [self.mla_lookup_server_worker_id]
+        else:
+            ranks = [i for i in range(self.tensor_parallel_size)]
 
         # Set timeout values from config
         timeout_ms = config.lookup_timeout_ms
@@ -72,9 +74,7 @@ class LMCacheLookupClient(LookupClientInterface):
         # same result.
         self.reqs_status: dict[str, int] = {}
 
-        for tp_rank in range(ranks):
-            if self.mla_lookup_server_worker_id >= 0:
-                tp_rank = self.mla_lookup_server_worker_id
+        for tp_rank in ranks:
             socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup", rpc_port, tp_rank
             )

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -34,12 +34,10 @@ class LMCacheLookupClient(LookupClientInterface):
     Related extra_config:
     - mla_lookup_server_worker_id:
         is a flag to control whether to create lookup server only on one worker.
-        if mla is not enabled(return -1):
-            start lookup server on all workers
-        if mla is enabled(default is 0):
-            - if mla_lookup_server_worker_id < 0, start lookup server on all workers
-            - if mla_lookup server_worker_id >= 0, start lookup server on the given
-              worker
+        if mla is not enabled, default is -1;
+        if mla is enabled, default is 0;
+        - if mla_lookup_server_worker_id < 0, start lookup server on all workers
+        - if mla_lookup server_worker_id >= 0, start lookup server on the given worker
     """
 
     def __init__(

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -38,7 +38,8 @@ class LMCacheLookupClient(LookupClientInterface):
             start lookup server on all workers
         if mla is enabled(default is 0):
             - if mla_lookup_server_worker_id < 0, start lookup server on all workers
-            - if mla_lookup server_worker_id >= 0, start lookup server on the given worker
+            - if mla_lookup server_worker_id >= 0, start lookup server on the given
+              worker
     """
 
     def __init__(

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -32,8 +32,11 @@ class LMCacheLookupClient(LookupClientInterface):
     ZMQ-based lookup client that communicates with a lookup server.
 
     Related extra_config:
-    - create_lookup_server_only_on_worker_0_for_mla:
-        is a flag to control whether to create lookup server only on worker 0.
+    - create_lookup_server_only_on_one_worker_for_mla:
+        is a flag to control whether to create lookup server only on one worker.
+    - lookup_server_rank:
+        if create_lookup_server_only_on_one_worker_for_mla is True, start lookup
+        server on lookup_server_rank, default is 0.
     """
 
     def __init__(
@@ -50,14 +53,14 @@ class LMCacheLookupClient(LookupClientInterface):
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
         use_mla = mla_enabled(vllm_config.model_config)
-        self.create_lookup_server_only_on_worker_0_for_mla = (
+        self.create_lookup_server_only_on_one_worker_for_mla = (
             config.get_extra_config_value(
-                "create_lookup_server_only_on_worker_0_for_mla", use_mla
+                "create_lookup_server_only_on_one_worker_for_mla", use_mla
             )
         )
         ranks = self.tensor_parallel_size
         self.sockets = []
-        if self.create_lookup_server_only_on_worker_0_for_mla:
+        if self.create_lookup_server_only_on_one_worker_for_mla:
             ranks = 1
 
         # Set timeout values from config
@@ -71,6 +74,8 @@ class LMCacheLookupClient(LookupClientInterface):
         self.reqs_status: dict[str, int] = {}
 
         for tp_rank in range(ranks):
+            if self.create_lookup_server_only_on_one_worker_for_mla:
+                tp_rank = config.get_extra_config_value("lookup_server_rank", 0)
             socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup", rpc_port, tp_rank
             )
@@ -122,7 +127,7 @@ class LMCacheLookupClient(LookupClientInterface):
             request_configs_str = json.dumps(request_configs)
         request_configs_buf = request_configs_str.encode("utf-8")
         ranks = self.tensor_parallel_size
-        if self.create_lookup_server_only_on_worker_0_for_mla:
+        if self.create_lookup_server_only_on_one_worker_for_mla:
             ranks = 1
 
         # NOTE(Jiayi): We cannot only send hashes when blending enabled

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -10,7 +10,7 @@ import torch
 import zmq
 
 # First Party
-from lmcache.integration.vllm.utils import create_lmcache_metadata, mla_enabled
+from lmcache.integration.vllm.utils import create_lmcache_metadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
@@ -32,11 +32,13 @@ class LMCacheLookupClient(LookupClientInterface):
     ZMQ-based lookup client that communicates with a lookup server.
 
     Related extra_config:
-    - create_lookup_server_only_on_one_worker_for_mla:
+    - mla_lookup_server_worker_id:
         is a flag to control whether to create lookup server only on one worker.
-    - lookup_server_rank:
-        if create_lookup_server_only_on_one_worker_for_mla is True, start lookup
-        server on lookup_server_rank, default is 0.
+        if mla is not enabled(return -1):
+            start lookup server on all workers
+        if mla is enabled(default is 0):
+            - if mla_lookup_server_worker_id < 0, start lookup server on all workers
+            - if mla_lookup server_worker_id >= 0, start lookup server on the given worker
     """
 
     def __init__(
@@ -52,15 +54,13 @@ class LMCacheLookupClient(LookupClientInterface):
             "lmcache_rpc_port", 0
         )
         self.tensor_parallel_size = vllm_config.parallel_config.tensor_parallel_size
-        use_mla = mla_enabled(vllm_config.model_config)
-        self.create_lookup_server_only_on_one_worker_for_mla = (
-            config.get_extra_config_value(
-                "create_lookup_server_only_on_one_worker_for_mla", use_mla
-            )
+        self.mla_lookup_server_worker_id = config.get_mla_lookup_server_worker_id(
+            metadata.use_mla
         )
+        assert self.mla_lookup_server_worker_id < metadata.world_size
         ranks = self.tensor_parallel_size
         self.sockets = []
-        if self.create_lookup_server_only_on_one_worker_for_mla:
+        if self.mla_lookup_server_worker_id >= 0:
             ranks = 1
 
         # Set timeout values from config
@@ -74,8 +74,8 @@ class LMCacheLookupClient(LookupClientInterface):
         self.reqs_status: dict[str, int] = {}
 
         for tp_rank in range(ranks):
-            if self.create_lookup_server_only_on_one_worker_for_mla:
-                tp_rank = config.get_extra_config_value("lookup_server_rank", 0)
+            if self.mla_lookup_server_worker_id >= 0:
+                tp_rank = self.mla_lookup_server_worker_id
             socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup", rpc_port, tp_rank
             )
@@ -127,7 +127,7 @@ class LMCacheLookupClient(LookupClientInterface):
             request_configs_str = json.dumps(request_configs)
         request_configs_buf = request_configs_str.encode("utf-8")
         ranks = self.tensor_parallel_size
-        if self.create_lookup_server_only_on_one_worker_for_mla:
+        if self.mla_lookup_server_worker_id >= 0:
             ranks = 1
 
         # NOTE(Jiayi): We cannot only send hashes when blending enabled


### PR DESCRIPTION
If mla is enabled, the read\write operations and lookup server will default to worker0, which will result in a higher workload for worker0 than other workers.

This PR support start lookup server on other worker, use `mla_lookup_server_worker_id` to replace 'create_lookup_server_only_on_worker_0_for_mla', the new config is as follows:
```
mla_lookup_server_worker_id: 1
```

if mla is enabled, the default value of `mla_lookup_server_worker_id` is 0, which means start lookup server on worker 0; if mla is not enabled, the default value of `mla_lookup_server_worker_id` is -1,  negative number means start lookup server on all workers.