### PR TITLE
[Bugfix]fix dataType of new_block_ids when update request tracker for vLLM 0.9.0 compatibility

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -207,9 +207,9 @@ class RequestTracker:
         )
 
     def update(
-        self,
-        new_token_ids: list[int],
-        new_block_ids: Union[Optional[tuple[list[int], ...]], list[int]],
+            self,
+            new_token_ids: list[int],
+            new_block_ids: Union[Optional[tuple[list[int], ...]], list[list[int]], list[int]],
     ) -> None:
         """Update the request tracker when a running request is
         scheduled again
@@ -224,6 +224,8 @@ class RequestTracker:
             new_block_ids = []
         elif len(new_block_ids) == 0:
             new_block_ids = []
+        elif isinstance(new_block_ids, tuple):
+            new_block_ids = new_block_ids[0]
         elif new_block_ids and isinstance(new_block_ids[0], list):
             new_block_ids = new_block_ids[0]
         elif isinstance(new_block_ids, list):

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -224,7 +224,7 @@ class RequestTracker:
             new_block_ids = []
         elif len(new_block_ids) == 0:
             new_block_ids = []
-        elif isinstance(new_block_ids, tuple):
+        elif isinstance(new_block_ids[0], list):
             new_block_ids = new_block_ids[0]
         elif isinstance(new_block_ids, list):
             pass

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -224,7 +224,7 @@ class RequestTracker:
             new_block_ids = []
         elif len(new_block_ids) == 0:
             new_block_ids = []
-        elif isinstance(new_block_ids[0], list):
+        elif new_block_ids and isinstance(new_block_ids[0], list):
             new_block_ids = new_block_ids[0]
         elif isinstance(new_block_ids, list):
             pass


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

FIX [TypeError When Update RequestTracker For vLLM 0.9.0](https://github.com/LMCache/LMCache/issues/1700)

For vLLM version = 0.9.0, type of request block_ids is List[List[]]. it will not go to 
` elif isinstance(new_block_ids, tuple):`, and there will be a TypeError for self.allocated_block_ids

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**
---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
