### PR TITLE
[Feat]: Add Async Remote Load (Mock + Redis)

### DIFF
--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -316,17 +316,23 @@ def repeat_prompts(prompts, repeat_count, mode: str):
 
 def add_cache_misses(prompts, hit_miss_ratio):
     """
-    Add cache misses to the prompts.
+    Add cache misses to the prompts and return a boolean mask aligned with prompts.
     """
     if hit_miss_ratio is None:
-        return prompts
+        return prompts, [False] * len(prompts)
 
     hit, miss = map(int, hit_miss_ratio.split(":", 1))
+    period = hit + miss
+    miss_mask = [False] * len(prompts)
 
     for i in range(len(prompts)):
-        if i % (hit + miss) >= hit:
-            prompts[i] = str(random.randint(-10000000, 10000000)) + " " + prompts[i]
-    return prompts
+        # every (hit+miss) window: first `hit` are hits, rest are misses
+        if period and (i % period) >= hit:
+            miss_mask[i] = True
+            prompts[i] = f"{random.randint(-10_000_000, 10_000_000)} {prompts[i]}"
+
+    return prompts, miss_mask
+
 
 
 def relative_time(df, start_time):
@@ -337,50 +343,63 @@ def relative_time(df, start_time):
     df["request_end"] = df["request_end"] - start_time
     df["ttft_time"] = df["request_start"] + df["ttft"]
 
-
 def visualize_results(warmup_df, benchmark_df):
-    """
-    Separate visualization for warmup and benchmark results.
-    """
+    def plot_bars(df, title, filename):
+        plt.figure(figsize=(12, 6))
 
-    # x axis is prompt id
-    # y axis is time (relative to the start of the benchmark) with three points:
-    # 1. request start
-    # 2. request first token
-    # 3. request end
-    plt.figure(figsize=(10, 5))
-    plt.scatter(
-        warmup_df["prompt_id"], warmup_df["request_start"], label="Request Start"
-    )
-    plt.scatter(
-        warmup_df["prompt_id"], warmup_df["ttft_time"], label="Request first token"
-    )
-    plt.scatter(warmup_df["prompt_id"], warmup_df["request_end"], label="Request End")
-    plt.xlabel("Prompt ID")
-    plt.ylabel("Time (s)")
-    plt.title("Warmup Round")
-    plt.legend()
-    plt.savefig("warmup_round.png")
-    plt.close()
-    plt.figure(figsize=(10, 5))
-    plt.scatter(
-        benchmark_df["prompt_id"], benchmark_df["request_start"], label="Request Start"
-    )
-    plt.scatter(
-        benchmark_df["prompt_id"],
-        benchmark_df["ttft_time"],
-        label="Request first token",
-    )
-    plt.scatter(
-        benchmark_df["prompt_id"], benchmark_df["request_end"], label="Request End"
-    )
-    plt.xlabel("Prompt ID")
-    plt.ylabel("Time (s)")
-    plt.title("Query Round")
-    plt.legend()
-    plt.savefig("query_round.png")
-    plt.close()
+        if "is_miss" in df.columns:
+            is_miss = df["is_miss"]
+        else:
+            is_miss = pd.Series(False, index=df.index)
 
+        hits = df[~is_miss]
+        misses = df[is_miss]
+
+        # Prefill: dark blue (hit), dark orange (miss)
+        if not hits.empty:
+            plt.barh(
+                hits["prompt_id"],
+                hits["ttft_time"] - hits["request_start"],
+                left=hits["request_start"],
+                color="darkblue",
+                label="Loading",  # prefill hits
+            )
+        if not misses.empty:
+            plt.barh(
+                misses["prompt_id"],
+                misses["ttft_time"] - misses["request_start"],
+                left=misses["request_start"],
+                color="darkorange",
+                label="Compute",  # prefill misses
+            )
+
+        # Decode: light blue (hit), light orange (miss)
+        if not hits.empty:
+            plt.barh(
+                hits["prompt_id"],
+                hits["request_end"] - hits["ttft_time"],
+                left=hits["ttft_time"],
+                color="skyblue",
+                label="Decoding after loading"
+            )
+        if not misses.empty:
+            plt.barh(
+                misses["prompt_id"],
+                misses["request_end"] - misses["ttft_time"],
+                left=misses["ttft_time"],
+                color="pink",
+                label="Decoding after compute"
+            )
+
+        plt.xlabel("Time (s)")
+        plt.ylabel("Prompt ID")
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(filename)
+        plt.close()
+
+    plot_bars(warmup_df, "Warmup Round", "warmup_round.png")
+    plot_bars(benchmark_df, "Query Round", "query_round.png")
 
 async def main(args):
     random.seed(args.shuffle_seed)
@@ -410,7 +429,7 @@ async def main(args):
     ]
 
     prompts = repeat_prompts(warmup_prompts, args.repeat_count, mode=args.repeat_mode)
-    prompts = add_cache_misses(prompts, args.hit_miss_ratio)
+    prompts, miss_mask = add_cache_misses(prompts, args.hit_miss_ratio)
 
     write_resp("------warm up round------\n")
     warmup_start_time = time.time()
@@ -441,7 +460,9 @@ async def main(args):
 
     warmup_df = pd.DataFrame([stats.__dict__ for stats in warmup_request_stats])
     relative_time(warmup_df, warmup_start_time)
+    warmup_df["is_miss"] = True
     benchmark_df = pd.DataFrame([stats.__dict__ for stats in benchmark_request_stats])
+    benchmark_df["is_miss"] = miss_mask
     relative_time(benchmark_df, benchmark_start_time)
 
     warmup_df.to_csv("warmup_round.csv", index=False)

--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -334,7 +334,6 @@ def add_cache_misses(prompts, hit_miss_ratio):
     return prompts, miss_mask
 
 
