### PR TITLE
[Core][Bugfix]Refactor Audit connector, avoid missing apis

### DIFF
--- a/lmcache/v1/storage_backend/connector/audit_adapter.py
+++ b/lmcache/v1/storage_backend/connector/audit_adapter.py
@@ -73,4 +73,5 @@ class AuditConnectorAdapter(ConnectorAdapter):
             context.config,
             context.metadata,
         )
-        return AuditConnector(connector.getWrappedConnector(), context.config)
+        # Metaclass dynamically implements all abstract methods at runtime
+        return AuditConnector(connector.getWrappedConnector(), context.config)  # type: ignore[abstract]

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -16,6 +16,15 @@ from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 logger = init_logger(__name__)
 
 
+def NotAudit(func):
+    """
+    Decorator to mark methods that should not be audited.
+    These methods will be directly forwarded to the real connector without logging.
+    """
+    func._not_audit = True
+    return func
+
+
 class RemoteConnector(metaclass=abc.ABCMeta):
     """
     Interface for remote connector
@@ -28,6 +37,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
     full_chunk_size: Optional[int] = None
     single_token_size: Optional[int] = None
 
+    @NotAudit
     def init_chunk_meta(
         self,
         config: Optional[LMCacheEngineConfig],
@@ -73,6 +83,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
             f"single token size: {self.single_token_size}"
         )
 
+    @NotAudit
     def reshape_partial_chunk(
         self,
         memory_obj: MemoryObj,
@@ -103,6 +114,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
 
         return memory_obj
 
+    @NotAudit
     def post_init(self):
         """
         Post-initialization method to be called after the connector is created.

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -125,5 +125,16 @@ class InstrumentedRemoteConnector(RemoteConnector):
     def support_batched_contains(self) -> bool:
         return self._connector.support_batched_contains()
 
