### PR TITLE
[core]Add cache/clear api to internal_api_server

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -980,11 +980,9 @@ class LMCacheEngine:
         if self.save_only_first_rank:
             if self.metadata.is_first_rank():
                 num_removed = self._clear(tokens, locations, request_configs)
-                self.broadcast_object_fn(num_removed, self.metadata.first_rank)
                 return num_removed
             else:
-                num_removed = self.broadcast_object_fn(None, self.metadata.first_rank)
-                return int(num_removed)
+                return 0
         return self._clear(tokens, locations, request_configs)
 
     def _clear(

--- a/lmcache/v1/internal_api_server/cache_api.py
+++ b/lmcache/v1/internal_api_server/cache_api.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import Annotated, List, Optional
+import json
 
 # Third Party
 from fastapi import APIRouter, Query
@@ -16,26 +17,69 @@ async def clear(
     locations: Annotated[Optional[List[str]], Query()] = None,
     request_configs: Optional[dict] = None,
 ):
+    """Clear cached data from the LMCache engine.
+
+    This endpoint provides a way to clear cached KV (Key-Value) data from the
+    LMCache engine. It can clear all cached data or selectively clear data
+    from specific storage locations.
+
+    Args:
+        request (Request): The FastAPI request object containing application state.
+        locations (Optional[List[str]], optional): List of storage backend locations
+            to clear cache from. If None, clears from all available locations.
+            Common values include ["LocalCPUBackend", "LocalDiskBackend"].
+            Defaults to None.
+        request_configs (Optional[dict], optional): Additional configuration
+            parameters for the clear operation. Currently unused but reserved
+            for future extensions. Defaults to None.
+
+    Returns:
+        PlainTextResponse: A plain text response
+
+    Example:
+        Clear all cached data:
+        ```bash
+        curl -X DELETE "http://localhost:8000/cache/clear"
+        # Response: {"status": "success", "num_removed": 10,
+        #           "locations": null, "request_configs": null}
+        ```
+
+        Clear cache from specific locations:
+        ```bash
+        curl -X DELETE "http://localhost:8000/cache/clear?locations=LocalCPUBackend&locations=LocalDiskBackend"
+        # Response: {"status": "success", "num_removed": 5,
+        #           "locations": ["LocalCPUBackend", "LocalDiskBackend"],
+        #           "request_configs": null}
+        ```
+    """
     try:
         lmcache_adapter = request.app.state.lmcache_adapter
-        if not hasattr(lmcache_adapter, "lmcache_engine"):
-            return PlainTextResponse(
-                content="/cache/clear api only work for lmcache_engine", status_code=500
-            )
-
-        lmcache_engine = lmcache_adapter.lmcache_engine
+        lmcache_engine = getattr(lmcache_adapter, "lmcache_engine", None)
         if not lmcache_engine:
+            error_info = {
+                "error": "/cache/clear API is unavailable",
+                "message": "LMCache engine not configured.",
+            }
             return PlainTextResponse(
-                content="/cache/clear api only work for lmcache_engine", status_code=500
+                content=json.dumps(error_info, indent=2),
+                media_type="application/json",
+                status_code=503,  # Service Unavailable
             )
         num_removed = lmcache_engine.clear(
             locations=locations, request_configs=request_configs
         )
+        success_info = {
+            "status": "success",
+            "num_removed": num_removed,
+        }
         return PlainTextResponse(
-            content=f"num_removed: {num_removed}",
+            content=json.dumps(success_info, indent=2),
+            media_type="application/json",
         )
     except Exception as e:
+        error_info = {"error": "Failed to clear cache", "message": str(e)}
         return PlainTextResponse(
-            content=f"Error: Failed to clear cache - {str(e)}",
+            content=json.dumps(error_info, indent=2),
+            media_type="application/json",
             status_code=500,
         )

--- a/lmcache/v1/internal_api_server/cache_api.py
+++ b/lmcache/v1/internal_api_server/cache_api.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Annotated, List, Optional
+
+# Third Party
+from fastapi import APIRouter, Query
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+router = APIRouter()
+
+
+@router.delete("/cache/clear")
+async def clear(
+    request: Request,
+    locations: Annotated[Optional[List[str]], Query()] = None,
+    request_configs: Optional[dict] = None,
+):
+    try:
+        lmcache_adapter = request.app.state.lmcache_adapter
+        if not hasattr(lmcache_adapter, "lmcache_engine"):
+            return PlainTextResponse(
+                content="/cache/clear api only work for lmcache_engine", status_code=500
+            )
+
+        lmcache_engine = lmcache_adapter.lmcache_engine
+        if not lmcache_engine:
+            return PlainTextResponse(
+                content="/cache/clear api only work for lmcache_engine", status_code=500
+            )
+        num_removed = lmcache_engine.clear(
+            locations=locations, request_configs=request_configs
+        )
+        return PlainTextResponse(
+            content=f"num_removed: {num_removed}",
+        )
+    except Exception as e:
+        return PlainTextResponse(
+            content=f"Error: Failed to clear cache - {str(e)}",
+            status_code=500,
+        )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,6 +4,7 @@ aiohttp
 awscrt
 cufile-python
 fastapi
+httpx
 msgspec
 numpy
 nvtx

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -31,3 +31,4 @@ sortedcontainers
 # 4. this torch version may also be overridden inside of LMCache/docker/Dockerfile
 torch
 transformers >= 4.51.1
+uvicorn

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,6 +3,7 @@ aiofiles
 aiohttp
 awscrt
 cufile-python
+fastapi
 msgspec
 numpy
 nvtx

--- a/tests/v1/internal_api_server/test_cache_clear.py
+++ b/tests/v1/internal_api_server/test_cache_clear.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.cache_engine import LMCacheEngine
+from lmcache.v1.internal_api_server.api_server import app
+
+
+class TestCacheClearAPI:
+    """Test suite for the /cache/clear API endpoint."""
+
+    @pytest.fixture
+    def mock_lmcache_adapter(self):
+        """Create a mock LMCacheConnectorV1Impl adapter."""
+        adapter = MagicMock()
+
+        # Create a mock LMCache engine
+        mock_engine = MagicMock(spec=LMCacheEngine)
+        mock_engine.clear.return_value = 5  # Mock return value for clear operation
+
+        adapter.lmcache_engine = mock_engine
+        return adapter
+
+    @pytest.fixture
+    def client_with_adapter(self, mock_lmcache_adapter):
+        """Create a test client with mocked adapter."""
+        app.state.lmcache_adapter = mock_lmcache_adapter
+        return TestClient(app)
+
+    @pytest.fixture
+    def client_without_engine(self):
+        """Create a test client without lmcache_engine."""
+        mock_adapter = MagicMock()
+        mock_adapter.lmcache_engine = None
+        app.state.lmcache_adapter = mock_adapter
+        return TestClient(app)
+
+    def test_cache_clear_success(self, client_with_adapter, mock_lmcache_adapter):
+        """Test successful cache clear operation."""
+        # Act
+        response = client_with_adapter.delete("/cache/clear")
+
+        # Assert
+        assert response.status_code == 200
+        assert response.text == "num_removed: 5"
+
+        # Verify that the clear method was called with correct parameters
+        mock_lmcache_adapter.lmcache_engine.clear.assert_called_once_with(
+            locations=None, request_configs=None
+        )
+
+    @pytest.mark.parametrize(
+        "locations,test_description",
+        [
+            (["LocalCPUBackend", "LocalDiskBackend"], "multiple locations"),
+            (["LocalCPUBackend"], "single location"),
+        ],
+    )
+    def test_cache_clear_with_locations(
+        self, client_with_adapter, mock_lmcache_adapter, locations, test_description
+    ):
+        """Test cache clear with specific locations."""
+        # Act
+        # curl -X DELETE "http://localhost:8000/cache/clear?locations=LocalCPUBackend&locations=LocalDiskBackend"
+        response = client_with_adapter.delete(
+            "/cache/clear", params={"locations": locations}
+        )
+
+        # Assert
+        assert response.status_code == 200
+        assert response.text == "num_removed: 5"
+
+        # Verify that the clear method was called with the correct locations
+        mock_lmcache_adapter.lmcache_engine.clear.assert_called_once()
+        call_args = mock_lmcache_adapter.lmcache_engine.clear.call_args
+
+        # Verify the locations parameter was passed correctly
+        assert call_args is not None
+        assert "locations" in call_args.kwargs
+        assert "request_configs" in call_args.kwargs
+
+        # Assert that the locations parameter matches what we sent
+        assert call_args.kwargs["locations"] == locations
+
+    def test_cache_clear_engine_exception(
+        self, client_with_adapter, mock_lmcache_adapter
+    ):
+        """Test cache clear when engine raises an exception."""
+        # Arrange
+        mock_lmcache_adapter.lmcache_engine.clear.side_effect = Exception("Cache error")
+
+        # Act
+        response = client_with_adapter.delete("/cache/clear")
+
+        # Assert
+        assert response.status_code == 500
+        assert "Error: Failed to clear cache - Cache error" in response.text
+
+    def test_cache_clear_negative_return_value(
+        self, client_with_adapter, mock_lmcache_adapter
+    ):
+        """Test cache clear when engine returns negative value (edge case)."""
+        # Arrange
+        mock_lmcache_adapter.lmcache_engine.clear.return_value = -1
+
+        # Act
+        response = client_with_adapter.delete("/cache/clear")
+
+        # Assert
+        assert response.status_code == 200
+        assert response.text == "num_removed: -1"
+
+    def test_cache_clear_adapter_attribute_error(self):
+        """Test cache clear when adapter doesn't have lmcache_engine attribute."""
+        # Arrange
+        mock_adapter = MagicMock()
+        del mock_adapter.lmcache_engine  # Remove the attribute
+        app.state.lmcache_adapter = mock_adapter
+        client = TestClient(app)
+
+        # Act
+        response = client.delete("/cache/clear")
+
+        # Assert
+        assert response.status_code == 500
+        assert "/cache/clear api only work for lmcache_engine" in response.text

--- a/tests/v1/internal_api_server/test_cache_clear.py
+++ b/tests/v1/internal_api_server/test_cache_clear.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from unittest.mock import MagicMock
+import json
 
 # Third Party
 from fastapi.testclient import TestClient
@@ -32,14 +33,6 @@ class TestCacheClearAPI:
         app.state.lmcache_adapter = mock_lmcache_adapter
         return TestClient(app)
 
-    @pytest.fixture
-    def client_without_engine(self):
-        """Create a test client without lmcache_engine."""
-        mock_adapter = MagicMock()
-        mock_adapter.lmcache_engine = None
-        app.state.lmcache_adapter = mock_adapter
-        return TestClient(app)
-
     def test_cache_clear_success(self, client_with_adapter, mock_lmcache_adapter):
         """Test successful cache clear operation."""
         # Act
@@ -47,7 +40,9 @@ class TestCacheClearAPI:
 
         # Assert
         assert response.status_code == 200
-        assert response.text == "num_removed: 5"
+        response_data = json.loads(response.text)
+        assert response_data["status"] == "success"
+        assert response_data["num_removed"] == 5
 
         # Verify that the clear method was called with correct parameters
         mock_lmcache_adapter.lmcache_engine.clear.assert_called_once_with(
@@ -73,7 +68,9 @@ class TestCacheClearAPI:
 
         # Assert
         assert response.status_code == 200
-        assert response.text == "num_removed: 5"
+        response_data = json.loads(response.text)
+        assert response_data["status"] == "success"
+        assert response_data["num_removed"] == 5
 
         # Verify that the clear method was called with the correct locations
         mock_lmcache_adapter.lmcache_engine.clear.assert_called_once()
@@ -99,7 +96,9 @@ class TestCacheClearAPI:
 
         # Assert
         assert response.status_code == 500
-        assert "Error: Failed to clear cache - Cache error" in response.text
+        response_data = json.loads(response.text)
+        assert response_data["error"] == "Failed to clear cache"
+        assert response_data["message"] == "Cache error"
 
     def test_cache_clear_negative_return_value(
         self, client_with_adapter, mock_lmcache_adapter
@@ -113,19 +112,23 @@ class TestCacheClearAPI:
 
         # Assert
         assert response.status_code == 200
-        assert response.text == "num_removed: -1"
+        response_data = json.loads(response.text)
+        assert response_data["status"] == "success"
+        assert response_data["num_removed"] == -1
 
     def test_cache_clear_adapter_attribute_error(self):
         """Test cache clear when adapter doesn't have lmcache_engine attribute."""
-        # Arrange
-        mock_adapter = MagicMock()
-        del mock_adapter.lmcache_engine  # Remove the attribute
-        app.state.lmcache_adapter = mock_adapter
-        client = TestClient(app)
 
+        # Arrange
+        class AdapterWithoutEngine:
+            pass
+
+        app.state.lmcache_adapter = AdapterWithoutEngine()
+        client = TestClient(app)
         # Act
         response = client.delete("/cache/clear")
-
         # Assert
-        assert response.status_code == 500
-        assert "/cache/clear api only work for lmcache_engine" in response.text
+        assert response.status_code == 503
+        response_data = json.loads(response.text)
+        assert response_data["error"] == "/cache/clear API is unavailable"
+        assert response_data["message"] == "LMCache engine not configured."


### PR DESCRIPTION
# Description

This PR add a new API `cache/clear`, it allows to clear the cache belongs specified backend or all backends if not specified.

# Test

Add some of UTs.