### PR TITLE
Add backward compatibility testing for the vLLM

### DIFF
--- a/.buildkite/configs/local_cpu_mla.yaml
+++ b/.buildkite/configs/local_cpu_mla.yaml
@@ -16,7 +16,7 @@ vllm:
     - "dummy"
     - "--no-enable-prefix-caching"
     - "--kv-transfer-config"
-    - '{"kv_connector":"LMCacheConnectorV1Dynamic","kv_role":"kv_both","kv_connector_module_path":"lmcache.integration.vllm.lmcache_connector_v1","kv_connector_extra_config":{"discard_partial_chunks":true}}'
+    - '{"kv_connector":"LMCacheConnectorV1Dynamic","kv_role":"kv_both","kv_connector_module_path":"lmcache.integration.vllm.lmcache_connector_v1_085","kv_connector_extra_config":{"discard_partial_chunks":true}}'
     - "--tensor-parallel-size"
     - "2"
     - "--block-size"

--- a/.buildkite/configs/local_cpu_mla.yaml
+++ b/.buildkite/configs/local_cpu_mla.yaml
@@ -7,6 +7,7 @@ docker:
   env:
     - "LMCACHE_CONFIG_FILE=/etc/lmcache/local_cpu_mla.yaml"
   gpu_count: 2
+  vllm_backward_compatibility: true
 
 vllm:
   model: "deepseek-ai/DeepSeek-V2-Lite-Chat"

--- a/.buildkite/configs/local_cpu_mla.yaml
+++ b/.buildkite/configs/local_cpu_mla.yaml
@@ -16,7 +16,7 @@ vllm:
     - "dummy"
     - "--no-enable-prefix-caching"
     - "--kv-transfer-config"
-    - '{"kv_connector":"LMCacheConnectorV1Dynamic","kv_role":"kv_both","kv_connector_module_path":"lmcache.integration.vllm.lmcache_connector_v1_085","kv_connector_extra_config":{"discard_partial_chunks":true}}'
+    - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_connector_extra_config":{"discard_partial_chunks":true}}'
     - "--tensor-parallel-size"
     - "2"
     - "--block-size"

--- a/.buildkite/configs/local_cpu_mla.yaml
+++ b/.buildkite/configs/local_cpu_mla.yaml
@@ -22,6 +22,6 @@ vllm:
     - "--block-size"
     - "64"
     - "--kv-cache-dtype"
-    - "fp8_e4m3"
+    - "fp8"
     - "--quantization"
     - "fp8"

--- a/.buildkite/scripts/vllm-integration-tests.sh
+++ b/.buildkite/scripts/vllm-integration-tests.sh
@@ -122,6 +122,9 @@ run_lmcache_vllmopenai_container() {
     source "$ORIG_DIR/.buildkite/scripts/pick-free-gpu.sh" "" "$gpu_count"
     best_gpu="${CUDA_VISIBLE_DEVICES}"
 
+    # Check if using vLLM backward compatibility mode (defaults to false if omitted)
+    use_vllm_bc=$(yq -r '.docker.vllm_backward_compatibility // false' "$cfg_file")
+
     # docker args
     docker_args=(
         --runtime nvidia
@@ -139,8 +142,16 @@ run_lmcache_vllmopenai_container() {
     # vllm args
     vllm_model="$(yq -r '.model' <<<"$vllm")"
     mapfile -t vllm_cli_args < <(yq -r '.args // [] | .[]' <<<"$vllm")
+    
+    # Select Docker image based on backward compatibility flag
+    if [ "$use_vllm_bc" = "true" ]; then
+        docker_image="lmcache/vllm-openai:vllm_backward_compatibility_build-latest"
+    else
+        docker_image="lmcache/vllm-openai:build-latest"
+    fi
+    
     cmd_args=(
-        lmcache/vllm-openai:build-latest
+        "$docker_image"
         "$vllm_model"
     )
     cmd_args+=("${vllm_cli_args[@]}")

--- a/.buildkite/scripts/vllm-integration-tests.sh
+++ b/.buildkite/scripts/vllm-integration-tests.sh
@@ -86,6 +86,12 @@ build_lmcache_vllmopenai_image() {
     ./test-build.sh
 }
 
+build_vllm_backward_compatibility_image() {
+    cp vllm_backward_compatibility_build.sh test-build-vllm-bc.sh
+    chmod 755 test-build-vllm-bc.sh
+    ./test-build-vllm-bc.sh
+}
+
 wait_for_openai_api_server() {
     local port="$1"
     local model="$2"
@@ -413,6 +419,7 @@ cd docker/
 
 # Create the container image
 build_lmcache_vllmopenai_image
+build_vllm_backward_compatibility_image
 
 ########
 # MAIN #

--- a/docker/vllm_backward_compatibility_build.sh
+++ b/docker/vllm_backward_compatibility_build.sh
@@ -1,0 +1,21 @@
+# Example script to build the LMCache integrated with vLLM container image
+
+# Update the following variables accordingly
+CUDA_VERSION=12.8
+DOCKERFILE_NAME='Dockerfile'
+VLLM_VERSION="v0.8.5"
+DOCKER_BUILD_PATH='../' # This path should point to the LMCache root for access to 'requirements' directory
+UBUNTU_VERSION=24.04
+
+# `image-build` target will use the latest LMCache and vLLM code
+# Change to 'image-release' target for using release package versions of vLLM and LMCache
+BUILD_TARGET=image-build 
+
+IMAGE_TAG='lmcache/vllm-openai:vllm_backward_compatibility_build-latest' # Name of container image to build
+
+docker build \
+    --build-arg CUDA_VERSION=$CUDA_VERSION \
+    --build-arg UBUNTU_VERSION=$UBUNTU_VERSION \
+    --build-arg VLLM_VERSION=$VLLM_VERSION \
+    --target $BUILD_TARGET --file $DOCKERFILE_NAME \
+    --tag $IMAGE_TAG  $DOCKER_BUILD_PATH


### PR DESCRIPTION
The industry may be using previous versions of the vLLM for various reasons. Let‘s add a backward compatibility test for the vLLM by building and using a previous version of the vLLM.