### PR TITLE
[FSConnector] support read ahead in FSConnector

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -23,13 +23,7 @@ class FsConnectorAdapter(ConnectorAdapter):
 
         logger.info(f"Creating FS connector for URL: {context.url}")
         parse_url = parse_remote_url(context.url)
-        relative_tmp_dir = (
-            None
-            if context.config is None
-            else context.config.get_extra_config_value(
-                "fs_connector_relative_tmp_dir", None
-            )
-        )
+
         return FSConnector(
-            parse_url.path, context.loop, context.local_cpu_backend, relative_tmp_dir
+            parse_url.path, context.loop, context.local_cpu_backend, context.config
         )

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -171,10 +171,16 @@ class FSConnector(RemoteConnector):
                         num_read_ahead = await f.readinto(
                             buffer[: self.read_ahead_size]
                         )
-                        assert num_read_ahead is not None
-                        num_read_tail = await f.readinto(buffer[self.read_ahead_size :])
-                        assert num_read_tail is not None
-                        num_read = num_read_ahead + num_read_tail
+                        assert num_read_ahead <= self.read_ahead_size
+
+                        if num_read_ahead == self.read_ahead_size:
+                            num_read_tail = await f.readinto(
+                                buffer[self.read_ahead_size :]
+                            )
+                            assert num_read_tail is not None
+                            num_read = num_read_ahead + num_read_tail
+                        else:
+                            num_read = num_read_ahead
                     # reshape and check
                     assert num_read is not None
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -169,7 +169,9 @@ class FSConnector(RemoteConnector):
                         num_read_ahead = await f.readinto(
                             buffer[: self.read_ahead_size]
                         )
+                        assert num_read_ahead is not None
                         num_read_tail = await f.readinto(buffer[self.read_ahead_size :])
+                        assert num_read_tail is not None
                         num_read = num_read_ahead + num_read_tail
                     # reshape and check
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -157,7 +157,8 @@ class FSConnector(RemoteConnector):
                 # Read the actual data into allocated memory
                 buffer = memory_obj.byte_array
                 if self.save_chunk_meta:
-                    # if save chunk meta, read meta will trigger read ahead if fs supported
+                    # if save chunk meta, read meta will trigger
+                    # read ahead if fs supported
                     num_read = await f.readinto(buffer)
                     if num_read != len(buffer):
                         raise RuntimeError(

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -174,6 +174,7 @@ class FSConnector(RemoteConnector):
                         assert num_read_tail is not None
                         num_read = num_read_ahead + num_read_tail
                     # reshape and check
+                    assert num_read is not None
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)
 
             return memory_obj

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -58,9 +58,7 @@ class FSConnector(RemoteConnector):
         relative_tmp_dir = (
             None
             if config is None
-            else config.get_extra_config_value(
-                "fs_connector_relative_tmp_dir", None
-            )
+            else config.get_extra_config_value("fs_connector_relative_tmp_dir", None)
         )
         self.relative_tmp_dir = None
         if relative_tmp_dir is not None:
@@ -70,9 +68,7 @@ class FSConnector(RemoteConnector):
         self.read_ahead_size = (
             None
             if config is None
-            else config.get_extra_config_value(
-                "fs_connector_read_ahead_size", None
-            )
+            else config.get_extra_config_value("fs_connector_read_ahead_size", None)
         )
 
         logger.info(
@@ -170,8 +166,10 @@ class FSConnector(RemoteConnector):
                     if self.read_ahead_size is None:
                         num_read = await f.readinto(buffer)
                     else:
-                        num_read_ahead = await f.readinto(buffer[:self.read_ahead_size])
-                        num_read_tail = await f.readinto(buffer[self.read_ahead_size:])
+                        num_read_ahead = await f.readinto(
+                            buffer[: self.read_ahead_size]
+                        )
+                        num_read_tail = await f.readinto(buffer[self.read_ahead_size :])
                         num_read = num_read_ahead + num_read_tail
                     # reshape and check
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -175,8 +175,8 @@ class FSConnector(RemoteConnector):
                         num_read_tail = await f.readinto(buffer[self.read_ahead_size :])
                         assert num_read_tail is not None
                         num_read = num_read_ahead + num_read_tail
-                        assert num_read is not None
                     # reshape and check
+                    assert num_read is not None
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)
 
             return memory_obj

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -157,6 +157,7 @@ class FSConnector(RemoteConnector):
                 # Read the actual data into allocated memory
                 buffer = memory_obj.byte_array
                 if self.save_chunk_meta:
