### PR TITLE
Optimized token chunking with PyTorch's unfold instead of loop slicing.

### DIFF
--- a/lmcache/cache_engine.py
+++ b/lmcache/cache_engine.py
@@ -86,10 +86,23 @@ class LMCacheEngine:
         :return: a generator of chunks of tokens, each with
                 shape [chunk_size]
         """
-        # TODO(Jiayi): the following step can be parallelized
+        # Use PyTorch's unfold method for vectorized chunking
         tokens = tokens.cpu()
-        for i in range(0, len(tokens), self.chunk_size):
-            yield tokens[i : i + self.chunk_size]
+        chunk_size = self.chunk_size
+        num_tokens = len(tokens)
+
+        # Calculate the number of complete chunks
+        num_complete_chunks = num_tokens // chunk_size
+
+        if num_complete_chunks > 0:
+            # Create a view using unfold to avoid data duplication
+            complete_tokens = tokens[: num_complete_chunks * chunk_size]
+            chunks = complete_tokens.unfold(0, chunk_size, chunk_size)
+            yield from chunks
+
+        # Handle the last incomplete chunk if it exists
+        if num_tokens % chunk_size > 0:
+            yield tokens[num_complete_chunks * chunk_size :]
 
     def _prefix_hash(
         self,


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

Optimized token chunking with PyTorch's unfold instead of loop slicing.

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

### Test Result
```
Test device: cuda | Chunk size: 1000 | Each test repeated 5 times
--------------------------------------------------------------------------------------------------------------
Data size    | Original loop(ms)  | Thread parallel(ms)  | Unfold vectorization(ms)   | Unfold speedup(x)
--------------------------------------------------------------------------------------------------------------
10,000       | 0.2251             | 1.3868               | 0.1292                     | 1.74
100,000      | 0.6119             | 8.8817               | 0.4746                     | 1.29
500,000      | 3.1143             | 13.6714              | 1.9103                     | 1.63
1,000,000    | 5.6594             | 32.7118              | 3.7168                     | 1.52
```

### Test_vs.py
```
import torch
import time
from concurrent.futures import ThreadPoolExecutor
from typing import Iterable

class TokenChunkBenchmark:
    def __init__(self, chunk_size: int = 1000):
        self.chunk_size = chunk_size

    # 1. Original loop chunking
    def chunk_original(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
        tokens = tokens.cpu()
        for i in range(0, len(tokens), self.chunk_size):
            yield tokens[i:i + self.chunk_size]

    # 2. Thread pool parallel chunking
    def _get_chunk(self, tokens: torch.Tensor, start_idx: int) -> torch.Tensor:
        return tokens[start_idx:start_idx + self.chunk_size]
    
    def chunk_parallel(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
        tokens = tokens.cpu()
        total = len(tokens)
        start_indices = range(0, total, self.chunk_size)
        
        with ThreadPoolExecutor() as executor:
            for chunk in executor.map(self._get_chunk, [tokens]*len(start_indices), start_indices):
                yield chunk

    # 3. Unfold vectorization chunking
    def chunk_unfold(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
        tokens = tokens.cpu()
        chunk_size = self.chunk_size
        num_tokens = len(tokens)

        # Calculate the number of complete chunks
        num_complete_chunks = num_tokens // chunk_size

        if num_complete_chunks > 0:
            # Create a view using unfold to avoid data duplication
            complete_tokens = tokens[: num_complete_chunks * chunk_size]
            chunks = complete_tokens.unfold(0, chunk_size, chunk_size)
            yield from chunks

        # Handle the last incomplete chunk if it exists
        if num_tokens % chunk_size > 0:
            yield tokens[num_complete_chunks * chunk_size :]

    # Main benchmark function
    def run_benchmark(self, token_lengths: list = None, repeat: int = 5):
        if token_lengths is None:
            token_lengths = [10_000, 100_000, 500_000, 1_000_000]  # Test different scales
        
        # Use GPU if available
        device = "cuda" if torch.cuda.is_available() else "cpu"
        print(f"Test device: {device} | Chunk size: {self.chunk_size} | Each test repeated {repeat} times")
        print("-" * 110)
        print(f"{'Data size':<12} | {'Original loop(ms)':<18} | {'Thread parallel(ms)':<20} | {'Unfold vectorization(ms)':<26} | {'Unfold speedup(x)'}")
        print("-" * 110)
        
        for length in token_lengths:
            # Generate test data
            tokens = torch.randint(0, 10000, (length,), device=device)
            
            # Test original loop
            start = time.perf_counter()
            for _ in range(repeat):
                list(self.chunk_original(tokens))  # Convert to list to ensure execution
            original_time = (time.perf_counter() - start) / repeat * 1000  # Convert to milliseconds
            
            # Test thread parallel
            start = time.perf_counter()
            for _ in range(repeat):
                list(self.chunk_parallel(tokens))
            parallel_time = (time.perf_counter() - start) / repeat * 1000
            
            # Test unfold vectorization
            start = time.perf_counter()
            for _ in range(repeat):
                list(self.chunk_unfold(tokens))
            unfold_time = (time.perf_counter() - start) / repeat * 1000
            
            # Calculate speedup of unfold vs original loop
            speedup = original_time / unfold_time
            
            # Print results
            print(f"{length:<12,} | {original_time:<18.4f} | {parallel_time:<20.4f} | {unfold_time:<26.4f} | {speedup:.2f}")

if __name__ == "__main__":
    # Initialize tester with chunk size
    benchmark = TokenChunkBenchmark(chunk_size=1000)
    # Run benchmark with different data scales
    benchmark.run_benchmark()
```


---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
