### PR TITLE
[Doc] fix cpu offloading example doc

### DIFF
--- a/docs/source/getting_started/quickstart/offload_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/offload_kv_cache.rst
@@ -336,7 +336,7 @@ Running the Example
 1. First, run the script without LMCache:
 
    .. code-block:: bash
-
+       export VLLM_WORKER_MULTIPROC_METHOD=spawn
        python cpu-offloading.py 
 
    You'll see output like:
@@ -351,7 +351,7 @@ Running the Example
 2. Now, run with LMCache enabled:
 
    .. code-block:: bash
-
+       export VLLM_WORKER_MULTIPROC_METHOD=spawn
        python cpu-offloading.py --enable-lmcache
 
    You'll see output like:

--- a/docs/source/getting_started/quickstart/offload_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/offload_kv_cache.rst
@@ -336,7 +336,6 @@ Running the Example
 1. First, run the script without LMCache:
 
    .. code-block:: bash
-       export VLLM_WORKER_MULTIPROC_METHOD=spawn
        python cpu-offloading.py 
 
    You'll see output like:
@@ -351,7 +350,6 @@ Running the Example
 2. Now, run with LMCache enabled:
 
    .. code-block:: bash
-       export VLLM_WORKER_MULTIPROC_METHOD=spawn
        python cpu-offloading.py --enable-lmcache
 
    You'll see output like:
@@ -376,3 +374,29 @@ LMCache now supports offloading KV cache to the following destinations:
 - :doc:`InfiniStore <../../kv_cache/storage_backends/infinistore>`
 - :doc:`Redis <../../kv_cache/storage_backends/redis>`
 - :doc:`ValKey <../../kv_cache/storage_backends/valkey>`
+
+Troubleshooting
+---------------
+
+If you encounter the following error:
+
+.. code-block:: text
+
+    (EngineCore_DP0 pid=55437) ERROR 10-04 14:44:47 [core.py:708] RuntimeError: 
+    Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
+
+You can resolve this issue using one of the following methods:
+
+- Set ``VLLM_WORKER_MULTIPROC_METHOD=spawn`` in the environment variables.
+- Or update the Python code to guard usage of vllm behind a if ``__name__ == '__main__':`` block.
+
+.. code-block:: python
+
+    if __name__ == '__main__':
+        from vllm import LLM, SamplingParams
+        from vllm.config import KVTransferConfig
+        from lmcache.v1.cache_engine import LMCacheEngineBuilder
+        from lmcache.integration.vllm.utils import ENGINE_NAME
+        main()
+
+For details, please refer to the `vLLM Troubleshooting Guide: Python multiprocessing <https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing>`_.

--- a/docs/source/getting_started/quickstart/offload_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/offload_kv_cache.rst
@@ -336,6 +336,7 @@ Running the Example
 1. First, run the script without LMCache:
 
    .. code-block:: bash
+
        python cpu-offloading.py 
 
    You'll see output like:
@@ -350,6 +351,7 @@ Running the Example
 2. Now, run with LMCache enabled:
 
    .. code-block:: bash
+
        python cpu-offloading.py --enable-lmcache
 
    You'll see output like:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When I ran the [example script](https://docs.lmcache.ai/getting_started/quickstart/offload_kv_cache.html#running-the-example), I got the following error:

```bash
(EngineCore_DP0 pid=55437) ERROR 10-04 14:44:47 [core.py:708] RuntimeError: 
Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```
This PR explicitly sets the `VLLM_WORKER_MULTIPROC_METHOD=spawn` environment variable to use the 'spawn' start method.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
