### PR TITLE
[Doc] updated cache controller API document

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,11 +93,12 @@ Documentation
    :caption: KV Cache management
 
    kv_cache_management/controller
-   kv_cache_management/lookup
-   kv_cache_management/persist
    kv_cache_management/clear
-   kv_cache_management/move
    kv_cache_management/compress
+   kv_cache_management/health
+   kv_cache_management/lookup
+   kv_cache_management/move
+   kv_cache_management/pin
    kv_cache_management/check_finish
 
 :raw-html:`<br />`

--- a/docs/source/kv_cache_management/clear.rst
+++ b/docs/source/kv_cache_management/clear.rst
@@ -3,26 +3,20 @@
 Clear the KV cache
 ==================
 
-The ``clear`` interface is defined as the following: 
+The ``clear`` interface is defined as the following:
 
 .. code-block:: python
 
-    clear(instance_id: str, tokens: Optional[List[int]], locations: Optional[List[str]]) -> success: bool
+    clear(instance_id: str, location: str) -> event_id: str, num_tokens: int
 
-The function takes the ``instance_id`` and optionally ``tokens`` and ``locations`` as input. 
-The return value is a boolean indicating whether the ``clear`` operation was successful or not.
-If ``tokens`` and ``locations`` are not provided, all the KV caches on the given instance will be cleared.
+The function removes the KV cache stored at ``location`` for the specified
+``instance_id``. It returns an ``event_id`` and the number of tokens scheduled
+for clearing.
 
 Example usage:
 ---------------------------------------
 
-First, we need to start the lmcache controller at port 9000 and the monitor at port 9001:
-
-.. code-block:: bash
-
-    python -m lmcache.v1.api_server --port 9000 --monitor-port 9001
-
-Second, we need a yaml file ``example.yaml`` to properly configure the lmcache instance:
+First, create a yaml file ``example.yaml`` to configure the lmcache instance:
 
 .. code-block:: yaml
 
@@ -37,51 +31,59 @@ Second, we need a yaml file ``example.yaml`` to properly configure the lmcache i
     distributed_url: "localhost:8002"
     lmcache_worker_port: 8001
 
-Third, we need to start the vllm/lmcache instance:
+Start the vllm/lmcache instance at port 8000:
 
 .. code-block:: bash
 
-    LMCACHE_USE_EXPERIMENTAL=True LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct --max-model-len 4096  --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+    CUDA_VISIBLE_DEVICES=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096 \
+      --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
 
-Then, we can send a request to vllm: 
+Start the lmcache controller at port 9000 and the monitor at port 9001:
+
+.. code-block:: bash
+
+    lmcache_controller --host localhost --port 9000 --monitor-port 9001
+
+Send a request to vllm:
 
 .. code-block:: bash
 
     curl -X POST http://localhost:8000/v1/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
-        "prompt": "Explain the significance of KV cache in language models.",
-        "max_tokens": 10
-    }'
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "prompt": "Explain the significance of KV cache in language models.",
+            "max_tokens": 10
+          }'
 
-We send a ``clear`` request to the lmcache controller:
+Clear the KV cache in the system:
 
 .. code-block:: bash
 
     curl -X POST http://localhost:9000/clear \
-    -H "Content-Type: application/json" \
-    -d '{
-        "instance_id": "lmcache_default_instance_id",
-        "location": "LocalCPUBackend"
-    }'
+      -H "Content-Type: application/json" \
+      -d '{
+            "instance_id": "lmcache_default_instance",
+            "location": "LocalCPUBackend"
+          }'
 
-We should be able to see the response like this:
+
+The controller responds with a message similar to:
 
 .. code-block:: text
 
-    {"success": True}
+    {"event_id": "xxx", "num_tokens": 12}
 
-This indicates all the KV caches on the ``lmcache_default_instance`` have been cleared.
-
-We can further verify this by sending a ``lookup`` request to the lmcache controller:
+This indicates that the KV cache for 12 tokens has been scheduled for clearing.
+We can verify the cache has been cleared by performing a lookup:
 
 .. code-block:: bash
 
     curl -X POST http://localhost:9000/lookup \
