### PR TITLE
[Core] fix nixl_storage_backend assert

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -47,7 +47,6 @@ from lmcache.v1.memory_management import (  # noqa: E501
     MemoryObjMetadata,
     MixedMemoryAllocator,
     NixlCPUMemoryAllocator,
-    PagedTensorMemoryAllocator,
     TensorMemoryObj,
 )
 from lmcache.v1.storage_backend.storage_manager import StorageManager
@@ -1368,25 +1367,16 @@ class LMCacheEngineBuilder:
                 metadata.worker_id,
             )
 
-            buffer = torch.empty(
-                config.nixl_buffer_size,
-                dtype=torch.uint8,
-                device=corrected_device,
-            )
-
-            if corrected_device == "cpu":
-                torch.cuda.cudart().cudaHostRegister(
-                    buffer.data_ptr(), config.nixl_buffer_size, 0
-                )
-            else:
+            if corrected_device != "cpu":
                 logger.info(f"Setting cuda device to {corrected_device} ")
                 torch.cuda.set_device(corrected_device)
 
-            return PagedTensorMemoryAllocator(
-                buffer,
-                torch.Size(metadata.kv_shape),
-                metadata.kv_dtype,
-                MemoryFormat.KV_2LTD,
+            return MixedMemoryAllocator(
+                size=config.nixl_buffer_size,
+                use_paging=True,
+                shape=torch.Size(metadata.kv_shape),
+                dtype=metadata.kv_dtype,
+                fmt=MemoryFormat.KV_2LTD,
             )
 
         if config.weka_path is not None or config.gds_path is not None:

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1464,24 +1464,29 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
         """
 
         self.numa_mapping = kwargs.get("numa_mapping", None)
+        self.device = kwargs.get("device", None)
 
         self.size = size
 
-        if self.numa_mapping:
-            current_device_id = torch.cuda.current_device()
-            gpu_to_numa_mapping = self.numa_mapping.gpu_to_numa_mapping
-            assert current_device_id in gpu_to_numa_mapping, (
-                f"Current device {current_device_id} is not in the GPU NUMA mapping."
-            )
-            numa_id = gpu_to_numa_mapping[current_device_id]
-            ptr = lmc_ops.alloc_pinned_numa_ptr(size, numa_id)
+        if self.device == "cpu":
+            self.buffer = torch.empty(size, torch.uint8, self.device)
+            torch.cuda.cudart().cudaHostRegister(self.buffer.data_ptr(), size, 0)
         else:
-            ptr = lmc_ops.alloc_pinned_ptr(size, 0)
-        array_type = ctypes.c_uint8 * size
-        buf = array_type.from_address(ptr)
-        self.buffer = torch.frombuffer(buf, dtype=torch.uint8)
-        self._unregistered = False
+            if self.numa_mapping:
+                device_id = torch.cuda.current_device()
+                gpu_to_numa_mapping = self.numa_mapping.gpu_to_numa_mapping
+                assert device_id in gpu_to_numa_mapping, (
+                    f"Current device {device_id} is not in the GPU NUMA mapping."
+                )
+                numa_id = gpu_to_numa_mapping[device_id]
+                ptr = lmc_ops.alloc_pinned_numa_ptr(size, numa_id)
+            else:
+                ptr = lmc_ops.alloc_pinned_ptr(size, 0)
+            array_type = ctypes.c_uint8 * size
+            buf = array_type.from_address(ptr)
+            self.buffer = torch.frombuffer(buf, dtype=torch.uint8)
 
+        self._unregistered = False
         self.pin_allocator: MemoryAllocatorInterface
         if use_paging:
             assert "shape" in kwargs, (
@@ -1593,11 +1598,14 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
 
     def close(self):
         if not self._unregistered:
-            torch.cuda.synchronize()
-            if self.numa_mapping:
-                lmc_ops.free_pinned_numa_ptr(self.buffer.data_ptr(), self.size)
+            if self.device == "cpu":
+                torch.cuda.cudart().cudaHostUnregister(self.buffer.data_ptr())
             else:
-                lmc_ops.free_pinned_ptr(self.buffer.data_ptr())
+                torch.cuda.synchronize()
+                if self.numa_mapping:
+                    lmc_ops.free_pinned_numa_ptr(self.buffer.data_ptr(), self.size)
+                else:
+                    lmc_ops.free_pinned_ptr(self.buffer.data_ptr())
             self._unregistered = True
 
     def __str__(self):

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -15,6 +15,7 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_server import LookupServerInterface
 from lmcache.v1.memory_management import (
     MemoryAllocatorInterface,
+    MixedMemoryAllocator,
     NixlCPUMemoryAllocator,
     PagedTensorMemoryAllocator,
 )
@@ -155,7 +156,13 @@ def CreateStorageBackends(
             NixlStorageBackend,
         )
 
-        if not isinstance(memory_allocator, PagedTensorMemoryAllocator):
+        if not isinstance(memory_allocator, MixedMemoryAllocator):
+            raise TypeError(
+                f"Expected MixedTensorMemoryAllocator,"
+                f" but got {type(memory_allocator).__name__}"
+            )
+
+        if not isinstance(memory_allocator.pin_allocator, PagedTensorMemoryAllocator):
             raise TypeError(
                 f"Expected PagedTensorMemoryAllocator,"
                 f" but got {type(memory_allocator).__name__}"

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -37,8 +37,10 @@ from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
+    MemoryFormat,
     MemoryObj,
     MemoryObjMetadata,
+    MixedMemoryAllocator,
     PagedTensorMemoryAllocator,
 )
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
@@ -139,14 +141,16 @@ class NixlStorageAgent:
 
     def __init__(
         self,
-        allocator: PagedTensorMemoryAllocator,
+        allocator: MixedMemoryAllocator,
         file_pool: NixlFilePool,
         device: str,
         backend: str,
     ):
-        buffer_ptr = allocator.buffer_ptr
-        buffer_size = allocator.buffer_size
-        page_size = allocator.align_bytes
+        assert isinstance(allocator, MixedMemoryAllocator)
+        assert isinstance(allocator.pin_allocator, PagedTensorMemoryAllocator)
+        buffer_ptr = allocator.pin_allocator.buffer_ptr
+        buffer_size = allocator.pin_allocator.buffer_size
+        page_size = allocator.pin_allocator.align_bytes
 
         self.agent_name = "NixlAgent_" + str(uuid.uuid4())
         nixl_conf = NixlAgentConfig(backends=[backend])
@@ -236,7 +240,7 @@ class NixlStorageBackend(StorageBackendInterface):
         self,
         nixl_config: NixlStorageConfig,
         loop: asyncio.AbstractEventLoop,
-        memory_allocator: PagedTensorMemoryAllocator,
+        memory_allocator: MixedMemoryAllocator,
     ):
         """
         Initialize the Nixl storage backend.
@@ -296,6 +300,7 @@ class NixlStorageBackend(StorageBackendInterface):
     ) -> None:
         with self.key_lock:
             assert key.chunk_hash not in self.key_dict
