### PR TITLE
[Fix] Remove ref_count_up from naive serde serialize()

### DIFF
--- a/lmcache/v1/storage_backend/naive_serde/naive_serde.py
+++ b/lmcache/v1/storage_backend/naive_serde/naive_serde.py
@@ -9,7 +9,6 @@ class NaiveSerializer(Serializer):
         pass
 
     def serialize(self, memory_obj: MemoryObj) -> MemoryObj:
-        memory_obj.ref_count_up()
         return memory_obj
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR will fix the the local CPU memory leaking bug caused by redundant ref_count_up() in naive serde serialization.

Fixes #1756 

 Tested local CPU memory leaking no longer happens with this change.

**Special notes for your reviewers**:

Analysis for naive serde [serialize()](https://github.com/LMCache/LMCache/blob/b58a9086b96017bc21fe4da3cb88fec466c9042a/lmcache/v1/storage_backend/naive_serde/naive_serde.py#L11) flow.

There are only 3 places calling the method.

[remote_backend.submit_put_task()](https://github.com/LMCache/LMCache/blob/b58a9086b96017bc21fe4da3cb88fec466c9042a/lmcache/v1/storage_backend/remote_backend.py#L233)

[remote_backend.batched_submit_put_task()](https://github.com/LMCache/LMCache/blob/b58a9086b96017bc21fe4da3cb88fec466c9042a/lmcache/v1/storage_backend/remote_backend.py#L271)

Both 1 and 2 are already wrapped by ref_count_up() and ref_count_down() in remote_backend. No additinoal ref_count_up() is needed.

[cache_engine.compress()](https://github.com/LMCache/LMCache/blob/b58a9086b96017bc21fe4da3cb88fec466c9042a/lmcache/v1/cache_engine.py#L910)
The memory_obj here is already pinned so no ref_count change is needed. (Even needed, we should also wrap it similar to remote_backend).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
