### PR TITLE
[CI] pytest benchmark for engine lookup store and retrieve operations

### DIFF
--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -1,71 +1,215 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
+import random
+
 # Third Party
+from utils import (
+    create_gpu_connector,
+    dumb_metadata,
+    generate_kv_cache_paged_list_tensors,
+    generate_tokens,
+)
 import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineConfig, LMCacheEngineMetadata
-from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
-from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
+from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+from lmcache.v1.config import LMCacheEngineConfig
 
 
-def generate_kv_cache(num_tokens, fmt, device):
-    ret = []
-    num_layers = 32
+# helper functions
+def generate_random_slot_mapping(num_blocks, block_size, num_tokens, device):
+    slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
+    return torch.tensor(slot_mapping, device=device)
+
+
+# test store 100GB data
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="store")
+def test_store_100GB(benchmark, autorelease_v1):
+    # model-related metadatas
     num_heads = 8
-    head_size = 128
-    shape = (
-        [num_tokens, num_heads, head_size]
-        if fmt == "vllm"
-        else [num_heads, num_tokens, head_size]
+    head_dim = 128
+    num_layers = 32
+    dtype = torch.bfloat16
+
+    # lmcache and vllm configs
+    device = "cuda"
+    fmt = "vllm"
+    num_tokens = 10000
+
+    num_blocks = 12500
+    block_size = 16
+
+    chunk_size = 256
+    kv_shape = (num_layers, 2, chunk_size, num_heads, head_dim)
+
+    # Test configs
+    num_requests = 80
+
+    # Initialize related modules
+    connector = create_gpu_connector(num_heads * head_dim, num_layers)
+    kv_cache = generate_kv_cache_paged_list_tensors(
+        num_blocks, device, block_size, dtype
     )
-    dtype = torch.bfloat16 if fmt == "vllm" else torch.float16
 
-    for i in range(num_layers):
-        k = torch.rand(shape, dtype=dtype, device=device)
-        v = torch.rand(shape, dtype=dtype, device=device)
-        ret.append((k, v))
+    list_tokens = [generate_tokens(num_tokens, device) for _ in range(num_requests)]
 
-    return tuple(ret)
+    list_slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
 
+    # TODO: Rewrite the config generation to another helper function
+    cfg = LMCacheEngineConfig.from_legacy(chunk_size=chunk_size, backend="cpu")
 
-def to_blob(kv_tuples):
-    return torch.stack(
-        [torch.stack(inner_tuple, dim=0) for inner_tuple in kv_tuples], dim=0
+    engine = autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            dumb_metadata(fmt, kv_shape),
+            connector,
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
     )
 
+    # Run benchmark
+    def run_func():
+        for t, s in zip(list_tokens, list_slot_mappings):
+            engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
-# @pytest.mark.parametrize("chunk_size", [64, 256, 768])
-# @pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
-# def test_cachegen_encoder_bench(benchmark, chunk_size, fmt):
-#    fmt = "vllm"
-#    config = LMCacheEngineConfig.from_defaults(chunk_size = chunk_size)
-#    metadata = LMCacheEngineMetadata(
-# model_name = "mistralai/Mistral-7B-Instruct-v0.2",
-# world_size = 1, worker_id = 0, fmt = fmt)
-#    serializer = CacheGenSerializer(config, metadata)
-#
-#    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
-#
-#    benchmark(serializer.to_bytes, kv)
+    benchmark.pedantic(run_func, rounds=1, iterations=1)
 
 
-@pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
-@pytest.mark.parametrize("chunk_size", [64, 256, 768])
-def test_cachegen_decoder_bench(benchmark, fmt, chunk_size):
-    config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
-    metadata = LMCacheEngineMetadata(
-        model_name="mistralai/Mistral-7B-Instruct-v0.2",
-        world_size=1,
-        worker_id=0,
-        fmt=fmt,
-        kv_dtype=torch.bfloat16,
-        kv_shape=None,
+# Test retrieve 100GB data (10 rounds, each round 10GB, 100% hit)
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="retrieve")
+def test_retrieve_100GB_allhit(benchmark, autorelease_v1):
+    # model-related metadatas
+    num_heads = 8
+    head_dim = 128
+    num_layers = 32
+    dtype = torch.bfloat16
+
+    # lmcache and vllm configs
+    device = "cuda"
+    fmt = "vllm"
+    num_tokens = 10000
+
+    num_blocks = 12500
+    block_size = 16
+
+    chunk_size = 256
+    kv_shape = (num_layers, 2, chunk_size, num_heads, head_dim)
+
+    # Test configs
+    num_requests = 8
+
+    # Initialize related modules
+    connector = create_gpu_connector(num_heads * head_dim, num_layers)
+    kv_cache = generate_kv_cache_paged_list_tensors(
+        num_blocks, device, block_size, dtype
     )
-    serializer = CacheGenSerializer(config, metadata)
-    deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
-    output = serializer.to_bytes(kv)
+    list_tokens = [generate_tokens(num_tokens, device) for _ in range(num_requests)]
 
-    benchmark(deserializer.from_bytes, output)
+    list_slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
+
+    # TODO: Rewrite the config generation to another helper function
+    cfg = LMCacheEngineConfig.from_defaults(
+        chunk_size=chunk_size, max_local_cpu_size=12
+    )
+
+    engine = autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            dumb_metadata(fmt, kv_shape),
+            connector,
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
+    )
+
+    for t, s in zip(list_tokens, list_slot_mappings):
+        engine.store(t, kvcaches=kv_cache, slot_mapping=s)
+
+    # Run benchmark
+    def run_func():
+        # TODO: remove the hard-code here
+        for i in range(10):
+            for t, s in zip(list_tokens, list_slot_mappings):
+                engine.retrieve(t, kvcaches=kv_cache, slot_mapping=s)
+
+    benchmark.pedantic(run_func, rounds=1, iterations=1)
+
+
+# Test lookup 10K * 10 requests, 100% hit
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="lookup")
+def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
+    # model-related metadatas
+    num_heads = 8
+    head_dim = 128
+    num_layers = 32
+    dtype = torch.bfloat16
+
+    # lmcache and vllm configs
+    device = "cuda"
+    fmt = "vllm"
+    num_tokens = 10000
+
+    num_blocks = 12500
+    block_size = 16
+
+    chunk_size = 256
+    kv_shape = (num_layers, 2, chunk_size, num_heads, head_dim)
+
+    # Test configs
+    num_requests = 10
+
+    # Initialize related modules
+    connector = create_gpu_connector(num_heads * head_dim, num_layers)
+    kv_cache = generate_kv_cache_paged_list_tensors(
+        num_blocks, device, block_size, dtype
+    )
+
+    list_tokens = [generate_tokens(num_tokens, device) for _ in range(num_requests)]
+
+    list_slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
+
+    # TODO: Rewrite the config generation to another helper function
+    cfg = LMCacheEngineConfig.from_defaults(
+        chunk_size=chunk_size, max_local_cpu_size=15
+    )
+
+    engine = autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            dumb_metadata(fmt, kv_shape),
+            connector,
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
+    )
+
+    for t, s in zip(list_tokens, list_slot_mappings):
+        engine.store(t, kvcaches=kv_cache, slot_mapping=s)
+
+    # Run benchmark
+    def run_func():
+        # TODO: remove the hard-code here
+        for t, s in zip(list_tokens, list_slot_mappings):
+            engine.lookup(t)
+
+    # Repeat for 10 iterations
+    benchmark.pedantic(run_func, rounds=10, iterations=1)

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -77,20 +77,22 @@ def create_config():
         yield partial(make_config, path=temp_dir)
 
 
