### PR TITLE
[Core] Implement nixl storage backend batched_get_non_blocking

### DIFF
--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -17,24 +17,35 @@ from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageBackend
 
 
-def run(config: LMCacheEngineConfig, shape, dtype):
-    BACKEND_NAME = "NixlStorageBackend"
-    TEST_KEY = CacheEngineKey(
+def create_key(chunk_hash: str):
+    return CacheEngineKey(
         fmt="MemoryFormat.KV_2LTD",
         model_name="meta-llama/Llama-3.1-70B-Instruct",
         world_size=8,
         worker_id=0,
-        chunk_hash=int(
-            "e3229141e680fb413d2c5d3ebb416c4ad300d381e309fc9e417757b91406c157", base=16
-        ),
+        chunk_hash=int(chunk_hash, base=16),
     )
+
+
+def run(config: LMCacheEngineConfig, shape, dtype):
+    BACKEND_NAME = "NixlStorageBackend"
+    keys = []
+    objs = []
+    keys.append(
+        create_key("e3229141e680fb413d2c5d3ebb416c4ad300d381e309fc9e417757b91406c157")
+    )
+    keys.append(
+        create_key("e3229141e680fb413d2c5d3ebb416c4ad300d381e309fc9e417757b91406d268")
+    )
+    bad_key = create_key("deadbeefdeadbeef")
+
     try:
         thread_loop = asyncio.new_event_loop()
         thread = threading.Thread(target=thread_loop.run_forever)
         thread.start()
 
         metadata = LMCacheEngineMetadata(
-            "TinyLlama-1.1B-Chat-v1.0",
+            "Llama-3.1-70B-Instruct",
             0,
             0,
             "MemoryFormat.KV_2LTD",
@@ -57,26 +68,48 @@ def run(config: LMCacheEngineConfig, shape, dtype):
         assert nixl_backend is not None
         assert nixl_backend.memory_allocator is not None
 
-        assert not nixl_backend.contains(TEST_KEY, False)
-        assert not nixl_backend.exists_in_put_tasks(TEST_KEY)
+        for key in keys:
+            assert not nixl_backend.contains(key, False)
+            assert not nixl_backend.exists_in_put_tasks(key)
 
-        memory_obj = nixl_backend.memory_allocator.allocate(shape=shape, dtype=dtype)
-        assert memory_obj is not None
-        assert memory_obj.tensor is not None
+            obj = nixl_backend.memory_allocator.allocate(shape=shape, dtype=dtype)
+            assert obj is not None
+            assert obj.tensor is not None
+            objs.append(obj)
 
         # small tensor changes for data validation
-        memory_obj.tensor[100, 200] = 1e-3
-        memory_obj.tensor[200, 100] = 1e-4
+        objs[0].tensor[100, 200] = 1e-3
+        objs[0].tensor[200, 100] = 1e-4
 
-        nixl_backend.batched_submit_put_task([TEST_KEY], [memory_obj])
+        objs[1].tensor[300, 400] = 1e-2
+        objs[1].tensor[400, 300] = 1e-5
 
-        returned_memory_obj = nixl_backend.get_blocking(TEST_KEY)
-        assert returned_memory_obj is not None
-        assert returned_memory_obj.get_size() == memory_obj.get_size()
-        assert returned_memory_obj.get_shape() == memory_obj.get_shape()
-        assert returned_memory_obj.get_dtype() == memory_obj.get_dtype()
-        assert returned_memory_obj.metadata.address != memory_obj.metadata.address
-        assert torch.equal(returned_memory_obj.tensor, memory_obj.tensor)
+        nixl_backend.batched_submit_put_task(keys, objs)
+
+        for key, obj in zip(keys, objs):
+            returned_memory_obj = nixl_backend.get_blocking(key)
+            assert returned_memory_obj is not None
+            assert returned_memory_obj.get_size() == obj.get_size()
+            assert returned_memory_obj.get_shape() == obj.get_shape()
+            assert returned_memory_obj.get_dtype() == obj.get_dtype()
+            assert returned_memory_obj.metadata.address != obj.metadata.address
+            assert torch.equal(returned_memory_obj.tensor, obj.tensor)
+
+        obj_list = asyncio.run(
+            nixl_backend.batched_get_non_blocking(lookup_id="test", keys=keys)
+        )
+
+        for i, obj in enumerate(objs):
+            returned_memory_obj = obj_list[i]
+            assert returned_memory_obj is not None
+            assert returned_memory_obj.get_size() == obj.get_size()
+            assert returned_memory_obj.get_shape() == obj.get_shape()
+            assert returned_memory_obj.get_dtype() == obj.get_dtype()
+            assert returned_memory_obj.metadata.address != obj.metadata.address
+            assert torch.equal(returned_memory_obj.tensor, obj.tensor)
+
+        bad_obj = nixl_backend.get_blocking(bad_key)
+        assert bad_obj is None
     finally:
         if thread_loop.is_running():
             thread_loop.call_soon_threadsafe(thread_loop.stop)


### PR DESCRIPTION
Abstract backend's get_non_blocking function was removed in favor of batched_get_non_blocking. Adapt NixlStorageBackend to this change.

Also add batching to NixlStorageBackend unit tests.
