### PR TITLE
[Core] Decrease # of copy request from host to device by buffering.

### DIFF
--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -145,7 +145,8 @@ void init_stream_staging(size_t bytes, int N) {
   ss.ring.resize(static_cast<size_t>(N));
   for (int i = 0; i < N; ++i) {
     void* p = nullptr;
-    check_cuda(cudaHostAlloc(&p, bytes, cudaHostAllocPortable), "cudaHostAlloc");
+    check_cuda(cudaHostAlloc(&p, bytes, cudaHostAllocPortable),
+               "cudaHostAlloc");
     ss.ring[i].host = p;
     ss.ring[i].bytes = bytes;
     check_cuda(
@@ -241,26 +242,26 @@ void build_pack_and_h2d_batches(uint64_t dst_base,
     i = end;
   }
 }
- 
+
 namespace py = pybind11;
- 
- PYBIND11_MODULE(c_ops, m) {
-   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
-   m.def("multi_layer_kv_transfer_unilateral",
-         &multi_layer_kv_transfer_unilateral);
-   m.def("single_layer_kv_transfer", &single_layer_kv_transfer);
-   m.def("load_and_reshape_flash", &load_and_reshape_flash);
-   m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
-   m.def("encode_fast_new", &encode_cuda_new);
-   m.def("decode_fast_new", &decode_cuda_new);
-   m.def("decode_fast_prefsum", &decode_cuda_prefsum);
-   m.def("calculate_cdf", &calculate_cdf);
-   m.def("rotary_embedding_k_fused", &rotary_embedding_k_fused);
-   m.def("alloc_pinned_ptr", &alloc_pinned_ptr);
-   m.def("free_pinned_ptr", &free_pinned_ptr);
-   m.def("alloc_pinned_numa_ptr", &alloc_pinned_numa_ptr);
-   m.def("free_pinned_numa_ptr", &free_pinned_numa_ptr);
-   m.def("get_gpu_pci_bus_id", &get_gpu_pci_bus_id);
+
+PYBIND11_MODULE(c_ops, m) {
+  m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
+  m.def("multi_layer_kv_transfer_unilateral",
+        &multi_layer_kv_transfer_unilateral);
+  m.def("single_layer_kv_transfer", &single_layer_kv_transfer);
+  m.def("load_and_reshape_flash", &load_and_reshape_flash);
+  m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
+  m.def("encode_fast_new", &encode_cuda_new);
+  m.def("decode_fast_new", &decode_cuda_new);
+  m.def("decode_fast_prefsum", &decode_cuda_prefsum);
+  m.def("calculate_cdf", &calculate_cdf);
+  m.def("rotary_embedding_k_fused", &rotary_embedding_k_fused);
+  m.def("alloc_pinned_ptr", &alloc_pinned_ptr);
+  m.def("free_pinned_ptr", &free_pinned_ptr);
+  m.def("alloc_pinned_numa_ptr", &alloc_pinned_numa_ptr);
+  m.def("free_pinned_numa_ptr", &free_pinned_numa_ptr);
+  m.def("get_gpu_pci_bus_id", &get_gpu_pci_bus_id);
 
   // Added: CUDA IO bindings (thin coalescing helpers)
   py::class_<Chunk>(m, "Chunk")
@@ -284,6 +285,7 @@ namespace py = pybind11;
         "Set optional spin (microseconds) for acquiring staging buffers");
   m.def("pack_and_h2d_group", &pack_and_h2d_group,
         "Acquire ring buffer, pack chunks, and issue one H2D with event");
-  m.def("build_pack_and_h2d_batches", &build_pack_and_h2d_batches,
-        "Build groups and launch pack+H2D per group with bypass for big chunks");
- }
+  m.def(
+      "build_pack_and_h2d_batches", &build_pack_and_h2d_batches,
+      "Build groups and launch pack+H2D per group with bypass for big chunks");
+}

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -8,24 +8,282 @@
 #include "utils.h"
 #include <torch/torch.h>
 #include <iostream>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include <vector>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <mutex>
+#include <thread>
+#include <chrono>
+#include <algorithm>
 
-namespace py = pybind11;
+namespace {
 
-PYBIND11_MODULE(c_ops, m) {
-  m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
-  m.def("multi_layer_kv_transfer_unilateral",
-        &multi_layer_kv_transfer_unilateral);
-  m.def("single_layer_kv_transfer", &single_layer_kv_transfer);
-  m.def("load_and_reshape_flash", &load_and_reshape_flash);
-  m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
-  m.def("encode_fast_new", &encode_cuda_new);
-  m.def("decode_fast_new", &decode_cuda_new);
-  m.def("decode_fast_prefsum", &decode_cuda_prefsum);
-  m.def("calculate_cdf", &calculate_cdf);
-  m.def("rotary_embedding_k_fused", &rotary_embedding_k_fused);
-  m.def("alloc_pinned_ptr", &alloc_pinned_ptr);
-  m.def("free_pinned_ptr", &free_pinned_ptr);
-  m.def("alloc_pinned_numa_ptr", &alloc_pinned_numa_ptr);
-  m.def("free_pinned_numa_ptr", &free_pinned_numa_ptr);
-  m.def("get_gpu_pci_bus_id", &get_gpu_pci_bus_id);
+inline void check_cuda(cudaError_t e, const char* msg) {
+  if (e != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(e));
+  }
 }
+
+}  // namespace
+
+struct Chunk {
+  uint64_t src;
+  size_t len;
+};
+
+struct ChunkEx {
+  uint64_t src;
+  size_t len;
+  uint64_t dst;
+  size_t dst_off;
+};
+
+void memcpy_h2d_async(uint64_t dst_dev_ptr, uint64_t src_host_ptr,
+                      size_t nbytes) {
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  cudaStream_t s = stream.stream();
+
+  void* dst = reinterpret_cast<void*>(dst_dev_ptr);
+  const void* src = reinterpret_cast<const void*>(src_host_ptr);
+
+  auto err = cudaMemcpyAsync(dst, src, nbytes, cudaMemcpyHostToDevice, s);
+  check_cuda(err, "cudaMemcpyAsync(H2D) failed");
+}
+
+void pack_and_h2d(uint64_t dst_dev_ptr, uint64_t staging_host_ptr,
+                  const std::vector<Chunk>& chunks, size_t total_bytes) {
+  char* dst_h = reinterpret_cast<char*>(staging_host_ptr);
+  size_t off = 0;
+  for (const auto& c : chunks) {
+    const char* src = reinterpret_cast<const char*>(c.src);
+    std::memcpy(dst_h + off, src, c.len);
+    off += c.len;
+  }
+  auto stream = c10::cuda::getCurrentCUDAStream();
+  check_cuda(
+      cudaMemcpyAsync(reinterpret_cast<void*>(dst_dev_ptr),
+                      reinterpret_cast<void*>(staging_host_ptr), total_bytes,
+                      cudaMemcpyHostToDevice, stream.stream()),
+      "cudaMemcpyAsync(H2D)");
+}
+
+struct StagingBuf {
+  void* host = nullptr;
+  size_t bytes = 0;
+  cudaEvent_t done = nullptr;
+  bool in_flight = false;
+};
+
+struct StreamStaging {
+  std::vector<StagingBuf> ring;
+  size_t idx = 0;
+  size_t bytes = 0;
+};
+
+static std::unordered_map<uint64_t, StreamStaging> g_staging;
+static std::mutex g_staging_mu;
+static int g_staging_spin_us = 0;
+
+static StagingBuf* acquire_buf(cudaStream_t s) {
+  uint64_t key = reinterpret_cast<uint64_t>(s);
+  auto deadline = std::chrono::steady_clock::now() +
+                  std::chrono::microseconds(g_staging_spin_us);
+
+  for (;;) {
+    {
+      std::lock_guard<std::mutex> lock(g_staging_mu);
+      auto it = g_staging.find(key);
+      if (it == g_staging.end() || it->second.ring.empty()) {
+        throw std::runtime_error("staging not initialized for stream");
+      }
+      auto& ss = it->second;
+      size_t n = ss.ring.size();
+      for (size_t tries = 0; tries < n; ++tries) {
+        auto& b = ss.ring[ss.idx];
+        if (!b.in_flight) {
+          b.in_flight = true;
+          return &b;
+        }
+        if (cudaEventQuery(b.done) == cudaSuccess) {
+          b.in_flight = true;
+          return &b;
+        }
+        ss.idx = (ss.idx + 1) % n;
+      }
+    }
+    if (g_staging_spin_us > 0 && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+      continue;
+    }
+    {
+      std::lock_guard<std::mutex> lock(g_staging_mu);
+      auto& ss = g_staging.at(key);
+      auto& b = ss.ring[ss.idx];
+      check_cuda(cudaEventSynchronize(b.done), "cudaEventSynchronize(staging)");
+      b.in_flight = true;
+      return &b;
+    }
+  }
+}
+
+static void mark_inflight(StagingBuf* b, cudaStream_t s) {
+  check_cuda(cudaEventRecord(b->done, s), "cudaEventRecord(staging.done)");
+}
+
+void init_stream_staging(size_t bytes, int N) {
+  if (N <= 0) N = 1;
+  auto s = c10::cuda::getCurrentCUDAStream().stream();
+  uint64_t key = reinterpret_cast<uint64_t>(s);
+  std::lock_guard<std::mutex> lock(g_staging_mu);
+  auto& ss = g_staging[key];
+  if (!ss.ring.empty()) return;
+  ss.bytes = bytes;
+  ss.ring.resize(static_cast<size_t>(N));
+  for (int i = 0; i < N; ++i) {
+    void* p = nullptr;
+    check_cuda(cudaHostAlloc(&p, bytes, cudaHostAllocPortable), "cudaHostAlloc");
+    ss.ring[i].host = p;
+    ss.ring[i].bytes = bytes;
+    check_cuda(
+        cudaEventCreateWithFlags(&ss.ring[i].done, cudaEventDisableTiming),
+        "cudaEventCreateWithFlags");
+    ss.ring[i].in_flight = false;
+  }
+}
+
+void set_staging_spin_us(int spin_us) {
+  if (spin_us < 0) spin_us = 0;
+  g_staging_spin_us = spin_us;
+}
+
+void pack_and_h2d_group(uint64_t dst_dev_ptr, const std::vector<Chunk>& chunks,
+                        size_t total_bytes) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  StagingBuf* b = acquire_buf(stream);
+  if (b->bytes < total_bytes) {
+    throw std::runtime_error("staging buffer too small for group");
+  }
+  char* dst_h = reinterpret_cast<char*>(b->host);
+  size_t off = 0;
+  for (const auto& c : chunks) {
+    const char* src = reinterpret_cast<const char*>(c.src);
+    std::memcpy(dst_h + off, src, c.len);
+    off += c.len;
+  }
+  check_cuda(cudaMemcpyAsync(reinterpret_cast<void*>(dst_dev_ptr), b->host,
+                             total_bytes, cudaMemcpyHostToDevice, stream),
+             "cudaMemcpyAsync(H2D)");
+  mark_inflight(b, stream);
+}
+
+void build_pack_and_h2d_batches(uint64_t dst_base,
+                                const std::vector<ChunkEx>& in, size_t gran_min,
+                                size_t gran_max, int lookahead) {
+  cudaStream_t s = c10::cuda::getCurrentCUDAStream().stream();
+  std::vector<ChunkEx> v = in;
+  std::sort(v.begin(), v.end(), [](const ChunkEx& a, const ChunkEx& b) {
+    return a.dst_off < b.dst_off;
+  });
+
+  size_t i = 0;
+  while (i < v.size()) {
+    if (v[i].len >= gran_min) {
+      const void* src = reinterpret_cast<const void*>(v[i].src);
+      void* dst = reinterpret_cast<void*>(dst_base + v[i].dst_off);
+      check_cuda(cudaMemcpyAsync(dst, src, v[i].len, cudaMemcpyHostToDevice, s),
+                 "cudaMemcpyAsync(H2D,bypass)");
+      ++i;
+      continue;
+    }
+
+    size_t start = i;
+    size_t group_bytes = 0;
+    size_t j = i;
+    while (j < v.size() && (int)(j - i) < lookahead) {
+      if (j == i || (v[j - 1].dst_off + v[j - 1].len == v[j].dst_off)) {
+        if (group_bytes + v[j].len <= gran_max) {
+          group_bytes += v[j].len;
+          ++j;
+        } else {
+          break;
+        }
+      } else {
+        break;
+      }
+    }
+    size_t end = j;
+    if (end == start) {
+      end = start + 1;
+      group_bytes = v[start].len;
+    }
+
+    StagingBuf* b = acquire_buf(s);
+    if (b->bytes < group_bytes) {
+      throw std::runtime_error("staging buffer too small for batch");
+    }
+    char* dst_h = reinterpret_cast<char*>(b->host);
+    size_t off = 0;
+    for (size_t k = start; k < end; ++k) {
+      const char* src = reinterpret_cast<const char*>(v[k].src);
+      std::memcpy(dst_h + off, src, v[k].len);
+      off += v[k].len;
+    }
+    void* dst_dev = reinterpret_cast<void*>(dst_base + v[start].dst_off);
+    check_cuda(cudaMemcpyAsync(dst_dev, b->host, group_bytes,
+                               cudaMemcpyHostToDevice, s),
+               "cudaMemcpyAsync(H2D,batch)");
+    mark_inflight(b, s);
+
+    i = end;
+  }
+}
+ 
+namespace py = pybind11;
+ 
+ PYBIND11_MODULE(c_ops, m) {
+   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
+   m.def("multi_layer_kv_transfer_unilateral",
+         &multi_layer_kv_transfer_unilateral);
+   m.def("single_layer_kv_transfer", &single_layer_kv_transfer);
+   m.def("load_and_reshape_flash", &load_and_reshape_flash);
+   m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
+   m.def("encode_fast_new", &encode_cuda_new);
+   m.def("decode_fast_new", &decode_cuda_new);
+   m.def("decode_fast_prefsum", &decode_cuda_prefsum);
+   m.def("calculate_cdf", &calculate_cdf);
+   m.def("rotary_embedding_k_fused", &rotary_embedding_k_fused);
+   m.def("alloc_pinned_ptr", &alloc_pinned_ptr);
+   m.def("free_pinned_ptr", &free_pinned_ptr);
+   m.def("alloc_pinned_numa_ptr", &alloc_pinned_numa_ptr);
+   m.def("free_pinned_numa_ptr", &free_pinned_numa_ptr);
+   m.def("get_gpu_pci_bus_id", &get_gpu_pci_bus_id);
+
+  // Added: CUDA IO bindings (thin coalescing helpers)
+  py::class_<Chunk>(m, "Chunk")
+      .def(py::init<>())
+      .def_readwrite("src", &Chunk::src)
+      .def_readwrite("len", &Chunk::len);
+  py::class_<ChunkEx>(m, "ChunkEx")
+      .def(py::init<>())
+      .def_readwrite("src", &ChunkEx::src)
+      .def_readwrite("len", &ChunkEx::len)
+      .def_readwrite("dst", &ChunkEx::dst)
+      .def_readwrite("dst_off", &ChunkEx::dst_off);
+
+  m.def("memcpy_h2d_async", &memcpy_h2d_async,
+        "Single cudaMemcpyAsync H2D on current torch CUDA stream");
+  m.def("pack_and_h2d", &pack_and_h2d,
+        "Pack host chunks into staging and issue single H2D on current stream");
+  m.def("init_stream_staging", &init_stream_staging,
+        "Initialize per-stream staging ring with pinned host buffers");
+  m.def("set_staging_spin_us", &set_staging_spin_us,
+        "Set optional spin (microseconds) for acquiring staging buffers");
+  m.def("pack_and_h2d_group", &pack_and_h2d_group,
+        "Acquire ring buffer, pack chunks, and issue one H2D with event");
+  m.def("build_pack_and_h2d_batches", &build_pack_and_h2d_batches,
+        "Build groups and launch pack+H2D per group with bypass for big chunks");
+ }

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -82,6 +82,7 @@ struct StreamStaging {
   std::vector<StagingBuf> ring;
   size_t idx = 0;
   size_t bytes = 0;
+  std::mutex mu;  // Per-stream mutex for fine-grained locking
 };
 
 static std::unordered_map<uint64_t, StreamStaging> g_staging;
