### PR TITLE
[CI][BugFix]: Enable non-CUDA unit testing for all tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           python -m pip install -r requirements/test.txt
           python -m pip install -r requirements/common.txt
 
-      - name: "Run non-CUDA unit tests (v1/storage_backend)"
+      - name: "Run non-CUDA unit tests"
         run: |
           pytest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install vllm
           python -m pip install -r requirements/test.txt
           python -m pip install -r requirements/common.txt
-          python -m pip install torch==2.7.1 torchaudio==2.7.1 torchvision==0.22.1
 
       - name: "Run non-CUDA unit tests (v1/storage_backend)"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,6 @@ jobs:
     strategy:
       matrix:
         python:
-          # Disable 3.9 until code supports it in https://github.com/LMCache/LMCache/pull/1584
-          # - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -80,5 +78,5 @@ jobs:
 
       - name: "Run non-CUDA unit tests (v1/storage_backend)"
         run: |
-          pytest tests/v1/storage_backend/
+          pytest
 

--- a/docs/source/developer_guide/contributing.rst
+++ b/docs/source/developer_guide/contributing.rst
@@ -135,12 +135,7 @@ It will run automatically when you add a commit. You can also run it manually on
 Unit tests
 ^^^^^^^^^^
 
-.. note::
-    The Unit tests require `NVIDIA Inference Xfer Library (NIXL) <https://github.com/ai-dynamo/nixl>`_ to be installed. Please follow the details in the NIXL GitHub repo to install.
-    The NIXL unit tests also require `vLLM <https://github.com/vllm-project/vllm>`_ and `msgpack <https://github.com/msgpack/msgpack-python/>`_.
-    If you are unable to install NIXL you can circumvent the NIXL unit tests by using the following pytest flags: `--ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py --ignore=tests/v1/test_nixl_storage.py`.
-
-When making changes, run the tests before pushing the changes. Running unit tests ensures your contributions do not break exiting code. We use the `pytest <https://docs.pytest.org/>`_ framework to run unit tests. The framework is setup to run all files in the `tests <https://github.com/LMCache/LMCache/tree/dev/tests>`_ directory which have a prefix or posfix of "test".
+When making changes, run the tests before pushing the changes. Running unit tests ensures your contributions do not break existing code. We use the `pytest <https://docs.pytest.org/>`_ framework to run unit tests. The framework is setup to run all files in the `tests <https://github.com/LMCache/LMCache/tree/dev/tests>`_ directory which have a prefix or posfix of "test".
 
 Running unit tests is as simple as:
 
@@ -148,11 +143,9 @@ Running unit tests is as simple as:
 
     pytest
 
-Alternatively, running unit tests (minus NIXL tests) is as follows:
+.. note::
 
-.. code-block:: bash
-
-    pytest --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py --ignore=tests/v1/test_nixl_storage.py
+    ``vLLM`` (``pip install vllm``) and the dependencies in ``requirements/test.txt`` need to be installed prior to running unit tests.
 
 By default, all tests found within the tests directory are run. However, specific unit tests can run by passing filenames, classes and/or methods to `pytest`. The following example invokes a single test method "test_lm_connector" that is declared in the "tests/test_connector.py" file:
 
@@ -160,9 +153,14 @@ By default, all tests found within the tests directory are run. However, specifi
 
     pytest tests/test_connector.py::test_lm_connector
 
-.. warning::
+.. note::
 
-    Currently, unit tests do not run on non Linux NVIDIA GPU platforms. If you don't have access to this platform to run unit tests locally, rely on the continuous integration system to run the tests for now.
+    Some unit tests require a NVIDIA GPU. This means that on a non Linux NVIDIA GPU system, the full suite of tests will not be run (tests requiring CUDA will be skipped). The Buildkite continuous integration (CI)  system executes a full run of all the tests.
+
+.. note::
+
+    The `NVIDIA Inference Xfer Library (NIXL) <https://github.com/ai-dynamo/nixl>`_ unit tests require NIXL to be to be installed. This is not installed by LMCache by and therefore requires you to install it separately. Please follow the details in the NIXL GitHub repo to install.
+    If the NIXL package is not installed, the NIXL unit tests are skipped.
 
 Building the docs
 ^^^^^^^^^^^^^^^^^

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -1315,6 +1315,10 @@ def test_builder_destroy_multiple_instances(autorelease_v1):
     LMCacheEngineBuilder.destroy(instance_id2)
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Requires CUDA for test_multi_device_backends",
+)
 def test_multi_device_backends(autorelease_v1):
     """Test running GPU-related backend with local CPU backends
     together


### PR DESCRIPTION
GitHub workflow are only running tests on `tests/v1/storage_backend/`. This PR enables it for all. It is a follow on from 
#1575 where we missed that test only ran on storage backends.