### PR TITLE
[Backend][BugFix]: Refactor StorageBackendInterface constructor to enable dynamic loading

### DIFF
--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -11,7 +11,7 @@ Backend Definition Requirements
 4. Package as an installable Python module
 
 How to Integrate the Backend with LMCache
--------------------------------------
+-----------------------------------------
 1. Install your backend package in the LMCache environment
 2. Add ``external_backends`` and its related ``module_path`` and ``class_name`` to ``extra_config`` section of LMCache configuration as follows:
 

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -22,8 +22,8 @@ How to Integrate the Backend with LMCache
     max_local_cpu_size: 5
     external_backends: <backend_name>
     extra_config:
-      external_backend.log_external_backend.module_path: <module_path>
-      external_backend.log_external_backend.class_name: <class_name>
+      external_backend.<backend_name>.module_path: <module_path>
+      external_backend.<backend_name>.class_name: <class_name>
 
 .. note::
 

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -3,37 +3,34 @@ External Storage Backends
 
 LMCache supports integrating custom storage backends through dynamic loading. This allows extending cache storage capabilities without modifying core code.
 
-Configuration
--------------
-Add the following to your ``lmcache.yaml``:
+Backend Definition Requirements
+-------------------------------
+1. Inherit from ``StorageBackendInterface``
+2. Add constructor with the same signature as ``StorageBackendInterface``
+3. Implement all abstract methods
+4. Package as an installable Python module
+
+How to Integrate the Backend with LMCache
+-------------------------------------
+1. Install your backend package in the LMCache environment
+2. Add ``external_backends`` and its related ``module_path`` and ``class_name`` to ``extra_config`` section of LMCache configuration as follows:
 
 .. code-block:: yaml
 
     chunk_size: 64
     local_cpu: False
     max_local_cpu_size: 5
-    external_backends: "log_external_backend"
+    external_backends: <backend_name>
     extra_config:
