### PR TITLE
[bugfix] Fix the lookup socket state error once timeout occurred

### DIFF
--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -91,8 +91,9 @@ class LMCacheLookupClient(LookupClientInterface):
 
         for params in self.socket_params:
             logger.info(
-                f"lmcache lookup client connect to rank {params.rank} "
-                f"with socket path {params.socket_path}"
+                "lmcache lookup client connect to rank %s with socket path %s",
+                params.rank,
+                params.socket_path,
             )
             socket = get_zmq_socket(
                 self.ctx,
@@ -132,7 +133,9 @@ class LMCacheLookupClient(LookupClientInterface):
                     old_socket.close(linger=0)
                 except zmq.ZMQError as e:
                     logger.warning(
-                        f"ZMQ error closing old socket for rank {rank_idx}: {e}"
+                        "ZMQ error closing old socket for rank %s: %s",
+                        rank_idx,
+                        e,
                     )
                 except AttributeError:
                     # Socket already closed or invalid
@@ -141,8 +144,9 @@ class LMCacheLookupClient(LookupClientInterface):
             # Create new socket using stored parameters
             params = self.socket_params[rank_idx]
             logger.info(
-                f"Recreating socket for rank {params.rank} "
-                f"with path {params.socket_path}"
+                "Recreating socket for rank %s with path %s",
+                params.rank,
+                params.socket_path,
             )
 
             new_socket = get_zmq_socket(
@@ -214,14 +218,17 @@ class LMCacheLookupClient(LookupClientInterface):
                 results.append(result)
         except zmq.Again as e:
             logger.error(
-                f"Timeout occurred for rank {failed_rank}, "
-                f"recreating all sockets. Error: {str(e)}"
+                "Timeout occurred for rank %s, recreating all sockets. Error: %s",
+                failed_rank,
+                e,
             )
             self._recreate_socket()
             return 0
         except zmq.ZMQError as e:
             logger.error(
-                f"ZMQ error for rank {failed_rank}: {str(e)}, recreating all sockets"
+                "ZMQ error for rank %s: %s, recreating all sockets",
+                failed_rank,
+                e,
             )
             self._recreate_socket()
             return 0
@@ -229,8 +236,9 @@ class LMCacheLookupClient(LookupClientInterface):
         assert len(results) == self.num_ranks
         if len(set(results)) > 1:
             logger.warning(
-                f"Lookup results (number of hit tokens) differ "
-                f"across (TP and PP) ranks: {results}."
+                "Lookup results (number of hit tokens) differ "
+                "across (TP and PP) ranks: %s.",
+                results,
             )
         # NOTE: it is possible that the number of hit tokens is different
         # across (TP and PP) ranks, so we can use the minimum value as the
@@ -252,13 +260,13 @@ class LMCacheLookupClient(LookupClientInterface):
             try:
                 socket.close(linger=0)
             except Exception as e:
-                logger.warning(f"Error closing socket: {e}")
+                logger.warning("Error closing socket: %s", e)
 
         try:
             if self.ctx:
                 self.ctx.term()
         except Exception as e:
-            logger.warning(f"Error terminating ZMQ context: {e}")
+            logger.warning("Error terminating ZMQ context: %s", e)
 
 
 class LMCacheLookupServer:
@@ -318,7 +326,7 @@ class LMCacheLookupServer:
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)
 
-        logger.info(f"lmcache lookup server start on {socket_path}")
+        logger.info("lmcache lookup server start on %s", socket_path)
         self.thread = threading.Thread(target=process_request, daemon=True)
         self.thread.start()
 

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from collections import namedtuple
 from typing import TYPE_CHECKING, Optional, Union
 import json
 import threading
@@ -68,8 +69,19 @@ class LMCacheLookupClient(LookupClientInterface):
         else:
             ranks = [i for i in range(self.num_ranks)]
 
-        # Set timeout values from config
-        timeout_ms = config.lookup_timeout_ms
+        # Store socket creation parameters for recreation
+        SocketParams = namedtuple("SocketParams", ["socket_path", "rank"])
+        self.socket_params = [
+            SocketParams(
+                socket_path=get_zmq_rpc_path_lmcache(
+                    vllm_config, "lookup", rpc_port, rank
+                ),
+                rank=rank,
+            )
+            for rank in ranks
+        ]
+        self.timeout_ms = config.lookup_timeout_ms
+        self.socket_lock = threading.Lock()
 
         # NOTE: map from lookup_id (i.e., req_id) to req's status.
         # int indicates number of hit tokens.
@@ -78,25 +90,22 @@ class LMCacheLookupClient(LookupClientInterface):
         # same result.
         self.reqs_status: dict[str, int] = {}
 
-        for rank in ranks:
-            socket_path = get_zmq_rpc_path_lmcache(
-                vllm_config, "lookup", rpc_port, rank
-            )
+        for params in self.socket_params:
             logger.info(
-                f"lmcache lookup client connect to rank {rank} "
-                f"with socket path {socket_path}"
+                f"lmcache lookup client connect to rank {params.rank} "
+                f"with socket path {params.socket_path}"
             )
             socket = get_zmq_socket(
                 self.ctx,
-                socket_path,
+                params.socket_path,
                 "ipc",
                 zmq.REQ,
                 "connect",
             )
 
             # Set socket timeout during initialization
-            socket.setsockopt(zmq.RCVTIMEO, timeout_ms)
-            socket.setsockopt(zmq.SNDTIMEO, timeout_ms)
+            socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
+            socket.setsockopt(zmq.SNDTIMEO, self.timeout_ms)
 
             self.sockets.append(socket)
 
@@ -113,6 +122,42 @@ class LMCacheLookupClient(LookupClientInterface):
             self.token_database = SegmentTokenDatabase(config, metadata)
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
+
+    def _recreate_socket(self) -> None:
+        """Recreate all sockets."""
+        with self.socket_lock:
+            for rank_idx in range(self.num_ranks):
+                # Close old socket
+                old_socket = self.sockets[rank_idx]
+                if old_socket is not None:
+                    try:
+                        old_socket.close(linger=0)
+                    except zmq.ZMQError as e:
+                        logger.warning(
+                            f"ZMQ error closing old socket for rank {rank_idx}: {e}"
+                        )
+                    except AttributeError:
+                        # Socket already closed or invalid
+                        pass
+
+                # Create new socket using stored parameters
+                params = self.socket_params[rank_idx]
+                logger.info(
+                    f"Recreating socket for rank {params.rank} "
+                    f"with path {params.socket_path}"
+                )
+
+                new_socket = get_zmq_socket(
+                    self.ctx,
+                    params.socket_path,
+                    "ipc",
+                    zmq.REQ,
+                    "connect",
+                )
+                new_socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
+                new_socket.setsockopt(zmq.SNDTIMEO, self.timeout_ms)
+
+                self.sockets[rank_idx] = new_socket
 
     def lookup(
         self,
@@ -157,20 +202,32 @@ class LMCacheLookupClient(LookupClientInterface):
             ]
 
         results = []
+        failed_rank = -1
         try:
             for i in range(self.num_ranks):
-                self.sockets[i].send_multipart(msg_buf, copy=False)
+                failed_rank = i
+                with self.socket_lock:
+                    self.sockets[i].send_multipart(msg_buf, copy=False)
 
             # TODO(Jiayi): we can use zmq poll to optimize a bit
             for i in range(self.num_ranks):
-                resp = self.sockets[i].recv()
+                failed_rank = i
+                with self.socket_lock:
+                    resp = self.sockets[i].recv()
                 result = int.from_bytes(resp, "big")
                 results.append(result)
-        except zmq.Again:
-            logger.error(f"Timeout occurred for rank {i}")
+        except zmq.Again as e:
+            logger.error(
+                f"Timeout occurred for rank {failed_rank}, "
+                f"recreating all sockets. Error: {str(e)}"
+            )
+            self._recreate_socket()
             return 0
         except zmq.ZMQError as e:
-            logger.error(f"ZMQ error for rank {i}: {str(e)}")
+            logger.error(
+                f"ZMQ error for rank {failed_rank}: {str(e)}, recreating all sockets"
+            )
+            self._recreate_socket()
             return 0
 
         assert len(results) == self.num_ranks

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -81,7 +81,6 @@ class LMCacheLookupClient(LookupClientInterface):
             for rank in ranks
         ]
         self.timeout_ms = config.lookup_timeout_ms
