### PR TITLE
[Feat] Generate random instance id when the instance id is not defined

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 import json
 import os
 import re
+import uuid
 
 # Third Party
 import yaml
@@ -177,7 +178,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "lmcache_instance_id": {
         "type": str,
-        "default": "lmcache_default_instance",
+        "default": None,
         "env_converter": str,
     },
     "controller_pull_url": {
@@ -404,6 +405,9 @@ def _create_config_class():
     from dataclasses import make_dataclass
 
     def _post_init(self):
+        # Generate random instance ID if not set
+        if self.lmcache_instance_id is None:
+            self.lmcache_instance_id = f"lmcache_instance_{uuid.uuid4().hex}"
         self.validate()
 
     cls = make_dataclass(

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -177,7 +177,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": _to_bool,
     },
     "lmcache_instance_id": {
-        "type": str,
+        "type": Optional[str],
         "default": None,
         "env_converter": str,
     },
@@ -406,7 +406,7 @@ def _create_config_class():
 
     def _post_init(self):
         # Generate random instance ID if not set
-        if self.lmcache_instance_id is None:
+        if not self.lmcache_instance_id:
             self.lmcache_instance_id = f"lmcache_instance_{uuid.uuid4().hex}"
         self.validate()
 


### PR DESCRIPTION
In k8s, the vllm backends can be scaled by replica in which case the instance id will be the same across replicas.
This PR tries to generate random instance id when the instance id is not defined

**PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to LMCache! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Core]</code> for changes in the core LMCache logic (e.g., <code>LMCacheEngine</code>, <code>Backend</code> etc.)</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient unit tests to ensure the change is stay correct and robust. The unit and integration tests will always run and our comprehensive test will be triggered after the "full" label is tagged onto a PR.</li>
</ul>

<h3>What to Expect for the Reviews</h3>

We aim to address all PRs in a timely manner. If no one reviews your PR within 5 days, please @-mention one of KuntaiDu, ApostaC or YaoJiayi.

</details>
