### PR TITLE
[BugFix][Testing]: Enable unit tests for GDS backend

### DIFF
--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence
+from concurrent.futures import Future
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union
 import abc
 import asyncio
 
@@ -72,12 +73,17 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
         keys: Sequence[CacheEngineKey],
         objs: List[MemoryObj],
         transfer_spec: Any = None,
-    ) -> None:
+    ) -> Union[List[Future], None]:
         """
         An async function to put the MemoryObj into the storage backend.
 
         :param List[CacheEngineKey] keys: The keys of the MemoryObjs.
         :param List[MemoryObj] objs: The MemoryObjs to be stored.
+
+        :return:  Union[List[Future], None]: A list of `Future` objects if the
+        storage persistence operation is asynchronous and is successful.
+        `None` if the operation is synchronous, or the asynchronous fails
+        or is skipped.
 
         :note: This function will have the side effect that modifies the
             underlying key-value mappings in the storage backend. The side

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -408,9 +408,12 @@ class GdsBackend(AllocatorBackendInterface):
         keys: Sequence[CacheEngineKey],
         memory_objs: List[MemoryObj],
         transfer_spec: Any = None,
-    ) -> None:
+    ) -> List[Future]:
+        futures = []
         for key, memory_obj in zip(keys, memory_objs, strict=False):
-            self.submit_put_task(key, memory_obj)
+            future = self.submit_put_task(key, memory_obj)
+            futures.append(future)
+        return futures
 
     async def _async_save_bytes_to_disk(
         self,

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -2,7 +2,7 @@
 # Standard
 from collections import OrderedDict
 from concurrent.futures import Future
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple, Union
 import asyncio
 import ctypes
 import json
@@ -408,7 +408,7 @@ class GdsBackend(AllocatorBackendInterface):
         keys: Sequence[CacheEngineKey],
         memory_objs: List[MemoryObj],
         transfer_spec: Any = None,
-    ) -> List[Future]:
+    ) -> Union[List[Future], None]:
         futures = []
         for key, memory_obj in zip(keys, memory_objs, strict=False):
             future = self.submit_put_task(key, memory_obj)

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -35,7 +35,7 @@ def create_test_key(key_id: int = 0) -> CacheEngineKey:
 
 
 def create_test_memory_obj(
-    shape=(2, 16, 8, 128), dtype=torch.bfloat16, device="cpu"
+    shape=(2, 16, 8, 128), dtype=torch.bfloat16, device="cuda"
 ) -> MemoryObj:
     allocator = AdHocMemoryAllocator(device=device)
     memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
@@ -81,7 +81,7 @@ def gds_backend(temp_gds_path, async_loop):
         config=config,
         loop=async_loop,
         metadata=metadata,
-        dst_device="cuda" if torch.cuda.is_available() else "cpu",
+        dst_device="cuda:0",
     )
 
 
@@ -99,10 +99,10 @@ class TestGdsBackend:
             config=config,
             loop=async_loop,
             metadata=metadata,
-            dst_device="cuda" if torch.cuda.is_available() else "cpu",
+            dst_device="cuda:0",
         )
         assert backend.gds_path == temp_gds_path
-        assert backend.dst_device in ("cuda", "cpu")
+        assert backend.dst_device == "cuda:0"
         assert os.path.exists(temp_gds_path)
 
     def test_str(self, gds_backend):
@@ -145,7 +145,7 @@ class TestGdsBackend:
     )
     async def test_submit_put_task_and_get_blocking(self, gds_backend):
         key = create_test_key(0)
-        memory_obj = create_test_memory_obj(device="cpu")
+        memory_obj = create_test_memory_obj(device="cuda")
         # submit_put_task returns a Future
         future = gds_backend.submit_put_task(key, memory_obj)
         assert future is not None
@@ -162,7 +162,7 @@ class TestGdsBackend:
     @pytest.mark.asyncio
     async def test_batched_submit_put_task(self, gds_backend):
         keys = [create_test_key(i) for i in range(2, 5)]
-        memory_objs = [create_test_memory_obj(device="cpu") for _ in range(3)]
+        memory_objs = [create_test_memory_obj(device="cuda") for _ in range(3)]
         futures = gds_backend.batched_submit_put_task(keys, memory_objs)
         assert futures is not None
         assert len(futures) == 3
@@ -183,7 +183,5 @@ class TestGdsBackend:
 
     def test_pin_unpin_not_implemented(self, gds_backend):
         key = create_test_key(0)
-        with pytest.raises(NotImplementedError):
-            gds_backend.pin(key)
-        with pytest.raises(NotImplementedError):
-            gds_backend.unpin(key)
+        assert not gds_backend.pin(key)
+        assert not gds_backend.unpin(key)

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -90,7 +90,6 @@ def gds_backend(temp_gds_path, async_loop):
     reason="Requires CUDA for TestGdsBackend",
 )
 @pytest.mark.skipif(sys.platform != "linux", reason="TestGdsBackend runs only on Linux")
-@pytest.mark.skip(reason="Thisn currently fails on the test system")
 class TestGdsBackend:
     def test_init(self, temp_gds_path, async_loop):
         config = create_test_config(temp_gds_path)

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat, MemoryObj
@@ -41,6 +42,18 @@ def create_test_memory_obj(
     return memory_obj
 
 
+def create_test_metadata():
+    """Create a test metadata for LMCacheEngineMetadata."""
+    return LMCacheEngineMetadata(
+        model_name="test_model",
+        world_size=1,
+        worker_id=0,
+        fmt="vllm",
+        kv_dtype=torch.bfloat16,
+        kv_shape=(28, 2, 256, 8, 128),
+    )
+
+
 @pytest.fixture
 def temp_gds_path():
     temp_dir = tempfile.mkdtemp()
@@ -61,18 +74,14 @@ def async_loop():
 
 
 @pytest.fixture
-def memory_allocator():
-    return AdHocMemoryAllocator(device="cpu")
-
-
-@pytest.fixture
-def gds_backend(temp_gds_path, async_loop, memory_allocator):
+def gds_backend(temp_gds_path, async_loop):
     config = create_test_config(temp_gds_path)
+    metadata = create_test_metadata()
     return GdsBackend(
         config=config,
         loop=async_loop,
-        memory_allocator=memory_allocator,
-        dst_device="cuda",
+        metadata=metadata,
+        dst_device="cuda" if torch.cuda.is_available() else "cpu",
     )
 
 
@@ -83,16 +92,16 @@ def gds_backend(temp_gds_path, async_loop, memory_allocator):
 @pytest.mark.skipif(sys.platform != "linux", reason="TestGdsBackend runs only on Linux")
 @pytest.mark.skip(reason="Thisn currently fails on the test system")
 class TestGdsBackend:
-    def test_init(self, temp_gds_path, async_loop, memory_allocator):
+    def test_init(self, temp_gds_path, async_loop):
         config = create_test_config(temp_gds_path)
+        metadata = create_test_metadata()
         backend = GdsBackend(
             config=config,
             loop=async_loop,
-            memory_allocator=memory_allocator,
-            dst_device="cuda",
+            metadata=metadata,
+            dst_device="cuda" if torch.cuda.is_available() else "cpu",
         )
         assert backend.gds_path == temp_gds_path
-        assert backend.memory_allocator == memory_allocator
         assert backend.dst_device in ("cuda", "cpu")
         assert os.path.exists(temp_gds_path)
 

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -1315,6 +1315,10 @@ def test_builder_destroy_multiple_instances(autorelease_v1):
     LMCacheEngineBuilder.destroy(instance_id2)
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Requires CUDA for test_multi_device_backends",
+)
 def test_multi_device_backends(autorelease_v1):
     """Test running GPU-related backend with local CPU backends
     together


### PR DESCRIPTION
The async library should always have been available for testing. The check for skipping the GDS tests was removed as the logic was skewed to be checking for the library to ignore the tests.

FIX #1592 

**Note: DO NOT MERGE** until #1677 does.
