### PR TITLE
[Bugfix] Fix blending bugs introduced by recent updates

### DIFF
--- a/examples/blend_kv_v1/blend.py
+++ b/examples/blend_kv_v1/blend.py
@@ -31,8 +31,11 @@ def setup_environment_variables(
     os.environ["LMCACHE_ENABLE_BLENDING"] = "True"
     os.environ["LMCACHE_BLEND_SPECIAL_STR"] = blend_special_str
     os.environ["LMCACHE_USE_LAYERWISE"] = "True"
+    os.environ["LMCACHE_BLEND_CHECK_LAYERS"] = "1"
+    os.environ["LMCACHE_BLEND_RECOMPUTE_RATIOS"] = "0.15"
 
     if enable_sparse:
+        os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
         os.environ["LMCACHE_EXTRA_CONFIG"] = '{"enable_sparse": true}'
 
     if use_disk:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -851,7 +851,11 @@ class LMCacheConnectorV1Impl:
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
             return
-
+        if self._parent._connector_metadata is None:
+            logger.warning(
+                "In connector.save_kv_layer, but the connector metadata is None"
+            )
+            return
         connector_metadata = self._parent._get_connector_metadata()
         assert isinstance(connector_metadata, LMCacheConnectorMetadata)
 

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -103,14 +103,14 @@ class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
                     (q.size(0), q.size(1)), dtype=torch.float32, device=q.device
                 )
             else:
-                _check_shape_dtype_device(
+                check_shape_dtype_device(
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
 
         if out is None:
             out = torch.empty_like(q, dtype=self._o_dtype)
         else:
-            _check_shape_dtype_device(out, q.shape, self._o_dtype, q.device, "out")
+            check_shape_dtype_device(out, q.shape, self._o_dtype, q.device, "out")
 
         if self._backend == "fa3":
             if (

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -9,7 +9,7 @@ from flashinfer.page import block_sparse_indices_to_vector_sparse_offsets
 from flashinfer.utils import (
     TensorLayout,
     _check_pos_encoding_mode,
-    _check_shape_dtype_device,
+    check_shape_dtype_device,
     device_support_pdl,
 )
 from vllm.attention import Attention

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from lmcache.v1.compute.attention.metadata import LMCAttnMetadata
 
 
+# NOTE(Jiayi): This flashinfer version is 0.3.1.
 class HackBSAWrapper(VariableBlockSparseAttentionWrapper):
     def run(
         self,

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -40,11 +40,13 @@ class LMCBlender:
         # TODO: remove this hardcode
         self.num_layers = len(vllm_model.model.layers)
 
-        # TODO (Jiayi): make this less hard-coded
+        # TODO(Jiayi): support threshold-based blending
+        # TODO(Jiayi): support different ratios for different layers
+        # TODO(Jiayi): support "skipping blending if hit too short"
         self.common_metadata = LMCBlendCommonMetadata(
-            check_layers=[1],
-            recomp_ratios=[0.15],
-            thresholds=None,
+            check_layers=config.blend_check_layers,
+            recomp_ratios=config.blend_recompute_ratios,
+            thresholds=config.blend_thresholds,
         )
 
         # This will be set during the blending process

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Optional
+from typing import Optional, Union
 
 # Third Party
 import torch
@@ -150,13 +150,17 @@ class LMCBlender:
 
     def blend(
         self,
-        tokens: torch.Tensor,
+        tokens: Union[torch.Tensor, list[int]],
         mask: Optional[torch.Tensor] = None,
         **kwargs,
     ):
         """
         Perform blending for the given tokens.
         """
+
+        if isinstance(tokens, list):
+            tokens = torch.tensor(tokens).cuda()
+
         layerwise_blender = self.blend_layer(tokens, mask, **kwargs)
 
         for i in range(self.num_layers + 2):

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -38,6 +38,17 @@ def _to_int_list(
     parts = [p.strip() for p in str(value).split(",") if p.strip()]
     return [int(p) for p in parts]
 
+def _to_float_list(
+    value: Optional[Union[str, float, list[Any]]],
+) -> Optional[list[float]]:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [float(x) for x in value]
+    if isinstance(value, float):
+        return [value]
+    parts = [p.strip() for p in str(value).split(",") if p.strip()]
+    return [float(p) for p in parts]
 
 def _to_str_list(
     value: Optional[Union[str, list[str]]],
@@ -113,7 +124,9 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": False,
         "env_converter": _to_bool,
     },
-    "blend_recompute_ratio": {"type": float, "default": 0.15, "env_converter": float},
+    "blend_recompute_ratios": {"type": Optional[list[float]], "default": [0.15], "env_converter": _to_float_list},
+    "blend_thresholds": {"type": Optional[list[float]], "default": None, "env_converter": _to_float_list},
+    "blend_check_layers": {"type": list[int], "default": [1], "env_converter": _to_int_list},
     "blend_min_tokens": {"type": int, "default": 256, "env_converter": int},
     "blend_special_str": {"type": str, "default": " # # ", "env_converter": str},
     # P2P configurations
@@ -428,7 +441,7 @@ def _to_original_config(self):
         pipelined_backend=False,
         save_decode_cache=self.save_decode_cache,
         enable_blending=self.enable_blending,
-        blend_recompute_ratio=self.blend_recompute_ratio,
+        blend_recompute_ratio=self.blend_recompute_ratios[0],
         blend_min_tokens=self.blend_min_tokens,
         blend_separator="[BLEND_SEP]",
         blend_add_special_in_precomp=False,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -128,7 +128,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "blend_recompute_ratios": {
         "type": Optional[list[float]],
-        "default": [0.15],
+        "default": lambda: [0.15],
         "env_converter": _to_float_list,
     },
     "blend_thresholds": {
@@ -138,7 +138,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "blend_check_layers": {
         "type": list[int],
-        "default": [1],
+        "default": lambda: [1],
         "env_converter": _to_int_list,
     },
     "blend_min_tokens": {"type": int, "default": 256, "env_converter": int},
@@ -455,7 +455,7 @@ def _to_original_config(self):
         pipelined_backend=False,
         save_decode_cache=self.save_decode_cache,
         enable_blending=self.enable_blending,
-        blend_recompute_ratio=self.blend_recompute_ratios[0],
+        blend_recompute_ratio=0.15,
         blend_min_tokens=self.blend_min_tokens,
         blend_separator="[BLEND_SEP]",
         blend_add_special_in_precomp=False,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -38,6 +38,7 @@ def _to_int_list(
     parts = [p.strip() for p in str(value).split(",") if p.strip()]
     return [int(p) for p in parts]
 
+
 def _to_float_list(
     value: Optional[Union[str, float, list[Any]]],
 ) -> Optional[list[float]]:
@@ -49,6 +50,7 @@ def _to_float_list(
         return [value]
     parts = [p.strip() for p in str(value).split(",") if p.strip()]
     return [float(p) for p in parts]
+
 
 def _to_str_list(
     value: Optional[Union[str, list[str]]],
@@ -124,9 +126,21 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": False,
         "env_converter": _to_bool,
     },
-    "blend_recompute_ratios": {"type": Optional[list[float]], "default": [0.15], "env_converter": _to_float_list},
-    "blend_thresholds": {"type": Optional[list[float]], "default": None, "env_converter": _to_float_list},
-    "blend_check_layers": {"type": list[int], "default": [1], "env_converter": _to_int_list},
+    "blend_recompute_ratios": {
+        "type": Optional[list[float]],
+        "default": [0.15],
+        "env_converter": _to_float_list,
+    },
+    "blend_thresholds": {
+        "type": Optional[list[float]],
+        "default": None,
+        "env_converter": _to_float_list,
+    },
+    "blend_check_layers": {
+        "type": list[int],
+        "default": [1],
+        "env_converter": _to_int_list,
+    },
     "blend_min_tokens": {"type": int, "default": 256, "env_converter": int},
     "blend_special_str": {"type": str, "default": " # # ", "env_converter": str},
     # P2P configurations

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -128,7 +128,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "blend_recompute_ratios": {
         "type": Optional[list[float]],
-        "default": lambda: [0.15],
+        "default": None,
         "env_converter": _to_float_list,
     },
     "blend_thresholds": {
@@ -138,7 +138,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "blend_check_layers": {
         "type": list[int],
-        "default": lambda: [1],
+        "default": None,
         "env_converter": _to_int_list,
     },
     "blend_min_tokens": {"type": int, "default": 256, "env_converter": int},

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -79,8 +79,9 @@ class LMCacheLookupClient(LookupClientInterface):
             TokenDatabase,
         )
 
+        self.enable_blending = config.enable_blending
         self.token_database: TokenDatabase
-        if config.enable_blending:
+        if self.enable_blending:
             self.token_database = SegmentTokenDatabase(config, metadata)
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
@@ -92,7 +93,7 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
-        if not conifg.enable_blending:
+        if not self.enable_blending:
             hashes = []
             offsets = []
             for start, end, key in self.token_database.process_tokens(
@@ -111,7 +112,6 @@ class LMCacheLookupClient(LookupClientInterface):
             ranks = self.tensor_parallel_size
             if self.create_lookup_server_only_on_worker_0_for_mla:
                 ranks = 1
-            results = []
             msg_buf = [
                 hash_buf,
                 offset_buf,
@@ -128,7 +128,6 @@ class LMCacheLookupClient(LookupClientInterface):
             ranks = self.tensor_parallel_size
             if self.create_lookup_server_only_on_worker_0_for_mla:
                 ranks = 1
-            results = []
             msg_buf = [
                 tokens_buf,
                 lookup_id_buf,
@@ -138,6 +137,7 @@ class LMCacheLookupClient(LookupClientInterface):
         for i in range(ranks):
             self.sockets[i].send_multipart(msg_buf, copy=False)
 
+        results = []
         # TODO(Jiayi): we can use zmq poll to optimize a bit
         for i in range(ranks):
             resp = self.sockets[i].recv()
@@ -225,7 +225,6 @@ class LMCacheLookupServer:
                     )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)
-
 
         logger.info(f"lmcache lookup server start on {socket_path}")
         self.thread = threading.Thread(target=process_request, daemon=True)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -85,37 +85,56 @@ class LMCacheLookupClient(LookupClientInterface):
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
 
+    # FIXME(Jiayi): Cacheblend need token ids
     def lookup(
         self,
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
-        hashes = []
-        offsets = []
-        for start, end, key in self.token_database.process_tokens(
-            token_ids, make_key=False
-        ):
-            hashes.append(key)
-            offsets.append(end - start)
-        hash_buf = self.encoder.encode(hashes)
-        offset_buf = self.encoder.encode(offsets)
+        if not conifg.enable_blending:
+            hashes = []
+            offsets = []
+            for start, end, key in self.token_database.process_tokens(
+                token_ids, make_key=False
+            ):
+                hashes.append(key)
+                offsets.append(end - start)
+            hash_buf = self.encoder.encode(hashes)
+            offset_buf = self.encoder.encode(offsets)
 
-        lookup_id_buf = lookup_id.encode("utf-8")
-        request_configs_str = ""
-        if request_configs is not None and len(request_configs) != 0:
-            request_configs_str = json.dumps(request_configs)
-        request_configs_buf = request_configs_str.encode("utf-8")
-        ranks = self.tensor_parallel_size
-        if self.create_lookup_server_only_on_worker_0_for_mla:
-            ranks = 1
-        results = []
-        msg_buf = [
-            hash_buf,
-            offset_buf,
-            lookup_id_buf,
-            request_configs_buf,
-        ]  # hash_offset_bufs+ [lookup_id_buf, request_configs_buf]
+            lookup_id_buf = lookup_id.encode("utf-8")
+            request_configs_str = ""
+            if request_configs is not None and len(request_configs) != 0:
+                request_configs_str = json.dumps(request_configs)
+            request_configs_buf = request_configs_str.encode("utf-8")
+            ranks = self.tensor_parallel_size
+            if self.create_lookup_server_only_on_worker_0_for_mla:
+                ranks = 1
+            results = []
+            msg_buf = [
+                hash_buf,
+                offset_buf,
+                lookup_id_buf,
+                request_configs_buf,
+            ]
+        else:
+            tokens_buf = self.encoder.encode(token_ids)
+            lookup_id_buf = lookup_id.encode("utf-8")
+            request_configs_str = ""
+            if request_configs is not None and len(request_configs) != 0:
+                request_configs_str = json.dumps(request_configs)
+            request_configs_buf = request_configs_str.encode("utf-8")
+            ranks = self.tensor_parallel_size
+            if self.create_lookup_server_only_on_worker_0_for_mla:
+                ranks = 1
+            results = []
+            msg_buf = [
+                tokens_buf,
+                lookup_id_buf,
+                request_configs_buf,
+            ]
+
         for i in range(ranks):
             self.sockets[i].send_multipart(msg_buf, copy=False)
 
@@ -165,33 +184,48 @@ class LMCacheLookupServer:
         self.lmcache_engine = lmcache_engine
         self.running = True
 
+        self.enable_blending = lmcache_engine.config.enable_blending
+
         def process_request():
             while self.running:
                 frames = self.socket.recv_multipart(copy=False)
-                hash_frames = frames[0]
-                offset_frames = frames[1]
+                if not self.enable_blending:
+                    hash_frames = frames[0]
+                    offset_frames = frames[1]
 
-                lookup_id = frames[-2].bytes.decode("utf-8")
-                request_configs_str = frames[-1].bytes.decode("utf-8")
-                request_configs = None
-                if request_configs_str != "":
-                    request_configs = json.loads(request_configs_str)
+                    lookup_id = frames[-2].bytes.decode("utf-8")
+                    request_configs_str = frames[-1].bytes.decode("utf-8")
+                    request_configs = None
+                    if request_configs_str != "":
+                        request_configs = json.loads(request_configs_str)
 
-                hashes = self.decoder.decode(hash_frames)
-                offsets = self.decoder.decode(offset_frames)
-                result = self.lmcache_engine.lookup(
-                    hashes=hashes,
-                    offsets=offsets,
-                    lookup_id=lookup_id,
-                    pin=True,
-                    request_configs=request_configs,
-                )
+                    hashes = self.decoder.decode(hash_frames)
+                    offsets = self.decoder.decode(offset_frames)
+                    result = self.lmcache_engine.lookup(
+                        hashes=hashes,
+                        offsets=offsets,
+                        lookup_id=lookup_id,
+                        pin=True,
+                        request_configs=request_configs,
+                    )
+                else:
+                    token_frames = frames[0]
+                    lookup_id = frames[-2].bytes.decode("utf-8")
+                    request_configs_str = frames[-1].bytes.decode("utf-8")
+                    request_configs = None
+                    if request_configs_str != "":
+                        request_configs = json.loads(request_configs_str)
+
+                    tokens = self.decoder.decode(token_frames)
+                    result = self.lmcache_engine.lookup(
+                        tokens=tokens,
+                        lookup_id=lookup_id,
+                        pin=True,
+                        request_configs=request_configs,
+                    )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)
-                # except Exception as e:
-                #    logger.error("Error in LMCache lookup server: %s", e)
-                #    break
-                # continue
+
 
         logger.info(f"lmcache lookup server start on {socket_path}")
         self.thread = threading.Thread(target=process_request, daemon=True)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -93,7 +93,6 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
-
         lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -93,6 +93,18 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
+
+        lookup_id_buf = lookup_id.encode("utf-8")
+        request_configs_str = ""
+        if request_configs is not None and len(request_configs) != 0:
+            request_configs_str = json.dumps(request_configs)
+        request_configs_buf = request_configs_str.encode("utf-8")
+        ranks = self.tensor_parallel_size
+        if self.create_lookup_server_only_on_worker_0_for_mla:
+            ranks = 1
+
+        # NOTE(Jiayi): We cannot only send hashes when blending enabled
+        # because the blender need the input embedding.
         if not self.enable_blending:
             hashes = []
             offsets = []
@@ -103,15 +115,6 @@ class LMCacheLookupClient(LookupClientInterface):
                 offsets.append(end - start)
             hash_buf = self.encoder.encode(hashes)
             offset_buf = self.encoder.encode(offsets)
-
-            lookup_id_buf = lookup_id.encode("utf-8")
-            request_configs_str = ""
-            if request_configs is not None and len(request_configs) != 0:
-                request_configs_str = json.dumps(request_configs)
-            request_configs_buf = request_configs_str.encode("utf-8")
-            ranks = self.tensor_parallel_size
-            if self.create_lookup_server_only_on_worker_0_for_mla:
-                ranks = 1
             msg_buf = [
                 hash_buf,
                 offset_buf,
@@ -120,14 +123,6 @@ class LMCacheLookupClient(LookupClientInterface):
             ]
         else:
             tokens_buf = self.encoder.encode(token_ids)
-            lookup_id_buf = lookup_id.encode("utf-8")
-            request_configs_str = ""
-            if request_configs is not None and len(request_configs) != 0:
-                request_configs_str = json.dumps(request_configs)
-            request_configs_buf = request_configs_str.encode("utf-8")
-            ranks = self.tensor_parallel_size
-            if self.create_lookup_server_only_on_worker_0_for_mla:
-                ranks = 1
             msg_buf = [
                 tokens_buf,
                 lookup_id_buf,
@@ -189,16 +184,14 @@ class LMCacheLookupServer:
         def process_request():
             while self.running:
                 frames = self.socket.recv_multipart(copy=False)
+                lookup_id = frames[-2].bytes.decode("utf-8")
+                request_configs_str = frames[-1].bytes.decode("utf-8")
+                request_configs = None
+                if request_configs_str != "":
+                    request_configs = json.loads(request_configs_str)
                 if not self.enable_blending:
                     hash_frames = frames[0]
                     offset_frames = frames[1]
-
-                    lookup_id = frames[-2].bytes.decode("utf-8")
-                    request_configs_str = frames[-1].bytes.decode("utf-8")
-                    request_configs = None
-                    if request_configs_str != "":
-                        request_configs = json.loads(request_configs_str)
-
                     hashes = self.decoder.decode(hash_frames)
                     offsets = self.decoder.decode(offset_frames)
                     result = self.lmcache_engine.lookup(
@@ -210,12 +203,6 @@ class LMCacheLookupServer:
                     )
                 else:
                     token_frames = frames[0]
-                    lookup_id = frames[-2].bytes.decode("utf-8")
-                    request_configs_str = frames[-1].bytes.decode("utf-8")
-                    request_configs = None
-                    if request_configs_str != "":
-                        request_configs = json.loads(request_configs_str)
-
                     tokens = self.decoder.decode(token_frames)
                     result = self.lmcache_engine.lookup(
                         tokens=tokens,

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -311,7 +311,7 @@ class SegmentTokenDatabase(TokenDatabase):
         # to use `1:` (whether there's a special starting token
         # in the beginning)
         self.sep_tokens = self.tokenizer.encode(config.blend_special_str)[1:]
-        self.sep_tokens = torch.tensor(self.sep_tokens, device="cuda")
+        self.sep_tokens = torch.tensor(self.sep_tokens, device="cpu")
         self.sep_len = len(self.sep_tokens)
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
@@ -374,9 +374,9 @@ class SegmentTokenDatabase(TokenDatabase):
 
         if tokens is not None:
             if not isinstance(tokens, torch.Tensor):
-                tokens = torch.tensor(tokens, dtype=torch.long, device="cuda")
+                tokens = torch.tensor(tokens, dtype=torch.long, device="cpu")
             else:
-                tokens = tokens.to(device="cuda", dtype=torch.long)
+                tokens = tokens.to(device="cpu", dtype=torch.long)
 
             if mask is not None:
                 num_falses = mask.numel() - mask.long().sum().item()

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -393,7 +393,6 @@ class SegmentTokenDatabase(TokenDatabase):
                 if idx > 0:
                     start_idx += self.sep_len
                     end_idx += self.sep_len
-                    # end_idx = min(end_idx, len(tokens))
                 if start_idx >= num_falses:
                     if make_key:
                         yield (

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -311,7 +311,7 @@ class SegmentTokenDatabase(TokenDatabase):
         # to use `1:` (whether there's a special starting token
         # in the beginning)
         self.sep_tokens = self.tokenizer.encode(config.blend_special_str)[1:]
-        self.sep_tokens = torch.tensor(self.sep_tokens, device="cpu")
+        self.sep_tokens = torch.tensor(self.sep_tokens, device="cuda")
         self.sep_len = len(self.sep_tokens)
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
@@ -374,7 +374,7 @@ class SegmentTokenDatabase(TokenDatabase):
 
         if tokens is not None:
             if not isinstance(tokens, torch.Tensor):
-                tokens = torch.tensor(tokens, dtype=torch.long)
+                tokens = torch.tensor(tokens, dtype=torch.long, device="cuda")
 
             if mask is not None:
                 num_falses = mask.numel() - mask.long().sum().item()

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -375,6 +375,8 @@ class SegmentTokenDatabase(TokenDatabase):
         if tokens is not None:
             if not isinstance(tokens, torch.Tensor):
                 tokens = torch.tensor(tokens, dtype=torch.long, device="cuda")
+            else:
+                tokens = tokens.to(device="cuda", dtype=torch.long)
 
             if mask is not None:
                 num_falses = mask.numel() - mask.long().sum().item()

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -372,36 +372,55 @@ class SegmentTokenDatabase(TokenDatabase):
 
         """
 
-        if not isinstance(tokens, torch.Tensor):
-            tokens = torch.tensor(tokens, dtype=torch.long)
+        if tokens is not None:
+            if not isinstance(tokens, torch.Tensor):
+                tokens = torch.tensor(tokens, dtype=torch.long)
 
-        if mask is not None:
-            num_falses = mask.numel() - mask.long().sum().item()
-        else:
-            num_falses = 0
-        assert num_falses < len(tokens), (
-            "The number of Falses in the mask shouldn't "
-            "be less than the length of tokens."
-        )
+            if mask is not None:
+                num_falses = mask.numel() - mask.long().sum().item()
+            else:
+                num_falses = 0
+            assert num_falses < len(tokens), (
+                "The number of Falses in the mask shouldn't "
+                "be less than the length of tokens."
+            )
 
-        token_chunks = self._fast_split_by_subtensor(tokens)
-        start_idx = 0
-        for idx, token_chunk in enumerate(token_chunks):
-            token_chunk_len = len(token_chunk)
-            end_idx = start_idx + token_chunk_len
-            if idx > 0:
-                start_idx += self.sep_len
-                end_idx += self.sep_len
-                # end_idx = min(end_idx, len(tokens))
-            if start_idx >= num_falses:
+            token_chunks = self._fast_split_by_subtensor(tokens)
+            start_idx = 0
+            for idx, token_chunk in enumerate(token_chunks):
+                token_chunk_len = len(token_chunk)
+                end_idx = start_idx + token_chunk_len
+                if idx > 0:
+                    start_idx += self.sep_len
+                    end_idx += self.sep_len
+                    # end_idx = min(end_idx, len(tokens))
+                if start_idx >= num_falses:
+                    if make_key:
+                        yield (
+                            start_idx,
+                            end_idx,
+                            self._make_key_by_hash(
+                                self._hash_tokens(token_chunk), request_configs
+                            ),
+                        )
+                    else:
+                        yield start_idx, end_idx, self._hash_tokens(token_chunk)
+                start_idx = end_idx
+        elif hashes is not None:
+            assert offsets is not None, (
+                "If hashes are provided, offsets must also be provided."
+            )
+            start_idx = 0
+            for hash_val, offset in zip(hashes, offsets, strict=False):
+                end_idx = start_idx + offset
                 if make_key:
                     yield (
                         start_idx,
                         end_idx,
-                        self._make_key_by_hash(
-                            self._hash_tokens(token_chunk), request_configs
-                        ),
+                        self._make_key_by_hash(hash_val, request_configs),
                     )
                 else:
-                    yield start_idx, end_idx, self._hash_tokens(token_chunk)
-            start_idx = end_idx
+                    yield start_idx, end_idx, hash_val
+                start_idx = end_idx
+        else:
+            raise ValueError("Either tokens or hashes must be provided.")

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -57,8 +57,6 @@ def test_remote_mla_worker_id_as0(mock_stream):
         use_layerwise=False,
         save_decode_cache=False,
         enable_blending=False,
-        blend_recompute_ratio=0.15,
-        blend_min_tokens=256,
         extra_config={"remote_enable_mla_worker_id_as0": True},
     )
 


### PR DESCRIPTION
Fix blending bugs introduced by recent updates.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
