### PR TITLE
Support override config by env

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -265,6 +265,10 @@ class LMCacheEngineConfig:
 
         return config.log_config()
 
+    def update_config_from_env(self):
+        """Update the configuration from the environment variables"""
+        pass
+
     def log_config(self) -> "LMCacheEngineConfig":
         """Log all configuration settings"""
         config_dict = {

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -267,6 +267,7 @@ class LMCacheEngineConfig:
 
     def update_config_from_env(self):
         """Update the configuration from the environment variables"""
+        # TODO(baoloongmao): implement this when needed
         pass
 
     def log_config(self) -> "LMCacheEngineConfig":

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -57,7 +57,8 @@ def lmcache_get_config() -> Union[Config, V1Config]:
         config_file = os.environ["LMCACHE_CONFIG_FILE"]
         logger.info(f"Loading LMCache config file {config_file}")
         config = LMCacheEngineConfig.from_file(config_file)
-
+        # Update config from environment variables
+        config.update_config_from_env()
     return config
 
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -577,6 +577,8 @@ def _update_config_from_env(self):
                 # Keep existing value if conversion fails
 
     return self
+
+
 def _from_env(cls):
     """Load configuration from environment variables"""
     instance = cls.from_defaults()

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -576,7 +576,7 @@ def _update_config_from_env(self):
                 logger.warning(f"Failed to parse {get_env_name(name)}: {e}")
                 # Keep existing value if conversion fails
 
-
+    return self
 def _from_env(cls):
     """Load configuration from environment variables"""
     instance = cls.from_defaults()

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -357,6 +357,7 @@ def _create_config_class():
             "from_legacy": classmethod(_from_legacy),
             "from_file": classmethod(_from_file),
             "from_env": classmethod(_from_env),
+            "update_config_from_env": _update_config_from_env,
             "__str__": lambda self: str(
                 {name: getattr(self, name) for name in _CONFIG_DEFINITIONS}
             ),
@@ -540,8 +541,8 @@ def _from_file(cls, file_path: str):
     return instance.log_config()
 
 
-def _from_env(cls):
-    """Load configuration from environment variables"""
+def _update_config_from_env(self):
+    """Update an existing config object with environment variable configurations."""
 
     def get_env_name(attr_name: str) -> str:
         return f"LMCACHE_{attr_name.upper()}"
@@ -564,22 +565,22 @@ def _from_env(cls):
     # Resolve aliases and handle deprecated configurations
     resolved_config = _resolve_config_aliases(env_config, "environment variables")
 
-    config_values = {}
+    # Update config object with environment values
     for name, config in _CONFIG_DEFINITIONS.items():
-        value = resolved_config.get(name, config["default"])
-
-        # Convert environment variable values
         if name in resolved_config:
             try:
-                value = config["env_converter"](value)
+                value = resolved_config[name]
+                converted_value = config["env_converter"](value)
+                setattr(self, name, converted_value)
             except (ValueError, json.JSONDecodeError) as e:
                 logger.warning(f"Failed to parse {get_env_name(name)}: {e}")
-                value = config["default"]
+                # Keep existing value if conversion fails
 
-        config_values[name] = value
 
-    instance = cls(**config_values)
-    return instance.log_config()
+def _from_env(cls):
+    """Load configuration from environment variables"""
+    instance = cls.from_defaults()
+    return _update_config_from_env(instance).log_config()
 
 
 def _from_dict(cls, config_dict: dict):

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -580,7 +580,8 @@ def _update_config_from_env(self):
 def _from_env(cls):
     """Load configuration from environment variables"""
     instance = cls.from_defaults()
-    return _update_config_from_env(instance).log_config()
+    _update_config_from_env(instance)
+    return instance.log_config()
 
 
 def _from_dict(cls, config_dict: dict):


### PR DESCRIPTION
# Motivation

The existing logic of configuration of LMCache is that we could only get config from one of `lmcache.yaml` file or env vars, could not treat env vars as a supplement.

After this PR, LMCache will read config from `lmcache.yaml` first, then override the configs which configured by env var.

In another word, the `env var` config source should treat as higher priority  than file `lmcache.yaml`.

# Test

- lmcahe.yaml
```yaml
chunk_size: 64
remote_serde: "naive"
local_cpu: True
max_local_cpu_size: 0.1
extra_config:
  save_only_first_rank: True
  create_lookup_server_only_on_worker_0_for_mla: True
  audit_exclude_cmds: exists,get
  tag_keys: ["user"]
  plugin.frontend.port: 8080
  external_backend.log_external_backend.module_path: lmc_external_log_backend.lmc_external_log_backend
  external_backend.log_external_backend.class_name: ExternalLogBackend
internal_api_server_enabled: True
internal_api_server_port_start: 9090
internal_api_server_include_index_list: [0, 1]
plugin_locations: ["/opt/venv/lib/python3.12/site-packages/lmcache_frontend/lmcache_plugin/"]
internal_api_server_socket_path_prefix: "/tmp/lmcache_internal_api_server/socket"
# external_backends: "log_external_backend"

```

- env
```
export LMCACHE_CHUNK_SIZE=512
```

- Result
<img width="1850" height="518" alt="image" src="https://github.com/user-attachments/assets/1944f6f3-5523-4df1-8386-92e0384542f1" />

The blue rectangle comes from `lmcache.yaml`, the green rectangle comes from `env var`.