### PR TITLE
[Core] Support NIXL storage obj backend

### DIFF
--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -35,13 +35,13 @@ Example ``lmcache-config.yaml``:
     nixl_buffer_size: 1073741824 # 1GB
     nixl_buffer_device: cpu
     extra_config: {enable_nixl_storage: true, nixl_backend: POSIX, \
-                   nixl_file_pool_size: 64, nixl_path: /mnt/nixl/cache/}
+                   nixl_pool_size: 64, nixl_path: /mnt/nixl/cache/}
 
 Key settings:
 
 - ``nixl_buffer_size``: buffer size for NIXL transfers.
 
-- ``nixl_file_pool_size``: number of files opened at init time for nixl backend.
+- ``nixl_pool_size``: number of descriptors opened at init time for nixl backend.
 
 - ``nixl_path``: directory under which the storage files will be saved (e.g. /mnt/nixl/). Needed for NIXL backends that store to file.
 

--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -27,15 +27,18 @@ Passed in through ``LMCACHE_CONFIG_FILE=lmcache-config.yaml``
 
 ``LMCACHE_USE_EXPERIMENTAL`` MUST be set.
 
-Example ``lmcache-config.yaml``:
+Example ``lmcache-config.yaml`` for POSIX backend:
 
 .. code-block:: yaml
 
     chunk_size: 256
     nixl_buffer_size: 1073741824 # 1GB
     nixl_buffer_device: cpu
-    extra_config: {enable_nixl_storage: true, nixl_backend: POSIX, \
-                   nixl_pool_size: 64, nixl_path: /mnt/nixl/cache/}
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: POSIX
+      nixl_pool_size: 64
+      nixl_path: /mnt/nixl/cache/
 
 Key settings:
 
@@ -45,6 +48,30 @@ Key settings:
 
 - ``nixl_path``: directory under which the storage files will be saved (e.g. /mnt/nixl/). Needed for NIXL backends that store to file.
 
-- ``nixl_backend``: configuration of which nixl backend to use for storage. Options are: ["GDS", "GDS_MT", "POSIX", "HF3FS"].
+- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS" and "GDS_MT" backends - for "POSIX", "HF3FS" & "OBJ", must be "cpu".
 
-- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS" and "GDS_MT" backends - for "POSIX" and "HF3FS", must be "cpu".
+- ``nixl_backend``: configuration of which nixl backend to use for storage.
+
+  .. note::
+
+    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ"].
+
+    Backend specific params should be provided via ``extra_config.nixl_backend_params``. Please refer to NIXL documentation for specifics.
+
+Example ``lmcache-config.yaml`` for OBJ backend using S3 API:
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    nixl_buffer_size: 1073741824 # 1GB
+    nixl_buffer_device: cpu
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: OBJ
+      nixl_pool_size: 64
+      nixl_path: /mnt/nixl/cache/
+      nixl_backend_params:
+        access_key: <your_access_key>
+        secret_key: <your_secret_key>
+        bucket: <your_bucket>
+        region: <your_region>

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -501,8 +501,7 @@ def _validate_config(self):
 
     if enable_nixl_storage:
         assert self.extra_config.get("nixl_backend") is not None
-        assert self.extra_config.get("nixl_path") is not None
-        assert self.extra_config.get("nixl_file_pool_size") is not None
+        assert self.extra_config.get("nixl_pool_size") is not None
         assert self.nixl_buffer_size is not None
         assert self.nixl_buffer_device is not None
 

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -62,7 +62,7 @@ class NixlStorageConfig:
     def validate_nixl_backend(backend: str, device: str):
         if backend in ("GDS", "GDS_MT"):
             return device == "cpu" or device == "cuda"
-        elif backend in ("POSIX", "HF3FS"):
+        elif backend in ("POSIX", "HF3FS", "OBJ"):
             return device == "cpu"
         else:
             return False

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 # Standard
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, List, Optional, Sequence, Set, cast
 import asyncio
@@ -51,7 +52,7 @@ logger = init_logger(__name__)
 @dataclass
 class NixlStorageConfig:
     buffer_size: int
-    file_pool_size: int
+    pool_size: int
     buffer_device: str
     path: str
     backend: str
@@ -75,12 +76,16 @@ class NixlStorageConfig:
         extra_config = config.extra_config
         assert extra_config is not None
         assert extra_config.get("enable_nixl_storage")
