### PR TITLE
[bugfix] assertion error in local cpu backend

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -21,6 +21,7 @@ from lmcache.v1.memory_management import (
     MemoryObj,
     MixedMemoryAllocator,
     NixlCPUMemoryAllocator,
+    PagedTensorMemoryAllocator,
 )
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy
@@ -258,7 +259,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         assert isinstance(self.memory_allocator, MixedMemoryAllocator) or isinstance(
             self.memory_allocator, NixlCPUMemoryAllocator
-        )
+        ) or isinstance(self.memory_allocator, PagedTensorMemoryAllocator)
 
         evict_keys_count = 0
         num_attempts = 0
@@ -356,7 +357,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         assert isinstance(self.memory_allocator, MixedMemoryAllocator) or isinstance(
             self.memory_allocator, NixlCPUMemoryAllocator
-        )
+        ) or isinstance(self.memory_allocator, PagedTensorMemoryAllocator)
 
         evict_keys_count = 0
         num_attempts = 0

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -257,7 +257,10 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_obj is not None or not eviction:
             return memory_obj
 
-        assert isinstance(self.memory_allocator, (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator))
+        assert isinstance(
+            self.memory_allocator,
+            (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator)
+        )
 
         evict_keys_count = 0
         num_attempts = 0
@@ -353,7 +356,10 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_objs is not None or not eviction:
             return memory_objs
 
-        assert isinstance(self.memory_allocator, (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator))
+        assert isinstance(
+            self.memory_allocator,
+            (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator)
+        )
 
         evict_keys_count = 0
         num_attempts = 0

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -353,9 +353,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_objs is not None or not eviction:
             return memory_objs
 
-        assert isinstance(self.memory_allocator, MixedMemoryAllocator) or isinstance(
-            self.memory_allocator, NixlCPUMemoryAllocator
-        ) or isinstance(self.memory_allocator, PagedTensorMemoryAllocator)
+        assert isinstance(self.memory_allocator, (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator))
 
         evict_keys_count = 0
         num_attempts = 0

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -257,9 +257,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_obj is not None or not eviction:
             return memory_obj
 
-        assert isinstance(self.memory_allocator, MixedMemoryAllocator) or isinstance(
-            self.memory_allocator, NixlCPUMemoryAllocator
-        ) or isinstance(self.memory_allocator, PagedTensorMemoryAllocator)
+        assert isinstance(self.memory_allocator, (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator))
 
         evict_keys_count = 0
         num_attempts = 0

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -259,7 +259,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         assert isinstance(
             self.memory_allocator,
-            (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator)
+            (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator),
         )
 
         evict_keys_count = 0
@@ -358,7 +358,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         assert isinstance(
             self.memory_allocator,
-            (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator)
+            (MixedMemoryAllocator, NixlCPUMemoryAllocator, PagedTensorMemoryAllocator),
         )
 
         evict_keys_count = 0


### PR DESCRIPTION
After introducing nixl storage backend, PagedTensorMemoryAllocator is used in memory allocation. So local cpu backend assertions have to handle PagedTensorMemoryAllocator too

see issue https://github.com/LMCache/LMCache/issues/1482