### PR TITLE
[Bugfix][Core] Fix LocalCPUBackend clear() eviction logic and add clear() to LocalDiskBackend

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -455,7 +455,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
     def clear(self) -> int:
         """
-        counts the number of memory objects removed
+        Returns the number of tokens removed
         """
         if not self.use_hot:
             return 0
@@ -465,9 +465,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
             for key in self.hot_cache:
                 memory_obj = self.hot_cache[key]
                 if memory_obj.can_evict:
-                    continue
-                clear_keys.append(key)
-                num_cleared_tokens += memory_obj.get_num_tokens()
+                    clear_keys.append(key)
+                    num_cleared_tokens += memory_obj.get_num_tokens()
 
         # TODO(Jiayi): might not be accurate if we don't calculate
         # `num_cleared_token` and remove the keys in an atomic way.

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -552,6 +552,27 @@ class LocalDiskBackend(StorageBackendInterface):
             f"Bandwidth: {size / disk_read_time / 1e6:.2f} MB/s"
         )
 
+    def clear(self) -> int:
+        """
+        Returns the number of tokens removed
+        """
+        clear_keys = []
+        num_cleared_tokens = 0
+        with self.disk_lock:
+            for key in self.dict:
+                metadata = self.dict[key]
+                if metadata.can_evict:
+                    clear_keys.append(key)
+                    if metadata.shape is not None and metadata.fmt is not None:
+                        token_dim = metadata.fmt.token_dim()
+                        num_cleared_tokens += metadata.shape[token_dim]
+
+        self.batched_remove(clear_keys)
+        if clear_keys:
+            super()._on_evict(clear_keys)
+
+        return num_cleared_tokens
+
     def close(self) -> None:
         self.disk_worker.close()
         with self.disk_lock:


### PR DESCRIPTION
### Description
- Fix bug in `LocalCPUBackend.clear()`  
  - Evictable objects were not being removed due to incorrect logic  
  - Now correctly clears evictable objects and returns the number of tokens removed  

- Add `clear()` implementation for `LocalDiskBackend`  
  - Supports removing evictable objects stored on disk  

Verified that after the modification, the `clear` api correctly clears the KV cache

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>