### PR TITLE
[patch]: allow 0 buffer + layerwise detection for lmserver

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 # Standard
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import asyncio
 import hashlib
 import threading
@@ -99,6 +99,22 @@ TORCH_DTYPE_TO_STR_DTYPE = {
 }
 
 STR_DTYPE_TO_TORCH_DTYPE = {v: k for k, v in TORCH_DTYPE_TO_STR_DTYPE.items()}
+
+
+def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
+    """Parse a key string into either a CacheEngineKey or LayerCacheEngineKey.
+
+    Args:
+        key_str: String in format:
+            fmt@model@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
+
+    Returns:
+        CacheEngineKey if no layer_id, LayerCacheEngineKey if valid layer_id
+    """
+    parts = key_str.strip().split("@")
+    if len(parts) >= 6 and parts[5].isdigit():
+        return LayerCacheEngineKey.from_string(key_str)
+    return CacheEngineKey.from_string(key_str)
 
 
 @dataclass(order=True)

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1485,6 +1485,8 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
         if not self._unregistered:
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
+            if self.buffer.numel() == 0:
+                return
             lmc_ops.free_pinned_ptr(self.buffer.data_ptr())
             self._unregistered = True
 
@@ -1626,6 +1628,8 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
         if not self._unregistered:
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
+            if self.buffer.numel() == 0:
+                return
             if self.numa_mapping:
                 lmc_ops.free_pinned_numa_ptr(self.buffer.data_ptr(), self.size)
             else:

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -301,6 +301,8 @@ def _allocate_cpu_memory(
     size: int,
     numa_mapping: Optional[NUMAMapping] = None,
 ) -> torch.Tensor:
+    if size == 0:
+        return torch.empty(0, dtype=torch.uint8)
     if numa_mapping:
         if torch.cuda.is_available():
             current_device_id = torch.cuda.current_device()
@@ -1406,10 +1408,13 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
         :param int size: The size of the pinned memory in bytes.
         """
 
-        ptr = lmc_ops.alloc_pinned_ptr(size, 0)
-        array_type = ctypes.c_uint8 * size
-        buf = array_type.from_address(ptr)
-        self.buffer = torch.frombuffer(buf, dtype=torch.uint8)
+        if size == 0:
+            self.buffer = torch.empty(0, dtype=torch.uint8)
+        else:
+            ptr = lmc_ops.alloc_pinned_ptr(size, 0)
+            array_type = ctypes.c_uint8 * size
+            buf = array_type.from_address(ptr)
+            self.buffer = torch.frombuffer(buf, dtype=torch.uint8)
         self._unregistered = False
 
         self.allocator: MemoryAllocatorInterface

--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -2,14 +2,14 @@
 # Standard
 from dataclasses import dataclass
 from enum import IntEnum, auto
-from typing import Optional
+from typing import Optional, Union
 import struct
 
 # Third Party
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import CacheEngineKey, LayerCacheEngineKey, parse_cache_key
 from lmcache.v1.memory_management import MemoryFormat
 
 MAX_KEY_LENGTH = 150
@@ -131,7 +131,7 @@ class ClientMetaMessage:
     """
 
     command: ClientCommand
-    key: CacheEngineKey
+    key: Union[CacheEngineKey, LayerCacheEngineKey]
     length: int
     fmt: MemoryFormat
     dtype: Optional[torch.dtype]
@@ -170,7 +170,7 @@ class ClientMetaMessage:
         )
         return ClientMetaMessage(
             ClientCommand(command),
-            CacheEngineKey.from_string(key.decode().strip()),
+            parse_cache_key(key.decode().strip()),
             length,
             MemoryFormat(fmt),
             INT_TO_DTYPE[dtype],


### PR DESCRIPTION
@zerofishnoodles will release 0.3.8 right after this

For example, PD without offloading benefits from having no CPU buffer. 

Thanks https://github.com/LMCache/LMCache/issues/1768 for finding this!

Also added layer vs regular cache engine key detection from https://github.com/LMCache/LMCache/issues/1790