### PR TITLE
[metrics] add request_cache_hit_rate metric

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -959,7 +959,7 @@ class PrometheusLogger:
         ]
         self.histogram_request_cache_hit_rate = self._histogram_cls(
             name="lmcache:request_cache_hit_rate",
-            documentation="Reqeust cache hit rate",
+            documentation="Request cache hit rate",
             labelnames=labelnames,
             buckets=request_cache_hit_rate,
         )

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -74,16 +74,15 @@ class LMCacheStats:
     p2p_time_to_transfer: List[float]
     p2p_transfer_speed: List[float]  # Tokens per second
 
-    # request cache hit rate
-    interval_request_cache_hit_rate: List[float]
+    # request lookup hit rates
+    interval_lookup_hit_rates: List[float]
 
 
 @dataclass
 class LookupRequestStats:
     num_tokens: int
     hit_tokens: int
-    start_time: float
-    end_time: float
+    is_finished: bool
 
     def hit_rate(self):
         if self.num_tokens == 0:
@@ -209,12 +208,10 @@ class LMCStatsMonitor:
         This function is called when a lookup request is sent to the cache.
         It will record the number of tokens requested.
         """
-        curr_time = time.time()
         lookup_stats = LookupRequestStats(
             num_tokens=num_tokens,
             hit_tokens=0,
-            start_time=curr_time,
-            end_time=0,
+            is_finished=False,
         )
         self.interval_lookup_requests += 1
         self.interval_lookup_tokens += num_tokens
@@ -228,11 +225,10 @@ class LMCStatsMonitor:
         This function is called when a lookup request is finished.
         It will record the number of tokens hit.
         """
-        curr_time = time.time()
         assert request_id in self.lookup_requests
         lookup_stats = self.lookup_requests[request_id]
         lookup_stats.hit_tokens = num_hit_tokens
-        lookup_stats.end_time = curr_time
+        lookup_stats.is_finished = True
         self.interval_lookup_hits += num_hit_tokens
 
     @thread_safe
@@ -432,7 +428,7 @@ class LMCStatsMonitor:
 
         new_lookup_requests = {}
         for request_id, lookup_stats in self.lookup_requests.items():
-            if lookup_stats.end_time == 0:
+            if not lookup_stats.is_finished:
                 new_lookup_requests[request_id] = lookup_stats
         self.lookup_requests = new_lookup_requests
 
@@ -483,10 +479,10 @@ class LMCStatsMonitor:
             [stats.transfer_speed() for stats in self.p2p_requests.values()]
         )
 
