### PR TITLE
[patch]: add eagle decode layer

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -400,29 +400,29 @@ def need_gpu_interm_buffer(lmcache_config: LMCacheEngineConfig):
         return True
 
 
-def _calculate_mtp_layers(vllm_config, model_config):
-    num_mtp_layers = 0
+def _calculate_draft_layers(vllm_config, model_config):
+    num_draft_layers = 0
     if vllm_config is not None and vllm_config.speculative_config is not None:
         logger.info(f"vllm_config.speculative_config: {vllm_config.speculative_config}")
-        # TODO(baoloongmao): Support other MTP methods
+        # TODO(baoloongmao): Support other MTP/draft methods
         if vllm_config.speculative_config.method == "deepseek_mtp":
-            num_mtp_layers = getattr(
+            num_draft_layers = getattr(
                 model_config.hf_config, "num_nextn_predict_layers", 0
             )
         elif vllm_config.speculative_config.use_eagle():
             try:
                 draft_model_config = vllm_config.speculative_config.draft_model_config
-                num_mtp_layers = draft_model_config.get_num_layers(
+                num_draft_layers = draft_model_config.get_num_layers(
                     vllm_config.parallel_config
                 )
-                logger.info(f"EAGLE detected {num_mtp_layers} extra layer(s)")
+                logger.info(f"EAGLE detected {num_draft_layers} extra layer(s)")
             except Exception:
                 logger.info(
                     "EAGLE detected, but failed to get the number of extra layers"
                     "falling back to 1"
                 )
-                num_mtp_layers = 1
-    return num_mtp_layers
+                num_draft_layers = 1
+    return num_draft_layers
 
 
 def _init_lmcache_engine(
@@ -464,14 +464,14 @@ def _init_lmcache_engine(
 
     # construct kv shape (for mem pool)
     num_layer = model_config.get_num_layers(parallel_config)
-    num_mtp_layers = _calculate_mtp_layers(vllm_config, model_config)
-    num_layer += num_mtp_layers
+    num_draft_layers = _calculate_draft_layers(vllm_config, model_config)
+    num_layer += num_draft_layers
     chunk_size = lmcache_config.chunk_size
     num_kv_head = model_config.get_num_kv_heads(parallel_config)
     head_size = model_config.get_head_size()
     kv_shape = (num_layer, 1 if use_mla else 2, chunk_size, num_kv_head, head_size)
     logger.info(
-        f"use mla: {use_mla}, kv shape: {kv_shape}, num_mtp_layers:{num_mtp_layers}"
+        f"use mla: {use_mla}, kv shape: {kv_shape}, num_draft_layers:{num_draft_layers}"
     )
 
     # Change current device.

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -410,8 +410,18 @@ def _calculate_mtp_layers(vllm_config, model_config):
                 model_config.hf_config, "num_nextn_predict_layers", 0
             )
         elif vllm_config.speculative_config.use_eagle():
-            # EAGLE typically adds one decoder layer as the draft model for spec decode
-            num_mtp_layers = 1
+            try:
+                draft_model_config = vllm_config.speculative_config.draft_model_config
+                num_mtp_layers = draft_model_config.get_num_layers(
+                    vllm_config.parallel_config
+                )
+                logger.info(f"EAGLE detected {num_mtp_layers} extra layer(s)")
+            except Exception:
+                logger.info(
+                    "EAGLE detected, but failed to get the number of extra layers"
+                    "falling back to 1"
+                )
+                num_mtp_layers = 1
             logger.info(f"EAGLE detected, adding {num_mtp_layers} extra layer(s)")
     return num_mtp_layers
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -422,7 +422,6 @@ def _calculate_mtp_layers(vllm_config, model_config):
                     "falling back to 1"
                 )
                 num_mtp_layers = 1
-            logger.info(f"EAGLE detected, adding {num_mtp_layers} extra layer(s)")
     return num_mtp_layers
 
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -409,6 +409,10 @@ def _calculate_mtp_layers(vllm_config, model_config):
             num_mtp_layers = getattr(
                 model_config.hf_config, "num_nextn_predict_layers", 0
             )
+        elif vllm_config.speculative_config.use_eagle():
+            # EAGLE typically adds one decoder layer as the draft model for spec decode
+            num_mtp_layers = 1
+            logger.info(f"EAGLE detected, adding {num_mtp_layers} extra layer(s)")
     return num_mtp_layers
 
 


### PR DESCRIPTION
Tested with: 
```bash
vllm serve meta-llama/Meta-Llama-3-8B-Instruct \
 --speculative-config '{"model": "yuhuili/EAGLE-LLaMA3-Instruct-8B", "method": "eagle", "num_speculative_tokens": 2, "draft_tensor_parallel_size": 1}'    --kv-transfer-config \
   '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
```


```bash

   curl -X POST http://localhost:8000/v1/completions \
       -H "Content-Type: application/json" \
       -d '{
       "model": "meta-llama/Meta-Llama-3-8B-Instruct",
       "prompt": "Explain the significance of KV cache in language models.",
       "max_tokens": 100
       }'

```

Thanks @maobaolong for introducing the `_num_mtp_layers()`!