-
 def relative_time(df, start_time):
     """
     Relative time to the start of the benchmark.
@@ -342,6 +341,7 @@ def relative_time(df, start_time):
     df["request_start"] = df["request_start"] - start_time
     df["request_end"] = df["request_end"] - start_time
     df["ttft_time"] = df["request_start"] + df["ttft"]
+
 
 def visualize_results(warmup_df, benchmark_df):
     def plot_bars(df, title, filename):
@@ -380,7 +380,7 @@ def visualize_results(warmup_df, benchmark_df):
                 hits["request_end"] - hits["ttft_time"],
                 left=hits["ttft_time"],
                 color="skyblue",
-                label="Decoding after loading"
+                label="Decoding after loading",
             )
         if not misses.empty:
             plt.barh(
@@ -388,7 +388,7 @@ def visualize_results(warmup_df, benchmark_df):
                 misses["request_end"] - misses["ttft_time"],
                 left=misses["ttft_time"],
                 color="pink",
-                label="Decoding after compute"
+                label="Decoding after compute",
             )
 
         plt.xlabel("Time (s)")
@@ -400,6 +400,7 @@ def visualize_results(warmup_df, benchmark_df):
 
     plot_bars(warmup_df, "Warmup Round", "warmup_round.png")
     plot_bars(benchmark_df, "Query Round", "query_round.png")
+
 
 async def main(args):
     random.seed(args.shuffle_seed)

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -2,7 +2,6 @@
 # Standard
 from typing import TYPE_CHECKING, Optional, Union
 import threading
-import time
 
 # Third Party
 from vllm.utils import make_zmq_socket
@@ -178,7 +177,9 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             ranks = 1
         for i in range(ranks):
             self.push_sockets[i].send_multipart(msg_buf, copy=False)
-        time.sleep(self.lookup_backoff_time)
+        # it is okay for the scheduler to busy loop as long as we are using
+        # --distributed-executor-backen "mp" or else the GIL will stall the worker
+        # time.sleep(self.lookup_backoff_time)
         return None
 
     def process_responses_from_workers(self):

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -125,9 +125,11 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         )
         self.thread.start()
 
+        # default backoff time
+        self.lookup_backoff_time = 0.01
         if config.extra_config is not None:
             self.lookup_backoff_time = float(
-                config.extra_config.get("lookup_backoff_time", 0.01)
+                config.extra_config.get("lookup_backoff_time", self.lookup_backoff_time)
             )
 
     # TODO(Jiayi): Consider batching here
@@ -207,7 +209,25 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         return True
 
     def close(self):
-        self.socket.close(linger=0)
+        self.running = False
+        try:
+            if self.thread.is_alive():
+                self.thread.join(timeout=1.0)
+        except Exception:
+            pass
+        for s in self.push_sockets:
+            try:
+                s.close(linger=0)  # type: ignore[arg-type]
+            except Exception:
+                pass
+        try:
+            self.pull_socket.close(linger=0)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        try:
+            self.ctx.term()
+        except Exception:
+            pass
 
 
 class LMCacheAsyncLookupServer:
@@ -294,5 +314,21 @@ class LMCacheAsyncLookupServer:
         self.push_socket.send_multipart([lookup_id_buf, num_hit_tokens_buf], copy=False)
 
     def close(self):
-        self.socket.close(linger=0)
-        # TODO: close the thread!
+        self.running = False
+        try:
+            if self.thread.is_alive():
+                self.thread.join(timeout=1.0)
+        except Exception:
+            pass
+        try:
+            self.push_socket.close(linger=0)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        try:
+            self.pull_socket.close(linger=0)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        try:
+            self.ctx.term()
+        except Exception:
+            pass

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -2,6 +2,7 @@
 # Standard
 from typing import TYPE_CHECKING, Optional, Union
 import threading
+import time
 
 # Third Party
 from vllm.utils import make_zmq_socket
@@ -177,9 +178,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             ranks = 1
         for i in range(ranks):
             self.push_sockets[i].send_multipart(msg_buf, copy=False)
-        # it is okay for the scheduler to busy loop as long as we are using
-        # --distributed-executor-backen "mp" or else the GIL will stall the worker
-        # time.sleep(self.lookup_backoff_time)
+        time.sleep(self.lookup_backoff_time)
         return None
 
     def process_responses_from_workers(self):
@@ -214,21 +213,12 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         try:
             if self.thread.is_alive():
                 self.thread.join(timeout=1.0)
-        except Exception:
-            pass
-        for s in self.push_sockets:
-            try:
+            for s in self.push_sockets:
                 s.close(linger=0)  # type: ignore[arg-type]
-            except Exception:
-                pass
-        try:
             self.pull_socket.close(linger=0)  # type: ignore[arg-type]
-        except Exception:
-            pass
-        try:
             self.ctx.term()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to join thread during close: {e}")
 
 
 class LMCacheAsyncLookupServer:
@@ -319,17 +309,9 @@ class LMCacheAsyncLookupServer:
         try:
             if self.thread.is_alive():
                 self.thread.join(timeout=1.0)
-        except Exception:
-            pass
-        try:
-            self.push_socket.close(linger=0)  # type: ignore[arg-type]
-        except Exception:
-            pass
-        try:
+            for s in self.push_sockets:
+                s.close(linger=0)  # type: ignore[arg-type]
             self.pull_socket.close(linger=0)  # type: ignore[arg-type]
-        except Exception:
-            pass
-        try:
             self.ctx.term()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to join thread during close: {e}")

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -242,5 +242,38 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    def support_batched_async_contains(self) -> bool: 
+        """
+        Connectors that support batched async contains should override this method.
+        """
+        return False
+
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        """
+        Check if the remote server contains the keys
+        """
+        raise NotImplementedError
+    
+    def support_batched_get_non_blocking(self) -> bool: 
+        """
+        Connectors that support batched get non-blocking should override this method.
+        """
+        return False
+    
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+    ) -> list[MemoryObj]:
+        """
+        Batched get the memory_objs of the corresponding keys
+        """
+        raise NotImplementedError
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}>"

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -242,7 +242,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def support_batched_async_contains(self) -> bool: 
+    def support_batched_async_contains(self) -> bool:
         """
         Connectors that support batched async contains should override this method.
         """
@@ -258,13 +258,13 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         Check if the remote server contains the keys
         """
         raise NotImplementedError
-    
-    def support_batched_get_non_blocking(self) -> bool: 
+
+    def support_batched_get_non_blocking(self) -> bool:
         """
         Connectors that support batched get non-blocking should override this method.
         """
         return False
