### PR TITLE
Get a default value if old vllm doesn't have priority

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1132,7 +1132,7 @@ class LMCacheConnectorV1Impl:
         ):
             return 0
 
-        self._requests_priority[request.request_id] = request.priority
+        self._requests_priority[request.request_id] = getattr(request, "priority", 0)
 
         token_ids = request.prompt_token_ids
 


### PR DESCRIPTION
Since old versions of the vLLM do not support priority, we need to have a default fallback value.