### PR TITLE
feat: Optimize the response handling using ZMQ poll

### DIFF
--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -139,19 +139,46 @@ class LMCacheLookupClient(LookupClientInterface):
 
         results = []
         try:
+            # Send requests to all sockets first
             for i in range(ranks):
                 self.sockets[i].send_multipart(msg_buf, copy=False)
 
-            # TODO(Jiayi): we can use zmq poll to optimize a bit
-            for i in range(ranks):
-                resp = self.sockets[i].recv()
-                result = int.from_bytes(resp, "big")
-                results.append(result)
+            # Use ZMQ Poller to handle responses as they arrive
+            poller = zmq.Poller()
+            # Monitor for incoming messages
+            for socket in self.sockets:
+                poller.register(socket, zmq.POLLIN)
+
+            remaining_responses = ranks
+            while remaining_responses > 0:
+                # Wait for activity on any socket with timeout
+                # Returns list of (socket, event_mask) tuples for ready sockets
+                events = poller.poll(self.config.lookup_timeout_ms)
+
+                if not events:
+                    logger.error(f"Timeout waiting for {remaining_responses} responses")
+                    return 0
+
+                # Process all ready sockets
+                for socket, _ in events:
+                    try:
+                        # Receive response from ready socket
+                        resp = socket.recv()
+                        result = int.from_bytes(resp, "big")
+                        results.append(result)
+
+                        # Stop monitoring this socket
+                        poller.unregister(socket)
+                        remaining_responses -= 1
+                    except zmq.ZMQError as e:
+                        logger.error(f"ZMQ error receiving response: {str(e)}")
+                        return 0
+
         except zmq.Again:
-            logger.error(f"Timeout occurred for rank {i}")
+            logger.error("Timeout occurred during request processing")
             return 0
         except zmq.ZMQError as e:
-            logger.error(f"ZMQ error for rank {i}: {str(e)}")
+            logger.error(f"ZMQ error during request processing: {str(e)}")
             return 0
 
         assert len(results) == ranks


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

To optimize the response handling using `ZMQ poll`, we can leverage `zmq.Poller` to monitor multiple sockets simultaneously, allowing us to process responses as they arrive rather than waiting sequentially.

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
