### PR TITLE
fix error in local cpu backend's clear()

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -577,7 +577,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         with self.cpu_lock:
             for key in self.hot_cache:
                 memory_obj = self.hot_cache[key]
-                if memory_obj.can_evict:
+                if not memory_obj.can_evict:
                     continue
                 clear_keys.append(key)
                 num_cleared_tokens += memory_obj.get_num_tokens()


### PR DESCRIPTION
Issue https://github.com/LMCache/LMCache/issues/1660 describes how kv cache in CPU backend can not be cleared via controller's clear interface. The issue is reproducible.

Before commit https://github.com/LMCache/LMCache/commit/451501601d79181ab5d177bff08949f7459b39d3
This line used to be:
`if memory_obj.get_ref_count() > 1:`
which skips removal if such memory object is referenced more than once.
<img width="482" height="78" alt="image" src="https://github.com/user-attachments/assets/7057163d-0b74-4480-a152-4b30eccf6345" />

I believe that the new code was expected to skip removal if memory object is NOT evictable, unfortunately 'not' was neglected

Please review this @YaoJiayi 