### PR TITLE
[Core] NixlStorageBackend support eviction

### DIFF
--- a/tests/v1/data/nixl.yaml
+++ b/tests/v1/data/nixl.yaml
@@ -6,5 +6,5 @@ nixl_buffer_device: cpu
 extra_config:
   enable_nixl_storage: true
   nixl_backend: POSIX
-  nixl_pool_size: 64
+  nixl_pool_size: 2
   nixl_path: /tmp/nixl/cache


### PR DESCRIPTION
Support eviction based on existing cache_policy configuration for NixlStorageBackend.
Also supporting pin/unpin semantics.

- [ ] this PR contains unit tests
