### PR TITLE
[doc] add UCX_NET_DEVICES as kind of reminder

### DIFF
--- a/examples/disagg_prefill/1p1d_experimental/disagg_vllm_launcher.sh
+++ b/examples/disagg_prefill/1p1d_experimental/disagg_vllm_launcher.sh
@@ -24,7 +24,7 @@ if [[ $1 == "prefiller" ]]; then
     prefill_config_file=$SCRIPT_DIR/configs/lmcache-prefiller-config.yaml
 
     UCX_TLS=cuda_ipc,cuda_copy,tcp \
-    UCX_NET_DEVICES=all \
+        UCX_NET_DEVICES=all \
         LMCACHE_CONFIG_FILE=$prefill_config_file \
         VLLM_ENABLE_V1_MULTIPROCESSING=1 \
         VLLM_WORKER_MULTIPROC_METHOD=spawn \

--- a/examples/disagg_prefill/1p1d_experimental/disagg_vllm_launcher.sh
+++ b/examples/disagg_prefill/1p1d_experimental/disagg_vllm_launcher.sh
@@ -24,6 +24,7 @@ if [[ $1 == "prefiller" ]]; then
     prefill_config_file=$SCRIPT_DIR/configs/lmcache-prefiller-config.yaml
 
     UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    UCX_NET_DEVICES=all \
         LMCACHE_CONFIG_FILE=$prefill_config_file \
         VLLM_ENABLE_V1_MULTIPROCESSING=1 \
         VLLM_WORKER_MULTIPROC_METHOD=spawn \


### PR DESCRIPTION
This just a tips to remind the users:

Nixl uses **UCX** instead of **NCCL**,
so Nixl requires UCX_** env var,
previous NCCL_IB_HCA, NCCL_SOCKET_IFNAME are useless to Nixl.

FILL IN THE PR DESCRIPTION HERE

FIX #NA