-        assert extra_config.get("nixl_backend") is not None
-        assert extra_config.get("nixl_path") is not None
-        assert extra_config.get("nixl_file_pool_size") is not None
+
+        pool_size = extra_config.get("nixl_pool_size")
+        backend = extra_config.get("nixl_backend")
+        path = extra_config.get("nixl_path")
+
+        assert pool_size is not None
+        assert backend is not None
 
         assert NixlStorageConfig.validate_nixl_backend(
-            extra_config.get("nixl_backend"), config.nixl_buffer_device
+            backend, config.nixl_buffer_device
         ), "Invalid NIXL backend & device combination"
 
         corrected_device = get_correct_device(
@@ -89,25 +94,20 @@ class NixlStorageConfig:
 
         return NixlStorageConfig(
             buffer_size=config.nixl_buffer_size,
-            file_pool_size=extra_config.get("nixl_file_pool_size"),
+            pool_size=pool_size,
             buffer_device=corrected_device,
-            path=extra_config.get("nixl_path"),
-            backend=extra_config.get("nixl_backend"),
+            path=path,
+            backend=backend,
         )
 
 
-class NixlFilePool:
-    def __init__(self, path: str, size: int):
+class NixlDescPool(ABC):
+    def __init__(self, size: int):
         self.lock = threading.Lock()
         self.size: int = size
-        self.fds: List[int] = []
         self.indices: List[int] = []
 
-        for i in reversed(range(size)):
-            tmp_path = path + f"obj_{i}_{uuid.uuid4().hex[0:4]}.bin"
-            fd = os.open(tmp_path, os.O_CREAT | os.O_RDWR)
-            self.fds.append(fd)
-            self.indices.append(i)
+        self.indices.extend(reversed(range(size)))
 
     def pop(self) -> int:
         with self.lock:
@@ -119,6 +119,24 @@ class NixlFilePool:
             assert len(self.indices) < self.size
             self.indices.append(index)
 
+    @abstractmethod
+    def close(self):
+        pass
+
+
+class NixlFilePool(NixlDescPool):
+    def __init__(self, size: int, path: str):
+        super().__init__(size)
+        self.fds: List[int] = []
+
+        assert path is not None
+
+        for i in reversed(range(size)):
+            filename = f"obj_{i}_{uuid.uuid4().hex[0:4]}.bin"
+            tmp_path = os.path.join(path, filename)
+            fd = os.open(tmp_path, os.O_CREAT | os.O_RDWR)
+            self.fds.append(fd)
+
     def close(self):
         # TODO: do we need to delete the files?
         with self.lock:
@@ -127,21 +145,34 @@ class NixlFilePool:
                 os.close(fd)
 
 
+class NixlObjectPool(NixlDescPool):
+    def __init__(self, size: int):
+        super().__init__(size)
+        self.keys: List[str] = []
+
+        for i in reversed(range(size)):
+            key = f"obj_{i}_{uuid.uuid4().hex[0:4]}"
+            self.keys.append(key)
+
+    def close(self):
+        pass
+
+
 class NixlStorageAgent:
     agent_name: str
     nixl_agent: NixlAgent
-    file_pool: NixlFilePool
-    reg_descs: nixlBind.nixlRegDList
-    file_reg_descs: nixlBind.nixlRegDList
-    xfer_descs: nixlBind.nixlXferDList
-    file_xfer_descs: nixlBind.nixlXferDList
-    xfer_handler: NixlDlistHandle
-    file_xfer_handler: NixlDlistHandle
+    pool: NixlDescPool
+    mem_reg_descs: nixlBind.nixlRegDList
+    storage_reg_descs: nixlBind.nixlRegDList
+    mem_xfer_descs: nixlBind.nixlXferDList
+    storage_xfer_descs: nixlBind.nixlXferDList
+    mem_xfer_handler: NixlDlistHandle
+    storage_xfer_handler: NixlDlistHandle
 
     def __init__(
         self,
         allocator: PagedTensorMemoryAllocator,
-        file_pool: NixlFilePool,
+        pool: NixlDescPool,
         device: str,
         backend: str,
     ):
@@ -154,11 +185,16 @@ class NixlStorageAgent:
         self.nixl_agent = NixlAgent(self.agent_name, nixl_conf)
 
         device_id = torch.cuda.current_device()
-        self.init_handlers(device, buffer_ptr, buffer_size, page_size, device_id)
+        self.init_mem_handlers(device, buffer_ptr, buffer_size, page_size, device_id)
 
-        self.init_file_handlers(page_size, file_pool.fds)
+        if isinstance(pool, NixlFilePool):
+            self.init_storage_handlers_file(page_size, pool.fds)
+        elif isinstance(pool, NixlObjectPool):
+            self.init_storage_handlers_object(page_size, pool.keys)
+        else:
+            raise TypeError(f"Unsupported pool type: {type(pool).__name__}")
 
-    def init_handlers(self, device, buffer_ptr, buffer_size, page_size, device_id):
+    def init_mem_handlers(self, device, buffer_ptr, buffer_size, page_size, device_id):
         reg_list = [(buffer_ptr, buffer_size, device_id, "")]
         xfer_desc = [
             (base_addr, page_size, device_id)
@@ -176,35 +212,58 @@ class NixlStorageAgent:
             "", xfer_descs, mem_type=mem_type
         )
 
-        self.reg_descs = reg_descs
-        self.xfer_descs = xfer_descs
-        self.xfer_handler = xfer_handler
+        self.mem_reg_descs = reg_descs
+        self.mem_xfer_descs = xfer_descs
+        self.mem_xfer_handler = xfer_handler
 
-    def init_file_handlers(self, page_size, fds):
-        reg_list = [(0, page_size, fd, "") for fd in fds]
-        xfer_desc = [(0, page_size, fd) for fd in fds]
+    def init_storage_handlers_file(self, page_size, fds):
+        reg_list = []
+        xfer_desc = []
+        for fd in fds:
+            reg_list.append((0, page_size, fd, ""))
+            xfer_desc.append((0, page_size, fd))
         reg_descs = self.nixl_agent.register_memory(reg_list, mem_type="FILE")
         xfer_descs = self.nixl_agent.get_xfer_descs(xfer_desc, mem_type="FILE")
         xfer_handler = self.nixl_agent.prep_xfer_dlist(
             self.agent_name, xfer_desc, mem_type="FILE"
         )
 
-        self.file_reg_descs = reg_descs
-        self.file_xfer_descs = xfer_descs
-        self.file_xfer_handler = xfer_handler
+        self.storage_reg_descs = reg_descs
+        self.storage_xfer_descs = xfer_descs
+        self.storage_xfer_handler = xfer_handler
 
-    def get_gpu_to_file_handle(self, mem_indices, file_indices) -> NixlXferHandle:
-        return self.nixl_agent.make_prepped_xfer(
-            "WRITE",
-            self.xfer_handler,
-            mem_indices,
-            self.file_xfer_handler,
-            file_indices,
+    def init_storage_handlers_object(self, page_size, keys):
+        reg_list = []
+        xfer_desc = []
+        for i, key in enumerate(keys):
+            reg_list.append((0, page_size, i, key))
+            xfer_desc.append((0, page_size, i))
+        reg_descs = self.nixl_agent.register_memory(reg_list, mem_type="OBJ")
+        xfer_descs = self.nixl_agent.get_xfer_descs(xfer_desc, mem_type="OBJ")
+        xfer_handler = self.nixl_agent.prep_xfer_dlist(
+            self.agent_name, xfer_desc, mem_type="OBJ"
         )
 
-    def get_file_to_gpu_handle(self, mem_indices, file_indices) -> NixlXferHandle:
+        self.storage_reg_descs = reg_descs
+        self.storage_xfer_descs = xfer_descs
+        self.storage_xfer_handler = xfer_handler
+
+    def get_mem_to_storage_handle(self, mem_indices, storage_indices) -> NixlXferHandle:
         return self.nixl_agent.make_prepped_xfer(
-            "READ", self.xfer_handler, mem_indices, self.file_xfer_handler, file_indices
+            "WRITE",
+            self.mem_xfer_handler,
+            mem_indices,
+            self.storage_xfer_handler,
+            storage_indices,
+        )
+
+    def get_storage_to_mem_handle(self, mem_indices, storage_indices) -> NixlXferHandle:
+        return self.nixl_agent.make_prepped_xfer(
+            "READ",
+            self.mem_xfer_handler,
+            mem_indices,
+            self.storage_xfer_handler,
+            storage_indices,
         )
 
     def post_blocking(self, handle: NixlXferHandle):
@@ -219,10 +278,10 @@ class NixlStorageAgent:
         self.nixl_agent.release_xfer_handle(handle)
 
     def close(self):
-        self.nixl_agent.release_dlist_handle(self.file_xfer_handler)
-        self.nixl_agent.release_dlist_handle(self.xfer_handler)
-        self.nixl_agent.deregister_memory(self.file_reg_descs)
-        self.nixl_agent.deregister_memory(self.reg_descs)
+        self.nixl_agent.release_dlist_handle(self.storage_xfer_handler)
+        self.nixl_agent.release_dlist_handle(self.mem_xfer_handler)
+        self.nixl_agent.deregister_memory(self.storage_reg_descs)
+        self.nixl_agent.deregister_memory(self.mem_reg_descs)
 
 
 class NixlStorageBackend(AllocatorBackendInterface):
@@ -232,6 +291,15 @@ class NixlStorageBackend(AllocatorBackendInterface):
     Currently, the put is synchronized and blocking, to simplify the
     implementation.
     """
+
+    @staticmethod
+    def createPool(backend: str, size: int, path: str):
+        if backend in ("GDS", "GDS_MT", "POSIX", "HF3FS"):
+            return NixlFilePool(size, path)
+        elif backend in ("OBJ"):
+            return NixlObjectPool(size)
+        else:
+            raise ValueError(f"Unsupported NIXL backend: {backend}")
 
     def __init__(
         self,
@@ -257,11 +325,14 @@ class NixlStorageBackend(AllocatorBackendInterface):
 
         self.memory_allocator = self.initialize_allocator(config, metadata)
 
-        self.file_pool = NixlFilePool(nixl_config.path, nixl_config.file_pool_size)
+        self.pool = NixlStorageBackend.createPool(
+            nixl_config.backend, nixl_config.pool_size, nixl_config.path
+        )
+        assert self.pool is not None
 
         self.agent = NixlStorageAgent(
             self.memory_allocator,
-            self.file_pool,
+            self.pool,
             nixl_config.buffer_device,
             nixl_config.backend,
         )
@@ -307,18 +378,18 @@ class NixlStorageBackend(AllocatorBackendInterface):
                 address=index,
             )
 
-    async def gpu_to_file(
+    async def mem_to_storage(
         self, keys: Sequence[CacheEngineKey], mem_objs: List[MemoryObj]
     ) -> None:
         mem_indices = [mem_obj.meta.address for mem_obj in mem_objs]
 
-        file_indices = []
+        storage_indices = []
         for i in range(len(keys)):
-            index = self.file_pool.pop()
-            file_indices.append(index)
+            index = self.pool.pop()
+            storage_indices.append(index)
             self.add_key_to_dict(keys[i], mem_objs[i].meta, index)
 
-        handle = self.agent.get_gpu_to_file_handle(mem_indices, file_indices)
+        handle = self.agent.get_mem_to_storage_handle(mem_indices, storage_indices)
         self.agent.post_blocking(handle)
         self.agent.release_handle(handle)
 
@@ -326,12 +397,12 @@ class NixlStorageBackend(AllocatorBackendInterface):
             with self.progress_lock:
                 self.progress_set.discard(key.chunk_hash)
 
-    async def file_to_gpu(
+    async def storage_to_mem(
         self, keys: list[CacheEngineKey]
     ) -> list[Optional[MemoryObj]]:
         obj_list: list[Optional[MemoryObj]] = []
         mem_indices = []
-        file_indices = []
+        storage_indices = []
         with self.key_lock:
             for key in keys:
                 metadata = self.key_dict.get(key.chunk_hash)
@@ -352,12 +423,12 @@ class NixlStorageBackend(AllocatorBackendInterface):
                 obj_list.append(obj)
 
                 mem_indices.append(obj.metadata.address)
-                file_indices.append(metadata.address)
+                storage_indices.append(metadata.address)
 
         if not mem_indices:
             return obj_list
 
-        handle = self.agent.get_file_to_gpu_handle(mem_indices, file_indices)
+        handle = self.agent.get_storage_to_mem_handle(mem_indices, storage_indices)
         self.agent.post_blocking(handle)
         self.agent.release_handle(handle)
 
@@ -373,7 +444,9 @@ class NixlStorageBackend(AllocatorBackendInterface):
             for key in keys:
                 self.progress_set.add(key.chunk_hash)
 
-        asyncio.run_coroutine_threadsafe(self.gpu_to_file(keys, memory_objs), self.loop)
+        asyncio.run_coroutine_threadsafe(
+            self.mem_to_storage(keys, memory_objs), self.loop
+        )
 
     def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """
@@ -384,7 +457,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
         :return: MemoryObj. None if the key does not exist.
         """
 
-        future = asyncio.run_coroutine_threadsafe(self.file_to_gpu([key]), self.loop)
+        future = asyncio.run_coroutine_threadsafe(self.storage_to_mem([key]), self.loop)
 
         if future is None:
             return None
@@ -398,7 +471,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
         keys: list[CacheEngineKey],
         transfer_spec: Any = None,
     ) -> list[MemoryObj]:
-        obj_list = await self.file_to_gpu(keys)
+        obj_list = await self.storage_to_mem(keys)
         assert None not in obj_list
         return cast(list[MemoryObj], obj_list)
 
@@ -414,7 +487,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
             if metadata is None:
                 return False
 
-        self.file_pool.push(metadata.address)
+        self.pool.push(metadata.address)
         return True
 
     def pin(self, key: CacheEngineKey) -> bool:
@@ -429,7 +502,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
         """
         self.agent.close()
 
-        self.file_pool.close()
+        self.pool.close()
 
         self.memory_allocator.close()
 

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -56,6 +56,7 @@ class NixlStorageConfig:
     buffer_device: str
     path: str
     backend: str
+    backend_params: dict[str, str]
 
     @staticmethod
     def validate_nixl_backend(backend: str, device: str):
@@ -88,6 +89,10 @@ class NixlStorageConfig:
             backend, config.nixl_buffer_device
         ), "Invalid NIXL backend & device combination"
 
+        backend_params = extra_config.get("nixl_backend_params")
+        if backend_params is None:
+            backend_params = {}
+
         corrected_device = get_correct_device(
             config.nixl_buffer_device, metadata.worker_id
         )
@@ -98,6 +103,7 @@ class NixlStorageConfig:
             buffer_device=corrected_device,
             path=path,
             backend=backend,
+            backend_params=backend_params,
         )
 
 
