### PR TITLE
[CI]: add new url triton dependency from latest vllm to fix integration tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,12 +86,15 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
     if [ "$VLLM_VERSION" = "nightly" ]; then \
-        uv pip install 'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' && \
-        uv pip install --prerelease=allow 'vllm[runai,tensorizer,flashinfer]' \
+        uv pip install --prerelease=allow \
+            'vllm[runai,tensorizer,flashinfer]' \
+            'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' \
             --extra-index-url https://wheels.vllm.ai/nightly \
-            --index-strategy unsafe-best-match ; \
+            --index-strategy unsafe-best-match
     else \
-        uv pip install --prerelease=allow "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" ; \
+        uv pip install --prerelease=allow \
+            "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" \
+            'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' ; \
     fi && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,6 +86,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
     if [ "$VLLM_VERSION" = "nightly" ]; then \
+        uv pip install 'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' && \
         uv pip install --prerelease=allow 'vllm[runai,tensorizer,flashinfer]' \
             --extra-index-url https://wheels.vllm.ai/nightly \
             --index-strategy unsafe-best-match ; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,7 +90,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
             'vllm[runai,tensorizer,flashinfer]' \
             'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' \
             --extra-index-url https://wheels.vllm.ai/nightly \
-            --index-strategy unsafe-best-match
+            --index-strategy unsafe-best-match ; \
     else \
         uv pip install --prerelease=allow \
             "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" \


### PR DESCRIPTION
recent PRs are failing integration tests because uv cannot install implicit url dependencies which was just added to https://github.com/vllm-project/vllm/blob/main/requirements/cuda.txt