+                    # if save chunk meta, read meta will trigger read ahead if fs supported
                     num_read = await f.readinto(buffer)
                     if num_read != len(buffer):
                         raise RuntimeError(
@@ -168,11 +169,15 @@ class FSConnector(RemoteConnector):
                     else:
                         if not isinstance(buffer, memoryview):
                             buffer = memoryview(buffer)
+
+                        # trigger read head if fs supported
                         num_read_ahead = await f.readinto(
                             buffer[: self.read_ahead_size]
                         )
                         assert num_read_ahead <= self.read_ahead_size
 
+                        # if num_read_ahead == self.read_ahead_size,
+                        # means there may still be some remaining content
                         if num_read_ahead == self.read_ahead_size:
                             num_read_tail = await f.readinto(
                                 buffer[self.read_ahead_size :]

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -12,6 +12,7 @@ import aiofiles.os
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.protocol import RemoteMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
@@ -35,13 +36,14 @@ class FSConnector(RemoteConnector):
         base_paths_str: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
-        relative_tmp_dir: Optional[str],
+        config: Optional[LMCacheEngineConfig],
     ):
         """
         Args:
             base_paths_str: Comma separated storage paths
             loop: Asyncio event loop
             local_cpu_backend: Memory allocator interface
+            config: Lmcache engine config
         """
         # Parse comma separated paths
         self.base_paths = (
@@ -52,15 +54,31 @@ class FSConnector(RemoteConnector):
 
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
-        self.relative_tmp_dir = (
-            None if relative_tmp_dir is None else Path(relative_tmp_dir)
+
+        relative_tmp_dir = (
+            None
+            if config is None
+            else config.get_extra_config_value(
+                "fs_connector_relative_tmp_dir", None
+            )
         )
-        if self.relative_tmp_dir is not None:
+        self.relative_tmp_dir = None
+        if relative_tmp_dir is not None:
+            self.relative_tmp_dir = Path(relative_tmp_dir)
             assert not self.relative_tmp_dir.is_absolute()
+
+        self.read_ahead_size = (
+            None
+            if config is None
+            else config.get_extra_config_value(
+                "fs_connector_read_ahead_size", None
+            )
+        )
 
         logger.info(
             f"Initialized FSConnector with base paths {self.base_paths}, "
-            f"relative tmp dir: {self.relative_tmp_dir}"
+            f"relative tmp dir: {self.relative_tmp_dir}, "
+            f"read ahead size: {self.read_ahead_size}"
         )
         # Create directories for all paths
         for path in self.base_paths:
@@ -142,15 +160,20 @@ class FSConnector(RemoteConnector):
 
                 # Read the actual data into allocated memory
                 buffer = memory_obj.byte_array
-                num_read = await f.readinto(buffer)
                 if self.save_chunk_meta:
+                    num_read = await f.readinto(buffer)
                     if num_read != len(buffer):
                         raise RuntimeError(
                             f"Partial read data {len(buffer)} got {num_read}"
                         )
                 else:
+                    if self.read_ahead_size is None:
+                        num_read = await f.readinto(buffer)
+                    else:
+                        num_read_ahead = await f.readinto(buffer[:self.read_ahead_size])
+                        num_read_tail = await f.readinto(buffer[self.read_ahead_size:])
+                        num_read = num_read_ahead + num_read_tail
                     # reshape and check
-                    assert num_read is not None
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)
 
             return memory_obj

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -166,6 +166,8 @@ class FSConnector(RemoteConnector):
                     if self.read_ahead_size is None:
                         num_read = await f.readinto(buffer)
                     else:
+                        if not isinstance(buffer, memoryview):
+                            buffer = memoryview(buffer)
                         num_read_ahead = await f.readinto(
                             buffer[: self.read_ahead_size]
                         )
@@ -173,8 +175,8 @@ class FSConnector(RemoteConnector):
                         num_read_tail = await f.readinto(buffer[self.read_ahead_size :])
                         assert num_read_tail is not None
                         num_read = num_read_ahead + num_read_tail
+                        assert num_read is not None
                     # reshape and check
-                    assert num_read is not None
                     memory_obj = self.reshape_partial_chunk(memory_obj, num_read)
 
             return memory_obj


### PR DESCRIPTION
When `save_chunk_meta` is set to `False`,  `num_read = await f.readinto(buffer)` will read the contents of the file at once, the read ahead of DFS may not be effective. This PR supports read twice, the first time reading a small IO to trigger a read ahead, and the second time reading from memory.

We can enable this feature by the following config, default is `None`, means staying consistent with previous behavior.
```
extra_config:
  fs_connector_read_ahead_size: 1048576
```