### PR TITLE
[CD]: Lightweight Dockerfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,3 +253,14 @@ jobs:
               run: |
                 docker push lmcache/vllm-openai:latest
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}
+            
+            - name: Build lmcache/vllm-openai:light
+              run: | 
+                docker build \
+                --tag lmcache/vllm-openai:light --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-light \
+                --file docker/Dockerfile.light
+            
+            - name: Push lmcache/vllm-openai:light image to DockerHub
+              run: |
+                docker push lmcache/vllm-openai:light
+                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-light

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -254,13 +254,13 @@ jobs:
                 docker push lmcache/vllm-openai:latest
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}
             
-            - name: Build lmcache/vllm-openai:light
+            - name: Build lmcache/vllm-openai:lightweight
               run: | 
                 docker build \
-                --tag lmcache/vllm-openai:light --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-light \
-                --file docker/Dockerfile.light
+                --tag lmcache/vllm-openai:lightweight --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-lightweight \
+                --file docker/Dockerfile.lightweight
             
-            - name: Push lmcache/vllm-openai:light image to DockerHub
+            - name: Push lmcache/vllm-openai:lightweight image to DockerHub
               run: |
-                docker push lmcache/vllm-openai:light
-                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-light
+                docker push lmcache/vllm-openai:lightweight
+                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-lightweight

--- a/docker/Dockerfile.light
+++ b/docker/Dockerfile.light
@@ -1,0 +1,22 @@
+# vllm/vllm-openai:latest currently has lmcache bundled
+# this is in case vllm does not have lmcache bundled in the future
+# this docker file will not be able to run PD (no nixl)
+FROM vllm/vllm-openai:latest
+
+RUN uv pip install --system --no-cache lmcache
+
+
+# Build: 
+# docker build -f Dockerfile.light -t 'lmcache/vllm-openai:light' .
+
+# Run: 
+# export HF_TOKEN=<your_huggingface_token>
+# docker run --runtime nvidia --gpus all \
+#    -v ~/.cache/huggingface:/root/.cache/huggingface \
+#    --env "HUGGING_FACE_HUB_TOKEN=$HF_TOKEN" \
+#    -p 8000:8000 \
+#    --ipc=host \
+#    lmcache/vllm-openai:light \
+#    --model Qwen/Qwen3-0.6B \
+#    --kv-transfer-config \
+#    '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'

--- a/docker/Dockerfile.lightweight
+++ b/docker/Dockerfile.lightweight
@@ -1,6 +1,5 @@
-# vllm/vllm-openai:latest currently has lmcache bundled
-# this is in case vllm does not have lmcache bundled in the future
-# this docker file will not be able to run PD (no nixl)
+# This is a lightweight image of the latest release of LMCache (without NIXL) bundled with the latest release of vLLM.
+# Note: You will not be able to run Prefill-Decode Disaggregation (PD) with this image because NIXL is not installed.
 FROM vllm/vllm-openai:latest
 
 RUN uv pip install --system --no-cache lmcache
@@ -13,7 +12,7 @@ RUN uv pip install --system --no-cache lmcache
 # export HF_TOKEN=<your_huggingface_token>
 # docker run --runtime nvidia --gpus all \
 #    -v ~/.cache/huggingface:/root/.cache/huggingface \
-#    --env "HUGGING_FACE_HUB_TOKEN=$HF_TOKEN" \
+#    --env "HF_TOKEN=$HF_TOKEN" \
 #    -p 8000:8000 \
 #    --ipc=host \
 #    lmcache/vllm-openai:light \

--- a/docs/source/production/docker_deployment.rst
+++ b/docs/source/production/docker_deployment.rst
@@ -28,5 +28,6 @@ See example run file in `docker <https://github.com/LMCache/LMCache/tree/dev/doc
 
 .. note::
     DockerHub contains the following image types:
-    - Nightly build images of LMCache and vLLM latest code
-    - Images of stable releases of LMCache and vLLM
+    - Nightly build images of LMCache and vLLM latest code (e.g. tagged with `latest-nightly` and `nightly-<date>`)
+    - Images of stable releases of LMCache and vLLM (tagged with `v0.x.x`, the exact version of vllm a version of lmcache was built with can be discovered by consulting the compatibility matrix inside of `installation <../installation.rst>`_)
+    - Light image without nixl (tagged with `light`)

--- a/docs/source/production/docker_deployment.rst
+++ b/docs/source/production/docker_deployment.rst
@@ -27,7 +27,10 @@ The image name and tag can be found on DockerHub - `LMCache/vllm-openai <https:/
 See example run file in `docker <https://github.com/LMCache/LMCache/tree/dev/docker>`_ for more details.
 
 .. note::
+
     DockerHub contains the following image types:
+
     - Nightly build images of LMCache and vLLM latest code (e.g. tagged with `latest-nightly` and `nightly-<date>`)
     - Images of stable releases of LMCache and vLLM (tagged with `v0.x.x`, the exact version of vllm a version of lmcache was built with can be discovered by consulting the compatibility matrix inside of `installation <../installation.rst>`_)
-    - Light image without nixl (tagged with `light`)
+    
+    - Lightweight image that cannot run PD disaggregation (tagged with `lightweight`)


### PR DESCRIPTION
<img width="1379" height="227" alt="Screenshot 2025-09-04 at 2 22 12 AM" src="https://github.com/user-attachments/assets/11ded690-f156-4eea-9321-6f7804f67785" />


Lightweight version of the `lmcache/vllm-openai` container image which does not contain NIXL installation.
