### PR TITLE
[Patch] Update import for `get_kv_cache_torch_dtype` after vllm/utils/__init__.py refactoring

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -133,7 +133,7 @@ def create_lmcache_metadata(
     try:
         # Third Party
         from vllm.utils.torch_utils import get_kv_cache_torch_dtype
-    except ImportError:
+    except (ModuleNotFoundError, ImportError):
         from vllm.utils import get_kv_cache_torch_dtype
     # First Party
     from lmcache.config import LMCacheEngineMetadata

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -130,7 +130,8 @@ def create_lmcache_metadata(
         tuple: (LMCacheEngineMetadata, LMCacheEngineConfig)
     """
     # Third Party
-    from vllm.utils import get_kv_cache_torch_dtype
+    from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+
 
     # First Party
     from lmcache.config import LMCacheEngineMetadata

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -131,10 +131,10 @@ def create_lmcache_metadata(
     """
     # Third Party
     try:
+        # Third Party
         from vllm.utils.torch_utils import get_kv_cache_torch_dtype
     except ImportError:
         from vllm.utils import get_kv_cache_torch_dtype
-
     # First Party
     from lmcache.config import LMCacheEngineMetadata
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -130,8 +130,10 @@ def create_lmcache_metadata(
         tuple: (LMCacheEngineMetadata, LMCacheEngineConfig)
     """
     # Third Party
-    from vllm.utils.torch_utils import get_kv_cache_torch_dtype
-
+    try:
+        from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+    except ImportError:
+        from vllm.utils import get_kv_cache_torch_dtype
 
     # First Party
     from lmcache.config import LMCacheEngineMetadata

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -19,7 +19,10 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.sampling_params import SamplingParams
 from vllm.utils import cdiv
-from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+try:
+    from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+except ImportError:
+    from vllm.utils import get_kv_cache_torch_dtype
 
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.version import __version__ as VLLM_VERSION

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -23,7 +23,7 @@ from vllm.utils import cdiv
 try:
     # Third Party
     from vllm.utils.torch_utils import get_kv_cache_torch_dtype
-except ImportError:
+except (ModuleNotFoundError, ImportError):
     from vllm.utils import get_kv_cache_torch_dtype
 
 # Third Party

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -18,7 +18,9 @@ from vllm.distributed.parallel_state import (
     get_tp_group,
 )
 from vllm.sampling_params import SamplingParams
-from vllm.utils import cdiv, get_kv_cache_torch_dtype
+from vllm.utils import cdiv
+from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.version import __version__ as VLLM_VERSION
 import torch

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -19,11 +19,14 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.sampling_params import SamplingParams
 from vllm.utils import cdiv
+
 try:
+    # Third Party
     from vllm.utils.torch_utils import get_kv_cache_torch_dtype
 except ImportError:
     from vllm.utils import get_kv_cache_torch_dtype
 
+# Third Party
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.version import __version__ as VLLM_VERSION
 import torch


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This patch updates LMCache’s vLLM integration to align with the recent refactor of vLLM that moved 
`get_kv_cache_torch_dtype` from `vllm/utils/__init__.py` to `vllm/utils/torch_utils.py`, which caused vLLM Integration Tests to fail:
<img width="1496" height="572" alt="image" src="https://github.com/user-attachments/assets/0303cf4a-34ec-4d62-a02b-3522a6b10d9e" />

**Special notes for your reviewers**:
 The update is for the latest vllm, but also is compatible to the older version.
