### PR TITLE
[core]add error handling in kv loading

### DIFF
--- a/lmcache/integration/vllm/lmcache_connector_v1.py
+++ b/lmcache/integration/vllm/lmcache_connector_v1.py
@@ -114,6 +114,10 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         """
         return self._lmcache_engine.get_finished(finished_req_ids)
 
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Return block IDs that failed to load during the last interval."""
+        return self._lmcache_engine.get_block_ids_with_load_errors()
+
     # ==============================
     # Scheduler-side methods
     # ==============================

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -911,6 +911,11 @@ class LMCacheConnectorV1Impl:
                     )
                     self._invalid_block_ids.update(missing_blocks)
 
+            self._stats_monitor.update_interval_vllm_hit_tokens(
+                request.load_spec.vllm_cached_tokens
+            )
+            self._stats_monitor.update_interval_prompt_tokens(len(tokens))
+
     def record_failed_blocks(
         self,
         request_id: str,
@@ -984,11 +989,6 @@ class LMCacheConnectorV1Impl:
             len(missing_blocks),
         )
         return missing_blocks
-
-            self._stats_monitor.update_interval_vllm_hit_tokens(
-                request.load_spec.vllm_cached_tokens
-            )
-            self._stats_monitor.update_interval_prompt_tokens(len(tokens))
 
     @_lmcache_nvtx_annotate
     def wait_for_layer_load(self, layer_name: str) -> None:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -934,9 +934,9 @@ class LMCacheConnectorV1Impl:
             ret_mask: Boolean tensor indicating which tokens were actually
                 successfully retrieved from LMCache. True means the token was
                 successfully loaded. For example, if 256 tokens are expected to be
-                loaded, but only 192 tokens are successfully loaded, then the 
+                loaded, but only 192 tokens are successfully loaded, then the
                 ret_mask will be a tensor of 256 items like [T, T, ..., F, F, ...]
-                where the first 192 elements are True and the last 64 elements 
+                where the first 192 elements are True and the last 64 elements
                 are False.
             slot_mapping: Tensor indicating slot IDs for each token. The block
                 ID is computed by dividing the slot ID by the block size.
@@ -947,7 +947,7 @@ class LMCacheConnectorV1Impl:
             missing_mask = expected_mask & ~ret_mask = [F, F, T, T]
             missing_indices = [2, 3]
             then missing_blocks is calculated from slot_mapping and missing_indices
