### PR TITLE
[Agents] Improve LRU prefix matching with reverse iteration and early exit on full match

### DIFF
--- a/examples/agents/prefix_analysis.py
+++ b/examples/agents/prefix_analysis.py
@@ -68,7 +68,6 @@ class LRUTokenPool:
                 if common_len == len(tokens):
                     break
 
-
         # Update LRU ordering
         if best_id != -1:
             self.requests.move_to_end(best_id)

--- a/examples/agents/prefix_analysis.py
+++ b/examples/agents/prefix_analysis.py
@@ -50,7 +50,8 @@ class LRUTokenPool:
         best_len = 0
         best_id = -1
 
-        for req_id, req_tokens in reversed(self.requests):
+        # Iterate from most recently used to least (LRU ordering)
+        for req_id in reversed(self.requests):
             req_tokens = self.requests[req_id]
             common_len = 0
             for i in range(min(len(tokens), len(req_tokens))):

--- a/examples/agents/prefix_analysis.py
+++ b/examples/agents/prefix_analysis.py
@@ -50,7 +50,8 @@ class LRUTokenPool:
         best_len = 0
         best_id = -1
 
-        for req_id, req_tokens in self.requests.items():
+        for req_id, req_tokens in reversed(self.requests):
+            req_tokens = self.requests[req_id]
             common_len = 0
             for i in range(min(len(tokens), len(req_tokens))):
                 if tokens[i] == req_tokens[i]:
@@ -61,6 +62,11 @@ class LRUTokenPool:
             if common_len > best_len:
                 best_len = common_len
                 best_id = req_id
+
+                # Early exit on perfect match
+                if common_len == len(tokens):
+                    break
+
 
         # Update LRU ordering
         if best_id != -1:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Part of https://github.com/LMCache/LMCache/issues/1826, following the work in this https://github.com/LMCache/LMCache/pull/1851. This PR improves the efficiency of prefix matching in the LRU token pool by:

1. Reversing the iteration order over the request pool to prioritise more recently used entries, increasing the likelihood of early hits.
2. Adding early stopping logic to exit the search loop immediately when a full prefix match is found, reducing unnecessary comparisons.
@kobe0938  Could you have a look please. 