### PR TITLE
[Core]: Add logic in LocalDiskBackend  to save metadata dict to disk and reconstruct the dict during initialization

### DIFF
--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -183,6 +183,9 @@ class LMCFlashInferSparseBackend(AttentionInterface):
     for efficient attention computation.
     """
 
+    # Workspace buffer size in bytes (128 MiB)
+    _WORKSPACE_BUFFER_SIZE_BYTES = 128 * 1024 * 1024
+
     def __init__(
         self,
         vllm_attn: Attention,
@@ -194,7 +197,7 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         self.device = torch.device(f"cuda:{idx}")
 
         self.workspace_buffer = torch.empty(
-            128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
+            self._WORKSPACE_BUFFER_SIZE_BYTES, dtype=torch.uint8, device=self.device
         )
 
         self.num_qo_heads = self.vllm_attn_impl.num_heads

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -84,6 +84,10 @@ _DEPRECATED_CONFIGS = {
 
 # Single configuration definition center - add new config items only here
 _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
+    # Prefetch disk cache to CPU on startup if persistence is enabled
+    "populate_disk_cache_to_cpu_on_start": {"type": bool, "default": True, "env_converter": _to_bool},
+    # Disk persistence for local disk backend
+    "local_disk_persistence": {"type": bool, "default": False, "env_converter": _to_bool},
     # Basic configurations
     "chunk_size": {"type": int, "default": 256, "env_converter": int},
     "local_cpu": {

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -277,13 +277,40 @@ class LocalDiskBackend(StorageBackendInterface):
 
         size = metadata.get("size")
         if size is None:
-            size_int = os.path.getsize(data_path)
+            try:
+                size_int = os.path.getsize(data_path)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to stat data file for %s when size missing: %s",
+                    data_path,
+                    exc,
+                )
+                size_int = 0
         else:
             try:
                 size_int = int(size)
             except (TypeError, ValueError):
                 logger.warning("Invalid size metadata for %s: %s", data_path, size)
-                size_int = os.path.getsize(data_path)
+                try:
+                    size_int = os.path.getsize(data_path)
+                except OSError as exc:
+                    logger.warning(
+                        "Failed to stat data file for %s when size invalid: %s",
+                        data_path,
+                        exc,
+                    )
+                    size_int = 0
+            else:
+                if size_int <= 0:
+                    try:
+                        size_int = os.path.getsize(data_path)
+                    except OSError as exc:
+                        logger.warning(
+                            "Failed to stat data file for %s when size non-positive: %s",
+                            data_path,
+                            exc,
+                        )
+                        size_int = 0
 
         return size_int, shape, dtype, fmt
 
@@ -428,8 +455,13 @@ class LocalDiskBackend(StorageBackendInterface):
             return False
 
         path = meta.path
-        size = meta.size
-        self.usage -= size
+        size = int(meta.size)
+        if size <= 0:
+            try:
+                size = os.path.getsize(path)
+            except OSError:
+                size = 0
+        self.usage = max(0, self.usage - size)
         self.stats_monitor.update_local_storage_usage(self.usage)
 
         # NOTE: The following code will cause deadlock
@@ -501,7 +533,7 @@ class LocalDiskBackend(StorageBackendInterface):
         self.disk_worker.insert_put_task(key)
 
         # TODO(Jiayi): Fragmentation is not considered here.
-        required_size = memory_obj.get_physical_size()
+        required_size = memory_obj.get_size()
         all_evict_keys = []
         evict_success = True
         with self.disk_lock:
@@ -674,8 +706,8 @@ class LocalDiskBackend(StorageBackendInterface):
         buffer = memory_obj.byte_array
         path = self._key_to_path(key)
 
-        size = len(buffer)
-        self.usage += size
+        data_size = len(buffer)
+        self.usage += data_size
         self.stats_monitor.update_local_storage_usage(self.usage)
 
         # TODO(Jiayi): need to add ref count in disk memory object
@@ -685,13 +717,13 @@ class LocalDiskBackend(StorageBackendInterface):
         # `submit_put_task` above.
         # Ref count down better be before `insert_key` for testing
         # purposes (e.g., testing mem_leak).
-        size = memory_obj.get_physical_size()
+        stored_size = data_size
         shape = memory_obj.metadata.shape
         dtype = memory_obj.metadata.dtype
         fmt = memory_obj.metadata.fmt
         memory_obj.ref_count_down()
 
-        self.insert_key(key, size, shape, dtype, fmt)
+        self.insert_key(key, stored_size, shape, dtype, fmt)
 
         self.disk_worker.remove_put_task(key)
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -3,6 +3,7 @@
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
+import json
 import os
 import threading
 import time
@@ -13,7 +14,13 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
-from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
+from lmcache.utils import (
+    CacheEngineKey,
+    DiskCacheMetadata,
+    STR_DTYPE_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_STR_DTYPE,
+    _lmcache_nvtx_annotate,
+)
 from lmcache.v1.cache_controller.message import KVAdmitMsg, KVEvictMsg
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
@@ -29,6 +36,32 @@ if TYPE_CHECKING:
     from lmcache.v1.cache_controller.worker import LMCacheWorker
 
 logger = init_logger(__name__)
+
+_METADATA_SUFFIX = ".meta"
+_METADATA_VERSION = 1
+
+
+def _dtype_to_string(dtype: torch.dtype) -> str:
+    if dtype in TORCH_DTYPE_TO_STR_DTYPE:
+        return TORCH_DTYPE_TO_STR_DTYPE[dtype]
+    dtype_str = str(dtype)
+    if dtype_str.startswith("torch."):
+        dtype_str = dtype_str[len("torch.") :]
+    return dtype_str
+
+
+def _string_to_dtype(dtype_str: Optional[str]) -> Optional[torch.dtype]:
+    if dtype_str is None:
+        return None
+    if dtype_str in STR_DTYPE_TO_TORCH_DTYPE:
+        return STR_DTYPE_TO_TORCH_DTYPE[dtype_str]
+    if dtype_str.startswith("torch."):
+        dtype_str = dtype_str[len("torch.") :]
+    try:
+        return getattr(torch, dtype_str)
+    except AttributeError:
+        logger.warning("Unsupported torch dtype string in metadata: %s", dtype_str)
+        return None
 
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
@@ -148,39 +181,20 @@ class LocalDiskBackend(StorageBackendInterface):
         self.usage = 0
 
         # Disk persistence: repopulate in-memory index from disk if enabled
-        self.local_disk_persistence = getattr(config, "local_disk_persistence", False)
-        self.populate_disk_cache_to_cpu_on_start = getattr(config, "populate_disk_cache_to_cpu_on_start", True)
+        self.local_disk_persistence = bool(
+            getattr(config, "local_disk_persistence", False)
+        )
+        self.populate_disk_cache_to_cpu_on_start = bool(
+            getattr(config, "populate_disk_cache_to_cpu_on_start", True)
+        )
         if self.local_disk_persistence:
-            logger.info("Local disk persistence enabled. Scanning for existing cache files...")
-            disk_keys = []
-            for fname in os.listdir(self.path):
-                if not fname.endswith(".pt"):
-                    continue
-                # Remove .pt, replace '-' back to '/' for key string
-                key_str = fname[:-3].replace("-", "/")
-                try:
-                    key = CacheEngineKey.from_string(key_str)
-                except Exception as e:
-                    logger.warning(f"Failed to parse cache key from file {fname}: {e}")
-                    continue
-                fpath = os.path.join(self.path, fname)
-                fsize = os.path.getsize(fpath)
-                # Metadata: shape, dtype, fmt are unknown here, will be filled on first access
-                self.dict[key] = DiskCacheMetadata(fpath, fsize, None, None, None, 0)
-                self.current_cache_size += fsize
-                disk_keys.append(key)
-            logger.info(f"Restored {len(self.dict)} disk cache entries from {self.path}.")
-
-            # Optionally prefetch disk cache to CPU
-            if self.populate_disk_cache_to_cpu_on_start and disk_keys:
-                logger.info(f"Prefetching {len(disk_keys)} disk cache entries to CPU memory...")
-                for key in disk_keys:
-                    # This will load the cache into CPU memory (local_cpu_backend)
-                    try:
-                        _ = self.get_blocking(key)
-                    except Exception as e:
-                        logger.warning(f"Failed to prefetch cache for key {key}: {e}")
-                logger.info("Disk cache prefetch to CPU complete.")
+            disk_keys = self._restore_persistent_cache()
+            if (
+                self.populate_disk_cache_to_cpu_on_start
+                and self.use_local_cpu
+                and disk_keys
+            ):
+                self._prefetch_persisted_cache(disk_keys)
 
     def __str__(self):
         return "LocalDiskBackend"
@@ -190,6 +204,169 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
     ) -> str:
         return os.path.join(self.path, key.to_string().replace("/", "-") + ".pt")
+
+    def _metadata_path(self, data_path: str) -> str:
+        return data_path + _METADATA_SUFFIX
+
+    def _write_metadata_file(self, metadata: DiskCacheMetadata) -> None:
+        if metadata.shape is None or metadata.dtype is None:
+            raise ValueError("Metadata must contain shape and dtype to persist to disk")
+
+        fmt_name = metadata.fmt.name if metadata.fmt is not None else None
+        metadata_dict = {
+            "version": _METADATA_VERSION,
+            "size": int(metadata.size),
+            "shape": [int(dim) for dim in metadata.shape],
+            "dtype": _dtype_to_string(metadata.dtype),
+            "fmt": fmt_name,
+        }
+        meta_path = self._metadata_path(metadata.path)
+        tmp_path = meta_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(metadata_dict, f)
+        os.replace(tmp_path, meta_path)
+
+    def _read_metadata_from_disk(
+        self, data_path: str
+    ) -> Optional[tuple[int, torch.Size, torch.dtype, Optional[MemoryFormat]]]:
+        meta_path = self._metadata_path(data_path)
+        if not os.path.exists(meta_path):
+            logger.warning("Missing metadata file for persisted cache %s", data_path)
+            return None
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        except Exception as e:
+            logger.warning("Failed to read metadata file %s: %s", meta_path, e)
+            return None
+
+        version = metadata.get("version")
+        if version != _METADATA_VERSION:
+            logger.warning(
+                "Unsupported metadata version %s for %s", version, meta_path
+            )
+            return None
+
+        shape_value = metadata.get("shape")
+        if not isinstance(shape_value, list):
+            logger.warning("Invalid shape metadata for %s: %s", data_path, shape_value)
+            return None
+        try:
+            shape = torch.Size([int(dim) for dim in shape_value])
+        except (TypeError, ValueError) as exc:
+            logger.warning("Failed to parse shape metadata for %s: %s", data_path, exc)
+            return None
+
+        dtype = _string_to_dtype(metadata.get("dtype"))
+        if dtype is None:
+            logger.warning("Invalid dtype metadata for %s", data_path)
+            return None
+
+        fmt_str = metadata.get("fmt")
+        fmt: Optional[MemoryFormat] = None
+        if fmt_str is not None:
+            try:
+                fmt = MemoryFormat[fmt_str]
+            except KeyError:
+                logger.warning(
+                    "Invalid memory format metadata for %s: %s", data_path, fmt_str
+                )
+                fmt = None
+
+        size = metadata.get("size")
+        if size is None:
+            size_int = os.path.getsize(data_path)
+        else:
+            try:
+                size_int = int(size)
+            except (TypeError, ValueError):
+                logger.warning("Invalid size metadata for %s: %s", data_path, size)
+                size_int = os.path.getsize(data_path)
+
+        return size_int, shape, dtype, fmt
+
+    def _remove_metadata_file(self, data_path: str) -> None:
+        meta_path = self._metadata_path(data_path)
+        try:
+            os.remove(meta_path)
+        except FileNotFoundError:
+            return
+        except OSError as e:
+            logger.warning("Failed to remove metadata file %s: %s", meta_path, e)
+
+    def _restore_persistent_cache(self) -> list[CacheEngineKey]:
+        logger.info(
+            "Local disk persistence enabled. Scanning for existing cache files..."
+        )
+        disk_keys: list[CacheEngineKey] = []
+        total_size = 0
+        for entry in sorted(os.listdir(self.path)):
+            if not entry.endswith(".pt"):
+                continue
+            data_path = os.path.join(self.path, entry)
+            if not os.path.isfile(data_path):
+                continue
+            key_str = entry[:-3].replace("-", "/")
+            try:
+                key = CacheEngineKey.from_string(key_str)
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse cache key from file %s: %s", entry, e
+                )
+                continue
+
+            metadata = self._read_metadata_from_disk(data_path)
+            if metadata is None:
+                continue
+            size, shape, dtype, fmt = metadata
+            disk_meta = DiskCacheMetadata(data_path, size, shape, dtype, fmt, 0)
+            self.dict[key] = disk_meta
+            self.cache_policy.update_on_put(key)
+            disk_keys.append(key)
+            total_size += size
+
+        self.current_cache_size = float(total_size)
+        self.usage = total_size
+        self.stats_monitor.update_local_storage_usage(self.usage)
+        if total_size:
+            logger.info(
+                "Restored %d disk cache entries (%.2f MB) from %s.",
+                len(disk_keys),
+                total_size / 1e6,
+                self.path,
+            )
+        else:
+            logger.info("No existing disk cache entries found in %s.", self.path)
+
+        return disk_keys
+
+    def _prefetch_persisted_cache(self, keys: list[CacheEngineKey]) -> None:
+        logger.info(
+            "Prefetching %d disk cache entries to CPU memory...",
+            len(keys),
+        )
+        for key in keys:
+            memory_obj: Optional[MemoryObj] = None
+            try:
+                memory_obj = self.get_blocking(key)
+            except Exception as e:
+                logger.warning("Failed to prefetch cache for key %s: %s", key, e)
+                continue
+
+            if memory_obj is None:
+                logger.warning("Persisted cache for key %s missing on disk", key)
+                continue
+
+            try:
+                self.local_cpu_backend.submit_put_task(key, memory_obj)
+            except Exception as e:
+                logger.warning(
+                    "Failed to populate CPU cache for persisted key %s: %s", key, e
+                )
+            finally:
+                memory_obj.ref_count_down()
+
+        logger.info("Disk cache prefetch to CPU complete.")
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self.disk_lock:
@@ -259,8 +436,10 @@ class LocalDiskBackend(StorageBackendInterface):
         # res.result()
 
         os.remove(path)
+        self._remove_metadata_file(path)
 
         if force:
+            self.current_cache_size = max(0.0, self.current_cache_size - size)
             self.cache_policy.update_on_force_evict(key)
             self.disk_lock.release()
 
@@ -283,13 +462,19 @@ class LocalDiskBackend(StorageBackendInterface):
         path = self._key_to_path(key)
 
         has_stored = False
+        metadata_entry = DiskCacheMetadata(path, size, shape, dtype, fmt, False)
         with self.disk_lock:
             # Need to do reinsert to update cache recency
             if key in self.dict:
                 self.dict.pop(key)
                 has_stored = True
 
-            self.dict[key] = DiskCacheMetadata(path, size, shape, dtype, fmt, False)
+            self.dict[key] = metadata_entry
+
+        try:
+            self._write_metadata_file(metadata_entry)
+        except Exception as e:
+            logger.warning("Failed to persist metadata for key %s: %s", key, e)
 
         # push kv admit msg
         if self.lmcache_worker is not None and not has_stored:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -209,6 +209,8 @@ class LocalDiskBackend(StorageBackendInterface):
         return data_path + _METADATA_SUFFIX
 
     def _write_metadata_file(self, metadata: DiskCacheMetadata) -> None:
+        if not self.local_disk_persistence:
+            return        
         if metadata.shape is None or metadata.dtype is None:
             raise ValueError("Metadata must contain shape and dtype to persist to disk")
 
@@ -286,6 +288,8 @@ class LocalDiskBackend(StorageBackendInterface):
         return size_int, shape, dtype, fmt
 
     def _remove_metadata_file(self, data_path: str) -> None:
+        if not self.local_disk_persistence:
+            return
         meta_path = self._metadata_path(data_path)
         try:
             os.remove(meta_path)

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -238,8 +238,8 @@ class LocalDiskBackend(StorageBackendInterface):
         try:
             with open(meta_path, "r", encoding="utf-8") as f:
                 metadata = json.load(f)
-        except Exception as e:
-            logger.warning("Failed to read metadata file %s: %s", meta_path, e)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to read metadata file %s: %s", meta_path, exc)
             return None
 
         version = metadata.get("version")
@@ -313,9 +313,9 @@ class LocalDiskBackend(StorageBackendInterface):
             key_str = entry[:-3].replace("-", "/")
             try:
                 key = CacheEngineKey.from_string(key_str)
-            except Exception as e:
+            except ValueError as exc:
                 logger.warning(
-                    "Failed to parse cache key from file %s: %s", entry, e
+                    "Failed to parse cache key from file %s: %s", entry, exc
                 )
                 continue
 
@@ -353,8 +353,8 @@ class LocalDiskBackend(StorageBackendInterface):
             memory_obj: Optional[MemoryObj] = None
             try:
                 memory_obj = self.get_blocking(key)
-            except Exception as e:
-                logger.warning("Failed to prefetch cache for key %s: %s", key, e)
+            except (IOError, FileNotFoundError) as exc:
+                logger.warning("Failed to prefetch cache for key %s: %s", key, exc)
                 continue
 
             if memory_obj is None:
@@ -363,9 +363,9 @@ class LocalDiskBackend(StorageBackendInterface):
 
             try:
                 self.local_cpu_backend.submit_put_task(key, memory_obj)
-            except Exception as e:
+            except (RuntimeError, MemoryError) as exc:
                 logger.warning(
-                    "Failed to populate CPU cache for persisted key %s: %s", key, e
+                    "Failed to populate CPU cache for persisted key %s: %s", key, exc
                 )
             finally:
                 memory_obj.ref_count_down()
@@ -477,8 +477,8 @@ class LocalDiskBackend(StorageBackendInterface):
 
         try:
             self._write_metadata_file(metadata_entry)
-        except Exception as e:
-            logger.warning("Failed to persist metadata for key %s: %s", key, e)
+        except (ValueError, OSError) as exc:
+            logger.warning("Failed to persist metadata for key %s: %s", key, exc)
 
         # push kv admit msg
         if self.lmcache_worker is not None and not has_stored:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -147,6 +147,41 @@ class LocalDiskBackend(StorageBackendInterface):
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.usage = 0
 
+        # Disk persistence: repopulate in-memory index from disk if enabled
+        self.local_disk_persistence = getattr(config, "local_disk_persistence", False)
+        self.populate_disk_cache_to_cpu_on_start = getattr(config, "populate_disk_cache_to_cpu_on_start", True)
+        if self.local_disk_persistence:
+            logger.info("Local disk persistence enabled. Scanning for existing cache files...")
+            disk_keys = []
+            for fname in os.listdir(self.path):
+                if not fname.endswith(".pt"):
+                    continue
+                # Remove .pt, replace '-' back to '/' for key string
+                key_str = fname[:-3].replace("-", "/")
+                try:
+                    key = CacheEngineKey.from_string(key_str)
+                except Exception as e:
+                    logger.warning(f"Failed to parse cache key from file {fname}: {e}")
+                    continue
+                fpath = os.path.join(self.path, fname)
+                fsize = os.path.getsize(fpath)
+                # Metadata: shape, dtype, fmt are unknown here, will be filled on first access
+                self.dict[key] = DiskCacheMetadata(fpath, fsize, None, None, None, 0)
+                self.current_cache_size += fsize
+                disk_keys.append(key)
+            logger.info(f"Restored {len(self.dict)} disk cache entries from {self.path}.")
+
+            # Optionally prefetch disk cache to CPU
+            if self.populate_disk_cache_to_cpu_on_start and disk_keys:
+                logger.info(f"Prefetching {len(disk_keys)} disk cache entries to CPU memory...")
+                for key in disk_keys:
+                    # This will load the cache into CPU memory (local_cpu_backend)
+                    try:
+                        _ = self.get_blocking(key)
+                    except Exception as e:
+                        logger.warning(f"Failed to prefetch cache for key {key}: {e}")
+                logger.info("Disk cache prefetch to CPU complete.")
+
     def __str__(self):
         return "LocalDiskBackend"
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -41,14 +41,18 @@ class MockLMCacheWorker:
         self.messages.append(msg)
 
 
-def create_test_config(disk_path: str, max_disk_size: float = 1.0):
+def create_test_config(
+    disk_path: str, max_disk_size: float = 1.0, **overrides
+):
     """Create a test configuration for LocalDiskBackend."""
-    config = LMCacheEngineConfig.from_defaults(
+    config_kwargs = dict(
         chunk_size=256,
         local_disk=disk_path,
         max_local_disk_size=max_disk_size,
         lmcache_instance_id="test_instance",
     )
+    config_kwargs.update(overrides)
+    config = LMCacheEngineConfig.from_defaults(**config_kwargs)
     return config
 
 
@@ -260,3 +264,103 @@ class TestLocalDiskBackend:
         )
         assert memory_obj is not None
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_disk_persistence_restore_and_prefetch(
+        self, temp_disk_path, async_loop, memory_allocator
+    ):
+        """Disk entries are restored and prefetched to CPU on restart."""
+        config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=True,
+            populate_disk_cache_to_cpu_on_start=True,
+        )
+        cpu_backend = LocalCPUBackend(config, memory_allocator=memory_allocator)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(42)
+        memory_obj = create_test_memory_obj()
+        data_path = backend._key_to_path(key)
+        meta_path = data_path + ".meta"
+
+        try:
+            backend.async_save_bytes_to_disk(key, memory_obj)
+            assert os.path.exists(data_path)
+            assert os.path.exists(meta_path)
+        finally:
+            backend.close()
+            cpu_backend.memory_allocator.close()
+
+        restore_config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=True,
+            populate_disk_cache_to_cpu_on_start=True,
+        )
+        restore_cpu_backend = LocalCPUBackend(
+            restore_config, memory_allocator=memory_allocator
+        )
+        restored_backend = LocalDiskBackend(
+            config=restore_config,
+            loop=async_loop,
+            local_cpu_backend=restore_cpu_backend,
+            dst_device="cuda",
+        )
+
+        try:
+            assert key in restored_backend.dict
+            restored_meta = restored_backend.dict[key]
+            assert restored_meta.shape == memory_obj.metadata.shape
+            assert restored_meta.dtype == memory_obj.metadata.dtype
+            assert restored_meta.fmt == memory_obj.metadata.fmt
+            assert restored_meta.size == os.path.getsize(data_path)
+            assert restored_backend.current_cache_size == float(restored_meta.size)
+            assert restored_backend.usage == restored_meta.size
+
+            cpu_obj = restored_backend.local_cpu_backend.get_blocking(key)
+            assert cpu_obj is not None
+            assert cpu_obj.metadata.shape == memory_obj.metadata.shape
+            assert cpu_obj.metadata.dtype == memory_obj.metadata.dtype
+            cpu_obj.ref_count_down()
+        finally:
+            restored_backend.close()
+            restore_cpu_backend.memory_allocator.close()
+
+    def test_remove_deletes_metadata_file(
+        self, temp_disk_path, async_loop, memory_allocator
+    ):
+        """Removing an entry deletes both data and metadata files."""
+        config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=True,
+        )
+        cpu_backend = LocalCPUBackend(config, memory_allocator=memory_allocator)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(55)
+        memory_obj = create_test_memory_obj()
+        data_path = backend._key_to_path(key)
+        meta_path = data_path + ".meta"
+
+        try:
+            backend.async_save_bytes_to_disk(key, memory_obj)
+            assert os.path.exists(data_path)
+            assert os.path.exists(meta_path)
+
+            removed = backend.remove(key)
+            assert removed
+            assert not os.path.exists(data_path)
+            assert not os.path.exists(meta_path)
+            assert key not in backend.dict
+            assert backend.usage == 0
+        finally:
+            backend.close()
+            cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -265,6 +265,35 @@ class TestLocalDiskBackend:
         assert memory_obj is not None
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
+    def test_metadata_not_written_without_persistence(
+        self, temp_disk_path, async_loop, memory_allocator
+    ):
+        """Metadata sidecar files are skipped when persistence is disabled."""
+        config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=False,
+        )
+        cpu_backend = LocalCPUBackend(config, memory_allocator=memory_allocator)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(99)
+        memory_obj = create_test_memory_obj()
+        data_path = backend._key_to_path(key)
+        meta_path = data_path + ".meta"
+
+        try:
+            backend.async_save_bytes_to_disk(key, memory_obj)
+            assert os.path.exists(data_path)
+            assert not os.path.exists(meta_path)
+        finally:
+            backend.close()
+            cpu_backend.memory_allocator.close()
+
     def test_disk_persistence_restore_and_prefetch(
         self, temp_disk_path, async_loop, memory_allocator
     ):

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -133,12 +133,17 @@ def local_cpu_backend(memory_allocator):
 def local_disk_backend(temp_disk_path, async_loop, local_cpu_backend):
     """Create a LocalDiskBackend for testing."""
     config = create_test_config(temp_disk_path)
-    return LocalDiskBackend(
+    backend = LocalDiskBackend(
         config=config,
         loop=async_loop,
         local_cpu_backend=local_cpu_backend,
         dst_device="cuda",
     )
+
+    try:
+        yield backend
+    finally:
+        backend.close()
 
 
 class TestLocalDiskBackend:
@@ -154,16 +159,18 @@ class TestLocalDiskBackend:
             dst_device="cuda",
         )
 
-        assert backend.dst_device == "cuda"
-        assert backend.local_cpu_backend == local_cpu_backend
-        assert backend.path == temp_disk_path
-        assert os.path.exists(temp_disk_path)
-        assert backend.lmcache_worker is None
-        assert backend.instance_id == "test_instance"
-        assert backend.usage == 0
-        assert len(backend.dict) == 0
-
-        local_cpu_backend.memory_allocator.close()
+        try:
+            assert backend.dst_device == "cuda"
+            assert backend.local_cpu_backend == local_cpu_backend
+            assert backend.path == temp_disk_path
+            assert os.path.exists(temp_disk_path)
+            assert backend.lmcache_worker is None
+            assert backend.instance_id == "test_instance"
+            assert backend.usage == 0
+            assert len(backend.dict) == 0
+        finally:
+            backend.close()
+            local_cpu_backend.memory_allocator.close()
 
     def test_init_with_lookup_server_and_worker(
         self, temp_disk_path, async_loop, local_cpu_backend
@@ -180,9 +187,11 @@ class TestLocalDiskBackend:
             lmcache_worker=lmcache_worker,
         )
 
-        assert backend.lmcache_worker == lmcache_worker
-
-        local_cpu_backend.memory_allocator.close()
+        try:
+            assert backend.lmcache_worker == lmcache_worker
+        finally:
+            backend.close()
+            local_cpu_backend.memory_allocator.close()
 
     def test_str(self, local_disk_backend):
         """Test string representation."""

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import shutil
 import tempfile
+import threading
 
 # Third Party
 import pytest
@@ -98,7 +99,23 @@ def async_loop():
     """Create an asyncio event loop for testing."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
