### PR TITLE
[BugFix] return original function when nvtx is not available

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -15,12 +15,7 @@ try:
     from nvtx import annotate  # type: ignore
     _NVTX_AVAILABLE = True
 except ImportError:
-    # Stub implementation for environments where nvtx is not available.
-    def annotate(message=None, color=None, domain=None):
-        """Stub implementation of nvtx annotate decorator."""
-        def decorator(func):
-            return func
-        return decorator
+    # NVTX not available (e.g., NON-NVIDIA platforms)
     _NVTX_AVAILABLE = False
 
 import torch
@@ -317,13 +312,11 @@ def _get_color_for_nvtx(name):
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
     """Decorator for applying nvtx annotations to methods in lmcache.
-    
-    Falls back to no-op decorator when nvtx is not available (e.g., on GCU400).
     """
     if not _NVTX_AVAILABLE:
-        # No-op decorator when nvtx is not available
+        # return original function when nvtx is not available
         return func
-    
+
     return annotate(
         message=func.__qualname__,
         color=_get_color_for_nvtx(func.__qualname__),

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -11,7 +11,18 @@ import threading
 import traceback
 
 # Third Party
-from nvtx import annotate  # type: ignore
+try:
+    from nvtx import annotate  # type: ignore
+    _NVTX_AVAILABLE = True
+except ImportError:
+    # Stub implementation for environments where nvtx is not available.
+    def annotate(message=None, color=None, domain=None):
+        """Stub implementation of nvtx annotate decorator."""
+        def decorator(func):
+            return func
+        return decorator
+    _NVTX_AVAILABLE = False
+
 import torch
 
 # First Party
@@ -305,7 +316,14 @@ def _get_color_for_nvtx(name):
 
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
-    """Decorator for applying nvtx annotations to methods in lmcache."""
+    """Decorator for applying nvtx annotations to methods in lmcache.
+    
+    Falls back to no-op decorator when nvtx is not available (e.g., on GCU400).
+    """
+    if not _NVTX_AVAILABLE:
+        # No-op decorator when nvtx is not available
+        return func
+    
     return annotate(
         message=func.__qualname__,
         color=_get_color_for_nvtx(func.__qualname__),

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -311,8 +311,7 @@ def _get_color_for_nvtx(name):
 
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
-    """Decorator for applying nvtx annotations to methods in lmcache.
-    """
+    """Decorator for applying nvtx annotations to methods in lmcache."""
     if not _NVTX_AVAILABLE:
         # return original function when nvtx is not available
         return func


### PR DESCRIPTION
return original functon when nvtx is not available on on-nvidia platform.


test code:

```
import sys
sys.path.insert(0, 'LMCache')
from lmcache.utils import _lmcache_nvtx_annotate, _NVTX_AVAILABLE

print(f'NVTX available: {_NVTX_AVAILABLE}')

@_lmcache_nvtx_annotate
def test_func():
    return 'test successful'

result = test_func()

print(f'test result: {result}')

```

@KuntaiDu, @ApostaC @YaoJiayi


