### PR TITLE
[metrics] add request cache hit rate

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -848,6 +848,7 @@ class LMCacheConnectorV1Impl:
                         token_mask[:lmcache_cached_tokens],
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
+                        total_tokens=total_tokens_len,
                     )
                 else:
                     layerwise_retriever = self.lmcache_engine.retrieve_layer(
@@ -856,7 +857,7 @@ class LMCacheConnectorV1Impl:
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         sync=sync,
-                        num_tokens=total_tokens_len,
+                        total_tokens=total_tokens_len,
                     )
                     # NOTE: retrieve for two layers at the first layer
                     next(layerwise_retriever)
@@ -870,7 +871,7 @@ class LMCacheConnectorV1Impl:
                     slot_mapping=slot_mapping[:lmcache_cached_tokens],
                     request_configs=request.request_configs,
                     req_id=request.req_id,
-                    num_tokens=total_tokens_len,
+                    total_tokens=total_tokens_len,
                 )
 
                 # Check the result

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -818,14 +818,15 @@ class LMCacheConnectorV1Impl:
                 continue
 
             tokens = request.token_ids
+            total_tokens_len = len(tokens)
             # TODO: have a pre-allocated buffer to hold the slot_mappings
             slot_mapping = request.slot_mapping.cuda()
-            assert len(tokens) == len(slot_mapping)
+            assert total_tokens_len == len(slot_mapping)
 
             self._stats_monitor.update_interval_vllm_hit_tokens(
                 request.load_spec.vllm_cached_tokens
             )
-            token_mask = torch.ones(len(tokens), dtype=torch.bool)
+            token_mask = torch.ones(total_tokens_len, dtype=torch.bool)
             masked_token_count = (
                 request.load_spec.vllm_cached_tokens
                 // self._lmcache_chunk_size
@@ -855,6 +856,7 @@ class LMCacheConnectorV1Impl:
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         sync=sync,
+                        num_tokens=total_tokens_len,
                     )
                     # NOTE: retrieve for two layers at the first layer
                     next(layerwise_retriever)
@@ -868,6 +870,7 @@ class LMCacheConnectorV1Impl:
                     slot_mapping=slot_mapping[:lmcache_cached_tokens],
                     request_configs=request.request_configs,
                     req_id=request.req_id,
+                    num_tokens=total_tokens_len,
                 )
 
                 # Check the result

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -101,6 +101,7 @@ class RetrieveRequestStats:
     def hit_rate(self):
         if self.num_tokens == 0:
             return 0
+        assert self.local_hit_tokens <= self.num_tokens
         return self.local_hit_tokens / self.num_tokens
 
 
@@ -393,7 +394,9 @@ class LMCStatsMonitor:
         )
 
         request_cache_hit_rate = [
-            stats.hit_rate() for stats in self.retrieve_requests.values() if stats.end_time != 0
+            stats.hit_rate()
+            for stats in self.retrieve_requests.values()
+            if stats.end_time != 0
         ]
 
         ret = LMCacheStats(

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -68,6 +68,9 @@ class LMCacheStats:
     retrieve_speed: List[float]  # Tokens per second
     store_speed: List[float]  # Tokens per second
 
+    # request cache hit rate
+    interval_request_cache_hit_rate: List[float]
+
 
 @dataclass
 class LookupRequestStats:
@@ -94,6 +97,11 @@ class RetrieveRequestStats:
         return (
             self.local_hit_tokens + self.remote_hit_tokens
         ) / self.time_to_retrieve()
+
+    def hit_rate(self):
+        if self.num_tokens == 0:
+            return 0
+        return self.local_hit_tokens / self.num_tokens
 
 
 @dataclass
@@ -384,6 +392,10 @@ class LMCStatsMonitor:
             [stats.store_speed() for stats in self.store_requests.values()]
         )
 
+        request_cache_hit_rate = [
+            stats.hit_rate() for stats in self.retrieve_requests.values() if stats.end_time != 0
+        ]
+
         ret = LMCacheStats(
             interval_retrieve_requests=self.interval_retrieve_requests,
             interval_store_requests=self.interval_store_requests,
@@ -419,6 +431,7 @@ class LMCStatsMonitor:
             retrieve_speed=retrieve_speed,
             store_speed=store_speed,
             interval_vllm_hit_tokens=self.interval_vllm_hit_tokens,
+            interval_request_cache_hit_rate=request_cache_hit_rate,
         )
         self._clear()
         return ret
@@ -785,6 +798,25 @@ class PrometheusLogger:
             buckets=remote_time_to_get_sync,
         )
 
