### PR TITLE
[Improve] Add timeout for lookup client 

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -332,11 +332,6 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": _to_str_list,
     },
     # Lookup client configurations
-    "lookup_max_retries": {
-        "type": int,
-        "default": 3,
-        "env_converter": int,
-    },
     "lookup_timeout_ms": {
         "type": int,
         "default": 3000,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -331,6 +331,17 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": _to_str_list,
     },
+    # Lookup client configurations
+    "lookup_max_retries": {
+        "type": int,
+        "default": 3,
+        "env_converter": int,
+    },
+    "lookup_timeout_ms": {
+        "type": int,
+        "default": 5000,
+        "env_converter": int,
+    },
 }
 
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -339,7 +339,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "lookup_timeout_ms": {
         "type": int,
-        "default": 5000,
+        "default": 3000,
         "env_converter": int,
     },
 }

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -56,6 +56,10 @@ class LMCacheLookupClient(LookupClientInterface):
         self.sockets = []
         if self.create_lookup_server_only_on_worker_0_for_mla:
             ranks = 1
+
+        # Set timeout values from config
+        timeout_ms = config.lookup_timeout_ms
+
         for tp_rank in range(ranks):
             socket_path = get_zmq_rpc_path_lmcache(
                 vllm_config, "lookup", rpc_port, tp_rank
@@ -70,6 +74,10 @@ class LMCacheLookupClient(LookupClientInterface):
                 zmq.REQ,  # type: ignore[attr-defined]
                 bind=False,
             )
+
+            # Set socket timeout during initialization
+            socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
+            socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
 
             self.sockets.append(socket)
 
@@ -130,68 +138,21 @@ class LMCacheLookupClient(LookupClientInterface):
             ]
 
         results = []
-        max_retries = self.config.lookup_max_retries  # Get from config
-        timeout_ms = self.config.lookup_timeout_ms  # Get from config
+        try:
+            for i in range(ranks):
+                self.sockets[i].send_multipart(msg_buf, copy=False)
 
-        for i in range(ranks):
-            socket = self.sockets[i]
-
-            # Check socket state
-            if socket.closed:
-                logger.error(f"Socket for rank {i} is closed")
-                return 0
-
-            # Set socket timeout
-            socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
-            socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
-
-            retry_count = 0
-            send_success = False
-            recv_success = False
-
-            # Send retry loop
-            while retry_count < max_retries and not send_success:
-                try:
-                    socket.send_multipart(msg_buf, copy=False)
-                    send_success = True
-                except zmq.Again:
-                    retry_count += 1
-                    logger.warning(
-                        f"Send timeout (retry {retry_count}/{max_retries}) for rank {i}"
-                    )
-                except zmq.ZMQError as e:
-                    logger.error(f"ZMQ error during send to rank {i}: {str(e)}")
-                    return 0
-
-            # If send fails, log error and break
-            if not send_success:
-                logger.error(f"Failed to send to rank {i} after {max_retries} retries")
-                return 0
-
-            # Receive retry loop
-            retry_count = 0
-            while retry_count < max_retries and not recv_success:
-                try:
-                    resp = socket.recv()
-                    result = int.from_bytes(resp, "big")
-                    recv_success = True
-                    results.append(result)
-                except zmq.Again:
-                    retry_count += 1
-                    logger.warning(
-                        f"Receive timeout (retry {retry_count}/{max_retries}) "
-                        f"for rank {i}"
-                    )
-                except zmq.ZMQError as e:
-                    logger.error(f"ZMQ error during receive from rank {i}: {str(e)}")
-                    return 0
-
-            # If receive fails, log error
-            if not recv_success:
-                logger.error(
-                    f"Failed to receive from rank {i} after {max_retries} retries"
-                )
-                return 0
+            # TODO(Jiayi): we can use zmq poll to optimize a bit
+            for i in range(ranks):
+                resp = self.sockets[i].recv()
+                result = int.from_bytes(resp, "big")
+                results.append(result)
+        except zmq.Again:
+            logger.error(f"Timeout occurred for rank {i}")
+            return 0
+        except zmq.ZMQError as e:
+            logger.error(f"ZMQ error for rank {i}: {str(e)}")
+            return 0
 
         assert len(results) == ranks
         if len(set(results)) > 1:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -182,6 +182,9 @@ class LMCacheLookupClient(LookupClientInterface):
                         f"Receive timeout (retry {retry_count}/{max_retries}) "
                         f"for rank {i}"
                     )
+                except zmq.ZMQError as e:
+                    logger.error(f"ZMQ error during receive from rank {i}: {str(e)}")
+                    return 0
 
             # If receive fails, log error
             if not recv_success:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -41,6 +41,7 @@ class LMCacheLookupClient(LookupClientInterface):
 
         self.encoder = msgspec.msgpack.Encoder()
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        self.config = config
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
         )
@@ -128,16 +129,62 @@ class LMCacheLookupClient(LookupClientInterface):
                 request_configs_buf,
             ]
 
-        for i in range(ranks):
-            self.sockets[i].send_multipart(msg_buf, copy=False)
-
         results = []
