### PR TITLE
fix to use correct mem obj in async loading

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1089,7 +1089,7 @@ class LMCacheEngine:
             chunk_mask_list = [True] * num_chunks
 
         # Now chunk_mask_list is like [F, F, T, ..., T]
-        # where False means the chunk is in upper layer's cache and 
+        # where False means the chunk is in upper layer's cache and
         # doesn't need to be retrieved.
         # So we can use this list to filter out the chunks that are not needed.
         used_indices = set()

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1074,43 +1074,41 @@ class LMCacheEngine:
         # the same order as the lookup order.
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
 
-        # First, iterate through all tokens with an all-true mask to get the
-        # correct mapping between chunk indices and memory objects
-        all_chunks_info = list(
+        # First, generate a list indicating which chunks are needed
+        num_chunks = len(tokens) // self.config.chunk_size
+        if mask is not None:
+            chunk_mask_list = []
+            for i in range(num_chunks):
+                start_idx = i * self.config.chunk_size
+                end_idx = start_idx + self.config.chunk_size
+                # Check if all values in this chunk are True
+                chunk_is_valid = all(mask[start_idx:end_idx])
+                chunk_mask_list.append(chunk_is_valid)
+        else:
+            # If no mask, all chunks are needed
+            chunk_mask_list = [True] * num_chunks
+
+        # Now chunk_mask_list is like [F, F, T, ..., T]
+        # where False means the chunk is in upper layer's cache and 
+        # doesn't need to be retrieved.
+        # So we can use this list to filter out the chunks that are not needed.
+        used_indices = set()
+        for idx, (start, end, key) in enumerate(
             self.token_database.process_tokens(
                 tokens=tokens,
-                mask=None,  # Use all-true mask to get all chunks
+                mask=None,
                 request_configs=request_configs,
             )
-        )
-
-        # Build a mapping from (start, end) to memory object index
-        chunk_to_idx = {
-            (chunk_start, chunk_end): idx
-            for idx, (chunk_start, chunk_end, _) in enumerate(all_chunks_info)
-        }
-
-        # Now iterate with the actual mask to determine which chunks to use
-        used_indices = set()
-        for start, end, key in self.token_database.process_tokens(
-            tokens=tokens,
-            mask=mask,
-            request_configs=request_configs,
         ):
+            if not chunk_mask_list[idx]:
+                continue
+
             assert isinstance(key, CacheEngineKey)
-
-            # Find the correct memory object index by matching the chunk
-            mem_obj_idx = chunk_to_idx.get((start, end))
-
-            assert mem_obj_idx is not None, (
-                f"Could not find matching chunk for start={start}, end={end}"
-            )
-
-            memory_obj = memory_objs[mem_obj_idx]
+            memory_obj = memory_objs[idx]
             chunks.append((key, memory_obj, start, end))
             tot_kv_size += memory_obj.get_size()
             ret_mask[start:end] = True
-            used_indices.add(mem_obj_idx)
+            used_indices.add(idx)
 
         # NOTE: free the memory objects that are not hit.
         for idx, unused_mem_obj in enumerate(memory_objs):

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1075,7 +1075,7 @@ class LMCacheEngine:
         # NOTE(Jiayi): here we assume the retrieved memory_objs have
         # the same order as the lookup order.
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
- 
+
         # First, iterate through all tokens with an all-true mask to get the
         # correct mapping between chunk indices and memory objects
         all_chunks_info = list(

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1075,22 +1075,49 @@ class LMCacheEngine:
         # NOTE(Jiayi): here we assume the retrieved memory_objs have
         # the same order as the lookup order.
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
-        for idx, (start, end, key) in enumerate(
+ 
+        # First, iterate through all tokens with an all-true mask to get the
+        # correct mapping between chunk indices and memory objects
+        all_chunks_info = list(
             self.token_database.process_tokens(
                 tokens=tokens,
-                mask=mask,
+                mask=None,  # Use all-true mask to get all chunks
                 request_configs=request_configs,
             )
+        )
+
+        # Build a mapping from (start, end) to memory object index
+        chunk_to_idx = {
+            (chunk_start, chunk_end): idx
+            for idx, (chunk_start, chunk_end, _) in enumerate(all_chunks_info)
+        }
+
+        # Now iterate with the actual mask to determine which chunks to use
+        used_indices = set()
+        for start, end, key in self.token_database.process_tokens(
+            tokens=tokens,
+            mask=mask,
+            request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)
-            memory_obj = memory_objs[idx]
+
+            # Find the correct memory object index by matching the chunk
+            mem_obj_idx = chunk_to_idx.get((start, end))
+
+            assert mem_obj_idx is not None, (
+                f"Could not find matching chunk for start={start}, end={end}"
+            )
+
+            memory_obj = memory_objs[mem_obj_idx]
             chunks.append((key, memory_obj, start, end))
             tot_kv_size += memory_obj.get_size()
             ret_mask[start:end] = True
+            used_indices.add(mem_obj_idx)
 
         # NOTE: free the memory objects that are not hit.
-        for unused_mem_obj in memory_objs[len(chunks) :]:
-            unused_mem_obj.ref_count_down()
+        for idx, unused_mem_obj in enumerate(memory_objs):
+            if idx not in used_indices:
+                unused_mem_obj.ref_count_down()
 
         return chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1073,37 +1073,14 @@ class LMCacheEngine:
         # NOTE(Jiayi): here we assume the retrieved memory_objs have
         # the same order as the lookup order.
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
-
-        # First, generate a list indicating which chunks are needed
-        num_chunks = len(tokens) // self.config.chunk_size
-        if mask is not None:
-            chunk_mask_list = []
-            for i in range(num_chunks):
-                start_idx = i * self.config.chunk_size
-                end_idx = start_idx + self.config.chunk_size
-                # Check if all values in this chunk are True
-                chunk_is_valid = all(mask[start_idx:end_idx])
-                chunk_mask_list.append(chunk_is_valid)
-        else:
-            # If no mask, all chunks are needed
-            chunk_mask_list = [True] * num_chunks
-
-        # Now chunk_mask_list is like [F, F, T, ..., T]
-        # where False means the chunk is in upper layer's cache and
-        # doesn't need to be retrieved.
-        # So we can use this list to filter out the chunks that are not needed.
         used_indices = set()
-        for idx, (start, end, key) in enumerate(
-            self.token_database.process_tokens(
-                tokens=tokens,
-                mask=None,
-                request_configs=request_configs,
-            )
+        for start, end, key in self.token_database.process_tokens(
+            tokens=tokens,
+            mask=None,
+            request_configs=request_configs,
         ):
-            if not chunk_mask_list[idx]:
-                continue
-
             assert isinstance(key, CacheEngineKey)
+            idx = start // self.config.chunk_size
             memory_obj = memory_objs[idx]
             chunks.append((key, memory_obj, start, end))
             tot_kv_size += memory_obj.get_size()

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1076,7 +1076,7 @@ class LMCacheEngine:
         used_indices = set()
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
-            mask=None,
+            mask=mask,
             request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)


### PR DESCRIPTION
**Why**
As described in issue #1866, when vllm's prefix cache and LMCache are both enabled and async load is enabled. In the test case, LMCache chose the wrong memory object from prefetched objects. It happens as:

When async_lookup_and_prefetch is called, it retrieves memory objects for all chunks (without considering the mask). Later, when _async_process_tokens_internal is called with a mask that has False values at the beginning:
1. The  process_tokens method skips chunks corresponding to the  False values in the mask
2. Current code used idx (iteration counter) to index into memory_objs, but idx only counted the iterations that weren't skipped
3. This caused the wrong memory objects to be selected 

Example: With 256 tokens total (4 chunks of 64 tokens each), if the mask has 192  False values followed by 64 True values:
- memory_objs contains 4 memory objects (for all chunks)
- process_tokens with mask only iterates once (for the 4th chunk at positions 192-256)
Current code: idx=0 → selects memory_objs[0] (1st chunk) ❌ WRONG
Expected: Maps (start=192, end=256) → memory_objs[3] (4th chunk) ✅ CORRECT

**What**
The fix creates a mapping from (start, end) positions to memory object indices by:
1. First iterating through all tokens with mask=None to get all chunk positions
2. Building a dictionary mapping (start, end) → memory object index
3. When iterating with the actual mask, using this mapping to select the correct memory object
4. Properly freeing unused memory objects by tracking which indices were used
This ensures that the correct memory objects are matched to their corresponding token ranges, regardless of how many chunks are skipped due to the mask.

**Test**
The prompt described in issue #1866 is tested. Response is as expected