### PR TITLE
[core] support set limit of cache hit

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -356,7 +356,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": 3000,
         "env_converter": int,
     },
-    "hit_limit_upper": {
+    "hit_miss_ratio": {
         "type": Optional[float],
         "default": None,
         "env_converter": float,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -356,6 +356,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": 3000,
         "env_converter": int,
     },
+    "hit_limit_upper": {
+        "type": Optional[float],
+        "default": None,
+        "env_converter": float,
+    },
 }
 
 

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -65,7 +65,7 @@ class LookupClientFactory:
             else:
                 client = LMCacheLookupClient(vllm_config)
 
-        if config.hit_limit_upper is not None and 0 <= config.hit_limit_upper <= 1:
+        if config.hit_miss_ratio is not None and 0 <= config.hit_miss_ratio <= 1:
             return HitLimitLookupClient(client, config)
         return client
 

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -7,6 +7,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.lookup_client.hit_limit_lookup_client import HitLimitLookupClient
 from lmcache.v1.lookup_client.mooncake_lookup_client import MooncakeLookupClient
 
 if TYPE_CHECKING:
@@ -47,7 +48,7 @@ class LookupClientFactory:
                 raise ValueError(
                     "Asynchronous loading is not supported for external lookup clients."
                 )
-            return LookupClientFactory._create_external_lookup_client(
+            client = LookupClientFactory._create_external_lookup_client(
                 config.external_lookup_client, vllm_config
             )
         else:
@@ -60,9 +61,13 @@ class LookupClientFactory:
             )
 
             if config.enable_async_loading:
-                return LMCacheAsyncLookupClient(vllm_config)
+                client = LMCacheAsyncLookupClient(vllm_config)
             else:
