### PR TITLE
[infinistore] Remove infinistore dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -151,7 +151,6 @@ autodoc_mock_imports = [
     "lmcache.c_ops",
     "aiofiles",
     "zmq",
-    "infinistore",
     "transformers",
     "safetensors",
     "torch.Tensor",

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,7 +3,6 @@ aiofiles
 aiohttp
 awscrt
 cufile-python
-infinistore
 msgspec
 numpy
 nvtx


### PR DESCRIPTION
Remnove infinistore dependency, and who can install it when need, for lmcache core, it should not add each remote storage backend.