-    -H "Content-Type: application/json" \
-    -d '{
-        "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13]
-    }'
+      -H "Content-Type: application/json" \
+      -d '{
+            "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13]
+          }'
 
-We should be able to see an empty the response, indicating the KV cache for the given tokens has been cleared.
+The lookup should return an empty result, confirming that the KV cache has been
+cleared for the given tokens.

--- a/docs/source/kv_cache_management/compress.rst
+++ b/docs/source/kv_cache_management/compress.rst
@@ -1,6 +1,116 @@
 .. _compress:
 
-Compress the KV cache
-=====================
+Compress and Decompress the KV cache
+=====================================
 
-Coming soon...
+The ``compress`` interface is defined as the following:
+
+.. code-block:: python
+
+    compress(instance_id: str, method: str, location: str, tokens: list[int]) -> event_id: str, num_tokens: int
+    decompress(instance_id: str, method: str, location: str, tokens: list[int]) -> event_id: str, num_tokens: int
+
+These 2 functions compresses/decompresses the KV cache chunks specified by ``tokens`` using the
+given ``method`` in the storage ``location``. The controller returns an ``event_id`` and the number of tokens scheduled for compression or decompression.
+
+Example usage:
+---------------------------------------
+
+First, we need a yaml file ``example.yaml`` to properly configure the lmcache instance:
+
+.. code-block:: yaml
+
+      chunk_size: 256
+      local_cpu: True
+      max_local_cpu_size: 5
+
+      # cache controller configurations
+      enable_controller: True
+      lmcache_instance_id: "lmcache_default_instance"
+      controller_url: "localhost:9001"
+      lmcache_worker_port: 8001
+      distributed_url: "localhost:8005"
+
+Second, we need to start the vllm/lmcache instance at port 8000:
+
+.. code-block:: bash
+
+    CUDA_VISIBLE_DEVICES=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096  --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+
+Third, we need to start the lmcache controller at port 9000 and the monitor at port 9001:
+
+.. code-block:: bash
+
+    lmcache_controller --host localhost --port 9000 --monitor-port 9001
+
+Then we can send a request to vllm to see if it works properly:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/v1/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "prompt": "Explain the significance of KV cache in language models.",
+        "max_tokens": 10
+      }'
+
+Now we send a request to tokenize the prompt:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/tokenize \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "prompt": "Explain the significance of KV cache in language models."
+      }'
+
+We should be able to see token ids in response:
+
+.. code-block:: text
+
+    {"count":12,"max_model_len":4096,"tokens":[128000,849,21435,279,26431,315,85748,6636,304,4221,4211,13],"token_strs":null}
+
+After all, we issue a ``compress`` request:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:9000/compress \
+      -H "Content-Type: application/json" \
+      -d '{
+          "instance_id": "lmcache_default_instance",
+          "method": "cachegen",
+          "location": "LocalCPUBackend",
+          "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13]
+      }'
+
+The controller responds with a message similar to:
+
+.. code-block:: text
+
+    {"event_id": "xxx", "num_tokens": 12}
+
+This indicates that 12 tokens are being compressed. The ``event_id`` can be used to query the status of the operation.
+
+Once the kv cache is compressed, we can use cachegen to decompress
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:9000/decompress \
+      -H "Content-Type: application/json" \
+      -d '{
+          "instance_id": "lmcache_default_instance",
+          "method": "cachegen",
+          "location": "LocalCPUBackend",
+          "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13]
+      }'
+
+The controller responds with a message similar to:
+
+.. code-block:: text
+
+    {"event_id": "xxx", "num_tokens": 12}
+
+This indicates that 12 tokens are being decompressed. The ``event_id`` can be used to query the status of the operation.
+

--- a/docs/source/kv_cache_management/controller.rst
+++ b/docs/source/kv_cache_management/controller.rst
@@ -5,9 +5,10 @@ LMCache Controller exposes a set of APIs for users and orchestrators to manage t
 
 Currently, the controller provides the following APIs:
 
