### PR TITLE
Remove redundancy. Also old version of vllm do not support size local.

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -663,8 +663,7 @@ class LMCacheConnectorV1Impl:
 
         # TODO(baoloongmao): Internal api server & plugin framework support dp > 1
         if (
-            vllm_config.parallel_config.data_parallel_size_local == 1
-            or vllm_config.parallel_config.data_parallel_rank_local == 0
+            vllm_config.parallel_config.data_parallel_rank_local == 0
         ):
             # Start internal API server if enabled
             # The enabled check is in the InternalAPIServer constructor

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -662,9 +662,7 @@ class LMCacheConnectorV1Impl:
         self._requests_priority: dict[str, int] = {}
 
         # TODO(baoloongmao): Internal api server & plugin framework support dp > 1
-        if (
-            vllm_config.parallel_config.data_parallel_rank_local == 0
-        ):
+        if vllm_config.parallel_config.data_parallel_rank_local == 0:
             # Start internal API server if enabled
             # The enabled check is in the InternalAPIServer constructor
             self.api_server = InternalAPIServer(self)


### PR DESCRIPTION
We don't need to have the first condition because in the case of TP=1, the local rank is 0, which satisfies the second condition.