### PR TITLE
Add metrics remote_put_task_num

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -812,6 +812,12 @@ class PrometheusLogger:
             labelnames=labelnames,
             multiprocess_mode="livemostrecent",
         ).labels(**self.labels)
+        self.remote_put_task_num = self._gauge_cls(
+            name="lmcache:remote_put_task_num",
+            documentation="The number of remote put tasks",
+            labelnames=labelnames,
+            multiprocess_mode="livemostrecent",
+        ).labels(**self.labels)
 
     def _log_gauge(self, gauge, data: Union[int, float]) -> None:
         # Convenience function for logging to gauge.

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -9,7 +9,7 @@ import time
 # First Party
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
-from lmcache.observability import LMCStatsMonitor
+from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_server import LookupServerInterface
@@ -89,6 +89,15 @@ class RemoteBackend(StorageBackendInterface):
 
         # Start the remote monitor thread (if ping is supported)
         self.remote_monitor.start()
+
+        self._setup_metrics()
+
+    def _setup_metrics(self):
+        prometheus_logger = PrometheusLogger.GetInstanceOrNone()
+        if prometheus_logger is not None:
+            prometheus_logger.remote_put_task_num.set_function(
+                lambda: len(self.put_tasks)
+            )
 
     def __str__(self):
         return self.__class__.__name__


### PR DESCRIPTION
# Motivation

This new added metrics `remote_put_task_num` indicate how busy remote backend are.

# Test

<img width="1670" height="170" alt="image" src="https://github.com/user-attachments/assets/6dbd8ec3-af54-498e-b1c6-3b3855246e9d" />