-    
+
     async def batched_get_non_blocking(
         self,
         lookup_id: str,

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -251,7 +251,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
     async def batched_async_contains(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
+        keys: List[CacheEngineKey],
         pin: bool = False,
     ) -> int:
         """
@@ -268,8 +268,8 @@ class RemoteConnector(metaclass=abc.ABCMeta):
     async def batched_get_non_blocking(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
-    ) -> list[MemoryObj]:
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
         """
         Batched get the memory_objs of the corresponding keys
         """

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -82,10 +82,10 @@ class InstrumentedRemoteConnector(RemoteConnector):
 
     def support_batched_get(self) -> bool:
         return self._connector.support_batched_get()
-    
+
     def support_batched_async_contains(self) -> bool:
         return self._connector.support_batched_async_contains()
-    
+
     async def batched_async_contains(
         self,
         lookup_id: str,
@@ -93,10 +93,10 @@ class InstrumentedRemoteConnector(RemoteConnector):
         pin: bool = False,
     ) -> int:
         return await self._connector.batched_async_contains(lookup_id, keys, pin)
-    
+
     def support_batched_get_non_blocking(self) -> bool:
         return self._connector.support_batched_get_non_blocking()
-    
+
     async def batched_get_non_blocking(
         self,
         lookup_id: str,
@@ -113,6 +113,6 @@ class InstrumentedRemoteConnector(RemoteConnector):
         self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
     ):
         return await self._connector.batched_put(keys, memory_objs)
-    
+
     def __repr__(self) -> str:
         return f"InstrumentedRemoteConnector({self._connector})"

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -77,13 +77,42 @@ class InstrumentedRemoteConnector(RemoteConnector):
     async def ping(self) -> int:
         return await self._connector.ping()
 
+    def support_batched_put(self) -> bool:
+        return self._connector.support_batched_put()
+
     def support_batched_get(self) -> bool:
         return self._connector.support_batched_get()
+    
+    def support_batched_async_contains(self) -> bool:
+        return self._connector.support_batched_async_contains()
+    
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        return await self._connector.batched_async_contains(lookup_id, keys, pin)
+    
+    def support_batched_get_non_blocking(self) -> bool:
+        return self._connector.support_batched_get_non_blocking()
+    
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+    ) -> list[MemoryObj]:
+        return await self._connector.batched_get_non_blocking(lookup_id, keys)
 
     async def batched_get(
         self, keys: List[CacheEngineKey]
     ) -> List[Optional[MemoryObj]]:
         return await self._connector.batched_get(keys)
 
+    async def batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        return await self._connector.batched_put(keys, memory_objs)
+    
     def __repr__(self) -> str:
         return f"InstrumentedRemoteConnector({self._connector})"

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -89,7 +89,7 @@ class InstrumentedRemoteConnector(RemoteConnector):
     async def batched_async_contains(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
+        keys: List[CacheEngineKey],
         pin: bool = False,
     ) -> int:
         return await self._connector.batched_async_contains(lookup_id, keys, pin)
@@ -100,8 +100,8 @@ class InstrumentedRemoteConnector(RemoteConnector):
     async def batched_get_non_blocking(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
-    ) -> list[MemoryObj]:
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
         return await self._connector.batched_get_non_blocking(lookup_id, keys)
 
     async def batched_get(

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -289,11 +289,11 @@ class MockConnector(RemoteConnector):
     async def _batched_async_contains(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
+        keys: List[CacheEngineKey],
         pin: bool = False,
     ) -> int:
         num_hit_counts = 0
-        for key in keys: 
+        for key in keys:
             await self.pressure_manager.on_exists()
             if not await self.lru_store.exists(key):
                 return num_hit_counts
@@ -303,7 +303,7 @@ class MockConnector(RemoteConnector):
     async def batched_async_contains(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
+        keys: List[CacheEngineKey],
         pin: bool = False,
     ) -> int:
         return await self.pq_executor.submit_job(
@@ -316,8 +316,8 @@ class MockConnector(RemoteConnector):
     async def batched_get_non_blocking(
         self,
         lookup_id: str,
-        keys: list[CacheEngineKey],
-    ) -> list[MemoryObj]:
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
         # batched get is already async and the non-blocking element is handled
         # in the StorageManager
         return await self.pq_executor.submit_job(

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -4,25 +4,27 @@
 # Standard
 from collections import OrderedDict
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import List, Optional
 import asyncio
-from enum import IntEnum
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj, MemoryObjMetadata, TensorMemoryObj
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
-from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 
-class Priorities(IntEnum): 
-    PEEK = 0 
+
+class Priorities(IntEnum):
+    PEEK = 0
     PREFETCH = 1
     GET = 2
     PUT = 3
+
 
 @dataclass
 class MockMemoryObj:
@@ -277,8 +279,10 @@ class MockConnector(RemoteConnector):
             memory_objs.append(memory_obj)
 
         return memory_objs
-    
-    async def batched_get(self, keys: List[CacheEngineKey]) -> List[Optional[MemoryObj]]:
+
+    async def batched_get(
+        self, keys: List[CacheEngineKey]
+    ) -> List[Optional[MemoryObj]]:
         return await self.pq_executor.submit_job(
             self._batched_get, keys=keys, priority=Priorities.GET
         )
@@ -307,7 +311,11 @@ class MockConnector(RemoteConnector):
         pin: bool = False,
     ) -> int:
         return await self.pq_executor.submit_job(
-            self._batched_async_contains, lookup_id=lookup_id, keys=keys, pin=pin, priority=Priorities.PEEK
+            self._batched_async_contains,
+            lookup_id=lookup_id,
+            keys=keys,
+            pin=pin,
+            priority=Priorities.PEEK,
         )
 
     def support_batched_get_non_blocking(self) -> bool:
@@ -323,7 +331,6 @@ class MockConnector(RemoteConnector):
         return await self.pq_executor.submit_job(
             self._batched_get, keys=keys, priority=Priorities.PREFETCH
         )
-
 
     async def close(self):
         await self.lru_store.close()

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import List, Optional
 import asyncio
+from enum import IntEnum
 
 # First Party
 from lmcache.logging import init_logger
@@ -13,9 +14,15 @@ from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj, MemoryObjMetadata, TensorMemoryObj
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
 
 logger = init_logger(__name__)
 
+class Priorities(IntEnum): 
+    PEEK = 0 
+    PREFETCH = 1
+    GET = 2
+    PUT = 3
 
 @dataclass
 class MockMemoryObj:
@@ -185,14 +192,24 @@ class MockConnector(RemoteConnector):
         self.read_throughput = read_throughput
         self.write_throughput = write_throughput
 
-    async def exists(self, key: CacheEngineKey) -> bool:
+        # only for the async loading codepath
+        # MockConnector is naturally async so we don't need to use a thread pool
+        # for avoiding R-W interference
+        self.pq_executor = AsyncPQExecutor(loop)
+
+    async def _exists(self, key: CacheEngineKey) -> bool:
         await self.pressure_manager.on_exists()
         return await self.lru_store.exists(key)
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return await self.pq_executor.submit_job(
+            self._exists, key=key, priority=Priorities.PEEK
+        )
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         raise NotImplementedError("MockConnector does not support synchronous exists")
 
-    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+    async def _get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         mock_obj = await self.lru_store.get(key)
         if mock_obj is None:
             return None
@@ -209,10 +226,20 @@ class MockConnector(RemoteConnector):
             return None
         return memory_obj
 
-    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        return await self.pq_executor.submit_job(
+            self._get, key=key, priority=Priorities.GET
+        )
+
+    async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         mock_obj = MockMemoryObj.from_tensor_memory_obj(memory_obj)
         await self.lru_store.put(key, mock_obj)
         await self.pressure_manager.on_put(mock_obj)
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        await self.pq_executor.submit_job(
+            self._put, key=key, memory_obj=memory_obj, priority=Priorities.PUT
+        )
 
     async def list(self) -> List[str]:
         keys = await self.lru_store.list()
@@ -221,7 +248,7 @@ class MockConnector(RemoteConnector):
     def support_batched_get(self) -> bool:
         return True
 
-    async def batched_get(
+    async def _batched_get(
         self, keys: List[CacheEngineKey]
     ) -> List[Optional[MemoryObj]]:
         mock_objs = await self.lru_store.batched_get(keys)
@@ -250,9 +277,57 @@ class MockConnector(RemoteConnector):
             memory_objs.append(memory_obj)
 
         return memory_objs
+    
+    async def batched_get(self, keys: List[CacheEngineKey]) -> List[Optional[MemoryObj]]:
+        return await self.pq_executor.submit_job(
+            self._batched_get, keys=keys, priority=Priorities.GET
+        )
+
+    def support_batched_async_contains(self) -> bool:
+        return True
+
+    async def _batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        num_hit_counts = 0
+        for key in keys: 
+            await self.pressure_manager.on_exists()
+            if not await self.lru_store.exists(key):
+                return num_hit_counts
+            num_hit_counts += 1
+        return num_hit_counts
+
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        return await self.pq_executor.submit_job(
+            self._batched_async_contains, lookup_id=lookup_id, keys=keys, pin=pin, priority=Priorities.PEEK
+        )
+
+    def support_batched_get_non_blocking(self) -> bool:
+        return True
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+    ) -> list[MemoryObj]:
+        # batched get is already async and the non-blocking element is handled
+        # in the StorageManager
+        return await self.pq_executor.submit_job(
+            self._batched_get, keys=keys, priority=Priorities.PREFETCH
+        )
+
 
     async def close(self):
         await self.lru_store.close()
+        await self.pq_executor.shutdown(wait=True)
 
     def __repr__(self) -> str:
         return (

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -4,7 +4,7 @@
 # Standard
 from collections import OrderedDict
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import IntEnum, auto
 from typing import List, Optional
 import asyncio
 
@@ -20,10 +20,10 @@ logger = init_logger(__name__)
 
 
 class Priorities(IntEnum):
-    PEEK = 0
-    PREFETCH = 1
-    GET = 2
-    PUT = 3
+    PEEK = auto()
+    PREFETCH = auto()
+    GET = auto()
+    PUT = auto()
 
 
 @dataclass

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -6,7 +6,7 @@ import inspect
 import os
 
 # Third Party
-import redis
+import redis.asyncio as redis
 
 # First Party
 from lmcache.logging import init_logger
@@ -35,19 +35,23 @@ class RedisConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
-        self.connection = redis.from_url(url=url, decode_responses=False)
+        # set a large max
+        max_connections = 100
+        self.pool = redis.ConnectionPool.from_url(url, max_connections=max_connections)
+        self.connection = redis.Redis.from_pool(self.pool)
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return bool(self.connection.exists(key.to_string() + "metadata"))
+        return bool(await self.connection.exists(key.to_string() + "metadata"))
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
-        return bool(self.connection.exists(key.to_string() + "metadata"))
+        future = asyncio.run_coroutine_threadsafe(self.exists(key), self.loop)
+        return bool(future.result())
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        metadata_bytes = self.connection.get(key_str + "metadata")
+        metadata_bytes = await self.connection.get(key_str + "metadata")
 
         if metadata_bytes is None:
             return None
@@ -66,7 +70,7 @@ class RedisConnector(RemoteConnector):
             return None
 
         # TODO(Jiayi): Find a way to do `get` inplace
-        kv_bytes = self.connection.get(key_str + "kv_bytes")
+        kv_bytes = await self.connection.get(key_str + "kv_bytes")
         assert not inspect.isawaitable(kv_bytes)
 
         if kv_bytes is None:
@@ -78,7 +82,7 @@ class RedisConnector(RemoteConnector):
                 "Key exists but KV cache does not exist."
                 "Might happen when the cache is evicted by redis."
             )
-            self.connection.delete(key_str + "metadata")
+            await self.connection.delete(key_str + "metadata")
             return None
 
         if isinstance(memory_obj.byte_array, memoryview):
@@ -99,6 +103,16 @@ class RedisConnector(RemoteConnector):
 
         return memory_obj
 
+    def support_batched_put(self) -> bool:
+        return True
+
+    async def batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        await asyncio.gather(
+            *(self.put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+        )
+
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         # TODO(Jiayi): The following code is ugly.
         # Please use a function like `memory_obj.to_meta()`.
@@ -112,8 +126,9 @@ class RedisConnector(RemoteConnector):
         ).serialize()
 
         key_str = key.to_string()
-        self.connection.set(key_str + "metadata", metadata_bytes)
-        self.connection.set(key_str + "kv_bytes", kv_bytes)
+        # kv bytes needs to be set first to avoid race condition
+        await self.connection.set(key_str + "kv_bytes", kv_bytes)
+        await self.connection.set(key_str + "metadata", metadata_bytes)
 
     # TODO
     @no_type_check
@@ -121,8 +136,35 @@ class RedisConnector(RemoteConnector):
         pass
 
     async def close(self):
-        self.connection.close()
+        await self.connection.close()
         logger.info("Closed the redis connection")
+
+    def support_batched_async_contains(self) -> bool:
+        return True
+
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        num_hit_counts = 0
+        for key in keys:
+            if not await self.connection.exists(key.to_string() + "metadata"):
+                return num_hit_counts
+            num_hit_counts += 1
+        return num_hit_counts
+
+    def support_batched_get_non_blocking(self) -> bool:
+        return True
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
+        results = await asyncio.gather(*(self.get(key) for key in keys))
+        return [r for r in results if r is not None]
 
 
 class RedisSentinelConnector(RemoteConnector):

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from collections import OrderedDict
-from dataclasses import dataclass
 from enum import IntEnum
 from typing import List, Optional, Tuple, no_type_check
 import asyncio
@@ -10,12 +8,11 @@ import os
 
 # Third Party
 import redis.asyncio as redis
-import torch
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
-from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.protocol import RemoteMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
@@ -36,80 +33,6 @@ class Priorities(IntEnum):
     PUT = 3
 
 
-@dataclass
-class Metadata:
-    length: int
-    shape: torch.Size
-    dtype: Optional[torch.dtype]
-    fmt: MemoryFormat
-
-
-class MetadataDict:
-    def __init__(self):
-        self.metadata_dict = OrderedDict()
-        # 5 TB overestimation
-        # Metadata is cheap to store but we just want to
-        # prevent infinite growth (mem leak)
-        # LRU evict
-        self.capacity = 5 * 1024**4
-        # number of bytes
-        self.size = 0
-        self.lock = asyncio.Lock()
-
-    async def apeek(self, key_str: str) -> bool:
-        async with self.lock:
-            return key_str in self.metadata_dict
-
-    async def aget(self, key_str: str) -> Optional[Metadata]:
-        async with self.lock:
-            if key_str in self.metadata_dict:
-                self.metadata_dict.move_to_end(key_str)
-                return self.metadata_dict[key_str]
-            else:
-                return None
-
-    async def aset(self, key_str: str, value: Metadata):
-        async with self.lock:
-            self.metadata_dict[key_str] = value
-            self.size += value.length
-            if self.size > self.capacity:
-                self.size -= self.metadata_dict.popitem(last=False).length
-
-    async def adel(self, key_str: str):
-        """
-        Safe async metadata deletion (even if does not exist)
-        """
-        async with self.lock:
-            if key_str in self.metadata_dict:
-                value = self.metadata_dict.pop(key_str)
-                self.size -= value.length
-
-
-class ConnectionPoolSafe:
-    def __init__(self, url: str, max_connections: int = 150):
-        self.max_connections = max_connections
-        self.pool = redis.ConnectionPool.from_url(url, max_connections=max_connections)
-        self.connection = redis.Redis.from_pool(self.pool)
-        # redis will crash if we have more than max_connections connections
-        self.sem = asyncio.Semaphore(self.max_connections)
-
-    async def exists(self, key_str: str) -> bool:
-        async with self.sem:
-            return await self.connection.exists(key_str)
-
-    async def get(self, key_str: str) -> Optional[bytes]:
-        async with self.sem:
-            return await self.connection.get(key_str)
-
-    async def set(self, key_str: str, value: bytes):
-        async with self.sem:
-            return await self.connection.set(key_str, value)
-
-    async def close(self):
-        await self.connection.close()
-        self.pool.close()
-
-
 class RedisConnector(RemoteConnector):
     """
     The remote url should start with "redis://" and only have one host-port pair
@@ -121,21 +44,22 @@ class RedisConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        # set a large max
+        self.max_connections = 150
+        # redis will crash if we have more than max_connections connections
+        self.sem = asyncio.Semaphore(self.max_connections)
+        self.pool = redis.ConnectionPool.from_url(
+            url, max_connections=self.max_connections
+        )
+        self.connection = redis.Redis.from_pool(self.pool)
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
         self.pq_executor = AsyncPQExecutor(loop)
-        self.connection_pool = ConnectionPoolSafe(url)
-        self.metadata_dict = MetadataDict()
 
     async def _exists(self, key: CacheEngineKey) -> bool:
-        key_str = key.to_string()
-        # need to check for bytes, not metadata
-        if not bool(await self.connection_pool.exists(key_str)):
-            # delete metadata if kv_bytes is not found
-            await self.metadata_dict.adel(key_str)
-            return False
-        return True
+        async with self.sem:
+            return bool(await self.connection.exists(key.to_string() + "metadata"))
 
     async def exists(self, key: CacheEngineKey) -> bool:
         return await self.pq_executor.submit_job(
@@ -148,24 +72,27 @@ class RedisConnector(RemoteConnector):
 
     async def _get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        metadata = await self.metadata_dict.aget(key_str)
+        async with self.sem:
+            metadata_bytes = await self.connection.get(key_str + "metadata")
 
-        assert not inspect.isawaitable(metadata)
+            if metadata_bytes is None:
+                return None
 
-        if metadata is None:
-            return None
+            assert not inspect.isawaitable(metadata_bytes)
 
-        memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
-            metadata.fmt,
-        )
-        if memory_obj is None:
-            logger.warning("Failed to allocate memory during remote receive")
-            return None
+            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
-        # TODO(Jiayi): Find a way to do `get` inplace
-        kv_bytes = await self.connection_pool.get(key_str)
+            memory_obj = self.local_cpu_backend.allocate(
+                metadata.shape,
+                metadata.dtype,
+                metadata.fmt,
+            )
+            if memory_obj is None:
+                logger.warning("Failed to allocate memory during remote receive")
+                return None
+
+            # TODO(Jiayi): Find a way to do `get` inplace
+            kv_bytes = await self.connection.get(key_str + "kv_bytes")
         assert not inspect.isawaitable(kv_bytes)
 
         if kv_bytes is None:
@@ -173,7 +100,12 @@ class RedisConnector(RemoteConnector):
             # consistency issues.
             # TODO (Jiayi): A better way is to aggregate metadata
             # and kv cache in one key.
-            await self.metadata_dict.adel(key_str)
+            logger.warning(
+                "Key exists but KV cache does not exist."
+                "Might happen when the cache is evicted by redis."
+            )
+            async with self.sem:
+                await self.connection.delete(key_str + "metadata")
             return None
 
         if isinstance(memory_obj.byte_array, memoryview):
@@ -228,11 +160,15 @@ class RedisConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata = Metadata(len(kv_bytes), kv_shape, kv_dtype, memory_format)
+        metadata_bytes = RemoteMetadata(
+            len(kv_bytes), kv_shape, kv_dtype, memory_format
+        ).serialize()
 
         key_str = key.to_string()
-        await self.metadata_dict.aset(key_str, metadata)
-        await self.connection_pool.set(key_str, kv_bytes)
+        # kv bytes needs to be set first to avoid race condition
+        async with self.sem:
+            await self.connection.set(key_str + "kv_bytes", kv_bytes)
+            await self.connection.set(key_str + "metadata", metadata_bytes)
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         await self.pq_executor.submit_job(
@@ -243,6 +179,11 @@ class RedisConnector(RemoteConnector):
     @no_type_check
     async def list(self) -> List[str]:
         pass
+
+    async def close(self):
+        await self.pq_executor.shutdown(wait=True)
+        await self.connection.close()
+        logger.info("Closed the redis connection")
 
     def support_batched_async_contains(self) -> bool:
         return True
@@ -255,10 +196,9 @@ class RedisConnector(RemoteConnector):
     ) -> int:
         num_hit_counts = 0
         for key in keys:
-            key_str = key.to_string()
-            if not await self.connection_pool.exists(key_str):
-                await self.metadata_dict.adel(key_str)
-                return num_hit_counts
+            async with self.sem:
+                if not await self.connection.exists(key.to_string() + "metadata"):
+                    return num_hit_counts
             num_hit_counts += 1
         return num_hit_counts
 
@@ -299,11 +239,6 @@ class RedisConnector(RemoteConnector):
             keys=keys,
             priority=Priorities.PREFETCH,
         )