-# test store 100GB data
+# test store 10GB data (1GB * 10)
 @pytest.mark.no_shared_allocator
 @pytest.mark.benchmark(group="store")
 @pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
-def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
+def test_store_1GB(benchmark, backend, create_config, autorelease_v1):
     """
-    In this test, it will run engine.store to store 100GB data in total.
+    In this test, it will run engine.store to store 10GB data in total.
     The configs are carefully tuned to have:
-    - Each request has 10K tokens and 1.25GB KV cache
-    - There will be 80 store requests (storing 100GB data) in total.
+    - Each request has 2K tokens and 0.25GB KV cache
+    - There will be 40 store requests (storing 10GB data) in total.
     - The store requests are split into 10 rounds, where each round has
-    10GB data.
+    1GB data.
+    - The benchmark tool will measure the time for each round (time to
+    store 1GB)
 
-    When creating the LMCache engine, it will first create a 15GB buffer, so
+    When creating the LMCache engine, it will first create a 1.5GB buffer, so
     there will be eviction starting from the second round.
 
     At the end of each round, we will run `engine.lookup` to ensure that all
@@ -99,7 +101,7 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
     the rounds.
 
     pytest-benchmark will report the average time. To calculate the store
-    throughput, we can use 10GB / average_round_time.
+    throughput, we can use 1GB / average_round_time.
     """
     # model-related metadatas
     num_heads = 8
@@ -110,9 +112,9 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
     # lmcache and vllm configs
     device = "cuda"
     fmt = "vllm"
-    num_tokens = 10000
+    num_tokens = 2000
 
-    num_blocks = 5000
+    num_blocks = 1000
     block_size = 16
 
     chunk_size = 256
@@ -121,7 +123,7 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
     # Test configs
     # - single request has 1.25GB KV, 8 requests has 10GB
     # so we want to do 10 rounds
-    num_requests = 8
+    num_requests = 4
     num_repeats = 10
 
     # Initialize related modules
@@ -130,7 +132,7 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
         num_blocks, device, block_size, dtype
     )
 
-    cache_size = 15  # Allocate 15 GB KV cache buffer
+    cache_size = 1.5  # Allocate 15 GB KV cache buffer
     cfg = create_config(backend, cache_size)
 
     engine = autorelease_v1(
@@ -172,21 +174,23 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
     benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)
 
 
-# Test retrieve 100GB data (10 rounds, each round 10GB, 100% hit)
+# Test retrieve 10data (10 rounds, each round 1GB, 100% hit)
 @pytest.mark.no_shared_allocator
 @pytest.mark.benchmark(group="retrieve")
 @pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
