### PR TITLE
[Doc] Fix blending related docs

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -101,9 +101,9 @@ Settings related to cache blending functionality.
      - LMCACHE_ENABLE_BLENDING
      - Whether to enable blending. Values: true/false. Default: false
    * - blend_recompute_ratios
-     - LMCACHE_BLEND_RECOMPUTE_RATIO
+     - LMCACHE_BLEND_RECOMPUTE_RATIOS
      - Ratio of blending recompute. Default: 0.15
-    * - blend_check_layers
+   * - blend_check_layers
       - LMCACHE_BLEND_CHECK_LAYERS
       - Layers to determine the recomputed tokens. Default: 1
    * - blend_special_str

--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -103,6 +103,9 @@ Settings related to cache blending functionality.
    * - blend_recompute_ratios
      - LMCACHE_BLEND_RECOMPUTE_RATIO
      - Ratio of blending recompute. Default: 0.15
+    * - blend_check_layers
+      - LMCACHE_BLEND_CHECK_LAYERS
+      - Layers to determine the recomputed tokens. Default: 1
    * - blend_special_str
      - LMCACHE_BLEND_SPECIAL_STR
      - Separator string for blending. Default: " # # "

--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -87,7 +87,8 @@ Settings related to cache blending functionality.
 
 .. note::
 
-    Cache blending is not supported in the latest version. We are working on it and will add it back soon.
+    We have an end-to-end `example <https://github.com/LMCache/LMCache/tree/dev/examples/blend_kv_v1>`_.
+    We also have more :doc:`detailed documentation <../kv_cache_optimizations/blending>`.
 
 .. list-table::
    :header-rows: 1
@@ -99,12 +100,9 @@ Settings related to cache blending functionality.
    * - enable_blending
      - LMCACHE_ENABLE_BLENDING
      - Whether to enable blending. Values: true/false. Default: false
-   * - blend_recompute_ratio
+   * - blend_recompute_ratios
      - LMCACHE_BLEND_RECOMPUTE_RATIO
      - Ratio of blending recompute. Default: 0.15
-   * - blend_min_tokens
-     - LMCACHE_BLEND_MIN_TOKENS
-     - Minimum number of tokens for blending. Default: 256
    * - blend_special_str
      - LMCACHE_BLEND_SPECIAL_STR
      - Separator string for blending. Default: " # # "

--- a/docs/source/kv_cache/storage_backends/redis.rst
+++ b/docs/source/kv_cache/storage_backends/redis.rst
@@ -283,7 +283,7 @@ If you would like to feel the TTFT speed up with offloading and KV Cache reuse, 
 
 Here, we are instead going to demonstrate how to search for and modify LMCache KV Chunk entries in Redis.
 
-Please note that the official LMCache way to achieve this redis-specific functionality of viewing and modifying LMCache KV Chunks is available in :doc:`LMCache Controller <../../kv_cache_management/controller>`.
+Please note that the official LMCache way to achieve this redis-specific functionality of viewing and modifying LMCache KV Chunks is available in :doc:`LMCache Controller <../../kv_cache_management/index>`.
 
 Let's warm/populate LMCache first with ``curl`` this time:
 
@@ -417,7 +417,7 @@ larger than the ``metadata`` entry.
 This tutorial utilized the ``redis-cli`` to directly peak into a remote backend and manipualte
 KV Chunks.
 
-Once again, please refer to the :doc:`LMCache Controller <../../kv_cache_management/controller>`
+Once again, please refer to the :doc:`LMCache Controller <../../kv_cache_management/index>`
 for the official LMCache way of controlling and routing your KV Caches in your LMCache instances.
 
 **Step 4. Clean up:**

--- a/docs/source/kv_cache_optimizations/blending.rst
+++ b/docs/source/kv_cache_optimizations/blending.rst
@@ -7,7 +7,7 @@ For example, CacheBlend can combine multiple (pre-)computed KV caches, when thei
 Configuring CacheBlend in RAG scenarios
 -------------------------------------------------
 
-Here, we will explain the code in `example <We have an end-to-end `example <https://github.com/LMCache/LMCache/tree/dev/examples/blend_kv_v1/blend.py>`_>`.
+Here, we will explain the code in our end-to-end `example <https://github.com/LMCache/LMCache/tree/dev/examples/blend_kv_v1/blend.py>`_>.
 
 Below are some blending-related configurations (and explanations):
 
@@ -34,12 +34,11 @@ Below are some blending-related configurations (and explanations):
         os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
         os.environ["LMCACHE_EXTRA_CONFIG"] = '{"enable_sparse": true}'
 
-Firstly, we preprocess texts into tokens as the tokenization results of tokenize(txt_1, txt_2) might be different than (tokenize(txt_1), tokenize(txt_2)).
+Firstly, we preprocess texts into tokens, as tokenizing a concatenated string may produce different tokens than concatenating the results of tokenizing each string individually.
 For example, assume we have a system prompt and three text chunks. We need to preprocess them into tokens before sending to the LLM:
 
 .. code-block:: python
 