+        request_cache_hit_rate = [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+        ]
+        self.histogram_request_cache_hit_rate = self._histogram_cls(
+            name="lmcache:request_cache_hit_rate",
+            documentation="Reqeust cache hit rate",
+            labelnames=labelnames,
+            buckets=request_cache_hit_rate,
+        )
+
         # Ping latency metrics: use a gauge to record the latest ping latency
         self.gauge_remote_ping_latency = self._gauge_cls(
             name="lmcache:remote_ping_latency",
@@ -926,6 +958,9 @@ class PrometheusLogger:
         self._log_histogram(
             self.histogram_remote_time_to_get_sync,
             stats.interval_remote_time_to_get_sync,
+        )
+        self._log_histogram(
+            self.histogram_request_cache_hit_rate, stats.interval_request_cache_hit_rate
         )
         self._log_gauge(
             self.gauge_remote_ping_latency, stats.interval_remote_ping_latency

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -80,7 +80,8 @@ class LookupRequestStats:
 
 @dataclass
 class RetrieveRequestStats:
-    num_tokens: int
+    requested_tokens: int  # Retrieve request tokens
+    total_tokens: int  # The total tokens of the prompt
     local_hit_tokens: int
     remote_hit_tokens: int  # Not used for now
     start_time: float
@@ -99,10 +100,10 @@ class RetrieveRequestStats:
         ) / self.time_to_retrieve()
 
     def hit_rate(self):
-        if self.num_tokens == 0:
+        if self.total_tokens == 0:
             return 0
-        assert self.local_hit_tokens <= self.num_tokens
-        return self.local_hit_tokens / self.num_tokens
+        assert (self.local_hit_tokens + self.remote_hit_tokens) <= self.total_tokens
+        return (self.local_hit_tokens + self.remote_hit_tokens) / self.total_tokens
 
 
 @dataclass
@@ -189,20 +190,21 @@ class LMCStatsMonitor:
         self.interval_lookup_hits += num_hit_tokens
 
     @thread_safe
-    def on_retrieve_request(self, num_tokens: int) -> int:
+    def on_retrieve_request(self, requested_tokens: int, total_tokens: int = 0) -> int:
         """
         Returns the internal "request id" that will be used in
         on_retrieve_finished
         """
         curr_time = time.time()
         retrieve_stats = RetrieveRequestStats(
-            num_tokens=num_tokens,
+            requested_tokens=requested_tokens,
+            total_tokens=total_tokens,
             local_hit_tokens=0,
             remote_hit_tokens=0,
             start_time=curr_time,
             end_time=0,
         )
-        self.interval_requested_tokens += num_tokens
+        self.interval_requested_tokens += requested_tokens
         self.interval_retrieve_requests += 1
         self.retrieve_requests[self.retrieve_request_id] = retrieve_stats
         self.retrieve_request_id += 1
@@ -396,7 +398,7 @@ class LMCStatsMonitor:
         request_cache_hit_rate = [
             stats.hit_rate()
             for stats in self.retrieve_requests.values()
-            if stats.end_time != 0
+            if (stats.end_time != 0 and stats.total_tokens != 0)
         ]
 
         ret = LMCacheStats(

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -815,7 +815,7 @@ class PrometheusLogger:
         ]
         self.histogram_request_cache_hit_rate = self._histogram_cls(
             name="lmcache:request_cache_hit_rate",
-            documentation="Reqeust cache hit rate",
+            documentation="Request cache hit rate",
             labelnames=labelnames,
             buckets=request_cache_hit_rate,
         )

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -451,7 +451,9 @@ class LMCacheEngine:
             num_required_tokens = len(tokens)
 
         total_tokens = kwargs["total_tokens"] if "total_tokens" in kwargs else 0
-        monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens, total_tokens)
+        monitor_req_id = self.stats_monitor.on_retrieve_request(
+            num_required_tokens, total_tokens
+        )
 
         ret_mask = torch.zeros(len(tokens), dtype=torch.bool, device="cpu")
 
@@ -558,7 +560,9 @@ class LMCacheEngine:
             num_required_tokens = len(tokens)
 
         total_tokens = kwargs["total_tokens"] if "total_tokens" in kwargs else 0
-        monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens, total_tokens)
+        monitor_req_id = self.stats_monitor.on_retrieve_request(
+            num_required_tokens, total_tokens
+        )
 
         ret_mask = torch.zeros(len(tokens), dtype=torch.bool, device="cpu")
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -445,15 +445,13 @@ class LMCacheEngine:
         tot_kv_size = 0
         t = time.perf_counter()
 
