### PR TITLE
[Feat] Support vLLM async-scheduling

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1316,7 +1316,7 @@ class LMCacheConnectorV1Impl:
         for request in scheduler_output.scheduled_new_reqs:
             # Right now, we only load KV for new requests
             load_spec = self.load_specs.pop(request.req_id, None)
-            
+
             # Calculate the total number of tokens that will be computed after
             # this scheduling step:
             #   - request.num_computed_tokens: tokens computed before this step
@@ -1325,7 +1325,7 @@ class LMCacheConnectorV1Impl:
                 request.num_computed_tokens
                 + scheduler_output.num_scheduled_tokens[request.req_id]
             )
-            
+
             # For async scheduling support: subtract placeholders
             # In async scheduling, num_computed_tokens includes tokens that have been
             # scheduled but not yet generated (placeholders). We need to subtract them
@@ -1333,11 +1333,14 @@ class LMCacheConnectorV1Impl:
             # For sync scheduling, num_output_placeholders will be None or empty dict,
             # so num_output_placeholders defaults to 0.
             num_output_placeholders = 0
-            if scheduler_output.num_output_placeholders:
+            if (
+                hasattr(scheduler_output, "num_output_placeholders")
+                and scheduler_output.num_output_placeholders
+            ):
                 num_output_placeholders = scheduler_output.num_output_placeholders.get(
                     request.req_id, 0
                 )
-            
+
             # Real computed tokens = scheduled tokens - placeholders
             num_tokens_to_compute -= num_output_placeholders
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1316,10 +1316,31 @@ class LMCacheConnectorV1Impl:
         for request in scheduler_output.scheduled_new_reqs:
             # Right now, we only load KV for new requests
             load_spec = self.load_specs.pop(request.req_id, None)
+            
+            # Calculate the total number of tokens that will be computed after
+            # this scheduling step:
+            #   - request.num_computed_tokens: tokens computed before this step
+            #   - num_scheduled_tokens: tokens scheduled in this step
             num_tokens_to_compute = (
                 request.num_computed_tokens
                 + scheduler_output.num_scheduled_tokens[request.req_id]
             )
+            
+            # For async scheduling support: subtract placeholders
+            # In async scheduling, num_computed_tokens includes tokens that have been
+            # scheduled but not yet generated (placeholders). We need to subtract them
+            # to get the actual number of tokens to save to LMCache.
+            # For sync scheduling, num_output_placeholders will be None or empty dict,
+            # so num_output_placeholders defaults to 0.
+            num_output_placeholders = 0
+            if scheduler_output.num_output_placeholders:
+                num_output_placeholders = scheduler_output.num_output_placeholders.get(
+                    request.req_id, 0
+                )
+            
+            # Real computed tokens = scheduled tokens - placeholders
+            num_tokens_to_compute -= num_output_placeholders
+
             lmcache_cached_tokens = 0
             if load_spec is not None:
                 lmcache_cached_tokens = load_spec.lmcache_cached_tokens


### PR DESCRIPTION
Fixed #1883 
PRs https://github.com/vllm-project/vllm/pull/27647 and https://github.com/vllm-project/vllm/pull/27648 are intended to add async scheduling support for the KV connector.

## Summary
Adds async scheduling support to the LMCache connector, addressing incorrect KV cache saving when vLLM enables async-scheduling.
## Motivation
vLLM’s async scheduling can schedule tokens before they are generated (placeholders). The connector was treating scheduled tokens as computed, saving incomplete KV cache states.
## Changes
- Handles placeholder tokens in the build_connector_meta() token computation logic
- Subtracts num_output_placeholders before computing tokens to save
- Remains compatible with synchronous scheduling (placeholders default to 0)
## Testing Todo
- Verified behavior with both sync and async scheduling
- Confirmed no regressions for existing synchronous workloads