### PR TITLE
[feat] Add a request level skip_save parameter

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -292,10 +292,8 @@ class ReqMeta:
         )
 
         # NOTE(vladnosiv): for disagg, you cannot skip saving, as saving is a transfer
-        # Check if request_configs has lmcache.cache.skip set to True
-        request_skip = False
-        if tracker.request_configs is not None:
-            request_skip = tracker.request_configs.get("lmcache.skip_save", False)
+        # Check if request_configs has lmcache.skip_save set to True
+        request_skip = (tracker.request_configs or {}).get("lmcache.skip_save", False)
 
         skip_save = tracker.disagg_spec is None and (
             skip_save

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -292,10 +292,16 @@ class ReqMeta:
         )
 
         # NOTE(vladnosiv): for disagg, you cannot skip saving, as saving is a transfer
+        # Check if request_configs has lmcache.cache.skip set to True
+        request_skip = False
+        if tracker.request_configs is not None:
+            request_skip = tracker.request_configs.get("lmcache.skip_save", False)
+
         skip_save = tracker.disagg_spec is None and (
             skip_save
             or (tracker.num_saved_tokens > 0 and input_token_len < chunk_boundary)
             or (tracker.is_decode_phase and not save_decode_cache)
+            or request_skip
         )
 
         if skip_save and load_spec is None:


### PR DESCRIPTION
# Highlight

This PR is co-authored by @xshwu 

# Motivation

In our scenario, some of the request doesn't need to save kvcache, so we need to skip the kvcache saving for this kind of request.

# Test
Tested set `mcache.skip_save` to true can prevent save kvcache, otherwise, as normal, it save kvcache for the request.

```
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
    "model": "vllm_cpu_offload",
    "messages": [
        {
            "role": "user",
            "content": "Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?Hello, how are you?"
        }
    ],
    "max_tokens": 10,
    "temperature": 0,
    "top_p": 0.95,
    "stream": true,
    "stream_options": {
         "include_usage": true
    },
    "kv_transfer_params":{
            "lmcache.skip_save":true
        }
    }'
```