-- :ref:`Lookup <lookup>`: Lookup the KV cache for a given list of tokens.
 - :ref:`Clear <clear>`: Clear the KV caches.
-- :ref:`Pin <pin>`: Persist or set the TTL of a KV cache.
-- :ref:`Move <move>`: Move the KV cache to a different location.
 - :ref:`Compress <compress>`: Compress the KV cache.
+- :ref:`Health <health>`: Check the health status of cache workers.
+- :ref:`Lookup <lookup>`: Lookup the KV cache for a given list of tokens.
+- :ref:`Move <move>`: Move the KV cache to a different location.
+- :ref:`Pin <pin>`: Persist the KV cache to prevent it from being evicted.
 - :ref:`CheckFinish <check_finish>`: Check whether a (non-blocking) control event has finished or not.

--- a/docs/source/kv_cache_management/health.rst
+++ b/docs/source/kv_cache_management/health.rst
@@ -1,0 +1,40 @@
+.. _health:
+
+Check controller health
+=======================
+
+The ``health`` interface is defined as the following:
+
+.. code-block:: python
+
+    health(instance_id: str) -> event_id: str, error_codes: Dict[int, int]
+
+The function returns an ``event_id`` and a dictionary mapping ``worker_id`` to
+``error_code``. A value of ``0`` indicates a healthy worker, while a non-zero
+value signals an error.
+
+Example usage:
+---------------------------------------
+
+First, start the lmcache controller at port 9000 and the monitor at port 9001:
+
+.. code-block:: bash
+
+    PYTHONHASHSEED=123 lmcache_controller --host localhost --port 9000 --monitor-port 9001
+
+Then send a health check request:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:9000/health \
+      -H "Content-Type: application/json" \
+      -d '{"instance_id": "lmcache_default_instance"}'
+
+The controller responds with a message similar to the following:
+
+.. code-block:: json
+
+    {"event_id": "health47ce328d-f27e-48ae-ab0c-c2218aabce95", "error_codes": {"0": 0, "1": 0}}
+
+Here ``error_codes`` lists each worker's ``error_code``. ``0`` represents a healthy
+worker, while non-zero values indicate an error.

--- a/docs/source/kv_cache_management/lookup.rst
+++ b/docs/source/kv_cache_management/lookup.rst
@@ -7,21 +7,15 @@ The ``lookup`` interface is defined as the following:
 
 .. code-block:: python
 
-    lookup(tokens: List[int]) -> layout_info: Dict[str, Tuple[str, int]]
+    lookup(tokens: List[int]) -> event_id: str, layout_info: Dict[str, Tuple[str, int]]
 
-The function takes a list of tokens as input and returns a dictionary containing the layout information for each token. 
+The function takes a list of tokens as input and returns event_id and a dictionary containing the layout information for each token.
 The layout information is represented as a mapping between ``instance_id`` and a tuple of ``(location, matched_prefix_length)``.
 
 Example usage:
 ---------------------------------------
 
-First, we need to start the lmcache controller at port 9000 and the monitor at port 9001:
-
-.. code-block:: bash
-
-    python -m lmcache.v1.api_server --port 9000 --monitor-port 9001
-
-Second, we need a yaml file ``example.yaml`` to properly configure the lmcache instance:
+First, we need a yaml file ``example.yaml`` to properly configure the lmcache instance:
 
 .. code-block:: yaml
 
@@ -36,38 +30,61 @@ Second, we need a yaml file ``example.yaml`` to properly configure the lmcache i
     distributed_url: "localhost:8002"
     lmcache_worker_port: 8001
 
-Third, we need to start the vllm/lmcache instance:
+Second, we need to start the vllm/lmcache instance at port 8000:
 
 .. code-block:: bash
 
-    LMCACHE_USE_EXPERIMENTAL=True LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct --max-model-len 4096  --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+    PYTHONHASHSEED=123 CUDA_VISIBLE_DEVICES=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096  --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
 
