### PR TITLE
[Benchmark] Emphasize query round results in long_doc_qa

### DIFF
--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -487,12 +487,10 @@ async def main(args):
     query_mean_ttft = benchmark_df["ttft"].mean()
     CSI = "\x1b["
     RESET = CSI + "0m"
+    print(f"Warmup round mean TTFT: {warmup_mean_ttft:.3f}s")
+    print(f"Warmup round time: {warmup_end_time - warmup_start_time:.3f}s")
+    print(f"Warmup round prompt count: {len(warmup_df)}")
     print(f"{CSI}36;1m\n=== BENCHMARK RESULTS ==={RESET}")
-    print(f"{CSI}32mWarmup round mean TTFT: {warmup_mean_ttft:.3f}s{RESET}")
-    print(
-        f"{CSI}33mWarmup round time: {warmup_end_time - warmup_start_time:.3f}s{RESET}"
-    )
-    print(f"{CSI}35mWarmup round prompt count: {len(warmup_df)}{RESET}")
     print(f"{CSI}32mQuery round mean TTFT: {query_mean_ttft:.3f}s{RESET}")
     print(
         f"{CSI}33mQuery round time: "


### PR DESCRIPTION
Make it less misleading to general users

Before
<img width="552" height="250" alt="CleanShot 2025-09-30 at 13 05 46@2x" src="https://github.com/user-attachments/assets/f351d830-24fd-4d82-996e-f4ac1c461917" />

After
<img width="572" height="278" alt="CleanShot 2025-09-30 at 13 08 23@2x" src="https://github.com/user-attachments/assets/42fe6aaf-6ffe-4ca4-90ed-8046f0cb620e" />


FIX #xxxx (*link existing issues this PR will resolve*)

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
