### PR TITLE
Replace default python package manager with uv to ensure fast & smooth experience + add vllm in minimal example to streamline user experience

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -12,7 +12,8 @@ Prerequisites
 - OS: Linux
 - Python: 3.9 -- 3.13
 - GPU: NVIDIA compute capability 7.0+ (e.g., V100, T4, RTX20xx, A100, L4, H100, B200, etc.)
-- CUDA 12.8+
+- CUDA 12.1+
+- uv (Python package manager): ``curl -LsSf https://astral.sh/uv/install.sh | sh``
 
 .. note::
     LMCache does not support Windows natively. To run LMCache on Windows, you can use the Windows Subsystem for Linux (WSL) with a compatible Linux distribution, or use some community-maintained forks.
@@ -24,14 +25,16 @@ The simplest way to install the latest stable release of LMCache is through PyPI
 If you require a different version of torch for the LMCache instance that you built with (symbol undefined error), please follow the install from source instructions below.
 
 .. code-block:: bash
-    
+
+    uv venv --python 3.12
+    source .venv/bin/activate
     # LMCache wheels are built with the latest version of torch.
-    pip install lmcache
+    # vllm is required for LMCache to work; you may also choose to install it separately.
+    uv pip install lmcache vllm
 
 .. important::
 
    You're all set! You can now start using LMCache. For hands-on guides and more usage examples, see the :ref:`quickstart_examples` section.
-
 
 Install Latest LMCache from TestPyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,10 +43,12 @@ TestPyPI wheels are continually built from the latest LMCache source code (not o
 
 .. code-block:: bash
 
+    uv venv --python 3.12
+    source .venv/bin/activate
     # By default, this will adopt the version of torch from the latest *NIGHTLY* vLLM wheel.
     # If you require a different version of torch for the LMCache instance that you built with (symbol undefined error), please
     # follow the install from source instructions below. 
-    pip install --index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple lmcache==0.3.4.dev61
+    uv pip install --index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple lmcache==0.3.4.dev61
 
 See the latest pre-release of LMCache: `latest LMCache pre-releases <https://test.pypi.org/project/lmcache/#history>`__ and replace `0.3.4.dev61` with the latest pre-release version.
 
@@ -69,33 +74,6 @@ avoiding a potential issue where LMCache's kernels are compiled with `torch.util
 inside of `setup.py` with one torch version while during runtime, the version of torch differs across major versions 
 (which is possible because LMCache intentionally has an unpinned torch version in `requirements/common.txt`), causing 
 linker issues that will show up as undefined symbol references.
-
-.. code-block:: bash
-
-    git clone https://github.com/LMCache/LMCache.git
-    cd LMCache
-
-    # Need to install these packages manually to avoid build isolation
-    pip install -r requirements/build.txt
-
-    # Option 1. 
-    # select the torch version that matches the dependency of your serving engine
-    # 2.7.1 is an example for vllm 0.10.0
-    pip install torch==2.7.1
-
-    # Option 2. 
-    # install your serving engine with its required torch version bundled
-    # example: vllm 0.10.0 will install torch 2.7.1
-    pip install vllm==0.10.0
-
-    # no build isolation requires torch to already be installed
-    # with your desired version
-    pip install -e . --no-build-isolation
-
-Install LMCache with uv
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-We recommend developers to use `uv` for faster package management.
 
 .. code-block:: bash
 
@@ -135,7 +113,7 @@ LMCache is integrated with the latest vLLM (vLLM v1). To use it, install the lat
 
 .. code-block:: bash
 
-    pip install vllm
+    uv pip install vllm
 
 Test whether LMCache works with vLLM v1 by running:
 


### PR DESCRIPTION
As titled.

1. Replace default python package manager with `uv` to ensure fast & smooth experience
2. Add vllm in minimal example in one line with lmcache `uv pip install lmcache vllm` to streamline user experience
3. correct the minimal required cuda version to 12.1

FIX #xxxx (*link existing issues this PR will resolve*)

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
