### PR TITLE
[logging]: less verbose async logs

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1169,7 +1169,7 @@ class LMCacheConnectorV1Impl:
         )
 
         if num_external_hit_tokens is None:
-            logger.info(
+            logger.debug(
                 "Reqid: %s, Total tokens %d, LMCache hit tokens: None.",
                 request.request_id,
                 request.num_tokens,


### PR DESCRIPTION
for remote storage, these logs can be excessive