### PR TITLE
Improve the log message clarity when retrieve tokens

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -515,14 +515,15 @@ class LMCacheEngine:
         retrieved_tokens = torch.sum(ret_mask)
         self.stats_monitor.on_retrieve_finished(monitor_req_id, retrieved_tokens)
         logger.info(
-            "Retrieved %d out of total %d out of total %d tokens. size: %.4f gb,"
+            "Retrieved %d out of %d required tokens (from %d total tokens)."
+            " size: %.4f gb,"
             " cost %.4f ms, throughput: %.4f GB/s;",
             retrieved_tokens,
             num_required_tokens,
             len(tokens),
             tot_kv_size / 1024**3,
             onload_time * 1000,
-            tot_kv_size / onload_time / 1024**3,
+            tot_kv_size / onload_time / 1024**3 if onload_time > 0 else 0,
         )
         return ret_mask
 


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

Improve the log message clarity when retrieve tokens.


**Before**
```
Retrieved 128 out of total 256 out of total 512 tokens. size: 0.0625 gb, cost 25.4321 ms, throughput: 2.4581 GB/s;
```

**Patch**
```
Retrieved 128 out of 256 required tokens (from 512 total tokens). size: 0.0625 gb, cost 25.4321 ms, throughput: 2.4581 GB/s;
```


**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
