### PR TITLE
support tmp path in FSConnector

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -23,5 +23,11 @@ class FsConnectorAdapter(ConnectorAdapter):
 
         logger.info(f"Creating FS connector for URL: {context.url}")
         parse_url = parse_remote_url(context.url)
-        relative_tmp_dir = None if context.config is None else context.config.get_extra_config_value("relative_tmp_dir", None)
-        return FSConnector(parse_url.path, context.loop, context.local_cpu_backend, relative_tmp_dir)
+        relative_tmp_dir = (
+            None
+            if context.config is None
+            else context.config.get_extra_config_value("relative_tmp_dir", None)
+        )
+        return FSConnector(
+            parse_url.path, context.loop, context.local_cpu_backend, relative_tmp_dir
+        )

--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -26,7 +26,7 @@ class FsConnectorAdapter(ConnectorAdapter):
         relative_tmp_dir = (
             None
             if context.config is None
-            else context.config.get_extra_config_value("relative_tmp_dir", None)
+            else context.config.get_extra_config_value("fs_connector_relative_tmp_dir", None)
         )
         return FSConnector(
             parse_url.path, context.loop, context.local_cpu_backend, relative_tmp_dir

--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -26,7 +26,9 @@ class FsConnectorAdapter(ConnectorAdapter):
         relative_tmp_dir = (
             None
             if context.config is None
-            else context.config.get_extra_config_value("fs_connector_relative_tmp_dir", None)
+            else context.config.get_extra_config_value(
+                "fs_connector_relative_tmp_dir", None
+            )
         )
         return FSConnector(
             parse_url.path, context.loop, context.local_cpu_backend, relative_tmp_dir

--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -23,4 +23,5 @@ class FsConnectorAdapter(ConnectorAdapter):
 
         logger.info(f"Creating FS connector for URL: {context.url}")
         parse_url = parse_remote_url(context.url)
-        return FSConnector(parse_url.path, context.loop, context.local_cpu_backend)
+        relative_tmp_dir = None if context.config is None else context.config.get_extra_config_value("relative_tmp_dir", None)
+        return FSConnector(parse_url.path, context.loop, context.local_cpu_backend, relative_tmp_dir)

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -155,6 +155,7 @@ class FSConnector(RemoteConnector):
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """Store data to file system"""
         final_path, temp_path = self._get_file_path(key, True)
+        assert temp_path is not None
 
         try:
             # Prepare metadata

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -68,11 +68,8 @@ class FSConnector(RemoteConnector):
             if self.relative_tmp_dir is not None:
                 (path / self.relative_tmp_dir).mkdir(parents=False, exist_ok=True)
 
-    def _get_file_path(
-        self, key: CacheEngineKey, generate_tmp_path=False
-    ) -> Tuple[Path, Optional[Path]]:
-        """Get file path and tmp path for the given key"""
-        # If there's only one path, use it directly
+    def _get_base_path(self, key: CacheEngineKey) -> Path:
+        """Get file base path for the given key"""
         if len(self.base_paths) == 1:
             base_path = self.base_paths[0]
         else:
@@ -81,29 +78,41 @@ class FSConnector(RemoteConnector):
             idx = hash_val % len(self.base_paths)
             base_path = self.base_paths[idx]
 
-        key_path = key.to_string().replace("/", "-") + ".data"
-        data_path = base_path / key_path
-        tmp_path = None
-        if generate_tmp_path:
-            if self.relative_tmp_dir is not None:
-                tmp_path = base_path / self.relative_tmp_dir / key_path
-            else:
-                tmp_path = data_path.with_suffix(".tmp")
-        return data_path, tmp_path
+        return base_path
+
+    def _get_file_name(self, key: CacheEngineKey) -> str:
+        return key.to_string().replace("/", "-") + ".data"
+
+    def _get_file_path(self, key: CacheEngineKey) -> Path:
+        """Get file path for the given key"""
+        base_path = self._get_base_path(key)
+        file_name = self._get_file_name(key)
+        return base_path / file_name
+
+    def _get_file_and_tmp_path(self, key: CacheEngineKey) -> Tuple[Path, Path]:
+        """Get file and tmp path for the given key"""
+        base_path = self._get_base_path(key)
+        file_name = self._get_file_name(key)
+        file_path = base_path / file_name
+        if self.relative_tmp_dir is not None:
+            tmp_path = base_path / self.relative_tmp_dir / file_name
+        else:
+            tmp_path = file_path.with_suffix(".tmp")
+        return file_path, tmp_path
 
     async def exists(self, key: CacheEngineKey) -> bool:
         """Check if key exists in file system"""
-        file_path, _ = self._get_file_path(key)
+        file_path = self._get_file_path(key)
         return await aiofiles.os.path.exists(file_path)
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         """Check if key exists in file system synchronized"""
-        file_path, _ = self._get_file_path(key)
+        file_path = self._get_file_path(key)
         return os.path.exists(file_path)
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Get data from file system"""
-        file_path, _ = self._get_file_path(key)
+        file_path = self._get_file_path(key)
 
         try:
             async with aiofiles.open(file_path, "rb") as f:
@@ -154,8 +163,7 @@ class FSConnector(RemoteConnector):
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """Store data to file system"""
-        final_path, temp_path = self._get_file_path(key, True)
-        assert temp_path is not None
+        final_path, temp_path = self._get_file_and_tmp_path(key)
 
         try:
             # Prepare metadata

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from pathlib import Path
-from typing import List, Optional, no_type_check
+from typing import List, Optional, Tuple, no_type_check
 import asyncio
 import os
 
@@ -70,7 +70,7 @@ class FSConnector(RemoteConnector):
 
     def _get_file_path(
         self, key: CacheEngineKey, generate_tmp_path=False
-    ) -> (Path, Optional[Path]):
+    ) -> Tuple[Path, Optional[Path]]:
         """Get file path and tmp path for the given key"""
         # If there's only one path, use it directly
         if len(self.base_paths) == 1:

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -35,6 +35,7 @@ class FSConnector(RemoteConnector):
         base_paths_str: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
+        relative_tmp_dir: Optional[str],
     ):
         """
         Args:
@@ -51,14 +52,19 @@ class FSConnector(RemoteConnector):
 
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        self.relative_tmp_dir = None if relative_tmp_dir is None else Path(relative_tmp_dir)
+        if self.relative_tmp_dir is not None:
+            assert not self.relative_tmp_dir.is_absolute()
 
-        logger.info(f"Initialized FSConnector with base paths {self.base_paths}")
+        logger.info(f"Initialized FSConnector with base paths {self.base_paths}, relative tmp dir: {self.relative_tmp_dir}")
         # Create directories for all paths
         for path in self.base_paths:
             path.mkdir(parents=True, exist_ok=True)
+            if self.relative_tmp_dir is not None:
+                (path / self.relative_tmp_dir).mkdir(parents=False, exist_ok=True)
 
-    def _get_file_path(self, key: CacheEngineKey) -> Path:
-        """Get file path for the given key"""
+    def _get_file_path(self, key: CacheEngineKey, generate_tmp_path=False) -> (Path, Optional[Path]):
+        """Get file path and tmp path for the given key"""
         # If there's only one path, use it directly
         if len(self.base_paths) == 1:
             base_path = self.base_paths[0]
@@ -69,21 +75,28 @@ class FSConnector(RemoteConnector):
             base_path = self.base_paths[idx]
 
         key_path = key.to_string().replace("/", "-") + ".data"
-        return base_path / key_path
+        data_path = base_path / key_path
+        tmp_path = None
+        if generate_tmp_path:
+            if self.relative_tmp_dir is not None:
+                tmp_path = base_path / self.relative_tmp_dir / key_path
+            else:
+                tmp_path = data_path.with_suffix(".tmp")
+        return data_path, tmp_path
 
     async def exists(self, key: CacheEngineKey) -> bool:
         """Check if key exists in file system"""
-        file_path = self._get_file_path(key)
+        file_path, _ = self._get_file_path(key)
         return await aiofiles.os.path.exists(file_path)
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         """Check if key exists in file system synchronized"""
-        file_path = self._get_file_path(key)
+        file_path, _ = self._get_file_path(key)
         return os.path.exists(file_path)
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Get data from file system"""
-        file_path = self._get_file_path(key)
+        file_path, _ = self._get_file_path(key)
 
         try:
             async with aiofiles.open(file_path, "rb") as f:
@@ -134,8 +147,7 @@ class FSConnector(RemoteConnector):
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """Store data to file system"""
-        final_path = self._get_file_path(key)
-        temp_path = final_path.with_suffix(".tmp")
+        final_path, temp_path = self._get_file_path(key, True)
 
         try:
             # Prepare metadata

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -52,18 +52,25 @@ class FSConnector(RemoteConnector):
 
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
-        self.relative_tmp_dir = None if relative_tmp_dir is None else Path(relative_tmp_dir)
+        self.relative_tmp_dir = (
+            None if relative_tmp_dir is None else Path(relative_tmp_dir)
+        )
         if self.relative_tmp_dir is not None:
             assert not self.relative_tmp_dir.is_absolute()
 
-        logger.info(f"Initialized FSConnector with base paths {self.base_paths}, relative tmp dir: {self.relative_tmp_dir}")
+        logger.info(
+            f"Initialized FSConnector with base paths {self.base_paths}, "
+            f"relative tmp dir: {self.relative_tmp_dir}"
+        )
         # Create directories for all paths
         for path in self.base_paths:
             path.mkdir(parents=True, exist_ok=True)
             if self.relative_tmp_dir is not None:
                 (path / self.relative_tmp_dir).mkdir(parents=False, exist_ok=True)
 
-    def _get_file_path(self, key: CacheEngineKey, generate_tmp_path=False) -> (Path, Optional[Path]):
+    def _get_file_path(
+        self, key: CacheEngineKey, generate_tmp_path=False
+    ) -> (Path, Optional[Path]):
         """Get file path and tmp path for the given key"""
         # If there's only one path, use it directly
         if len(self.base_paths) == 1:


### PR DESCRIPTION
# DESCEPTION
Support set tmp path in FSConnector. 

There are the following benefits：
- The data is more intuitive. The data directory only contains the data files, and all temporary files are placed in a temporary directory.
- When there is a large amount of data, it is convenient to clean up temporary files

# HOW TO USE
set `fs_connector_relative_tmp_dir` in `extra_config` to enable this feature, such as
```
remote_url: "fs://host:0/data/test"
extra_config:
  fs_connector_relative_tmp_dir: "tmp"
```
the `fs_connector_relative_tmp_dir` must be a relative path, if `fs_connector_relative_tmp_dir` is set and use `FSConnector`, in the example above, tmp path `/data/test/tmp` will be created, the `put` operation will write data file in `/data/test/tmp`  first, and then move the data file to`/data/test` . 