### PR TITLE
Refactor lmcache_get_config to lmcache_get_or_create_config

### DIFF
--- a/examples/plugins/scheduler_foo_plugin.py
+++ b/examples/plugins/scheduler_foo_plugin.py
@@ -10,7 +10,7 @@ import signal
 import time
 
 # First Party
-from lmcache.integration.vllm.utils import lmcache_get_config
+from lmcache.integration.vllm.utils import lmcache_get_or_create_config
 from lmcache.v1.config import LMCacheEngineConfig
 
 
@@ -30,7 +30,7 @@ try:
     config = LMCacheEngineConfig.from_json(config_str)
 except json.JSONDecodeError as e:
     print(f"Error parsing LMCACHE_PLUGIN_CONFIG: {e}")
-    config = lmcache_get_config()
+    config = lmcache_get_or_create_config()
 
 print(
     f"Python plugin running with role: {role}, worker_id: {worker_id}, "

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -2,6 +2,7 @@
 # Standard
 from typing import TYPE_CHECKING, Tuple, Union
 import os
+import threading
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -21,46 +22,58 @@ from lmcache.v1.config import (
 logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
 
+# Thread-safe singleton storage
+_config_instance = None
+_config_lock = threading.Lock()
+
 
 def is_false(value: str) -> bool:
     """Check if the given string value is equivalent to 'false'."""
     return value.lower() in ("false", "0", "no", "n", "off")
 
 
-def lmcache_get_config() -> Union[Config, V1Config]:
+def lmcache_get_or_create_config() -> Union[Config, V1Config]:
     """Get the LMCache configuration from the environment variable
     `LMCACHE_CONFIG_FILE`. If the environment variable is not set, this
     function will return the default configuration.
+
+    This function is thread-safe and implements singleton pattern,
+    ensuring the configuration is loaded only once.
     """
+    global _config_instance
 
-    if is_false(os.getenv("LMCACHE_USE_EXPERIMENTAL", "True")):
-        logger.warning(
-            "Detected LMCACHE_USE_EXPERIMENTAL is set to False. "
-            "Using legacy configuration is deprecated and will "
-            "be remove soon! Please set LMCACHE_USE_EXPERIMENTAL "
-            "to True."
-        )
-        LMCacheEngineConfig = Config  # type: ignore[assignment]
-    else:
-        LMCacheEngineConfig = V1Config  # type: ignore[assignment]
+    # Double-checked locking for thread-safe singleton
+    if _config_instance is None:
+        with _config_lock:
+            if _config_instance is None:  # Check again within lock
+                if is_false(os.getenv("LMCACHE_USE_EXPERIMENTAL", "True")):
+                    logger.warning(
+                        "Detected LMCACHE_USE_EXPERIMENTAL is set to False. "
+                        "Using legacy configuration is deprecated and will "
+                        "be remove soon! Please set LMCACHE_USE_EXPERIMENTAL "
+                        "to True."
+                    )
+                    LMCacheEngineConfig = Config  # type: ignore[assignment]
+                else:
+                    LMCacheEngineConfig = V1Config  # type: ignore[assignment]
 
-    if "LMCACHE_CONFIG_FILE" not in os.environ:
-        logger.warn(
-            "No LMCache configuration file is set. Trying to read"
-            " configurations from the environment variables."
-        )
-        logger.warn(
-            "You can set the configuration file through "
-            "the environment variable: LMCACHE_CONFIG_FILE"
-        )
-        config = LMCacheEngineConfig.from_env()
-    else:
-        config_file = os.environ["LMCACHE_CONFIG_FILE"]
-        logger.info(f"Loading LMCache config file {config_file}")
-        config = LMCacheEngineConfig.from_file(config_file)
-        # Update config from environment variables
-        config.update_config_from_env()
-    return config
+                if "LMCACHE_CONFIG_FILE" not in os.environ:
+                    logger.warn(
+                        "No LMCache configuration file is set. Trying to read"
+                        " configurations from the environment variables."
+                    )
+                    logger.warn(
+                        "You can set the configuration file through "
+                        "the environment variable: LMCACHE_CONFIG_FILE"
+                    )
+                    _config_instance = LMCacheEngineConfig.from_env()
+                else:
+                    config_file = os.environ["LMCACHE_CONFIG_FILE"]
+                    logger.info(f"Loading LMCache config file {config_file}")
+                    _config_instance = LMCacheEngineConfig.from_file(config_file)
+                    # Update config from environment variables
+                    _config_instance.update_config_from_env()
+    return _config_instance
 
 
 def hex_hash_to_int16(s: str) -> int:
@@ -122,7 +135,7 @@ def create_lmcache_metadata(
     # First Party
     from lmcache.config import LMCacheEngineMetadata
 
-    config = lmcache_get_config()
+    config = lmcache_get_or_create_config()
     # Support both vllm_config object and individual config parameters
     if vllm_config is not None:
         model_cfg = vllm_config.model_config

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -23,7 +23,7 @@ logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
 
 # Thread-safe singleton storage
-_config_instance = None
+_config_instance: Union[Config, V1Config, None] = None
 _config_lock = threading.Lock()
 
 
@@ -58,11 +58,11 @@ def lmcache_get_or_create_config() -> Union[Config, V1Config]:
                     LMCacheEngineConfig = V1Config  # type: ignore[assignment]
 
                 if "LMCACHE_CONFIG_FILE" not in os.environ:
-                    logger.warn(
+                    logger.warning(
                         "No LMCache configuration file is set. Trying to read"
                         " configurations from the environment variables."
                     )
-                    logger.warn(
+                    logger.warning(
                         "You can set the configuration file through "
                         "the environment variable: LMCACHE_CONFIG_FILE"
                     )

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -31,7 +31,7 @@ from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
     extract_mm_features,
-    lmcache_get_config,
+    lmcache_get_or_create_config,
     mla_enabled,
 )
 from lmcache.logging import init_logger
@@ -556,7 +556,7 @@ class LMCacheConnectorV1Impl:
         self._parent = parent
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.worker_count = vllm_config.parallel_config.tensor_parallel_size
-        config = lmcache_get_config()
+        config = lmcache_get_or_create_config()
         assert isinstance(config, LMCacheEngineConfig), (
             "LMCache v1 configuration is should be passed for vLLM v1."
         )


### PR DESCRIPTION
This refactor can make sure there is only one instance of `LMCacheEngineConfig` same time