-        self.socket_lock = threading.Lock()
 
         # NOTE: map from lookup_id (i.e., req_id) to req's status.
         # int indicates number of hit tokens.
@@ -125,39 +124,38 @@ class LMCacheLookupClient(LookupClientInterface):
 
     def _recreate_socket(self) -> None:
         """Recreate all sockets."""
-        with self.socket_lock:
-            for rank_idx in range(self.num_ranks):
-                # Close old socket
-                old_socket = self.sockets[rank_idx]
-                if old_socket is not None:
-                    try:
-                        old_socket.close(linger=0)
-                    except zmq.ZMQError as e:
-                        logger.warning(
-                            f"ZMQ error closing old socket for rank {rank_idx}: {e}"
-                        )
-                    except AttributeError:
-                        # Socket already closed or invalid
-                        pass
+        for rank_idx in range(self.num_ranks):
+            # Close old socket
+            old_socket = self.sockets[rank_idx]
+            if old_socket is not None:
+                try:
+                    old_socket.close(linger=0)
+                except zmq.ZMQError as e:
+                    logger.warning(
+                        f"ZMQ error closing old socket for rank {rank_idx}: {e}"
+                    )
+                except AttributeError:
+                    # Socket already closed or invalid
+                    pass
 
-                # Create new socket using stored parameters
-                params = self.socket_params[rank_idx]
-                logger.info(
-                    f"Recreating socket for rank {params.rank} "
-                    f"with path {params.socket_path}"
-                )
+            # Create new socket using stored parameters
+            params = self.socket_params[rank_idx]
+            logger.info(
+                f"Recreating socket for rank {params.rank} "
+                f"with path {params.socket_path}"
+            )
 