-                
+
         Returns:
             set[int]: Set of block IDs that failed to load.
         """

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -671,6 +671,9 @@ class LMCacheConnectorV1Impl:
 
         self._requests_priority: dict[str, int] = {}
 
+        # Track block IDs associated with failed load attempts.
+        self._invalid_block_ids: set[int] = set()
+
         # TODO(baoloongmao): Internal api server & plugin framework support dp > 1
         if vllm_config.parallel_config.data_parallel_rank_local == 0:
             # Start internal API server if enabled
@@ -885,6 +888,59 @@ class LMCacheConnectorV1Impl:
                         num_retrieved_tokens,
                         num_expected_tokens,
                     )
+                self.record_failed_blocks(
+                    request.req_id,
+                    token_mask[:lmcache_cached_tokens],
+                    ret_token_mask,
+                    slot_mapping[:lmcache_cached_tokens],
+                )
+
+    def record_failed_blocks(
+        self,
+        request_id: str,
+        expected_mask: torch.Tensor,
+        ret_mask: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        """Record block IDs associated with failed load attempts."""
+
+        if expected_mask.numel() == 0:
+            return
+
+        expected_mask_cpu = expected_mask.to(device="cpu", dtype=torch.bool)
+        ret_mask_cpu = ret_mask.to(device="cpu", dtype=torch.bool)
+
+        if ret_mask_cpu.shape[0] != expected_mask_cpu.shape[0]:
+            logger.debug("expected_mask_cpu.shape[0] != ret_mask_cpu.shape[0]")
+            return
+
+        missing_mask = expected_mask_cpu & ~ret_mask_cpu
+        if not torch.any(missing_mask):
+            return
+
+        missing_indices = torch.nonzero(missing_mask, as_tuple=False).view(-1)
+        if missing_indices.numel() == 0:
+            return
+
+        slot_mapping_cpu = slot_mapping.to(device="cpu", dtype=torch.long)
+        if slot_mapping_cpu.shape[0] > missing_mask.shape[0]:
+            slot_mapping_cpu = slot_mapping_cpu[: missing_mask.shape[0]]
+
+        missing_blocks_tensor = torch.unique(
+            slot_mapping_cpu[missing_indices] // self._block_size
+        )
+        missing_blocks = {int(block.item()) for block in missing_blocks_tensor}
+
+        if not missing_blocks:
+            return
+
+        logger.warning(
+            "Request %s failed to load %d token(s) across %d block(s); marking blocks invalid.",
+            request_id,
+            missing_indices.numel(),
+            len(missing_blocks),
+        )
+        self._invalid_block_ids.update(missing_blocks)
 
     @_lmcache_nvtx_annotate
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -1116,6 +1172,11 @@ class LMCacheConnectorV1Impl:
         self, finished_req_ids: set[str]
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
         return None, None
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        invalid_blocks = self._invalid_block_ids.copy()
+        self._invalid_block_ids.clear()
+        return invalid_blocks
 
     ###################
     # Scheduler side APIs

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -900,12 +900,16 @@ class LMCacheConnectorV1Impl:
                         num_retrieved_tokens,
                         num_expected_tokens,
                     )
-                self.record_failed_blocks(
-                    request.req_id,
-                    token_mask[:lmcache_cached_tokens],
-                    ret_token_mask,
-                    slot_mapping[:lmcache_cached_tokens],
-                )
+                    """
+                    Report failed block IDs in case of partial failure.
+                    """
+                    missing_blocks = self.record_failed_blocks(
+                        request.req_id,
+                        token_mask[:lmcache_cached_tokens],
+                        ret_token_mask,
+                        slot_mapping[:lmcache_cached_tokens],
+                    )
+                    self._invalid_block_ids.update(missing_blocks)
 
     def record_failed_blocks(
         self,
@@ -913,26 +917,53 @@ class LMCacheConnectorV1Impl:
         expected_mask: torch.Tensor,
         ret_mask: torch.Tensor,
         slot_mapping: torch.Tensor,
-    ) -> None:
-        """Record block IDs associated with failed load attempts."""
+    ) -> set[int]:
+        """Record block IDs associated with failed load attempts.
+
+        Args:
+            request_id: request id from vLLM.
+            expected_mask: Boolean tensor indicating which tokens were expected to
+                be loaded from LMCache. True means the token should be loaded,
+                False means the token is already cached in vLLM and does not need
+                to be loaded from LMCache.
+            ret_mask: Boolean tensor indicating which tokens were actually
+                successfully retrieved from LMCache. True means the token was
+                successfully loaded. For example, if 256 tokens are expected to be
+                loaded, but only 192 tokens are successfully loaded, then the 
+                ret_mask will be a tensor of 256 items like [T, T, ..., F, F, ...]
+                where the first 192 elements are True and the last 64 elements 
+                are False.
+            slot_mapping: Tensor indicating slot IDs for each token. The block
+                ID is computed by dividing the slot ID by the block size.
+
+        Example:
+            expected_mask = [F, T, T, T] meaning the 1st is in vLLM cache
+            ret_mask = [F, T, F, F] meaning failure from loading the 3rd
+            missing_mask = expected_mask & ~ret_mask = [F, F, T, T]
+            missing_indices = [2, 3]
+            then missing_blocks is calculated from slot_mapping and missing_indices
+                
+        Returns:
+            set[int]: Set of block IDs that failed to load.
+        """
 
         if expected_mask.numel() == 0:
-            return
+            return set()
 
         expected_mask_cpu = expected_mask.to(device="cpu", dtype=torch.bool)
         ret_mask_cpu = ret_mask.to(device="cpu", dtype=torch.bool)
 
         if ret_mask_cpu.shape[0] != expected_mask_cpu.shape[0]:
             logger.debug("expected_mask_cpu.shape[0] != ret_mask_cpu.shape[0]")
-            return
+            return set()
 
         missing_mask = expected_mask_cpu & ~ret_mask_cpu
         if not torch.any(missing_mask):
-            return
+            return set()
 
         missing_indices = torch.nonzero(missing_mask, as_tuple=False).view(-1)
         if missing_indices.numel() == 0:
-            return
+            return set()
 
         slot_mapping_cpu = slot_mapping.to(device="cpu", dtype=torch.long)
         if slot_mapping_cpu.shape[0] > missing_mask.shape[0]:
@@ -944,7 +975,7 @@ class LMCacheConnectorV1Impl:
         missing_blocks = {int(block.item()) for block in missing_blocks_tensor}
 
         if not missing_blocks:
-            return
+            return set()
 
         logger.warning(
             "Request %s failed to load %d tokens across %d blocks",
@@ -952,7 +983,7 @@ class LMCacheConnectorV1Impl:
             missing_indices.numel(),
             len(missing_blocks),
         )
-        self._invalid_block_ids.update(missing_blocks)
+        return missing_blocks
 
             self._stats_monitor.update_interval_vllm_hit_tokens(
                 request.load_spec.vllm_cached_tokens

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -935,7 +935,7 @@ class LMCacheConnectorV1Impl:
             return
 
         logger.warning(
-            "Request %s failed to load %d token(s) across %d block(s); marking blocks invalid.",
+            "Request %s failed to load %d tokens across %d blocks",
             request_id,
             missing_indices.numel(),
             len(missing_blocks),


### PR DESCRIPTION
**Why**:
In most implementation of backends/connectors, lookup() and get() are not atomic. There is a chance that lookup() returns OK and get_num_new_matched_tokens() returns full length of existing cache, but some of cached data is removed or become unreadable before get(). In such cases, lmcache returns shorter-than-expected KV cache to vLLM and may cause wrong output in following computation.

Fortunately vLLM just introduced feature (https://github.com/vllm-project/vllm/pull/19330) that recompute the failed blocks from KV connector. LMCache should have implement such function soon.

**What**:
Added method record_failed_blocks() in vllm_v1_adapter.py to compare `token_mask` and r`et_token_mask` to verify if there is any failure in loading kv. if so, generate a list of invalid block ID `_invalid_block_ids ` from `slot_mapping` 

@ApostaC please kindly review this since I found you are also the reviewer of PR https://github.com/vllm-project/vllm/pull/19330, thanks

**Test**:
to reproduce the issue and verify the change, see in the comment below