-Then, we can send a request to vllm: 
+Third, we need to start the lmcache controller at port 9000 and the monitor at port 9001:
+
+.. code-block:: bash
+
+    PYTHONHASHSEED=123 lmcache_controller --host localhost --port 9000 --monitor-port 9001
+
+Then we can send a request to vllm to see if it works properly:
 
 .. code-block:: bash
 
     curl -X POST http://localhost:8000/v1/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
         "prompt": "Explain the significance of KV cache in language models.",
         "max_tokens": 10
-    }'
+      }'
+
+Now we send a request to tokenize the prompt:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/tokenize \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "prompt": "Explain the significance of KV cache in language models."
+      }'
+
+We should be able to see token ids in response:
+
+.. code-block:: text
+
+    {"count":12,"max_model_len":4096,"tokens":[128000,849,21435,279,26431,315,85748,6636,304,4221,4211,13],"token_strs":null}
 
 Finally, we can send a ``lookup`` request to the lmcache controller:
 
 .. code-block:: bash
 
     curl -X POST http://localhost:9000/lookup \
-    -H "Content-Type: application/json" \
-    -d '{
+      -H "Content-Type: application/json" \
+      -d '{
         "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13]
-    }'
+      }'
 
 We should be able to see the response like this:
 
 .. code-block:: text
 
-    {"lmcache_default_instance_id": ["LocalCPUBackend",12]}
+    {"event_id": "xxx", "lmcache_default_instance": ("LocalCPUBackend", 12)}
 
-This means that the KV cache for the given tokens is stored in ``lmcache_default_instance``'s CPU memory and the matched prefix length is 12.
+The field ``lmcache_default_instance`` shows the instance ID, followed by a tuple of ``(location, matched_prefix_length)`` indicating the cache location within that instance and matched prefix length. ``event_id`` is an identifier of the controller operation and can typically be ignored.

--- a/docs/source/kv_cache_management/move.rst
+++ b/docs/source/kv_cache_management/move.rst
@@ -1,6 +1,110 @@
 .. _move:
 
 Move the KV cache
-==================
+=================
 
-Coming soon... 
+The ``move`` interface is defined as the following:
+
+.. code-block:: python
+
+    move(old_position: Tuple[str, str], new_position: Tuple[str, str],
+         tokens: Optional[List[int]] = [], copy: Optional[bool] = False) -> event_id: str, num_tokens: int
+
+The function moves the KV cache chunks identified by ``tokens`` from
+``old_position`` to ``new_position``. Each position is a tuple of
+``(instance_id, location)``. Setting ``copy`` to ``True`` copies the
+KV cache instead of moving it.
+
+Example usage:
+---------------------------------------
+
+First, prepare two yaml files ``instance1.yaml`` and ``instance2.yaml`` to
+configure two lmcache instances:
+
+.. code-block:: yaml
+
+    # instance1.yaml
+    chunk_size: 256
+    local_cpu: True
+    max_local_cpu_size: 5
+
+    enable_controller: True
+    lmcache_instance_id: "lmcache_instance_1"
+    controller_url: "localhost:9001"
+    lmcache_worker_port: 8002
+    distributed_url: "localhost:8004"
+
+.. code-block:: yaml
+
+    # instance2.yaml
+    chunk_size: 256
+    local_cpu: True
+    max_local_cpu_size: 5
+
+    enable_controller: True
+    lmcache_instance_id: "lmcache_instance_2"
+    controller_url: "localhost:9001"
+    lmcache_worker_port: 8003
+    distributed_url: "localhost:8005"
+
+Start two vllm engines:
+
+.. code-block:: bash
+
+    CUDA_VISIBLE_DEVICES=0 LMCACHE_CONFIG_FILE=instance1.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096 \
+      --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+
+.. code-block:: bash
+
+    CUDA_VISIBLE_DEVICES=1 LMCACHE_CONFIG_FILE=instance2.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096 \
+      --gpu-memory-utilization 0.8 --port 8001 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+
+Start the lmcache controller at port 9000 and the monitor at port 9001:
+
+.. code-block:: bash
+
+    lmcache_controller --host localhost --port 9000 --monitor-port 9001
+
+Send a request to vllm engine 1:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/v1/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "prompt": "Explain the significance of KV cache in language models.",
+            "max_tokens": 10
+          }'
+
+Tokenize the prompt to obtain token ids:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/tokenize \
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "prompt": "Explain the significance of KV cache in language models."
+          }'
+
+Move the KV cache from engine 1's CPU to engine 2's CPU using the token ids:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:9000/move \
+      -H "Content-Type: application/json" \
+      -d '{
+            "old_position": ["lmcache_instance_1", "LocalCPUBackend"],
+            "new_position": ["lmcache_instance_2", "LocalCPUBackend"],
+            "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13]
+          }'
+
+The controller responds with a message similar to:
+
+.. code-block:: text
+
+    {"num_tokens": 12, "event_id": "xxx"}
+
+``num_tokens`` indicates how many tokens' KV cache are being moved. The
+returned ``event_id`` can be used to query the status of the operation.