-def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1):
+def test_retrieve_1GB_allhit(benchmark, backend, create_config, autorelease_v1):
     """
-    In this test, it will run engine.retrieve to retrieve 100GB data in total.
+    In this test, it will run engine.retrieve to retrieve 10GB data in total.
     The configs are carefully tuned to have:
-    - Each request has 10K tokens and 1.25GB KV cache
-    - There will be 80 retrieve requests (retrieving 100GB data) in total.
+    - Each request has 2K tokens and 0.25GB KV cache
+    - There will be 40 retrieve requests (retrieving 10GB data) in total.
     - The retrieve requests are split into 10 rounds, where each round has
-    10GB data.
+    1GB data.
+    - The benchmark tool will measure the time for each round (time to
+    retrieve 1GB)
 
-    When creating the LMCache engine, it will first create a 15GB buffer, and
-    then store 8 requests (10GB) into the engine.
+    When creating the LMCache engine, it will first create a 1.5GB buffer, and
+    then store 4 requests (1GB) into the engine.
     After that, there will be 10 rounds of retrieve, where each round queries
     the same set of requests (but shuffled) with a 100% hit rate.
 
@@ -194,7 +198,7 @@ def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1
     time across the rounds.
 
     pytest-benchmark will report the average time. To calculate the retrieve
-    throughput, we can use 10GB / average_round_time.
+    throughput, we can use 1GB / average_round_time.
     """
     # model-related metadatas
     num_heads = 8
@@ -205,9 +209,9 @@ def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1
     # lmcache and vllm configs
     device = "cuda"
     fmt = "vllm"
-    num_tokens = 10000
+    num_tokens = 2000
 
-    num_blocks = 5000
+    num_blocks = 1000
     block_size = 16
 
     chunk_size = 256
@@ -216,7 +220,7 @@ def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1
     # Test configs
     # - Single request has 1.25 GB KV, 8 requests will use 10GB,
     # so num repeats should be 10 to achieve 100 GB access
-    num_requests = 8
+    num_requests = 4
     num_repeats = 10
 
     # Initialize related modules
@@ -232,7 +236,7 @@ def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1
         for _ in range(num_requests)
     ]
 
-    cache_size = 15  # 15 GB KV cache buffer
+    cache_size = 1.5  # 2 GB KV cache buffer
     cfg = create_config(backend, cache_size)
 
     engine = autorelease_v1(
@@ -248,6 +252,18 @@ def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1
 
     for t, s in zip(list_tokens, list_slot_mappings):
         engine.store(t, kvcaches=kv_cache, slot_mapping=s)
+
+    # Wait for kv cache to be ready
+    timeout = 60
+    start = time.time()
+    ready = False
+    while time.time() - start < timeout:
+        ready = all([engine.lookup(t) == len(t) for t in list_tokens])
+        if ready:
+            break
+        else:
+            time.sleep(0.1)
+    assert ready, "Store is not finished in 60 seconds"
 
     # Run benchmark
     def setup():
@@ -265,20 +281,20 @@ def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1
     benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)
 
 
-# Test lookup 10K * 10 requests, 100% hit
+# Test lookup 2K * 10 requests, 100% hit
 @pytest.mark.no_shared_allocator
 @pytest.mark.benchmark(group="lookup")
 @pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
