### PR TITLE
[Doc] Fold the navigation bar for KV Cache management

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,14 +93,7 @@ Documentation
    :maxdepth: 2
    :caption: KV Cache management
 
-   kv_cache_management/controller
-   kv_cache_management/clear
-   kv_cache_management/compress
-   kv_cache_management/health
-   kv_cache_management/lookup
-   kv_cache_management/move
-   kv_cache_management/pin
-   kv_cache_management/check_finish
+   kv_cache_management/index
 
 :raw-html:`<br />`
 

--- a/docs/source/kv_cache_management/index.rst
+++ b/docs/source/kv_cache_management/index.rst
@@ -12,3 +12,15 @@ Currently, the controller provides the following APIs:
 - :ref:`Move <move>`: Move the KV cache to a different location.
 - :ref:`Pin <pin>`: Persist the KV cache to prevent it from being evicted.
 - :ref:`CheckFinish <check_finish>`: Check whether a (non-blocking) control event has finished or not.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   clear
+   compress
+   health
+   lookup
+   move
+   pin
+   check_finish


### PR DESCRIPTION
A little improvement to reduce redundancy and save vertical space on the left side.

Before:

<img width="510" height="680" alt="image" src="https://github.com/user-attachments/assets/09e8e7cb-4899-41da-ba58-c5ab3c63248a" />

After:

<img width="482" height="144" alt="image" src="https://github.com/user-attachments/assets/3658b69e-783b-4fb6-8461-149ce84fcbe1" />
<img width="502" height="718" alt="image" src="https://github.com/user-attachments/assets/60340bed-c06e-4fe6-bf8a-c09e913986d9" />


**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
