### PR TITLE
Fix bug in nixl_channel.py where incorrect variables were used when cleaning up NIXL resources

### DIFF
--- a/lmcache/v1/transfer_channel/nixl_channel.py
+++ b/lmcache/v1/transfer_channel/nixl_channel.py
@@ -555,10 +555,11 @@ class NixlChannel(BaseTransferChannel):
         for thread in self.running_threads:
             thread.join()
         self.zmq_context.term()
-        self.agent.deregister_memory(self.reg_descs)
-        self.agent.release_dlist_handle(self.xfer_handler)
+        self.nixl_agent.deregister_memory(self.nixl_wrapper.reg_descs)
+        self.nixl_agent.release_dlist_handle(self.nixl_wrapper.xfer_handler)
+
         for remote_xfer_handler in self.remote_xfer_handlers_dict.values():
-            self.agent.release_dlist_handle(remote_xfer_handler)
+            self.nixl_agent.release_dlist_handle(remote_xfer_handler)
 
 
 @dataclass


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

This pull request addresses a bug in the nixl_channel's closure mechanism.

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
