### PR TITLE
[bugfix] fix not hit in LocalCpuBackend

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -101,7 +101,7 @@ class CacheEngineKey:
                 if k.startswith("lmcache.tag."):
                     if tags is None:
                         tags = {}
-                    tags[k[len("lmcache.tag.") :]] = v
+                    tags[k[len("lmcache.tag.") :]] = str(v)
         self.tags = tags
 
     def __hash__(self):
@@ -125,6 +125,19 @@ class CacheEngineKey:
                 "%".join([f"{k}={v}" for k, v in self.tags.items()]),
             )
         )
+
+    def __eq__(self, other):
+        if type(self) == type(other):
+            return (
+                self.fmt == other.fmt
+                and self.model_name == other.model_name
+                and self.world_size == other.world_size
+                and self.worker_id == other.worker_id
+                and self.chunk_hash == other.chunk_hash
+                and self.tags == other.tags
+            )
+
+        return False
 
     def to_string(self):
         s = (
@@ -253,6 +266,12 @@ class LayerCacheEngineKey(CacheEngineKey):
                 self.layer_id,
             )
         )
+
+    def __eq__(self, other):
+        if super().__eq__(other):
+            return self.layer_id == other.layer_id
+
+        return False
 
     def to_string(self):
         s = (

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -127,7 +127,7 @@ class CacheEngineKey:
         )
 
     def __eq__(self, other):
-        if type(self) == type(other):
+        if type(self) is type(other):
             return (
                 self.fmt == other.fmt
                 and self.model_name == other.model_name


### PR DESCRIPTION
if use request configs and `LocalCpuBackend`, the request configs is as follows:
```
"kv_transfer_params": {
      "lmcache.tag.xxx": 60
 }
```
if the type of value is `int` or other numeric type, when the `lookup` method is called, these params will be transfer to `str`, which will result in not hit in `LocalCpuBackend`.

This PR override the `__eq__` method, use tags_str to judge equals. In my tests, the change works good.