### PR TITLE
[Core] Remove `lookup_id` and use `req_id` instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ lmcache/experimental/tests
 /examples/offline_inference/buggy_example.py
 /examples/test_example
 
+# benchmark results
+*.csv
+
 # disk cache
 /remote_disk
 /local_disk

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -547,7 +547,7 @@ def _init_lmcache_engine(
 @dataclass
 class LMCacheConnectorMetadata(KVConnectorMetadata):
     requests: list[ReqMeta] = field(default_factory=list)
-    lookup_requests_in_step: list[str] = field(default_factory=list)
+    # lookup_requests_in_step: list[str] = field(default_factory=list)
 
     @_lmcache_nvtx_annotate
     def add_request(self, req_meta: ReqMeta) -> None:
@@ -602,7 +602,7 @@ class LMCacheConnectorV1Impl:
                 vllm_config, config
             )
             self._unfinished_requests: dict[str, Request] = {}
-            self._lookup_requests_in_step: list[str] = []
+            # self._lookup_requests_in_step: list[str] = []
             self.lmcache_engine = None
         else:
             self.lmcache_engine = _init_lmcache_engine(
@@ -1022,7 +1022,7 @@ class LMCacheConnectorV1Impl:
         connector_metadata = self._parent._get_connector_metadata()
         assert isinstance(connector_metadata, LMCacheConnectorMetadata)
 
-        self.lmcache_engine.lookup_unpin(connector_metadata.lookup_requests_in_step)
+        # self.lmcache_engine.lookup_unpin(connector_metadata.lookup_requests_in_step)
 
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
@@ -1031,6 +1031,10 @@ class LMCacheConnectorV1Impl:
         if self.use_layerwise:
             for layerwise_storer in self.layerwise_storers:
                 next(layerwise_storer)
+            
+            # unpin the kv caches according to req_id
+            for request in connector_metadata.requests:
+                self.lmcache_engine.lookup_unpin(request.req_id)
             return
 
         assert len(self.kv_caches) > 0
@@ -1039,6 +1043,10 @@ class LMCacheConnectorV1Impl:
         assert self.lmcache_engine is not None
 
         for request in connector_metadata.requests:
+            
+            # unpin the kv caches according to req_id
+            self.lmcache_engine.lookup_unpin(request.req_id)
+
             save_spec = request.save_spec
             if (
                 save_spec is None or not save_spec.can_save
@@ -1157,12 +1165,12 @@ class LMCacheConnectorV1Impl:
         request_configs = extract_request_configs(request.sampling_params)
         if self.skip_last_n_tokens > 0:
             token_ids = token_ids[: -self.skip_last_n_tokens]
-        if self.async_loading:
-            lookup_id = request.request_id
-        else:
-            lookup_id = str(uuid.uuid4())
+        #if self.async_loading:
+        lookup_id = request.request_id
+        # else:
+        #    lookup_id = str(uuid.uuid4())
 
-        self._lookup_requests_in_step.append(lookup_id)
+        # self._lookup_requests_in_step.append(lookup_id)
 
         num_external_hit_tokens = self.lookup_client.lookup(
             token_ids,
@@ -1219,6 +1227,10 @@ class LMCacheConnectorV1Impl:
         For SharedStorageConnector, update _request_needs_load
         if the CacheManager this allocated blocks for us.
         """
+
+        # Clear local status in lookup client when a new request is
+        # successfully scheduled.
+        self.lookup_client.clear_lookup_status(request.request_id)
 
         kv_transfer_params = (
             request.kv_transfer_params
@@ -1291,8 +1303,8 @@ class LMCacheConnectorV1Impl:
         meta = LMCacheConnectorMetadata()
 
         # set and update lookup requests for unpin
-        meta.lookup_requests_in_step = self._lookup_requests_in_step
-        self._lookup_requests_in_step = []
+        # meta.lookup_requests_in_step = self._lookup_requests_in_step
+        # self._lookup_requests_in_step = []
 
         for finished_req_id in scheduler_output.finished_req_ids:
             self._request_trackers.pop(finished_req_id, None)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
 import os
-import uuid
 
 # Third Party
 from vllm.config import (
@@ -547,7 +546,6 @@ def _init_lmcache_engine(
 @dataclass
 class LMCacheConnectorMetadata(KVConnectorMetadata):
     requests: list[ReqMeta] = field(default_factory=list)
-    # lookup_requests_in_step: list[str] = field(default_factory=list)
 
     @_lmcache_nvtx_annotate
     def add_request(self, req_meta: ReqMeta) -> None:
@@ -602,7 +600,6 @@ class LMCacheConnectorV1Impl:
                 vllm_config, config
             )
             self._unfinished_requests: dict[str, Request] = {}
-            # self._lookup_requests_in_step: list[str] = []
             self.lmcache_engine = None
         else:
             self.lmcache_engine = _init_lmcache_engine(
@@ -1022,8 +1019,6 @@ class LMCacheConnectorV1Impl:
         connector_metadata = self._parent._get_connector_metadata()
         assert isinstance(connector_metadata, LMCacheConnectorMetadata)
 
-        # self.lmcache_engine.lookup_unpin(connector_metadata.lookup_requests_in_step)
-
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
             return
@@ -1031,7 +1026,7 @@ class LMCacheConnectorV1Impl:
         if self.use_layerwise:
             for layerwise_storer in self.layerwise_storers:
                 next(layerwise_storer)
-            
+
             # unpin the kv caches according to req_id
             for request in connector_metadata.requests:
                 self.lmcache_engine.lookup_unpin(request.req_id)
@@ -1043,7 +1038,6 @@ class LMCacheConnectorV1Impl:
         assert self.lmcache_engine is not None
 
         for request in connector_metadata.requests:
-            
             # unpin the kv caches according to req_id
             self.lmcache_engine.lookup_unpin(request.req_id)
 
@@ -1165,12 +1159,8 @@ class LMCacheConnectorV1Impl:
         request_configs = extract_request_configs(request.sampling_params)
         if self.skip_last_n_tokens > 0:
             token_ids = token_ids[: -self.skip_last_n_tokens]
-        #if self.async_loading:
-        lookup_id = request.request_id
-        # else:
-        #    lookup_id = str(uuid.uuid4())
 
-        # self._lookup_requests_in_step.append(lookup_id)
+        lookup_id = request.request_id
 
         num_external_hit_tokens = self.lookup_client.lookup(
             token_ids,
@@ -1301,10 +1291,6 @@ class LMCacheConnectorV1Impl:
         force_skip_save = self.kv_role == "kv_consumer" or self.force_skip_save
 
         meta = LMCacheConnectorMetadata()
-
-        # set and update lookup requests for unpin
-        # meta.lookup_requests_in_step = self._lookup_requests_in_step
-        # self._lookup_requests_in_step = []
 
         for finished_req_id in scheduler_output.finished_req_ids:
             self._request_trackers.pop(finished_req_id, None)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -740,7 +740,6 @@ class LMCacheEngine:
             if pin:
                 self.storage_manager.touch_cache()
 
-    # FIXME
     @_lmcache_nvtx_annotate
     def move(
         self,
@@ -963,11 +962,10 @@ class LMCacheEngine:
         return num_tokens
 
     @_lmcache_nvtx_annotate
-    def lookup_unpin(self, lookup_ids: list[str]) -> None:
-        for lookup_id in lookup_ids:
-            if lookup_id in self.lookup_pins:
-                self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
-                del self.lookup_pins[lookup_id]
+    def lookup_unpin(self, lookup_id: str) -> None:
+        if lookup_id in self.lookup_pins:
+            self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
+            del self.lookup_pins[lookup_id]
 
     @_lmcache_nvtx_annotate
     def clear(

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -51,3 +51,12 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
             True if producer reuse is supported, False otherwise
         """
         return False
+    
+    def clear_lookup_status(self, lookup_id: str) -> None:
+        """
+        Clear temporary lookup status for a given lookup ID.
+
+        Args:
+            lookup_id: The lookup ID whose status needs to be cleared.
+        """
+        return

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -51,7 +51,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
             True if producer reuse is supported, False otherwise
         """
         return False
-    
+
     def clear_lookup_status(self, lookup_id: str) -> None:
         """
         Clear temporary lookup status for a given lookup ID.

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -5,7 +5,7 @@ import threading
 import time
 
 # Third Party
-from vllm.utils import make_zmq_socket
+from vllm.utils import make_zmq_socket, get_zmq_context
 import msgspec
 import torch
 import zmq
@@ -42,7 +42,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         metadata, config = create_lmcache_metadata(vllm_config)
 
         self.encoder = msgspec.msgpack.Encoder()
-        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        self.ctx = get_zmq_context(use_asyncio=False)
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
         )
@@ -107,15 +107,15 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         # (e.g., worker process).
         self.lock = threading.Lock()
 
-        # map from lookup_id to req's status.
+        # map from lookup_id (i.e., req_id) to req's status.
         # None indicates ongoing.
         # int indicates number of hit tokens.
         self.reqs_status: dict[str, Optional[int]] = {}
 
-        # map from lookup_id to number of hit tokens for each worker
+        # map from lookup_id (i.e., req_id) to number of hit tokens for each worker
         self.res_for_each_worker: dict[str, list[int]] = {}
 
-        # The two parts are [lookup_id, num_hit_tokens]
+        # The two parts are [lookup_id (i.e., req_id), num_hit_tokens]
         self.num_parts = 2
 
         self.running = True
@@ -146,7 +146,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 time.sleep(self.lookup_backoff_time)
                 return None
             elif req_status != -1:
-                self.reqs_status.pop(lookup_id)
+                # self.reqs_status.pop(lookup_id)
                 return req_status
             self.reqs_status[lookup_id] = None
         hashes = []
@@ -207,6 +207,10 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                     # can use the minimum value as the number of
                     # hit tokens.
                     self.reqs_status[lookup_id] = min(all_res)
+    
+    def clear_lookup_status(self, lookup_id: str) -> None:
+        with self.lock:
+            self.reqs_status.pop(lookup_id, None)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports producer kvcache reuse"""

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -5,7 +5,6 @@ import threading
 import time
 
 # Third Party
-from vllm.utils import get_zmq_context, make_zmq_socket
 import msgspec
 import torch
 import zmq
@@ -15,7 +14,11 @@ from lmcache.integration.vllm.utils import create_lmcache_metadata, mla_enabled
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
-from lmcache.v1.rpc_utils import get_zmq_rpc_path_lmcache
+from lmcache.v1.rpc_utils import (
+    get_zmq_context,
+    get_zmq_rpc_path_lmcache,
+    get_zmq_socket,
+)
 
 if TYPE_CHECKING:
     # Third Party
@@ -66,11 +69,12 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 f"with worker socket path {worker_socket_path}"
             )
 
-            push_socket = make_zmq_socket(
+            push_socket = get_zmq_socket(
                 self.ctx,
                 worker_socket_path,
+                "ipc",
                 zmq.PUSH,  # type: ignore[attr-defined]
-                bind=False,
+                "connect",
             )
 
             self.push_sockets.append(push_socket)
@@ -78,11 +82,12 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         scheduler_socket_path = get_zmq_rpc_path_lmcache(
             vllm_config, "lookup_scheduler", rpc_port, 0
         )
-        self.pull_socket = make_zmq_socket(
+        self.pull_socket = get_zmq_socket(
             self.ctx,
             scheduler_socket_path,
+            "ipc",
             zmq.PULL,  # type: ignore[attr-defined]
-            bind=True,
+            "bind",
         )
         logger.info(
             f"lmcache lookup client connect to scheduler "
@@ -244,17 +249,19 @@ class LMCacheAsyncLookupServer:
         scheduler_socket_path = get_zmq_rpc_path_lmcache(
             vllm_config, "lookup_scheduler", rpc_port, 0
         )
-        self.push_socket = make_zmq_socket(
+        self.push_socket = get_zmq_socket(
             self.ctx,
             scheduler_socket_path,
+            "ipc",
             zmq.PUSH,  # type: ignore[attr-defined]
-            bind=False,
+            "connect",
         )
-        self.pull_socket = make_zmq_socket(
+        self.pull_socket = get_zmq_socket(
             self.ctx,
             worker_socket_path,
+            "ipc",
             zmq.PULL,  # type: ignore[attr-defined]
-            bind=True,
+            "bind",
         )
 
         self.lmcache_engine = lmcache_engine

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -5,7 +5,7 @@ import threading
 import time
 
 # Third Party
-from vllm.utils import make_zmq_socket, get_zmq_context
+from vllm.utils import get_zmq_context, make_zmq_socket
 import msgspec
 import torch
 import zmq
@@ -146,7 +146,6 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 time.sleep(self.lookup_backoff_time)
                 return None
             elif req_status != -1:
-                # self.reqs_status.pop(lookup_id)
                 return req_status
             self.reqs_status[lookup_id] = None
         hashes = []
@@ -207,7 +206,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                     # can use the minimum value as the number of
                     # hit tokens.
                     self.reqs_status[lookup_id] = min(all_res)
-    
+
     def clear_lookup_status(self, lookup_id: str) -> None:
         with self.lock:
             self.reqs_status.pop(lookup_id, None)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -5,7 +5,7 @@ import json
 import threading
 
 # Third Party
-from vllm.utils import make_zmq_socket
+from vllm.utils import make_zmq_socket, get_zmq_context
 import msgspec
 import torch
 import zmq
@@ -40,7 +40,7 @@ class LMCacheLookupClient(LookupClientInterface):
         metadata, config = create_lmcache_metadata(vllm_config)
 
         self.encoder = msgspec.msgpack.Encoder()
-        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        self.ctx = get_zmq_context(use_asyncio=False)
         self.config = config
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
@@ -59,6 +59,13 @@ class LMCacheLookupClient(LookupClientInterface):
 
         # Set timeout values from config
         timeout_ms = config.lookup_timeout_ms
+
+        # NOTE: map from lookup_id (i.e., req_id) to req's status.
+        # int indicates number of hit tokens.
+        # The assumption here is that once a request is looked up,
+        # the following lookups of the same request must have the
+        # same result.
+        self.req_status: dict[str, int] = {}
 
         for tp_rank in range(ranks):
             socket_path = get_zmq_rpc_path_lmcache(
@@ -95,7 +102,6 @@ class LMCacheLookupClient(LookupClientInterface):
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
 
-    # FIXME(Jiayi): Cacheblend need token ids
     def lookup(
         self,
         token_ids: Union[torch.Tensor, list[int]],
@@ -163,7 +169,14 @@ class LMCacheLookupClient(LookupClientInterface):
         # NOTE: it is possible that the number of hit tokens is different
         # across TP ranks, so we can use the minimum value as the
         # number of hit tokens.
-        return min(results)
+        num_hit_toks = min(results)
+        self.req_status[lookup_id] = num_hit_toks
+
+        return num_hit_toks
+    
+    def clear_lookup_status(self, lookup_id: str) -> None:
+        with self.lock:
+            self.reqs_status.pop(lookup_id, None)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports producer kvcache reuse"""

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -112,6 +112,10 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
+        cached_num_hit_toks = self.reqs_status.get(lookup_id, None)
+        if cached_num_hit_toks is not None:
+            return cached_num_hit_toks
+
         lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -5,7 +5,7 @@ import json
 import threading
 
 # Third Party
-from vllm.utils import make_zmq_socket, get_zmq_context
+from vllm.utils import get_zmq_context, make_zmq_socket
 import msgspec
 import torch
 import zmq
@@ -65,7 +65,7 @@ class LMCacheLookupClient(LookupClientInterface):
         # The assumption here is that once a request is looked up,
         # the following lookups of the same request must have the
         # same result.
-        self.req_status: dict[str, int] = {}
+        self.reqs_status: dict[str, int] = {}
 
         for tp_rank in range(ranks):
             socket_path = get_zmq_rpc_path_lmcache(
@@ -170,13 +170,12 @@ class LMCacheLookupClient(LookupClientInterface):
         # across TP ranks, so we can use the minimum value as the
         # number of hit tokens.
         num_hit_toks = min(results)
-        self.req_status[lookup_id] = num_hit_toks
+        self.reqs_status[lookup_id] = num_hit_toks
 
         return num_hit_toks
-    
+
     def clear_lookup_status(self, lookup_id: str) -> None:
-        with self.lock:
-            self.reqs_status.pop(lookup_id, None)
+        self.reqs_status.pop(lookup_id, None)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports producer kvcache reuse"""

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -5,7 +5,6 @@ import json
 import threading
 
 # Third Party
-from vllm.utils import get_zmq_context, make_zmq_socket
 import msgspec
 import torch
 import zmq
@@ -15,7 +14,11 @@ from lmcache.integration.vllm.utils import create_lmcache_metadata, mla_enabled
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
-from lmcache.v1.rpc_utils import get_zmq_rpc_path_lmcache
+from lmcache.v1.rpc_utils import (
+    get_zmq_context,
+    get_zmq_rpc_path_lmcache,
+    get_zmq_socket,
+)
 
 if TYPE_CHECKING:
     # Third Party
@@ -75,11 +78,12 @@ class LMCacheLookupClient(LookupClientInterface):
                 f"lmcache lookup client connect to tp_rank {tp_rank} "
                 f"with socket path {socket_path}"
             )
-            socket = make_zmq_socket(
+            socket = get_zmq_socket(
                 self.ctx,
                 socket_path,
-                zmq.REQ,  # type: ignore[attr-defined]
-                bind=False,
+                "ipc",
+                zmq.REQ,
+                "connect",
             )
 
             # Set socket timeout during initialization
@@ -207,11 +211,12 @@ class LMCacheLookupServer:
         socket_path = get_zmq_rpc_path_lmcache(
             vllm_config, "lookup", rpc_port, vllm_config.parallel_config.rank
         )
-        self.socket = make_zmq_socket(
+        self.socket = get_zmq_socket(
             self.ctx,
             socket_path,
+            "ipc",
             zmq.REP,  # type: ignore[attr-defined]
-            bind=True,
+            "bind",
         )
 
         self.lmcache_engine = lmcache_engine

--- a/lmcache/v1/rpc_utils.py
+++ b/lmcache/v1/rpc_utils.py
@@ -113,7 +113,7 @@ def get_zmq_rpc_path_lmcache(
     )
 
     socket_path = (
-        f"ipc://{base_url}/engine_{engine_id}_service_{service_name}_"
+        f"{base_url}/engine_{engine_id}_service_{service_name}_"
         f"lmcache_rpc_port_{rpc_port}"
     )
 


### PR DESCRIPTION
Remove `lookup_id` and use `req_id` instead

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
