### PR TITLE
[Chore]: Remove Python 3.9 as the minimum Python version

### DIFF
--- a/docs/source/developer_guide/contributing.rst
+++ b/docs/source/developer_guide/contributing.rst
@@ -90,7 +90,7 @@ The following prerequisites are required:
 The following tools are required:
 
 - `git <https://git-scm.com>`_
-- `python <https://www.python.org>`_ (v3.9 -- v3.13)
+- `python <https://www.python.org>`_ (v3.10 -- v3.13)
 - `pip <https://pypi.org/project/pip/>`_ (v23.0+)
 
 The first step is to install the necessary Python packages required for development. The commands to do this are as follows:

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -72,7 +72,7 @@ async def lifespan(app: FastAPI):
             raise ValueError(
                 "Length mismatch between hosts and ports lists for pairing"
             )
-        return list(zip(hosts, ports))
+        return list(zip(hosts, ports, strict=False))
 
     prefill_pairs = pair_hosts_and_ports(
         pref_hosts, pref_ports, global_args.num_prefillers

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -203,7 +203,7 @@ def extract_mm_features(
     """
     if getattr(request, "mm_features", None):
         mm_hashes, mm_positions = zip(
-            *((f.identifier, f.mm_position) for f in request.mm_features)
+            *((f.identifier, f.mm_position) for f in request.mm_features), strict=False
         )
         return (list(mm_hashes), list(mm_positions))
     elif getattr(request, "mm_hashes", None):

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -139,7 +139,10 @@ class RedisConnector(RemoteConnector):
     ):
         # calling self.put will create a circular dependency
         await asyncio.gather(
-            *(self._put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+            *(
+                self._put(key, memory_obj)
+                for key, memory_obj in zip(keys, memory_objs, strict=False)
+            )
         )
 
     async def batched_put(

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -650,7 +650,7 @@ class GdsBackend(AllocatorBackendInterface):
                 fd,
                 file_size,
                 prot=mmap.PROT_READ,
-                flags=mmap.MAP_PRIVATE | mmap.MAP_POPULATE,
+                flags=mmap.MAP_PRIVATE | mmap.MAP_POPULATE,  # type: ignore [attr-defined]
             )
             os.close(fd)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Operating System :: POSIX :: Linux",
     "Environment :: GPU",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -40,7 +39,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.10,<3.14"
 dynamic = ["dependencies", "version"]
 
 [project.scripts]

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -150,7 +150,7 @@ def test_store_1GB(benchmark, backend, create_config, autorelease_v1):
 
     # Run benchmark
     def run_func(tokens, slot_mappings):
-        for t, s in zip(tokens, slot_mappings):
+        for t, s in zip(tokens, slot_mappings, strict=False):
             engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
         # Wait for all tokens are being stored
@@ -253,7 +253,7 @@ def test_retrieve_1GB_allhit(benchmark, backend, create_config, autorelease_v1):
         )
     )
 
-    for t, s in zip(list_tokens, list_slot_mappings):
+    for t, s in zip(list_tokens, list_slot_mappings, strict=False):
         engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
     # Wait for kv cache to be ready
@@ -278,7 +278,7 @@ def test_retrieve_1GB_allhit(benchmark, backend, create_config, autorelease_v1):
         ), {}
 
     def run_func(tokens, slot_mappings):
-        for t, s in zip(tokens, slot_mappings):
+        for t, s in zip(tokens, slot_mappings, strict=False):
             engine.retrieve(t, kvcaches=kv_cache, slot_mapping=s)
 
     benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)
@@ -355,7 +355,7 @@ def test_lookup_20K_tokens(benchmark, backend, create_config, autorelease_v1):
         )
     )
 
-    for t, s in zip(list_tokens, list_slot_mappings):
+    for t, s in zip(list_tokens, list_slot_mappings, strict=False):
         engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
     # Make sure all the requests are stored
@@ -380,7 +380,7 @@ def test_lookup_20K_tokens(benchmark, backend, create_config, autorelease_v1):
         ), {}
 
     def run_func(tokens, slot_mappings):
-        for t, s in zip(tokens, slot_mappings):
+        for t, s in zip(tokens, slot_mappings, strict=False):
             assert engine.lookup(t) == len(t)
 
     benchmark.pedantic(run_func, setup=setup, rounds=num_repeats, iterations=1)

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -1155,7 +1155,7 @@ def test_force_store_wait(autorelease_v1):
         )
 
         # Store kv cache into slow devices
-        for t, s in zip(list_tokens, list_slot_mappings):
+        for t, s in zip(list_tokens, list_slot_mappings, strict=False):
             engine.store(t, kvcaches=kv_cache, slot_mapping=s)
 
         # Sleep 10 seconds for the last request


### PR DESCRIPTION
LMCache was built on Python 3.10 and as such has keywords like match which are not compatible in Python 3.9. We therefore would need to make changes to the code base. Ref: https://github.com/LMCache/LMCache/pull/1584#pullrequestreview-3224555325

Python 3.9 will no longer be supported next month (https://en.wikipedia.org/wiki/History_of_Python#Support). Therefore, it is more practical to support 3.10 as the minimum version.

This is a revert of some of the changes in:
https://github.com/LMCache/LMCache/pull/1440