-        request_cache_hit_rate = [
+        request_lookup_hit_rates = [
             stats.hit_rate()
             for stats in self.lookup_requests.values()
-            if stats.end_time != 0
+            if stats.is_finished
         ]
 
         ret = LMCacheStats(
@@ -528,7 +524,7 @@ class LMCStatsMonitor:
             interval_p2p_transferred_tokens=self.interval_p2p_transferred_tokens,
             p2p_time_to_transfer=p2p_time_to_transfer,
             p2p_transfer_speed=p2p_transfer_speed,
-            interval_request_cache_hit_rate=request_cache_hit_rate,
+            interval_lookup_hit_rates=request_lookup_hit_rates,
         )
         self._clear()
         return ret
@@ -1113,7 +1109,7 @@ class PrometheusLogger:
             stats.interval_remote_time_to_get_sync,
         )
         self._log_histogram(
-            self.histogram_request_cache_hit_rate, stats.interval_request_cache_hit_rate
+            self.histogram_request_cache_hit_rate, stats.interval_lookup_hit_rates
         )
         self._log_gauge(
             self.gauge_remote_ping_latency, stats.interval_remote_ping_latency

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -74,11 +74,21 @@ class LMCacheStats:
     p2p_time_to_transfer: List[float]
     p2p_transfer_speed: List[float]  # Tokens per second
 
+    # request cache hit rate
+    interval_request_cache_hit_rate: List[float]
+
 
 @dataclass
 class LookupRequestStats:
     num_tokens: int
     hit_tokens: int
+    start_time: float
+    end_time: float
+
+    def hit_rate(self):
+        if self.num_tokens == 0:
+            return 0
+        return self.hit_tokens / self.num_tokens
 
 
 @dataclass
@@ -187,25 +197,42 @@ class LMCStatsMonitor:
 
         self.retrieve_requests: Dict[int, RetrieveRequestStats] = {}
         self.store_requests: Dict[int, StoreRequestStats] = {}
+        self.lookup_requests: Dict[int, LookupRequestStats] = {}
 
         self.retrieve_request_id = 0
         self.store_request_id = 0
+        self.lookup_request_id = 0
 
     @thread_safe
-    def on_lookup_request(self, num_tokens: int):
+    def on_lookup_request(self, num_tokens: int) -> int:
         """
         This function is called when a lookup request is sent to the cache.
         It will record the number of tokens requested.
         """
+        curr_time = time.time()
+        lookup_stats = LookupRequestStats(
+            num_tokens=num_tokens,
+            hit_tokens=0,
+            start_time=curr_time,
+            end_time=0,
+        )
         self.interval_lookup_requests += 1
         self.interval_lookup_tokens += num_tokens
+        self.lookup_requests[self.lookup_request_id] = lookup_stats
+        self.lookup_request_id += 1
+        return self.lookup_request_id - 1
 
     @thread_safe
-    def on_lookup_finished(self, num_hit_tokens: int):
+    def on_lookup_finished(self, request_id: int, num_hit_tokens: int):
         """
         This function is called when a lookup request is finished.
         It will record the number of tokens hit.
         """
+        curr_time = time.time()
+        assert request_id in self.lookup_requests
+        lookup_stats = self.lookup_requests[request_id]
+        lookup_stats.hit_tokens = num_hit_tokens
+        lookup_stats.end_time = curr_time
         self.interval_lookup_hits += num_hit_tokens
 
     @thread_safe
@@ -403,6 +430,12 @@ class LMCStatsMonitor:
                 new_p2p_requests[request_id] = p2p_stats
         self.p2p_requests = new_p2p_requests
 
+        new_lookup_requests = {}
+        for request_id, lookup_stats in self.lookup_requests.items():
+            if lookup_stats.end_time == 0:
+                new_lookup_requests[request_id] = lookup_stats
+        self.lookup_requests = new_lookup_requests
+
     @thread_safe
     def get_stats_and_clear(self) -> LMCacheStats:
         """
@@ -450,6 +483,12 @@ class LMCStatsMonitor:
             [stats.transfer_speed() for stats in self.p2p_requests.values()]
         )
 
+        request_cache_hit_rate = [
+            stats.hit_rate()
+            for stats in self.lookup_requests.values()
+            if stats.end_time != 0
+        ]
+
         ret = LMCacheStats(
             interval_retrieve_requests=self.interval_retrieve_requests,
             interval_store_requests=self.interval_store_requests,
@@ -489,6 +528,7 @@ class LMCStatsMonitor:
             interval_p2p_transferred_tokens=self.interval_p2p_transferred_tokens,
             p2p_time_to_transfer=p2p_time_to_transfer,
             p2p_transfer_speed=p2p_transfer_speed,
+            interval_request_cache_hit_rate=request_cache_hit_rate,
         )
         self._clear()
         return ret
@@ -905,6 +945,25 @@ class PrometheusLogger:
             buckets=remote_time_to_get_sync,
         )
 
+        request_cache_hit_rate = [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+        ]
+        self.histogram_request_cache_hit_rate = self._histogram_cls(
+            name="lmcache:request_cache_hit_rate",
+            documentation="Reqeust cache hit rate",
+            labelnames=labelnames,
+            buckets=request_cache_hit_rate,
+        )
+
         # Ping latency metrics: use a gauge to record the latest ping latency
         self.gauge_remote_ping_latency = self._gauge_cls(
             name="lmcache:remote_ping_latency",
@@ -1052,6 +1111,9 @@ class PrometheusLogger:
         self._log_histogram(
             self.histogram_remote_time_to_get_sync,
             stats.interval_remote_time_to_get_sync,
+        )
+        self._log_histogram(
+            self.histogram_request_cache_hit_rate, stats.interval_request_cache_hit_rate
         )
         self._log_gauge(
             self.gauge_remote_ping_latency, stats.interval_remote_ping_latency

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -679,11 +679,11 @@ class LMCacheEngine:
         """
 
         if tokens is not None:
-            self.stats_monitor.on_lookup_request(len(tokens))
+            lookup_request_id = self.stats_monitor.on_lookup_request(len(tokens))
         else:
             assert offsets is not None
             assert hashes is not None
-            self.stats_monitor.on_lookup_request(sum(offsets))
+            lookup_request_id = self.stats_monitor.on_lookup_request(sum(offsets))
 
         try:
             end = 0
@@ -735,7 +735,7 @@ class LMCacheEngine:
             # all tokens where found, return the maximal end
             return end
         finally:
-            self.stats_monitor.on_lookup_finished(end)
+            self.stats_monitor.on_lookup_finished(lookup_request_id, end)
             # vllm lookup sets pin to True
             if pin:
                 self.storage_manager.touch_cache()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -61,7 +61,7 @@ def test_update_local_storage_usage(stats_monitor):
 
 
 def test_on_lookup_request(stats_monitor):
-    stats_monitor.on_lookup_request(num_tokens=50)
+    lookup_request_id = stats_monitor.on_lookup_request(num_tokens=50)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 1
     assert stats.interval_lookup_tokens == 50
@@ -69,8 +69,8 @@ def test_on_lookup_request(stats_monitor):
 
 
 def test_on_lookup_finished(stats_monitor):
-    stats_monitor.on_lookup_request(num_tokens=100)
-    stats_monitor.on_lookup_finished(num_hit_tokens=80)
+    lookup_request_id = stats_monitor.on_lookup_request(num_tokens=100)
+    stats_monitor.on_lookup_finished(request_id=lookup_request_id, num_hit_tokens=80)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 1
     assert stats.interval_lookup_tokens == 100
@@ -143,10 +143,10 @@ def test_retrieve_and_store_speed(stats_monitor):
 
 def test_multiple_lookup_operations(stats_monitor):
     # Test multiple lookup operations
-    stats_monitor.on_lookup_request(num_tokens=100)
-    stats_monitor.on_lookup_finished(num_hit_tokens=80)
-    stats_monitor.on_lookup_request(num_tokens=200)
-    stats_monitor.on_lookup_finished(num_hit_tokens=150)
+    lookup_request_id_1 = stats_monitor.on_lookup_request(num_tokens=100)
+    stats_monitor.on_lookup_finished(request_id=lookup_request_id_1, num_hit_tokens=80)
+    lookup_request_id_2 = stats_monitor.on_lookup_request(num_tokens=200)
+    stats_monitor.on_lookup_finished(request_id=lookup_request_id_2, num_hit_tokens=150)
 
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 2
@@ -205,7 +205,7 @@ def test_combined_operations(stats_monitor):
 
 def test_stats_clearing(stats_monitor):
     # Add some data
-    stats_monitor.on_lookup_request(num_tokens=100)
+    lookup_request_id = stats_monitor.on_lookup_request(num_tokens=100)
     stats_monitor.update_interval_remote_read_metrics(read_bytes=1024)
     stats_monitor.update_remote_ping_latency(latency=25.0)
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -61,21 +61,29 @@ def test_update_local_storage_usage(stats_monitor):
 
 
 def test_on_lookup_request(stats_monitor):
-    lookup_request_id = stats_monitor.on_lookup_request(num_tokens=50)
+    stats_monitor.on_lookup_request(num_tokens=50)
+    assert len(stats_monitor.lookup_requests) == 1
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 1
     assert stats.interval_lookup_tokens == 50
     assert stats.lookup_hit_rate == 0
+    assert len(stats.interval_request_cache_hit_rate) == 0
+    # on_lookup_finished is not called, lookup_requests is not clear
+    assert len(stats_monitor.lookup_requests) == 1
 
 
 def test_on_lookup_finished(stats_monitor):
     lookup_request_id = stats_monitor.on_lookup_request(num_tokens=100)
+    assert len(stats_monitor.lookup_requests) == 1
     stats_monitor.on_lookup_finished(request_id=lookup_request_id, num_hit_tokens=80)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 1
     assert stats.interval_lookup_tokens == 100
     assert stats.interval_lookup_hits == 80
     assert stats.lookup_hit_rate == 0.8
+    assert len(stats.interval_request_cache_hit_rate) == 1
+    assert stats.interval_request_cache_hit_rate[0] == 0.8
+    assert len(stats_monitor.lookup_requests) == 0
 
 
 def test_remote_read_metrics(stats_monitor):
@@ -147,12 +155,17 @@ def test_multiple_lookup_operations(stats_monitor):
     stats_monitor.on_lookup_finished(request_id=lookup_request_id_1, num_hit_tokens=80)
     lookup_request_id_2 = stats_monitor.on_lookup_request(num_tokens=200)
     stats_monitor.on_lookup_finished(request_id=lookup_request_id_2, num_hit_tokens=150)
+    assert len(stats_monitor.lookup_requests) == 2
+    assert stats_monitor.lookup_requests[lookup_request_id_1].hit_rate() == 0.8
+    assert stats_monitor.lookup_requests[lookup_request_id_2].hit_rate() == 0.75
 
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 2
     assert stats.interval_lookup_tokens == 300
     assert stats.interval_lookup_hits == 230
     assert stats.lookup_hit_rate == 230 / 300
+    assert len(stats.interval_request_cache_hit_rate) == 2
+    assert len(stats_monitor.lookup_requests) == 0
 
 
 def test_mixed_remote_operations(stats_monitor):
@@ -209,17 +222,43 @@ def test_stats_clearing(stats_monitor):
     stats_monitor.update_interval_remote_read_metrics(read_bytes=1024)
     stats_monitor.update_remote_ping_latency(latency=25.0)
 
+    assert len(stats_monitor.lookup_requests) == 1
+
     # Get stats (which should clear them)
     stats = stats_monitor.get_stats_and_clear()
     assert stats.interval_lookup_requests == 1
+    assert stats.interval_lookup_tokens == 100
+    assert stats.interval_lookup_hits == 0
     assert stats.interval_remote_read_requests == 1
+    assert stats.interval_remote_read_bytes == 1024
     assert stats.interval_remote_ping_latency == 25.0
+    assert len(stats.interval_request_cache_hit_rate) == 0
 
     # Get stats again - should be cleared
     stats2 = stats_monitor.get_stats_and_clear()
     assert stats2.interval_lookup_requests == 0
+    assert stats2.interval_lookup_tokens == 0
+    assert stats2.interval_lookup_hits == 0
     assert stats2.interval_remote_read_requests == 0
+    assert stats2.interval_remote_read_bytes == 0
     assert stats2.interval_remote_ping_latency == 0
+    assert len(stats2.interval_request_cache_hit_rate) == 0
+
+    assert len(stats_monitor.lookup_requests) == 1
+
+    # finish lookup request
+    stats_monitor.on_lookup_finished(request_id=lookup_request_id, num_hit_tokens=80)
+    stats3 = stats_monitor.get_stats_and_clear()
+    assert stats3.interval_lookup_requests == 0
+    assert stats3.interval_lookup_tokens == 0
+    assert stats3.interval_lookup_hits == 80
+    assert stats3.interval_remote_read_requests == 0
+    assert stats3.interval_remote_read_bytes == 0
+    assert stats3.interval_remote_ping_latency == 0
+    assert len(stats3.interval_request_cache_hit_rate) == 1
+    assert stats3.interval_request_cache_hit_rate[0] == 0.8
+
+    assert len(stats_monitor.lookup_requests) == 0
 
 
 def test_zero_division_protection(stats_monitor):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -67,7 +67,7 @@ def test_on_lookup_request(stats_monitor):
     assert stats.interval_lookup_requests == 1
     assert stats.interval_lookup_tokens == 50
     assert stats.lookup_hit_rate == 0
-    assert len(stats.interval_request_cache_hit_rate) == 0
+    assert len(stats.interval_lookup_hit_rates) == 0
     # on_lookup_finished is not called, lookup_requests is not clear
     assert len(stats_monitor.lookup_requests) == 1
 
@@ -81,8 +81,8 @@ def test_on_lookup_finished(stats_monitor):
     assert stats.interval_lookup_tokens == 100
     assert stats.interval_lookup_hits == 80
     assert stats.lookup_hit_rate == 0.8
-    assert len(stats.interval_request_cache_hit_rate) == 1
-    assert stats.interval_request_cache_hit_rate[0] == 0.8
+    assert len(stats.interval_lookup_hit_rates) == 1
+    assert stats.interval_lookup_hit_rates[0] == 0.8
     assert len(stats_monitor.lookup_requests) == 0
 
 
@@ -164,7 +164,7 @@ def test_multiple_lookup_operations(stats_monitor):
     assert stats.interval_lookup_tokens == 300
     assert stats.interval_lookup_hits == 230
     assert stats.lookup_hit_rate == 230 / 300
-    assert len(stats.interval_request_cache_hit_rate) == 2
+    assert len(stats.interval_lookup_hit_rates) == 2
     assert len(stats_monitor.lookup_requests) == 0
 
 
@@ -232,7 +232,7 @@ def test_stats_clearing(stats_monitor):
     assert stats.interval_remote_read_requests == 1
     assert stats.interval_remote_read_bytes == 1024
     assert stats.interval_remote_ping_latency == 25.0
-    assert len(stats.interval_request_cache_hit_rate) == 0
+    assert len(stats.interval_lookup_hit_rates) == 0
 
     # Get stats again - should be cleared
     stats2 = stats_monitor.get_stats_and_clear()
@@ -242,7 +242,7 @@ def test_stats_clearing(stats_monitor):
     assert stats2.interval_remote_read_requests == 0
     assert stats2.interval_remote_read_bytes == 0
     assert stats2.interval_remote_ping_latency == 0
-    assert len(stats2.interval_request_cache_hit_rate) == 0
+    assert len(stats2.interval_lookup_hit_rates) == 0
 
     assert len(stats_monitor.lookup_requests) == 1
 
@@ -255,8 +255,8 @@ def test_stats_clearing(stats_monitor):
     assert stats3.interval_remote_read_requests == 0
     assert stats3.interval_remote_read_bytes == 0
     assert stats3.interval_remote_ping_latency == 0
-    assert len(stats3.interval_request_cache_hit_rate) == 1
-    assert stats3.interval_request_cache_hit_rate[0] == 0.8
+    assert len(stats3.interval_lookup_hit_rates) == 1
+    assert stats3.interval_lookup_hit_rates[0] == 0.8
 
     assert len(stats_monitor.lookup_requests) == 0
 


### PR DESCRIPTION
add a Histogram metric `lmcache:request_cache_hit_rate`, indicates the distribution of hit rates for each request.