### PR TITLE
Fix two bugs in async loading with MLA and TP > 1

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -603,7 +603,8 @@ class LMCacheConnectorV1Impl:
                 get_tensor_model_parallel_rank(),
             )
 
-            if self.async_loading:
+            # In case of MLA, the lookup server is only created on worker 0
+            if self.async_loading and self.lookup_server is not None:
                 assert isinstance(self.lookup_server, LMCacheAsyncLookupServer)
                 self.lmcache_engine.post_init(async_lookup_server=self.lookup_server)
 

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -195,7 +195,10 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                     self.res_for_each_worker[lookup_id].append(res)
                 all_res = self.res_for_each_worker[lookup_id]
 
-                if len(all_res) == self.tensor_parallel_size:
+                if len(all_res) == self.tensor_parallel_size or (
+                    self.create_lookup_server_only_on_worker_0_for_mla
+                    and len(all_res) == 1
+                ):
                     self.res_for_each_worker.pop(lookup_id)
 
                     # NOTE: it is possible that the number of hit


### PR DESCRIPTION
When we use MLA, we likely have lookup server only on worker process 0.
This causes two issues:
1. Other workers have self.lookup_server = None, and hence fails the assertion.
2. len(all_res) is only 1, and it will never enter the if branch. As a result, req_status will never be updated.

I’ve updated the code to properly handle MLA with TP > 1.

