### PR TITLE
[feat][internal_api] Add inference info internal api

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -2,7 +2,6 @@
 # Standard
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
-import json
 import os
 import uuid
 
@@ -675,11 +674,11 @@ class LMCacheConnectorV1Impl:
             f"{getattr(self.lmcache_engine, 'metadata', None)}"
         )
 
-    def get_inference_info(self) -> str:
+    def get_inference_info(self) -> dict:
         """Get inference information including vLLM config and related details.
 
         Returns:
-            str: JSON string containing inference information
+            dict: Dictionary containing inference information
         """
         # Get vLLM config information
         vllm_config = self._vllm_config
@@ -697,25 +696,17 @@ class LMCacheConnectorV1Impl:
                 ),
                 "vocab_size": getattr(vllm_config.model_config, "vocab_size", None),
                 "num_layers": getattr(
-                    vllm_config.model_config, "get_num_layers", lambda x: None
-                )(vllm_config.parallel_config)
-                if hasattr(vllm_config.model_config, "get_num_layers")
-                else None,
+                    vllm_config.model_config, "get_num_layers", lambda _: None
+                )(vllm_config.parallel_config),
                 "num_attention_heads": getattr(
-                    vllm_config.model_config, "get_num_attention_heads", lambda x: None
-                )(vllm_config.parallel_config)
-                if hasattr(vllm_config.model_config, "get_num_attention_heads")
-                else None,
+                    vllm_config.model_config, "get_num_attention_heads", lambda _: None
+                )(vllm_config.parallel_config),
                 "num_kv_heads": getattr(
-                    vllm_config.model_config, "get_num_kv_heads", lambda x: None
-                )(vllm_config.parallel_config)
-                if hasattr(vllm_config.model_config, "get_num_kv_heads")
-                else None,
+                    vllm_config.model_config, "get_num_kv_heads", lambda _: None
+                )(vllm_config.parallel_config),
                 "head_size": getattr(
                     vllm_config.model_config, "get_head_size", lambda: None
-                )()
-                if hasattr(vllm_config.model_config, "get_head_size")
-                else None,
+                )(),
             },
             "cache_config": {
                 "block_size": getattr(vllm_config.cache_config, "block_size", None),
@@ -732,7 +723,7 @@ class LMCacheConnectorV1Impl:
             },
         }
 
