### PR TITLE
[Core] Add async Redis cluster connector + unit tests

### DIFF
--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -75,3 +75,48 @@ class RedisSentinelConnectorAdapter(ConnectorAdapter):
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
         )
+
+
+class RedisClusterConnectorAdapter(ConnectorAdapter):
+    """Adapter for Redis Cluster connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("redis-cluster://")
+
+    def can_parse(self, url: str) -> bool:
+        return url.startswith(self.schema)
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        # Local
+        from .redis_connector import RedisClusterConnector
+
+        logger.info(f"Creating Redis Cluster connector for URL: {context.url}")
+        url = context.url[len(self.schema) :]
+
+        # Parse username and password
+        username: str = ""
+        password: str = ""
+        if "@" in url:
+            auth, url = url.split("@", 1)
+            if ":" in auth:
+                username, password = auth.split(":", 1)
+            else:
+                username = auth
+
+        # Parse host and port
+        hosts_and_ports: List[Tuple[str, int]] = []
+        assert self.schema is not None
+        for sub_url in url.split(","):
+            if not sub_url.startswith(self.schema):
+                sub_url = self.schema + sub_url
+
+            parsed_url = parse_remote_url(sub_url)
+            hosts_and_ports.append((parsed_url.host, parsed_url.port))
+
+        return RedisClusterConnector(
+            hosts_and_ports=hosts_and_ports,
+            username=username,
+            password=password,
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+        )

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -7,6 +7,7 @@ import inspect
 import os
 
 # Third Party
+from redis.asyncio.cluster import ClusterNode, RedisCluster
 import redis.asyncio as redis
 
 # First Party
@@ -384,3 +385,229 @@ class RedisSentinelConnector(RemoteConnector):
     async def close(self):
         self.master.close()
         self.slave.close()
+
+
+class RedisClusterConnector(RemoteConnector):
+    """
+    The remote url starts with "redis-cluster:// and can include one or
+    multiple hosts:ports, separated by commas.
+
+    Example:
+        remote_url: "redis-cluster://host1:7000,host2:7000,host3:7000"
+
+    Extra environment variables:
+    - REDIS_TIMEOUT (optional) -- Timeout in seconds, default is 1 if not set
+    """
+
+    def __init__(
+        self,
+        hosts_and_ports: List[Tuple[str, int]],
+        username: str,
+        password: str,
+        loop: asyncio.AbstractEventLoop,
+        local_cpu_backend: LocalCPUBackend,
+    ):
+        # Convert hosts_and_ports to startup_nodes format expected by RedisCluster
+        startup_nodes = [ClusterNode(h, p) for (h, p) in hosts_and_ports]
+
+        # set a large max
+        self.max_connections = 150
+        # redis will crash if we have more than max_connections connections
+        self.sem = asyncio.Semaphore(self.max_connections)
+
+        # Initialize cluster connection
+        self.cluster = RedisCluster(
+            startup_nodes=startup_nodes,
+            username=username,
+            password=password,
+            max_connections=self.max_connections,
+            decode_responses=False,
+        )
+        self.loop = loop
+        self.local_cpu_backend = local_cpu_backend
+
+        self.pq_executor = AsyncPQExecutor(loop)
+
+    async def _exists(self, key: CacheEngineKey) -> bool:
+        async with self.sem:
+            return bool(await self.cluster.exists(key.to_string() + "metadata"))
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        return await self.pq_executor.submit_job(
+            self._exists, key=key, priority=Priorities.PEEK
+        )
+
+    def exists_sync(self, key: CacheEngineKey) -> bool:
+        future = asyncio.run_coroutine_threadsafe(self.exists(key), self.loop)
+        return bool(future.result())
+
+    async def _get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        key_str = key.to_string()
+        async with self.sem:
+            metadata_bytes = await self.cluster.get(key_str + "metadata")
+
+            if metadata_bytes is None:
+                return None
+
+            assert not inspect.isawaitable(metadata_bytes)
+
+            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+
+            memory_obj = self.local_cpu_backend.allocate(
+                metadata.shape,
+                metadata.dtype,
+                metadata.fmt,
+            )
+            if memory_obj is None:
+                logger.warning("Failed to allocate memory during remote receive")
+                return None
+
+            # TODO(Jiayi): Find a way to do `get` inplace
+            kv_bytes = await self.cluster.get(key_str + "kv_bytes")
+
+        assert not inspect.isawaitable(kv_bytes)
+
+        if kv_bytes is None:
+            # TODO (Jiayi): We might need a way to better handle
+            # consistency issues.
+            # TODO (Jiayi): A better way is to aggregate metadata
+            # and kv cache in one key.
+            logger.warning(
+                "Key exists but KV cache does not exist."
+                "Might happen when the cache is evicted by redis."
+            )
+            async with self.sem:
+                await self.cluster.delete(key_str + "metadata")
+            return None
+
+        if isinstance(memory_obj.byte_array, memoryview):
+            view = memory_obj.byte_array
+            if view.format == "<B":
+                view = view.cast("B")
+        else:
+            view = memoryview(memory_obj.byte_array)
+
+        if isinstance(kv_bytes, (bytes, bytearray)):
+            view[: metadata.length] = kv_bytes
+        elif isinstance(kv_bytes, str):
+            converted = kv_bytes.encode("utf-8")
+            view[: metadata.length] = converted
+        else:
+            converted = bytes(kv_bytes)
+            view[: metadata.length] = converted
+
+        return memory_obj
+
+    async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        return await self.pq_executor.submit_job(
+            self._get, key=key, priority=Priorities.GET
+        )
+
+    def support_batched_put(self) -> bool:
+        return True
+
+    async def _batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        # calling self.put will create a circular dependency
+        await asyncio.gather(
+            *(self._put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+        )
+
+    async def batched_put(
+        self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
+    ):
+        await self.pq_executor.submit_job(
+            self._batched_put,
+            keys=keys,
+            memory_objs=memory_objs,
+            priority=Priorities.PUT,
+        )
+
+    async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        # TODO(Jiayi): The following code is ugly.
+        # Please use a function like `memory_obj.to_meta()`.
+        kv_bytes = memory_obj.byte_array
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        metadata_bytes = RemoteMetadata(
+            len(kv_bytes), kv_shape, kv_dtype, memory_format
+        ).serialize()
+
+        key_str = key.to_string()
+        # kv bytes needs to be set first to avoid race condition
+        async with self.sem:
+            await self.cluster.set(key_str + "kv_bytes", kv_bytes)
+            await self.cluster.set(key_str + "metadata", metadata_bytes)
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
+        await self.pq_executor.submit_job(
+            self._put, key=key, memory_obj=memory_obj, priority=Priorities.PUT
+        )
+
+    # TODO
+    @no_type_check
+    async def list(self) -> List[str]:
+        pass
+
+    async def close(self):
+        await self.pq_executor.shutdown(wait=True)
+        await self.cluster.close()
+        logger.info("Closed the redis cluster connection")
+
+    def support_batched_async_contains(self) -> bool:
+        return True
+
+    async def _batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        num_hit_counts = 0
+        for key in keys:
+            async with self.sem:
+                if not await self.cluster.exists(key.to_string() + "metadata"):
+                    return num_hit_counts
+            num_hit_counts += 1
+        return num_hit_counts
+
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        return await self.pq_executor.submit_job(
+            self._batched_async_contains,
+            lookup_id=lookup_id,
+            keys=keys,
+            pin=pin,
+            priority=Priorities.PEEK,
+        )
+
+    def support_batched_get_non_blocking(self) -> bool:
+        return True
+
+    async def _batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
+        # calling self.get will create a circular dependency
+        results = await asyncio.gather(*(self._get(key) for key in keys))
+        return [r for r in results if r is not None]
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: List[CacheEngineKey],
+    ) -> List[MemoryObj]:
+        return await self.pq_executor.submit_job(
+            self._batched_get_non_blocking,
+            lookup_id=lookup_id,
+            keys=keys,
+            priority=Priorities.PREFETCH,
+        )

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -140,7 +140,10 @@ class RedisConnector(RemoteConnector):
     ):
         # calling self.put will create a circular dependency
         await asyncio.gather(
-            *(self._put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+            *(
+                self._put(key, memory_obj)
+                for key, memory_obj in zip(keys, memory_objs, strict=False)
+            )
         )
 
     async def batched_put(
@@ -511,7 +514,10 @@ class RedisClusterConnector(RemoteConnector):
     ):
         # calling self.put will create a circular dependency
         await asyncio.gather(
-            *(self._put(key, memory_obj) for key, memory_obj in zip(keys, memory_objs))
+            *(
+                self._put(key, memory_obj)
+                for key, memory_obj in zip(keys, memory_objs, strict=False)
+            )
         )
 
     async def batched_put(


### PR DESCRIPTION
1. Added new async Redis Cluster support for remote connector with redis-cluster:// prefix, allowing URLs with one or multiple comma-separated host:port pairs (such as a single configuration endpoint for ElastiCache or multiple host:port pairs for self-managed clusters)
2. Created RedisClusterConnector class to interface with Redis Cluster for distributed caching operations and RedisClusterConnectorAdapter class to parse and extract host addresses and ports
3. Tested multi-node URLs and ElastiCache URLs, verifying key existence, storage, retrieval, and cleanup, as well as deletion of metadata key when kv_bytes is missing
4. For Elasticache cluster connections, currently only works when Transit encryption mode is set to preferred

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
