### PR TITLE
Add sphinx-multiversion for tracing docs versions

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          # for setuptools-scm
+          # Full git history needed for sphinx-multiversion to detect all tags/branches
           fetch-depth: 0
+          # Fetch all branches and tags
+          fetch-tags: true
 
       - name: Setup Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -36,9 +38,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/docs.txt
 
-      - name: Build Sphinx Documentation
+      - name: Build Versioned Sphinx Documentation
         run: |
-          sphinx-build docs/source output
+          sphinx-multiversion docs/source output
         continue-on-error: false
 
       - name: Add .nojekyll

--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -1,0 +1,17 @@
+{%- if versions %}
+<div class="version-selector">
+  <label for="version-select">Version:</label>
+  <select id="version-select" onchange="location.href=this.value;">
+    {%- for version in versions %}
+    <option value="{{ version.url }}" 
+            {%- if version.name == current_version %} selected="selected"{% endif %}>
+      {%- if version.name == smv_latest_version -%}
+        {{ version.name }} (latest)
+      {%- else -%}
+        {{ version.name }}
+      {%- endif -%}
+    </option>
+    {%- endfor %}
+  </select>
+</div>
+{%- endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosectionlabel",
     # "sphinx_copybutton",
+    "sphinx_multiversion",
 ]
 
 copybutton_prompt_text = r"^(\$ |>>> |\# )"
@@ -155,3 +156,21 @@ autodoc_mock_imports = [
     "safetensors",
     "torch.Tensor",
 ]
+
+# -- sphinx-multiversion configuration -------------------------------------------
+
+# Whitelist pattern for tags (build docs for all v* tags)
+smv_tag_whitelist = r"^v\d+\.\d+.*$"
+
+# Whitelist pattern for branches (build docs for dev and main)
+smv_branch_whitelist = r"^(dev|main)$"
+
+# Pattern for released versions (tags only)
+smv_released_pattern = r"^tags/v.*$"
+
+# Remote whitelist pattern (for security)
+smv_remote_whitelist = r"^(origin)$"
+
+# Output directories
+smv_latest_version = "dev"  # Point latest to dev branch
+smv_prefer_remote_refs = False

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,4 +9,5 @@ sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinxawesome_theme==5.3.2
 sphinx-copybutton==0.5.2
+sphinx-multiversion==0.2.4
 msgspec


### PR DESCRIPTION
Add versioning so that users/developers can refer to past docs like vllm does.

build doc command:

```
sphinx-multiversion docs/source docs/output
python -m http.server 8000 --directory build/html
```

effect:

default(point to latest release):
<img width="1440" height="1027" alt="image" src="https://github.com/user-attachments/assets/269ab64c-6669-4cab-af73-557c8d61a600" />


v0.2.0
<img width="1440" height="1011" alt="image" src="https://github.com/user-attachments/assets/3a27dcac-4a8a-4cbb-bf2c-4008bd8dece6" />

v0.3.6
<img width="1440" height="1007" alt="image" src="https://github.com/user-attachments/assets/edf24951-519e-4c31-9a28-09a7e5ea946b" />



---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