@@ -175,14 +181,16 @@ class NixlStorageAgent:
         pool: NixlDescPool,
         device: str,
         backend: str,
+        backend_params: dict[str, str],
     ):
         buffer_ptr = allocator.buffer_ptr
         buffer_size = allocator.buffer_size
         page_size = allocator.align_bytes
 
         self.agent_name = "NixlAgent_" + str(uuid.uuid4())
-        nixl_conf = NixlAgentConfig(backends=[backend])
+        nixl_conf = NixlAgentConfig(backends=[])
         self.nixl_agent = NixlAgent(self.agent_name, nixl_conf)
+        self.nixl_agent.create_backend(backend, backend_params)
 
         device_id = torch.cuda.current_device()
         self.init_mem_handlers(device, buffer_ptr, buffer_size, page_size, device_id)
@@ -335,6 +343,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
             self.pool,
             nixl_config.buffer_device,
             nixl_config.backend,
+            nixl_config.backend_params,
         )
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:

--- a/tests/v1/data/nixl.yaml
+++ b/tests/v1/data/nixl.yaml
@@ -3,4 +3,4 @@ chunk_size: 256
 
 nixl_buffer_size: 1073741824
 nixl_buffer_device: cpu
-extra_config: {enable_nixl_storage: true, nixl_backend: POSIX, nixl_file_pool_size: 64, nixl_path: /tmp/nixl/cache/}
+extra_config: {enable_nixl_storage: true, nixl_backend: POSIX, nixl_pool_size: 64, nixl_path: /tmp/nixl/cache/}

--- a/tests/v1/data/nixl.yaml
+++ b/tests/v1/data/nixl.yaml
@@ -3,4 +3,8 @@ chunk_size: 256
 
 nixl_buffer_size: 1073741824
 nixl_buffer_device: cpu
-extra_config: {enable_nixl_storage: true, nixl_backend: POSIX, nixl_pool_size: 64, nixl_path: /tmp/nixl/cache/}
+extra_config:
+  enable_nixl_storage: true
+  nixl_backend: POSIX
+  nixl_pool_size: 64
+  nixl_path: /tmp/nixl/cache


### PR DESCRIPTION
    Support NIXL obj backend
    
    Adding support for NIXL obj backend.
    
    in order to use this backend, AWS parameters should be provided via
    extra_config.nixl_backend_params in the yaml file, for example:
    
    extra_config:
      enable_nixl_storage: true
      nixl_backend: OBJ
      nixl_pool_size: 64
      nixl_path: /mnt/nixl/cache/
      nixl_backend_params:
        access_key: <your_access_key>
        secret_key: <your_secret_key>
        bucket: <your_bucket>
        region: <your_region>