### PR TITLE
[Bugfix] re-validate LMCacheEngineConfig after updating from environment …

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -705,7 +705,7 @@ def _update_config_from_env(self):
                 )
                 # Keep existing value if conversion fails
 
-    return self
+    return self.validate()
 
 
 def _from_env(cls):


### PR DESCRIPTION
This PR fixes PR #1572, which prioritizes environment variables over the configuration file. However, the current implementation does not re-validate the configurations after updating them from environment variables, potentially leading to undefined behavior.