+            assert obj.fmt != MemoryFormat.BINARY_BUFFER
             self.key_dict[key.chunk_hash] = MemoryObjMetadata(
                 shape=obj.shape,
                 dtype=obj.dtype,
@@ -411,7 +416,7 @@ class NixlStorageBackend(StorageBackendInterface):
         config: LMCacheEngineConfig,
         loop: asyncio.AbstractEventLoop,
         metadata: LMCacheEngineMetadata,
-        memory_allocator: PagedTensorMemoryAllocator,
+        memory_allocator: MixedMemoryAllocator,
     ):
         """
         Create a Nixl backend with the given configuration.

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -13,7 +13,10 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import PagedTensorMemoryAllocator
+from lmcache.v1.memory_management import (
+    MixedMemoryAllocator,
+    PagedTensorMemoryAllocator,
+)
 from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageBackend
 
@@ -55,7 +58,10 @@ def run(config: LMCacheEngineConfig, shape, dtype):
 
         nixl_backend = backends[BACKEND_NAME]
         assert isinstance(nixl_backend, NixlStorageBackend)
-        assert isinstance(nixl_backend.memory_allocator, PagedTensorMemoryAllocator)
+        assert isinstance(nixl_backend.memory_allocator, MixedMemoryAllocator)
+        assert isinstance(
+            nixl_backend.memory_allocator.pin_allocator, PagedTensorMemoryAllocator
+        )
         assert nixl_backend is not None
         assert nixl_backend.memory_allocator is not None
 


### PR DESCRIPTION
an assert is hit when local_cpu_backend tries to allocate, because allocator type is not MixedMemoryAllocator.

In order to adapt to this assert, change nixl_storage_backend to use MixedMemoryAllocator with paging=true, which will create a PagedTensorMemoryAllocator internally. then use this internal allocator for NIXL instead of creating PagedTensorMemoryAllocator.