### PR TITLE
[RFC][Core] centralized memory pool layer phase 1

### DIFF
--- a/lmcache/v1/memory_pool.py
+++ b/lmcache/v1/memory_pool.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
+# Future
 from __future__ import annotations
 
+# Standard
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, cast
 import threading
 
+# Third Party
 import torch
 
+# First Party
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.v1.memory_management import (
@@ -17,6 +21,7 @@ from lmcache.v1.memory_management import (
 )
 
 if TYPE_CHECKING:
+    # First Party
     from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 
 logger = init_logger(__name__)
@@ -41,15 +46,15 @@ class PoolRequest:
     def resolve_shape(self) -> torch.Size:
         if self.fmt == MemoryFormat.BINARY_BUFFER:
             if self.size is None and self.shape is None:
-                msg = "PoolRequest for BINARY_BUFFER expects size or shape"
-                raise ValueError(msg)
+                raise ValueError("PoolRequest for BINARY_BUFFER expects size or shape")
             if self.shape is not None:
                 return self.shape
             return torch.Size([self.size])  # type: ignore[arg-type]
 
         if self.shape is None or self.dtype is None:
-            msg = "PoolRequest requires shape and dtype for tensor allocations"
-            raise ValueError(msg)
+            raise ValueError(
+                "PoolRequest requires shape and dtype for tensor allocations"
+            )
         return self.shape
 
 
@@ -89,8 +94,9 @@ class MemoryPool:
                     req.fmt != MemoryFormat.BINARY_BUFFER
                 ):
                     if req.dtype is None:
-                        msg = "PoolRequest dtype must be set for backend allocations"
-                        raise ValueError(msg)
+                        raise ValueError(
+                            "PoolRequest dtype must be set for backend allocations"
+                        )
                     memory_obj = backend_allocate(
                         shape,
                         req.dtype,
@@ -103,8 +109,9 @@ class MemoryPool:
         else:
             memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
         if memory_obj is None:
-            msg = f"MemoryPool failed to allocate object (fmt={req.fmt}, tag={req.tag})"
-            raise RuntimeError(msg)
+            raise RuntimeError(
+                f"MemoryPool failed to allocate object (fmt={req.fmt}, tag={req.tag})"
+            )
 
         memory_obj_any = cast(Any, memory_obj)
         original_parent = getattr(memory_obj_any, "parent_allocator", None)
@@ -131,13 +138,13 @@ class MemoryPool:
         phy_size = memory_obj.meta.phy_size
         already_released = getattr(memory_obj_any, "_memory_pool_released", False)
         if already_released:
-            logger.warning("MemoryPool.release called multiple times for %s", memory_obj)
+            logger.warning(
+                "MemoryPool.release called multiple times for %s", memory_obj
+            )
             return
         memory_obj_any._memory_pool_released = True
 
-        original_parent = getattr(
-            memory_obj_any, "_memory_pool_original_parent", None
-        )
+        original_parent = getattr(memory_obj_any, "_memory_pool_original_parent", None)
         if original_parent is None or original_parent is self:
             original_parent = self._allocator
 
@@ -176,9 +183,7 @@ class MemoryPool:
 
     def _update_metrics(self) -> None:
         update_custom_metric = getattr(
-            self._stats_monitor,
-            "update_custom_metric",
-            None,
+            self._stats_monitor, "update_custom_metric", None
         )
         if callable(update_custom_metric):
             update_custom_metric(self._STAT_LIVE_LEASES, self._live_leases)
@@ -186,9 +191,7 @@ class MemoryPool:
 
         if self._prometheus_logger is not None:
             update_custom_gauge = getattr(
-                self._prometheus_logger,
-                "update_custom_gauge",
-                None,
+                self._prometheus_logger, "update_custom_gauge", None
             )
             if callable(update_custom_gauge):
                 update_custom_gauge(self._STAT_LIVE_LEASES, self._live_leases)

--- a/lmcache/v1/memory_pool.py
+++ b/lmcache/v1/memory_pool.py
@@ -83,7 +83,7 @@ class MemoryPool:
     def borrow(self, req: PoolRequest) -> MemoryObj:
         """Borrow a MemoryObj from the underlying allocator."""
         shape = req.resolve_shape()
-        memory_obj: Optional[MemoryObj]
+        memory_obj: Optional[MemoryObj] = None
         if self._backend is not None:
             allocate_from_pool = getattr(self._backend, "allocate_from_pool", None)
             if callable(allocate_from_pool):
@@ -94,9 +94,8 @@ class MemoryPool:
                     req.fmt != MemoryFormat.BINARY_BUFFER
                 ):
                     if req.dtype is None:
-                        raise ValueError(
-                            "PoolRequest dtype must be set for backend allocations"
-                        )
+                        msg = "PoolRequest dtype must be set for backend allocations"
+                        raise ValueError(msg)
                     memory_obj = backend_allocate(
                         shape,
                         req.dtype,
@@ -104,9 +103,7 @@ class MemoryPool:
                         eviction=req.eviction,
                         busy_loop=req.busy_loop,
                     )
