### PR TITLE
[optimize] reduce calls to contains for sync path

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -877,6 +877,7 @@ class LMCacheConnectorV1Impl:
                     slot_mapping=slot_mapping[:lmcache_cached_tokens],
                     request_configs=request.request_configs,
                     req_id=request.req_id,
+                    skip_contains_check=True,
                 )
 
                 # Check the result

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1146,11 +1146,12 @@ class LMCacheEngine:
                 pass
             else:
                 # NOTE: key should always be in the lookup cache once we support it.
+                # TODO: use lookup_cache to skip the contains
                 if (
                     skip_contains_check
-                    and len(self.storage_manager.actual_storage_names) == 1
+                    and len(self.storage_manager.non_allocator_backends) == 1
                 ):
-                    location = self.storage_manager.actual_storage_names[0]
+                    location = self.storage_manager.non_allocator_backends[0]
                 else:
                     location = self.storage_manager.contains(key)
                 if location is None:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1131,6 +1131,7 @@ class LMCacheEngine:
         ):
             assert isinstance(key, CacheEngineKey)
 
+            location = None
             if key in self.lookup_cache:
                 # TODO(Jiayi): we can reduce the number of `contains` calls
                 # by checking the lookup cache first (should be updated in `lookup`)
@@ -1140,7 +1141,7 @@ class LMCacheEngine:
                 # we support it.
 
                 if len(self.storage_manager.actual_storage_names) == 1:
-                    # Only lookup result is True, will reach this branch, if there is only
+                    # Only lookup is True, will reach this branch, if there is only
                     # one storage backend, there is no need to check 'contains' again
                     location = self.storage_manager.actual_storage_names[0]
                 else:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1129,7 +1129,9 @@ class LMCacheEngine:
         # passed in must exist in LMCache, and we can set skip_contains_check to True.
         # When skip_contains_check is True and there is only one backend, the `contains`
         # call can be skipped.
-        skip_contains_check = kwargs["skip_contains_check"] if "skip_contains_check" in kwargs else False
+        skip_contains_check = (
+            kwargs["skip_contains_check"] if "skip_contains_check" in kwargs else False
+        )
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
@@ -1144,7 +1146,10 @@ class LMCacheEngine:
                 pass
             else:
                 # NOTE: key should always be in the lookup cache once we support it.
-                if skip_contains_check and len(self.storage_manager.actual_storage_names) == 1:
+                if (
+                    skip_contains_check
+                    and len(self.storage_manager.actual_storage_names) == 1
+                ):
                     location = self.storage_manager.actual_storage_names[0]
                 else:
                     location = self.storage_manager.contains(key)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1124,6 +1124,12 @@ class LMCacheEngine:
         if request_configs is not None and len(request_configs) != 0:
             assert isinstance(request_configs, dict)
 
+        # In some scenarios, lookup is called first, and then the original tokens
+        # is sliced based on the lookup result. In these scenarios, the tokens
+        # passed in must exist in LMCache, and we can set skip_contains_check to True.
+        # When skip_contains_check is True and there is only one backend, the `contains`
+        # call can be skipped.
+        skip_contains_check = kwargs["skip_contains_check"] if "skip_contains_check" in kwargs else False
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
@@ -1137,12 +1143,8 @@ class LMCacheEngine:
                 # by checking the lookup cache first (should be updated in `lookup`)
                 pass
             else:
-                # NOTE: key should always be in the lookup cache once
-                # we support it.
-
-                if len(self.storage_manager.actual_storage_names) == 1:
-                    # Only lookup is True, will reach this branch, if there is only
-                    # one storage backend, there is no need to check 'contains' again
+                # NOTE: key should always be in the lookup cache once we support it.
+                if skip_contains_check and len(self.storage_manager.actual_storage_names) == 1:
                     location = self.storage_manager.actual_storage_names[0]
                 else:
                     location = self.storage_manager.contains(key)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1138,7 +1138,13 @@ class LMCacheEngine:
             else:
                 # NOTE: key should always be in the lookup cache once
                 # we support it.
-                location = self.storage_manager.contains(key)
+
+                if len(self.storage_manager.actual_storage_names) == 1:
+                    # Only lookup result is True, will reach this branch, if there is only
+                    # one storage backend, there is no need to check 'contains' again
+                    location = self.storage_manager.actual_storage_names[0]
+                else:
+                    location = self.storage_manager.contains(key)
                 if location is None:
                     break
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -209,6 +209,9 @@ class StorageManager:
             )
         )
 
+        # the backend used for actual storage
+        self.actual_storage_names = self.get_actual_storage_names()
+
         self.enable_pd = config.enable_pd
 
         self.allocator_backend = self._get_allocator_backend(config)
@@ -812,6 +815,23 @@ class StorageManager:
             if not backend.get_memory_allocator().memcheck():
                 return False
         return True
+
+    def get_actual_storage_names(self) -> List[str]:
+        """
+        Get the name of the actual storage backends. Some backends,
+        such as LocalCPUBackend and PDBackend, in some cases, only
+        serve as a backend for allocation
+        """
+        storage_names = []
+        for backend_name, backend in self.storage_backends.items():
+            if "LocalCPUBackend" == backend_name and not self.config.local_cpu:
+                # if local_cpu is False, means LocalCPUBackend is only a allocator
+                continue
+            if "PDBackend" == backend_name and backend.pd_config.role == "sender":
+                # if pd_config.role is sender, means PDBackend is only a allocator
+                continue
+            storage_names.append(backend_name)
+        return storage_names
 
     def close(self):
         for backend in self.storage_backends.values():

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -827,7 +827,7 @@ class StorageManager:
             if "LocalCPUBackend" == backend_name and not self.config.local_cpu:
                 # if local_cpu is False, means LocalCPUBackend is only a allocator
                 continue
-            if "PDBackend" == backend_name and backend.pd_config.role == "sender":
+            if "PDBackend" == backend_name and backend.pd_config.role == "sender":  # type: ignore
                 # if pd_config.role is sender, means PDBackend is only a allocator
                 continue
             storage_names.append(backend_name)

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -210,7 +210,7 @@ class StorageManager:
         )
 
         # the backend used for actual storage
-        self.actual_storage_names = self.get_actual_storage_names()
+        self.non_allocator_backends = self.get_non_allocator_backends()
 
         self.enable_pd = config.enable_pd
 
@@ -816,11 +816,11 @@ class StorageManager:
                 return False
         return True
 
-    def get_actual_storage_names(self) -> List[str]:
+    def get_non_allocator_backends(self) -> List[str]:
         """
-        Get the name of the actual storage backends. Some backends,
+        Get the names of the actual storage backends. Some backends,
         such as LocalCPUBackend and PDBackend, in some cases, only
-        serve as a backend for allocation
+        serve as a backend for allocation.
         """
         storage_names = []
         for backend_name, backend in self.storage_backends.items():


### PR DESCRIPTION
If lookup result is `True`, and there is only one actual storage backend, there is no need to check `contains` again.