### PR TITLE
[MISC] Print version info while lmcache started 

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -21,9 +21,11 @@ from vllm.distributed.parallel_state import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils import cdiv, get_kv_cache_torch_dtype
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.version import __version__ as VLLM_VERSION
 import torch
 
 # First Party
+from lmcache import utils
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
@@ -641,6 +643,12 @@ class LMCacheConnectorV1Impl:
             else self.lmcache_engine.metadata.worker_id,
         )
         self.plugin_launcher.launch_plugins()
+        logger.info(
+            f"LMCache initialized for role {role} with version {utils.get_version()}, "
+            f"vllm version {VLLM_VERSION}, "
+            "lmcache cache_engine metadata: "
+            f"{getattr(self.lmcache_engine, 'metadata', None)}"
+        )
 
     @_lmcache_nvtx_annotate
     def _init_kv_caches_from_forward_context(self, forward_context: "ForwardContext"):

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -39,6 +39,22 @@ logger = init_logger(__name__)
 # Type definition
 KVCache = Tuple[Tuple[torch.Tensor, torch.Tensor], ...]
 
+try:
+    # First Party
+    from lmcache import _version  # type: ignore[attr-defined]
+
+    VERSION = getattr(_version, "__version__", "")
+    COMMIT_ID = getattr(_version, "__commit_id__", "")
+except ImportError:
+    VERSION = ""
+    COMMIT_ID = ""
+
+
+def get_version():
+    version_display = VERSION if VERSION else "NA"
+    commit_id_display = COMMIT_ID if COMMIT_ID else "NA"
+    return f"{version_display}-{commit_id_display}"
+
 
 @dataclass
 class DiskCacheMetadata:

--- a/lmcache/v1/internal_api_server/version_api.py
+++ b/lmcache/v1/internal_api_server/version_api.py
@@ -4,33 +4,22 @@
 # Third Party
 from fastapi import APIRouter
 
+# First Party
+from lmcache import utils
+
 router = APIRouter()
-
-try:
-    # First Party
-    from lmcache import _version  # type: ignore[attr-defined]
-
-    VERSION = getattr(_version, "__version__", "")
-    COMMIT_ID = getattr(_version, "__commit_id__", "")
-except ImportError:
-    VERSION = ""
-    COMMIT_ID = ""
 
 
 @router.get("/lmc_version")
 async def get_lmc_version():
-    return VERSION
+    return utils.VERSION
 
 
 @router.get("/commit_id")
 async def get_commit_id():
-    return COMMIT_ID
+    return utils.COMMIT_ID
 
 
 @router.get("/version")
 async def get_version():
-    version = await get_lmc_version()
-    commit_id = await get_commit_id()
-    version_display = version if version else "NA"
-    commit_id_display = commit_id if commit_id else "NA"
-    return f"{version_display}-{commit_id_display}"
+    return utils.get_version()


### PR DESCRIPTION
# Motivation
With this log, we can clearly get the lmcache and vllm version information.

# Changes
- Do refactor, abstract version related code to `utils` for reuse purpose
- Print a log in the end of the constructor of `LMCacheConnectorV1Impl`

# Log sample
```
(VllmWorker rank=0 pid=2459502) [2025-09-10 11:43:47,687] LMCache INFO: LMCache initialized for role KVConnectorRole.WORKER with version 0.3.4.dev123-g0c8ca6fe9, vllm version 0.10.0, lmcache cache_engine metadata: LMCacheEngineMetadata(model_name='/data1/DeepSeek-V2-Lite-Chat', world_size=2, worker_id=0, fmt='vllm', kv_dtype=torch.bfloat16, kv_shape=(27, 1, 64, 1, 576), use_mla=True) (vllm_v1_adapter.py:646:lmcache.integration.vllm.vllm_v1_adapter)
```