### PR TITLE
fix: minor changes to make SGL+LMCache work for TP==1

### DIFF
--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -223,6 +223,10 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
     def global_min_tokens(
         self, local_tokens: int, tp_group: dist.ProcessGroup, device: torch.device
     ):
+        # If tensor parallel size is 1, no need for all_reduce
+        if self.tp_size == 1:
+            return local_tokens
+
         t = torch.tensor([local_tokens], dtype=torch.int32, device=device)
         dist.all_reduce(t, op=dist.ReduceOp.MIN, group=tp_group)
         return int(t.item())
@@ -265,7 +269,7 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         )
 
         retrieve_token_num = self.global_min_tokens(
-            retrieve_token_num, self.tp_group, self.rank
+            retrieve_token_num, self.tp_group, torch.device(f"cuda:{self.rank}")
         )
 
         layerwise_retriever = self.lmcache_engine.retrieve_layer(
@@ -310,4 +314,4 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         for _ in range(self.sgl_config.num_hidden_layers):
             next(layerwise_storer)
 
-        self.lmcache_engine.lookup_unpin([lookup_id])
+        self.lmcache_engine.lookup_unpin(lookup_id)

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -246,7 +246,7 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         for i in sorted(indices_to_remove, reverse=True):
             del self.layerwise_retrievers[i]
             del self.layer_load_layer[i]
-            self.lmcache_engine.lookup_unpin([self.lookup_id_list[i]])
+            self.lmcache_engine.lookup_unpin(self.lookup_id_list[i])
             del self.lookup_id_list[i]
 
         return


### PR DESCRIPTION
**What this PR does / why we need it**:
fix a couple of issues during launching sglang + LMCache when trying out below:
```bash
cat > "/tmp/example_config.yaml" <<EOF
# Basic configurations
chunk_size: 256
# CPU offloading configurations
local_cpu: true
use_layerwise: true
max_local_cpu_size: 10 # number of CPU backend GB
EOF

export LMCACHE_USE_EXPERIMENTAL=True
export LMCACHE_CONFIG_FILE=/tmp/example_config.yaml
python -m sglang.launch_server \
  --model-path Qwen/Qwen3-0.6B \
  --enable-lmcache
```