+    def init_chunk_meta(self, config, metadata) -> None:
+        return self._connector.init_chunk_meta(config, metadata)
+
+    def reshape_partial_chunk(
+        self, memory_obj: MemoryObj, bytes_read: int
+    ) -> MemoryObj:
+        return self._connector.reshape_partial_chunk(memory_obj, bytes_read)
+
+    def post_init(self):
+        return self._connector.post_init()
+
     def __repr__(self) -> str:
         return f"InstrumentedRemoteConnector({self._connector})"

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -209,7 +209,8 @@ class MockConnector(RemoteConnector):
         )
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
-        raise NotImplementedError("MockConnector does not support synchronous exists")
+        """Synchronous exists check without async lock (for testing purposes)"""
+        return key in self.lru_store.dict
 
     async def _get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         mock_obj = await self.lru_store.get(key)

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -1,0 +1,637 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from io import StringIO
+import asyncio
+import logging
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import (
+    AdHocMemoryAllocator,
+    MemoryFormat,
+    MemoryObj,
+    TensorMemoryObj,
+)
+from lmcache.v1.storage_backend.connector.audit_connector import AuditConnector
+from lmcache.v1.storage_backend.connector.mock_connector import MockConnector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+
+def create_test_key(key_id: str) -> CacheEngineKey:
+    """Helper to create a test CacheEngineKey"""
+    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id))
+
+
+def create_mock_memory_obj(backend: LocalCPUBackend, data: bytes) -> MemoryObj:
+    """Helper to create a mock MemoryObj with proper structure"""
+    tensor = torch.tensor(
+        [ord(c) for c in data.decode("latin1") if ord(c) < 256], dtype=torch.uint8
+    )
+    if len(tensor) == 0:
+        tensor = torch.tensor([0], dtype=torch.uint8)
+
+    memory_obj = backend.allocate(
+        shape=tensor.shape,
+        dtype=tensor.dtype,
+        fmt=MemoryFormat.KV_2LTD,
+    )
+
+    if memory_obj is not None and isinstance(memory_obj, TensorMemoryObj):
+        memory_obj.tensor.copy_(tensor)
+
+    return memory_obj
+
+
+@pytest.fixture
+def event_loop():
+    """Create an event loop for async tests"""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+
+    # Simplified cleanup logic
+    try:
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+
+        if not loop.is_closed():
+            loop.call_soon(loop.stop)
+            loop.run_forever()
+            loop.close()
+    except Exception:
+        pass
+    finally:
+        asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def local_cpu_backend():
+    """Fixture for LocalCPUBackend"""
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=1,
+        remote_url="mock://test",
+        extra_config={},
+    )
+    allocator = AdHocMemoryAllocator(device="cpu")
+    return LocalCPUBackend(config=config, memory_allocator=allocator)
+
+
+@pytest.fixture
+def mock_connector(event_loop, local_cpu_backend):
+    """Fixture for mock connector"""
+    connector = MockConnector(
+        url="mock://test",
+        loop=event_loop,
+        local_cpu_backend=local_cpu_backend,
+        capacity=1,
+        peeking_latency=0.0,
+        read_throughput=100.0,
+        write_throughput=100.0,
+    )
+    yield connector
+    # No cleanup needed, let event_loop fixture handle it
+
+
+class LogCaptureHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+        self.stream = StringIO()
+
+    def emit(self, record):
+        self.records.append(record)
+        msg = self.format(record)
+        self.stream.write(msg + "\n")
+
+    def get_records(self):
+        return self.records
+
+    def get_logs(self):
+        return self.stream.getvalue()
+
+    def clear(self):
+        self.records = []
+        self.stream = StringIO()
+
+
+@pytest.fixture
+def log_capture():
+    """Fixture for capturing logs"""
+    handler = LogCaptureHandler()
+    handler.setFormatter(logging.Formatter("%(name)s - %(levelname)s - %(message)s"))
+
+    # Get audit logger and add handler
+    audit_logger = logging.getLogger(
+        "lmcache.v1.storage_backend.connector.audit_connector"
+    )
+    original_level = audit_logger.level
+    audit_logger.setLevel(logging.INFO)
+    audit_logger.addHandler(handler)
+
+    yield handler
+
+    # Cleanup
+    audit_logger.removeHandler(handler)
+    audit_logger.setLevel(original_level)
+
+
+class TestAuditConnector:
+    """Test AuditConnector functionality"""
+
+    def test_initialization_basic(self, mock_connector, log_capture):
+        """Test basic initialization"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+        audit = AuditConnector(mock_connector, config)
+
+        assert audit.real_connector is mock_connector
+        assert audit.verify_checksum is False
+        assert audit.calc_checksum is False
+        assert len(audit.excluded_cmds) == 0
+
+        print("\nCaptured logs:")
+        print(log_capture.get_logs())
+
+        init_logs = [
+            r.msg
+            for r in log_capture.get_records()
+            if "[REMOTE_AUDIT]" in r.msg and "INITIALIZED" in r.msg
+        ]
+
+        assert len(init_logs) > 0, (
+            f"Expected INITIALIZED log. Got logs: {log_capture.get_logs()}"
+        )
+
+    def test_initialization_with_checksum(self, mock_connector, log_capture):
+        """Test initialization with checksum enabled"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={
+                "audit_calc_checksum": True,
+                "audit_verify_checksum": True,
+            },
+        )
+        audit = AuditConnector(mock_connector, config)
+
+        assert audit.verify_checksum is True
+        assert audit.calc_checksum is True
+        assert audit.registry_lock is not None
+
+        print("\nCaptured logs:")
+        print(log_capture.get_logs())
+
+        init_logs = [r for r in log_capture.get_records() if "INITIALIZED" in r.msg]
+        assert len(init_logs) > 0, (
+            f"Expected INITIALIZED log. Got logs: {log_capture.get_logs()}"
+        )
+        assert "Calc Checksum:True" in init_logs[0].msg
+
+    def test_initialization_with_excluded_cmds(self, mock_connector, log_capture):
+        """Test initialization with excluded commands"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={
+                "audit_exclude_cmds": "exists,list",
+            },
+        )
+        audit = AuditConnector(mock_connector, config)
+
+        assert "exists" in audit.excluded_cmds
+        assert "list" in audit.excluded_cmds
+
+        print("\nCaptured logs:")
+        print(log_capture.get_logs())
+
+        init_logs = [r for r in log_capture.get_records() if "INITIALIZED" in r.msg]
+        assert len(init_logs) > 0, (
+            f"Expected INITIALIZED log. Got logs: {log_capture.get_logs()}"
+        )
+        assert "Excluded Cmds:" in init_logs[0].msg
+
+    def test_put_and_get_with_audit_log(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test put and get operations with audit log verification"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key = create_test_key("test_key")
+            memory_obj = create_mock_memory_obj(local_cpu_backend, b"test_data")
+
+            log_capture.clear()
+
+            await audit.put(key, memory_obj)
+
+            print("\nAfter PUT:")
+            print(log_capture.get_logs())
+
+            put_logs = [
+                r
+                for r in log_capture.get_records()
+                if "PUT" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(put_logs) > 0, (
+                f"Expected PUT audit log. Got logs: {log_capture.get_logs()}"
+            )
+            assert "Cost:" in put_logs[0].msg
+            assert "Size:" in put_logs[0].msg
+
+            log_capture.clear()
+
+            result = await audit.get(key)
+            assert result is not None
+            assert result.metadata.shape == memory_obj.metadata.shape
+
+            print("\nAfter GET:")
+            print(log_capture.get_logs())
+
+            get_logs = [
+                r
+                for r in log_capture.get_records()
+                if "GET" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(get_logs) > 0, (
+                f"Expected GET audit log. Got logs: {log_capture.get_logs()}"
+            )
+            assert "Cost:" in get_logs[0].msg
+
+        event_loop.run_until_complete(run_test())
+
+    def test_exists_with_audit_log(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test exists operation with audit log"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key = create_test_key("test_key")
+
+            log_capture.clear()
+
+            result = await audit.exists(key)
+            assert result is False
+
+            print("\nAfter EXISTS:")
+            print(log_capture.get_logs())
+
+            exists_logs = [
+                r
+                for r in log_capture.get_records()
+                if "EXISTS" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(exists_logs) > 0, (
+                f"Expected EXISTS audit log. Got logs: {log_capture.get_logs()}"
+            )
+            assert "Cost:" in exists_logs[0].msg
+
+        event_loop.run_until_complete(run_test())
+
+    def test_put_with_checksum_audit_log(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test put with checksum calculation and audit log"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={
+                "audit_calc_checksum": True,
+                "audit_verify_checksum": True,
+            },
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key = create_test_key("test_key")
+            memory_obj = create_mock_memory_obj(local_cpu_backend, b"test_data")
+
+            log_capture.clear()
+
+            await audit.put(key, memory_obj)
+
+            print("\nAfter PUT with checksum:")
+            print(log_capture.get_logs())
+
+            put_logs = [
+                r
+                for r in log_capture.get_records()
+                if "PUT" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(put_logs) > 0, (
+                f"Expected PUT audit log. Got logs: {log_capture.get_logs()}"
+            )
+            assert "Checksum:" in put_logs[0].msg
+            assert "Checksum:N/A" not in put_logs[0].msg
+
+        event_loop.run_until_complete(run_test())
+
+    def test_put_and_get_with_kwargs(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test put and get operations with keyword arguments
+        to ensure robust argument handling."""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key = create_test_key("test_key_kwargs")
+            memory_obj = create_mock_memory_obj(local_cpu_backend, b"test_data_kwargs")
+
+            log_capture.clear()
+
+            # Use keyword arguments to test argument passing
+            await audit.put(key=key, memory_obj=memory_obj)
+
+            put_logs = [
+                r
+                for r in log_capture.get_records()
+                if "PUT" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(put_logs) > 0, "Expected PUT audit log with keyword arguments."
+
+            log_capture.clear()
+
+            result = await audit.get(key=key)
+            assert result is not None
+
+            get_logs = [
+                r
+                for r in log_capture.get_records()
+                if "GET" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(get_logs) > 0, "Expected GET audit log with keyword arguments."
+
+        event_loop.run_until_complete(run_test())
+
+    def test_excluded_command_no_audit_log(
+        self, mock_connector, event_loop, log_capture
+    ):
+        """Test that excluded commands don't generate audit logs"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={
+                "audit_exclude_cmds": "exists",
+            },
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key = create_test_key("test_key")
+
+            log_capture.clear()
+
+            await audit.exists(key)
+
+            print("\nAfter excluded EXISTS:")
+            print(log_capture.get_logs())
+
+            exists_logs = [
+                r
+                for r in log_capture.get_records()
+                if "EXISTS" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(exists_logs) == 0, (
+                f"Excluded command should not log. Got logs: {log_capture.get_logs()}"
+            )
+
+        event_loop.run_until_complete(run_test())
+
+    def test_non_excluded_command_has_audit_log(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test that non-excluded commands generate audit logs"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={
+                "audit_exclude_cmds": "exists",
+            },
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key = create_test_key("test_key")
+            memory_obj = create_mock_memory_obj(local_cpu_backend, b"test_data")
+
+            log_capture.clear()
+
+            await audit.put(key, memory_obj)
+
+            print("\nAfter non-excluded PUT:")
+            print(log_capture.get_logs())
+
+            put_logs = [
+                r
+                for r in log_capture.get_records()
+                if "PUT" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(put_logs) > 0, (
+                f"Non-excluded command should log. Got logs: {log_capture.get_logs()}"
+            )
+
+        event_loop.run_until_complete(run_test())
+
+    def test_not_audit_decorator(self, mock_connector, log_capture):
+        """Test that @NotAudit methods don't generate operation audit logs"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+        audit = AuditConnector(mock_connector, config)
+
+        log_capture.clear()
+
+        audit.post_init()
+        audit.init_chunk_meta(None, None)
+
+        print("\nAfter @NotAudit methods:")
+        print(log_capture.get_logs())
+
+        operation_logs = [
+            r
+            for r in log_capture.get_records()
+            if "POST_INIT" in r.msg or "INIT_CHUNK_META" in r.msg
+        ]
+        operation_logs = [r for r in operation_logs if "SUCCESS" in r.msg]
+        assert len(operation_logs) == 0, (
+            f"@NotAudit methods should not generate operation audit logs. "
+            f"Got logs: {log_capture.get_logs()}"
+        )
+
+    def test_batched_get_with_audit_log(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test batched get with audit log"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key1 = create_test_key("key1")
+            key2 = create_test_key("key2")
+
+            await audit.put(key1, create_mock_memory_obj(local_cpu_backend, b"data1"))
+            await audit.put(key2, create_mock_memory_obj(local_cpu_backend, b"data2"))
+
+            log_capture.clear()
+
+            results = await audit.batched_get([key1, key2])
+            assert len(results) == 2
+            assert all(r is not None for r in results)
+
+            print("\nAfter BATCHED_GET:")
+            print(log_capture.get_logs())
+
+            batched_logs = [
+                r
+                for r in log_capture.get_records()
+                if "BATCHED_GET" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(batched_logs) > 0, (
+                f"Expected BATCHED_GET audit log. Got logs: {log_capture.get_logs()}"
+            )
+            assert "Cost:" in batched_logs[0].msg
+
+        event_loop.run_until_complete(run_test())
+
+    def test_batched_async_contains_with_audit_log(
+        self, mock_connector, local_cpu_backend, event_loop, log_capture
+    ):
+        """Test batched async contains with audit log"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+
+        async def run_test():
+            audit = AuditConnector(mock_connector, config)
+            key1 = create_test_key("key1")
+            key2 = create_test_key("key2")
+            key3 = create_test_key("key3")
+
+            await audit.put(key1, create_mock_memory_obj(local_cpu_backend, b"data1"))
+            await audit.put(key2, create_mock_memory_obj(local_cpu_backend, b"data2"))
+
+            log_capture.clear()
+
+            count = await audit.batched_async_contains("lookup1", [key1, key2, key3])
+            assert count == 2
+
+            print("\nAfter BATCHED_ASYNC_CONTAINS:")
+            print(log_capture.get_logs())
+
+            batched_logs = [
+                r
+                for r in log_capture.get_records()
+                if "BATCHED_ASYNC_CONTAINS" in r.msg and "SUCCESS" in r.msg
+            ]
+            assert len(batched_logs) > 0, (
+                f"Expected BATCHED_ASYNC_CONTAINS audit log. "
+                f"Got logs: {log_capture.get_logs()}"
+            )
+            assert "Cost:" in batched_logs[0].msg
+
+        event_loop.run_until_complete(run_test())
+
+    def test_support_methods(self, mock_connector):
+        """Test support_* methods are properly forwarded"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+        audit = AuditConnector(mock_connector, config)
+
+        assert audit.support_batched_get() is True
+        assert audit.support_batched_async_contains() is True
+
+    def test_exists_sync_with_audit_log(self, mock_connector, log_capture):
+        """Test exists_sync synchronous operation with audit log"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={},
+        )
+        audit = AuditConnector(mock_connector, config)
+        key = create_test_key("test_key")
+
+        log_capture.clear()
+
+        result = audit.exists_sync(key)
+        assert result is False
+
+        print("\nAfter EXISTS_SYNC:")
+        print(log_capture.get_logs())
+
+        exists_sync_logs = [
+            r
+            for r in log_capture.get_records()
+            if "EXISTS_SYNC" in r.msg and "SUCCESS" in r.msg
+        ]
+        assert len(exists_sync_logs) > 0, (
+            f"Expected EXISTS_SYNC audit log. Got logs: {log_capture.get_logs()}"
+        )
+        assert "Cost:" in exists_sync_logs[0].msg
+
+    def test_exists_sync_excluded_no_audit_log(self, mock_connector, log_capture):
+        """Test that excluded exists_sync doesn't generate audit logs"""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=1,
+            remote_url="mock://test",
+            extra_config={
+                "audit_exclude_cmds": "exists_sync",
+            },
+        )
+        audit = AuditConnector(mock_connector, config)
+        key = create_test_key("test_key")
+
+        log_capture.clear()
+
+        result = audit.exists_sync(key)
+        assert result is False
+
+        print("\nAfter excluded EXISTS_SYNC:")
+        print(log_capture.get_logs())
+
+        exists_sync_logs = [
+            r
+            for r in log_capture.get_records()
+            if "EXISTS_SYNC" in r.msg and "SUCCESS" in r.msg
+        ]
+        assert len(exists_sync_logs) == 0, (
+            f"Excluded exists_sync should not log. Got logs: {log_capture.get_logs()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/v1/storage_backend/test_connector_completeness.py
+++ b/tests/v1/storage_backend/test_connector_completeness.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Test to ensure wrapper connectors (AuditConnector and InstrumentedRemoteConnector)
+implement all methods defined in the base RemoteConnector class.
+"""
+
+# Standard
+from typing import Dict, List, Set
+import inspect
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.connector.audit_connector import AuditConnector
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.connector.instrumented_connector import (
+    InstrumentedRemoteConnector,
+)
+
+
+def get_all_methods_from_base(base_class) -> Set[str]:
+    """
+    Get all public methods defined in the base class (excluding inherited from object).
+    """
+    methods = set()
+    for name in dir(base_class):
+        # Skip private and special methods
+        if name.startswith("_"):
+            continue
+        attr = getattr(base_class, name)
+        if callable(attr):
+            methods.add(name)
+    return methods
+
+
+def get_methods_implemented_in_class(cls) -> Set[str]:
+    """
+    Get methods that are actually implemented in the class itself (not just inherited).
+    This checks if the method is defined in the class's own __dict__
+    or its direct parents (excluding the base class we're checking against).
+
+    For classes that dynamically generate methods (like AuditConnector), we check
+    the class __dict__ directly without instantiation.
+    """
+    implemented = set()
+
+    # Check the class's own __dict__ for methods
+    # This works for both regular methods and dynamically generated ones
+    for name in cls.__dict__:
+        if name.startswith("_"):
+            continue
+        attr = cls.__dict__[name]
+        # Check if it's callable (function, method, etc.)
+        if callable(attr):
+            implemented.add(name)
+
+    # Also check using getattr to catch any dynamically added methods
+    # that might not be in __dict__ but are accessible
+    for name in dir(cls):
+        if name.startswith("_"):
+            continue
+        if name in implemented:
+            continue  # Already found
+        try:
+            attr = getattr(cls, name)
+            if callable(attr):
+                # Verify it's not inherited from RemoteConnector
+                # by checking if it exists in the class's MRO
+                # (excluding RemoteConnector)
+                for base in cls.__mro__:
+                    if base is RemoteConnector:
+                        break
+                    if name in base.__dict__:
+                        implemented.add(name)
+                        break
+        except AttributeError:
+            pass
+
+    return implemented
+
+
+def get_abstract_methods(cls) -> Set[str]:
+    """
+    Get all abstract methods from a class.
+    """
+    abstract_methods = set()
+    for name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
+        if getattr(method, "__isabstractmethod__", False):
+            abstract_methods.add(name)
+    return abstract_methods
+
+
+def check_method_signatures(base_class, wrapper_class, wrapper_name: str) -> List[Dict]:
+    """
+    Check if method signatures in wrapper class match the base class.
+    Returns a list of mismatches.
+    """
+    base_methods = get_all_methods_from_base(base_class)
+    signature_mismatches = []
+
+    for method_name in base_methods:
+        base_method = getattr(base_class, method_name)
+        wrapper_method = getattr(wrapper_class, method_name, None)
+
+        if wrapper_method is None:
+            continue
+
+        try:
+            base_sig = inspect.signature(base_method)
+            wrapper_sig = inspect.signature(wrapper_method)
+
+            # Compare parameter names (excluding 'self')
+            base_params = [p for p in base_sig.parameters.keys() if p != "self"]
+            wrapper_params = [p for p in wrapper_sig.parameters.keys() if p != "self"]
+
+            if base_params != wrapper_params:
+                signature_mismatches.append(
+                    {
+                        "method": method_name,
+                        "base_params": base_params,
+                        "wrapper_params": wrapper_params,
+                    }
+                )
+        except (ValueError, TypeError):
+            # Some methods might not have inspectable signatures
+            pass
+
+    return signature_mismatches
+
+
+class TestConnectorCompleteness:
+    """Test that wrapper connectors implement all base connector methods"""
+
+    def test_audit_connector_completeness(self):
+        """
+        Comprehensive test to verify AuditConnector implements all methods
+        from RemoteConnector with correct signatures.
+        """
+        # 1. Get all methods from base class
+        base_methods = get_all_methods_from_base(RemoteConnector)
+
+        # 2. Get methods actually implemented in AuditConnector
+        audit_implemented = get_methods_implemented_in_class(AuditConnector)
+
+        # 3. Check which base methods are missing in the implementation
+        missing_methods = base_methods - audit_implemented
+
+        assert len(missing_methods) == 0, (
+            f"AuditConnector is missing {len(missing_methods)} methods from "
+            f"RemoteConnector: {sorted(missing_methods)}\n"
+            f"Base methods: {sorted(base_methods)}\n"
+            f"Implemented methods: {sorted(audit_implemented)}"
+        )
+
+        # 4. Check all abstract methods are implemented
+        abstract_methods = get_abstract_methods(RemoteConnector)
+        audit_missing_abstract = []
+        for method_name in abstract_methods:
+            # Check if the method is actually implemented in AuditConnector
+            if method_name not in audit_implemented:
+                audit_missing_abstract.append(method_name)
+
+        assert len(audit_missing_abstract) == 0, (
+            f"AuditConnector has not implemented {len(audit_missing_abstract)} "
+            f"abstract methods: {sorted(audit_missing_abstract)}"
+        )
+
+        # 5. Check method signatures match
+        signature_mismatches = check_method_signatures(
+            RemoteConnector, AuditConnector, "AuditConnector"
+        )
+
+        assert len(signature_mismatches) == 0, (
+            f"AuditConnector has {len(signature_mismatches)} method signature "
+            f"mismatches:\n"
+            + "\n".join(
+                f"  - {m['method']}: base={m['base_params']}, "
+                f"audit={m['wrapper_params']}"
+                for m in signature_mismatches
+            )
+        )
+
+    def test_instrumented_connector_completeness(self):
+        """
+        Comprehensive test to verify InstrumentedRemoteConnector implements all methods
+        from RemoteConnector with correct signatures.
+        """
+        # 1. Get all methods from base class
+        base_methods = get_all_methods_from_base(RemoteConnector)
+
+        # 2. Get methods actually implemented in InstrumentedRemoteConnector
+        instrumented_implemented = get_methods_implemented_in_class(
+            InstrumentedRemoteConnector
+        )
+
+        # 3. Check which base methods are missing in the implementation
+        missing_methods = base_methods - instrumented_implemented
+
+        assert len(missing_methods) == 0, (
+            f"InstrumentedRemoteConnector is missing {len(missing_methods)} methods "
+            f"from RemoteConnector: {sorted(missing_methods)}\n"
+            f"Base methods: {sorted(base_methods)}\n"
+            f"Implemented methods: {sorted(instrumented_implemented)}"
+        )
+
+        # 4. Check all abstract methods are implemented
+        abstract_methods = get_abstract_methods(RemoteConnector)
+        instrumented_missing_abstract = []
+        for method_name in abstract_methods:
+            # Check if the method is actually implemented in InstrumentedRemoteConnector
+            if method_name not in instrumented_implemented:
+                instrumented_missing_abstract.append(method_name)
+
+        assert len(instrumented_missing_abstract) == 0, (
+            f"InstrumentedRemoteConnector has not implemented "
+            f"{len(instrumented_missing_abstract)} abstract methods: "
+            f"{sorted(instrumented_missing_abstract)}"
+        )
+
+        # 5. Check method signatures match
+        signature_mismatches = check_method_signatures(
+            RemoteConnector, InstrumentedRemoteConnector, "InstrumentedRemoteConnector"
+        )
+
+        assert len(signature_mismatches) == 0, (
+            f"InstrumentedRemoteConnector has {len(signature_mismatches)} method "
+            f"signature mismatches:\n"
+            + "\n".join(
+                f"  - {m['method']}: base={m['base_params']}, "
+                f"instrumented={m['wrapper_params']}"
+                for m in signature_mismatches
+            )
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
# Motivation

In fact, the existing code exist bugs while using `Audit Connector`, since the `Audit connector` has not implement all of the method defined in the `RemoteConnector`, once we use the Audit Connector, the call cannot route to the real connector.

This bugs happened since there are lots of api methods defined in the `RemoteConnector` and it is possible to missing the new added api method into the `audit connector`.

# How this approach resolve the issue

So, I submit this PR to invent an approach to build `Audit Connector` with metaclass `AuditConnectorMeta`, which introduced `__new__` method to help to define the real `audit connector` class dynamically, it can make sure all the methods except the method marked `NotAudit` from `RemoteConnector` can be implemented.


# Test

Create a bundle of test cases.

The audit log can be like the following.
```
[REMOTE_AUDIT][MockConnector]:INITIALIZED|Calc Checksum:False｜Verify Checksum: False|Excluded Cmds: set()
[REMOTE_AUDIT][MockConnector]:PUT|SUCCESS|Size:9|Checksum:abc12345|Cost:0.123ms|Saved:1|Key:...
[REMOTE_AUDIT][MockConnector]:GET|SUCCESS|Checksum:abc12345|Cost:0.456ms|Saved:1|Key:...
[REMOTE_AUDIT][MockConnector]:EXISTS|SUCCESS|Cost:0.078ms
[REMOTE_AUDIT][MockConnector]:BATCHED_GET|SUCCESS|Cost:0.234ms
[REMOTE_AUDIT][MockConnector]:BATCHED_ASYNC_CONTAINS|SUCCESS|Cost:0.156ms
```