### PR TITLE
[hotfix] Reduce async loading log verbosity

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -613,7 +613,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         # calculate budget with safety margin
         max_chunks = total_memory // aligned_chunk_bytes
 
-        return int(max_chunks)
+        return max_chunks
 
     def get_keys(self) -> List[CacheEngineKey]:
         """

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -573,7 +573,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         Returns:
             int: The estimated chunk budget for concurrent allocations
         """
-        logger.info("Attempting to calculate chunk budget for async loading")
+        logger.debug("Attempting to calculate chunk budget for async loading")
         assert self.metadata is not None, (
             "metadata required for chunk budget calculation"
         )
@@ -597,13 +597,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
         else:
             # full: [kv_size, num_layers, chunk_tokens, hidden_dim]
             chunk_bytes = kv_size * num_layers * chunk_tokens * hidden_dim * dtype_size
-        logger.info(
+        logger.debug(
             f"Stats received: num_layers={num_layers}, kv_size={kv_size}, "
             f"chunk_tokens={chunk_tokens}, head_dim={head_size}, "
             f"dtype_size={dtype_size}, "
             f"hidden_dim={hidden_dim}"
         )
-        logger.info(f"Calculated bytes per chunk per rank: {chunk_bytes}")
+        logger.debug(f"Calculated bytes per chunk per rank: {chunk_bytes}")
         # add alignment overhead
         # (MixedMemoryAllocator uses TensorMemoryAllocator with 4KB alignment)
         assert hasattr(self.memory_allocator, "align_bytes")
@@ -613,8 +613,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         # calculate budget with safety margin
         max_chunks = total_memory // aligned_chunk_bytes
 
-        chunk_budget = int(max_chunks)
-        return chunk_budget
+        return int(max_chunks)
 
     def get_keys(self) -> List[CacheEngineKey]:
         """

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -240,7 +240,9 @@ class StorageManager:
             )
             self.async_lookup_server = kwargs.pop("async_lookup_server")
         # PDBackend has't supported calculate_chunk_budget
-        if not self.enable_pd:
+        if not self.enable_pd and (
+            self.config.enable_async_loading or self.config.use_layerwise
+        ):
             self.async_serializer = AsyncSerializer(self.allocator_backend, self.loop)
 
     def _get_allocator_backend(

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -119,7 +119,7 @@ class WeightedSemaphore:
             )
 
         async with self._cond:
-            logger.info(f"WeightedSemaphore: Attempting to acquire {n} chunks")
+            logger.debug(f"WeightedSemaphore: Attempting to acquire {n} chunks")
             if n <= self._concurrent_budget_cap:
                 await self._cond.wait_for(lambda: self._current_chunks >= n)
                 self._current_chunks -= n
@@ -130,7 +130,7 @@ class WeightedSemaphore:
                 )
                 # Reserve everything
                 self._current_chunks = 0
-            logger.info(
+            logger.debug(
                 f"WeightedSemaphore: Acquired {n} chunks, "
                 f"remaining chunks: {self._current_chunks}"
             )


### PR DESCRIPTION
@maobaolong report that current post_init produce too many log caused by async serializer init.