### PR TITLE
[Misc] add dummy decorator when nvtx is not available

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -314,7 +314,6 @@ def _get_color_for_nvtx(name):
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
     """Decorator for applying nvtx annotations to methods in lmcache."""
-
     return annotate(
         message=func.__qualname__,
         color=_get_color_for_nvtx(func.__qualname__),

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -15,12 +15,7 @@ try:
     from nvtx import annotate  # type: ignore
     _NVTX_AVAILABLE = True
 except ImportError:
-    # Stub implementation for environments where nvtx is not available.
-    def annotate(message=None, color=None, domain=None):
-        """Stub implementation of nvtx annotate decorator."""
-        def decorator(func):
-            return func
-        return decorator
+    # NVTX not available (e.g., NON-NVIDIA platforms)
     _NVTX_AVAILABLE = False
 
 import torch
@@ -317,13 +312,11 @@ def _get_color_for_nvtx(name):
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
     """Decorator for applying nvtx annotations to methods in lmcache.
-    
-    Falls back to no-op decorator when nvtx is not available (e.g., on GCU400).
     """
     if not _NVTX_AVAILABLE:
-        # No-op decorator when nvtx is not available
+        # return original function when nvtx is not available
         return func
-    
+
     return annotate(
         message=func.__qualname__,
         color=_get_color_for_nvtx(func.__qualname__),

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -10,16 +10,21 @@ import hashlib
 import threading
 import traceback
 
-# Third Party
 try:
+    # Third Party
     from nvtx import annotate  # type: ignore
 except ImportError:
+
     def annotate(*args, **kwargs):
         """Dummy decorator when nvtx is not available."""
+
         def decorator(func):
             return func
+
         return decorator
 
+
+# Third Party
 import torch
 
 # First Party

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -11,7 +11,18 @@ import threading
 import traceback
 
 # Third Party
-from nvtx import annotate  # type: ignore
+try:
+    from nvtx import annotate  # type: ignore
+    _NVTX_AVAILABLE = True
+except ImportError:
+    # Stub implementation for environments where nvtx is not available.
+    def annotate(message=None, color=None, domain=None):
+        """Stub implementation of nvtx annotate decorator."""
+        def decorator(func):
+            return func
+        return decorator
+    _NVTX_AVAILABLE = False
+
 import torch
 
 # First Party
@@ -305,7 +316,14 @@ def _get_color_for_nvtx(name):
 
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
-    """Decorator for applying nvtx annotations to methods in lmcache."""
+    """Decorator for applying nvtx annotations to methods in lmcache.
+    
+    Falls back to no-op decorator when nvtx is not available (e.g., on GCU400).
+    """
+    if not _NVTX_AVAILABLE:
+        # No-op decorator when nvtx is not available
+        return func
+    
     return annotate(
         message=func.__qualname__,
         color=_get_color_for_nvtx(func.__qualname__),

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -13,10 +13,12 @@ import traceback
 # Third Party
 try:
     from nvtx import annotate  # type: ignore
-    _NVTX_AVAILABLE = True
 except ImportError:
-    # NVTX not available (e.g., NON-NVIDIA platforms)
-    _NVTX_AVAILABLE = False
+    def annotate(*args, **kwargs):
+        """Dummy decorator when nvtx is not available."""
+        def decorator(func):
+            return func
+        return decorator
 
 import torch
 
@@ -312,9 +314,6 @@ def _get_color_for_nvtx(name):
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
     """Decorator for applying nvtx annotations to methods in lmcache."""
-    if not _NVTX_AVAILABLE:
-        # return original function when nvtx is not available
-        return func
 
     return annotate(
         message=func.__qualname__,

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -311,8 +311,7 @@ def _get_color_for_nvtx(name):
 
 
 def _lmcache_nvtx_annotate(func, domain="lmcache"):
-    """Decorator for applying nvtx annotations to methods in lmcache.
-    """
+    """Decorator for applying nvtx annotations to methods in lmcache."""
     if not _NVTX_AVAILABLE:
         # return original function when nvtx is not available
         return func


### PR DESCRIPTION
The PR is for：

- add dummy decorator when nvtx is not available

test code:
```
import sys
sys.path.insert(0, 'LMCache')
from lmcache.utils import _lmcache_nvtx_annotate

@_lmcache_nvtx_annotate
def test_func():
    return 'test successful'

result = test_func()

print(f'test result: {result}')
```

#python3.10 test.py
test result: test successful



@KuntaiDu, @ApostaC @YaoJiayi