-                return LMCacheLookupClient(vllm_config)
+                client = LMCacheLookupClient(vllm_config)
+
+        if config.hit_limit_upper is not None and 0 <= config.hit_limit_upper <= 1:
+            return HitLimitLookupClient(client, config)
+        return client
 
     @staticmethod
     def create_lookup_server(

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -44,7 +44,9 @@ class HitLimitLookupClient(LookupClientInterface):
         if result is not None:
             total_tokens_length = len(token_ids)
             assert result <= total_tokens_length
-            current_hit_rate = result / total_tokens_length
+            current_hit_rate = 0.0
+            if total_tokens_length > 0:
+                current_hit_rate = result / total_tokens_length
             # limit the hit tokens
             if current_hit_rate > self.hit_limit_upper:
                 origin_result = result

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Union, Optional
+from typing import Optional, Union
 
 # Third Party
 import torch
@@ -18,9 +18,12 @@ HitLimitLookupClient now is used for test, when lookup is called, cal the cache 
 - if the cache hit < hit_limit_upper, direct return the result
 - if the cache hit > hit_limit_upper, re-compute the result by hit_limit_upper
 """
+
 class HitLimitLookupClient(LookupClientInterface):
 
-    def __init__(self, actual_lookup_client: LookupClientInterface, config: LMCacheEngineConfig):
+    def __init__(
+        self, actual_lookup_client: LookupClientInterface, config: LMCacheEngineConfig
+    ):
         assert config.hit_limit_upper is not None and 0 <= config.hit_limit_upper <= 1
         self.actual_lookup_client = actual_lookup_client
         self.hit_limit_upper = config.hit_limit_upper
@@ -34,7 +37,7 @@ class HitLimitLookupClient(LookupClientInterface):
         self,
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
-        request_configs: Optional[dict] = None
+        request_configs: Optional[dict] = None,
     ) -> Optional[int]:
         # get real hit tokens
         result = self.actual_lookup_client.lookup(token_ids, lookup_id, request_configs)
@@ -46,7 +49,11 @@ class HitLimitLookupClient(LookupClientInterface):
             if current_hit_rate > self.hit_limit_upper:
                 origin_result = result
                 # align to chunk size
-                new_result = int(total_tokens_length * self.hit_limit_upper) // self.chunk_size * self.chunk_size
+                new_result = (
+                    int(total_tokens_length * self.hit_limit_upper)
+                    // self.chunk_size
+                    * self.chunk_size
+                )
                 # check again
                 result = min(result, new_result)
                 logger.debug(

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -20,7 +20,6 @@ HitLimitLookupClient now is used for test, when lookup is called, cal the cache 
 """
 
 class HitLimitLookupClient(LookupClientInterface):
-
     def __init__(
         self, actual_lookup_client: LookupClientInterface, config: LMCacheEngineConfig
     ):
@@ -58,7 +57,8 @@ class HitLimitLookupClient(LookupClientInterface):
                 result = min(result, new_result)
                 logger.debug(
                     f"hit limit upper: {self.hit_limit_upper} is smaller than "
-                    f"the real hit rate {current_hit_rate}, the origin result is {origin_result}, "
+                    f"the real hit rate {current_hit_rate}, "
+                    f"the origin result is {origin_result}, "
                     f"the new result is {new_result}, the final result is {result}"
                 )
         return result

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -15,8 +15,8 @@ logger = init_logger(__name__)
 
 """
 HitLimitLookupClient now is used for test, when lookup is called, cal the cache hit,
-- if the cache hit < hit_limit_upper, direct return the result
-- if the cache hit > hit_limit_upper, re-compute the result by hit_limit_upper
+- if the cache hit < hit_miss_ratio, direct return the result
+- if the cache hit > hit_miss_ratio, re-compute the result by hit_miss_ratio
 """
 
 
@@ -24,13 +24,13 @@ class HitLimitLookupClient(LookupClientInterface):
     def __init__(
         self, actual_lookup_client: LookupClientInterface, config: LMCacheEngineConfig
     ):
-        assert config.hit_limit_upper is not None and 0 <= config.hit_limit_upper <= 1
+        assert config.hit_miss_ratio is not None and 0 <= config.hit_miss_ratio <= 1
         self.actual_lookup_client = actual_lookup_client
-        self.hit_limit_upper = config.hit_limit_upper
+        self.hit_miss_ratio = config.hit_miss_ratio
         self.chunk_size = config.chunk_size
         logger.info(
-            f"create HitLimitLookupClient succeed, the hit limit upper "
-            f"is {self.hit_limit_upper}, chunk size is {self.chunk_size}"
+            f"create HitLimitLookupClient succeed, the hit miss ratio "
+            f"is {self.hit_miss_ratio}, chunk size is {self.chunk_size}"
         )
 
     def lookup(
@@ -48,18 +48,18 @@ class HitLimitLookupClient(LookupClientInterface):
             if total_tokens_length > 0:
                 current_hit_rate = result / total_tokens_length
             # limit the hit tokens
-            if current_hit_rate > self.hit_limit_upper:
+            if current_hit_rate > self.hit_miss_ratio:
                 origin_result = result
                 # align to chunk size
                 new_result = (
-                    int(total_tokens_length * self.hit_limit_upper)
+                    int(total_tokens_length * self.hit_miss_ratio)
                     // self.chunk_size
                     * self.chunk_size
                 )
                 # check again
                 result = min(result, new_result)
                 logger.debug(
-                    f"hit limit upper: {self.hit_limit_upper} is smaller than "
+                    f"hit miss ratio: {self.hit_miss_ratio} is smaller than "
                     f"the real hit rate {current_hit_rate}, "
                     f"the origin result is {origin_result}, "
                     f"the new result is {new_result}, the final result is {result}"

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -19,6 +19,7 @@ HitLimitLookupClient now is used for test, when lookup is called, cal the cache 
 - if the cache hit > hit_limit_upper, re-compute the result by hit_limit_upper
 """
 
+
 class HitLimitLookupClient(LookupClientInterface):
     def __init__(
         self, actual_lookup_client: LookupClientInterface, config: LMCacheEngineConfig

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Union, Optional
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+
+logger = init_logger(__name__)
+
+
+"""
+HitLimitLookupClient now is used for test, when lookup is called, cal the cache hit,
+- if the cache hit < hit_limit_upper, direct return the result
+- if the cache hit > hit_limit_upper, re-compute the result by hit_limit_upper
+"""
+class HitLimitLookupClient(LookupClientInterface):
+
+    def __init__(self, actual_lookup_client: LookupClientInterface, config: LMCacheEngineConfig):
+        assert config.hit_limit_upper is not None and 0 <= config.hit_limit_upper <= 1
+        self.actual_lookup_client = actual_lookup_client
+        self.hit_limit_upper = config.hit_limit_upper
+        self.chunk_size = config.chunk_size
+        logger.info(
+            f"create HitLimitLookupClient succeed, the hit limit upper "
+            f"is {self.hit_limit_upper}, chunk size is {self.chunk_size}"
+        )
+
+    def lookup(
+        self,
+        token_ids: Union[torch.Tensor, list[int]],
+        lookup_id: str,
+        request_configs: Optional[dict] = None
+    ) -> Optional[int]:
+        # get real hit tokens
+        result = self.actual_lookup_client.lookup(token_ids, lookup_id, request_configs)
+        if result is not None:
+            total_tokens_length = len(token_ids)
+            assert result <= total_tokens_length
+            current_hit_rate = result / total_tokens_length
+            # limit the hit tokens
+            if current_hit_rate > self.hit_limit_upper:
+                origin_result = result
+                # align to chunk size
+                new_result = int(total_tokens_length * self.hit_limit_upper) // self.chunk_size * self.chunk_size
+                # check again
+                result = min(result, new_result)
+                logger.debug(
+                    f"hit limit upper: {self.hit_limit_upper} is smaller than "
+                    f"the real hit rate {current_hit_rate}, the origin result is {origin_result}, "
+                    f"the new result is {new_result}, the final result is {result}"
+                )
+        return result
+
+    def supports_producer_reuse(self) -> bool:
+        return self.actual_lookup_client.supports_producer_reuse()
+
+    def close(self) -> None:
+        self.actual_lookup_client.close()

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -15,8 +15,8 @@ logger = init_logger(__name__)
 
 """
 HitLimitLookupClient now is used for test, when lookup is called, cal the cache hit,
-- if the cache hit < hit_miss_ratio, direct return the result
-- if the cache hit > hit_miss_ratio, re-compute the result by hit_miss_ratio
+- if the cache hit <= (1 - hit_miss_ratio), direct return the result
+- if the cache hit > (1 - hit_miss_ratio), re-compute the result by hit_miss_ratio
 """
 
 
@@ -26,11 +26,11 @@ class HitLimitLookupClient(LookupClientInterface):
     ):
         assert config.hit_miss_ratio is not None and 0 <= config.hit_miss_ratio <= 1
         self.actual_lookup_client = actual_lookup_client
-        self.hit_miss_ratio = config.hit_miss_ratio
+        self.hit_ratio_upper = 1 - config.hit_miss_ratio
         self.chunk_size = config.chunk_size
         logger.info(
-            f"create HitLimitLookupClient succeed, the hit miss ratio "
-            f"is {self.hit_miss_ratio}, chunk size is {self.chunk_size}"
+            f"create HitLimitLookupClient succeed, the hit ratio upper"
+            f"is {self.hit_ratio_upper}, chunk size is {self.chunk_size}"
         )
 
     def lookup(
@@ -44,23 +44,23 @@ class HitLimitLookupClient(LookupClientInterface):
         if result is not None:
             total_tokens_length = len(token_ids)
             assert result <= total_tokens_length
-            current_hit_rate = 0.0
+            current_hit_ratio = 0.0
             if total_tokens_length > 0:
-                current_hit_rate = result / total_tokens_length
+                current_hit_ratio = result / total_tokens_length
             # limit the hit tokens
-            if current_hit_rate > self.hit_miss_ratio:
+            if current_hit_ratio > self.hit_ratio_upper:
                 origin_result = result
                 # align to chunk size
                 new_result = (
-                    int(total_tokens_length * self.hit_miss_ratio)
+                    int(total_tokens_length * self.hit_ratio_upper)
                     // self.chunk_size
                     * self.chunk_size
                 )
                 # check again
                 result = min(result, new_result)
                 logger.debug(
-                    f"hit miss ratio: {self.hit_miss_ratio} is smaller than "
-                    f"the real hit rate {current_hit_rate}, "
+                    f"hit ratio upper: {self.hit_ratio_upper} is smaller than "
+                    f"the real hit ratio {current_hit_ratio}, "
                     f"the origin result is {origin_result}, "
                     f"the new result is {new_result}, the final result is {result}"
                 )


### PR DESCRIPTION
This PR support set hit limit, which is used for test. We can enable it by the following config:
```
hit_miss_ratio: 0.7
```
the `hit_miss_ratio` is set to `0.7`, which means the max hit ratio is `30%`

In our scenario, we want to test the performance under different hit rates, but it is difficult to find such a dataset. Therefore, it can be achieved through above config and the following two steps:
1. Run the dataset and save the data to lmcache
2. Run the same dataset again

By step 1, we can save all kv cache chunk in lmcache(Note: even if the hit rate is set to 30%, all data will still be stored). Then in step 2, the `hit_miss_ratio` will work. 

We have tested in our env, the metrics in grafana are as follows:
- lookup total tokens
<img width="907" height="204" alt="Clipboard_Screenshot_1758632829" src="https://github.com/user-attachments/assets/2a54984c-ead2-4564-94e7-39a9ebd6849d" />

- hit token tokens
<img width="902" height="204" alt="Clipboard_Screenshot_1758632849" src="https://github.com/user-attachments/assets/854d5cba-22bf-40c8-b112-0e4f1e8040a9" />

-hit rate
<img width="1004" height="476" alt="Clipboard_Screenshot_1758678923" src="https://github.com/user-attachments/assets/ffe564e6-2497-4db8-9084-79d15b71db43" />