-    warmup_prompt = tokenizer.encode("Nice to meet you" * 500)[1:]
     sys_prompt = tokenizer.encode("You are a very helpful assistant.")
     chunk1_prompt = tokenizer.encode("Hello, how are you?" * 500)[1:]
     chunk2_prompt = tokenizer.encode("Hello, what's up?" * 500)[1:]

--- a/docs/source/kv_cache_optimizations/blending.rst
+++ b/docs/source/kv_cache_optimizations/blending.rst
@@ -1,4 +1,84 @@
 Blending
-========
+================
 
-Coming soon... 
+CacheBlend enables KV cache reuse for non-prefix positions by recomputing a subset of tokens at non-prefix positions.
+For example, CacheBlend can combine multiple (pre-)computed KV caches, when their corresponding texts are concatenated in the LLM input
+
+Configuring CacheBlend in RAG scenarios
+-------------------------------------------------
+
+Here, we will explain the code in `example <We have an end-to-end `example <https://github.com/LMCache/LMCache/tree/dev/examples/blend_kv_v1/blend.py>`_>`.
+
+Below are some blending-related configurations (and explanations):
+
+.. code-block:: python
+
+    # Enable blending in LMCache
+    os.environ["LMCACHE_ENABLE_BLENDING"] = "True"
+
+    # Separator string between different chunks
+    os.environ["LMCACHE_BLEND_SPECIAL_STR"] = " # # "
+
+    # Layerwise must be turned on when blending is enabled
+    os.environ["LMCACHE_USE_LAYERWISE"] = "True"
+
+    # Determining which tokens to recompute at layer 1
+    os.environ["LMCACHE_BLEND_CHECK_LAYERS"] = "1"
+
+    # Ratio of tokens to recompute
+    os.environ["LMCACHE_BLEND_RECOMPUTE_RATIOS"] = "0.15"
+
+    # Optionally, we can use sparse attention to improve generation quality
+    # by using more accurate attention mask
+    if enable_sparse:
+        os.environ["VLLM_ATTENTION_BACKEND"] = "FLASHINFER"
+        os.environ["LMCACHE_EXTRA_CONFIG"] = '{"enable_sparse": true}'
+
+Firstly, we preprocess texts into tokens as the tokenization results of tokenize(txt_1, txt_2) might be different than (tokenize(txt_1), tokenize(txt_2)).
+For example, assume we have a system prompt and three text chunks. We need to preprocess them into tokens before sending to the LLM:
+
+.. code-block:: python
+
+    warmup_prompt = tokenizer.encode("Nice to meet you" * 500)[1:]
+    sys_prompt = tokenizer.encode("You are a very helpful assistant.")
+    chunk1_prompt = tokenizer.encode("Hello, how are you?" * 500)[1:]
+    chunk2_prompt = tokenizer.encode("Hello, what's up?" * 500)[1:]
+    chunk3_prompt = tokenizer.encode("Hi, what are you up to?" * 500)[1:]
+    blend_special_str = tokenizer.encode(os.getenv("LMCACHE_BLEND_SPECIAL_STR"))[1:]
+    first_prompt = (
+        sys_prompt
+        + blend_special_str
+        + chunk1_prompt
+        + blend_special_str
+        + chunk2_prompt
+        + blend_special_str
+        + chunk3_prompt
+        + blend_special_str
+        + tokenizer.encode("Hello, my name is")[1:]
+    )
+
+Then, we can send the tokenized prompt to vLLM. Meanwhile, LMCache will store the KV caches of different chunks according to the ``BLEND_SPECIAL_STR``.
+
+.. code-block:: python
+
+    llm.generate(prompts={"prompt_token_ids": first_prompt})
+
+Similarly, we build another prompt using the same chunks but with different orders.
+
+.. code-block:: python
+
+    second_prompt = (
+        sys_prompt
+        + blend_special_str
+        + chunk2_prompt
+        + blend_special_str
+        + chunk1_prompt
+        + blend_special_str
+        + chunk3_prompt
+        + blend_special_str
+        + tokenizer.encode("Hello, how are you?")[1:]
+    )
+    llm.generate(prompts={"prompt_token_ids": second_prompt})
+
+Even though the second prompt has a different order of chunks, LMCache can still reuse the KV caches of chunk1, chunk2, and chunk3.
+

--- a/docs/source/production/observability/vllm_endpoint.rst
+++ b/docs/source/production/observability/vllm_endpoint.rst
@@ -8,7 +8,7 @@ This section outlines how to enable and configure observability from embedded vL
 
 
 Quick Start Guide
------
+------------------
 
 1) On vLLM/LMCache side
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fix blending related docs

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
