### PR TITLE
[minor fix] use parent __init__ to init meta

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -336,8 +336,8 @@ class TensorMemoryObj(MemoryObj):
         parent_allocator: Optional["MemoryAllocatorInterface"],
     ):
         assert metadata.dtype is not None, "dtype must be specified for TensorMemoryObj"
+        super().__init__(metadata)
         self.raw_data = raw_data
-        self.meta = metadata
         self.valid = True
         self.lock = threading.Lock()
         self.parent_allocator = parent_allocator
@@ -486,7 +486,7 @@ class BytesBufferMemoryObj(MemoryObj):
         self.raw_data = raw_bytes
         if metadata is None:
             bytes_shape = torch.Size([len(self.raw_data), 0, 0, 0])
-            self.meta = MemoryObjMetadata(
+            metadata = MemoryObjMetadata(
                 shape=bytes_shape,
                 dtype=None,
                 address=0,
@@ -495,8 +495,7 @@ class BytesBufferMemoryObj(MemoryObj):
                 pin_count=0,
                 fmt=MemoryFormat.BINARY_BUFFER,
             )
-        else:
-            self.meta = metadata
+        super().__init__(metadata)
         self.valid = True
 
     def invalidate(self):


### PR DESCRIPTION
we can use `super().__init__` to init `self.meta`