### PR TITLE
[Improve] Support pass through the lmcache config from vllm extra config

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -38,7 +38,7 @@ from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.compute.blend import LMCBlenderBuilder
-from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config import LMCacheEngineConfig, validate_and_set_config_value
 from lmcache.v1.gpu_connector import (
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemGPUConnectorV2,
@@ -547,7 +547,24 @@ class LMCacheConnectorV1Impl:
         assert isinstance(config, LMCacheEngineConfig), (
             "LMCache v1 configuration is should be passed for vLLM v1."
         )
+        # Put the leading with "lmcache." and matched configs from
+        # vllm extra_config to the config
+        kv_connector_extra_config = (
+            vllm_config.kv_transfer_config.kv_connector_extra_config
+        )
+        if kv_connector_extra_config:
+            for key, value in kv_connector_extra_config.items():
+                if key.startswith("lmcache."):
+                    config_key = key[8:]  # Remove "lmcache." prefix
+                    if hasattr(config, config_key):
+                        validate_and_set_config_value(config, config_key, value)
+                        logger.info(
+                            f"Updated config {config_key} from vLLM "
+                            f"extra config: {value}"
+                        )
+
         self.config = config
+
         self.async_loading = config.enable_async_loading
         self.layerwise_retrievers: list[
             Generator[Optional[torch.Tensor], None, None]

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -38,7 +38,7 @@ from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.compute.blend import LMCBlenderBuilder
-from lmcache.v1.config import LMCacheEngineConfig, validate_and_set_config_value
+from lmcache.v1.config import LMCacheEngineConfig, _validate_and_set_config_value
 from lmcache.v1.gpu_connector import (
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemGPUConnectorV2,
@@ -556,8 +556,7 @@ class LMCacheConnectorV1Impl:
             for key, value in kv_connector_extra_config.items():
                 if key.startswith("lmcache."):
                     config_key = key[8:]  # Remove "lmcache." prefix
-                    if hasattr(config, config_key):
-                        validate_and_set_config_value(config, config_key, value)
+                    if _validate_and_set_config_value(config, config_key, value):
                         logger.info(
                             f"Updated config {config_key} from vLLM "
                             f"extra config: {value}"

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -615,15 +615,20 @@ def _to_json(self):
     return json.dumps(self.to_dict(), indent=2)
 
 
-def validate_and_set_config_value(config, config_key, value):
+def _validate_and_set_config_value(config, config_key, value):
     """Validate and set configuration value"""
+    if not hasattr(config, config_key):
+        logger.warning(f"Config key '{config_key}' does not exist in configuration")
+        return False
+
     try:
         setattr(config, config_key, value)
+        return True
     except Exception as e:
         logger.error(
             f"Failed to set config item '{config_key}' with value {value}: {e}"
         )
-        pass
+        return False
 
 
 # Create configuration class

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -615,5 +615,16 @@ def _to_json(self):
     return json.dumps(self.to_dict(), indent=2)
 
 
+def validate_and_set_config_value(config, config_key, value):
+    """Validate and set configuration value"""
+    try:
+        setattr(config, config_key, value)
+    except Exception as e:
+        logger.error(
+            f"Failed to set config item '{config_key}' with value {value}: {e}"
+        )
+        pass
+
+
 # Create configuration class
 LMCacheEngineConfig = _create_config_class()


### PR DESCRIPTION
Support pass through the lmcache config from vllm extra config.

# Test

```
vllm \
... \
        --kv-transfer-config \
        '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_parallel_size":2,"kv_connector_extra_config":{"discard_partial_chunks":true, "skip_last_n_tokens": 0, "lmcache.internal_api_server_include_index_list": [0,1], "lmcache.extra_config": {"save_only_first_rank":true, "first_rank_max_local_cpu_size": 10, "plugin.frontend.port": 7020,"plugin.frontend.heartbeat-url": "http://localhost:8080/lmcache_heartbeat/","plugin.frontend.heartbeat-initial-delay": 30, "plugin.frontend.heartbeat-interval": 60}}}'
```

<img width="2870" height="286" alt="image" src="https://github.com/user-attachments/assets/f08a113f-b62a-4be1-ae84-a65d237a9ba7" />