-        # in vllm_v1_adapter, the mask and tokens is only a slice, use mask or
-        # tokens to cal num_required_tokens may be inaccurate
-        if "num_tokens" in kwargs:
-            num_required_tokens = kwargs["num_tokens"]
-        elif mask is not None:
+        if mask is not None:
             num_required_tokens = torch.sum(mask).item()
         else:
             num_required_tokens = len(tokens)
-        monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens)
+
+        total_tokens = kwargs["total_tokens"] if "total_tokens" in kwargs else 0
+        monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens, total_tokens)
 
         ret_mask = torch.zeros(len(tokens), dtype=torch.bool, device="cpu")
 
@@ -516,7 +514,7 @@ class LMCacheEngine:
             " cost %.4f ms, throughput: %.4f GB/s;",
             retrieved_tokens,
             num_required_tokens,
-            len(tokens),
+            len(tokens) if total_tokens == 0 else total_tokens,
             tot_kv_size / 1024**3,
             onload_time * 1000,
             tot_kv_size / onload_time / 1024**3 if onload_time > 0 else 0,
@@ -554,13 +552,13 @@ class LMCacheEngine:
             the GPU.
         """
 
-        if "num_tokens" in kwargs:
-            num_required_tokens = kwargs["num_tokens"]
-        elif mask is not None:
+        if mask is not None:
             num_required_tokens = torch.sum(mask).item()
         else:
             num_required_tokens = len(tokens)
-        monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens)
+
+        total_tokens = kwargs["total_tokens"] if "total_tokens" in kwargs else 0
+        monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens, total_tokens)
 
         ret_mask = torch.zeros(len(tokens), dtype=torch.bool, device="cpu")
 
@@ -642,7 +640,7 @@ class LMCacheEngine:
         logger.info(
             f"Retrieved {retrieved_tokens} "
             f"out of {num_required_tokens} "
-            f"out of total {len(tokens)} tokens"
+            f"out of total {len(tokens) if total_tokens == 0 else total_tokens} tokens"
         )
 
         yield ret_mask

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -445,7 +445,11 @@ class LMCacheEngine:
         tot_kv_size = 0
         t = time.perf_counter()
 
-        if mask is not None:
+        # in vllm_v1_adapter, the mask and tokens is only a slice, use mask or
+        # tokens to cal num_required_tokens may be inaccurate
+        if "num_tokens" in kwargs:
+            num_required_tokens = kwargs["num_tokens"]
+        elif mask is not None:
             num_required_tokens = torch.sum(mask).item()
         else:
             num_required_tokens = len(tokens)
@@ -550,7 +554,9 @@ class LMCacheEngine:
             the GPU.
         """
 
-        if mask is not None:
+        if "num_tokens" in kwargs:
+            num_required_tokens = kwargs["num_tokens"]
+        elif mask is not None:
             num_required_tokens = torch.sum(mask).item()
         else:
             num_required_tokens = len(tokens)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -13,7 +13,7 @@ def stats_monitor():
 
 
 def test_on_retrieve_request(stats_monitor):
-    stats_monitor.on_retrieve_request(num_tokens=100)
+    stats_monitor.on_retrieve_request(requested_tokens=100)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_retrieve_requests == 1
     assert stats.retrieve_hit_rate == 0
@@ -23,7 +23,7 @@ def test_on_retrieve_request(stats_monitor):
 
 
 def test_on_retrieve_finished(stats_monitor):
-    request_id = stats_monitor.on_retrieve_request(num_tokens=100)
+    request_id = stats_monitor.on_retrieve_request(requested_tokens=100)
     stats_monitor.on_retrieve_finished(
         request_id=request_id,
         retrieved_tokens=100,
@@ -127,7 +127,7 @@ def test_remote_ping_errors(stats_monitor):
 
 def test_retrieve_and_store_speed(stats_monitor):
     # Test retrieve speed calculation
-    retrieve_id = stats_monitor.on_retrieve_request(num_tokens=1000)
+    retrieve_id = stats_monitor.on_retrieve_request(requested_tokens=1000)
     stats_monitor.on_retrieve_finished(request_id=retrieve_id, retrieved_tokens=1000)
 
     # Test store speed calculation
@@ -179,7 +179,7 @@ def test_mixed_remote_operations(stats_monitor):
 
 
 def test_combined_operations(stats_monitor):
-    retrieve_id = stats_monitor.on_retrieve_request(num_tokens=200)
+    retrieve_id = stats_monitor.on_retrieve_request(requested_tokens=200)
     stats_monitor.on_retrieve_finished(
         request_id=retrieve_id,
         retrieved_tokens=200,


### PR DESCRIPTION
add a Histogram metric `lmcache:request_cache_hit_rate`, indicates the distribution of hit rates for each request.