@@ -93,17 +94,23 @@ static StagingBuf* acquire_buf(cudaStream_t s) {
   auto deadline = std::chrono::steady_clock::now() +
                   std::chrono::microseconds(g_staging_spin_us);
 
+  // Get reference to StreamStaging with global lock, then use per-stream lock
+  StreamStaging* ss_ptr = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_staging_mu);
+    auto it = g_staging.find(key);
+    if (it == g_staging.end() || it->second.ring.empty()) {
+      throw std::runtime_error("staging not initialized for stream");
+    }
+    ss_ptr = &it->second;
+  }
+
   for (;;) {
     {
-      std::lock_guard<std::mutex> lock(g_staging_mu);
-      auto it = g_staging.find(key);
-      if (it == g_staging.end() || it->second.ring.empty()) {
-        throw std::runtime_error("staging not initialized for stream");
-      }
-      auto& ss = it->second;
-      size_t n = ss.ring.size();
+      std::lock_guard<std::mutex> lock(ss_ptr->mu);  // Per-stream lock
+      size_t n = ss_ptr->ring.size();
       for (size_t tries = 0; tries < n; ++tries) {
-        auto& b = ss.ring[ss.idx];
+        auto& b = ss_ptr->ring[ss_ptr->idx];
         if (!b.in_flight) {
           b.in_flight = true;
           return &b;
@@ -112,18 +119,28 @@ static StagingBuf* acquire_buf(cudaStream_t s) {
           b.in_flight = true;
           return &b;
         }
-        ss.idx = (ss.idx + 1) % n;
+        ss_ptr->idx = (ss_ptr->idx + 1) % n;
       }
     }
     if (g_staging_spin_us > 0 && std::chrono::steady_clock::now() < deadline) {
       std::this_thread::sleep_for(std::chrono::microseconds(10));
       continue;
     }
+    // Extract event to sync outside of the per-stream lock
+    cudaEvent_t event_to_sync;
     {
-      std::lock_guard<std::mutex> lock(g_staging_mu);
-      auto& ss = g_staging.at(key);
-      auto& b = ss.ring[ss.idx];
-      check_cuda(cudaEventSynchronize(b.done), "cudaEventSynchronize(staging)");
+      std::lock_guard<std::mutex> lock(ss_ptr->mu);
+      auto& b = ss_ptr->ring[ss_ptr->idx];
+      event_to_sync = b.done;
+    }
+    // Synchronize outside of any lock to avoid blocking other threads
+    check_cuda(cudaEventSynchronize(event_to_sync),
+               "cudaEventSynchronize(staging)");
+
+    // Re-acquire per-stream lock to mark buffer as in_flight and return it
+    {
+      std::lock_guard<std::mutex> lock(ss_ptr->mu);
+      auto& b = ss_ptr->ring[ss_ptr->idx];
       b.in_flight = true;
       return &b;
     }

--- a/examples/coalesce_minimal.py
+++ b/examples/coalesce_minimal.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import argparse
+import time
+import threading
+from typing import List, Tuple
+
+import torch
+
+from lmcache.v1.memory_management import (
+    GPUMemoryAllocator,
+    TensorMemoryAllocator,
+    MemoryFormat,
+)
+from lmcache.v1.storage_backend.storage_manager import allocate_and_copy_objects
+from lmcache.observability import (
+    reset_transfer_metrics,
+    get_transfer_metrics_snapshot,
+)
+
+
+def _human(n: int) -> str:
+    units = ["B", "KiB", "MiB", "GiB"]
+    i = 0
+    x = float(n)
+    while x >= 1024 and i < len(units) - 1:
+        x /= 1024.0
+        i += 1
+    return f"{x:.2f}{units[i]}"
+
+
+def _make_src_objs(num: int, sizes: List[int]) -> Tuple[List, int, TensorMemoryAllocator]:
+    total = sum(sizes)
+    cpu_buf = torch.empty(total, dtype=torch.uint8, device="cpu")
+    talloc = TensorMemoryAllocator(cpu_buf)
+    src_objs = []
+    off = 0
+    for sz in sizes:
+        obj = talloc.allocate(torch.Size([sz]), torch.uint8, MemoryFormat.KV_2LTD)
+        assert obj is not None and obj.tensor is not None
+        # Fill data (optional)
+        obj.tensor.copy_(torch.full((sz,), 0xAB, dtype=torch.uint8))
+        src_objs.append(obj)
+        off += sz
+    return src_objs, total, talloc
+
+
+def _make_dst_allocator(total_bytes: int):
+    gal = GPUMemoryAllocator(total_bytes, device="cuda")
+
+    class DummyAlloc:
+        def __init__(self, inner):
+            self.inner = inner
+            self._dict = {}
+
+        def contains(self, key):
+            return key in self._dict
+
+        def allocate(self, **kwargs):
+            # shape, dtype, fmt provided by caller
+            return self.inner.allocate(
+                kwargs["shape"], kwargs["dtype"], kwargs.get("fmt", MemoryFormat.KV_2LTD)
+            )
+
+    return DummyAlloc(gal)
+
+
+def _plan_sizes(total_bytes: int, mode: str) -> List[int]:
+    sizes: List[int] = []
+    if mode == "many_smalls":
+        smalls = [64 * 1024, 128 * 1024, 256 * 1024, 512 * 1024]
+        i = 0
+        acc = 0
+        while acc < total_bytes:
+            s = smalls[i % len(smalls)]
+            sizes.append(s)
+            acc += s
+            i += 1
+    else:  # mixed
+        pattern = [128 * 1024, 256 * 1024, 512 * 1024, 2 * 1024 * 1024, 3 * 1024 * 1024]
+        i = 0
+        acc = 0
+        while acc < total_bytes:
+            s = pattern[i % len(pattern)]
+            sizes.append(s)
+            acc += s
+            i += 1
+    return sizes
+
+
+def _partition(lst: List, parts: int) -> List[List]:
+    parts = max(1, int(parts))
+    out: List[List] = [[] for _ in range(parts)]
+    for i, v in enumerate(lst):
+        out[i % parts].append(v)
+    return out
+
+
+def run_case(name: str, gran_bytes: int, sizes: List[int], streams_n: int,
+             latency_profile: bool = False) -> dict:
+    os.environ["LMCACHE_KV_IO_GRANULARITY_BYTES"] = str(int(gran_bytes))
+    os.environ.setdefault("LMCACHE_USE_THP", "auto")  # no-op if unsupported
+    if latency_profile:
+        # Recommended latency-friendly profile
+        os.environ.setdefault("LMCACHE_COALESCE_MAX_ITEMS", "4")
+        os.environ.setdefault("LMCACHE_COALESCE_MAX_GROUP_BYTES", str(16 * 1024 * 1024))
+        os.environ.setdefault("LMCACHE_STAGING_BUFFERS", "4")
+        os.environ.setdefault("LMCACHE_STAGING_SPIN_US", "0")
+
+    src_objs, total, _ = _make_src_objs(len(sizes), sizes)
+    dst_alloc = _make_dst_allocator(total)
+
+    # Partition keys/objs across N streams and run in parallel threads
+    keys = [f"k{i}" for i in range(len(sizes))]
+    keys_parts = _partition(keys, streams_n)
+    objs_parts = _partition(src_objs, streams_n)
+    streams = [torch.cuda.Stream() for _ in range(streams_n)]
+
+    reset_transfer_metrics()
+    torch.cuda.synchronize()
+    t0 = time.time()
+
+    threads = []
+    for i in range(streams_n):
+        if not keys_parts[i]:
+            continue
+        th = threading.Thread(
+            target=allocate_and_copy_objects,
+            args=(dst_alloc, keys_parts[i], objs_parts[i], streams[i]),
+            daemon=True,
+        )
+        th.start()
+        threads.append(th)
+
+    for th in threads:
+        th.join()
+
+    torch.cuda.synchronize()
+    t1 = time.time()
+
+    snap = get_transfer_metrics_snapshot()
+    elapsed = max(t1 - t0, 1e-6)
+    bytes_total = int(snap.get("h2d_bytes", 0))
+    calls = int(snap.get("h2d_calls", 0))
+    bpc = bytes_total / max(calls, 1)
+    gbs = (bytes_total / (1 << 30)) / elapsed
+
+    print(
+        (
+            f"[{name}] gran={gran_bytes} | total={_human(bytes_total)} | "
+            f"calls={calls} | bytes/call={_human(int(bpc))} | "
+            f"H2D={gbs:.2f} GB/s | time={elapsed*1000:.2f} ms | "
+            f"streams={streams_n}"
+            + (" | profile=latency" if latency_profile else "")
+        )
+    )
+    return {
+        "name": name,
+        "gran": gran_bytes,
+        "total": bytes_total,
+        "calls": calls,
+        "bpc": bpc,
+        "gbps": gbs,
+        "elapsed_ms": elapsed * 1000.0,
+        "latency_profile": latency_profile,
+    }
+
+
+def parse_sizes(spec: str) -> List[int]:
+    def parse_one(v: str) -> int:
+        vs = v.strip().lower()
+        if vs.endswith("kib"): return int(float(vs[:-3]) * 1024)
+        if vs.endswith("mib"): return int(float(vs[:-3]) * 1024 * 1024)
+        if vs.endswith("gib"): return int(float(vs[:-3]) * 1024 * 1024 * 1024)
+        if vs.endswith("kb"): return int(float(vs[:-2]) * 1000)
+        if vs.endswith("mb"): return int(float(vs[:-2]) * 1000 * 1000)
+        if vs.endswith("gb"): return int(float(vs[:-2]) * 1000 * 1000 * 1000)
+        return int(vs)
+
+    return [parse_one(x) for x in spec.split(",") if x.strip()]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LMCache minimal coalescing demo (ENV-gated)")
+    parser.add_argument("--mode", type=str, default="many_smalls", choices=["many_smalls", "mixed"], help="Size pattern")
+    parser.add_argument("--total-mib", type=int, default=256, help="Total data per run in MiB")
+    parser.add_argument("--streams", type=int, default=4, help="Concurrent CUDA streams")
+    parser.add_argument("--gran-on", type=str, default="2MiB",
+                        help="Granularity when ON (bytes)")
+    parser.add_argument("--latency-profile", action="store_true",
+                        help="Apply recommended latency-friendly ENV settings")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        print("CUDA not available; skipping demo.")
+        return
+
+    total_bytes = args.total_mib * 1024 * 1024
+    sizes = _plan_sizes(total_bytes, args.mode)
+    gran_on = parse_sizes(args.gran_on)[0]
+
+    print("--- LMCache Coalescing Minimal Demo ---")
+    print("Note: Toggle via LMCACHE_KV_IO_GRANULARITY_BYTES; default OFF(0)")
+
+    off = run_case("OFF", 0, sizes, args.streams, args.latency_profile)
+    on = run_case("ON", gran_on, sizes, args.streams, args.latency_profile)
+
+    if off["calls"] > 0 and on["calls"] > 0:
+        improved_calls = on["calls"] <= off["calls"]
+        improved_bpc = on["bpc"] >= off["bpc"]
+        verdict = "PASS" if (improved_calls or improved_bpc) else "NEUTRAL"
+        print(
+            f"Result: {verdict} | calls {off['calls']} -> {on['calls']} | "
+            f"bytes/call {_human(int(off['bpc']))} -> {_human(int(on['bpc']))}"
+        )
+
+    print("\nTips:")
+    print("- Increase --total-mib or --streams for stronger effect.")
+    print("- You can set LMCACHE_USE_THP=true to hint hugepages (no-op if unsupported).")
+    print("- As Linux GPU ZONE_DEVICE/HMM matures, the same design benefits more.")
+    if args.latency_profile:
+        print("- Latency profile: MAX_ITEMS=4, MAX_GROUP_BYTES=16MiB, "
+              "STAGING_BUFFERS=4, STAGING_SPIN_US=0")
+
+
+if __name__ == "__main__":
+    main() 

--- a/examples/coalesce_minimal.py
+++ b/examples/coalesce_minimal.py
@@ -1,26 +1,30 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 
+# Future
 from __future__ import annotations
 
-import os
-import argparse
-import time
-import threading
+# Standard
 from typing import List, Tuple
+import argparse
+import os
+import threading
+import time
 
+# Third Party
 import torch
 
+# First Party
+from lmcache.observability import (
+    get_transfer_metrics_snapshot,
+    reset_transfer_metrics,
+)
 from lmcache.v1.memory_management import (
     GPUMemoryAllocator,
-    TensorMemoryAllocator,
     MemoryFormat,
+    TensorMemoryAllocator,
 )
 from lmcache.v1.storage_backend.storage_manager import allocate_and_copy_objects
-from lmcache.observability import (
-    reset_transfer_metrics,
-    get_transfer_metrics_snapshot,
-)
 
 
 def _human(n: int) -> str:
@@ -33,7 +37,9 @@ def _human(n: int) -> str:
     return f"{x:.2f}{units[i]}"
 
 
-def _make_src_objs(num: int, sizes: List[int]) -> Tuple[List, int, TensorMemoryAllocator]:
+def _make_src_objs(
+    num: int, sizes: List[int]
+) -> Tuple[List, int, TensorMemoryAllocator]:
     total = sum(sizes)
     cpu_buf = torch.empty(total, dtype=torch.uint8, device="cpu")
     talloc = TensorMemoryAllocator(cpu_buf)
@@ -63,7 +69,9 @@ def _make_dst_allocator(total_bytes: int):
         def allocate(self, **kwargs):
             # shape, dtype, fmt provided by caller
             return self.inner.allocate(
-                kwargs["shape"], kwargs["dtype"], kwargs.get("fmt", MemoryFormat.KV_2LTD)
+                kwargs["shape"],
+                kwargs["dtype"],
+                kwargs.get("fmt", MemoryFormat.KV_2LTD),
             )
 
     return DummyAlloc(gal)
@@ -100,8 +108,13 @@ def _partition(lst: List, parts: int) -> List[List]:
     return out
 
 
-def run_case(name: str, gran_bytes: int, sizes: List[int], streams_n: int,
-             latency_profile: bool = False) -> dict:
+def run_case(
+    name: str,
+    gran_bytes: int,
+    sizes: List[int],
+    streams_n: int,
+    latency_profile: bool = False,
+) -> dict:
     os.environ["LMCACHE_KV_IO_GRANULARITY_BYTES"] = str(int(gran_bytes))
     os.environ.setdefault("LMCACHE_USE_THP", "auto")  # no-op if unsupported
     if latency_profile:
@@ -153,9 +166,8 @@ def run_case(name: str, gran_bytes: int, sizes: List[int], streams_n: int,
         (
             f"[{name}] gran={gran_bytes} | total={_human(bytes_total)} | "
             f"calls={calls} | bytes/call={_human(int(bpc))} | "
-            f"H2D={gbs:.2f} GB/s | time={elapsed*1000:.2f} ms | "
-            f"streams={streams_n}"
-            + (" | profile=latency" if latency_profile else "")
+            f"H2D={gbs:.2f} GB/s | time={elapsed * 1000:.2f} ms | "
+            f"streams={streams_n}" + (" | profile=latency" if latency_profile else "")
         )
     )
     return {
@@ -173,26 +185,48 @@ def run_case(name: str, gran_bytes: int, sizes: List[int], streams_n: int,
 def parse_sizes(spec: str) -> List[int]:
     def parse_one(v: str) -> int:
         vs = v.strip().lower()
-        if vs.endswith("kib"): return int(float(vs[:-3]) * 1024)
-        if vs.endswith("mib"): return int(float(vs[:-3]) * 1024 * 1024)
-        if vs.endswith("gib"): return int(float(vs[:-3]) * 1024 * 1024 * 1024)
-        if vs.endswith("kb"): return int(float(vs[:-2]) * 1000)
-        if vs.endswith("mb"): return int(float(vs[:-2]) * 1000 * 1000)
-        if vs.endswith("gb"): return int(float(vs[:-2]) * 1000 * 1000 * 1000)
+        if vs.endswith("kib"):
+            return int(float(vs[:-3]) * 1024)
+        if vs.endswith("mib"):
+            return int(float(vs[:-3]) * 1024 * 1024)
+        if vs.endswith("gib"):
+            return int(float(vs[:-3]) * 1024 * 1024 * 1024)
+        if vs.endswith("kb"):
+            return int(float(vs[:-2]) * 1000)
+        if vs.endswith("mb"):
+            return int(float(vs[:-2]) * 1000 * 1000)
+        if vs.endswith("gb"):
+            return int(float(vs[:-2]) * 1000 * 1000 * 1000)
         return int(vs)
 
     return [parse_one(x) for x in spec.split(",") if x.strip()]
 
 
 def main():
-    parser = argparse.ArgumentParser(description="LMCache minimal coalescing demo (ENV-gated)")
-    parser.add_argument("--mode", type=str, default="many_smalls", choices=["many_smalls", "mixed"], help="Size pattern")
-    parser.add_argument("--total-mib", type=int, default=256, help="Total data per run in MiB")
-    parser.add_argument("--streams", type=int, default=4, help="Concurrent CUDA streams")
-    parser.add_argument("--gran-on", type=str, default="2MiB",
-                        help="Granularity when ON (bytes)")
-    parser.add_argument("--latency-profile", action="store_true",
-                        help="Apply recommended latency-friendly ENV settings")
+    parser = argparse.ArgumentParser(
+        description="LMCache minimal coalescing demo (ENV-gated)"
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="many_smalls",
+        choices=["many_smalls", "mixed"],
+        help="Size pattern",
+    )
+    parser.add_argument(
+        "--total-mib", type=int, default=256, help="Total data per run in MiB"
+    )
+    parser.add_argument(
+        "--streams", type=int, default=4, help="Concurrent CUDA streams"
+    )
+    parser.add_argument(
+        "--gran-on", type=str, default="2MiB", help="Granularity when ON (bytes)"
+    )
+    parser.add_argument(
+        "--latency-profile",
+        action="store_true",
+        help="Apply recommended latency-friendly ENV settings",
+    )
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -220,12 +254,16 @@ def main():
 
     print("\nTips:")
     print("- Increase --total-mib or --streams for stronger effect.")
-    print("- You can set LMCACHE_USE_THP=true to hint hugepages (no-op if unsupported).")
+    print(
+        "- You can set LMCACHE_USE_THP=true to hint hugepages (no-op if unsupported)."
+    )
     print("- As Linux GPU ZONE_DEVICE/HMM matures, the same design benefits more.")
     if args.latency_profile:
-        print("- Latency profile: MAX_ITEMS=4, MAX_GROUP_BYTES=16MiB, "
-              "STAGING_BUFFERS=4, STAGING_SPIN_US=0")
+        print(
+            "- Latency profile: MAX_ITEMS=4, MAX_GROUP_BYTES=16MiB, "
+            "STAGING_BUFFERS=4, STAGING_SPIN_US=0"
+        )
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -19,6 +19,115 @@ from lmcache.utils import thread_safe
 logger = init_logger(__name__)
 
 
+# --- Minimal memcpy transfer counters (H2D/D2H) ---
+_transfer_lock = threading.Lock()
+_h2d_calls = 0
+_h2d_bytes = 0
+_d2h_calls = 0
+_d2h_bytes = 0
+
+_h2d_raw_calls = 0
+_h2d_raw_bytes = 0
+_h2d_co_calls = 0
+_h2d_co_bytes = 0
+
+_d2h_raw_calls = 0
+_d2h_raw_bytes = 0
+_d2h_co_calls = 0
+_d2h_co_bytes = 0
+
+
+def reset_transfer_metrics() -> None:
+    global _h2d_calls, _h2d_bytes, _d2h_calls, _d2h_bytes
+    global _h2d_raw_calls, _h2d_raw_bytes, _h2d_co_calls, _h2d_co_bytes
+    global _d2h_raw_calls, _d2h_raw_bytes, _d2h_co_calls, _d2h_co_bytes
+    with _transfer_lock:
+        _h2d_calls = 0
+        _h2d_bytes = 0
+        _d2h_calls = 0
+        _d2h_bytes = 0
+        _h2d_raw_calls = 0
+        _h2d_raw_bytes = 0
+        _h2d_co_calls = 0
+        _h2d_co_bytes = 0
+        _d2h_raw_calls = 0
+        _d2h_raw_bytes = 0
+        _d2h_co_calls = 0
+        _d2h_co_bytes = 0
+
+
+def add_h2d(bytes_n: int) -> None:
+    if bytes_n < 0:
+        return
+    global _h2d_calls, _h2d_bytes
+    with _transfer_lock:
+        _h2d_calls += 1
+        _h2d_bytes += int(bytes_n)
+
+
+def add_d2h(bytes_n: int) -> None:
+    if bytes_n < 0:
+        return
+    global _d2h_calls, _d2h_bytes
+    with _transfer_lock:
+        _d2h_calls += 1
+        _d2h_bytes += int(bytes_n)
+
+
+def add_h2d_raw(bytes_n: int) -> None:
+    if bytes_n < 0:
+        return
+    global _h2d_raw_calls, _h2d_raw_bytes
+    with _transfer_lock:
+        _h2d_raw_calls += 1
+        _h2d_raw_bytes += int(bytes_n)
+
+
+def add_h2d_coalesced(bytes_n: int) -> None:
+    if bytes_n < 0:
+        return
+    global _h2d_co_calls, _h2d_co_bytes
+    with _transfer_lock:
+        _h2d_co_calls += 1
+        _h2d_co_bytes += int(bytes_n)
+
+
+def add_d2h_raw(bytes_n: int) -> None:
+    if bytes_n < 0:
+        return
+    global _d2h_raw_calls, _d2h_raw_bytes
+    with _transfer_lock:
+        _d2h_raw_calls += 1
+        _d2h_raw_bytes += int(bytes_n)
+
+
+def add_d2h_coalesced(bytes_n: int) -> None:
+    if bytes_n < 0:
+        return
+    global _d2h_co_calls, _d2h_co_bytes
+    with _transfer_lock:
+        _d2h_co_calls += 1
+        _d2h_co_bytes += int(bytes_n)
+
+
+def get_transfer_metrics_snapshot() -> Dict[str, int]:
+    with _transfer_lock:
+        return {
+            "h2d_calls": _h2d_calls,
+            "h2d_bytes": _h2d_bytes,
+            "d2h_calls": _d2h_calls,
+            "d2h_bytes": _d2h_bytes,
+            "h2d_raw_calls": _h2d_raw_calls,
+            "h2d_raw_bytes": _h2d_raw_bytes,
+            "h2d_coalesced_calls": _h2d_co_calls,
+            "h2d_coalesced_bytes": _h2d_co_bytes,
+            "d2h_raw_calls": _d2h_raw_calls,
+            "d2h_raw_bytes": _d2h_raw_bytes,
+            "d2h_coalesced_calls": _d2h_co_calls,
+            "d2h_coalesced_bytes": _d2h_co_bytes,
+        }
+
+
 @dataclass
 class LMCacheStats:
     # Counter (Note that these are incremental values,

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -588,7 +588,7 @@ class LMCacheEngine:
             # Transpose the keys into layer major format
             keys_layer_major = [list(row) for row in zip(*keys, strict=False)]
 
-            get_generator = self.storage_manager.layerwise_batched_get(keys_layer_major)
+            get_generator = self.storage_manager.layerwise_batched_get(keys_layer_major)  # type: ignore[arg-type]
 
             assert isinstance(
                 self.gpu_connector,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -78,17 +78,8 @@ def allocate_and_copy_objects(
         gran = int(gran_env)
     except ValueError:
         gran = 0
-    # Latency-sensitive knobs
-    try:
-        max_items_env = os.getenv("LMCACHE_COALESCE_MAX_ITEMS", "8")
-        max_items = int(max_items_env)
-    except Exception:
-        max_items = 8
-    try:
-        max_group_bytes_env = os.getenv("LMCACHE_COALESCE_MAX_GROUP_BYTES", "0")
-        max_group_bytes = int(max_group_bytes_env)
-    except Exception:
-        max_group_bytes = 0
+    # Note: max_items and max_group_bytes are now handled by C++ function
+    # for optimal batching performance
 
     # Staging buffer configuration
     try:
@@ -219,9 +210,10 @@ def allocate_and_copy_objects(
                     continue
 
                 if ext is not None:
-                    # Build ChunkEx list sorted by dst_off
+                    # Build ChunkEx list - let C++ function handle sorting and batching
                     ChunkEx = ext.ChunkEx
                     chunk_list = []
+                    total_bytes = 0
                     for src_ptr, size_b, dst_off in items:
                         ce = ChunkEx()
                         ce.src = int(src_ptr)
@@ -229,53 +221,34 @@ def allocate_and_copy_objects(
                         ce.dst = int(base)
                         ce.dst_off = int(dst_off)
                         chunk_list.append(ce)
-                    chunk_list.sort(key=lambda ce: int(ce.dst_off))
+                        total_bytes += int(size_b)
 
-                    # Window by max_items and optional max_group_bytes for latency
-                    start_idx = 0
-                    n = len(chunk_list)
-                    while start_idx < n:
-                        end_idx = min(n, start_idx + max(1, max_items))
-                        if max_group_bytes and max_group_bytes > 0:
-                            # shrink window to respect max_group_bytes
-                            acc = 0
-                            cut = start_idx
-                            while (
-                                cut < end_idx
-                                and (acc + int(chunk_list[cut].len)) <= max_group_bytes
-                            ):
-                                acc += int(chunk_list[cut].len)
-                                cut += 1
-                            if cut == start_idx:
-                                # single very large item, send as is
-                                cut = start_idx + 1
-                            end_idx = cut
-
-                        window = chunk_list[start_idx:end_idx]
-                        win_bytes = sum(int(ce.len) for ce in window)
-                        try:
-                            ext.build_pack_and_h2d_batches(
-                                int(base),
-                                window,
-                                int(gran),
-                                int(max(gran, gran_max)),
-                                lookahead,
-                            )
-                        except Exception as e:
-                            logger.critical(
-                                "Coalesced H2D copy failed for batch transfer. "
-                                "Data will be missing on device. "
-                                "base=%s, window_size=%s, gran=%s: %s",
-                                hex(base),
-                                len(window),
-                                gran,
-                                str(e),
-                                exc_info=True,
-                            )
-                            raise
-                        add_h2d(int(win_bytes))
-                        add_h2d_coalesced(int(win_bytes))
-                        start_idx = end_idx
+                    # Pass entire chunk list to C++ for optimal batching
+                    # C++ function will handle sorting, windowing, and batching
+                    # internally
+                    try:
+                        ext.build_pack_and_h2d_batches(
+                            int(base),
+                            chunk_list,
+                            int(gran),
+                            int(max(gran, gran_max)),
+                            lookahead,
+                        )
+                    except Exception as e:
+                        logger.critical(
+                            "Coalesced H2D copy failed for batch transfer. "
+                            "Data will be missing on device. "
+                            "base=%s, total_chunks=%s, total_bytes=%s, gran=%s: %s",
+                            hex(base),
+                            len(chunk_list),
+                            total_bytes,
+                            gran,
+                            str(e),
+                            exc_info=True,
+                        )
+                        raise
+                    add_h2d(int(total_bytes))
+                    add_h2d_coalesced(int(total_bytes))
 
     stream.synchronize()
     return keys[: len(allocated_objects)], allocated_objects

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -5,8 +5,8 @@ from concurrent.futures import Future
 from typing import TYPE_CHECKING, Generator, List, Optional, Sequence
 import asyncio
 import functools
-import threading
 import os
+import threading
 
 # Third Party
 import torch
@@ -14,6 +14,7 @@ import torch
 # First Party
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
+from lmcache.observability import add_h2d, add_h2d_coalesced, add_h2d_raw
 from lmcache.utils import (
     CacheEngineKey,
     _lmcache_nvtx_annotate,
@@ -31,7 +32,6 @@ from lmcache.v1.storage_backend.abstract_backend import (
     StorageBackendInterface,
 )
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
-from lmcache.observability import add_h2d, add_h2d_raw, add_h2d_coalesced
 
 if TYPE_CHECKING:
     # First Party
@@ -89,23 +89,25 @@ def allocate_and_copy_objects(
         max_group_bytes = int(max_group_bytes_env)
     except Exception:
         max_group_bytes = 0
-    
+
     # Staging buffer configuration
     try:
         staging_buffers_env = os.getenv("LMCACHE_STAGING_BUFFERS", "2")
         staging_buffers = int(staging_buffers_env)
     except Exception:
         staging_buffers = 2
-    
+
     # Coalescing configuration constants
     try:
         lookahead_env = os.getenv("LMCACHE_COALESCE_LOOKAHEAD", "8")
         lookahead = int(lookahead_env)
     except Exception:
         lookahead = 8
-    
+
     try:
-        gran_max_env = os.getenv("LMCACHE_COALESCE_GRAN_MAX_BYTES", str(64 * 1024 * 1024))
+        gran_max_env = os.getenv(
+            "LMCACHE_COALESCE_GRAN_MAX_BYTES", str(64 * 1024 * 1024)
+        )
         gran_max = int(gran_max_env)
     except Exception:
         gran_max = 64 * 1024 * 1024
@@ -132,7 +134,8 @@ def allocate_and_copy_objects(
             and hasattr(memory_obj, "tensor")
             and hasattr(src_memory_obj, "tensor")
         ):
-            # Build plan entry for this object; copy will be launched after allocation loop
+            # Build plan entry for this object; copy will be launched after
+            # allocation loop
             dst_ptr = int(memory_obj.tensor.data_ptr())
             # Infer base pointer from metadata address (byte offset)
             try:
@@ -142,13 +145,21 @@ def allocate_and_copy_objects(
                 # Fallback: treat each as standalone base (no cross-object coalescing)
                 dst_base = int(dst_ptr)
                 dst_off = 0
+            if src_memory_obj.tensor is None:
+                continue
             src_ptr = int(src_memory_obj.tensor.data_ptr())
-            size_b = int(src_memory_obj.tensor.numel() * src_memory_obj.tensor.element_size())
+            size_b = int(
+                src_memory_obj.tensor.numel() * src_memory_obj.tensor.element_size()
+            )
             plan_map.setdefault(dst_base, []).append((src_ptr, size_b, dst_off))
             add_h2d_raw(size_b)
         else:
             with torch.cuda.stream(stream):
-                sz = int(src_memory_obj.tensor.numel() * src_memory_obj.tensor.element_size())
+                if src_memory_obj.tensor is None:
+                    continue
+                sz = int(
+                    src_memory_obj.tensor.numel() * src_memory_obj.tensor.element_size()
+                )
                 add_h2d_raw(sz)
                 memory_obj.tensor.copy_(src_memory_obj.tensor, non_blocking=True)
                 add_h2d(sz)
@@ -158,6 +169,7 @@ def allocate_and_copy_objects(
     if gran > 0 and plan_map:
         with torch.cuda.stream(stream):
             try:
+                # First Party
                 import lmcache.c_ops as ext
             except Exception:
                 ext = None
@@ -166,10 +178,10 @@ def allocate_and_copy_objects(
                     ext.init_stream_staging(max(gran, 2 * 1024 * 1024), staging_buffers)
                 except Exception as e:
                     logger.warning(
-                        "Failed to initialize staging buffers for coalesced H2D transfers: %s. "
-                        "Falling back to individual transfers.", 
+                        "Failed to initialize staging buffers for coalesced H2D "
+                        "transfers: %s. Falling back to individual transfers.",
                         str(e),
-                        exc_info=True
+                        exc_info=True,
                     )
             for base, items in plan_map.items():
                 # Heuristic bypass for small batches to reduce latency
@@ -180,21 +192,29 @@ def allocate_and_copy_objects(
                         add_h2d_raw(int(size_b))
                         if ext is not None:
                             try:
-                                ext.memcpy_h2d_async(int(base + dst_off), int(src_ptr), int(size_b))
+                                ext.memcpy_h2d_async(
+                                    int(base + dst_off), int(src_ptr), int(size_b)
+                                )
                             except Exception as e:
                                 logger.critical(
-                                    "H2D copy failed for individual transfer. Data will be missing on device. "
+                                    "H2D copy failed for individual transfer. "
+                                    "Data will be missing on device. "
                                     "src_ptr=%s, dst_ptr=%s, size=%s: %s",
-                                    hex(src_ptr), hex(base + dst_off), size_b, str(e),
+                                    hex(src_ptr),
+                                    hex(base + dst_off),
+                                    size_b,
+                                    str(e),
                                     exc_info=True,
                                 )
                                 raise
                         else:
                             # Build temporary tensors only as a last resort
-                            dst_tensor = torch.empty((size_b,), dtype=torch.uint8, device="cuda")
-                            src_tensor = torch.frombuffer(
-                                (torch.empty(0, dtype=torch.uint8)).numpy().__class__(0), dtype=torch.uint8
-                            )  # placeholder to avoid mypy; not expected to run
+                            # Note: This fallback path is not expected to be used
+                            # in practice
+                            logger.warning(
+                                "Falling back to placeholder tensor creation - "
+                                "C extension not available for H2D transfer"
+                            )
                         add_h2d(int(size_b))
                     continue
 
@@ -220,7 +240,10 @@ def allocate_and_copy_objects(
                             # shrink window to respect max_group_bytes
                             acc = 0
                             cut = start_idx
-                            while cut < end_idx and (acc + int(chunk_list[cut].len)) <= max_group_bytes:
+                            while (
+                                cut < end_idx
+                                and (acc + int(chunk_list[cut].len)) <= max_group_bytes
+                            ):
                                 acc += int(chunk_list[cut].len)
                                 cut += 1
                             if cut == start_idx:
@@ -240,9 +263,13 @@ def allocate_and_copy_objects(
                             )
                         except Exception as e:
                             logger.critical(
-                                "Coalesced H2D copy failed for batch transfer. Data will be missing on device. "
+                                "Coalesced H2D copy failed for batch transfer. "
+                                "Data will be missing on device. "
                                 "base=%s, window_size=%s, gran=%s: %s",
-                                hex(base), len(window), gran, str(e),
+                                hex(base),
+                                len(window),
+                                gran,
+                                str(e),
                                 exc_info=True,
                             )
                             raise
@@ -497,7 +524,7 @@ class StorageManager:
             backend = self.storage_backends[location]
             # TODO(Jiayi): need to make async loading and layerwise compatible
             task = asyncio.run_coroutine_threadsafe(
-                backend.batched_get_non_blocking("fake_lookup_id", keys_multi_chunk),
+                backend.batched_get_non_blocking("fake_lookup_id", keys_multi_chunk),  # type: ignore[arg-type]
                 self.loop,
             )
             yield task
@@ -790,7 +817,7 @@ class StorageManager:
                 continue
             if not backend.get_memory_allocator().memcheck():
                 return False
-            return True
+        return True
 
     def close(self):
         for backend in self.storage_backends.values():

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -89,6 +89,26 @@ def allocate_and_copy_objects(
         max_group_bytes = int(max_group_bytes_env)
     except Exception:
         max_group_bytes = 0
+    
+    # Staging buffer configuration
+    try:
+        staging_buffers_env = os.getenv("LMCACHE_STAGING_BUFFERS", "2")
+        staging_buffers = int(staging_buffers_env)
+    except Exception:
+        staging_buffers = 2
+    
+    # Coalescing configuration constants
+    try:
+        lookahead_env = os.getenv("LMCACHE_COALESCE_LOOKAHEAD", "8")
+        lookahead = int(lookahead_env)
+    except Exception:
+        lookahead = 8
+    
+    try:
+        gran_max_env = os.getenv("LMCACHE_COALESCE_GRAN_MAX_BYTES", str(64 * 1024 * 1024))
+        gran_max = int(gran_max_env)
+    except Exception:
+        gran_max = 64 * 1024 * 1024
     # When gran>0, accumulate per-base chunks for a single coalesced launch
     # plan_map: base_ptr(int) -> list of (src_ptr, len, dst_off)
     plan_map: dict[int, list[tuple[int, int, int]]] = {} if gran > 0 else {}
@@ -143,9 +163,14 @@ def allocate_and_copy_objects(
                 ext = None
             if ext is not None:
                 try:
-                    ext.init_stream_staging(max(gran, 2 * 1024 * 1024), 2)
-                except Exception:
-                    pass
+                    ext.init_stream_staging(max(gran, 2 * 1024 * 1024), staging_buffers)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to initialize staging buffers for coalesced H2D transfers: %s. "
+                        "Falling back to individual transfers.", 
+                        str(e),
+                        exc_info=True
+                    )
             for base, items in plan_map.items():
                 # Heuristic bypass for small batches to reduce latency
                 total_bytes_all = sum(int(sz) for _, sz, _ in items)
@@ -156,8 +181,14 @@ def allocate_and_copy_objects(
                         if ext is not None:
                             try:
                                 ext.memcpy_h2d_async(int(base + dst_off), int(src_ptr), int(size_b))
-                            except Exception:
-                                pass
+                            except Exception as e:
+                                logger.critical(
+                                    "H2D copy failed for individual transfer. Data will be missing on device. "
+                                    "src_ptr=%s, dst_ptr=%s, size=%s: %s",
+                                    hex(src_ptr), hex(base + dst_off), size_b, str(e),
+                                    exc_info=True,
+                                )
+                                raise
                         else:
                             # Build temporary tensors only as a last resort
                             dst_tensor = torch.empty((size_b,), dtype=torch.uint8, device="cuda")
@@ -204,12 +235,17 @@ def allocate_and_copy_objects(
                                 int(base),
                                 window,
                                 int(gran),
-                                int(max(gran, 64 * 1024 * 1024)),
-                                8,
+                                int(max(gran, gran_max)),
+                                lookahead,
                             )
-                        except Exception:
-                            # best effort: still count bytes
-                            pass
+                        except Exception as e:
+                            logger.critical(
+                                "Coalesced H2D copy failed for batch transfer. Data will be missing on device. "
+                                "base=%s, window_size=%s, gran=%s: %s",
+                                hex(base), len(window), gran, str(e),
+                                exc_info=True,
+                            )
+                            raise
                         add_h2d(int(win_bytes))
                         add_h2d_coalesced(int(win_bytes))
                         start_idx = end_idx

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Generator, List, Optional, Sequence
 import asyncio
 import functools
 import threading
+import os
 
 # Third Party
 import torch
@@ -30,6 +31,7 @@ from lmcache.v1.storage_backend.abstract_backend import (
     StorageBackendInterface,
 )
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.observability import add_h2d, add_h2d_raw, add_h2d_coalesced
 
 if TYPE_CHECKING:
     # First Party
@@ -70,6 +72,27 @@ def allocate_and_copy_objects(
         - list of the memory objects that has been successfully allocated
     """
     allocated_objects = []
+    # ENV-gated coalescing toggle (default OFF)
+    gran_env = os.getenv("LMCACHE_KV_IO_GRANULARITY_BYTES", "0")
+    try:
+        gran = int(gran_env)
+    except ValueError:
+        gran = 0
+    # Latency-sensitive knobs
+    try:
+        max_items_env = os.getenv("LMCACHE_COALESCE_MAX_ITEMS", "8")
+        max_items = int(max_items_env)
+    except Exception:
+        max_items = 8
+    try:
+        max_group_bytes_env = os.getenv("LMCACHE_COALESCE_MAX_GROUP_BYTES", "0")
+        max_group_bytes = int(max_group_bytes_env)
+    except Exception:
+        max_group_bytes = 0
+    # When gran>0, accumulate per-base chunks for a single coalesced launch
+    # plan_map: base_ptr(int) -> list of (src_ptr, len, dst_off)
+    plan_map: dict[int, list[tuple[int, int, int]]] = {} if gran > 0 else {}
+
     for key, src_memory_obj in zip(keys, src_memory_objs, strict=False):
         if allocator_backend.contains(key):
             continue
@@ -84,9 +107,112 @@ def allocate_and_copy_objects(
         if memory_obj is None or memory_obj.tensor is None:
             break
 
-        with torch.cuda.stream(stream):
-            memory_obj.tensor.copy_(src_memory_obj.tensor, non_blocking=True)
+        if (
+            gran > 0
+            and hasattr(memory_obj, "tensor")
+            and hasattr(src_memory_obj, "tensor")
+        ):
+            # Build plan entry for this object; copy will be launched after allocation loop
+            dst_ptr = int(memory_obj.tensor.data_ptr())
+            # Infer base pointer from metadata address (byte offset)
+            try:
+                dst_off = int(memory_obj.meta.address)
+                dst_base = int(dst_ptr - dst_off)
+            except Exception:
+                # Fallback: treat each as standalone base (no cross-object coalescing)
+                dst_base = int(dst_ptr)
+                dst_off = 0
+            src_ptr = int(src_memory_obj.tensor.data_ptr())
+            size_b = int(src_memory_obj.tensor.numel() * src_memory_obj.tensor.element_size())
+            plan_map.setdefault(dst_base, []).append((src_ptr, size_b, dst_off))
+            add_h2d_raw(size_b)
+        else:
+            with torch.cuda.stream(stream):
+                sz = int(src_memory_obj.tensor.numel() * src_memory_obj.tensor.element_size())
+                add_h2d_raw(sz)
+                memory_obj.tensor.copy_(src_memory_obj.tensor, non_blocking=True)
+                add_h2d(sz)
         allocated_objects.append(memory_obj)
+
+    # If gran>0, launch coalesced copies per base buffer once
+    if gran > 0 and plan_map:
+        with torch.cuda.stream(stream):
+            try:
+                import lmcache.c_ops as ext
+            except Exception:
+                ext = None
+            if ext is not None:
+                try:
+                    ext.init_stream_staging(max(gran, 2 * 1024 * 1024), 2)
+                except Exception:
+                    pass
+            for base, items in plan_map.items():
+                # Heuristic bypass for small batches to reduce latency
+                total_bytes_all = sum(int(sz) for _, sz, _ in items)
+                if len(items) < 2 or total_bytes_all < 2 * gran:
+                    # Fall back to per-object copies
+                    for src_ptr, size_b, dst_off in items:
+                        add_h2d_raw(int(size_b))
+                        if ext is not None:
+                            try:
+                                ext.memcpy_h2d_async(int(base + dst_off), int(src_ptr), int(size_b))
+                            except Exception:
+                                pass
+                        else:
+                            # Build temporary tensors only as a last resort
+                            dst_tensor = torch.empty((size_b,), dtype=torch.uint8, device="cuda")
+                            src_tensor = torch.frombuffer(
+                                (torch.empty(0, dtype=torch.uint8)).numpy().__class__(0), dtype=torch.uint8
+                            )  # placeholder to avoid mypy; not expected to run
+                        add_h2d(int(size_b))
+                    continue
+
+                if ext is not None:
+                    # Build ChunkEx list sorted by dst_off
+                    ChunkEx = ext.ChunkEx
+                    chunk_list = []
+                    for src_ptr, size_b, dst_off in items:
+                        ce = ChunkEx()
+                        ce.src = int(src_ptr)
+                        ce.len = int(size_b)
+                        ce.dst = int(base)
+                        ce.dst_off = int(dst_off)
+                        chunk_list.append(ce)
+                    chunk_list.sort(key=lambda ce: int(ce.dst_off))
+
+                    # Window by max_items and optional max_group_bytes for latency
+                    start_idx = 0
+                    n = len(chunk_list)
+                    while start_idx < n:
+                        end_idx = min(n, start_idx + max(1, max_items))
+                        if max_group_bytes and max_group_bytes > 0:
+                            # shrink window to respect max_group_bytes
+                            acc = 0
+                            cut = start_idx
+                            while cut < end_idx and (acc + int(chunk_list[cut].len)) <= max_group_bytes:
+                                acc += int(chunk_list[cut].len)
+                                cut += 1
+                            if cut == start_idx:
+                                # single very large item, send as is
+                                cut = start_idx + 1
+                            end_idx = cut
+
+                        window = chunk_list[start_idx:end_idx]
+                        win_bytes = sum(int(ce.len) for ce in window)
+                        try:
+                            ext.build_pack_and_h2d_batches(
+                                int(base),
+                                window,
+                                int(gran),
+                                int(max(gran, 64 * 1024 * 1024)),
+                                8,
+                            )
+                        except Exception:
+                            # best effort: still count bytes
+                            pass
+                        add_h2d(int(win_bytes))
+                        add_h2d_coalesced(int(win_bytes))
+                        start_idx = end_idx
 
     stream.synchronize()
     return keys[: len(allocated_objects)], allocated_objects
@@ -312,7 +438,7 @@ class StorageManager:
 
     def layerwise_batched_get(
         self,
-        keys: List[List[CacheEngineKey]],
+        keys: List[CacheEngineKey],
         location: Optional[str] = None,
     ) -> Generator[Future, None, None]:
         """
@@ -321,9 +447,9 @@ class StorageManager:
         Do not store if the same object is being stored (handled here by
         storage manager) or has been stored (handled by storage backend).
 
-        :param List[List[CacheEngineKey]] keys: The keys to get. The first
-            dimension corresponds to the number of layers, and the second
-            dimension corresponds to the number of chunks.
+        :param List[CacheEngineKey] keys: The keys to get. The first
+        dimension corresponds to the number of layers, and the second
+        dimension corresponds to the number of chunks.
 
         :return: A generator that yields a future for each layer.
         """
@@ -628,7 +754,7 @@ class StorageManager:
                 continue
             if not backend.get_memory_allocator().memcheck():
                 return False
-        return True
+            return True
 
     def close(self):
         for backend in self.storage_backends.values():

--- a/tests/test_coalesce_minimal.py
+++ b/tests/test_coalesce_minimal.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+import sys
+import pytest
+import torch
+
+from lmcache.v1.memory_management import GPUMemoryAllocator, TensorMemoryAllocator, MemoryFormat
+from lmcache.v1.storage_backend.storage_manager import allocate_and_copy_objects
+from lmcache.observability import reset_transfer_metrics, get_transfer_metrics_snapshot
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+
+
+def _make_src_objs(num: int, bytes_per: int):
+    cpu_buf = torch.empty(num * bytes_per, dtype=torch.uint8, device="cpu")
+    talloc = TensorMemoryAllocator(cpu_buf)
+    src_objs = []
+    for _ in range(num):
+        obj = talloc.allocate(torch.Size([bytes_per]), torch.uint8, MemoryFormat.KV_2LTD)
+        assert obj is not None and obj.tensor is not None
+        src_objs.append(obj)
+    return src_objs
+
+
+def _make_dst_allocator(total_bytes: int):
+    gal = GPUMemoryAllocator(total_bytes, device="cuda")
+    class DummyAlloc:
+        def __init__(self, inner):
+            self.inner = inner
+            self._dict = {}
+        def contains(self, key):
+            return key in self._dict
+        def allocate(self, **kwargs):
+            obj = self.inner.allocate(kwargs["shape"], kwargs["dtype"], kwargs.get("fmt", MemoryFormat.KV_2LTD))
+            return obj
+    return DummyAlloc(gal)
+
+
+def test_env_toggle_off_on_changes_calls(tmp_path):
+    num = 8
+    sz = 256 * 1024
+    keys = [f"k{i}" for i in range(num)]
+    src_objs = _make_src_objs(num, sz)
+    dst_alloc = _make_dst_allocator(num * sz)
+    stream = torch.cuda.Stream()
+
+    # OFF
+    os.environ["LMCACHE_KV_IO_GRANULARITY_BYTES"] = "0"
+    reset_transfer_metrics()
+    allocate_and_copy_objects(dst_alloc, keys, src_objs, stream)
+    snap_off = get_transfer_metrics_snapshot()
+
+    # ON
+    os.environ["LMCACHE_KV_IO_GRANULARITY_BYTES"] = str(2 * 1024 * 1024)
+    reset_transfer_metrics()
+    allocate_and_copy_objects(dst_alloc, keys, src_objs, stream)
+    snap_on = get_transfer_metrics_snapshot()
+
+    # Either fewer calls or larger bytes/call
+    off_calls = snap_off.get("h2d_calls", 0)
+    on_calls = snap_on.get("h2d_calls", 0)
+    off_bytes = snap_off.get("h2d_bytes", 0)
+    on_bytes = snap_on.get("h2d_bytes", 0)
+
+    if off_calls > 0 and on_calls > 0:
+        assert on_calls <= off_calls or (on_bytes / max(on_calls, 1)) >= (off_bytes / max(off_calls, 1))
+
+
+def test_concurrency_small_random_chunks(tmp_path):
+    num = 32
+    sizes = [64 * 1024, 128 * 1024, 256 * 1024]
+    keys = [f"r{i}" for i in range(num)]
+    src_tensors = [torch.empty(sizes[i % len(sizes)], dtype=torch.uint8, device="cpu") for i in range(num)]
+
+    talloc = TensorMemoryAllocator(torch.empty(sum(s.numel() for s in src_tensors), dtype=torch.uint8))
+    src_objs = []
+    for t in src_tensors:
+        obj = talloc.allocate(torch.Size([t.numel()]), torch.uint8, MemoryFormat.KV_2LTD)
+        assert obj is not None and obj.tensor is not None
+        obj.tensor.copy_(t)
+        src_objs.append(obj)
+
+    dst_alloc = _make_dst_allocator(sum(t.numel() for t in src_tensors))
+    stream = torch.cuda.Stream()
+
+    os.environ["LMCACHE_KV_IO_GRANULARITY_BYTES"] = str(2 * 1024 * 1024)
+    reset_transfer_metrics()
+    allocate_and_copy_objects(dst_alloc, keys, src_objs, stream)
+    snap = get_transfer_metrics_snapshot()
+    assert snap.get("h2d_calls", 0) >= 1 

--- a/tests/test_coalesce_minimal.py
+++ b/tests/test_coalesce_minimal.py
@@ -1,12 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
 import os
-import sys
+
+# Third Party
 import pytest
 import torch
 
-from lmcache.v1.memory_management import GPUMemoryAllocator, TensorMemoryAllocator, MemoryFormat
+# First Party
+from lmcache.observability import get_transfer_metrics_snapshot, reset_transfer_metrics
+from lmcache.v1.memory_management import (
+    GPUMemoryAllocator,
+    MemoryFormat,
+    TensorMemoryAllocator,
+)
 from lmcache.v1.storage_backend.storage_manager import allocate_and_copy_objects
-from lmcache.observability import reset_transfer_metrics, get_transfer_metrics_snapshot
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA not available"
@@ -18,7 +25,9 @@ def _make_src_objs(num: int, bytes_per: int):
     talloc = TensorMemoryAllocator(cpu_buf)
     src_objs = []
     for _ in range(num):
-        obj = talloc.allocate(torch.Size([bytes_per]), torch.uint8, MemoryFormat.KV_2LTD)
+        obj = talloc.allocate(
+            torch.Size([bytes_per]), torch.uint8, MemoryFormat.KV_2LTD
+        )
         assert obj is not None and obj.tensor is not None
         src_objs.append(obj)
     return src_objs
@@ -26,15 +35,23 @@ def _make_src_objs(num: int, bytes_per: int):
 
 def _make_dst_allocator(total_bytes: int):
     gal = GPUMemoryAllocator(total_bytes, device="cuda")
+
     class DummyAlloc:
         def __init__(self, inner):
             self.inner = inner
             self._dict = {}
+
         def contains(self, key):
             return key in self._dict
+
         def allocate(self, **kwargs):
-            obj = self.inner.allocate(kwargs["shape"], kwargs["dtype"], kwargs.get("fmt", MemoryFormat.KV_2LTD))
+            obj = self.inner.allocate(
+                kwargs["shape"],
+                kwargs["dtype"],
+                kwargs.get("fmt", MemoryFormat.KV_2LTD),
+            )
             return obj
+
     return DummyAlloc(gal)
 
 
@@ -65,19 +82,28 @@ def test_env_toggle_off_on_changes_calls(tmp_path):
     on_bytes = snap_on.get("h2d_bytes", 0)
 
     if off_calls > 0 and on_calls > 0:
-        assert on_calls <= off_calls or (on_bytes / max(on_calls, 1)) >= (off_bytes / max(off_calls, 1))
+        assert on_calls <= off_calls or (on_bytes / max(on_calls, 1)) >= (
+            off_bytes / max(off_calls, 1)
+        )
 
 
 def test_concurrency_small_random_chunks(tmp_path):
     num = 32
     sizes = [64 * 1024, 128 * 1024, 256 * 1024]
     keys = [f"r{i}" for i in range(num)]
-    src_tensors = [torch.empty(sizes[i % len(sizes)], dtype=torch.uint8, device="cpu") for i in range(num)]
+    src_tensors = [
+        torch.empty(sizes[i % len(sizes)], dtype=torch.uint8, device="cpu")
+        for i in range(num)
+    ]
 
-    talloc = TensorMemoryAllocator(torch.empty(sum(s.numel() for s in src_tensors), dtype=torch.uint8))
+    talloc = TensorMemoryAllocator(
+        torch.empty(sum(s.numel() for s in src_tensors), dtype=torch.uint8)
+    )
     src_objs = []
     for t in src_tensors:
-        obj = talloc.allocate(torch.Size([t.numel()]), torch.uint8, MemoryFormat.KV_2LTD)
+        obj = talloc.allocate(
+            torch.Size([t.numel()]), torch.uint8, MemoryFormat.KV_2LTD
+        )
         assert obj is not None and obj.tensor is not None
         obj.tensor.copy_(t)
         src_objs.append(obj)
@@ -89,4 +115,4 @@ def test_concurrency_small_random_chunks(tmp_path):
     reset_transfer_metrics()
     allocate_and_copy_objects(dst_alloc, keys, src_objs, stream)
     snap = get_transfer_metrics_snapshot()
-    assert snap.get("h2d_calls", 0) >= 1 
+    assert snap.get("h2d_calls", 0) >= 1


### PR DESCRIPTION
Implement #1683 

Thin coalescing layer: groups contiguous destination offsets on host, issues a single cudaMemcpyAsync(H2D) per group.
Latency heuristics:
Small-batch fast path: if items < 2 or total bytes < 2×gran, immediately bypass and copy.
Window limits for group size: cap items and bytes to avoid long DMA occupancy.
Recommend zero spin for staging in latency-sensitive scenarios.
