### PR TITLE
[CI/Build] Add /opt/venv/bin to PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,8 @@ ENV NVCC_THREADS=$nvcc_threads
 
 ARG VLLM_VERSION=nightly
 
+ENV PATH="/opt/venv/bin:${PATH}"
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
     uv pip install -r build.txt


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The latest VLLM requires ninja binary at runtime based on the error log.

```
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/sample/sampler.py", line 100, in forward
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     sampled, processed_logprobs = self.sample(logits, sampling_metadata)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/sample/sampler.py", line 180, in sample
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     random_sampled, processed_logprobs = self.topk_topp_sampler(
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]                                          ^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     return self._call_impl(*args, **kwargs)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     return forward_call(*args, **kwargs)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/sample/ops/topk_topp_sampler.py", line 122, in forward_cuda
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     return flashinfer_sample(logits.contiguous(), k, p, generators), None
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/sample/ops/topk_topp_sampler.py", line 289, in flashinfer_sample
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/flashinfer/sampling.py", line 980, in top_k_top_p_sampling_from_logits
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     masked_logits = top_k_mask_logits(logits, top_k)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/flashinfer/sampling.py", line 1300, in top_k_mask_logits
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     return get_sampling_module().top_k_mask_logits(
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/flashinfer/sampling.py", line 47, in get_sampling_module
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     module = gen_sampling_module().build_and_load()
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/flashinfer/jit/core.py", line 160, in build_and_load
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     self.build(verbose, need_lock=False)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/flashinfer/jit/core.py", line 140, in build
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     run_ninja(jit_env.FLASHINFER_JIT_DIR, self.ninja_path, verbose)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/opt/venv/lib/python3.12/site-packages/flashinfer/jit/cpp_ext.py", line 258, in run_ninja
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     subprocess.run(
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/usr/lib/python3.12/subprocess.py", line 548, in run
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     with Popen(*popenargs, **kwargs) as process:
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     self._execute_child(args, executable, preexec_fn, close_fds,
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]   File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671]     raise child_exception_type(errno_num, err_msg, err_filename)
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671] FileNotFoundError: [Errno 2] No such file or directory: 'ninja'
(Worker_TP0 pid=428) ERROR 10-30 18:49:38 [multiproc_executor.py:671] 
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708] EngineCore failed to start.
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708] Traceback (most recent call last):
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 699, in run_engine_core
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 498, in __init__
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     super().__init__(vllm_config, executor_class, log_stats,
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 92, in __init__
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     self._initialize_kv_caches(vllm_config)
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 190, in _initialize_kv_caches
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     self.model_executor.determine_available_memory())
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/executor/abstract.py", line 85, in determine_available_memory
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     return self.collective_rpc("determine_available_memory")
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 264, in collective_rpc
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     result = get_response(w, dequeue_timeout,
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 248, in get_response
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708]     raise RuntimeError(
(EngineCore_DP0 pid=294) ERROR 10-30 18:49:38 [core.py:708] RuntimeError: Worker failed with error '[Errno 2] No such file or directory: 'ninja'', 
```


This PR is to fix the issue from https://github.com/LMCache/LMCache/issues/1889#issuecomment-3469585317.
Refs #1889 

Tested it works after this change.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
