### PR TITLE
docs: Update model reference from Llama-3.1-70B to Llama-3.1-8B

### DIFF
--- a/docs/source/kv_cache/storage_backends/gds.rst
+++ b/docs/source/kv_cache/storage_backends/gds.rst
@@ -76,7 +76,7 @@ Setup Example
 
 - vllm and lmcache installed (:doc:`Installation Guide <../../getting_started/installation>`)
 
-- Hugging Face access to ``meta-llama/Llama-3.1-70B-Instruct``
+- Hugging Face access to ``meta-llama/Llama-3.1-8B-Instruct``
 
 .. code-block:: bash
 
@@ -127,7 +127,7 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     LMCACHE_CONFIG_FILE="gds-backend.yaml" \
     LMCACHE_USE_EXPERIMENTAL=True \
     vllm serve \
-        meta-llama/Llama-3.1-70B-Instruct \
+        meta-llama/Llama-3.1-8B-Instruct \
         --max-model-len 65536 \
         --kv-transfer-config \
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'

--- a/docs/source/kv_cache/storage_backends/mooncake.rst
+++ b/docs/source/kv_cache/storage_backends/mooncake.rst
@@ -102,7 +102,7 @@ Create your ``mooncake-config.yaml``:
 
     LMCACHE_CONFIG_FILE="mooncake-config.yaml" \
     vllm serve \
-        meta-llama/Llama-3.1-70B-Instruct \
+        meta-llama/Llama-3.1-8B-Instruct \
         --max-model-len 65536 \
         --kv-transfer-config \
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
@@ -116,7 +116,7 @@ Test the integration with a sample request:
     curl -X POST "http://localhost:8000/v1/completions" \
          -H "Content-Type: application/json" \
          -d '{
-           "model": "meta-llama/Llama-3.1-70B-Instruct",
+           "model": "meta-llama/Llama-3.1-8B-Instruct",
            "prompt": "The future of AI is",
            "max_tokens": 100,
            "temperature": 0.7

--- a/docs/source/kv_cache/storage_backends/weka.rst
+++ b/docs/source/kv_cache/storage_backends/weka.rst
@@ -79,7 +79,7 @@ Setup Example
 
 - vllm and lmcache installed (:doc:`Installation Guide <../../getting_started/installation>`)
 
-- Hugging Face access to ``meta-llama/Llama-3.1-70B-Instruct``
+- Hugging Face access to ``meta-llama/Llama-3.1-8B-Instruct``
 
 .. code-block:: bash
 
@@ -131,7 +131,7 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     LMCACHE_CONFIG_FILE="weka-offload.yaml" \
     LMCACHE_USE_EXPERIMENTAL=True \
     vllm serve \
-        meta-llama/Llama-3.1-70B-Instruct \
+        meta-llama/Llama-3.1-8B-Instruct \
         --max-model-len 65536 \
         --kv-transfer-config \
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'


### PR DESCRIPTION
### Summary

Make the Mooncake/GDS/Weka integration docs consistent by switching the example model from **`meta-llama/Llama-3.1-70B-Instruct`** to **`meta-llama/Llama-3.1-8B-Instruct`**. This aligns the Mooncake/GDS/Weka page with the other KV backends that already use the 8B variant.

### Motivation

* We want to showcase the **same model across backends** so readers can compare apples-to-apples (latency, hit rates, setup friction).
* The **8B** model keeps the quickstart lightweight and accessible on common developer hardware while still being representative for KV cache behavior.
* The CPU RAM and Local Storage backend docs already demonstrate with 8B:

  * CPU RAM backend: [https://docs.lmcache.ai/kv\_cache/storage\_backends/cpu\_ram.html](https://docs.lmcache.ai/kv_cache/storage_backends/cpu_ram.html)
  * Local Storage backend: [https://docs.lmcache.ai/kv\_cache/storage\_backends/local\_storage.html](https://docs.lmcache.ai/kv_cache/storage_backends/local_storage.html)
    Using 8B on Mooncake avoids confusion for first-time users following multiple pages.

### What changed

* **docs/source/kv\_cache/storage\_backends/mooncake.rst**

  * Replace `Llama-3.1-70B-Instruct` → `Llama-3.1-8B-Instruct` in both the `vllm serve` command and the sample `curl` request.

### Impact

* **Docs-only change.** No code, APIs, flags, or behavior modified.
* **No breaking changes.** Commands remain the same aside from the model string.

### How I validated

1. Started Mooncake services with an existing `mooncake-config.yaml`.
2. Launched vLLM with:

   ```bash
   LMCACHE_CONFIG_FILE="mooncake-config.yaml" \
   vllm serve meta-llama/Llama-3.1-8B-Instruct \
     --max-model-len 65536 \
     --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
   ```
3. Verified completion path with:

   ```bash
   curl -X POST "http://localhost:8000/v1/completions" \
     -H "Content-Type: application/json" \
     -d '{
       "model": "meta-llama/Llama-3.1-8B-Instruct",
       "prompt": "The future of AI is",
       "max_tokens": 100,
       "temperature": 0.7
     }'
   ```
4. Confirmed a valid JSON response and no errors from LMCache connector logs.

### Alternatives considered

* Keeping 70B in Mooncake only: rejected for inconsistency and higher resource burden for newcomers.
* Switching all pages to 70B: rejected due to hardware friction and longer setup times.

### Follow-ups (optional)

* If desired, scan other pages for lingering 70B references in quickstarts and make them consistent with 8B for first-run examples, reserving larger models for performance/tuning sections.

### Checklist

* [x] Docs updated
* [x] Commands tested with 8B
* [x] No behavior or API changes
