### PR TITLE
[Bugfix]Fix connection is none issue while get timeout

### DIFF
--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -366,12 +366,11 @@ class RemoteBackend(StorageBackendInterface):
                         "batched get blocking timeout, trigger cancel the future task"
                     )
                     future.cancel()
-                with self.lock:
-                    self.connection = None
-                    self.failure_time = time.time()
-                logger.warning(
-                    f"Error occurred in batched_get_blocking: {e}, returning None list"
-                )
+                else:
+                    logger.warning(
+                        f"Error occurred in batched_get_blocking: {e}, "
+                        f"returning None list"
+                    )
                 return [None] * len(keys)
         else:
             futures = [
@@ -391,12 +390,10 @@ class RemoteBackend(StorageBackendInterface):
                                 "get blocking timeout, trigger cancel the future task"
                             )
                             fut.cancel()
-                        with self.lock:
-                            self.connection = None
-                            self.failure_time = time.time()
-                        logger.warning(
-                            f"Error occurred in get_blocking: {e}, returning None"
-                        )
+                        else:
+                            logger.warning(
+                                f"Error occurred in get_blocking: {e}, returning None"
+                            )
                         memory_obj = None
                     memory_objs.append(memory_obj)
                 else:


### PR DESCRIPTION
 
<img width="2904" height="494" alt="Clipboard_Screenshot_1761746416" src="https://github.com/user-attachments/assets/2c92721f-4677-436f-96f2-350e6ff28227" />

This issue is caused by
```
^[[1;36m(VllmWorker rank=0 engine_index=0 pid=7141)^[[0;0m ^[[33;20m[2025-10-29 14:58:17,031] LMCache WARNING:^[[0m get blocking timeout, trigger cancel the future task ^[[3m(remote_backend.py:376:lmcache.v1.storage_backend.remote_backend)^[[0m
```

And this PR fixed it.

Further more, if you need a complex but complete approach, it is `remote monitor`, you have to implement the `ping` api of `RemoteConnector`.