### PR TITLE
[benchmark] add random question to long docs

### DIFF
--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -54,6 +54,10 @@ Commandline arguments:
 
     --hit-miss-ratio: In query round, control how many of the prompts
     will miss the cache. For example, 3:1 means every fourth repeated prompt
+
+    --with-question: Whether to append a question to each prompt.
+
+    --question-length: Length of each random question appended.
 """
 
 # Standard
@@ -61,6 +65,7 @@ from dataclasses import dataclass
 import argparse
 import asyncio
 import random
+import string
 import sys
 import time
 
@@ -73,6 +78,53 @@ OUTPUT_FILE = None
 completions_mode = False
 visualize = False
 eos_token_id = None
+
+
+class RandomTokenGenerator:
+    def __init__(self, vocab_size: int = 2048, token_len_range=(2, 5)):
+        self._min_len = max(1, int(token_len_range[0]))
+        self._max_len = max(self._min_len, int(token_len_range[1]))
+        cap = max(1, int(vocab_size))
+        # Prebuild vocab to avoid rebuilding per call
+        # Each vocab word is guaranteed to be a single token when space-separated
+        self._vocab = [
+            "".join(
+                random.choices(
+                    string.ascii_lowercase,
+                    k=random.randint(self._min_len, self._max_len),
+                )
+            )
+            for _ in range(cap)
+        ]
+
+    def generate(self, num_tokens: int, chunk_size: int = 4096) -> str:
+        """
+        Generate exactly num_tokens tokens.
+
+        Each word from self._vocab is treated as exactly one token when
+        space-separated, ensuring accurate token count.
+
+        Args:
+            num_tokens: The exact number of tokens to generate
+            chunk_size: Process tokens in chunks to avoid memory issues
+
+        Returns:
+            A string containing exactly num_tokens space-separated tokens
+        """
+        if num_tokens <= 0:
+            return ""
+
+        remaining = int(num_tokens)
+        parts: list[str] = []
+
+        while remaining > 0:
+            k = min(chunk_size, remaining)
+            # Select exactly k tokens from vocab
+            tokens = random.choices(self._vocab, k=k)
+            parts.append(" ".join(tokens))
+            remaining -= k
+
+        return " ".join(parts)
 
 
 @dataclass
@@ -423,9 +475,10 @@ async def main(args):
         timeout=None,
     )
     model = args.model
+    # Instantiate once to avoid rebuilding vocab repeatedly
+    token_gen = RandomTokenGenerator()
 
-    pre_warmup_prompts = [str(i) + "xx" + " ".join(["hi"] * 1000) for i in range(5)]
-
+    pre_warmup_prompts = [str(i) + "xx" + token_gen.generate(1000) for i in range(5)]
     await test_long_document_qa(
         client=client,
         model=model,
@@ -438,11 +491,13 @@ async def main(args):
     # we append the document id at the beginning to avoid any of the document
     # being the prefix of other documents
     warmup_prompts = [
-        str(i) + " " + " ".join(["hi"] * args.document_length)
+        str(i) + " " + token_gen.generate(args.document_length)
         for i in range(args.num_documents)
     ]
 
     prompts = repeat_prompts(warmup_prompts, args.repeat_count, mode=args.repeat_mode)
+    if getattr(args, "with_question", False):
+        prompts = [p + " " + token_gen.generate(args.question_length) for p in prompts]
     prompts, miss_mask = add_cache_misses(prompts, args.hit_miss_ratio)
 
     write_resp("------warm up round------\n")
@@ -687,6 +742,20 @@ def create_argument_parser():
             "EOS token id. we bias against this token id so we always "
             "get the number of output tokens we specify"
         ),
+    )
+
+    parser.add_argument(
+        "--with-question",
+        action="store_true",
+        help="Append a random question to each document prompt.",
+    )
+
+    parser.add_argument(
+        "--question-length",
+        type=int,
+        default=16,
+        help="Length of each random question appended."
+        "(effective when --with-question is enabled)",
     )
 
     return parser

--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -65,7 +65,6 @@ from dataclasses import dataclass
 import argparse
 import asyncio
 import random
-import string
 import sys
 import time
 
@@ -85,17 +84,10 @@ class RandomTokenGenerator:
         self._min_len = max(1, int(token_len_range[0]))
         self._max_len = max(self._min_len, int(token_len_range[1]))
         cap = max(1, int(vocab_size))
-        # Prebuild vocab to avoid rebuilding per call
-        # Each vocab word is guaranteed to be a single token when space-separated
-        self._vocab = [
-            "".join(
-                random.choices(
-                    string.ascii_lowercase,
-                    k=random.randint(self._min_len, self._max_len),
-                )
-            )
-            for _ in range(cap)
-        ]
+        # Use a simple vocabulary with format "t{i}"
+        # to ensure each word is exactly one token
+        # This guarantees accurate token count generation
+        self._vocab = [f"t{i}" for i in range(cap)]
 
     def generate(self, num_tokens: int, chunk_size: int = 4096) -> str:
         """


### PR DESCRIPTION
Provide random question appending each "long doc"

Background (Why)

 Append a "random" “question” after each “long document” to make the benchmark closer to a "simplified version" of real-world RAG;(previously in log-doc-qa, there's no question after each doc, in multi-round-qa, the question is fixed for each doc.)
 
 The real world is like : enterprise has M documents , diff users will ask different questions ,  the RAG will select some of the M documents( in this long-doc, assuming select 1 for each time),  then append the user's question, as a total prompt.

The content of the M docs will not change, but the N question from users varies for each time.




What's Changed:

- Change the document from fixed "hi hi ..."( ' '.join(['hi'] * N) ) to lightweight random pseudo-word-generator, keeping the total length unchanged.

- add  `--with-question` and `--question-length` parameters to append random questions to the end of each repeated document, thereby introducing controllable variation to each request.



This PR just use most simple `benchmarks/long_doc_qa/long_doc_qa.py` as an explanation of this idea.
although `benchmarks/rag` has more complex design.






Testul result  with my local model
```
 python3 benchmarks/long_doc_qa/long_doc_qa.py    --document-length 100   --num-documents 2   --output-len 8   --repeat-count 1   --max-inflight-requests 1   --with-question   --question-length 20   --port 8000   --model "public/glm-4-9b-chat"
```


```
--- Sending prompt 1/5 ---

Response of request 0:
The text you've provided appears to

--- Sending prompt 2/5 ---

Response of request 1:
The text you've provided appears to

--- Sending prompt 3/5 ---

Response of request 2:
It appears that you've shared a

--- Sending prompt 4/5 ---

Response of request 3:
The text you've provided appears to

--- Sending prompt 5/5 ---

Response of request 4:
The text you've provided appears to
Repeat mode:  random
------warm up round------

--- Sending prompt 1/2 ---

Response of request 0:
The text you've provided appears to

--- Sending prompt 2/2 ---

Response of request 1:
It seems like you've provided a
------query round------

--- Sending prompt 1/2 ---

Response of request 0:
It seems like you've provided a

--- Sending prompt 2/2 ---

Response of request 1:
The text you've provided appears to

=== BENCHMARK RESULTS ===
Warmup round mean TTFT: 0.052s
Warmup round time: 0.489s
Warmup round prompt count: 2
Query round mean TTFT: 0.054s
Query round time: 0.492s
Query round prompt count: 2
```