--- a/docs/source/kv_cache_management/persist.rst
+++ b/docs/source/kv_cache_management/persist.rst
@@ -1,6 +1,0 @@
-.. _pin:
-
-Persist the KV cache
-====================
-
-Coming soon... 

--- a/docs/source/kv_cache_management/pin.rst
+++ b/docs/source/kv_cache_management/pin.rst
@@ -1,0 +1,89 @@
+.. _pin:
+
+Pin the KV cache
+================
+
+The ``pin`` interface is defined as the following:
+
+.. code-block:: python
+
+    pin(instance_id: str, location: str, tokens: List[int]) -> event_id: str, num_tokens: int
+
+The function pins (persists) the KV cache chunks specified by ``tokens`` in the
+given ``location`` of the ``instance_id``. The controller returns an ``event_id``
+and the number of tokens scheduled for pinning.
+
+Example usage:
+---------------------------------------
+
+First, create a yaml file ``example.yaml`` to configure the lmcache instance:
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    local_cpu: True
+    max_local_cpu_size: 5
+
+    # cache controller configurations
+    enable_controller: True
+    lmcache_instance_id: "lmcache_default_instance"
+    controller_url: "localhost:9001"
+    lmcache_worker_port: 8001
+    distributed_url: "localhost:8002"
+
+Start the vllm/lmcache instance at port 8000:
+
+.. code-block:: bash
+
+    CUDA_VISIBLE_DEVICES=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096 \
+      --gpu-memory-utilization 0.8 --port 8000 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+
+Start the lmcache controller at port 9000 and the monitor at port 9001:
+
+.. code-block:: bash
+
+    lmcache_controller --host localhost --port 9000 --monitor-port 9001
+
+Send a request to vllm:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/v1/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "prompt": "Explain the significance of KV cache in language models.",
+            "max_tokens": 10
+          }'
+
+Tokenize the prompt to obtain token ids:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/tokenize \
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "prompt": "Explain the significance of KV cache in language models."
+          }'
+
+Pin the KV cache in the system:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:9000/pin \
+      -H "Content-Type: application/json" \
+      -d '{
+            "tokens": [128000, 849, 21435, 279, 26431, 315, 85748, 6636, 304, 4221, 4211, 13],
+            "instance_id": "lmcache_default_instance",
+            "location": "LocalCPUBackend"
+          }'
+
+The controller responds with a message similar to:
+
+.. code-block:: text
+
+    {"event_id": "xxx", "num_tokens": 12}
+
+``num_tokens`` indicates how many tokens' KV cache are pinned. The
+returned ``event_id`` can be used to query the status of the operation.


### PR DESCRIPTION
Update cache controller document according to cache controller's examples
Changes include:

Added move, compress, decompress and health
Replaced persist with pin
Updated clear and lookup's request and response format
See https://github.com/LMCache/LMCache/issues/1218

the previous PR https://github.com/LMCache/LMCache/pull/1415 was obsolete because the branch was messed

please review @YaoJiayi and @sammshen 