-                else:
-                    memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
-        else:
+        if memory_obj is None:
             memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
         if memory_obj is None:
             raise RuntimeError(

--- a/lmcache/v1/memory_pool.py
+++ b/lmcache/v1/memory_pool.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Dict, Iterator, Optional, TYPE_CHECKING
+import threading
+
+# Third Party
+import torch
+
+from lmcache.logging import init_logger
+from lmcache.observability import LMCStatsMonitor, PrometheusLogger
+from lmcache.v1.memory_management import MemoryAllocatorInterface, MemoryFormat, MemoryObj
+
+if TYPE_CHECKING:
+    from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PoolRequest:
+    """
+    Describes a single borrow request from the MemoryPool. Callers can either
+    provide tensor shape/dtype/fmt or, for raw buffers, just the size.
+    """
+
+    shape: Optional[torch.Size] = None
+    dtype: Optional[torch.dtype] = None
+    fmt: MemoryFormat = MemoryFormat.KV_2LTD
+    size: Optional[int] = None
+    pinned: bool = False
+    tag: str = "generic"
+    eviction: bool = True
+    busy_loop: bool = True
+
+    def resolve_shape(self) -> torch.Size:
+        if self.fmt == MemoryFormat.BINARY_BUFFER:
+            if self.size is None and self.shape is None:
+                raise ValueError("PoolRequest for BINARY_BUFFER expects size or shape")
+            if self.shape is not None:
+                return self.shape
+            return torch.Size([self.size])  # type: ignore[arg-type]
+
+        if self.shape is None or self.dtype is None:
+            raise ValueError("PoolRequest requires shape and dtype for tensor allocations")
+        return self.shape
+
+
+class MemoryPool:
+    """
+    Thin facade that centralises engine-owned allocations and basic accounting.
+    """
+
+    _STAT_LIVE_LEASES = "pool_live_leases"
+    _STAT_BORROWED_BYTES = "pool_borrowed_bytes"
+
+    def __init__(
+        self,
+        allocator: MemoryAllocatorInterface,
+        backend: Optional["AllocatorBackendInterface"] = None,
+    ) -> None:
+        self._allocator = allocator
+        self._backend = backend
+        self._live_leases = 0
+        self._borrowed_bytes = 0
+        self._lock = threading.Lock()
+
+        self._stats_monitor = LMCStatsMonitor.GetOrCreate()
+        self._prometheus_logger = PrometheusLogger.GetInstanceOrNone()
+
+    def borrow(self, req: PoolRequest) -> MemoryObj:
+        """Borrow a MemoryObj from the underlying allocator."""
+        shape = req.resolve_shape()
+        memory_obj: Optional[MemoryObj]
+        if self._backend is not None:
+            allocate_from_pool = getattr(self._backend, "allocate_from_pool", None)
+            if callable(allocate_from_pool):
+                memory_obj = allocate_from_pool(req)
+            else:
+                backend_allocate = getattr(self._backend, "allocate", None)
+                if callable(backend_allocate) and req.fmt != MemoryFormat.BINARY_BUFFER:
+                    if req.dtype is None:
+                        raise ValueError("PoolRequest dtype must be set for backend allocations")
+                    memory_obj = backend_allocate(
+                        shape,
+                        req.dtype,
+                        req.fmt,
+                        eviction=req.eviction,
+                        busy_loop=req.busy_loop,
+                    )
+                else:
+                    memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
+        else:
+            memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
+        if memory_obj is None:
+            raise RuntimeError(
+                f"MemoryPool failed to allocate object (fmt={req.fmt}, tag={req.tag})"
+            )
+
+        original_parent = getattr(memory_obj, "parent_allocator", None)
+        setattr(memory_obj, "_memory_pool_original_parent", original_parent)
+        setattr(memory_obj, "_memory_pool_released", False)
+        memory_obj.parent_allocator = self  # type: ignore[attr-defined]
+
+        phy_size = memory_obj.meta.phy_size
+        with self._lock:
+            self._live_leases += 1
+            self._borrowed_bytes += phy_size
+            self._update_metrics()
+        logger.debug(
+            "MemoryPool borrowed %s bytes (tag=%s, fmt=%s, total_leases=%d)",
+            phy_size,
+            req.tag,
+            req.fmt,
+            self._live_leases,
+        )
+        return memory_obj
+
+    def release(self, memory_obj: MemoryObj) -> None:
+        phy_size = memory_obj.meta.phy_size
+        already_released = getattr(memory_obj, "_memory_pool_released", False)
+        if already_released:
+            logger.warning("MemoryPool.release called multiple times for %s", memory_obj)
+            return
+        setattr(memory_obj, "_memory_pool_released", True)
+
+        original_parent = getattr(memory_obj, "_memory_pool_original_parent", None)
+        if original_parent is None or original_parent is self:
+            original_parent = self._allocator
+
+        # Restore the original parent allocator before delegating free.
+        memory_obj.parent_allocator = original_parent  # type: ignore[attr-defined]
+        try:
+            original_parent.free(memory_obj)  # type: ignore[call-arg]
+        finally:
+            with self._lock:
+                self._live_leases -= 1
+                self._borrowed_bytes -= phy_size
+                if self._live_leases < 0 or self._borrowed_bytes < 0:
+                    logger.warning(
+                        "MemoryPool counters negative after release "
+                        "(leases=%d, bytes=%d)",
+                        self._live_leases,
+                        self._borrowed_bytes,
+                    )
+                    self._live_leases = max(self._live_leases, 0)
+                    self._borrowed_bytes = max(self._borrowed_bytes, 0)
+                self._update_metrics()
+            if hasattr(memory_obj, "_memory_pool_original_parent"):
+                delattr(memory_obj, "_memory_pool_original_parent")
+        logger.debug(
+            "MemoryPool released %s bytes (total_leases=%d)", phy_size, self._live_leases
+        )
+
+    def stats(self) -> Dict[str, int]:
+        with self._lock:
+            return {
+                "live_leases": self._live_leases,
+                "borrowed_bytes": self._borrowed_bytes,
+            }
+
+    def _update_metrics(self) -> None:
+        update_custom_metric = getattr(self._stats_monitor, "update_custom_metric", None)
+        if callable(update_custom_metric):
+            update_custom_metric(self._STAT_LIVE_LEASES, self._live_leases)
+            update_custom_metric(self._STAT_BORROWED_BYTES, self._borrowed_bytes)
+
+        if self._prometheus_logger is not None:
+            update_custom_gauge = getattr(
+                self._prometheus_logger, "update_custom_gauge", None
+            )
+            if callable(update_custom_gauge):
+                update_custom_gauge(self._STAT_LIVE_LEASES, self._live_leases)
+                update_custom_gauge(self._STAT_BORROWED_BYTES, self._borrowed_bytes)
+
+    def free(self, memory_obj: MemoryObj, allocator_type: Optional[str] = None) -> None:
+        """
+        Allows MemoryObj instances to treat the pool as their parent allocator.
+        """
+        self.release(memory_obj)
+
+
+@contextmanager
+def lease(pool: MemoryPool, req: PoolRequest) -> Iterator[MemoryObj]:
+    """
+    Convenience helper that guarantees release even if the caller throws.
+    """
+    memory_obj = pool.borrow(req)
+    try:
+        yield memory_obj
+    except Exception as exc:  # pragma: no cover - logged for observability
+        logger.exception("MemoryPool lease raised exception: %s", exc)
+        raise
+    finally:
+        pool.release(memory_obj)

--- a/lmcache/v1/memory_pool.py
+++ b/lmcache/v1/memory_pool.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# Future
+from __future__ import annotations
+
+# Standard
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, cast
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.observability import LMCStatsMonitor, PrometheusLogger
+from lmcache.v1.memory_management import (
+    MemoryAllocatorInterface,
+    MemoryFormat,
+    MemoryObj,
+)
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PoolRequest:
+    """
+    Describes a single borrow request from the MemoryPool. Callers can either
+    provide tensor shape/dtype/fmt or, for raw buffers, just the size.
+    """
+
+    shape: Optional[torch.Size] = None
+    dtype: Optional[torch.dtype] = None
+    fmt: MemoryFormat = MemoryFormat.KV_2LTD
+    size: Optional[int] = None
+    pinned: bool = False
+    tag: str = "generic"
+    eviction: bool = True
+    busy_loop: bool = True
+
+    def resolve_shape(self) -> torch.Size:
+        if self.fmt == MemoryFormat.BINARY_BUFFER:
+            if self.size is None and self.shape is None:
+                raise ValueError("PoolRequest for BINARY_BUFFER expects size or shape")
+            if self.shape is not None:
+                return self.shape
+            return torch.Size([self.size])  # type: ignore[arg-type]
+
+        if self.shape is None or self.dtype is None:
+            raise ValueError(
+                "PoolRequest requires shape and dtype for tensor allocations"
+            )
+        return self.shape
+
+
+class MemoryPool:
+    """
+    Thin facade that centralises engine-owned allocations and basic accounting.
+    """
+
+    _STAT_LIVE_LEASES = "pool_live_leases"
+    _STAT_BORROWED_BYTES = "pool_borrowed_bytes"
+
+    def __init__(
+        self,
+        allocator: MemoryAllocatorInterface,
+        backend: Optional["AllocatorBackendInterface"] = None,
+    ) -> None:
+        self._allocator = allocator
+        self._backend = backend
+        self._live_leases = 0
+        self._borrowed_bytes = 0
+        self._lock = threading.Lock()
+
+        self._stats_monitor = LMCStatsMonitor.GetOrCreate()
+        self._prometheus_logger = PrometheusLogger.GetInstanceOrNone()
+
+    def borrow(self, req: PoolRequest) -> MemoryObj:
+        """Borrow a MemoryObj from the underlying allocator."""
+        shape = req.resolve_shape()
+        memory_obj: Optional[MemoryObj]
+        if self._backend is not None:
+            allocate_from_pool = getattr(self._backend, "allocate_from_pool", None)
+            if callable(allocate_from_pool):
+                memory_obj = allocate_from_pool(req)
+            else:
+                backend_allocate = getattr(self._backend, "allocate", None)
+                if callable(backend_allocate) and (
+                    req.fmt != MemoryFormat.BINARY_BUFFER
+                ):
+                    if req.dtype is None:
+                        raise ValueError(
+                            "PoolRequest dtype must be set for backend allocations"
+                        )
+                    memory_obj = backend_allocate(
+                        shape,
+                        req.dtype,
+                        req.fmt,
+                        eviction=req.eviction,
+                        busy_loop=req.busy_loop,
+                    )
+                else:
+                    memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
+        else:
+            memory_obj = self._allocator.allocate(shape, req.dtype, req.fmt)
+        if memory_obj is None:
+            raise RuntimeError(
+                f"MemoryPool failed to allocate object (fmt={req.fmt}, tag={req.tag})"
+            )
+
+        memory_obj_any = cast(Any, memory_obj)
+        original_parent = getattr(memory_obj_any, "parent_allocator", None)
+        memory_obj_any._memory_pool_original_parent = original_parent
+        memory_obj_any._memory_pool_released = False
+        memory_obj_any.parent_allocator = self  # type: ignore[attr-defined]
+
+        phy_size = memory_obj.meta.phy_size
+        with self._lock:
+            self._live_leases += 1
+            self._borrowed_bytes += phy_size
+            self._update_metrics()
+        logger.debug(
+            "MemoryPool borrowed %s bytes (tag=%s, fmt=%s, total_leases=%d)",
+            phy_size,
+            req.tag,
+            req.fmt,
+            self._live_leases,
+        )
+        return memory_obj
+
+    def release(self, memory_obj: MemoryObj) -> None:
+        memory_obj_any = cast(Any, memory_obj)
+        phy_size = memory_obj.meta.phy_size
+        already_released = getattr(memory_obj_any, "_memory_pool_released", False)
+        if already_released:
+            logger.warning(
+                "MemoryPool.release called multiple times for %s", memory_obj
+            )
+            return
+        memory_obj_any._memory_pool_released = True
+
+        original_parent = getattr(
+            memory_obj_any, "_memory_pool_original_parent", None
+        )
+        if original_parent is None or original_parent is self:
+            original_parent = self._allocator
+
+        # Restore the original parent allocator before delegating free.
+        memory_obj_any.parent_allocator = original_parent  # type: ignore[attr-defined]
+        try:
+            original_parent.free(memory_obj)  # type: ignore[call-arg]
+        finally:
+            with self._lock:
+                self._live_leases -= 1
+                self._borrowed_bytes -= phy_size
+                if self._live_leases < 0 or self._borrowed_bytes < 0:
+                    logger.warning(
+                        "MemoryPool counters negative after release "
+                        "(leases=%d, bytes=%d)",
+                        self._live_leases,
+                        self._borrowed_bytes,
+                    )
+                    self._live_leases = max(self._live_leases, 0)
+                    self._borrowed_bytes = max(self._borrowed_bytes, 0)
+                self._update_metrics()
+            if hasattr(memory_obj_any, "_memory_pool_original_parent"):
+                delattr(memory_obj_any, "_memory_pool_original_parent")
+        logger.debug(
+            "MemoryPool released %s bytes (total_leases=%d)",
+            phy_size,
+            self._live_leases,
+        )
+
+    def stats(self) -> Dict[str, int]:
+        with self._lock:
+            return {
+                "live_leases": self._live_leases,
+                "borrowed_bytes": self._borrowed_bytes,
+            }
+
+    def _update_metrics(self) -> None:
+        update_custom_metric = getattr(
+            self._stats_monitor, "update_custom_metric", None
+        )
+        if callable(update_custom_metric):
+            update_custom_metric(self._STAT_LIVE_LEASES, self._live_leases)
+            update_custom_metric(self._STAT_BORROWED_BYTES, self._borrowed_bytes)
+
+        if self._prometheus_logger is not None:
+            update_custom_gauge = getattr(
+                self._prometheus_logger, "update_custom_gauge", None
+            )
+            if callable(update_custom_gauge):
+                update_custom_gauge(self._STAT_LIVE_LEASES, self._live_leases)
+                update_custom_gauge(self._STAT_BORROWED_BYTES, self._borrowed_bytes)
+
+    def free(self, memory_obj: MemoryObj, allocator_type: Optional[str] = None) -> None:
+        """
+        Allows MemoryObj instances to treat the pool as their parent allocator.
+        """
+        self.release(memory_obj)
+
+
+@contextmanager
+def lease(pool: MemoryPool, req: PoolRequest) -> Iterator[MemoryObj]:
+    """
+    Convenience helper that guarantees release even if the caller throws.
+    """
+    memory_obj = pool.borrow(req)
+    try:
+        yield memory_obj
+    except Exception as exc:  # pragma: no cover - logged for observability
+        logger.exception("MemoryPool lease raised exception: %s", exc)
+        raise
+    finally:
+        pool.release(memory_obj)

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -14,7 +14,10 @@ from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.gds_backend import GdsBackend
-from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.local_cpu_backend import (
+    LocalCPUBackend,
+    LocalCPUDisabledError,
+)
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 from lmcache.v1.storage_backend.p2p_backend import P2PBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
@@ -120,17 +123,33 @@ def CreateStorageBackends(
     # TODO(Jiayi): The hierarchy is fixed for now
     # NOTE(Jiayi): The local_cpu backend is always created because
     # other backends might need it as a buffer.
+    local_cpu_backend: Optional[LocalCPUBackend] = None
     if not config.enable_pd or config.local_cpu:
-        local_cpu_backend = LocalCPUBackend(
-            config,
-            metadata,
-            dst_device,
-            lmcache_worker,
-        )
-        backend_name = str(local_cpu_backend)
-        storage_backends[backend_name] = local_cpu_backend
+        try:
+            local_cpu_backend = LocalCPUBackend(
+                config,
+                metadata,
+                dst_device,
+                lmcache_worker,
+            )
+        except LocalCPUDisabledError as exc:
+            if config.local_cpu or not config.enable_pd:
+                raise ValueError(
+                    "LocalCPUBackend requires max_local_cpu_size > 0 when "
+                    "local_cpu is enabled or PD is disabled."
+                ) from exc
+            logger.info(
+                "Skipping LocalCPUBackend initialization because max_local_cpu_size "
+                "is non-positive while PD is enabled."
+            )
+            local_cpu_backend = None
+        else:
+            backend_name = str(local_cpu_backend)
+            storage_backends[backend_name] = local_cpu_backend
 
     if config.enable_p2p:
+        if local_cpu_backend is None:
+            raise ValueError("enable_p2p requires max_local_cpu_size > 0")
         p2p_backend = P2PBackend(
             config,
             metadata,
@@ -152,6 +171,8 @@ def CreateStorageBackends(
         )
 
     if config.local_disk and config.max_local_disk_size > 0:
+        if local_cpu_backend is None:
+            raise ValueError("local_disk backend requires max_local_cpu_size > 0")
         local_disk_backend = LocalDiskBackend(
             config, loop, local_cpu_backend, dst_device, lmcache_worker
         )
@@ -169,6 +190,8 @@ def CreateStorageBackends(
         gds_backend = GdsBackend(config, metadata, loop, dst_device)
         storage_backends[str(gds_backend)] = gds_backend
     if config.remote_url is not None:
+        if local_cpu_backend is None:
+            raise ValueError("remote_url requires max_local_cpu_size > 0")
         remote_backend = RemoteBackend(
             config,
             metadata,
@@ -179,7 +202,7 @@ def CreateStorageBackends(
         backend_name = str(remote_backend)
         storage_backends[backend_name] = remote_backend
 
-    if not config.enable_pd or config.local_cpu:
+    if (not config.enable_pd or config.local_cpu) and local_cpu_backend is not None:
         # Create dynamic backends from configuration
         create_dynamic_backends(
             config,

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -143,12 +143,18 @@ class FSConnector(RemoteConnector):
 
                     # Deserialize metadata and allocate memory
                     metadata = RemoteMetadata.deserialize(md_buffer)
-                    memory_obj = self.local_cpu_backend.allocate(
-                        metadata.shape, metadata.dtype, metadata.fmt
+                    memory_obj = self.local_cpu_backend.request_memory(
+                        metadata.shape,
+                        metadata.dtype,
+                        metadata.fmt,
+                        tag="fs/get",
                     )
                 else:
-                    memory_obj = self.local_cpu_backend.allocate(
-                        self.meta_shape, self.meta_dtype, self.meta_fmt
+                    memory_obj = self.local_cpu_backend.request_memory(
+                        self.meta_shape,
+                        self.meta_dtype,
+                        self.meta_fmt,
+                        tag="fs/get",
                     )
                 if memory_obj is None:
                     logger.debug("Memory allocation failed during async disk load.")

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -472,36 +472,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
             busy_loop=req.busy_loop,
         )
 
-    @_lmcache_nvtx_annotate
-    def allocate(
-        self,
-        shape: torch.Size,
-        dtype: torch.dtype,
-        fmt: Optional[MemoryFormat] = None,
-        eviction: bool = True,
-        busy_loop: bool = True,
-    ) -> Optional[MemoryObj]:
-        fmt_resolved = self._resolve_memory_format(fmt)
-        req = PoolRequest(
-            shape=shape,
-            dtype=dtype,
-            fmt=fmt_resolved,
-            tag="local_cpu.allocate",
-            eviction=eviction,
-            busy_loop=busy_loop,
-        )
-        try:
-            return self.memory_pool.borrow(req)
-        except RuntimeError:
-            return None
-
-    def request_memory(
+    def _request_from_pool(
         self,
         shape: torch.Size,
         dtype: torch.dtype,
         fmt: Optional[MemoryFormat] = None,
         *,
-        tag: str = "local_cpu.request",
+        tag: str,
         eviction: bool = True,
         busy_loop: bool = True,
     ) -> Optional[MemoryObj]:
@@ -518,6 +495,43 @@ class LocalCPUBackend(AllocatorBackendInterface):
             return self.memory_pool.borrow(req)
         except RuntimeError:
             return None
+
+    @_lmcache_nvtx_annotate
+    def allocate(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: Optional[MemoryFormat] = None,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        return self._request_from_pool(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt,
+            tag="local_cpu.allocate",
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+
+    def request_memory(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: Optional[MemoryFormat] = None,
+        *,
+        tag: str = "local_cpu.request",
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        return self._request_from_pool(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt,
+            tag=tag,
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
 
     @_lmcache_nvtx_annotate
     def batched_allocate(

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -22,6 +22,7 @@ from lmcache.v1.memory_management import (
     MixedMemoryAllocator,
     PagedCpuGpuMemoryAllocator,
 )
+from lmcache.v1.memory_pool import MemoryPool, PoolRequest
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy
 from lmcache.v1.system_detection import NUMADetector, SystemMemoryDetector
@@ -66,6 +67,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
             if memory_allocator is None
             else memory_allocator
         )
+        self.memory_pool = MemoryPool(self.memory_allocator, backend=self)
         self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
         self.cpu_lock = threading.Lock()
@@ -361,32 +363,24 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 numa_mapping=numa_mapping,
             )
 
-    @_lmcache_nvtx_annotate
-    def allocate(
+    def _resolve_memory_format(self, fmt: Optional[MemoryFormat]) -> MemoryFormat:
+        if fmt is not None:
+            return fmt
+        if self.layerwise:
+            return MemoryFormat.KV_2TD if self.enable_blending else MemoryFormat.KV_T2D
+        return MemoryFormat.KV_2LTD
+
+    def _allocate_internal(
         self,
         shape: torch.Size,
         dtype: torch.dtype,
-        fmt: Optional[MemoryFormat] = None,
-        eviction: bool = True,
-        busy_loop: bool = True,
+        fmt: MemoryFormat,
+        eviction: bool,
+        busy_loop: bool,
     ) -> Optional[MemoryObj]:
-        """
-        Allocate a memory object of shape and dtype
-        evict if necessary. Storage manager should always call
-        local_cpu_backend.allocate() to get memory objects
-        regardless of whether local_cpu is True or False
-        """
         logger.debug(
-            f"Allocating memory in local cpu backend with busy loop: {busy_loop}"
+            "Allocating memory in local cpu backend with busy loop: %s", busy_loop
         )
-        if fmt is None:
-            if self.layerwise:
-                if self.enable_blending:
-                    fmt = MemoryFormat.KV_2TD
-                else:
-                    fmt = MemoryFormat.KV_T2D
-            else:
-                fmt = MemoryFormat.KV_2LTD
 
         memory_obj = self.memory_allocator.allocate(shape, dtype, fmt)
         if memory_obj is not None or not eviction:
@@ -411,7 +405,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                         # and don't need to wait for other requests yet
                         wait_other_requests = False
                         logger.debug(
-                            f"Evicting {len(evict_keys)} chunks from cpu memory"
+                            "Evicting %d chunks from cpu memory", len(evict_keys)
                         )
                         # remove
                         self.batched_remove(evict_keys, force=False)
@@ -433,7 +427,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 logger.warning(
                     "No eviction candidates found in local cpu backend. "
                     "Local cpu memory is under pressure. "
-                    f"Waiting for {time_to_wait} seconds before retrying."
+                    "Waiting for %s seconds before retrying.",
+                    time_to_wait,
                 )
                 # self.memory_allocator.memcheck()
                 # do not hold the lock during sleep
@@ -445,12 +440,74 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
             num_attempts += 1
             logger.debug(
-                f"Unable to allocate memory object after {num_attempts}"
-                " attempts of local cpu backend allocate()"
+                "Unable to allocate memory object after %d attempts of local cpu backend allocate()",
+                num_attempts,
             )
 
         self.stats_monitor.update_local_cpu_evict_metrics(evict_keys_count)
         return memory_obj
+
+    def allocate_from_pool(self, req: PoolRequest) -> Optional[MemoryObj]:
+        fmt = self._resolve_memory_format(req.fmt)
+        if fmt != MemoryFormat.BINARY_BUFFER and req.dtype is None:
+            raise ValueError("dtype must be specified for tensor allocations")
+        shape = req.resolve_shape()
+        dtype = req.dtype if req.dtype is not None else torch.uint8
+        assert dtype is not None
+        return self._allocate_internal(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt,
+            eviction=req.eviction,
+            busy_loop=req.busy_loop,
+        )
+
+    @_lmcache_nvtx_annotate
+    def allocate(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: Optional[MemoryFormat] = None,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        fmt_resolved = self._resolve_memory_format(fmt)
+        req = PoolRequest(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt_resolved,
+            tag="local_cpu.allocate",
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+        try:
+            return self.memory_pool.borrow(req)
+        except RuntimeError:
+            return None
+
+    def request_memory(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: Optional[MemoryFormat] = None,
+        *,
+        tag: str = "local_cpu.request",
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        fmt_resolved = self._resolve_memory_format(fmt)
+        req = PoolRequest(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt_resolved,
+            tag=tag,
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+        try:
+            return self.memory_pool.borrow(req)
+        except RuntimeError:
+            return None
 
     @_lmcache_nvtx_annotate
     def batched_allocate(

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -22,6 +22,7 @@ from lmcache.v1.memory_management import (
     MixedMemoryAllocator,
     PagedCpuGpuMemoryAllocator,
 )
+from lmcache.v1.memory_pool import MemoryPool, PoolRequest
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy
 from lmcache.v1.system_detection import NUMADetector, SystemMemoryDetector
@@ -31,6 +32,10 @@ if TYPE_CHECKING:
     from lmcache.v1.cache_controller.worker import LMCacheWorker
 
 logger = init_logger(__name__)
+
+
+class LocalCPUDisabledError(RuntimeError):
+    """Raised when LocalCPUBackend is disabled due to zero configured capacity."""
 
 
 class LocalCPUBackend(AllocatorBackendInterface):
@@ -66,6 +71,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
             if memory_allocator is None
             else memory_allocator
         )
+        self.memory_pool = MemoryPool(self.memory_allocator, backend=self)
         self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
         self.cpu_lock = threading.Lock()
@@ -334,6 +340,11 @@ class LocalCPUBackend(AllocatorBackendInterface):
         # Calculate effective CPU memory size
         cpu_size = self._calculate_effective_cpu_size(cpu_size, config, metadata)
 
+        if cpu_size <= 0:
+            raise LocalCPUDisabledError(
+                "LocalCPUBackend disabled because max_local_cpu_size <= 0"
+            )
+
         if config.enable_p2p:
             assert metadata is not None
             meta_shape = torch.Size(metadata.kv_shape)
@@ -361,32 +372,24 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 numa_mapping=numa_mapping,
             )
 
-    @_lmcache_nvtx_annotate
-    def allocate(
+    def _resolve_memory_format(self, fmt: Optional[MemoryFormat]) -> MemoryFormat:
+        if fmt is not None:
+            return fmt
+        if self.layerwise:
+            return MemoryFormat.KV_2TD if self.enable_blending else MemoryFormat.KV_T2D
+        return MemoryFormat.KV_2LTD
+
+    def _allocate_internal(
         self,
         shape: torch.Size,
         dtype: torch.dtype,
-        fmt: Optional[MemoryFormat] = None,
-        eviction: bool = True,
-        busy_loop: bool = True,
+        fmt: MemoryFormat,
+        eviction: bool,
+        busy_loop: bool,
     ) -> Optional[MemoryObj]:
-        """
-        Allocate a memory object of shape and dtype
-        evict if necessary. Storage manager should always call
-        local_cpu_backend.allocate() to get memory objects
-        regardless of whether local_cpu is True or False
-        """
         logger.debug(
-            f"Allocating memory in local cpu backend with busy loop: {busy_loop}"
+            "Allocating memory in local cpu backend with busy loop: %s", busy_loop
         )
-        if fmt is None:
-            if self.layerwise:
-                if self.enable_blending:
-                    fmt = MemoryFormat.KV_2TD
-                else:
-                    fmt = MemoryFormat.KV_T2D
-            else:
-                fmt = MemoryFormat.KV_2LTD
 
         memory_obj = self.memory_allocator.allocate(shape, dtype, fmt)
         if memory_obj is not None or not eviction:
@@ -411,7 +414,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                         # and don't need to wait for other requests yet
                         wait_other_requests = False
                         logger.debug(
-                            f"Evicting {len(evict_keys)} chunks from cpu memory"
+                            "Evicting %d chunks from cpu memory", len(evict_keys)
                         )
                         # remove
                         self.batched_remove(evict_keys, force=False)
@@ -433,7 +436,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 logger.warning(
                     "No eviction candidates found in local cpu backend. "
                     "Local cpu memory is under pressure. "
-                    f"Waiting for {time_to_wait} seconds before retrying."
+                    "Waiting for %s seconds before retrying.",
+                    time_to_wait,
                 )
                 # self.memory_allocator.memcheck()
                 # do not hold the lock during sleep
@@ -445,12 +449,75 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
             num_attempts += 1
             logger.debug(
-                f"Unable to allocate memory object after {num_attempts}"
-                " attempts of local cpu backend allocate()"
+                "Unable to allocate memory object after %d attempts of "
+                "local cpu backend allocate()",
+                num_attempts,
             )
 
         self.stats_monitor.update_local_cpu_evict_metrics(evict_keys_count)
         return memory_obj
+
+    def allocate_from_pool(self, req: PoolRequest) -> Optional[MemoryObj]:
+        fmt = self._resolve_memory_format(req.fmt)
+        if fmt != MemoryFormat.BINARY_BUFFER and req.dtype is None:
+            raise ValueError("dtype must be specified for tensor allocations")
+        shape = req.resolve_shape()
+        dtype = req.dtype if req.dtype is not None else torch.uint8
+        assert dtype is not None
+        return self._allocate_internal(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt,
+            eviction=req.eviction,
+            busy_loop=req.busy_loop,
+        )
+
+    @_lmcache_nvtx_annotate
+    def allocate(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: Optional[MemoryFormat] = None,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        fmt_resolved = self._resolve_memory_format(fmt)
+        req = PoolRequest(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt_resolved,
+            tag="local_cpu.allocate",
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+        try:
+            return self.memory_pool.borrow(req)
+        except RuntimeError:
+            return None
+
+    def request_memory(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: Optional[MemoryFormat] = None,
+        *,
+        tag: str = "local_cpu.request",
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        fmt_resolved = self._resolve_memory_format(fmt)
+        req = PoolRequest(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt_resolved,
+            tag=tag,
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+        try:
+            return self.memory_pool.borrow(req)
+        except RuntimeError:
+            return None
 
     @_lmcache_nvtx_annotate
     def batched_allocate(

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    cast,
 )
 import asyncio
 import functools
@@ -28,10 +29,8 @@ from lmcache.utils import (
 )
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventStatus, EventType
-from lmcache.v1.memory_management import (
-    MemoryFormat,
-    MemoryObj,
-)
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.memory_pool import MemoryPool, PoolRequest
 from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,
@@ -215,6 +214,14 @@ class StorageManager:
         if config.local_cpu:
             self.local_cpu_backend = self.storage_backends["LocalCPUBackend"]
 
+        backend_owner = cast(Any, self.allocator_backend)
+        backend_pool = getattr(backend_owner, "memory_pool", None)
+        if backend_pool is None:
+            allocator = self.allocator_backend.get_memory_allocator()
+            backend_pool = MemoryPool(allocator, backend=self.allocator_backend)
+            backend_owner.memory_pool = backend_pool
+        self.memory_pool: MemoryPool = backend_pool
+
         self.manager_lock = threading.Lock()
 
         self.lmcache_worker = lmcache_worker
@@ -289,6 +296,42 @@ class StorageManager:
         return self.allocator_backend.batched_allocate(
             shape, dtype, batch_size, fmt, eviction=eviction, busy_loop=busy_loop
         )
+
+    def request_memory(
+        self,
+        *,
+        shape: Optional[torch.Size] = None,
+        dtype: Optional[torch.dtype] = None,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        size: Optional[int] = None,
+        tag: str = "generic",
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> MemoryObj:
+        """
+        Borrow a MemoryObj from the shared memory pool. This centralizes
+        allocation for connectors and other engine-owned components.
+        """
+        if self.memory_pool is None:
+            raise RuntimeError("MemoryPool is not available")
+        req = PoolRequest(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt,
+            size=size,
+            tag=tag,
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+        return self.memory_pool.borrow(req)
+
+    def release_memory(self, memory_obj: MemoryObj) -> None:
+        """
+        Release a previously borrowed MemoryObj back to the pool.
+        """
+        if self.memory_pool is None:
+            raise RuntimeError("MemoryPool is not available")
+        self.memory_pool.release(memory_obj)
 
     def put(
         self,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -28,10 +28,8 @@ from lmcache.utils import (
 )
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventStatus, EventType
-from lmcache.v1.memory_management import (
-    MemoryFormat,
-    MemoryObj,
-)
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.memory_pool import MemoryPool, PoolRequest
 from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,
@@ -215,6 +213,13 @@ class StorageManager:
         if config.local_cpu:
             self.local_cpu_backend = self.storage_backends["LocalCPUBackend"]
 
+        backend_pool = getattr(self.allocator_backend, "memory_pool", None)
+        if backend_pool is None:
+            allocator = self.allocator_backend.get_memory_allocator()
+            backend_pool = MemoryPool(allocator, backend=self.allocator_backend)
+            setattr(self.allocator_backend, "memory_pool", backend_pool)
+        self.memory_pool = backend_pool
+
         self.manager_lock = threading.Lock()
 
         self.lmcache_worker = lmcache_worker
@@ -289,6 +294,42 @@ class StorageManager:
         return self.allocator_backend.batched_allocate(
             shape, dtype, batch_size, fmt, eviction=eviction, busy_loop=busy_loop
         )
+
+    def request_memory(
+        self,
+        *,
+        shape: Optional[torch.Size] = None,
+        dtype: Optional[torch.dtype] = None,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        size: Optional[int] = None,
+        tag: str = "generic",
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> MemoryObj:
+        """
+        Borrow a MemoryObj from the shared memory pool. This centralizes
+        allocation for connectors and other engine-owned components.
+        """
+        if self.memory_pool is None:
+            raise RuntimeError("MemoryPool is not available")
+        req = PoolRequest(
+            shape=shape,
+            dtype=dtype,
+            fmt=fmt,
+            size=size,
+            tag=tag,
+            eviction=eviction,
+            busy_loop=busy_loop,
+        )
+        return self.memory_pool.borrow(req)
+
+    def release_memory(self, memory_obj: MemoryObj) -> None:
+        """
+        Release a previously borrowed MemoryObj back to the pool.
+        """
+        if self.memory_pool is None:
+            raise RuntimeError("MemoryPool is not available")
+        self.memory_pool.release(memory_obj)
 
     def put(
         self,

--- a/tests/v1/test_memory_pool.py
+++ b/tests/v1/test_memory_pool.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat
+from lmcache.v1.memory_pool import MemoryPool, PoolRequest, lease
+from lmcache.v1.storage_backend.local_cpu_backend import (
+    LocalCPUBackend,
+    LocalCPUDisabledError,
+)
+from tests.v1.utils import dumb_metadata
+
+
+def _make_pool():
+    allocator = AdHocMemoryAllocator(device="cpu")
+    pool = MemoryPool(allocator)
+    return pool, allocator
+
+
+def _sample_request(tag: str = "test") -> PoolRequest:
+    return PoolRequest(
+        shape=torch.Size([1, 1, 1, 1]),
+        dtype=torch.float32,
+        fmt=MemoryFormat.KV_2LTD,
+        tag=tag,
+    )
+
+
+def test_borrow_release_updates_stats_and_parent():
+    pool, allocator = _make_pool()
+    req = _sample_request()
+    memory_obj = pool.borrow(req)
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 1
+    assert stats["borrowed_bytes"] == memory_obj.meta.phy_size
+    assert memory_obj.parent_allocator is pool
+
+    pool.release(memory_obj)
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 0
+    assert stats["borrowed_bytes"] == 0
+    assert memory_obj.parent_allocator is allocator
+
+
+def test_lease_scope_releases_on_exception():
+    pool, _ = _make_pool()
+    req = _sample_request(tag="lease_exception")
+
+    with pytest.raises(RuntimeError):
+        with lease(pool, req):
+            raise RuntimeError("boom")
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 0
+    assert stats["borrowed_bytes"] == 0
+
+
+def test_ref_count_down_triggers_pool_release():
+    pool, _ = _make_pool()
+    req = _sample_request(tag="refcount")
+
+    memory_obj = pool.borrow(req)
+    assert pool.stats()["live_leases"] == 1
+
+    memory_obj.ref_count_down()
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 0
+    assert stats["borrowed_bytes"] == 0
+
+
+class _BackendStub:
+    def __init__(self, allocator):
+        self.allocator = allocator
+        self.calls = []
+
+    def allocate(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ):
+        self.calls.append((shape, dtype, fmt, eviction, busy_loop))
+        return self.allocator.allocate(shape, dtype, fmt)
+
+
+def test_backend_fallback_preserves_allocator_type():
+    allocator = AdHocMemoryAllocator(device="cpu")
+    backend = _BackendStub(allocator)
+    pool = MemoryPool(allocator, backend=backend)
+    req = _sample_request(tag="backend_fallback")
+
+    memory_obj = pool.borrow(req)
+    assert memory_obj is not None
+    assert backend.calls, "expected backend.allocate to be used in fallback path"
+
+
+def test_local_cpu_backend_zero_size_disables():
+    config = LMCacheEngineConfig.from_defaults()
+    config.max_local_cpu_size = 0.0
+    config.local_cpu = False
+    config.enable_pd = True
+    metadata = dumb_metadata()
+
+    with pytest.raises(LocalCPUDisabledError):
+        LocalCPUBackend(config, metadata, dst_device="cpu")

--- a/tests/v1/test_memory_pool.py
+++ b/tests/v1/test_memory_pool.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat
+from lmcache.v1.memory_pool import MemoryPool, PoolRequest, lease
+
+
+def _make_pool():
+    allocator = AdHocMemoryAllocator(device="cpu")
+    pool = MemoryPool(allocator)
+    return pool, allocator
+
+
+def _sample_request(tag: str = "test") -> PoolRequest:
+    return PoolRequest(
+        shape=torch.Size([1, 1, 1, 1]),
+        dtype=torch.float32,
+        fmt=MemoryFormat.KV_2LTD,
+        tag=tag,
+    )
+
+
+def test_borrow_release_updates_stats_and_parent():
+    pool, allocator = _make_pool()
+    req = _sample_request()
+    memory_obj = pool.borrow(req)
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 1
+    assert stats["borrowed_bytes"] == memory_obj.meta.phy_size
+    assert memory_obj.parent_allocator is pool
+
+    pool.release(memory_obj)
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 0
+    assert stats["borrowed_bytes"] == 0
+    assert memory_obj.parent_allocator is allocator
+
+
+def test_lease_scope_releases_on_exception():
+    pool, _ = _make_pool()
+    req = _sample_request(tag="lease_exception")
+
+    with pytest.raises(RuntimeError):
+        with lease(pool, req):
+            raise RuntimeError("boom")
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 0
+    assert stats["borrowed_bytes"] == 0
+
+
+def test_ref_count_down_triggers_pool_release():
+    pool, _ = _make_pool()
+    req = _sample_request(tag="refcount")
+
+    memory_obj = pool.borrow(req)
+    assert pool.stats()["live_leases"] == 1
+
+    memory_obj.ref_count_down()
+
+    stats = pool.stats()
+    assert stats["live_leases"] == 0
+    assert stats["borrowed_bytes"] == 0
+
+
+class _BackendStub:
+    def __init__(self, allocator):
+        self.allocator = allocator
+        self.calls = []
+
+    def allocate(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ):
+        self.calls.append((shape, dtype, fmt, eviction, busy_loop))
+        return self.allocator.allocate(shape, dtype, fmt)
+
+
+def test_backend_fallback_preserves_allocator_type():
+    allocator = AdHocMemoryAllocator(device="cpu")
+    backend = _BackendStub(allocator)
+    pool = MemoryPool(allocator, backend=backend)
+    req = _sample_request(tag="backend_fallback")
+
+    memory_obj = pool.borrow(req)
+    assert memory_obj is not None
+    assert backend.calls, "expected backend.allocate to be used in fallback path"


### PR DESCRIPTION
  What this PR does / why we need it:

  - Refs #1830 and #1713.
  - Adds lmcache/v1/memory_pool.py, providing a MemoryPool/PoolRequest facade so every CPU MemoryObj is borrowed and released through the engine rather than through connectors/backends.
  - Wires the pool into LocalCPUBackend and StorageManager; introduces StorageManager.request_memory(...) / release_memory(...) as the sanctioned API for connectors.
  - Guards zero-capacity configurations via LocalCPUDisabledError, preventing creation of 0-byte pinned buffers while still allowing PD deployments to skip the CPU backend entirely.
  - Updates the FS connector sample path to use the pool and refreshes README highlights.
  - Adds tests/v1/test_memory_pool.py coverage for borrow/release accounting, exception safety, backend fallback, and the zero-size guard.

  Special notes:

  - MemoryPool is always-on: there is no feature flag. Please sanity-check the PD fallback path (allocate_from_pool vs. backend allocate), since that was the critical review finding.
  - Confirm that other backends relying on LocalCPUBackend (p2p, local disk, remote) still require a positive CPU budget; configuration errors now surface immediately.

  If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
