### PR TITLE
[bugfix] Fix AttributeError for reasoning_content in long_doc_qa streaming responses

### DIFF
--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -97,7 +97,7 @@ def has_content(chunk):
         and chunk.choices[0].delta
         and (
             chunk.choices[0].delta.content is not None
-            or chunk.choices[0].delta.reasoning_content is not None
+            or getattr(chunk.choices[0].delta, "reasoning_content", None) is not None
         )
     )
 
@@ -119,8 +119,8 @@ def extract_content(chunk):
     """
     if chunk.choices[0].delta.content is not None:
         return chunk.choices[0].delta.content
-    elif chunk.choices[0].delta.reasoning_content is not None:
-        return chunk.choices[0].delta.reasoning_content
+    elif getattr(chunk.choices[0].delta, "reasoning_content", None) is not None:
+        return getattr(chunk.choices[0].delta, "reasoning_content", "")
     else:
         return ""
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #1884

This PR fixes an `AttributeError` that occurs when running the `benchmarks/long_doc_qa/long_doc_qa.py` benchmark with streaming responses. The error happens when the OpenAI API's `ChoiceDelta` object doesn't include the `reasoning_content` attribute, which is optional and only present for certain models.

**Changes:**
- Updated `has_content()` function to use `getattr()` for safe attribute access
- Updated `extract_content()` function to use `getattr()` for safe attribute access
- This ensures compatibility with all OpenAI-compatible streaming APIs, regardless of whether they support reasoning content

**Special notes for your reviewers**:

The `reasoning_content` field is optional in the OpenAI streaming API and only exists for models that support chain-of-thought reasoning. Using `getattr()` with a default value prevents `AttributeError` when this attribute is not present.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests