### PR TITLE
Fix device ordinal overflow bug in retrieve broadcast for TP > 8

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1195,10 +1195,11 @@ class LMCacheEngine:
 
                 # Create tensor and receive data
                 metadata = MemoryObjMetadata.from_dict(metadata_dict)
+                local_rank = self.metadata.worker_id % torch.cuda.device_count()
                 tensor = torch.empty(
                     metadata.shape,
                     dtype=metadata.dtype,
-                    device=f"cuda:{self.metadata.worker_id}",
+                    device=f"cuda:{local_rank}",
                 )
                 self.broadcast_fn(tensor, self.metadata.first_rank)
 


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

When we are using cross-node TP, like when TP = 16, the current code will attempt to create a tensor on cuda device id that is >= 8. In a word, we should use the local rank rather than the global rank.
