### PR TITLE
[Core] Add Redis Cluster remote connector + tests

### DIFF
--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -75,3 +75,47 @@ class RedisSentinelConnectorAdapter(ConnectorAdapter):
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
         )
+
+class RedisClusterConnectorAdapter(ConnectorAdapter):
+    """Adapter for Redis Cluster connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("redis-cluster://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .redis_connector import RedisClusterConnector
+
+        logger.info(f"Creating Redis Cluster connector for URL: {context.url}")
+        url = context.url[len(self.schema) :]
+
+        # Parse username and password
+        username: str = ""
+        password: str = ""
+        if "@" in url:
+            auth, url = url.split("@", 1)
+            if ":" in auth:
+                username, password = auth.split(":", 1)
+            else:
+                username = auth
+
+        # Parse host and port
+        hosts_and_ports: List[Tuple[str, int]] = []
+        assert self.schema is not None
+        for sub_url in url.split(","):
+            if not sub_url.startswith(self.schema):
+                sub_url = self.schema + sub_url
+
+            parsed_url = parse_remote_url(sub_url)
+            hosts_and_ports.append((parsed_url.host, parsed_url.port))
+
+        return RedisClusterConnector(
+            hosts_and_ports=hosts_and_ports,
+            username=username,
+            password=password,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+        )

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -7,6 +7,7 @@ import os
 
 # Third Party
 import redis
+from redis.cluster import RedisCluster, ClusterNode
 
 # First Party
 from lmcache.logging import init_logger
@@ -268,3 +269,130 @@ class RedisSentinelConnector(RemoteConnector):
     async def close(self):
         self.master.close()
         self.slave.close()
+
+class RedisClusterConnector(RemoteConnector):
+    """
+    The remote url starts with "redis-cluster:// and can include one or multiple hosts:ports, separated by commas.
+
+    Example:
+        remote_url: "redis-cluster://host1:7000,host2:7000,host3:7000"
+
+    Extra environment variables:
+    - REDIS_TIMEOUT (optional) -- Timeout in seconds, default is 1 if not set
+    """
+
+    ENV_REDIS_TIMEOUT = "REDIS_TIMEOUT"
+
+    def __init__(
+            self,
+            hosts_and_ports: List[Tuple[str, int]],
+            username: str,
+            password: str,
+            loop: asyncio.AbstractEventLoop,
+            local_cpu_backend: LocalCPUBackend,
+    ):
+        timeout: float = -1000.0
+
+        # Get timeout
+        match os.environ.get(self.ENV_REDIS_TIMEOUT):
+            case None:
+                timeout = 1
+            case value:
+                timeout = float(value)
+
+        logger.info(f"Connecting to Redis Cluster nodes, host and ports: {hosts_and_ports}")
+        startup_nodes = [ClusterNode(h, p) for (h, p) in hosts_and_ports]
+
+        self.cluster = redis.RedisCluster(
+            startup_nodes=startup_nodes,
+            username=username,
+            password=password,
+            socket_timeout=timeout,
+            decode_responses=False,
+        )
+        self.local_cpu_backend = local_cpu_backend
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return bool(self.cluster.exists(key.to_string() + "metadata"))
+
+    def exists_sync(self, key: CacheEngineKey) -> bool:
+        return bool(self.cluster.exists(key.to_string() + "metadata"))
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        key_str = key.to_string()
+        metadata_bytes = self.cluster.get(key_str + "metadata")
+
+        if metadata_bytes is None:
+            return None
+
+        assert not inspect.isawaitable(metadata_bytes)
+
+        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+
+        memory_obj = self.local_cpu_backend.allocate(
+            metadata.shape,
+            metadata.dtype,
+            metadata.fmt,
+        )
+        if memory_obj is None:
+            logger.warning("Failed to allocate memory during cluster receive")
+            return None
+
+        # TODO(Jiayi): Find a way to do `get` inplace
+        kv_bytes = self.cluster.get(key_str + "kv_bytes")
+        assert not inspect.isawaitable(kv_bytes)
+
+        if kv_bytes is None:
+            # TODO (Jiayi): We might need a way to better handle
+            # consistency issues.
+            # TODO (Jiayi): A better way is to aggregate metadata
+            # and kv cache in one key.
+            logger.warning(
+                "Key exists but KV cache does not exist."
+                "Might happen when the cache is evicted by redis."
+            )
+            self.cluster.delete(key_str + "metadata")
+            return None
+
+        if isinstance(memory_obj.byte_array, memoryview):
+            view = memory_obj.byte_array
+            if view.format == "<B":
+                view = view.cast("B")
+        else:
+            view = memoryview(memory_obj.byte_array)
+
+        if isinstance(kv_bytes, (bytes, bytearray)):
+            view[: metadata.length] = kv_bytes
+        elif isinstance(kv_bytes, str):
+            converted = kv_bytes.encode("utf-8")
+            view[: metadata.length] = converted
+        else:
+            converted = bytes(kv_bytes)
+            view[: metadata.length] = converted
+
+        return memory_obj
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        # TODO(Jiayi): The following code is ugly.
+        # Please use a function like `memory_obj.to_meta()`.
+        kv_bytes = memory_obj.byte_array
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        metadata_bytes = RemoteMetadata(
+            len(kv_bytes), kv_shape, kv_dtype, memory_format
+        ).serialize()
+
+        key_str = key.to_string()
+        self.cluster.set(key_str + "metadata", metadata_bytes)
+        self.cluster.set(key_str + "kv_bytes", kv_bytes)
+
+    # TODO
+    @no_type_check
+    async def list(self) -> List[str]:
+        pass
+
+    async def close(self):
+        self.cluster.close()
+        logger.info("Closed the redis cluster connection")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,31 @@ class MockRedisSentinel:
     ):
         return self.redis
 
+class MockRedisCluster:
+    def __init__(self, startup_nodes=None, socket_timeout=None, decode_responses=False, **kwargs):
+        self.store = {}
+        self.startup_nodes = startup_nodes or []
+        self.socket_timeout = socket_timeout
+        self.decode_responses = decode_responses
+
+    def set(self, key, value):
+        self.store[key] = value
+        return True
+
+    def get(self, key: str):
+        return self.store.get(key, None)
+
+    def exists(self, key: str):
+        return key in self.store
+
+    def delete(self, key):
+        if key in self.store:
+            self.store.pop(key, None)
+            return 1
+        return 0
+
+    def close(self):
+        pass
 
 @dataclass
 class LMCacheServerProcess:
@@ -197,6 +222,10 @@ def mock_redis_sentinel():
     with patch("redis.Sentinel", MockRedisSentinel) as mock:
         yield mock
 
+@pytest.fixture(scope="function", autouse=True)
+def mock_redis_cluster():
+    with patch("redis.RedisCluster", MockRedisCluster) as mock:
+        yield mock
 
 @pytest.fixture(scope="module")
 def lmserver_v1_process(request):

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -313,6 +313,9 @@ def test_redis_cluster_connector(url, autorelease_v1):
     Redis Cluster behavior without requiring an actual Redis Cluster setup.
     """
 
+    # Standard
+    import os
+
     os.environ["REDIS_TIMEOUT"] = "3.5"
 
     async_loop, async_thread = init_asyncio_loop()

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -13,6 +13,7 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PinMemoryAllocator
 from lmcache.v1.storage_backend.connector import CreateConnector
+from lmcache.v1.protocol import RemoteMetadata
 
 # Local
 from .utils import (
@@ -296,4 +297,93 @@ def test_redis_sentinel_connector(url, autorelease_v1):
 
     close_asyncio_loop(async_loop, async_thread)
 
+    memory_allocator.close()
+
+REDIS_CLUSTER_URLS = [
+    "redis-cluster://host1:7000,host2:7000,host3:7000",
+    "redis-cluster://clustercfg.cluster-name.id.region.cache.amazonaws.com:6379",
+    "redis-cluster://user:password@host1:7000,host2:7000,host3:7000"
+]
+
+@pytest.mark.parametrize("url", REDIS_CLUSTER_URLS)
+def test_redis_cluster_connector(url, autorelease_v1):
+    """Test Redis Cluster connector: exists, put, get operations.
+
+    This test uses the MockRedisCluster from conftest.py to simulate
+    Redis Cluster behavior without requiring an actual Redis Cluster setup.
+    """
+
+    os.environ["REDIS_TIMEOUT"] = "3.5"
+
+    async_loop, async_thread = init_asyncio_loop()
+    memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+
+    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+    assert connector._connector.cluster.socket_timeout == 3.5
+    assert connector._connector.cluster.decode_responses is False
+
+    random_key = dumb_cache_engine_key()
+
+    # Test 1: Verify key doesn't exist initially, test contains key not exist
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert not future.result()
+
+    # Test 2: Create and store test data
+    num_tokens = 1000
+    mem_obj_shape = [2, 32, num_tokens, 1024]
+    dtype = torch.bfloat16
+    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj.ref_count_up()
+
+    # Fill with deterministic test data
+    torch.manual_seed(42)
+    test_tensor = torch.randint(0, 100, memory_obj.raw_data.shape, dtype=torch.int64)
+    memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+    # Test 3: Put data
+    future = asyncio.run_coroutine_threadsafe(connector.put(random_key, memory_obj), async_loop)
+    future.result()
+
+    # Test 4: Verify key exists after putting data, test contains key exists
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert future.result()
+    assert memory_obj.get_ref_count() == 1
+
+    # Test 5: Retrieve and verify data
+    future = asyncio.run_coroutine_threadsafe(connector.get(random_key), async_loop)
+    retrieved_memory_obj = future.result()
+
+    check_mem_obj_equal([retrieved_memory_obj],[memory_obj])
+
+    close_asyncio_loop(async_loop, async_thread)
+    memory_allocator.close()
+
+@pytest.mark.parametrize("url", REDIS_CLUSTER_URLS)
+def test_cluster_metadata_without_kv_bytes(url, autorelease_v1): # test if metadata key survives in redis but kv_bytes evicted/expired
+    async_loop, async_thread = init_asyncio_loop()
+    memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+
+    random_key = dumb_cache_engine_key()
+    # Build a small mem obj just to derive correct metadata bytes
+    memory_obj = memory_allocator.allocate([2, 32, 8, 64], torch.bfloat16)
+    kv_bytes = memory_obj.byte_array
+    meta = RemoteMetadata(len(kv_bytes), memory_obj.get_shape(), memory_obj.get_dtype(), memory_obj.get_memory_format())
+    metadata_bytes = meta.serialize()
+
+    # clean up memory object after getting metadata
+    memory_obj.ref_count_down()
+
+    # inject only metadata, no kv_bytes
+    meta_key = random_key.to_string() + "metadata"
+    connector._connector.cluster.set(meta_key, metadata_bytes)
+
+    # get() should return None and remove the metadata without kv_bytes pair
+    future = asyncio.run_coroutine_threadsafe(connector.get(random_key), async_loop)
+    assert future.result() is None
+
+    future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
+    assert not future.result()
+
+    close_asyncio_loop(async_loop, async_thread)
     memory_allocator.close()

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -359,13 +359,13 @@ def test_redis_cluster_connector(url, autorelease_v1):
     memory_allocator.close()
 
 @pytest.mark.parametrize("url", REDIS_CLUSTER_URLS)
-def test_cluster_metadata_without_kv_bytes(url, autorelease_v1): # test if metadata key survives in redis but kv_bytes evicted/expired
+def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
     connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
 
     random_key = dumb_cache_engine_key()
-    # Build a small mem obj just to derive correct metadata bytes
+    # build a small mem obj to get correct metadata bytes
     memory_obj = memory_allocator.allocate([2, 32, 8, 64], torch.bfloat16)
     kv_bytes = memory_obj.byte_array
     meta = RemoteMetadata(len(kv_bytes), memory_obj.get_shape(), memory_obj.get_dtype(), memory_obj.get_memory_format())


### PR DESCRIPTION
1. Added new Redis Cluster support for remote connector with redis-cluster:// prefix, allowing URLs with one or multiple comma-separated host:port pairs (such as a single configuration endpoint for ElastiCache or multiple host:port pairs for self-managed clusters)
2. Created RedisClusterConnector class to interface with Redis Cluster for distributed caching operations and RedisClusterConnectorAdapter class to parse and extract host addresses and ports
3. Tested multi-node URLs and ElastiCache URLs, verifying key existence, storage, retrieval, and cleanup, as well as deletion of metadata key when kv_bytes is missing
4. For Elasticache cluster connections, currently only works when Transit encryption mode is set to preferred

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
