### PR TITLE
[Doc] Fix broken link to mooncake store

### DIFF
--- a/docs/source/kv_cache/storage_backends/mooncake.rst
+++ b/docs/source/kv_cache/storage_backends/mooncake.rst
@@ -22,7 +22,7 @@ Key Features
 - **RDMA optimization**: Built on Transfer Engine with support for TCP, RDMA (InfiniBand/RoCEv2/eRDMA/NVIDIA GPUDirect)
 - **Dynamic resource scaling**: Supports dynamically adding and removing nodes for elastic resource management
 
-For detailed architecture information, see the `Mooncake Architecture Guide <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/mooncake-store-preview.md>`_.
+For detailed architecture information, see the `Mooncake Architecture Guide <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/mooncake-store.md>`_.
 
 Quick Start
 -----------

--- a/docs/source/kv_cache/storage_backends/mooncake.rst
+++ b/docs/source/kv_cache/storage_backends/mooncake.rst
@@ -216,7 +216,7 @@ Configuration
 Additional Resources
 --------------------
 
-- `Mooncake Store Architecture <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/mooncake-store-preview.md>`_
+- `Mooncake Store Architecture <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/mooncake-store.md>`_
 - `Transfer Engine Documentation <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/transfer-engine.md>`_
 - `Build Instructions <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md>`_
 - `GitHub Repository <https://github.com/kvcache-ai/Mooncake>`_


### PR DESCRIPTION
Due to the filename change, the link to the mooncake store is broken, so fix it.