### PR TITLE
[Misc]: Improve the description provided for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,40 +1,12 @@
-FILL IN THE PR DESCRIPTION HERE
+<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
+1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
+2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
 
-FIX #xxxx (*link existing issues this PR will resolve*)
+**What this PR does / why we need it**:
 
-**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**
+**Special notes for your reviewers**:
 
----
+**If applicable**:
 
-<details>
-<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
-<summary><b> PR Checklist (Click to Expand) </b></summary>
-
-<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>
-
-<h3>PR Title and Classification</h3>
-<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
-<ul>
-    <li><code>[Bugfix]</code> for bug fixes.</li>
-    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
-    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
-    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
-    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
-    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
-</ul>
-<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>
-
-<h3>Code Quality</h3>
-
-<p>The PR need to meet the following code quality standards:</p>
-
-<ul>
-    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
-    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
-</ul>
-
-<h3>What to Expect for the Reviews</h3>
-
-We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.
-
-</details>
+- [ ] this PR contains user facing changes - docs added
+- [ ] this PR contains unit tests

--- a/docs/source/developer_guide/contributing.rst
+++ b/docs/source/developer_guide/contributing.rst
@@ -44,9 +44,26 @@ To contribute to this repo, you'll use the Fork and Pull model common in many op
 - Run unit tests and fix any broken tests
 - Submit a pull request with detailed descriptions
 
-When your contribution is ready, you can create a pull request. Pull requests are often referred to as "PRs". In general, we follow the standard `GitHub pull request <https://help.github.com/en/articles/about-pull-requests>`_ process. Follow the template to provide details about your pull request to the maintainers. It's best to break your contribution into smaller PRs with incremental changes, and include a good description of the changes. We require new unit tests to be contributed with any new functionality added.
+When your contribution is ready, you can create a pull request. Pull requests are often referred to as "PRs". In general, we follow the standard `GitHub pull request <https://help.github.com/en/articles/about-pull-requests>`_ process. Follow the template to provide details about your pull request to the maintainers.
 
-Before sending pull requests, make sure your changes pass code quality checks and unit tests. These checks will run with the pull request builds. Alternatively, you can run the checks manually on your local machine `as specified in Development <#development>`_ .
+Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:
+
+- [Bugfix] for bug fixes
+- [Build] for build fixes and improvements
+- [CI] for continuous integration fixes and iimprovements
+- [Core] for changes in the core LMCache logic (e.g., ``LMCacheEngine``, ``Backend`` etc.)
+- [Doc] for documentation fixes and improvements
+- [Misc] for PRs that do not fit the above categories. Please use this sparingly
+- [Model] for adding a new model or improving an existing model. Model name should appear in the title
+- [Test] for unit tests
+
+.. note::
+
+    If the PR spans more than one category, please include all relevant prefixes
+
+It's best to break your contribution into smaller PRs with incremental changes, and include a good description of the changes. We require new unit tests to be contributed with any new functionality added and docs if user facing changes.
+
+Before sending pull requests, make sure your changes pass code quality checks and unit tests. These checks will run when the pull request builds. Alternatively, you can run the checks manually on your local machine `as specified in Development <#development>`_ .
 
 DCO and Signed-off-by
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This commit updates the PR template so that it may guide users to provide more details about the PR being submitted. At the moment, it is usually just the issue number that it fixes.

The value is two-fold:

1. Its helps the reviewers understand what the PR does and if needed
2. It help others that find the PR later and understand the reason behind the changes

Note: It also moves details about identifier prefixes to the contributor guide which is a more relevant place for them.
