### PR TITLE
[FIX][Adapt_vllm] Fix ci failed by get_kv_cache_torch_dtype missed

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -130,8 +130,12 @@ def create_lmcache_metadata(
         tuple: (LMCacheEngineMetadata, LMCacheEngineConfig)
     """
     # Third Party
-    from vllm.utils.torch_utils import get_kv_cache_torch_dtype
-
+    # Try to import from old location before merged https://github.com/vllm-project/vllm/pull/26908
+    try:
+        # Third Party
+        from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+    except ImportError:
+        from vllm.utils import get_kv_cache_torch_dtype
     # First Party
     from lmcache.config import LMCacheEngineMetadata
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -19,7 +19,15 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.sampling_params import SamplingParams
 from vllm.utils import cdiv
-from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+
+# Try to import from old location before merged https://github.com/vllm-project/vllm/pull/26908
+try:
+    # Third Party
+    from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+except ImportError:
+    from vllm.utils import get_kv_cache_torch_dtype
+
+# Third Party
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.version import __version__ as VLLM_VERSION
 import torch


### PR DESCRIPTION
After merged https://github.com/vllm-project/vllm/pull/26908 the `get_kv_cache_torch_dtype` moved to new location, it caused LMCache failed.