-        return json.dumps(inference_info, indent=2, default=str)
+        return inference_info
 
     def get_inference_version(self) -> str:
         """Get vLLM version information.

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -554,6 +554,7 @@ class LMCacheConnectorV1Impl:
         parent: KVConnectorBase_V1,
     ):
         self._parent = parent
+        self._vllm_config = vllm_config
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.worker_count = vllm_config.parallel_config.tensor_parallel_size
         config = lmcache_get_or_create_config()
@@ -672,6 +673,76 @@ class LMCacheConnectorV1Impl:
             "lmcache cache_engine metadata: "
             f"{getattr(self.lmcache_engine, 'metadata', None)}"
         )
+
+    def get_inference_info(self) -> str:
+        """Get inference information including vLLM config and related details.
+
+        Returns:
+            str: JSON string containing inference information
+        """
+        # Get vLLM config information
+        vllm_config = self._vllm_config
+
+        # Use vLLM config's string representation and add specific configs
+        inference_info = {
+            "vllm_version": VLLM_VERSION,
+            "lmcache_version": utils.get_version(),
+            "vllm_config": str(vllm_config),
+            "model_config": {
+                "model": getattr(vllm_config.model_config, "model", None),
+                "dtype": str(getattr(vllm_config.model_config, "dtype", None)),
+                "max_model_len": getattr(
+                    vllm_config.model_config, "max_model_len", None
+                ),
+                "vocab_size": getattr(vllm_config.model_config, "vocab_size", None),
+                "num_layers": getattr(
+                    vllm_config.model_config, "get_num_layers", lambda x: None
+                )(vllm_config.parallel_config)
+                if hasattr(vllm_config.model_config, "get_num_layers")
+                else None,
+                "num_attention_heads": getattr(
+                    vllm_config.model_config, "get_num_attention_heads", lambda x: None
+                )(vllm_config.parallel_config)
+                if hasattr(vllm_config.model_config, "get_num_attention_heads")
+                else None,
+                "num_kv_heads": getattr(
+                    vllm_config.model_config, "get_num_kv_heads", lambda x: None
+                )(vllm_config.parallel_config)
+                if hasattr(vllm_config.model_config, "get_num_kv_heads")
+                else None,
+                "head_size": getattr(
+                    vllm_config.model_config, "get_head_size", lambda: None
+                )()
+                if hasattr(vllm_config.model_config, "get_head_size")
+                else None,
+            },
+            "cache_config": {
+                "block_size": getattr(vllm_config.cache_config, "block_size", None),
+                "cache_dtype": str(
+                    getattr(vllm_config.cache_config, "cache_dtype", None)
+                ),
+                "gpu_memory_utilization": getattr(
+                    vllm_config.cache_config, "gpu_memory_utilization", None
+                ),
+                "swap_space": getattr(vllm_config.cache_config, "swap_space", None),
+                "enable_prefix_caching": getattr(
+                    vllm_config.cache_config, "enable_prefix_caching", None
+                ),
+            },
+        }
+
+        # Standard
+        import json
+
+        return json.dumps(inference_info, indent=2, default=str)
+
+    def get_inference_version(self) -> str:
+        """Get vLLM version information.
+
+        Returns:
+            str: vLLM version string
+        """
+        return VLLM_VERSION
 
     @_lmcache_nvtx_annotate
     def _init_kv_caches_from_forward_context(self, forward_context: "ForwardContext"):

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -2,6 +2,7 @@
 # Standard
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
+import json
 import os
 import uuid
 
@@ -730,9 +731,6 @@ class LMCacheConnectorV1Impl:
                 ),
             },
         }
-
-        # Standard
-        import json
 
         return json.dumps(inference_info, indent=2, default=str)
 

--- a/lmcache/v1/internal_api_server/inference_api.py
+++ b/lmcache/v1/internal_api_server/inference_api.py
@@ -26,7 +26,10 @@ async def get_inference_info(request: Request, format: Optional[str] = None):
 
     try:
         inference_info = lmcache_adapter.get_inference_info()
-        return PlainTextResponse(content=inference_info, media_type="application/json")
+        return PlainTextResponse(
+            content=json.dumps(inference_info, indent=2, default=str),
+            media_type="application/json",
+        )
     except Exception as e:
         error_info = {"error": "Failed to get inference info", "message": str(e)}
         return PlainTextResponse(

--- a/lmcache/v1/internal_api_server/inference_api.py
+++ b/lmcache/v1/internal_api_server/inference_api.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Optional
+import json
+
+# Third Party
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+router = APIRouter()
+
+
+@router.get("/inference_info")
+async def get_inference_info(request: Request, format: Optional[str] = None):
+    """
+    Get inference information including vLLM config and LMCache details
+
+    Args:
+        format: Optional format parameter (currently unused, for future extension)
+
+    Returns:
+        PlainTextResponse: JSON string containing inference information
+    """
+    lmcache_adapter = request.app.state.lmcache_adapter
+
+    try:
+        inference_info = lmcache_adapter.get_inference_info()
+        return PlainTextResponse(content=inference_info, media_type="application/json")
+    except Exception as e:
+        error_info = {"error": "Failed to get inference info", "message": str(e)}
+        return PlainTextResponse(
+            content=json.dumps(error_info, indent=2),
+            media_type="application/json",
+            status_code=500,
+        )
+
+
+@router.get("/inference_version")
+async def get_inference_version(request: Request):
+    """
+    Get vLLM version information
+
+    Returns:
+        PlainTextResponse: vLLM version string
+    """
+    lmcache_adapter = request.app.state.lmcache_adapter
+
+    try:
+        version_info = lmcache_adapter.get_inference_version()
+        version_response = {"vllm_version": version_info}
+        return PlainTextResponse(
+            content=json.dumps(version_response, indent=2),
+            media_type="application/json",
+        )
+    except Exception as e:
+        error_info = {"error": "Failed to get inference version", "message": str(e)}
+        return PlainTextResponse(
+            content=json.dumps(error_info, indent=2),
+            media_type="application/json",
+            status_code=500,
+        )


### PR DESCRIPTION
# Description

In order to better understand the deployment and runtime status of lmcache and its inference engine vllm, we need to show more information about vllm.

# Test

<img width="1878" height="1262" alt="image" src="https://github.com/user-attachments/assets/b72796f8-1ab1-45c1-b15f-73a3ee9f876b" />

And lmcache frontend display the content via this api

<img width="1884" height="1568" alt="image" src="https://github.com/user-attachments/assets/4d2ead2f-2da3-43f5-afb2-028768959e80" />

