### PR TITLE
[Docs] Add KV Cache Sizes for Popular Models in faq

### DIFF
--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -1,4 +1,38 @@
 FAQ
 ===
 
-Coming soon... 
+What are the KV cache sizes for popular models? And why is LMCache important?
+-----------------------------------------------------------------------------
+
+You can calculate KV cache sizes using our :doc:`KV cache calculator <kv_cache_calculator>`. We also provide a reference table below with KV cache information for some popular models.
+
+As shown in the table, after loading Qwen/Qwen3-32B for example, there is only enough space in the spare GPU RAM to hold 275,760 tokens for KV caches. This supports only 6.73 concurrent users if each prompt is 40,960 tokens long. Once this capacity is exceeded, the KV cache must be evicted, and when the same user returns, their request needs to be re-prefilled, which takes significantly longer.
+
+**LMCache is designed to extend this virtual memory capacity**, enabling you to store more KV caches and avoid costly re-prefilling operations.
+
+**KV Cache Sizes for Popular Models**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 20 15 15
+
+   * - Model
+     - KV Cache Size per 1000 tokens
+     - Spare GPU RAM for KV cache
+     - Context length
+     - Number of full-length prompts that can be stored in GPU
+   * - Qwen/Qwen3-8B
+     - 0.1373 GB
+     - 50.32 GB (or 366,400 tokens)
+     - 40,960 tokens
+     - 8.95x
+   * - Qwen/Qwen3-32B (tp=2 on H100)
+     - 0.2441 GB
+     - 33.66 GB × 2 (or 275,760 tokens)
+     - 40,960 tokens
+     - 6.73x
+   * - meta-llama/Llama-3.1-70B (tp=4 on H100)
+     - 0.3052 GB
+     - 32.06 GB × 4 (or 420,208 tokens)
+     - 131,072 tokens
+     - 3.21x 


### PR DESCRIPTION
Add first faq about KV Cache Sizes for Popular Models, and a table to better comprehend the necessity of lmcache: <div class="tableView-content-wrap" data-prosemirror-initial-todom-render="true" data-prosemirror-content-type="node" data-prosemirror-node-name="table" data-prosemirror-node-block="true" data-pm-slice="1 1 []"><div data-testid="table-alignment-container" style="display: flex;justify-content: center"><div class="pm-table-resizer-container" style="--ak-editor-table-gutter-padding: calc(var(--ak-editor--large-gutter-padding) * 2); --ak-editor-table-width: min(calc(100cqw - calc(var(--ak-editor--large-gutter-padding) * 2)), 760px); width: var(--ak-editor-table-width);"><div class="resizer-item display-handle" style="--ak-editor-table-max-width: 1800px; --ak-editor-table-min-width: 145px; box-sizing: border-box; max-width: min(calc(100cqw - calc(var(--ak-editor--large-gutter-padding) * 2)), 1800px); min-width: var(--ak-editor-table-min-width); position: relative; user-select: auto; width: 760px;"><span class="resizer-hover-zone"><div class="pm-table-container" data-number-column="false" data-layout="default" data-testid="table-container"><div class="pm-table-sticky-sentinel-top" data-testid="sticky-sentinel-top"></div><div class="pm-table-row-controls-wrapper"><div></div></div><div class="pm-table-with-left-shadow" style="visibility: hidden"></div><div class="pm-table-wrapper">
Model | KV Cache Size per 1000 tokens | Spare GPU RAM for kv cache | Context length | Number of full-length prompts can be stored in GPU
-- | -- | -- | -- | --




</div><div class="pm-table-with-right-shadow" style="visibility: hidden"></div><div class="pm-table-sticky-sentinel-bottom" data-testid="sticky-sentinel-bottom"></div></div></span></div></div></div></div>
<img width="1454" height="1646" alt="CleanShot 2025-10-10 at 16 54 37@2x" src="https://github.com/user-attachments/assets/fbffd55d-6bdf-4016-a083-a0e57381d27d" />