-                new_socket = get_zmq_socket(
-                    self.ctx,
-                    params.socket_path,
-                    "ipc",
-                    zmq.REQ,
-                    "connect",
-                )
-                new_socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
-                new_socket.setsockopt(zmq.SNDTIMEO, self.timeout_ms)
+            new_socket = get_zmq_socket(
+                self.ctx,
+                params.socket_path,
+                "ipc",
+                zmq.REQ,
+                "connect",
+            )
+            new_socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
+            new_socket.setsockopt(zmq.SNDTIMEO, self.timeout_ms)
 
-                self.sockets[rank_idx] = new_socket
+            self.sockets[rank_idx] = new_socket
 
     def lookup(
         self,
@@ -206,14 +204,12 @@ class LMCacheLookupClient(LookupClientInterface):
         try:
             for i in range(self.num_ranks):
                 failed_rank = i
-                with self.socket_lock:
-                    self.sockets[i].send_multipart(msg_buf, copy=False)
+                self.sockets[i].send_multipart(msg_buf, copy=False)
 
             # TODO(Jiayi): we can use zmq poll to optimize a bit
             for i in range(self.num_ranks):
                 failed_rank = i
-                with self.socket_lock:
-                    resp = self.sockets[i].recv()
+                resp = self.sockets[i].recv()
                 result = int.from_bytes(resp, "big")
                 results.append(result)
         except zmq.Again as e:


### PR DESCRIPTION

<img width="3322" height="874" alt="Clipboard_Screenshot_1761955629" src="https://github.com/user-attachments/assets/db3f9939-9626-41d9-9f04-397be2722964" />


<img width="3388" height="728" alt="Clipboard_Screenshot_1761891526" src="https://github.com/user-attachments/assets/5ba0b355-a477-4881-a72a-478256db78c9" />

This PR can solve the above issue which happened after lookup timeout, after that, the socket cannot work anymore.

The reason is "ZMQ REQ/REP" mode, the REQ socket sequence must be `send -> recv -> send -> recv`, once timeout occurred, socket will enter to the error state.

This PR will recreate the socket if error occurred.