### PR TITLE
Fix duplicate cache_policy.update_on_hit() calls in LocalDiskBackend

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -343,11 +343,6 @@ class LocalDiskBackend(StorageBackendInterface):
             self.disk_lock.release()
             return None
 
-        self.cache_policy.update_on_hit(key, self.dict)
-
-        self.disk_lock.release()
-
-        self.disk_lock.acquire()
         # Update cache recency
         self.cache_policy.update_on_hit(key, self.dict)
 
@@ -380,9 +375,6 @@ class LocalDiskBackend(StorageBackendInterface):
             self.disk_lock.acquire()
             assert key in self.dict, f"Key {key} not found in disk cache after pinning"
 
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            self.cache_policy.update_on_hit(key, self.dict)
-
             path = self.dict[key].path
             dtype = self.dict[key].dtype
             shape = self.dict[key].shape
@@ -403,6 +395,7 @@ class LocalDiskBackend(StorageBackendInterface):
 
             self.dict[key].pin()
 
+            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
             # Update cache recency
             self.cache_policy.update_on_hit(key, self.dict)
 


### PR DESCRIPTION
## Problem
In `LocalDiskBackend`, there are duplicate calls to `cache_policy.update_on_hit()` in both `get_blocking()` and `batched_get_non_blocking()` methods.

## Impact
- **LFU Policy**: Frequency count is incorrectly incremented twice instead of once
- **LRU/MRU Policy**: Redundant `move_to_end()` operations
- **Performance**: Unnecessary function calls

## Location
- `lmcache/v1/storage_backend/local_disk_backend.py`
  - Line 346 & 352 in `get_blocking()` method
  - Line 384 & 407 in `batched_get_non_blocking()` method

## Solution
Remove the first call and keep only the one after all preparation work is completed (before releasing the lock).

## Files Changed
- `lmcache/v1/storage_backend/local_disk_backend.py`