### PR TITLE
[bugfix] ensure batched_put releases refs after async completion

### DIFF
--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -368,9 +368,7 @@ class StorageManager:
                 try:
                     fut.add_done_callback(_on_done)
                 except Exception:
-                    logger.exception(
-                        "Failed to register batched_put finalize callback"
-                    )
+                    logger.exception("Failed to register batched_put finalize callback")
 
         # The dictionary from backend cname to objects and keys
         obj_dict: dict[

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -354,8 +354,12 @@ class StorageManager:
             if not futures:
                 return
 
-            pending_counts[cn] += len(futures)
             lock = locks[cn]
+
+            # Increment under lock so callbacks firing synchronously see the
+            # pending count before attempting to decrement it.
+            with lock:
+                pending_counts[cn] += len(futures)
 
             def _on_done(_fut, name=cn, arr=objs, lk=lock):
                 with lk:
@@ -369,6 +373,11 @@ class StorageManager:
                     fut.add_done_callback(_on_done)
                 except Exception:
                     logger.exception("Failed to register batched_put finalize callback")
+                    with lock:
+                        if pending_counts[cn] > 0:
+                            pending_counts[cn] -= 1
+                        if pending_counts[cn] == 0:
+                            _finalize(cn, objs)
 
         # The dictionary from backend cname to objects and keys
         obj_dict: dict[

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from concurrent.futures import Future
 from typing import (
     TYPE_CHECKING,
@@ -323,6 +323,54 @@ class StorageManager:
         Do not store if the same object is being stored (handled here by
         storage manager) or has been stored (handled by storage backend).
         """
+        # Track async completion per connector (cname). We only drop refs once
+        # all async futures across *all* backends for that cname have finished.
+        pending_counts = defaultdict(int)
+        locks = defaultdict(threading.Lock)
+        finalized: set[str] = set()
+
+        def _normalize_futures(futs: Any) -> list[Any]:
+            if futs is None:
+                return []
+            if hasattr(futs, "add_done_callback"):
+                return [futs]
+            if isinstance(futs, (list, tuple)):
+                return [f for f in futs if hasattr(f, "add_done_callback")]
+            return []
+
+        def _finalize(cn: str, objs: list[MemoryObj]) -> None:
+            if cn in finalized:
+                return
+            for memory_obj in objs:
+                try:
+                    memory_obj.ref_count_down()
+                except Exception:
+                    logger.exception("ref_count_down failed in batched_put finalize")
+            finalized.add(cn)
+
+        def _register_callbacks(cn: str, objs: list[MemoryObj], futs: Any) -> None:
+            futures = _normalize_futures(futs)
+            if not futures:
+                return
+
+            pending_counts[cn] += len(futures)
+            lock = locks[cn]
+
+            def _on_done(_fut, name=cn, arr=objs, lk=lock):
+                with lk:
+                    if pending_counts[name] > 0:
+                        pending_counts[name] -= 1
+                    if pending_counts[name] == 0:
+                        _finalize(name, arr)
+
+            for fut in futures:
+                try:
+                    fut.add_done_callback(_on_done)
+                except Exception:
+                    logger.exception(
+                        "Failed to register batched_put finalize callback"
+                    )
+
         # The dictionary from backend cname to objects and keys
         obj_dict: dict[
             str,
@@ -345,14 +393,22 @@ class StorageManager:
                 )
                 obj_dict[cname] = (new_keys, new_objs)
 
-            # NOTE: the handling of exists_in_put_tasks
-            # is done in the backend
+            # NOTE: the handling of exists_in_put_tasks is done in the backend
             ks, objs = obj_dict[cname]
-            backend.batched_submit_put_task(ks, objs, transfer_spec=transfer_spec)
+            futs = backend.batched_submit_put_task(
+                ks, objs, transfer_spec=transfer_spec
+            )
 
+            _register_callbacks(cname, objs, futs)
+
+        # Finalize any cname with no async futures registered (sync path),
+        # or those not yet finalized due to zero pending futures.
         for cname, (ks, objs) in obj_dict.items():
-            for memory_obj in objs:
-                memory_obj.ref_count_down()
+            lock = locks[cname]
+            with lock:
+                if pending_counts[cname] != 0:
+                    continue
+                _finalize(cname, objs)
 
     def get(
         self,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Coroutine,
+    DefaultDict,
     Generator,
     List,
     Optional,
@@ -325,8 +326,8 @@ class StorageManager:
         """
         # Track async completion per connector (cname). We only drop refs once
         # all async futures across *all* backends for that cname have finished.
-        pending_counts = defaultdict(int)
-        locks = defaultdict(threading.Lock)
+        pending_counts: DefaultDict[str, int] = defaultdict(int)
+        locks: DefaultDict[str, threading.Lock] = defaultdict(threading.Lock)
         finalized: set[str] = set()
 
         def _normalize_futures(futs: Any) -> list[Any]:

--- a/tests/v1/storage_backend/test_storage_manager_batched_put.py
+++ b/tests/v1/storage_backend/test_storage_manager_batched_put.py
@@ -2,10 +2,10 @@
 # Standard
 from collections import OrderedDict
 from concurrent.futures import Future
-import threading
-import time
 from types import SimpleNamespace
 from typing import Callable, Optional, cast
+import threading
+import time
 
 # First Party
 from lmcache.utils import CacheEngineKey
@@ -14,7 +14,6 @@ from lmcache.v1.storage_backend.abstract_backend import (
     StorageBackendInterface,
 )
 from lmcache.v1.storage_backend.storage_manager import StorageManager
-
 
 OnRelease = Optional[Callable[[], None]]
 
@@ -213,3 +212,27 @@ def test_batched_put_async_future_completes_from_thread():
     assert released.wait(timeout=1.0), "ref_count_down never triggered"
     assert mem_obj.meta.ref_count == 0
     assert mem_obj.down_calls == 1
+
+
+def test_batched_put_backend_returns_non_future_treated_as_sync():
+    allocator = DummyAllocatorBackend()
+    bad_async_return = object()  # lacks add_done_callback -> should be treated sync
+    async_backend = DummyBackend(allocator, bad_async_return)
+
+    manager = _make_manager(
+        OrderedDict(
+            {
+                "LocalCPUBackend": allocator,
+                "AsyncBackend": async_backend,
+            }
+        )
+    )
+
+    mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
+    keys = _make_keys(len(mem_objs))
+
+    manager.batched_put(keys, mem_objs)
+
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 0
+        assert mem.down_calls == 1

--- a/tests/v1/storage_backend/test_storage_manager_batched_put.py
+++ b/tests/v1/storage_backend/test_storage_manager_batched_put.py
@@ -3,12 +3,14 @@
 from collections import OrderedDict
 from concurrent.futures import Future
 from types import SimpleNamespace
-
-# Third Party
-import pytest
+from typing import cast
 
 # First Party
 from lmcache.utils import CacheEngineKey
+from lmcache.v1.storage_backend.abstract_backend import (
+    AllocatorBackendInterface,
+    StorageBackendInterface,
+)
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 
@@ -53,16 +55,18 @@ class DummyBackend:
 
 
 def _make_keys(count: int):
-    return [
-        CacheEngineKey("fmt", "model", 1, 0, chunk_hash=i) for i in range(count)
-    ]
+    return [CacheEngineKey("fmt", "model", 1, 0, chunk_hash=i) for i in range(count)]
 
 
 def _make_manager(backends: OrderedDict[str, object]) -> StorageManager:
     manager = StorageManager.__new__(StorageManager)
-    manager.storage_backends = backends
+    manager.storage_backends = cast(
+        OrderedDict[str, StorageBackendInterface], backends
+    )
     # allocator backend keyed by LocalCPUBackend to match StorageManager expectations
-    manager.allocator_backend = backends["LocalCPUBackend"]
+    manager.allocator_backend = cast(
+        AllocatorBackendInterface, backends["LocalCPUBackend"]
+    )
     manager.internal_copy_stream = None
     return manager
 

--- a/tests/v1/storage_backend/test_storage_manager_batched_put.py
+++ b/tests/v1/storage_backend/test_storage_manager_batched_put.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 from concurrent.futures import Future
 from types import SimpleNamespace
-from typing import Callable, Optional, cast
+from typing import Callable, List, Optional, cast
 import threading
 import time
 
@@ -12,6 +12,7 @@ import pytest
 
 # First Party
 from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,
     StorageBackendInterface,
@@ -90,7 +91,7 @@ def test_batched_put_sync_finalize_once():
     mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
     keys = _make_keys(len(mem_objs))
 
-    manager.batched_put(keys, mem_objs)
+    manager.batched_put(keys, cast(List[MemoryObj], mem_objs))
 
     for mem in mem_objs:
         assert mem.meta.ref_count == 0
@@ -114,7 +115,7 @@ def test_batched_put_async_single_future_finalizes_after_completion():
     mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
     keys = _make_keys(len(mem_objs))
 
-    manager.batched_put(keys, mem_objs)
+    manager.batched_put(keys, cast(List[MemoryObj], mem_objs))
     # Still pending because future not completed.
     for mem in mem_objs:
         assert mem.meta.ref_count == 1
@@ -144,7 +145,7 @@ def test_batched_put_async_list_of_futures_waits_for_all():
     mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
     keys = _make_keys(len(mem_objs))
 
-    manager.batched_put(keys, mem_objs)
+    manager.batched_put(keys, cast(List[MemoryObj], mem_objs))
 
     f1.set_result(None)
     for mem in mem_objs:
@@ -176,7 +177,7 @@ def test_batched_put_multiple_async_backends_same_cname_waits_for_all():
     mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
     keys = _make_keys(len(mem_objs))
 
-    manager.batched_put(keys, mem_objs)
+    manager.batched_put(keys, cast(List[MemoryObj], mem_objs))
 
     f1.set_result(None)
     for mem in mem_objs:
@@ -207,7 +208,7 @@ def test_batched_put_async_future_completes_from_thread():
     mem_obj = DummyMemoryObj(on_release=released.set)
     keys = _make_keys(1)
 
-    manager.batched_put(keys, [mem_obj])
+    manager.batched_put(keys, cast(List[MemoryObj], [mem_obj]))
     assert mem_obj.down_calls == 0
 
     def _complete():
@@ -238,7 +239,7 @@ def test_batched_put_backend_returns_non_future_treated_as_sync():
     mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
     keys = _make_keys(len(mem_objs))
 
-    manager.batched_put(keys, mem_objs)
+    manager.batched_put(keys, cast(List[MemoryObj], mem_objs))
 
     for mem in mem_objs:
         assert mem.meta.ref_count == 0
@@ -276,7 +277,7 @@ def test_batched_put_allocation_failure_still_releases_refs(
     mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
     keys = _make_keys(len(mem_objs))
 
-    manager.batched_put(keys, mem_objs)
+    manager.batched_put(keys, cast(List[MemoryObj], mem_objs))
 
     assert allocation_called, "allocate_and_copy_objects should be invoked"
     for mem in mem_objs:

--- a/tests/v1/storage_backend/test_storage_manager_batched_put.py
+++ b/tests/v1/storage_backend/test_storage_manager_batched_put.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from collections import OrderedDict
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.storage_backend.storage_manager import StorageManager
+
+
+class DummyMemoryObj:
+    def __init__(self, ref_count: int = 1):
+        self.meta = SimpleNamespace(ref_count=ref_count)
+        self.down_calls = 0
+
+    def ref_count_down(self):
+        self.meta.ref_count -= 1
+        self.down_calls += 1
+
+
+class DummyAllocatorBackend:
+    """Allocator stub that acts as both allocator and storage backend."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get_allocator_backend(self):
+        return self
+
+    def batched_submit_put_task(self, keys, objs, transfer_spec=None):
+        self.calls += 1
+        return None
+
+
+class DummyBackend:
+    """Storage backend stub returning a predetermined value from submit."""
+
+    def __init__(self, allocator, submit_return):
+        self.allocator = allocator
+        self.submit_return = submit_return
+        self.calls = 0
+
+    def get_allocator_backend(self):
+        return self.allocator
+
+    def batched_submit_put_task(self, keys, objs, transfer_spec=None):
+        self.calls += 1
+        return self.submit_return
+
+
+def _make_keys(count: int):
+    return [
+        CacheEngineKey("fmt", "model", 1, 0, chunk_hash=i) for i in range(count)
+    ]
+
+
+def _make_manager(backends: OrderedDict[str, object]) -> StorageManager:
+    manager = StorageManager.__new__(StorageManager)
+    manager.storage_backends = backends
+    # allocator backend keyed by LocalCPUBackend to match StorageManager expectations
+    manager.allocator_backend = backends["LocalCPUBackend"]
+    manager.internal_copy_stream = None
+    return manager
+
+
+def test_batched_put_sync_finalize_once():
+    allocator = DummyAllocatorBackend()
+    manager = _make_manager(OrderedDict({"LocalCPUBackend": allocator}))
+
+    mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
+    keys = _make_keys(len(mem_objs))
+
+    manager.batched_put(keys, mem_objs)
+
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 0
+        assert mem.down_calls == 1
+
+
+def test_batched_put_async_single_future_finalizes_after_completion():
+    allocator = DummyAllocatorBackend()
+    fut = Future()
+    async_backend = DummyBackend(allocator, fut)
+
+    manager = _make_manager(
+        OrderedDict(
+            {
+                "LocalCPUBackend": allocator,
+                "AsyncBackend": async_backend,
+            }
+        )
+    )
+
+    mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
+    keys = _make_keys(len(mem_objs))
+
+    manager.batched_put(keys, mem_objs)
+    # Still pending because future not completed.
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 1
+        assert mem.down_calls == 0
+
+    fut.set_result(None)
+
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 0
+        assert mem.down_calls == 1
+
+
+def test_batched_put_async_list_of_futures_waits_for_all():
+    allocator = DummyAllocatorBackend()
+    f1, f2 = Future(), Future()
+    async_backend = DummyBackend(allocator, [f1, f2])
+
+    manager = _make_manager(
+        OrderedDict(
+            {
+                "LocalCPUBackend": allocator,
+                "AsyncBackend": async_backend,
+            }
+        )
+    )
+
+    mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
+    keys = _make_keys(len(mem_objs))
+
+    manager.batched_put(keys, mem_objs)
+
+    f1.set_result(None)
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 1
+        assert mem.down_calls == 0
+
+    f2.set_result(None)
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 0
+        assert mem.down_calls == 1
+
+
+def test_batched_put_multiple_async_backends_same_cname_waits_for_all():
+    allocator = DummyAllocatorBackend()
+    f1, f2 = Future(), Future()
+    backend_a = DummyBackend(allocator, f1)
+    backend_b = DummyBackend(allocator, f2)
+
+    manager = _make_manager(
+        OrderedDict(
+            {
+                "LocalCPUBackend": allocator,
+                "BackendA": backend_a,
+                "BackendB": backend_b,
+            }
+        )
+    )
+
+    mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
+    keys = _make_keys(len(mem_objs))
+
+    manager.batched_put(keys, mem_objs)
+
+    f1.set_result(None)
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 1
+        assert mem.down_calls == 0
+
+    f2.set_result(None)
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 0
+        assert mem.down_calls == 1

--- a/tests/v1/storage_backend/test_storage_manager_batched_put.py
+++ b/tests/v1/storage_backend/test_storage_manager_batched_put.py
@@ -7,6 +7,9 @@ from typing import Callable, Optional, cast
 import threading
 import time
 
+# Third Party
+import pytest
+
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.storage_backend.abstract_backend import (
@@ -43,6 +46,10 @@ class DummyAllocatorBackend:
     def batched_submit_put_task(self, keys, objs, transfer_spec=None):
         self.calls += 1
         return None
+
+
+class AltAllocatorBackend(DummyAllocatorBackend):
+    """Allocator with different cname to trigger allocate path."""
 
 
 class DummyBackend:
@@ -233,6 +240,45 @@ def test_batched_put_backend_returns_non_future_treated_as_sync():
 
     manager.batched_put(keys, mem_objs)
 
+    for mem in mem_objs:
+        assert mem.meta.ref_count == 0
+        assert mem.down_calls == 1
+
+
+def test_batched_put_allocation_failure_still_releases_refs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # First Party
+    from lmcache.v1.storage_backend import storage_manager as sm_module
+
+    allocator = DummyAllocatorBackend()
+    alt_allocator = AltAllocatorBackend()
+    failing_backend = DummyBackend(alt_allocator, None)
+
+    allocation_called = False
+
+    def fake_allocate(alloc, keys, objs, stream):
+        nonlocal allocation_called
+        allocation_called = True
+        return [], []
+
+    monkeypatch.setattr(sm_module, "allocate_and_copy_objects", fake_allocate)
+
+    manager = _make_manager(
+        OrderedDict(
+            {
+                "LocalCPUBackend": allocator,
+                "FailingBackend": failing_backend,
+            }
+        )
+    )
+
+    mem_objs = [DummyMemoryObj(), DummyMemoryObj()]
+    keys = _make_keys(len(mem_objs))
+
+    manager.batched_put(keys, mem_objs)
+
+    assert allocation_called, "allocate_and_copy_objects should be invoked"
     for mem in mem_objs:
         assert mem.meta.ref_count == 0
         assert mem.down_calls == 1

--- a/tests/v1/storage_backend/test_storage_manager_batched_put.py
+++ b/tests/v1/storage_backend/test_storage_manager_batched_put.py
@@ -2,8 +2,10 @@
 # Standard
 from collections import OrderedDict
 from concurrent.futures import Future
+import threading
+import time
 from types import SimpleNamespace
-from typing import cast
+from typing import Callable, Optional, cast
 
 # First Party
 from lmcache.utils import CacheEngineKey
@@ -14,14 +16,20 @@ from lmcache.v1.storage_backend.abstract_backend import (
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 
+OnRelease = Optional[Callable[[], None]]
+
+
 class DummyMemoryObj:
-    def __init__(self, ref_count: int = 1):
+    def __init__(self, ref_count: int = 1, on_release: OnRelease = None):
         self.meta = SimpleNamespace(ref_count=ref_count)
         self.down_calls = 0
+        self._on_release = on_release
 
     def ref_count_down(self):
         self.meta.ref_count -= 1
         self.down_calls += 1
+        if self._on_release is not None:
+            self._on_release()
 
 
 class DummyAllocatorBackend:
@@ -60,9 +68,7 @@ def _make_keys(count: int):
 
 def _make_manager(backends: OrderedDict[str, object]) -> StorageManager:
     manager = StorageManager.__new__(StorageManager)
-    manager.storage_backends = cast(
-        OrderedDict[str, StorageBackendInterface], backends
-    )
+    manager.storage_backends = cast(OrderedDict[str, StorageBackendInterface], backends)
     # allocator backend keyed by LocalCPUBackend to match StorageManager expectations
     manager.allocator_backend = cast(
         AllocatorBackendInterface, backends["LocalCPUBackend"]
@@ -175,3 +181,35 @@ def test_batched_put_multiple_async_backends_same_cname_waits_for_all():
     for mem in mem_objs:
         assert mem.meta.ref_count == 0
         assert mem.down_calls == 1
+
+
+def test_batched_put_async_future_completes_from_thread():
+    allocator = DummyAllocatorBackend()
+    fut = Future()
+    async_backend = DummyBackend(allocator, fut)
+
+    manager = _make_manager(
+        OrderedDict(
+            {
+                "LocalCPUBackend": allocator,
+                "AsyncBackend": async_backend,
+            }
+        )
+    )
+
+    released = threading.Event()
+    mem_obj = DummyMemoryObj(on_release=released.set)
+    keys = _make_keys(1)
+
+    manager.batched_put(keys, [mem_obj])
+    assert mem_obj.down_calls == 0
+
+    def _complete():
+        time.sleep(0.05)
+        fut.set_result(None)
+
+    threading.Thread(target=_complete, daemon=True).start()
+
+    assert released.wait(timeout=1.0), "ref_count_down never triggered"
+    assert mem_obj.meta.ref_count == 0
+    assert mem_obj.down_calls == 1


### PR DESCRIPTION
bugfix for #1802 

  What this PR does / why we need it:

  - centralizes batched_put finalization in StorageManager so refs drop once per cname only after all async futures
    complete
  - ensures sync paths still finalize once in the tail and guards against backends that return non-futures
  - adds unit tests covering sync, async (single and multiple futures), multi-backend, threaded completion, and
    misbehaving backend scenarios

  Special notes for your reviewers:

  - tests use lightweight dummy backends to avoid touching real connectors while asserting ref-count behavior
  If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests