### PR TITLE
[Core] Fix NixlStorageBackend import

### DIFF
--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -43,7 +43,7 @@ from lmcache.v1.memory_management import (
     PagedTensorMemoryAllocator,
 )
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
-from lmcache.v1.storage_backend.connector.nixl_utils import get_correct_nixl_device
+from lmcache.v1.transfer_channel.transfer_utils import get_correct_device
 
 logger = init_logger(__name__)
 
@@ -83,7 +83,7 @@ class NixlStorageConfig:
             extra_config.get("nixl_backend"), config.nixl_buffer_device
         ), "Invalid NIXL backend & device combination"
 
-        corrected_device = get_correct_nixl_device(
+        corrected_device = get_correct_device(
             config.nixl_buffer_device, metadata.worker_id
         )
 
@@ -442,12 +442,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
             "enable_nixl_storage"
         )
         assert enable_nixl_storage
-        # First Party
-        from lmcache.v1.storage_backend.connector.nixl_utils import (
-            get_correct_nixl_device,
-        )
-
-        corrected_device = get_correct_nixl_device(
+        corrected_device = get_correct_device(
             config.nixl_buffer_device,
             metadata.worker_id,
         )


### PR DESCRIPTION
Function get_correct_nixl_device was both moved and renamed in a recent refactor, causing import issues for NixlStorageBackend. This commit fixes this import.

Also gets rid of an extra unneeded import.