-        # TODO(Jiayi): we can use zmq poll to optimize a bit
-        for i in range(ranks):
-            resp = self.sockets[i].recv()
-            result = int.from_bytes(resp, "big")
-            results.append(result)
+        max_retries = self.config.lookup_max_retries  # Get from config
+        timeout_ms = self.config.lookup_timeout_ms  # Get from config
 
+        for i in range(ranks):
+            socket = self.sockets[i]
+
+            # Set socket timeout
+            socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
+            socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
+
+            retry_count = 0
+            send_success = False
+            recv_success = False
+
+            # Send retry loop
+            while retry_count < max_retries and not send_success:
+                try:
+                    socket.send_multipart(msg_buf, copy=False)
+                    send_success = True
+                except zmq.Again:
+                    retry_count += 1
+                    logger.warning(
+                        f"Send timeout (retry {retry_count}/{max_retries}) for rank {i}"
+                    )
+
+            # If send fails, log error and break
+            if not send_success:
+                logger.error(f"Failed to send to rank {i} after {max_retries} retries")
+                results.append(-1)  # Use -1 to indicate send failure
+                return None
+
+            # Receive retry loop
+            retry_count = 0
+            while retry_count < max_retries and not recv_success:
+                try:
+                    resp = socket.recv()
+                    result = int.from_bytes(resp, "big")
+                    recv_success = True
+                    results.append(result)
+                except zmq.Again:
+                    retry_count += 1
+                    logger.warning(
+                        f"Receive timeout (retry {retry_count}/{max_retries}) "
+                        f"for rank {i}"
+                    )
+
+            # If receive fails, log error
+            if not recv_success:
+                logger.error(
+                    f"Failed to receive from rank {i} after {max_retries} retries"
+                )
+                results.append(-2)  # Use -2 to indicate receive failure
+                return None
+
+        assert len(results) == ranks
         if len(set(results)) > 1:
             logger.warning(
                 f"Lookup results (number of hit tokens) differ "

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -158,8 +158,7 @@ class LMCacheLookupClient(LookupClientInterface):
             # If send fails, log error and break
             if not send_success:
                 logger.error(f"Failed to send to rank {i} after {max_retries} retries")
-                results.append(-1)  # Use -1 to indicate send failure
-                return None
+                return 0
 
             # Receive retry loop
             retry_count = 0
@@ -181,8 +180,7 @@ class LMCacheLookupClient(LookupClientInterface):
                 logger.error(
                     f"Failed to receive from rank {i} after {max_retries} retries"
                 )
-                results.append(-2)  # Use -2 to indicate receive failure
-                return None
+                return 0
 
         assert len(results) == ranks
         if len(set(results)) > 1:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -136,6 +136,11 @@ class LMCacheLookupClient(LookupClientInterface):
         for i in range(ranks):
             socket = self.sockets[i]
 
+            # Check socket state
+            if socket.closed:
+                logger.error(f"Socket for rank {i} is closed")
+                return 0
+
             # Set socket timeout
             socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
             socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
@@ -154,6 +159,9 @@ class LMCacheLookupClient(LookupClientInterface):
                     logger.warning(
                         f"Send timeout (retry {retry_count}/{max_retries}) for rank {i}"
                     )
+                except zmq.ZMQError as e:
+                    logger.error(f"ZMQ error during send to rank {i}: {str(e)}")
+                    return 0
 
             # If send fails, log error and break
             if not send_success:
@@ -198,7 +206,9 @@ class LMCacheLookupClient(LookupClientInterface):
         return True
 
     def close(self):
-        self.socket.close(linger=0)
+        for socket in self.sockets:
+            if not socket.closed:
+                socket.close(linger=0)
 
 
 class LMCacheLookupServer:


### PR DESCRIPTION
# issue

In some case, we make the socket path mismatch between `scheduler` process which act as `lmcache lookup client` and `worker` which act as `lmcache lookup server`.

But we cannot aware of this issue from the log, we found this root cause after several hours.

# Proposal

This PR aim to log the warn and error log to let user aware the connection error by a timeout and error handling. Eventually, the lookup function return 0 if exception occured.

# Log example

```
[2025-09-17 11:53:58,687] LMCache WARNING: Receive timeout (retry 1/3) for rank 0 (lmcache_lookup_client.py:181:lmcache.v1.lookup_client.lmcache_lookup_client)
[2025-09-17 11:54:03,692] LMCache WARNING: Receive timeout (retry 2/3) for rank 0 (lmcache_lookup_client.py:181:lmcache.v1.lookup_client.lmcache_lookup_client)
[2025-09-17 11:54:08,698] LMCache WARNING: Receive timeout (retry 3/3) for rank 0 (lmcache_lookup_client.py:181:lmcache.v1.lookup_client.lmcache_lookup_client)
[2025-09-17 11:54:08,698] LMCache ERROR: Failed to receive from rank 0 after 3 retries (lmcache_lookup_client.py:188:lmcache.v1.lookup_client.lmcache_lookup_client)
```