-def test_lookup_10reqs_10Ktokens(benchmark, backend, create_config, autorelease_v1):
+def test_lookup_20K_tokens(benchmark, backend, create_config, autorelease_v1):
     """
-    In this test, it will run engine.lookup to lookup 1M tokens in total.
+    In this test, it will run engine.lookup to lookup 200K tokens in total.
     The configs are carefully tuned to have:
-    - Each request has 10K tokens and 1.25GB KV cache
+    - Each request has 2K tokens and 0.25GB KV cache
     - There will be 100 lookup requests split into 10 rounds.
     - Each round will shuffle the requests.
 
-    When creating the LMCache engine, it will first create a 15GB buffer, and
-    then store 8 requests (10GB) into the engine.
+    When creating the LMCache engine, it will first create a 5GB buffer, and
+    then store 10 requests (3GB) into the engine.
     the same set of requests (but shuffled) with a 100% hit rate.
 
     The test will measure the time for each round and calculate the average
@@ -296,9 +312,9 @@ def test_lookup_10reqs_10Ktokens(benchmark, backend, create_config, autorelease_
     # lmcache and vllm configs
     device = "cuda"
     fmt = "vllm"
-    num_tokens = 10000
+    num_tokens = 2000
 
-    num_blocks = 5000
+    num_blocks = 1000
     block_size = 16
 
     chunk_size = 256
@@ -322,7 +338,7 @@ def test_lookup_10reqs_10Ktokens(benchmark, backend, create_config, autorelease_
     ]
 
     # TODO: Rewrite the config generation to another helper function
-    cache_size = 15  # 15 GB KV cache buffer
+    cache_size = 3  # 15 GB KV cache buffer
     cfg = create_config(backend, cache_size)
 
     engine = autorelease_v1(

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -82,6 +82,25 @@ def create_config():
 @pytest.mark.benchmark(group="store")
 @pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
 def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
+    """
+    In this test, it will run engine.store to store 100GB data in total.
+    The configs are carefully tuned to have:
+    - Each request has 10K tokens and 1.25GB KV cache
+    - There will be 80 store requests (storing 100GB data) in total.
+    - The store requests are split into 10 rounds, where each round has
+    10GB data.
+
+    When creating the LMCache engine, it will first create a 15GB buffer, so
+    there will be eviction starting from the second round.
+
+    At the end of each round, we will run `engine.lookup` to ensure that all
+    the data are successfully stored into the LMCache engine. The test will
+    measure the time for each round and calculate the average time across
+    the rounds.
+
+    pytest-benchmark will report the average time. To calculate the store
+    throughput, we can use 10GB / average_round_time.
+    """
     # model-related metadatas
     num_heads = 8
     head_dim = 128
@@ -111,8 +130,6 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
         num_blocks, device, block_size, dtype
     )
 
-    # TODO: Rewrite the config generation to another helper function
-    # cfg = LMCacheEngineConfig.from_legacy(chunk_size=chunk_size, backend="cpu")
     cache_size = 15  # Allocate 15 GB KV cache buffer
     cfg = create_config(backend, cache_size)
 
@@ -158,7 +175,27 @@ def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
 # Test retrieve 100GB data (10 rounds, each round 10GB, 100% hit)
 @pytest.mark.no_shared_allocator
 @pytest.mark.benchmark(group="retrieve")
-def test_retrieve_100GB_allhit(benchmark, autorelease_v1):
+@pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
+def test_retrieve_100GB_allhit(benchmark, backend, create_config, autorelease_v1):
+    """
+    In this test, it will run engine.retrieve to retrieve 100GB data in total.
+    The configs are carefully tuned to have:
+    - Each request has 10K tokens and 1.25GB KV cache
+    - There will be 80 retrieve requests (retrieving 100GB data) in total.
+    - The retrieve requests are split into 10 rounds, where each round has
+    10GB data.
+
+    When creating the LMCache engine, it will first create a 15GB buffer, and
+    then store 8 requests (10GB) into the engine.
+    After that, there will be 10 rounds of retrieve, where each round queries
+    the same set of requests (but shuffled) with a 100% hit rate.
+
+    The test will measure the time for each round and calculate the average
+    time across the rounds.
+
+    pytest-benchmark will report the average time. To calculate the retrieve
+    throughput, we can use 10GB / average_round_time.
+    """
     # model-related metadatas
     num_heads = 8
     head_dim = 128
@@ -195,10 +232,8 @@ def test_retrieve_100GB_allhit(benchmark, autorelease_v1):
         for _ in range(num_requests)
     ]
 
-    # TODO: Rewrite the config generation to another helper function
-    cfg = LMCacheEngineConfig.from_defaults(
-        chunk_size=chunk_size, max_local_cpu_size=12
-    )
+    cache_size = 15  # 15 GB KV cache buffer
+    cfg = create_config(backend, cache_size)
 
     engine = autorelease_v1(
         LMCacheEngineBuilder.get_or_create(
@@ -215,19 +250,43 @@ def test_retrieve_100GB_allhit(benchmark, autorelease_v1):
         engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
     # Run benchmark
-    def run_func():
-        # TODO: remove the hard-code here
-        for i in range(num_repeats):
-            for t, s in zip(list_tokens, list_slot_mappings):
-                engine.retrieve(t, kvcaches=kv_cache, slot_mapping=s)
+    def setup():
+        indexes = list(range(len(list_tokens)))
+        random.shuffle(indexes)
+        return (
+            [list_tokens[i] for i in indexes],
+            [list_slot_mappings[i] for i in indexes],
+        ), {}
 
-    benchmark.pedantic(run_func, rounds=1, iterations=1)
+    def run_func(tokens, slot_mappings):
+        for t, s in zip(tokens, slot_mappings):
+            engine.retrieve(t, kvcaches=kv_cache, slot_mapping=s)
+
+    benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)
 
 
 # Test lookup 10K * 10 requests, 100% hit
 @pytest.mark.no_shared_allocator
 @pytest.mark.benchmark(group="lookup")
-def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
+@pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
+def test_lookup_10reqs_10Ktokens(benchmark, backend, create_config, autorelease_v1):
+    """
+    In this test, it will run engine.lookup to lookup 1M tokens in total.
+    The configs are carefully tuned to have:
+    - Each request has 10K tokens and 1.25GB KV cache
+    - There will be 100 lookup requests split into 10 rounds.
+    - Each round will shuffle the requests.
+
+    When creating the LMCache engine, it will first create a 15GB buffer, and
+    then store 8 requests (10GB) into the engine.
+    the same set of requests (but shuffled) with a 100% hit rate.
+
+    The test will measure the time for each round and calculate the average
+    time across the rounds.
+
+    pytest-benchmark will report the average time. To calculate the lookup
+    throughput, we can use 100K tokens / average_round_time.
+    """
     # model-related metadatas
     num_heads = 8
     head_dim = 128
@@ -247,7 +306,7 @@ def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
 
     # Test configs
     num_requests = 10
-    num_repeats = 1
+    num_repeats = 10
 
     # Initialize related modules
     connector = create_gpu_connector(num_heads * head_dim, num_layers)
@@ -263,9 +322,8 @@ def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
     ]
 
     # TODO: Rewrite the config generation to another helper function
-    cfg = LMCacheEngineConfig.from_defaults(
-        chunk_size=chunk_size, max_local_cpu_size=15
-    )
+    cache_size = 15  # 15 GB KV cache buffer
+    cfg = create_config(backend, cache_size)
 
     engine = autorelease_v1(
         LMCacheEngineBuilder.get_or_create(
@@ -281,12 +339,29 @@ def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
     for t, s in zip(list_tokens, list_slot_mappings):
         engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
-    # Run benchmark
-    def run_func():
-        # TODO: remove the hard-code here
-        for i in range(num_repeats):
-            for t, s in zip(list_tokens, list_slot_mappings):
-                engine.lookup(t)
+    # Make sure all the requests are stored
+    timeout = 60
+    start = time.time()
+    ready = False
+    while time.time() - start < timeout:
+        ready = all([engine.lookup(t) == len(t) for t in list_tokens])
+        if ready:
+            break
+        else:
+            time.sleep(0.1)
+    assert ready, "Store is not finished in 60 seconds"
 
-    # Repeat for 10 iterations
-    benchmark.pedantic(run_func, rounds=10, iterations=1)
+    # Run benchmark
+    def setup():
+        indexes = list(range(len(list_tokens)))
+        random.shuffle(indexes)
+        return (
+            [list_tokens[i] for i in indexes],
+            [list_slot_mappings[i] for i in indexes],
+        ), {}
+
+    def run_func(tokens, slot_mappings):
+        for t, s in zip(tokens, slot_mappings):
+            assert engine.lookup(t) == len(t)
+
+    benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from functools import partial
+import os
 import random
+import tempfile
+import time
 
 # Third Party
 from utils import (
@@ -24,10 +28,60 @@ def generate_random_slot_mapping(num_blocks, block_size, num_tokens, device):
     return torch.tensor(slot_mapping, device=device)
 
 
+@pytest.fixture
+def create_config():
+    """
+    backend can be:
+    - cpu
+    - disk
+    - fsconnector
+    """
+
+    def make_config(backend, size, **kwargs):
+        match backend:
+            case "cpu":
+                return LMCacheEngineConfig.from_defaults(
+                    local_cpu=True,
+                    max_local_cpu_size=size,
+                    extra_config={"force_store_wait": False},
+                )
+            case "disk":
+                assert "path" in kwargs, "'path' is missing for disk backend"
+                return LMCacheEngineConfig.from_defaults(
+                    local_cpu=False,
+                    max_local_cpu_size=size,
+                    local_disk=kwargs["path"],
+                    max_local_disk_size=size,
+                    extra_config={"force_store_wait": False},
+                )
+            case "fsconnector":
+                assert "path" in kwargs, "'path' is missing for fsconnector"
+                p = kwargs["path"]
+                return LMCacheEngineConfig.from_defaults(
+                    local_cpu=False,
+                    max_local_cpu_size=size,
+                    remote_url=f"fs://host:0/{p}/",
+                    remote_serde="naive",
+                    extra_config={"force_store_wait": False},
+                )
+            case _:
+                print(f"Error: unknown backend: {backend}")
+                print("Supported backends: 'cpu', 'disk', and 'fsconnector'")
+                raise ValueError(f"Unknown backend: {backend}")
+
+    homedir = os.environ.get("HOME", "/tmp")
+    with tempfile.TemporaryDirectory(
+        dir=homedir, ignore_cleanup_errors=True
+    ) as temp_dir:
+        print("Temp dir is:", temp_dir)
+        yield partial(make_config, path=temp_dir)
+
+
 # test store 100GB data
 @pytest.mark.no_shared_allocator
 @pytest.mark.benchmark(group="store")
-def test_store_100GB(benchmark, autorelease_v1):
+@pytest.mark.parametrize("backend", ["cpu", "disk", "fsconnector"])
+def test_store_100GB(benchmark, backend, create_config, autorelease_v1):
     # model-related metadatas
     num_heads = 8
     head_dim = 128
@@ -39,14 +93,17 @@ def test_store_100GB(benchmark, autorelease_v1):
     fmt = "vllm"
     num_tokens = 10000
 
-    num_blocks = 12500
+    num_blocks = 5000
     block_size = 16
 
     chunk_size = 256
     kv_shape = (num_layers, 2, chunk_size, num_heads, head_dim)
 
     # Test configs
-    num_requests = 80
+    # - single request has 1.25GB KV, 8 requests has 10GB
+    # so we want to do 10 rounds
+    num_requests = 8
+    num_repeats = 10
 
     # Initialize related modules
     connector = create_gpu_connector(num_heads * head_dim, num_layers)
@@ -54,15 +111,10 @@ def test_store_100GB(benchmark, autorelease_v1):
         num_blocks, device, block_size, dtype
     )
 
-    list_tokens = [generate_tokens(num_tokens, device) for _ in range(num_requests)]
-
-    list_slot_mappings = [
-        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
-        for _ in range(num_requests)
-    ]
-
     # TODO: Rewrite the config generation to another helper function
-    cfg = LMCacheEngineConfig.from_legacy(chunk_size=chunk_size, backend="cpu")
+    # cfg = LMCacheEngineConfig.from_legacy(chunk_size=chunk_size, backend="cpu")
+    cache_size = 15  # Allocate 15 GB KV cache buffer
+    cfg = create_config(backend, cache_size)
 
     engine = autorelease_v1(
         LMCacheEngineBuilder.get_or_create(
@@ -76,11 +128,31 @@ def test_store_100GB(benchmark, autorelease_v1):
     )
 
     # Run benchmark
-    def run_func():
-        for t, s in zip(list_tokens, list_slot_mappings):
+    def run_func(tokens, slot_mappings):
+        for t, s in zip(tokens, slot_mappings):
             engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
-    benchmark.pedantic(run_func, rounds=1, iterations=1)
+        # Wait for all tokens are being stored
+        timeout = 60
+        start = time.time()
+        while time.time() - start < timeout:
+            ready = all([engine.lookup(t) == len(t) for t in tokens])
+            if ready:
+                return
+            else:
+                time.sleep(0.05)
+        raise TimeoutError(f"Store operation haven't finished in {timeout} seconds")
+
+    def setup():
+        list_tokens = [generate_tokens(num_tokens, device) for _ in range(num_requests)]
+
+        list_slot_mappings = [
+            generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+            for _ in range(num_requests)
+        ]
+        return (list_tokens, list_slot_mappings), {}
+
+    benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)
 
 
 # Test retrieve 100GB data (10 rounds, each round 10GB, 100% hit)
@@ -98,14 +170,17 @@ def test_retrieve_100GB_allhit(benchmark, autorelease_v1):
     fmt = "vllm"
     num_tokens = 10000
 
-    num_blocks = 12500
+    num_blocks = 5000
     block_size = 16
 
     chunk_size = 256
     kv_shape = (num_layers, 2, chunk_size, num_heads, head_dim)
 
     # Test configs
+    # - Single request has 1.25 GB KV, 8 requests will use 10GB,
+    # so num repeats should be 10 to achieve 100 GB access
     num_requests = 8
+    num_repeats = 10
 
     # Initialize related modules
     connector = create_gpu_connector(num_heads * head_dim, num_layers)
@@ -142,7 +217,7 @@ def test_retrieve_100GB_allhit(benchmark, autorelease_v1):
     # Run benchmark
     def run_func():
         # TODO: remove the hard-code here
-        for i in range(10):
+        for i in range(num_repeats):
             for t, s in zip(list_tokens, list_slot_mappings):
                 engine.retrieve(t, kvcaches=kv_cache, slot_mapping=s)
 
@@ -164,7 +239,7 @@ def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
     fmt = "vllm"
     num_tokens = 10000
 
-    num_blocks = 12500
+    num_blocks = 5000
     block_size = 16
 
     chunk_size = 256
@@ -172,6 +247,7 @@ def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
 
     # Test configs
     num_requests = 10
+    num_repeats = 1
 
     # Initialize related modules
     connector = create_gpu_connector(num_heads * head_dim, num_layers)
@@ -208,8 +284,9 @@ def test_lookup_10reqs_10Ktokens(benchmark, autorelease_v1):
     # Run benchmark
     def run_func():
         # TODO: remove the hard-code here
-        for t, s in zip(list_tokens, list_slot_mappings):
-            engine.lookup(t)
+        for i in range(num_repeats):
+            for t, s in zip(list_tokens, list_slot_mappings):
+                engine.lookup(t)
 
     # Repeat for 10 iterations
     benchmark.pedantic(run_func, rounds=10, iterations=1)

--- a/tests/benchmarks/test_cachegen.py
+++ b/tests/benchmarks/test_cachegen.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineConfig, LMCacheEngineMetadata
+from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
+from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
+
+
+def generate_kv_cache(num_tokens, fmt, device):
+    ret = []
+    num_layers = 32
+    num_heads = 8
+    head_size = 128
+    shape = (
+        [num_tokens, num_heads, head_size]
+        if fmt == "vllm"
+        else [num_heads, num_tokens, head_size]
+    )
+    dtype = torch.bfloat16 if fmt == "vllm" else torch.float16
+
+    for i in range(num_layers):
+        k = torch.rand(shape, dtype=dtype, device=device)
+        v = torch.rand(shape, dtype=dtype, device=device)
+        ret.append((k, v))
+
+    return tuple(ret)
+
+
+def to_blob(kv_tuples):
+    return torch.stack(
+        [torch.stack(inner_tuple, dim=0) for inner_tuple in kv_tuples], dim=0
+    )
+
+
+# @pytest.mark.parametrize("chunk_size", [64, 256, 768])
+# @pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
+# def test_cachegen_encoder_bench(benchmark, chunk_size, fmt):
+#    fmt = "vllm"
+#    config = LMCacheEngineConfig.from_defaults(chunk_size = chunk_size)
+#    metadata = LMCacheEngineMetadata(
+# model_name = "mistralai/Mistral-7B-Instruct-v0.2",
+# world_size = 1, worker_id = 0, fmt = fmt)
+#    serializer = CacheGenSerializer(config, metadata)
+#
+#    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
+#
+#    benchmark(serializer.to_bytes, kv)
+
+
+@pytest.mark.benchmark(group="cachegen")
+@pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
+@pytest.mark.parametrize("chunk_size", [64, 256, 768])
+def test_cachegen_decoder_bench(benchmark, fmt, chunk_size):
+    config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
+    metadata = LMCacheEngineMetadata(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        world_size=1,
+        worker_id=0,
+        fmt=fmt,
+        kv_dtype=torch.bfloat16,
+        kv_shape=None,
+    )
+    serializer = CacheGenSerializer(config, metadata)
+    deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
+
+    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
+    output = serializer.to_bytes(kv)
+
+    benchmark(deserializer.from_bytes, output)

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import asyncio
+import random
+import string
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+
+
+def recover_engine_states(engine):
+    engine.gpu_connector.kv_cache_pointers_on_gpu = {}
+
+
+def recover_gpu_connector_states(gpu_connector):
+    gpu_connector.kv_cache_pointers_on_gpu = {}
+
+
+def dumb_metadata(fmt="vllm", kv_shape=(32, 2, 256, 8, 128)):
+    return LMCacheEngineMetadata("test_model", 3, 123, fmt, torch.bfloat16, kv_shape)
+
+
+def dumb_metadata_with_model_name(
+    model_name: str, fmt="vllm", kv_shape=(32, 2, 256, 8, 128)
+):
+    return LMCacheEngineMetadata(model_name, 3, 123, fmt, torch.bfloat16, kv_shape)
+
+
+def dumb_cache_engine_key(id: int = 0) -> CacheEngineKey:
+    return CacheEngineKey("vllm", "test_model", 3, 123, id)
+
+
+def random_string(N):
+    return "".join(random.choices(string.ascii_uppercase + string.digits, k=N))
+
+
+def init_asyncio_loop():
+    async_loop = asyncio.new_event_loop()
+    async_thread = threading.Thread(target=async_loop.run_forever)
+    async_thread.start()
+    return async_loop, async_thread
+
+
+def close_asyncio_loop(async_loop, async_thread):
+    if async_loop.is_running():
+        async_loop.call_soon_threadsafe(async_loop.stop)
+    if async_thread.is_alive():
+        async_thread.join()
+
+
+def generate_kv_cache(num_tokens, fmt, device):
+    ret = []
+    num_layers = 32
+    num_heads = 8
+    head_size = 128
+    shape = (
+        [num_tokens, num_heads, head_size]
+        if fmt == "vllm"
+        else [num_heads, num_tokens, head_size]
+    )
+    dtype = torch.bfloat16 if fmt == "vllm" else torch.float16
+
+    for i in range(num_layers):
+        k = torch.rand(shape, dtype=dtype, device=device)
+        v = torch.rand(shape, dtype=dtype, device=device)
+        ret.append((k, v))
+
+    return tuple(ret)
+
+
+def generate_kv_cache_paged_list_tensors(
+    num_blocks, device, block_size=16, dtype=torch.bfloat16, use_mla=False
+):
+    """
+    Instead of Tuple[Tuple[Tensor, Tensor]], return List[Tensor]
+    where KV are in the same tensor
+    """
+    ret = []
+    num_layers = 32
+    num_heads = 1 if use_mla else 8
+    head_size = 128
+    shape = (
+        [num_blocks, block_size, head_size]
+        if use_mla
+        else [2, num_blocks, block_size, num_heads, head_size]
+    )
+
+    for i in range(num_layers):
+        kv = torch.rand(shape, dtype=dtype, device=device)
+        ret.append(kv)
+
+    return ret
+
+
+def generate_sglang_kv_cache_paged_list_tensors(
+    num_layers,
+    num_blocks,
+    block_size,
+    num_heads,
+    head_size,
+    use_mla=False,
+    device="cuda",
+    dtype=torch.bfloat16,
+):
+    """
+    Instead of Tuple[Tuple[Tensor, Tensor]], return List[Tensor]
+    where KV are in the same tensor
+    """
+    shape = (
+        [num_blocks * block_size, 1, head_size]
+        if use_mla
+        else [num_blocks * block_size, num_heads, head_size]
+    )
+    if use_mla:
+        kv_cache = [
+            torch.rand(shape, dtype=dtype, device=device) for i in range(num_layers)
+        ]
+    else:
+        k_cache = [
+            torch.rand(shape, dtype=dtype, device=device) for i in range(num_layers)
+        ]
+        v_cache = [
+            torch.rand(shape, dtype=dtype, device=device) for i in range(num_layers)
+        ]
+        kv_cache = k_cache + v_cache
+    return kv_cache
+
+
+def generate_mla_kv_cache_paged_list_tensors(
+    num_blocks, device, block_size=64, dtype=torch.bfloat16, num_layers=32
+):
+    """
+    return KV cache of MLA
+    """
+    ret = []
+    head_size = 576
+    shape = [num_blocks, block_size, head_size]
+
+    for i in range(num_layers):
+        kv = torch.rand(shape, dtype=dtype, device=device)
+        ret.append(kv)
+
+    return ret
+
+
+def generate_kv_cache_paged(num_blocks, device, block_size=16, dtype=torch.bfloat16):
+    ret = []
+    num_layers = 32
+    num_heads = 8
+    head_size = 128
+    shape = [num_blocks, block_size, num_heads, head_size]
+
+    for i in range(num_layers):
+        k = torch.rand(shape, dtype=dtype, device=device)
+        v = torch.rand(shape, dtype=dtype, device=device)
+        ret.append((k, v))
+
+    return tuple(ret)
+
+
+def generate_tokens(num_tokens, device, fixed=False):
+    if fixed:
+        return torch.tensor([-1] * num_tokens).to(device)
+    else:
+        # random tokens
+        return torch.randint(0, 10000, size=[num_tokens]).to(device)
+
+
+def concatenate_kv_caches(kv_chunks, fmt):
+    dim = 1 if fmt == "huggingface" else 0
+    ret = []
+    for kv_layer in zip(*kv_chunks, strict=False):
+        klist, vlist = zip(*kv_layer, strict=False)
+        klayer = torch.cat(klist, dim=dim)
+        vlayer = torch.cat(vlist, dim=dim)
+        ret.append((klayer, vlayer))
+    return tuple(ret)
+
+
+def check_mem_obj_equal(left, right, use_mla: bool = False):
+    """
+    check whether two memory objects are the same
+    """
+    for left_mem_obj, right_mem_obj in zip(left, right, strict=False):
+        left_tensor_size = left_mem_obj.tensor.size()
+        right_tensor_size = right_mem_obj.tensor.size()
+        if use_mla:
+            assert left_tensor_size[0] == 1
+            assert right_tensor_size[0] == 1
+
+            left_kv, right_kv = left_mem_obj.tensor[0], right_mem_obj.tensor[0]
+            right_kv = right_kv.to(left_kv.device)
+
+            assert len(left_kv.shape) == 3
+            assert len(right_kv.shape) == 3
+
+            assert (left_kv[:, :, :] == right_kv[:, :, :]).all()
+        else:
+            assert left_tensor_size[0] == 2
+            assert right_tensor_size[0] == 2
+
+            left_kv, right_kv = left_mem_obj.tensor, right_mem_obj.tensor
+            left_k, left_v = left_kv[0], left_kv[1]
+            right_k, right_v = right_kv[0], right_kv[1]
+            right_k = right_k.to(left_k.device)
+            right_v = right_v.to(left_v.device)
+
+            assert len(left_k.shape) == 3
+            assert len(left_v.shape) == 3
+            assert len(right_k.shape) == 3
+            assert len(right_v.shape) == 3
+
+            assert (left_k[:, :, :] == right_k[:, :, :]).all()
+            assert (left_v[:, :, :] == right_v[:, :, :]).all()
+
+
+def check_paged_kv_cache_equal(left, right, slot_mapping, num_heads=8, head_size=128):
+    """
+    check whether two paged kv caches are the same at slot_mapping
+    """
+    token_dim = 0
+    num_tokens = slot_mapping.shape[0]
+    for left_kv, right_kv in zip(left, right, strict=False):
+        left_k = left_kv[0].reshape(-1, num_heads, head_size)
+        left_v = left_kv[1].reshape(-1, num_heads, head_size)
+        right_k = right_kv[0].reshape(-1, num_heads, head_size)
+        right_v = right_kv[1].reshape(-1, num_heads, head_size)
+
+        assert len(left_k.shape) == 3
+        assert len(left_v.shape) == 3
+        assert len(right_k.shape) == 3
+        assert len(right_v.shape) == 3
+
+        assert left_k.shape[token_dim] >= num_tokens
+        assert left_v.shape[token_dim] >= num_tokens
+        assert right_k.shape[token_dim] >= num_tokens
+        assert right_v.shape[token_dim] >= num_tokens
+
+        assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
+        assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
+
+
+def check_sglang_paged_kv_cache_equal(
+    left, right, slot_mapping, num_heads=8, head_size=128
+):
+    """
+    check whether two paged kv caches are the same at slot_mapping
+    """
+    token_dim = 0
+    num_tokens = slot_mapping.shape[0]
+    for left_kv, right_kv in zip(left, right, strict=False):
+        _left_kv = left_kv.reshape(-1, num_heads, head_size)
+        _right_kv = right_kv.reshape(-1, num_heads, head_size)
+
+        assert len(_left_kv.shape) == 3
+        assert len(_right_kv.shape) == 3
+
+        assert _left_kv.shape[token_dim] >= num_tokens
+        assert _right_kv.shape[token_dim] >= num_tokens
+
+        assert (_left_kv[slot_mapping, :, :] == _right_kv[slot_mapping, :, :]).all()
+
+
+def check_paged_kv_cache_equal_with_mla(left, right, slot_mapping, head_size=128):
+    """
+    check whether two paged kv caches are the same at slot_mapping when use mla
+    """
+    token_dim = 0
+    num_tokens = slot_mapping.shape[0]
+    for left_kv, right_kv in zip(left, right, strict=False):
+        new_left_kv = left_kv.reshape(-1, head_size)
+        new_right_kv = right_kv.reshape(-1, head_size)
+
+        assert len(new_left_kv.shape) == 2
+        assert len(new_right_kv.shape) == 2
+
+        assert new_left_kv.shape[token_dim] >= num_tokens
+        assert new_right_kv.shape[token_dim] >= num_tokens
+
+        assert (new_left_kv[slot_mapping, :] == new_right_kv[slot_mapping, :]).all()
+
+
+def check_kv_cache_device(kvs, device):
+    for kv in kvs:
+        k, v = kv
+        assert k.device == torch.device(device)
+        assert v.device == torch.device(device)
+
+
+def create_gpu_connector(hidden_dim, num_layers):
+    return VLLMPagedMemGPUConnectorV2(hidden_dim, num_layers)


### PR DESCRIPTION
This PR fixes #1483 

TODO items:
- [x] Add different backends (at least cpu and disk)

This PR depends on #1499 

## How to read the result

Here's the screenshot of the unit test result:

<img width="3206" height="906" alt="image" src="https://github.com/user-attachments/assets/6c1bbf6a-8a3a-4158-af44-7b5bc0e010f3" />

We should read the `mean` column -- which shows the time to do the operation. The operation is described in the test name. For example

| Name | ... | Mean (ms) | ... |
|--------|--------|--------|--------|
| test_lookup_20K_tokens[**cpu**] | ... | 3.1956 (1.00) | ... |
| test_lookup_20K_tokens[**disk**] | ... | 3.4185 (1.05) | ... |
| test_lookup_20K_tokens[**fsconnector**] | ... | 31.2944 (9.79) | ... |

It means that:
- To look up 20K tokens, the CPU backend needs 3.19ms, the disk backend needs 3.41ms, and the remote backend + fsconnector needs 31.29ms
- The `1.00`, `1.05`, and `9.79` in the `Mean` column mean the slowdown compared to the row with the fastest speed.



---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
