### PR TITLE
[bugfix]: only update skip_leading_tokens on last PP rank in wait_for…

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1106,7 +1106,7 @@ class LMCacheConnectorV1Impl:
                 transfer_spec=request.disagg_spec,
                 request_configs=request.request_configs,
             )
-            
+
             if get_pp_group().is_last_rank:
                 # NOTE(Jiayi): We assume all tokens are saved
                 save_spec.skip_leading_tokens = len(token_ids)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1107,6 +1107,8 @@ class LMCacheConnectorV1Impl:
                 request_configs=request.request_configs,
             )
 
+            # Update skip_leading_tokens only on last rank to ensure
+            # each PP stage stores its own KV cache
             if get_pp_group().is_last_rank:
                 # NOTE(Jiayi): We assume all tokens are saved
                 save_spec.skip_leading_tokens = len(token_ids)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -14,6 +14,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
 )
 from vllm.distributed.parallel_state import (
+    get_pp_group,
     get_tensor_model_parallel_rank,
     get_tp_group,
 )
@@ -1105,11 +1106,12 @@ class LMCacheConnectorV1Impl:
                 transfer_spec=request.disagg_spec,
                 request_configs=request.request_configs,
             )
-
-            # NOTE(Jiayi): We assume all tokens are saved
-            save_spec.skip_leading_tokens = len(token_ids)
-            if request.disagg_spec:
-                request.disagg_spec.num_transferred_tokens = len(token_ids)
+            
+            if get_pp_group().is_last_rank:
+                # NOTE(Jiayi): We assume all tokens are saved
+                save_spec.skip_leading_tokens = len(token_ids)
+                if request.disagg_spec:
+                    request.disagg_spec.num_transferred_tokens = len(token_ids)
 
     @_lmcache_nvtx_annotate
     def get_finished(


### PR DESCRIPTION
🧠 Background / Motivation

After reviewing the changes in [#1813](https://github.com/LMCache/LMCache/pull/1813)
, I found that the issue does not originate from the lookup logic.
The lookup function only tracks how many tokens have been processed.
For new prompts, rank0 always calls wait_for_save() to store the KV cache.

However, in the current implementation, the following part at the end of wait_for_save():

save_spec.skip_leading_tokens = len(token_ids)
if request.disagg_spec:
    request.disagg_spec.num_transferred_tokens = len(token_ids)


is executed on rank0, which prematurely marks all token_ids as already saved.
As a result, rank1 (and later stages) will skip saving due to this check:

if skip_leading_tokens == len(token_ids):
    continue  # skip this request


This causes later pipeline stages to incorrectly skip KV cache saving.

🧰 What This PR Does

This PR updates the logic to ensure the save-state update only happens on the last PP rank:

if get_pp_group().is_last_rank:
    save_spec.skip_leading_tokens = len(token_ids)
    if request.disagg_spec:
        request.disagg_spec.num_transferred_tokens = len(token_ids)

✅ Impact

Fixes incorrect KV cache saving behavior under pipeline parallel (PP) mode.

Ensures each PP stage correctly saves its respective KV cache.

No behavioral change for single-rank or non-PP configurations.

🧪 Testing

Run inference with PP enabled.

Verify that:

Only the last PP rank updates skip_leading_tokens.

All PP ranks correctly save their portion of KV cache.

Confirm behavior remains identical in non-PP mode.

🔗 Related Issue

[#1807](https://github.com/LMCache/LMCache/issues/1807)