-
-    async def close(self):
-        await self.pq_executor.shutdown(wait=True)
-        await self.connection_pool.close()
-        logger.info("Closed the redis connection")
 
 
 class RedisSentinelConnector(RemoteConnector):

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from enum import IntEnum
+from enum import IntEnum, auto
 from typing import List, Optional, Tuple, no_type_check
 import asyncio
 import inspect
@@ -27,10 +27,10 @@ logger = init_logger(__name__)
 
 
 class Priorities(IntEnum):
-    PEEK = 0
-    PREFETCH = 1
-    GET = 2
-    PUT = 3
+    PEEK = auto()
+    PREFETCH = auto()
+    GET = auto()
+    PUT = auto()
 
 
 class RedisConnector(RemoteConnector):

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from enum import IntEnum
 from typing import List, Optional, Tuple, no_type_check
 import asyncio
 import inspect
@@ -14,6 +15,7 @@ from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.protocol import RemoteMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
@@ -22,6 +24,13 @@ logger = init_logger(__name__)
 # NOTE(Jiayi): `redis-py` supports async operations, but data copy
 # cannot be avoided. `hiredis` is more lower-level but asyncio is
 # not supported.
+
+
+class Priorities(IntEnum):
+    PEEK = 0
+    PREFETCH = 1
+    GET = 2
+    PUT = 3
 
 
 class RedisConnector(RemoteConnector):
@@ -46,15 +55,22 @@ class RedisConnector(RemoteConnector):
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
-    async def exists(self, key: CacheEngineKey) -> bool:
+        self.pq_executor = AsyncPQExecutor(loop)
+
+    async def _exists(self, key: CacheEngineKey) -> bool:
         async with self.sem:
             return bool(await self.connection.exists(key.to_string() + "metadata"))
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return await self.pq_executor.submit_job(
+            self._exists, key=key, priority=Priorities.PEEK
+        )
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         future = asyncio.run_coroutine_threadsafe(self.exists(key), self.loop)
         return bool(future.result())
 
-    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+    async def _get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
         async with self.sem:
             metadata_bytes = await self.connection.get(key_str + "metadata")
@@ -110,17 +126,33 @@ class RedisConnector(RemoteConnector):
 
         return memory_obj
 
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        return await self.pq_executor.submit_job(
+            self._get, key=key, priority=Priorities.GET
+        )
+
     def support_batched_put(self) -> bool:
         return True
+
+    async def _batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        # calling self.put will create a circular dependency
+        await asyncio.gather(
+            *(self._put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+        )
 
     async def batched_put(
         self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
     ):
-        await asyncio.gather(
-            *(self.put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+        await self.pq_executor.submit_job(
+            self._batched_put,
+            keys=keys,
+            memory_objs=memory_objs,
+            priority=Priorities.PUT,
         )
 
-    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+    async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         # TODO(Jiayi): The following code is ugly.
         # Please use a function like `memory_obj.to_meta()`.
         kv_bytes = memory_obj.byte_array
@@ -138,19 +170,25 @@ class RedisConnector(RemoteConnector):
             await self.connection.set(key_str + "kv_bytes", kv_bytes)
             await self.connection.set(key_str + "metadata", metadata_bytes)
 
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        await self.pq_executor.submit_job(
+            self._put, key=key, memory_obj=memory_obj, priority=Priorities.PUT
+        )
+
     # TODO
     @no_type_check
     async def list(self) -> List[str]:
         pass
 
     async def close(self):
+        await self.pq_executor.shutdown(wait=True)
         await self.connection.close()
         logger.info("Closed the redis connection")
 
     def support_batched_async_contains(self) -> bool:
         return True
 
-    async def batched_async_contains(
+    async def _batched_async_contains(
         self,
         lookup_id: str,
         keys: List[CacheEngineKey],
@@ -164,16 +202,43 @@ class RedisConnector(RemoteConnector):
             num_hit_counts += 1
         return num_hit_counts
 
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        return await self.pq_executor.submit_job(
+            self._batched_async_contains,
+            lookup_id=lookup_id,
+            keys=keys,
+            pin=pin,
+            priority=Priorities.PEEK,
+        )
+
     def support_batched_get_non_blocking(self) -> bool:
         return True
+
+    async def _batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
+        # calling self.get will create a circular dependency
+        results = await asyncio.gather(*(self._get(key) for key in keys))
+        return [r for r in results if r is not None]
 
     async def batched_get_non_blocking(
         self,
         lookup_id: str,
         keys: List[CacheEngineKey],
     ) -> List[MemoryObj]:
-        results = await asyncio.gather(*(self.get(key) for key in keys))
-        return [r for r in results if r is not None]
+        return await self.pq_executor.submit_job(
+            self._batched_get_non_blocking,
+            lookup_id=lookup_id,
+            keys=keys,
+            priority=Priorities.PREFETCH,
+        )
 
 
 class RedisSentinelConnector(RemoteConnector):

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -36,14 +36,19 @@ class RedisConnector(RemoteConnector):
         local_cpu_backend: LocalCPUBackend,
     ):
         # set a large max
-        max_connections = 100
-        self.pool = redis.ConnectionPool.from_url(url, max_connections=max_connections)
+        self.max_connections = 150
+        # redis will crash if we have more than max_connections connections
+        self.sem = asyncio.Semaphore(self.max_connections)
+        self.pool = redis.ConnectionPool.from_url(
+            url, max_connections=self.max_connections
+        )
         self.connection = redis.Redis.from_pool(self.pool)
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
     async def exists(self, key: CacheEngineKey) -> bool:
-        return bool(await self.connection.exists(key.to_string() + "metadata"))
+        async with self.sem:
+            return bool(await self.connection.exists(key.to_string() + "metadata"))
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         future = asyncio.run_coroutine_threadsafe(self.exists(key), self.loop)
@@ -51,26 +56,27 @@ class RedisConnector(RemoteConnector):
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        metadata_bytes = await self.connection.get(key_str + "metadata")
+        async with self.sem:
+            metadata_bytes = await self.connection.get(key_str + "metadata")
 
-        if metadata_bytes is None:
-            return None
+            if metadata_bytes is None:
+                return None
 
-        assert not inspect.isawaitable(metadata_bytes)
+            assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
-        memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
-            metadata.fmt,
-        )
-        if memory_obj is None:
-            logger.warning("Failed to allocate memory during remote receive")
-            return None
+            memory_obj = self.local_cpu_backend.allocate(
+                metadata.shape,
+                metadata.dtype,
+                metadata.fmt,
+            )
+            if memory_obj is None:
+                logger.warning("Failed to allocate memory during remote receive")
+                return None
 
-        # TODO(Jiayi): Find a way to do `get` inplace
-        kv_bytes = await self.connection.get(key_str + "kv_bytes")
+            # TODO(Jiayi): Find a way to do `get` inplace
+            kv_bytes = await self.connection.get(key_str + "kv_bytes")
         assert not inspect.isawaitable(kv_bytes)
 
         if kv_bytes is None:
@@ -82,7 +88,8 @@ class RedisConnector(RemoteConnector):
                 "Key exists but KV cache does not exist."
                 "Might happen when the cache is evicted by redis."
             )
-            await self.connection.delete(key_str + "metadata")
+            async with self.sem:
+                await self.connection.delete(key_str + "metadata")
             return None
 
         if isinstance(memory_obj.byte_array, memoryview):
@@ -127,8 +134,9 @@ class RedisConnector(RemoteConnector):
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition
-        await self.connection.set(key_str + "kv_bytes", kv_bytes)
-        await self.connection.set(key_str + "metadata", metadata_bytes)
+        async with self.sem:
+            await self.connection.set(key_str + "kv_bytes", kv_bytes)
+            await self.connection.set(key_str + "metadata", metadata_bytes)
 
     # TODO
     @no_type_check
@@ -150,8 +158,9 @@ class RedisConnector(RemoteConnector):
     ) -> int:
         num_hit_counts = 0
         for key in keys:
-            if not await self.connection.exists(key.to_string() + "metadata"):
-                return num_hit_counts
+            async with self.sem:
+                if not await self.connection.exists(key.to_string() + "metadata"):
+                    return num_hit_counts
             num_hit_counts += 1
         return num_hit_counts
 

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from collections import OrderedDict
+from dataclasses import dataclass
 from enum import IntEnum
 from typing import List, Optional, Tuple, no_type_check
 import asyncio
@@ -8,11 +10,12 @@ import os
 
 # Third Party
 import redis.asyncio as redis
+import torch
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
-from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.protocol import RemoteMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
@@ -33,6 +36,80 @@ class Priorities(IntEnum):
     PUT = 3
 
 
+@dataclass
+class Metadata:
+    length: int
+    shape: torch.Size
+    dtype: Optional[torch.dtype]
+    fmt: MemoryFormat
+
+
+class MetadataDict:
+    def __init__(self):
+        self.metadata_dict = OrderedDict()
+        # 5 TB overestimation
+        # Metadata is cheap to store but we just want to
+        # prevent infinite growth (mem leak)
+        # LRU evict
+        self.capacity = 5 * 1024**4
+        # number of bytes
+        self.size = 0
+        self.lock = asyncio.Lock()
+
+    async def apeek(self, key_str: str) -> bool:
+        async with self.lock:
+            return key_str in self.metadata_dict
+
+    async def aget(self, key_str: str) -> Optional[Metadata]:
+        async with self.lock:
+            if key_str in self.metadata_dict:
+                self.metadata_dict.move_to_end(key_str)
+                return self.metadata_dict[key_str]
+            else:
+                return None
+
+    async def aset(self, key_str: str, value: Metadata):
+        async with self.lock:
+            self.metadata_dict[key_str] = value
+            self.size += value.length
+            if self.size > self.capacity:
+                self.size -= self.metadata_dict.popitem(last=False).length
+
+    async def adel(self, key_str: str):
+        """
+        Safe async metadata deletion (even if does not exist)
+        """
+        async with self.lock:
+            if key_str in self.metadata_dict:
+                value = self.metadata_dict.pop(key_str)
+                self.size -= value.length
+
+
+class ConnectionPoolSafe:
+    def __init__(self, url: str, max_connections: int = 150):
+        self.max_connections = max_connections
+        self.pool = redis.ConnectionPool.from_url(url, max_connections=max_connections)
+        self.connection = redis.Redis.from_pool(self.pool)
+        # redis will crash if we have more than max_connections connections
+        self.sem = asyncio.Semaphore(self.max_connections)
+
+    async def exists(self, key_str: str) -> bool:
+        async with self.sem:
+            return await self.connection.exists(key_str)
+
+    async def get(self, key_str: str) -> Optional[bytes]:
+        async with self.sem:
+            return await self.connection.get(key_str)
+
+    async def set(self, key_str: str, value: bytes):
+        async with self.sem:
+            return await self.connection.set(key_str, value)
+
+    async def close(self):
+        await self.connection.close()
+        self.pool.close()
+
+
 class RedisConnector(RemoteConnector):
     """
     The remote url should start with "redis://" and only have one host-port pair
@@ -44,22 +121,21 @@ class RedisConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
-        # set a large max
-        self.max_connections = 150
-        # redis will crash if we have more than max_connections connections
-        self.sem = asyncio.Semaphore(self.max_connections)
-        self.pool = redis.ConnectionPool.from_url(
-            url, max_connections=self.max_connections
-        )
-        self.connection = redis.Redis.from_pool(self.pool)
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
         self.pq_executor = AsyncPQExecutor(loop)
+        self.connection_pool = ConnectionPoolSafe(url)
+        self.metadata_dict = MetadataDict()
 
     async def _exists(self, key: CacheEngineKey) -> bool:
-        async with self.sem:
-            return bool(await self.connection.exists(key.to_string() + "metadata"))
+        key_str = key.to_string()
+        # need to check for bytes, not metadata
+        if not bool(await self.connection_pool.exists(key_str)):
+            # delete metadata if kv_bytes is not found
+            await self.metadata_dict.adel(key_str)
+            return False
+        return True
 
     async def exists(self, key: CacheEngineKey) -> bool:
         return await self.pq_executor.submit_job(
@@ -72,27 +148,24 @@ class RedisConnector(RemoteConnector):
 
     async def _get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         key_str = key.to_string()
-        async with self.sem:
-            metadata_bytes = await self.connection.get(key_str + "metadata")
+        metadata = await self.metadata_dict.aget(key_str)
 
-            if metadata_bytes is None:
-                return None
+        assert not inspect.isawaitable(metadata)
 
-            assert not inspect.isawaitable(metadata_bytes)
+        if metadata is None:
+            return None
 
-            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+        memory_obj = self.local_cpu_backend.allocate(
+            metadata.shape,
+            metadata.dtype,
+            metadata.fmt,
+        )
+        if memory_obj is None:
+            logger.warning("Failed to allocate memory during remote receive")
+            return None
 
-            memory_obj = self.local_cpu_backend.allocate(
-                metadata.shape,
-                metadata.dtype,
-                metadata.fmt,
-            )
-            if memory_obj is None:
-                logger.warning("Failed to allocate memory during remote receive")
-                return None
-
-            # TODO(Jiayi): Find a way to do `get` inplace
-            kv_bytes = await self.connection.get(key_str + "kv_bytes")
+        # TODO(Jiayi): Find a way to do `get` inplace
+        kv_bytes = await self.connection_pool.get(key_str)
         assert not inspect.isawaitable(kv_bytes)
 
         if kv_bytes is None:
@@ -100,12 +173,7 @@ class RedisConnector(RemoteConnector):
             # consistency issues.
             # TODO (Jiayi): A better way is to aggregate metadata
             # and kv cache in one key.
-            logger.warning(
-                "Key exists but KV cache does not exist."
-                "Might happen when the cache is evicted by redis."
-            )
-            async with self.sem:
-                await self.connection.delete(key_str + "metadata")
+            await self.metadata_dict.adel(key_str)
             return None
 
         if isinstance(memory_obj.byte_array, memoryview):
@@ -160,15 +228,11 @@ class RedisConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
+        metadata = Metadata(len(kv_bytes), kv_shape, kv_dtype, memory_format)
 
         key_str = key.to_string()
-        # kv bytes needs to be set first to avoid race condition
-        async with self.sem:
-            await self.connection.set(key_str + "kv_bytes", kv_bytes)
-            await self.connection.set(key_str + "metadata", metadata_bytes)
+        await self.metadata_dict.aset(key_str, metadata)
+        await self.connection_pool.set(key_str, kv_bytes)
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         await self.pq_executor.submit_job(
@@ -179,11 +243,6 @@ class RedisConnector(RemoteConnector):
     @no_type_check
     async def list(self) -> List[str]:
         pass
-
-    async def close(self):
-        await self.pq_executor.shutdown(wait=True)
-        await self.connection.close()
-        logger.info("Closed the redis connection")
 
     def support_batched_async_contains(self) -> bool:
         return True
@@ -196,9 +255,10 @@ class RedisConnector(RemoteConnector):
     ) -> int:
         num_hit_counts = 0
         for key in keys:
-            async with self.sem:
-                if not await self.connection.exists(key.to_string() + "metadata"):
-                    return num_hit_counts
+            key_str = key.to_string()
+            if not await self.connection_pool.exists(key_str):
+                await self.metadata_dict.adel(key_str)
+                return num_hit_counts
             num_hit_counts += 1
         return num_hit_counts
 
@@ -239,6 +299,11 @@ class RedisConnector(RemoteConnector):
             keys=keys,
             priority=Priorities.PREFETCH,
         )
+
+    async def close(self):
+        await self.pq_executor.shutdown(wait=True)
+        await self.connection_pool.close()
+        logger.info("Closed the redis connection")
 
 
 class RedisSentinelConnector(RemoteConnector):

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from concurrent.futures import Future
 from typing import Any, Awaitable, Callable
 import asyncio
 import itertools
@@ -28,8 +29,12 @@ class AsyncPQExecutor(BaseJobExecutor):
         ] = asyncio.PriorityQueue(maxsize=max_size)
         self._counter = itertools.count()
         self.max_workers = max_workers
-        for _ in range(max_workers):
-            asyncio.run_coroutine_threadsafe(self._worker(), self.loop)
+        # we don't use asyncio.create_task so that PQ executor can be invoked
+        # from sync code
+        self._workers: list[Future] = [
+            asyncio.run_coroutine_threadsafe(self._worker(), loop)
+            for _ in range(max_workers)
+        ]
         self._closed = False
 
     async def submit_job(
@@ -77,7 +82,10 @@ class AsyncPQExecutor(BaseJobExecutor):
             )
         if wait:
             await self._queue.join()
-            await asyncio.gather(*self._workers, return_exceptions=True)
+            await asyncio.gather(
+                *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
+                return_exceptions=True,
+            )
 
     def shutdown(self, wait: bool = True) -> None:
         future = asyncio.run_coroutine_threadsafe(self._shutdown_async(wait), self.loop)
@@ -104,8 +112,11 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
         ] = asyncio.PriorityQueue(maxsize=max_size)
         self._counter = itertools.count()
         self.max_workers = max_workers
+        self._workers = []
         for _ in range(max_workers):
-            asyncio.run_coroutine_threadsafe(self._worker(), self.loop)
+            self._workers.append(
+                asyncio.run_coroutine_threadsafe(self._worker(), self.loop)
+            )
         self._closed = False
 
     async def _worker(self):
@@ -128,3 +139,26 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
                 # decrement task count
                 # join needs to wait until task count is zero
                 self._queue.task_done()
+
+    async def _shutdown_async(self, wait: bool = True) -> None:
+        self._closed = True
+        # Enqueue comparable sentinel tuples with the highest priority value so
+        # that outstanding work drains before shutdown signals are consumed.
+        # Use a very large integer to satisfy the typed queue's expected int priority
+        sentinel_priority = 2**31 - 1
+        for _ in range(self.max_workers):
+            await self._queue.put(
+                (sentinel_priority, next(self._counter), _SENTINEL, None, {}, None)
+            )
+        if wait:
+            await self._queue.join()
+            await asyncio.gather(
+                *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
+                return_exceptions=True,
+            )
+
+    def shutdown(self, wait: bool = True) -> None:
+        future = asyncio.run_coroutine_threadsafe(self._shutdown_async(wait), self.loop)
+        if wait:
+            # Propagate exceptions if any
+            future.result()

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -20,12 +20,11 @@ class AsyncPQExecutor(BaseJobExecutor):
             tuple[
                 int,
                 int,
-                Callable[..., Awaitable[Any]],
+                Callable[..., Awaitable[Any]] | object,
                 Any,
                 dict[str, Any],
-                asyncio.Future[Any],
+                asyncio.Future[Any] | None,
             ]
-            | object
         ] = asyncio.PriorityQueue(maxsize=max_size)
         self._counter = itertools.count()
         self.max_workers = max_workers
@@ -48,7 +47,10 @@ class AsyncPQExecutor(BaseJobExecutor):
     async def _worker(self):
         while True:
             item = await self._queue.get()
-            if item is _SENTINEL:
+            # Detect sentinel both as raw object and wrapped tuple
+            if item is _SENTINEL or (
+                isinstance(item, tuple) and len(item) >= 3 and item[2] is _SENTINEL
+            ):
                 self._queue.task_done()
                 break
 
@@ -65,8 +67,14 @@ class AsyncPQExecutor(BaseJobExecutor):
 
     async def _shutdown_async(self, wait: bool = True) -> None:
         self._closed = True
+        # Enqueue comparable sentinel tuples with the highest priority value so
+        # that outstanding work drains before shutdown signals are consumed.
+        # Use a very large integer to satisfy the typed queue's expected int priority
+        sentinel_priority = 2**31 - 1
         for _ in range(self.max_workers):
-            await self._queue.put(_SENTINEL)
+            await self._queue.put(
+                (sentinel_priority, next(self._counter), _SENTINEL, None, {}, None)
+            )
         if wait:
             await self._queue.join()
             await asyncio.gather(*self._workers, return_exceptions=True)
@@ -88,12 +96,11 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
             tuple[
                 int,
                 int,
-                Callable[..., Any],
+                Callable[..., Any] | object,
                 Any,
                 dict[str, Any],
-                asyncio.Future[Any],
+                asyncio.Future[Any] | None,
             ]
-            | object
         ] = asyncio.PriorityQueue(maxsize=max_size)
         self._counter = itertools.count()
         self.max_workers = max_workers
@@ -104,7 +111,10 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
     async def _worker(self):
         while True:
             item = await self._queue.get()
-            if item is _SENTINEL:
+            # Detect sentinel both as raw object and wrapped tuple
+            if item is _SENTINEL or (
+                isinstance(item, tuple) and len(item) >= 3 and item[2] is _SENTINEL
+            ):
                 self._queue.task_done()
                 break
 

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -63,13 +63,20 @@ class AsyncPQExecutor(BaseJobExecutor):
                 # join needs to wait until task count is zero
                 self._queue.task_done()
 
-    async def shutdown(self, wait: bool = True):
+    async def _shutdown_async(self, wait: bool = True) -> None:
         self._closed = True
         for _ in range(self.max_workers):
             await self._queue.put(_SENTINEL)
         if wait:
             await self._queue.join()
             await asyncio.gather(*self._workers, return_exceptions=True)
+
+    def shutdown(self, wait: bool = True) -> None:
+        future = asyncio.run_coroutine_threadsafe(self._shutdown_async(wait), self.loop)
+        if wait:
+            # Propagate exceptions if any
+            future.result()
+
 
 class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
     """Execute sync functions with a priority queue and using threadpool"""

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -11,7 +11,7 @@ _SENTINEL = object()
 
 
 class AsyncPQExecutor(BaseJobExecutor):
-    "Execute async functions with a priority queue andusing event loop"
+    """Execute async functions with a priority queue and using event loop"""
 
     def __init__(self, loop: asyncio.AbstractEventLoop, max_workers: int = 4):
         max_size = 0  # infinite
@@ -63,7 +63,7 @@ class AsyncPQExecutor(BaseJobExecutor):
                 # join needs to wait until task count is zero
                 self._queue.task_done()
 
-    async def shutdown(self, wait=True):
+    async def shutdown(self, wait: bool = True):
         self._closed = True
         for _ in range(self.max_workers):
             await self._queue.put(_SENTINEL)
@@ -71,9 +71,8 @@ class AsyncPQExecutor(BaseJobExecutor):
             await self._queue.join()
             await asyncio.gather(*self._workers, return_exceptions=True)
 
-
 class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
-    "Execute sync functions with a priority queue and using threadpool"
+    """Execute sync functions with a priority queue and using threadpool"""
 
     def __init__(self, loop: asyncio.AbstractEventLoop, max_workers: int = 4):
         max_size = 0  # infinite
@@ -90,6 +89,7 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
             | object
         ] = asyncio.PriorityQueue(maxsize=max_size)
         self._counter = itertools.count()
+        self.max_workers = max_workers
         for _ in range(max_workers):
             asyncio.run_coroutine_threadsafe(self._worker(), self.loop)
         self._closed = False

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -91,6 +91,7 @@ class LocalDiskWorker:
         self._closed = True
         self.executor.shutdown(wait=True)
 
+
 class LocalDiskBackend(StorageBackendInterface):
     def __init__(
         self,

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -85,7 +85,9 @@ class LocalDiskWorker:
 
     def close(self):
         # Gracefully shut down the executor
-        fut = asyncio.run_coroutine_threadsafe(self.executor.shutdown(wait=True), self.loop)
+        fut = asyncio.run_coroutine_threadsafe(
+            self.executor.shutdown(wait=True), self.loop
+        )
         fut.result()
 
 class LocalDiskBackend(StorageBackendInterface):

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -42,6 +42,7 @@ class LocalDiskWorker:
 
         # TODO(Jiayi): make executor and its parameters configurable
         self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=4)
+        self.loop = loop
 
     async def submit_task(
         self,
@@ -83,8 +84,9 @@ class LocalDiskWorker:
             return key in self.put_tasks
 
     def close(self):
-        self.executor.shutdown()
-
+        # Gracefully shut down the executor
+        fut = asyncio.run_coroutine_threadsafe(self.executor.shutdown(wait=True), self.loop)
+        fut.result()
 
 class LocalDiskBackend(StorageBackendInterface):
     def __init__(
@@ -558,3 +560,5 @@ class LocalDiskBackend(StorageBackendInterface):
             keys = list(self.dict.keys())
         if keys:
             super()._on_evict(keys)
+        # Close worker executor
+        self.disk_worker.close()

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -43,6 +43,7 @@ class LocalDiskWorker:
         # TODO(Jiayi): make executor and its parameters configurable
         self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=4)
         self.loop = loop
+        self._closed = False
 
     async def submit_task(
         self,
@@ -85,10 +86,10 @@ class LocalDiskWorker:
 
     def close(self):
         # Gracefully shut down the executor
-        fut = asyncio.run_coroutine_threadsafe(
-            self.executor.shutdown(wait=True), self.loop
-        )
-        fut.result()
+        if self._closed:
+            return
+        self._closed = True
+        self.executor.shutdown(wait=True)
 
 class LocalDiskBackend(StorageBackendInterface):
     def __init__(

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -386,6 +386,37 @@ class RemoteBackend(StorageBackendInterface):
         )
         return decompressed_memory_objs
 
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        num_hit_counts = 0
+        if self.connection is None:
+            logger.warning("Connection is None in batched_async_contains, returning 0")
+            return 0
+        if self._mla_worker_id_as0_mode:
+            keys = [
+                CacheEngineKey(
+                    key.fmt,
+                    key.model_name,
+                    key.world_size,
+                    0,
+                    key.chunk_hash,
+                    key.request_configs,
+                )
+                for key in keys
+            ]
+        
+        try:
+            assert self.connection.support_batched_async_contains(), \
+                f"Connector {self.connection} does not support batched async contains"
+            return await self.connection.batched_async_contains(lookup_id, keys, pin)
+        except Exception as e:
+            logger.warning(f"Error occurred in batched_async_contains: {e}")
+
+
     def pin(self, key: CacheEngineKey) -> bool:
         logger.debug(
             "Remote backend does not support pin. "

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -386,13 +386,18 @@ class RemoteBackend(StorageBackendInterface):
         )
         return decompressed_memory_objs
 
+    async def support_batched_async_contains(self) -> bool:
+        return (
+            self.connection is not None
+            and self.connection.support_batched_async_contains()
+        )
+
     async def batched_async_contains(
         self,
         lookup_id: str,
         keys: list[CacheEngineKey],
         pin: bool = False,
     ) -> int:
-        num_hit_counts = 0
         if self.connection is None:
             logger.warning("Connection is None in batched_async_contains, returning 0")
             return 0
@@ -408,14 +413,33 @@ class RemoteBackend(StorageBackendInterface):
                 )
                 for key in keys
             ]
-        
+
         try:
-            assert self.connection.support_batched_async_contains(), \
+            assert self.connection.support_batched_async_contains(), (
                 f"Connector {self.connection} does not support batched async contains"
+            )
             return await self.connection.batched_async_contains(lookup_id, keys, pin)
         except Exception as e:
             logger.warning(f"Error occurred in batched_async_contains: {e}")
+            return 0
 
+    async def support_batched_get_non_blocking(self) -> bool:
+        return (
+            self.connection is not None
+            and self.connection.support_batched_get_non_blocking()
+        )
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
+        if self.connection is None:
+            logger.warning(
+                "Connection is None in batched_get_non_blocking, returning empty list"
+            )
+            return []
+        return await self.connection.batched_get_non_blocking(lookup_id, keys)
 
     def pin(self, key: CacheEngineKey) -> bool:
         logger.debug(

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -116,14 +116,10 @@ class RemoteMonitor:
                         if self.original_connector is None:
                             continue
                         if not self.original_connector.support_ping():
-                            try:
-                                logger.info(
-                                    f"Connector {self.original_connector} "
-                                    "does not support ping, break RemoteMonitor thread."
-                                )
-                            except (ValueError, OSError):
-                                # Stream closed during teardown, ignore
-                                pass
+                            logger.info(
+                                f"Connector {self.original_connector} "
+                                "does not support ping, break RemoteMonitor thread."
+                            )
                             break
 
             try:

--- a/lmcache/v1/storage_backend/remote_monitor.py
+++ b/lmcache/v1/storage_backend/remote_monitor.py
@@ -116,10 +116,14 @@ class RemoteMonitor:
                         if self.original_connector is None:
                             continue
                         if not self.original_connector.support_ping():
-                            logger.info(
-                                f"Connector {self.original_connector} "
-                                "does not support ping, break RemoteMonitor thread."
-                            )
+                            try:
+                                logger.info(
+                                    f"Connector {self.original_connector} "
+                                    "does not support ping, break RemoteMonitor thread."
+                                )
+                            except (ValueError, OSError):
+                                # Stream closed during teardown, ignore
+                                pass
                             break
 
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch==2.7.1",
+    "torch==2.8.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Side-Effect of this PR: bump stable wheel (and docker image) torch version to 2.8.0 (since vllm has as well) 

# Benchmarking Results: 

## Mock Config
```yaml
# example.yaml
chunk_size: 256
local_cpu: False
max_local_cpu_size: 80
enable_async_loading: True
remote_url: "mock://100/?peeking_latency=0&read_throughput=0.5&write_throughput=2"
```

## Deploy
```bash
# mxfp4 quantized by default
LMCACHE_ENABLE_ASYNC_LOADING=True \
PYTHONHASHSEED=0 \
LMCACHE_CONFIG_FILE=example.yaml \
  vllm serve openai/gpt-oss-120b \
  --kv-transfer-config \
  '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' \
  --disable-log-requests \
  --disable-hybrid-kv-cache-manager \
  --tensor-parallel-size 4 \
  --load-format dummy \
  --no-enable-prefix-caching
  ```
  
## Before Async Request-level loading: 
```text
=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 2.784s
Warmup round time: 111.178s
Warmup round prompt count: 50
Query round mean TTFT: 2.525s
Query round time: 58.486s
Query round prompt count: 50
```

<img width="540" height="296" alt="Screenshot 2025-09-09 at 2 03 02 PM" src="https://github.com/user-attachments/assets/f4820eba-424a-4c12-832b-909aca99d6de" />


## After Async Request-level loading: 
```text
=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 2.912s
Warmup round time: 113.024s
Warmup round prompt count: 50
Query round mean TTFT: 1.181s
Query round time: 36.150s
Query round prompt count: 50
```

<img width="512" height="299" alt="Screenshot 2025-09-09 at 2 03 16 PM" src="https://github.com/user-attachments/assets/4067b7de-a2ad-44e0-b229-982364d18b1c" />