-      external_backend.log_external_backend.module_path: lmc_external_log_backend.lmc_external_log_backend
-      external_backend.log_external_backend.class_name: ExternalLogBackend
-
-Implementation Example
-----------------------
-A sample backend implementation (e.g., https://github.com/opendataio/lmc_external_log_backend/ ):
-
-Key Requirements
-----------------
-1. Inherit from ``StorageBackendInterface``
-2. Implement all abstract methods
-3. Provide the constructor as this example
-4. Package as installable Python module
-
-Usage Notes
------------
-1. Install your backend package in LMCache environment
-2. Add ``external_backends`` configuration and its related ``module_path`` and  ``class_name`` to ``extra_config`` section
-3. Backends are initialized during LMCache startup
-4. Use ``external_backends`` list to enable specific backends
+      external_backend.log_external_backend.module_path: <module_path>
+      external_backend.log_external_backend.class_name: <class_name>
 
 .. note::
-   Backends are loaded in order - earlier backends have higher priority during cache lookups.
+
+   - Backends are initialized in order during LMCache startup - earlier backends have higher priority during cache lookups
+   - ``external_backends`.<backend_name>` distinguishes the different dynamic loaded backends
+
+Backend Implementation Example
+------------------------------
+A sample backend implementation can be viewed at https://github.com/opendataio/lmc_external_log_backend/
+

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -25,6 +25,18 @@ How to Integrate the Backend with LMCache
       external_backend.<backend_name>.module_path: <module_path>
       external_backend.<backend_name>.class_name: <class_name>
 
+An example configuration for a logging backend is as follows:
+
+.. code-block:: yaml
+
+    chunk_size: 64
+    local_cpu: False
+    max_local_cpu_size: 5
+    external_backends: "log_external_backend"
+    extra_config:
+      external_backend.log_external_backend.module_path: lmc_external_log_backend.lmc_external_log_backend
+      external_backend.log_external_backend.class_name: ExternalLogBackend
+
 .. note::
 
    - Backends are initialized in order during LMCache startup - earlier backends have higher priority during cache lookups

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -28,7 +28,7 @@ How to Integrate the Backend with LMCache
 .. note::
 
    - Backends are initialized in order during LMCache startup - earlier backends have higher priority during cache lookups
-   - ``external_backends`.<backend_name>` distinguishes the different dynamic loaded backends
+   - ``external_backends.<backend_name>`` distinguishes the different dynamic loaded backends
 
 Backend Implementation Example
 ------------------------------

--- a/docs/source/kv_cache/storage_backends/external_backend.rst
+++ b/docs/source/kv_cache/storage_backends/external_backend.rst
@@ -1,14 +1,18 @@
-External Storage Backends
-=========================
+Configurable Storage Backends
+=============================
 
-LMCache supports integrating custom storage backends through dynamic loading. This allows extending cache storage capabilities without modifying core code.
+LMCache supports integrating custom storage backends through dynamic loading or plug and play capability. This allows extending cache storage capabilities without modifying core code.
 
 Backend Definition Requirements
 -------------------------------
-1. Inherit from ``StorageBackendInterface``
-2. Add constructor with the same signature as ``StorageBackendInterface``
-3. Implement all abstract methods
-4. Package as an installable Python module
+1. Inherit from ``ConfigurableStorageBackendInterface``
+2. Implement all the abstract methods of the parent interface of ``ConfigurableStorageBackendInterface``- ``StorageBackendInterface``
+3. Package as an installable Python module
+
+.. note::
+
+  The interface constructor is the instantiation contract that the LMCache loading system will use when loading configurable storage backends.
+  If you wish to implement a constructor, it should have the same parameter signature and call the interface constructor.
 
 How to Integrate the Backend with LMCache
 -----------------------------------------

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -78,11 +78,11 @@ def create_dynamic_backends(
 
             # Create the backend instance
             backend_instance = backend_class(
-                config,
-                metadata,
-                loop,
-                local_cpu_backend,
-                dst_device,
+                config=config,
+                dst_device=dst_device,
+                metadata=metadata,
+                local_cpu_backend=local_cpu_backend,
+                loop=loop,
             )
 
             # Add to storage backends

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -27,11 +27,6 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
     def __init__(
         self,
         dst_device: str = "cuda",
-        config: Optional[LMCacheEngineConfig] = None,
-        metadata: Optional[LMCacheEngineMetadata] = None,
-        local_cpu_backend: Optional["LocalCPUBackend"] = None,
-        lookup_server: Optional[LookupServerInterface] = None,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         """
         Initialize the storage backend.
@@ -334,3 +329,42 @@ class AllocatorBackendInterface(StorageBackendInterface):
         :rtype: Optional[MemoryObj]
         """
         raise NotImplementedError
+
+
+class ConfigurableStorageBackendInterface(StorageBackendInterface):
+    """The Configurable Storage Backend Interface needs to be implemented
+    when you want to add a storage backend in a configurable or plug and play
+    fashion."""
+
+    def __init__(
+        self,
+        dst_device: str = "cuda",
+        config: Optional[LMCacheEngineConfig] = None,
+        metadata: Optional[LMCacheEngineMetadata] = None,
+        local_cpu_backend: Optional["LocalCPUBackend"] = None,
+        lookup_server: Optional[LookupServerInterface] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ):
+        """
+        Initialize a configurable storage backend. This constructor will be called
+        when loading the configurable storage backends from the configuration file.
+
+        :param str dst_device: The target device for tensor operations
+            (e.g., "cuda" or "cpu").
+        :param LMCacheEngineConfig config: Optional configuration object for the
+            cache engine.
+        :param LMCacheEngineMetadata metadata: Optional metadata describing the cache
+            engine state or version.
+        :param LocalCPUBackend local_cpu_backend: Optional backend for local CPU-based
+            inference or caching.
+        :param LookupServerInterface lookup_server: Optional interface to a remote
+            lookup server for distributed caching.
+        :param asyncio.AbstractEventLoop loop: Optional asyncio event loop for
+            asynchronous operations.
+        """
+        super().__init__(dst_device=dst_device)
+        self.config = config
+        self.metadata = metadata
+        self.local_cpu_backend = local_cpu_backend
+        self.lookup_server = lookup_server
+        self.loop = loop

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Any, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence
 import abc
+import asyncio
 
 # Third Party
 import torch
@@ -10,17 +11,27 @@ import torch
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.lookup_server import LookupServerInterface
 from lmcache.v1.memory_management import (
     MemoryAllocatorInterface,
     MemoryFormat,
     MemoryObj,
 )
 
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.storage_backend import LocalCPUBackend
+
 
 class StorageBackendInterface(metaclass=abc.ABCMeta):
     def __init__(
         self,
         dst_device: str = "cuda",
+        config: Optional[LMCacheEngineConfig] = None,
+        metadata: Optional[LMCacheEngineMetadata] = None,
+        local_cpu_backend: Optional["LocalCPUBackend"] = None,
+        lookup_server: Optional[LookupServerInterface] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         """
         Initialize the storage backend.

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -11,7 +11,6 @@ import torch
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.lookup_server import LookupServerInterface
 from lmcache.v1.memory_management import (
     MemoryAllocatorInterface,
     MemoryFormat,
@@ -342,7 +341,6 @@ class ConfigurableStorageBackendInterface(StorageBackendInterface):
         config: Optional[LMCacheEngineConfig] = None,
         metadata: Optional[LMCacheEngineMetadata] = None,
         local_cpu_backend: Optional["LocalCPUBackend"] = None,
-        lookup_server: Optional[LookupServerInterface] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         """
@@ -357,8 +355,6 @@ class ConfigurableStorageBackendInterface(StorageBackendInterface):
             engine state or version.
         :param LocalCPUBackend local_cpu_backend: Optional backend for local CPU-based
             inference or caching.
-        :param LookupServerInterface lookup_server: Optional interface to a remote
-            lookup server for distributed caching.
         :param asyncio.AbstractEventLoop loop: Optional asyncio event loop for
             asynchronous operations.
         """
@@ -366,5 +362,4 @@ class ConfigurableStorageBackendInterface(StorageBackendInterface):
         self.config = config
         self.metadata = metadata
         self.local_cpu_backend = local_cpu_backend
-        self.lookup_server = lookup_server
         self.loop = loop

--- a/lmcache/v1/storage_backend/audit_backend.py
+++ b/lmcache/v1/storage_backend/audit_backend.py
@@ -19,7 +19,7 @@ class AuditBackend(StorageBackendInterface):
     """
 
     def __init__(self, real_backend: StorageBackendInterface):
-        super().__init__(real_backend.dst_device)
+        super().__init__(dst_device=real_backend.dst_device)
         self.real_backend = real_backend
         self.logger = logger.getChild("audit")
         self.logger.info(

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -184,7 +184,7 @@ class GdsBackend(AllocatorBackendInterface):
         dst_device: str = "cuda",
     ):
         assert dst_device.startswith("cuda")
-        super().__init__(dst_device)
+        super().__init__(dst_device=dst_device)
 
         self.config = config
         self.loop = loop

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -31,7 +31,7 @@ class RemoteBackend(StorageBackendInterface):
         local_cpu_backend: LocalCPUBackend,
         dst_device: str = "cuda",
     ):
-        super().__init__(dst_device)
+        super().__init__(dst_device=dst_device)
         self.put_tasks: Set[CacheEngineKey] = set()
         self.lock = threading.Lock()
 

--- a/lmcache/v1/storage_backend/weka_gds_backend.py
+++ b/lmcache/v1/storage_backend/weka_gds_backend.py
@@ -134,7 +134,7 @@ class WekaGdsBackend(AllocatorBackendInterface):
         self.cufile = cufile
 
         assert dst_device.startswith("cuda")
-        super().__init__(dst_device)
+        super().__init__(dst_device=dst_device)
 
         self.config = config
         self.loop = loop


### PR DESCRIPTION
There is no clear definition of the constructor required so that a customized backend can be loaded properly during LMCache startup.

~This PR refactors the StorageBackendInterface constructor to make the interface required to be more concise for the implementer.~

This PR adds a new interface  `ConfigurableStorageBackendInterface` to define the interface required tto be implemented which includes the constructor signature.

FIX #1635 
