### PR TITLE
[Misc] Add MRU cache policy to v1

### DIFF
--- a/lmcache/v1/storage_backend/cache_policy/__init__.py
+++ b/lmcache/v1/storage_backend/cache_policy/__init__.py
@@ -4,19 +4,22 @@ from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy
 from lmcache.v1.storage_backend.cache_policy.fifo import FIFOCachePolicy
 from lmcache.v1.storage_backend.cache_policy.lfu import LFUCachePolicy
 from lmcache.v1.storage_backend.cache_policy.lru import LRUCachePolicy
+from lmcache.v1.storage_backend.cache_policy.mru import MRUCachePolicy
 
 
 def get_cache_policy(policy_name: str) -> BaseCachePolicy:
     """
     Factory function to get the cache policy instance based on the policy name.
     """
-    supported_policies = ["LRU", "LFU", "FIFO"]
+    supported_policies = ["LRU", "LFU", "FIFO", "MRU"]
     if policy_name == "LRU":
         return LRUCachePolicy()
     elif policy_name == "LFU":
         return LFUCachePolicy()
     elif policy_name == "FIFO":
         return FIFOCachePolicy()
+    elif policy_name == "MRU":
+        return MRUCachePolicy()
     else:
         raise ValueError(
             f"Unknown cache policy: {policy_name}"

--- a/lmcache/v1/storage_backend/cache_policy/mru.py
+++ b/lmcache/v1/storage_backend/cache_policy/mru.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from collections import OrderedDict
+from typing import Any
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy
+
+logger = init_logger(__name__)
+
+
+class MRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
+    """
+    MRU cache policy.
+    """
+
+    def __init__(self):
+        logger.info("Initializing MRUCachePolicy")
+
+    def init_mutable_mapping(self) -> OrderedDict[CacheEngineKey, Any]:
+        return OrderedDict()
+
+    def update_on_hit(
+        self,
+        key: CacheEngineKey,
+        cache_dict: OrderedDict[CacheEngineKey, Any],
+    ) -> None:
+        # since MRU evicts from the back, the logic is same as LRU.
+        cache_dict.move_to_end(key, last=True)
+
+    def update_on_put(
+        self,
+        key: CacheEngineKey,
+    ) -> None:
+        # No action needed for MRU on put, as the key is already at the back.
+        pass
+
+    def update_on_force_evict(
+        self,
+        key: CacheEngineKey,
+    ) -> None:
+        pass
+
+    # NOTE(Jiayi): We do best effort to get eviction candidates so the number
+    # of returned keys mignt be smaller than num_candidates.
+    def get_evict_candidates(
+        self,
+        cache_dict: OrderedDict[CacheEngineKey, Any],
+        num_candidates: int = 1,
+    ) -> list[CacheEngineKey]:
+        evict_keys = []
+        # Since the most recent object is at the end, we reverse the order here
+        for key, cache in reversed(cache_dict.items()):
+            if not cache.can_evict:
+                continue
+            evict_keys.append(key)
+            if len(evict_keys) == num_candidates:
+                break
+
+        return evict_keys

--- a/tests/v1/test_cache_policy.py
+++ b/tests/v1/test_cache_policy.py
@@ -159,3 +159,49 @@ def test_lfu_with_pin():
     evict_candidates = policy.get_evict_candidates(cache_dict, num_candidates=2)
 
     assert evict_candidates == [key3, key2]
+
+
+def test_mru():
+    policy = get_cache_policy("MRU")
+    cache_dict = policy.init_mutable_mapping()
+    obj1 = DummyMemoryObj()
+    obj2 = DummyMemoryObj()
+    obj3 = DummyMemoryObj()
+    key1 = dumb_cache_engine_key(1)
+    key2 = dumb_cache_engine_key(2)
+    key3 = dumb_cache_engine_key(3)
+
+    cache_dict[key1] = obj1
+    policy.update_on_put(key1)
+    cache_dict[key2] = obj2
+    policy.update_on_put(key2)
+    cache_dict[key3] = obj3
+    policy.update_on_put(key3)
+
+    policy.update_on_hit(key1, cache_dict)
+    evict_candidates = policy.get_evict_candidates(cache_dict, num_candidates=2)
+    # key1 is the most recent, followed by key3.
+    assert evict_candidates == [key1, key3], (evict_candidates, [key1, key3])
+
+
+def test_mru_with_pin():
+    policy = get_cache_policy("MRU")
+    cache_dict = policy.init_mutable_mapping()
+    obj1 = DummyMemoryObj()
+    obj2 = DummyMemoryObj()
+    obj3 = DummyMemoryObj(can_evict=False)  # Pinned object
+    key1 = dumb_cache_engine_key(1)
+    key2 = dumb_cache_engine_key(2)
+    key3 = dumb_cache_engine_key(3)
+
+    cache_dict[key1] = obj1
+    policy.update_on_put(key1)
+    cache_dict[key2] = obj2
+    policy.update_on_put(key2)
+    cache_dict[key3] = obj3
+    policy.update_on_put(key3)
+
+    policy.update_on_hit(key1, cache_dict)
+    evict_candidates = policy.get_evict_candidates(cache_dict, num_candidates=2)
+    # key1 is most recent, followed by key3, but since key3 is pinned, wo go to key2.
+    assert evict_candidates == [key1, key2], (evict_candidates, [key1, key2])


### PR DESCRIPTION
Implement Most Recent Used Cache policy in v1.

Logic is very similar to LRU but we reverse the traversal of cache_dict during eviction, to avoid adding cache_dict as an argument for the `update_on_put` method.