+
+    loop_started = threading.Event()
+
+    def _run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop_started.set()
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=_run_loop, name="test-async-loop")
+    loop_thread.start()
+    loop_started.wait()
+
     yield loop
+
+    loop.call_soon_threadsafe(loop.stop)
+    loop_thread.join()
+    asyncio.set_event_loop(None)
     loop.close()
 
 


### PR DESCRIPTION
## Issues
- Previously, LocalDiskBackend only saved the raw tensor bytes to `.pt` files while keeping all metadata (shape, dtype, memory format, etc.) in process memory via `DiskCacheMetadata`.
- During restart the backend could only reconstruct file paths and sizes, leaving shape/dtype/format as `None`, which caused later `get_blocking` or async prefetch logic to hit assertions and treat the on-disk cache as unusable.
- As a result the earlier implementation never truly persisted KV caches—without the required metadata the restarted process had no way to reuse disk entries.

## Fixes
- LocalDiskBackend now persists cache metadata by writing to .meta files.
- LocalDiskBackend can restore entries, usage stats, and cache policy state on startup whenever local_disk_persistence is enabled.
- Persisted entries can be prefetched back into the CPU cache during initialization, and deletions clean up both tensor data and metadata files to keep disk state consistent.
- Regression tests cover the persistence restore/prefetch workflow and confirm that metadata files are removed alongside their payloads



---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
