### PR TITLE
Support remove around quotes in env config

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -99,24 +99,6 @@ def _parse_quoted_string(value: str) -> str:
     return value
 
 
-def _manual_unescape(s: str) -> str:
-    """Manually handle common escape sequences."""
-    replacements = {
-        "\\n": "\n",
-        "\\t": "\t",
-        "\\r": "\r",
-        "\\\\": "\\",
-        '\\"': '"',
-        "\\'": "'",
-    }
-
-    result = s
-    for escaped, unescaped in replacements.items():
-        result = result.replace(escaped, unescaped)
-
-    return result
-
-
 # Configuration aliases and deprecated mappings
 _CONFIG_ALIASES = {
     # Maps deprecated names to current names

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -71,6 +71,62 @@ def _to_bool(
     return str(value).strip().lower() in ["true", "1"]
 
 
+def _parse_quoted_string(value: str) -> str:
+    """Parse a string that may be surrounded by quotes and handle escape characters.
+
+    Args:
+        value: The input string that may be quoted
+
+    Returns:
+        The unquoted string with escape characters properly handled
+    """
+    if not value:
+        return value
+
+    value = value.strip()
+
+    # Check if the string is surrounded by quotes (single or double)
+    if len(value) >= 2:
+        if (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            # Remove the surrounding quotes
+            quoted_content = value[1:-1]
+
+            # Handle escape sequences
+            # Use json.loads for proper escape sequence handling if it's double-quoted
+            if value.startswith('"'):
+                try:
+                    # Wrap in quotes again for json.loads to work properly
+                    return json.loads(f'"{quoted_content}"')
+                except json.JSONDecodeError:
+                    # If json.loads fails, manually handle common escape sequences
+                    return _manual_unescape(quoted_content)
+            else:
+                # For single-quoted strings, manually handle escape sequences
+                return _manual_unescape(quoted_content)
+
+    return value
+
+
+def _manual_unescape(s: str) -> str:
+    """Manually handle common escape sequences."""
+    replacements = {
+        "\\n": "\n",
+        "\\t": "\t",
+        "\\r": "\r",
+        "\\\\": "\\",
+        '\\"': '"',
+        "\\'": "'",
+    }
+
+    result = s
+    for escaped, unescaped in replacements.items():
+        result = result.replace(escaped, unescaped)
+
+    return result
+
+
 # Configuration aliases and deprecated mappings
 _CONFIG_ALIASES = {
     # Maps deprecated names to current names
@@ -632,11 +688,15 @@ def _update_config_from_env(self):
     for name, config in _CONFIG_DEFINITIONS.items():
         if name in resolved_config:
             try:
-                value = resolved_config[name]
+                # Parse quoted strings and handle escape characters
+                raw_value = resolved_config[name]  # Keep original value for logging
+                value = _parse_quoted_string(raw_value)
                 converted_value = config["env_converter"](value)
                 setattr(self, name, converted_value)
             except (ValueError, json.JSONDecodeError) as e:
-                logger.warning(f"Failed to parse {get_env_name(name)}: {e}")
+                logger.warning(
+                    f"Failed to parse {get_env_name(name)}={raw_value!r}: {e}"
+                )
                 # Keep existing value if conversion fails
 
     return self

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import Any, Optional, Union
+import ast
 import json
 import os
 import re
@@ -85,26 +86,15 @@ def _parse_quoted_string(value: str) -> str:
 
     value = value.strip()
 
-    # Check if the string is surrounded by quotes (single or double)
-    if len(value) >= 2:
-        if (value.startswith('"') and value.endswith('"')) or (
-            value.startswith("'") and value.endswith("'")
-        ):
-            # Remove the surrounding quotes
-            quoted_content = value[1:-1]
-
-            # Handle escape sequences
-            # Use json.loads for proper escape sequence handling if it's double-quoted
-            if value.startswith('"'):
-                try:
-                    # Wrap in quotes again for json.loads to work properly
-                    return json.loads(f'"{quoted_content}"')
-                except json.JSONDecodeError:
-                    # If json.loads fails, manually handle common escape sequences
-                    return _manual_unescape(quoted_content)
-            else:
-                # For single-quoted strings, manually handle escape sequences
-                return _manual_unescape(quoted_content)
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        try:
+            evaluated = ast.literal_eval(value)
+            if isinstance(evaluated, str):
+                return evaluated
+        except (ValueError, SyntaxError):
+            # If ast.literal_eval fails, it's not a valid Python literal.
+            # Fall back to simply stripping the outer quotes.
+            return value[1:-1]
 
     return value
 

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -31,3 +31,80 @@ def check_extra_config(config: "LMCacheEngineConfig"):
     assert len(config.extra_config) == 2
     assert config.extra_config["key1"] == "value1"
     assert config.extra_config["key2"] == "value2"
+
+
+def test_update_config_from_env_basic():
+    config = LMCacheEngineConfig.from_defaults()
+    original_chunk_size = config.chunk_size
+    os.environ["LMCACHE_CHUNK_SIZE"] = "  512  "
+    os.environ["LMCACHE_REMOTE_URL"] = "  http://example.com:8080  "
+    config.update_config_from_env()
+    assert config.chunk_size == 512 and config.chunk_size != original_chunk_size
+    assert config.remote_url == "http://example.com:8080"
+    del os.environ["LMCACHE_CHUNK_SIZE"]
+    del os.environ["LMCACHE_REMOTE_URL"]
+
+
+def test_update_config_from_env_quotes():
+    config = LMCacheEngineConfig.from_defaults()
+    os.environ["LMCACHE_REMOTE_URL"] = "'http://example.com:8080'"
+    os.environ["LMCACHE_PD_ROLE"] = '"sender"'
+    os.environ["LMCACHE_BLEND_SPECIAL_STR"] = "' ### '"
+    config.update_config_from_env()
+    assert config.remote_url == "http://example.com:8080"
+    assert config.pd_role == "sender" and config.blend_special_str == " ### "
+    del os.environ["LMCACHE_REMOTE_URL"]
+    del os.environ["LMCACHE_PD_ROLE"]
+    del os.environ["LMCACHE_BLEND_SPECIAL_STR"]
+
+
+def test_update_config_from_env_extra_config():
+    config = LMCacheEngineConfig.from_defaults()
+    test_cases = [
+        (
+            '  {"test_key": "test_value", "number": 42}  ',
+            {"test_key": "test_value", "number": 42},
+        ),
+        ('\'{"nested": {"key": "value"}}\'', {"nested": {"key": "value"}}),
+        ('"{\\"config\\": \\"prod\\"}"', {"config": "prod"}),
+    ]
+    for test_input, expected in test_cases:
+        os.environ["LMCACHE_EXTRA_CONFIG"] = test_input
+        config.update_config_from_env()
+        assert config.extra_config == expected
+        del os.environ["LMCACHE_EXTRA_CONFIG"]
+
+
+def test_update_config_from_env_internal_api_server_include_index_list():
+    config = LMCacheEngineConfig.from_defaults()
+    test_cases = [
+        ("  1,2,3,4  ", [1, 2, 3, 4]),
+        ('"1,2,3,4"', [1, 2, 3, 4]),
+        ("'1,2,3,4'", [1, 2, 3, 4]),
+        (" 1 , 2 , 3 , 4 ", [1, 2, 3, 4]),
+        ("  5  ", [5]),
+        ('"10"', [10]),
+    ]
+    for test_input, expected in test_cases:
+        os.environ["LMCACHE_INTERNAL_API_SERVER_INCLUDE_INDEX_LIST"] = test_input
+        config.update_config_from_env()
+        assert config.internal_api_server_include_index_list == expected
+        del os.environ["LMCACHE_INTERNAL_API_SERVER_INCLUDE_INDEX_LIST"]
+
+
+def test_update_config_from_env_error_handling():
+    config = LMCacheEngineConfig.from_defaults()
+    original_chunk_size, original_extra_config = config.chunk_size, config.extra_config
+    os.environ["LMCACHE_CHUNK_SIZE"] = "invalid_number"
+    os.environ["LMCACHE_EXTRA_CONFIG"] = "invalid_json{"
+    config.update_config_from_env()
+    assert (
+        config.chunk_size == original_chunk_size
+        and config.extra_config == original_extra_config
+    )
+    os.environ["LMCACHE_CONTROLLER_PULL_URL"] = "http://controller.example.com"
+    config.update_config_from_env()
+    assert config.controller_pull_url == "http://controller.example.com"
+    del os.environ["LMCACHE_CHUNK_SIZE"]
+    del os.environ["LMCACHE_EXTRA_CONFIG"]
+    del os.environ["LMCACHE_CONTROLLER_PULL_URL"]


### PR DESCRIPTION
For some reason, there are quotes surround the config value from environment variable. 
This PR aims to detect this case and remove the extra heading and tailing quote.