### PR TITLE
Add XPU support to LMCache for CPU/disk offloading

### DIFF
--- a/lmcache/integration/vllm/vllm_adapter.py
+++ b/lmcache/integration/vllm/vllm_adapter.py
@@ -35,6 +35,7 @@ from vllm.config import (
     ParallelConfig,
     SchedulerConfig,
 )
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 # First Party
@@ -51,7 +52,7 @@ from lmcache.v1.cache_engine import LMCacheEngineBuilder
 
 logger = init_logger(__name__)
 
-if torch.cuda.is_available():
+if current_platform.is_cuda_alike():
     LMCACHE_CUDA_STREAM = torch.cuda.Stream()
 
 SUPPORTED_BACKEND_METADATA = (

--- a/lmcache/integration/vllm/vllm_adapter.py
+++ b/lmcache/integration/vllm/vllm_adapter.py
@@ -51,7 +51,8 @@ from lmcache.v1.cache_engine import LMCacheEngineBuilder
 
 logger = init_logger(__name__)
 
-LMCACHE_CUDA_STREAM = torch.cuda.Stream()
+if torch.cuda.is_available():
+    LMCACHE_CUDA_STREAM = torch.cuda.Stream()
 
 SUPPORTED_BACKEND_METADATA = (
     FlashAttentionMetadata,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -34,6 +34,7 @@ except ImportError:
     from vllm.utils import get_kv_cache_torch_dtype
 
 # Third Party
+from vllm.platforms import current_platform
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.version import __version__ as VLLM_VERSION
 import torch
@@ -60,7 +61,6 @@ from lmcache.v1.gpu_connector import (
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemLayerwiseGPUConnector,
 )
-from lmcache.v1.xpu_connector import VLLMPagedMemXPUConnectorV2
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.lookup_client import LookupClientFactory
 from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
@@ -68,6 +68,7 @@ from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
 )
 from lmcache.v1.offload_server.zmq_server import ZMQOffloadServer
 from lmcache.v1.plugin.plugin_launcher import PluginLauncher
+from lmcache.v1.xpu_connector import VLLMPagedMemXPUConnectorV2
 
 if TYPE_CHECKING:
     # Third Party
@@ -493,11 +494,11 @@ def _init_lmcache_engine(
     )
 
     # Change current device.
-    if torch.cuda.is_available():
+    if current_platform.is_cuda_alike():
         logger.info("CUDA device is available. Using CUDA for LMCache engine.")
         torch_dev = torch.cuda
         dev_name = "cuda"
-    elif torch.xpu.is_available():
+    elif current_platform.is_xpu():
         logger.info("XPU device is available. Using XPU for LMCache engine.")
         torch_dev = torch.xpu
         dev_name = "xpu"
@@ -555,9 +556,9 @@ def _init_lmcache_engine(
             )
         tpg = get_tp_group()
     else:
-        if torch.cuda.is_available():
+        if current_platform.is_cuda_alike():
             connector_cls = VLLMPagedMemGPUConnectorV2
-        elif torch.xpu.is_available():
+        elif current_platform.is_xpu():
             connector_cls = VLLMPagedMemXPUConnectorV2
         else:
             raise RuntimeError("No supported connector found for the current platform.")

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -60,6 +60,7 @@ from lmcache.v1.gpu_connector import (
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemLayerwiseGPUConnector,
 )
+from lmcache.v1.xpu_connector import VLLMPagedMemXPUConnectorV2
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.lookup_client import LookupClientFactory
 from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
@@ -492,10 +493,19 @@ def _init_lmcache_engine(
     )
 
     # Change current device.
-    num_gpus = torch.cuda.device_count()
+    if torch.cuda.is_available():
+        torch_dev = torch.cuda
+        dev_name = "cuda"
+    elif torch.xpu.is_available():
+        torch_dev = torch.xpu
+        dev_name = "xpu"
+    else:
+        raise RuntimeError("Unsupported device platform for LMCache engine.")
+
+    num_gpus = torch_dev.device_count()
     local_rank = parallel_config.rank % num_gpus
-    torch.cuda.set_device(local_rank)
-    device = torch.device(f"cuda:{local_rank}")
+    torch_dev.set_device(local_rank)
+    device = torch.device(f"{dev_name}:{local_rank}")
     metadata = LMCacheEngineMetadata(
         model_config.model,
         parallel_config.world_size,
@@ -543,7 +553,14 @@ def _init_lmcache_engine(
             )
         tpg = get_tp_group()
     else:
-        vllm_gpu_connector = VLLMPagedMemGPUConnectorV2(
+        if torch.cuda.is_available():
+            connector_cls = VLLMPagedMemGPUConnectorV2
+        elif torch.xpu.is_available():
+            connector_cls = VLLMPagedMemXPUConnectorV2
+        else:
+            raise RuntimeError("No supported connector found for the current platform.")
+
+        vllm_gpu_connector = connector_cls(
             hidden_dim_size,
             num_layer,
             use_gpu=use_gpu,
@@ -863,7 +880,7 @@ class LMCacheConnectorV1Impl:
 
             tokens = request.token_ids
             # TODO: have a pre-allocated buffer to hold the slot_mappings
-            slot_mapping = request.slot_mapping.cuda()
+            slot_mapping = request.slot_mapping.to(kvcaches[0][0].device)
             assert len(tokens) == len(slot_mapping)
 
             token_mask = torch.ones(len(tokens), dtype=torch.bool)
@@ -1096,7 +1113,7 @@ class LMCacheConnectorV1Impl:
                 assert len(slot_mapping) == len(token_ids)
 
                 # TODO: have a pre-allocated buffer to hold the slot_mappings
-                slot_mapping = slot_mapping.cuda()
+                slot_mapping = slot_mapping.to(kvcaches[0][0].device)
 
                 if self.kv_role == "kv_producer":
                     skip_leading_tokens = 0
@@ -1185,7 +1202,7 @@ class LMCacheConnectorV1Impl:
             assert len(slot_mapping) == len(token_ids)
 
             # TODO: have a pre-allocated buffer to hold the slot_mappings
-            slot_mapping = slot_mapping.cuda()
+            slot_mapping = slot_mapping.to(kvcaches[0][0].device)
 
             skip_leading_tokens = save_spec.skip_leading_tokens
             if self.kv_role == "kv_producer":

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -494,9 +494,11 @@ def _init_lmcache_engine(
 
     # Change current device.
     if torch.cuda.is_available():
+        logger.info("CUDA device is available. Using CUDA for LMCache engine.")
         torch_dev = torch.cuda
         dev_name = "cuda"
     elif torch.xpu.is_available():
+        logger.info("XPU device is available. Using XPU for LMCache engine.")
         torch_dev = torch.xpu
         dev_name = "xpu"
     else:
@@ -611,6 +613,7 @@ class LMCacheConnectorV1Impl:
     ):
         self._parent = parent
         self._vllm_config = vllm_config
+        self.device = vllm_config.device_config.device
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.worker_count = vllm_config.parallel_config.tensor_parallel_size
         config = lmcache_get_or_create_config()
@@ -880,7 +883,7 @@ class LMCacheConnectorV1Impl:
 
             tokens = request.token_ids
             # TODO: have a pre-allocated buffer to hold the slot_mappings
-            slot_mapping = request.slot_mapping.to(kvcaches[0][0].device)
+            slot_mapping = request.slot_mapping.to(self.device)
             assert len(tokens) == len(slot_mapping)
 
             token_mask = torch.ones(len(tokens), dtype=torch.bool)
@@ -1113,7 +1116,7 @@ class LMCacheConnectorV1Impl:
                 assert len(slot_mapping) == len(token_ids)
 
                 # TODO: have a pre-allocated buffer to hold the slot_mappings
-                slot_mapping = slot_mapping.to(kvcaches[0][0].device)
+                slot_mapping = slot_mapping.to(self.device)
 
                 if self.kv_role == "kv_producer":
                     skip_leading_tokens = 0
@@ -1202,7 +1205,7 @@ class LMCacheConnectorV1Impl:
             assert len(slot_mapping) == len(token_ids)
 
             # TODO: have a pre-allocated buffer to hold the slot_mappings
-            slot_mapping = slot_mapping.to(kvcaches[0][0].device)
+            slot_mapping = slot_mapping.to(self.device)
 
             skip_leading_tokens = save_spec.skip_leading_tokens
             if self.kv_role == "kv_producer":

--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -243,6 +243,11 @@ class UsageContext:
             gpu_count = torch.cuda.device_count()
             gpu_type = device_property.name
             gpu_memory_per_device = device_property.total_memory
+        elif torch.xpu.is_available():
+            device_property = torch.xpu.get_device_properties(0)
+            gpu_count = torch.xpu.device_count()
+            gpu_type = device_property.name
+            gpu_memory_per_device = device_property.total_memory
         else:
             gpu_count = psutil.cpu_count(logical=False)
             gpu_type = platform.processor()

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -115,9 +115,10 @@ def CreateStorageBackends(
 ) -> OrderedDict[str, StorageBackendInterface]:
     if is_cuda_worker(metadata):
         dst_device = f"cuda:{torch.cuda.current_device()}"
+    elif dst_device == "xpu":
+        dst_device = f"xpu:{torch.xpu.current_device()}"
     else:
         dst_device = "cpu"
-
     storage_backends: OrderedDict[str, StorageBackendInterface] = OrderedDict()
 
     extra_config = config.extra_config

--- a/lmcache/v1/xpu_connector.py
+++ b/lmcache/v1/xpu_connector.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024-2025 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Standard
+from typing import List, Optional
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+
+logger = init_logger(__name__)
+
+
+class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
+    """
+    The GPU KV cache should be a nested tuple of K and V tensors.
+    More specifically, we have:
+    - GPUTensor = Tuple[KVLayer, ...]
+    - KVLayer = Tuple[Tensor, Tensor]
+    - Tensor: [num_blocks, block_size, num_heads, head_size]
+
+    It will produce / consume memory object with KV_2LTD format
+    """
+
+    def __init__(
+        self,
+        hidden_dim_size: int,
+        num_layers: int,
+        use_gpu: bool = False,
+        **kwargs,
+    ):
+        """
+        If use_gpu is true, it will create a gpu intermediate buffer. In this
+        case, it requires the following kwargs:
+        - chunk_size: The MAX size of the chunk to be copied to GPU.
+        - dtype: The data type of the intermediate buffer.
+        """
+        self.hidden_dim_size = hidden_dim_size
+        self.num_layers = num_layers
+        self.kv_cache_pointers = torch.empty(
+            num_layers, dtype=torch.int64, device="cpu"
+        )
+        # Not sure we need a dict here. Maybe a single GPU connector always
+        # works with a single device?
+        self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
+        self.page_buffer_size = 0
+
+        self.kvcaches: Optional[List[torch.Tensor]] = None
+        self.gpu_buffer: Optional[torch.Tensor] = None
+        self.use_mla = "use_mla" in kwargs and kwargs["use_mla"]
+        if use_gpu:
+            assert "chunk_size" in kwargs, (
+                "chunk_size should be provided to create a GPU buffer."
+            )
+            assert "dtype" in kwargs, "dtype should be provided to create a GPU buffer."
+            assert "device" in kwargs, (
+                "device should be provided to create a GPU buffer."
+            )
+            shape = self.get_shape(kwargs["chunk_size"])
+            self.gpu_buffer = torch.empty(
+                shape, dtype=kwargs["dtype"], device=kwargs["device"]
+            )
+
+    @_lmcache_nvtx_annotate
+    def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
+        The kvcaches should correspond to the "WHOLE token sequence".
+
+        Note:
+          1. This function expects the 'slot_mapping' is a "full slot mapping"
+             where it's length is the same as the whole token sequence.
+          2. In the case that there is prefix caching, slot_mapping will starts
+             with -1s until the end of the matched prefix. The start and end
+             should NEVER overlap with the prefix caching (which means the
+             underlying CUDA kernel will never see -1 in slot_mapping)
+
+
+        :raises ValueError: If 'kvcaches' is not provided in kwargs.
+        :raises AssertionError: If the memory object does not have a tensor.
+        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        """
+        assert memory_obj.tensor is not None
+
+        if self.use_mla:
+            if memory_obj.metadata.fmt != MemoryFormat.KV_MLA_FMT:
+                raise ValueError(
+                    "The memory object should be in KV_MLA_FMT format in"
+                    " order to be processed by VLLMPagedMemXPUConnector"
+                )
+        else:
+            if memory_obj.metadata.fmt != MemoryFormat.KV_2LTD:
+                raise ValueError(
+                    "The memory object should be in KV_2LTD format in"
+                    " order to be processed by VLLMPagedMemXPUConnector"
+                )
+
+        if "kvcaches" not in kwargs:
+            raise ValueError("'kvcaches' should be provided in kwargs.")
+
+        if "slot_mapping" not in kwargs:
+            raise ValueError("'slot_mapping' should be provided in kwargs.")
+
+        kvcaches: List[torch.Tensor] = kwargs["kvcaches"]
+        slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+        slices = slot_mapping[start:end]
+
+        if self.use_mla:
+            tmp = memory_obj.tensor[0].to(slot_mapping.device)
+            num_blocks, block_size, head_size = kvcaches[0].shape
+            total_blocks = num_blocks * block_size
+            for i, kvcache in enumerate(kvcaches):
+                kvcache.view(total_blocks, head_size).index_copy_(0, slices, tmp[i])
+        else:
+            tmp_k = memory_obj.tensor[0].to(slot_mapping.device)
+            tmp_v = memory_obj.tensor[1].to(slot_mapping.device)
+            num_blocks, block_size, num_heads, head_size = kvcaches[0][0].shape
+            total_blocks = num_blocks * block_size
+            d = num_heads * head_size
+            for i, (kcache, vcache) in enumerate(kvcaches):
+                kcache.view(total_blocks, d).index_copy_(0, slices, tmp_k[i])
+                vcache.view(total_blocks, d).index_copy_(0, slices, tmp_v[i])
+
+    @_lmcache_nvtx_annotate
+    def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
+        The kvcaches should correspond to the "WHOLE token sequence".
+
+        Will set the memory_obj.metadata.fmt to MemoryFormat.KV_2LTD.
+
+        Note:
+          1. This function expects the 'slot_mapping' is a "full slot mapping"
+             where it's length is the same as the whole token sequence.
+          2. In the case that there is prefix caching, slot_mapping will starts
+             with -1s until the end of the matched prefix. The start and end
+             should NEVER overlap with the prefix caching (which means the
+             underlying CUDA kernel will never see -1 in slot_mapping)
+
+        :raises ValueError: If 'kvcaches' is not provided in kwargs,
+        :raises AssertionError: If the memory object does not have a tensor.
+        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        """
+        assert memory_obj.tensor is not None
+
+        if "kvcaches" not in kwargs:
+            raise ValueError("'kvcaches' should be provided in kwargs.")
+
+        if "slot_mapping" not in kwargs:
+            raise ValueError("'slot_mapping' should be provided in kwargs.")
+
+        kvcaches: List[torch.Tensor] = kwargs["kvcaches"]
+        slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+        slices = slot_mapping[start:end]
+
+        if self.use_mla:
+            num_blocks, block_size, head_size = kvcaches[0].shape
+            total_blocks = num_blocks * block_size
+            tmp = torch.stack(
+                [
+                    kvcache.view(total_blocks, head_size).index_select(0, slices)
+                    for kvcache in kvcaches
+                ]
+            )
+        else:
+            num_blocks, block_size, num_heads, head_size = kvcaches[0][0].shape
+            total_blocks = num_blocks * block_size
+            d = num_heads * head_size
+            tmp_k = torch.stack(
+                [
+                    kvcache[0].view(total_blocks, d).index_select(0, slices)
+                    for kvcache in kvcaches
+                ]
+            )
+            tmp_v = torch.stack(
+                [
+                    kvcache[1].view(total_blocks, d).index_select(0, slices)
+                    for kvcache in kvcaches
+                ]
+            )
+            tmp = torch.stack([tmp_k, tmp_v])
+        memory_obj.tensor.copy_(tmp, non_blocking=True)
+
+        if not memory_obj.tensor.is_xpu:
+            # Force a synchronize if the target buffer is NOT XPU device
+            # NOTE: for better performance, we may not want to sync for every
+            # memory object
+            torch.xpu.synchronize()
+
+        if self.use_mla:
+            memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
+
+    # TODO(Jiayi): need to optimize to enable real batching
+    def batched_to_gpu(self, memory_objs, starts, ends, **kwargs):
+        for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
+            self.to_gpu(memory_obj, start, end, **kwargs)

--- a/lmcache/v1/xpu_connector.py
+++ b/lmcache/v1/xpu_connector.py
@@ -20,7 +20,6 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 
@@ -77,7 +76,6 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
                 shape, dtype=kwargs["dtype"], device=kwargs["device"]
             )
 
-    @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
         """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
         The kvcaches should correspond to the "WHOLE token sequence".
@@ -136,7 +134,6 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
                 kcache.view(total_blocks, d).index_copy_(0, slices, tmp_k[i])
                 vcache.view(total_blocks, d).index_copy_(0, slices, tmp_v[i])
 
-    @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
         """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
         The kvcaches should correspond to the "WHOLE token sequence".


### PR DESCRIPTION
# Purpose

- Add XPU connector for cpu/disk offloading

# Results

running [example](https://docs.lmcache.ai/kv_cache/storage_backends/cpu_ram.html) on XPU

```bash
First run:
Adding requests:   0%|
...
(EngineCore_DP0 pid=640506) [2025-09-15 12:32:07,137] LMCache INFO: Stored 1819 out of total 1819 tokens. size: 0.2220 gb, cost 14.2378 ms, throughput: 15.5955 GB/s; offload_time: 14.2046 ms, put_time: 0.0332 ms (cache_engine.py:309:lmcache.v1.cache_engine)
Processed prompts: 100%|███████████████████████████████████████████████| 10/10 [00:11<00:00,  1.20s/it, est. speed input: 8374.62 toks/s, output: 0.84 toks/s]Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
First run time: 12.17 seconds

Second run:
Adding requests:   0%| 
...
(EngineCore_DP0 pid=640506) [2025-09-15 12:32:08,094] LMCache INFO: Retrieved 10011 out of total 10011 out of total 10011 tokens. size: 1.2220 gb, cost 91.5921 ms, throughput: 13.3423 GB/s; (cache_engine.py:519:lmcache.v1.cache_engine)
Processed prompts:  20%|█████████▍                                     | 2/10 [00:00<00:03,  2.58it/s, est. speed input: 25812.48 toks/s, output: 2.58 toks/s]
(EngineCore_DP0 pid=640506) [2025-09-15 12:32:08,156] LMCache INFO: Reqid: 18, Total tokens 10011, LMCache hit tokens: 10011, need to load: 10010 (vllm_v1_adapter.py:1133:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=640506) [2025-09-15 12:32:08,157] LMCache INFO: Reqid: 19, Total tokens 10011, LMCache hit tokens: 10011, need to load: 10010 (vllm_v1_adapter.py:1133:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=640506) [2025-09-15 12:32:08,251] LMCache INFO: Retrieved 10011 out of total 10011 out of total 10011 tokens. size: 1.2220 gb, cost 91.5162 ms, throughput: 13.3533 GB/s; (cache_engine.py:519:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=640506) [2025-09-15 12:32:08,342] LMCache INFO: Retrieved 10011 out of total 10011 out of total 10011 tokens. size: 1.2220 gb, cost 91.3324 ms, throughput: 13.3802 GB/s; (cache_engine.py:519:lmcache.v1.cache_engine)
Processed prompts: 100%|██████████████████████████████████████████████| 10/10 [00:01<00:00,  9.84it/s, est. speed input: 98484.65 toks/s, output: 9.84 toks/s]
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Generated text: ' I'
Second run time: 1.25 seconds

Speedup (first run / second run): 9.72x

```