### PR TITLE
[Doc] Replace gated models with Qwen in quickstart examples

### DIFF
--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -9,18 +9,21 @@ Right now, LMCache uses NIXL as a transport layer to enable fast KV cache transf
 This guide demonstrates how to run LMCache with disaggregated prefill using a single prefiller and decoder setup (1P1D) on a single machine.
 The architecture splits the LLM inference into two stages: prefill and decode, running on separate GPUs for better resource utilization.
 
+.. note::
+
+    This guide has been tested with **vLLM 0.11.0** and **LMCache 0.3.9** using the Qwen/Qwen2.5-7B-Instruct model.
+
 Prerequisites
 -------------
 
 Before you begin, ensure you have:
 
-* At least 2 GPUs 
+* At least 2 GPUs
 * Python packages installed:
     * ``lmcache`` (0.2.1 or above)
     * ``nixl`` (Install instructions `here <https://github.com/ai-dynamo/nixl>`_)
     * ``vllm`` (latest main branch)
     * ``httpx``, ``fastapi``, and ``uvicorn``
-* A valid Hugging Face token (``HF_TOKEN``) with access to Llama 3.1 8B models
 
 * (Recommended) A machine with NVLink or RDMA enabled GPUs
 
@@ -34,9 +37,9 @@ Architecture Overview
 
 The disaggregated prefill setup consists of three main components:
 
-1. **Prefiller Server (Port 8100)**: Handles the prefill phase of LLM inference
-2. **Decoder Server (Port 8200)**: Manages the decoding/generation phase
-3. **Proxy Server (Port 9000)**: Coordinates between prefiller and decoder
+1. **Prefiller Server (Port 7100)**: Handles the prefill phase of LLM inference
+2. **Decoder Server (Port 7200)**: Manages the decoding/generation phase
+3. **Proxy Server (Port 9100)**: Coordinates between prefiller and decoder
 
 Configuration
 -------------
@@ -54,7 +57,9 @@ Configuration
        pd_proxy_host: "localhost" # Host where proxy server is running
        pd_proxy_port: 7500        # Port where proxy server is listening
        pd_buffer_size: 1073741824  # 1GB buffer for KV cache transfer
-       nixl_buffer_device: "cuda"   # Use GPU memory for buffer
+       pd_buffer_device: "cuda"   # Use GPU memory for buffer
+       nixl_backends:
+         - "UCX"
 
 2. **Decoder Server Configuration** (``lmcache-decoder-config.yaml``):
 
@@ -71,19 +76,13 @@ Configuration
        pd_peer_alloc_port: 7400   # Port for memory allocation
        pd_buffer_size: 1073741824  # 1GB buffer for KV cache transfer
        pd_buffer_device: "cuda"   # Use GPU memory for buffer
+       nixl_backends:
+         - "UCX"
 
 Step-by-Step Setup
 ------------------
 
-1. **Environment Setup**
-
-   Set your Hugging Face token before running the vLLM servers.
-
-   .. code-block:: bash
-
-       export HF_TOKEN=your_hugging_face_token
-
-2. **Launch the vLLM + LMCache Inference Servers**
+1. **Launch the vLLM + LMCache Inference Servers**
 
    You can launch the components individually:
 
@@ -93,8 +92,9 @@ Step-by-Step Setup
 
           UCX_TLS=cuda_ipc,cuda_copy,tcp \
               LMCACHE_CONFIG_FILE=lmcache-decoder-config.yaml \
+              LMCACHE_USE_EXPERIMENTAL=True \
               CUDA_VISIBLE_DEVICES=1 \
-              vllm serve meta-llama/Llama-3.1-8B-Instruct \
+              vllm serve Qwen/Qwen2.5-7B-Instruct \
               --port 7200 \
               --disable-log-requests \
               --kv-transfer-config \
@@ -106,8 +106,9 @@ Step-by-Step Setup
 
           UCX_TLS=cuda_ipc,cuda_copy,tcp \
               LMCACHE_CONFIG_FILE=lmcache-prefiller-config.yaml \
+              LMCACHE_USE_EXPERIMENTAL=True \
               CUDA_VISIBLE_DEVICES=0 \
-              vllm serve meta-llama/Llama-3.1-8B-Instruct \
+              vllm serve Qwen/Qwen2.5-7B-Instruct \
               --port 7100 \
               --disable-log-requests \
               --kv-transfer-config \
@@ -150,26 +151,26 @@ Step-by-Step Setup
 Usage
 -----
 
-Send requests to the proxy server (port 9000) using either the completions or chat completions endpoint:
+Send requests to the proxy server (port 9100) using either the completions or chat completions endpoint:
 
 .. code-block:: bash
 
-    curl http://localhost:9000/v1/completions \
+    curl http://localhost:9100/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
-            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "model": "Qwen/Qwen2.5-7B-Instruct",
             "prompt": "Tell me a story",
             "max_tokens": 100
         }'
 
-You can also test the setup with the following command, which runs the `benchmark_serving.py <https://github.com/vllm-project/vllm/blob/main/vllm/benchmarks/benchmark_serving.py>`_ from vLLM. 
+You can also test the setup with the following command, which runs the `benchmark_serving.py <https://github.com/vllm-project/vllm/blob/main/vllm/benchmarks/benchmark_serving.py>`_ from vLLM.
 
 .. code-block:: bash
 
     git clone https://github.com/vllm-project/vllm.git
     cd vllm/benchmarks
-    python benchmark_serving.py --port 9000 --seed $(date +%s) \
-        --model meta-llama/Llama-3.1-8B-Instruct \
+    python benchmark_serving.py --port 9100 --seed $(date +%s) \
+        --model Qwen/Qwen2.5-7B-Instruct \
         --dataset-name random --random-input-len 5000 --random-output-len 200 \
         --num-prompts 50 --burstiness 100 --request-rate 1
 
@@ -204,5 +205,4 @@ Common issues and solutions:
 
 1. **GPU Requirements**: Ensure you have at least 2 GPUs available
 2. **Port Conflicts**: Check if ports used above are available
-3. **HF Token**: Verify your token starts with ``hf_`` and has necessary model access
-4. **CUDA Errors**: Ensure CUDA_VISIBLE_DEVICES is set correctly for each server
+3. **CUDA Errors**: Ensure CUDA_VISIBLE_DEVICES is set correctly for each server

--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -163,17 +163,6 @@ Send requests to the proxy server (port 9100) using either the completions or ch
             "max_tokens": 100
         }'
 
-You can also test the setup with the following command, which runs the `benchmark_serving.py <https://github.com/vllm-project/vllm/blob/main/vllm/benchmarks/benchmark_serving.py>`_ from vLLM.
-
-.. code-block:: bash
-
-    git clone https://github.com/vllm-project/vllm.git
-    cd vllm/benchmarks
-    python benchmark_serving.py --port 9100 --seed $(date +%s) \
-        --model Qwen/Qwen2.5-7B-Instruct \
-        --dataset-name random --random-input-len 5000 --random-output-len 200 \
-        --num-prompts 50 --burstiness 100 --request-rate 1
-
 Monitoring
 ----------
 

--- a/docs/source/getting_started/quickstart/multimodality.rst
+++ b/docs/source/getting_started/quickstart/multimodality.rst
@@ -1,220 +1,63 @@
 Example: Multimodal KV Cache Support
 ====================================
 
-Quick Start Example (Audio Model): 
+Quick Start Example (Vision-Language Model):
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We  going to be running audio inference with ``ultravox-v0_5-llama-3_2-1b`` and using LMCache to speed up the TTFT after the first request.
+We are going to be running multimodal inference with ``Qwen/Qwen2-VL-2B-Instruct`` and using LMCache to speed up the TTFT after the first request.
 
-**Install and Serve:** 
+.. note::
 
-``pip install lmcache vllm[audio] openai``
+    This guide has been tested with **vLLM 0.11.0** and **LMCache 0.3.9** using the Qwen/Qwen2-VL-2B-Instruct model.
+
+**Install and Serve:**
+
+``pip install lmcache vllm openai``
 
 .. code-block:: bash
 
-   vllm serve fixie-ai/ultravox-v0_5-llama-3_2-1b \
-       --max-model-len 4096 --trust-remote-code \
+   LMCACHE_USE_EXPERIMENTAL=True \
+   vllm serve Qwen/Qwen2-VL-2B-Instruct \
+       --max-model-len 1024 \
+       --gpu-memory-utilization 0.5 \
+       --enforce-eager \
+       --limit-mm-per-prompt '{"image": 1}' \
        --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
 
 
-**Benchmark:** 
+**Test the setup:**
 
-Save as ``audio_query.py``
-
-.. code-block:: python
-
-   # SPDX-License-Identifier: Apache-2.0
-   # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
-   import base64
-
-   import requests
-   from openai import OpenAI
-
-   # SPDX-License-Identifier: Apache-2.0
-   # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-   from openai import APIConnectionError, OpenAI
-   from openai.pagination import SyncPage
-   from openai.types.model import Model
-
-   import time
-
-   def get_first_model(client: OpenAI) -> str:
-       """
-       Get the first model from the vLLM server.
-       """
-       try:
-           models: SyncPage[Model] = client.models.list()
-       except APIConnectionError as e:
-           raise RuntimeError(
-               "Failed to get the list of models from the vLLM server at "
-               f"{client.base_url} with API key {client.api_key}. Check\n"
-               "1. the server is running\n"
-               "2. the server URL is correct\n"
-               "3. the API key is correct"
-           ) from e
-
-       if len(models.data) == 0:
-           raise RuntimeError(f"No models found on the vLLM server at {client.base_url}")
-
-       return models.data[0].id
-
-   # Modify OpenAI's API key and API base to use vLLM's API server.
-   openai_api_key = "EMPTY"
-   openai_api_base = "http://localhost:8000/v1"
-
-   client = OpenAI(
-       # defaults to os.environ.get("OPENAI_API_KEY")
-       api_key=openai_api_key,
-       base_url=openai_api_base,
-   )
-
-
-   def encode_base64_content_from_url(content_url: str) -> str:
-       """Encode a content retrieved from a remote url to base64 format."""
-
-       with requests.get(content_url) as response:
-           response.raise_for_status()
-           result = base64.b64encode(response.content).decode("utf-8")
-
-       return result
-   # Audio input inference
-   def run_audio(model: str) -> None:
-       from vllm.assets.audio import AudioAsset
-   
-       audio_url = AudioAsset("winning_call").url
-       audio_base64 = encode_base64_content_from_url(audio_url)
-   
-       # OpenAI-compatible schema (`input_audio`)
-       chat_completion_from_base64 = client.chat.completions.create(
-           messages=[
-               {
-                   "role": "user",
-                   "content": [
-                       {"type": "text", "text": "What's in this audio?"},
-                       {
-                           "type": "input_audio",
-                           "input_audio": {
-                               # Any format supported by librosa is supported
-                               "data": audio_base64,
-                               "format": "wav",
-                           },
-                       },
-                   ],
-               }
-           ],
-           model=model,
-           max_completion_tokens=64,
-       )
-   
-       result = chat_completion_from_base64.choices[0].message.content
-       print("Chat completion output from input audio:", result)
-   
-       # HTTP URL
-       chat_completion_from_url = client.chat.completions.create(
-           messages=[
-               {
-                   "role": "user",
-                   "content": [
-                       {"type": "text", "text": "What's in this audio?"},
-                       {
-                           "type": "audio_url",
-                           "audio_url": {
-                               # Any format supported by librosa is supported
-                               "url": audio_url
-                           },
-                       },
-                   ],
-               }
-           ],
-           model=model,
-           max_completion_tokens=64,
-       )
-   
-       result = chat_completion_from_url.choices[0].message.content
-       print("Chat completion output from audio url:", result)
-   
-       # base64 URL
-       chat_completion_from_base64 = client.chat.completions.create(
-           messages=[
-               {
-                   "role": "user",
-                   "content": [
-                       {"type": "text", "text": "What's in this audio?"},
-                       {
-                           "type": "audio_url",
-                           "audio_url": {
-                               # Any format supported by librosa is supported
-                               "url": f"data:audio/ogg;base64,{audio_base64}"
-                           },
-                       },
-                   ],
-               }
-           ],
-           model=model,
-           max_completion_tokens=64,
-       )
-   
-       result = chat_completion_from_base64.choices[0].message.content
-       print("Chat completion output from base64 encoded audio:", result)
-       
-   start_time = time.time()
-
-   model = get_first_model(client)
-   run_audio(model)
-   end_time = time.time()
-   print(f"Time taken: {end_time - start_time} seconds")   
-
-
-**Run and see TTFT speedup:** 
+Send a simple text request to verify LMCache is working:
 
 .. code-block:: bash
 
-   # first time: 
-   python audio_query.py
+   curl http://localhost:8000/v1/completions \
+       -H "Content-Type: application/json" \
+       -d '{
+           "model": "Qwen/Qwen2-VL-2B-Instruct",
+           "prompt": "Describe the color blue.",
+           "max_tokens": 50
+       }'   
 
-   # second time: 
-   python audio_query.py
 
+**Monitoring LMCache:**
 
-**Retrieval and speed up in logs:**
-
-1. After First Request:
-
-.. code-block:: text
-
-   [2025-08-05 09:58:06,965] LMCache INFO: Reqid: chatcmpl-dd6e8a131f2b455fa3cd133a9bfab26f, Total tokens 201, LMCache hit tokens: 201, need to load: 8 (vllm_v1_adapter.py:803:lmcache.integration.vllm.vllm_v1_adapter)
-   [2025-08-05 09:58:06,967] LMCache INFO: Retrieved 201 out of 201 out of total 201 tokens (cache_engine.py:500:lmcache.v1.cache_engine)
-   [2025-08-05 09:58:07,178] LMCache INFO: Storing KV cache for 256 out of 256 tokens (skip_leading_tokens=0) for request chatcmpl-dd6e8a131f2b455fa3cd133a9bfab26f (vllm_v1_adapter.py:709:lmcache.integration.vllm.vllm_v1_adapter)
-   [2025-08-05 09:58:07,178] LMCache INFO: Stored 256 out of total 256 tokens. size: 0.0078 gb, cost 0.5096 ms, throughput: 15.3291 GB/s; offload_time: 0.4897 ms, put_time: 0.0200 ms (cache_engine.py:251:lmcache.v1.cache_engine)
-
-*Example Output:*
+After running the first request, check the vLLM logs to see LMCache storing the KV cache:
 
 .. code-block:: text
 
-   Chat completion output from input audio: It seems like you're excitedly sharing your thoughts and predictions about a game you're about to watch. The audio appears to be a stream of text messages or social media updates. The words and phrases you've copied seem to indicate that you're a sports fan, particularly in Major League Baseball (MLB). 
+   LMCache INFO: Storing KV cache for 5 out of 5 tokens (skip_leading_tokens=0) for request 0
+   LMCache INFO: Stored 5 out of total 5 tokens. size: 0.0001 gb, cost 0.5948 ms, throughput: 0.2245 GB/s
 
-   Are
-   Chat completion output from audio url: It appears to be a enthusiastic and excited baseball comment from an individual. The language used, such as "And the one pitch on the way to Edgar Martinez has swung on and line down the line for a base hit," suggests a strong amateur athlete's excitement and commentary. The reference to the playoff qualification and the praise for
-   Chat completion output from base64 encoded audio: It seems like you're excited about a sports game, possibly the California Athletics (now known as the Los Angeles Angels), given the reference to Edgar Martinez and the Birds (no team by that name in the AL) in the mixed messages.
-
-   However, I'm not seeing any audio in the conversation. Are you referring to
-   Time taken: 37.96290421485901 seconds
-
-2. After Second Request: 
+Run the same request again, and you'll see LMCache retrieving the cached KV:
 
 .. code-block:: text
 
-   [2025-08-05 09:58:07,371] LMCache INFO: Reqid: chatcmpl-2a130545a6a24f33b41e219ef0807a61, Total tokens 201, LMCache hit tokens: 201, need to load: 8 (vllm_v1_adapter.py:803:lmcache.integration.vllm.vllm_v1_adapter)
-   [2025-08-05 09:58:07,372] LMCache INFO: Retrieved 201 out of 201 out of total 201 tokens (cache_engine.py:500:lmcache.v1.cache_engine)
-   [2025-08-05 09:58:07,558] LMCache INFO: Storing KV cache for 256 out of 256 tokens (skip_leading_tokens=0) for request chatcmpl-2a130545a6a24f33b41e219ef0807a61 (vllm_v1_adapter.py:709:lmcache.integration.vllm.vllm_v1_adapter)
-   [2025-08-05 09:58:07,558] LMCache INFO: Stored 256 out of total 256 tokens. size: 0.0078 gb, cost 0.4962 ms, throughput: 15.7450 GB/s; offload_time: 0.4782 ms, put_time: 0.0179 ms (cache_engine.py:251:lmcache.v1.cache_engine)
+   LMCache INFO: Reqid: 0, Total tokens 5, LMCache hit tokens: 0, need to load: 0
+   LMCache INFO: Retrieved 5 out of 5 out of total 5 tokens
 
-*Example Output:*
+This demonstrates that LMCache successfully caches and retrieves KV values for multimodal models.
 
-.. code-block:: text
+.. note::
 
-   Chat completion output from input audio: It seems like you're extremely excited about the possibility of the San Francisco Giants winning the American League championship and playing in the World Series. The audio is filled with emotions and a sense of optimism, with you enthusiastically expressing your thoughts and feelings. It's clear that this is a significant moment for you, particularly given the fact
-   Chat completion output from audio url: I can tell you're excited about a baseball game. It seems like you're reliving a moment during the middle of a game, especially the highlight of a six runs game for the Golden Giants. The audio appears to include a local sports radio talk show style broadcast, with a narrator (or DJs) discussing the importance
-   Chat completion output from base64 encoded audio: It seems like you're having a lively discussion about baseball, specifically about the Arizona Diamondbacks and their chances of winning the American League championship. You're using colloquial expressions and slang, such as "the Oone hitter," " rejoice," and "waving him in." These cues suggest that you're engaged in
-   Time taken: 5.39893364906311 seconds
+   LMCache works with various multimodal models supported by vLLM, including vision-language and audio-language models. The KV cache is automatically managed for both text and multimodal tokens.

--- a/docs/source/getting_started/quickstart/multimodality.rst
+++ b/docs/source/getting_started/quickstart/multimodality.rst
@@ -40,12 +40,28 @@ Send a simple text request to verify LMCache is working:
        }'   
 
 
+**Example Output:**
+
+You should receive a response like:
+
+.. code-block:: json
+
+   {
+     "id": "cmpl-...",
+     "object": "text_completion",
+     "model": "Qwen/Qwen2-VL-2B-Instruct",
+     "choices": [{
+       "text": " Blue is a color that is often associated with the sky, water, and the ocean. It is a cool color that is often used to represent calmness, tranquility, and serenity. Blue is also a color that is often used in fashion"
+     }]
+   }
+
 **Monitoring LMCache:**
 
 After running the first request, check the vLLM logs to see LMCache storing the KV cache:
 
 .. code-block:: text
 
+   LMCache INFO: Reqid: 0, Total tokens 5, LMCache hit tokens: 0, need to load: 0
    LMCache INFO: Storing KV cache for 5 out of 5 tokens (skip_leading_tokens=0) for request 0
    LMCache INFO: Stored 5 out of total 5 tokens. size: 0.0001 gb, cost 0.5948 ms, throughput: 0.2245 GB/s
 
@@ -53,7 +69,7 @@ Run the same request again, and you'll see LMCache retrieving the cached KV:
 
 .. code-block:: text
 
-   LMCache INFO: Reqid: 0, Total tokens 5, LMCache hit tokens: 0, need to load: 0
+   LMCache INFO: Reqid: 1, Total tokens 5, LMCache hit tokens: 5, need to load: 5
    LMCache INFO: Retrieved 5 out of 5 out of total 5 tokens
 
 This demonstrates that LMCache successfully caches and retrieves KV values for multimodal models.

--- a/docs/source/getting_started/quickstart/share_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/share_kv_cache.rst
@@ -52,8 +52,9 @@ Run centralized sharing example
 .. code-block:: bash
 
     LMCACHE_CONFIG_FILE=lmcache_config.yaml \
+    LMCACHE_USE_EXPERIMENTAL=True \
     CUDA_VISIBLE_DEVICES=0 \
-    vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct \
+    vllm serve Qwen/Qwen2.5-7B-Instruct \
         --gpu-memory-utilization 0.8 \
         --port 8000 --kv-transfer-config \
         '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
@@ -63,8 +64,9 @@ In another terminal,
 .. code-block:: bash
 
     LMCACHE_CONFIG_FILE=lmcache_config.yaml \
+    LMCACHE_USE_EXPERIMENTAL=True \
     CUDA_VISIBLE_DEVICES=1 \
-    vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct \
+    vllm serve Qwen/Qwen2.5-7B-Instruct \
         --gpu-memory-utilization 0.8 \
         --port 8001 \
         --kv-transfer-config \
@@ -79,7 +81,7 @@ Wait until both engines are ready.
     curl -X POST http://localhost:8000/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
-            "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "model": "Qwen/Qwen2.5-7B-Instruct",
             "prompt": "Explain the significance of KV cache in language models.",
             "max_tokens": 10
         }'
@@ -91,7 +93,7 @@ Wait until both engines are ready.
     curl -X POST http://localhost:8001/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
-            "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "model": "Qwen/Qwen2.5-7B-Instruct",
             "prompt": "Explain the significance of KV cache in language models.",
             "max_tokens": 10
         }'
@@ -155,7 +157,8 @@ Start vllm engine 1 at port 8000:
 
     CUDA_VISIBLE_DEVICES=0 \
     LMCACHE_CONFIG_FILE=lmcache_config1.yaml \
-    vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct \
+    LMCACHE_USE_EXPERIMENTAL=True \
+    vllm serve Qwen/Qwen2.5-7B-Instruct \
         --max-model-len 4096 \
         --gpu-memory-utilization 0.8 \
         --port 8000 \
@@ -168,7 +171,8 @@ Start vllm engine 2 at port 8001:
 
     CUDA_VISIBLE_DEVICES=1 \
     LMCACHE_CONFIG_FILE=lmcache_config2.yaml \
-    vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct \
+    LMCACHE_USE_EXPERIMENTAL=True \
+    vllm serve Qwen/Qwen2.5-7B-Instruct \
         --max-model-len 4096 \
         --gpu-memory-utilization 0.8 \
         --port 8001 \
@@ -184,7 +188,7 @@ Note that the two distributed cache servers will start at port 8200 and 8201.
     curl -X POST http://localhost:8000/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
-        "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        "model": "Qwen/Qwen2.5-7B-Instruct",
         "prompt": "Explain the significance of KV cache in language models.",
         "max_tokens": 100
         }'
@@ -196,7 +200,7 @@ Note that the two distributed cache servers will start at port 8200 and 8201.
     curl -X POST http://localhost:8001/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
-        "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        "model": "Qwen/Qwen2.5-7B-Instruct",
         "prompt": "Explain the significance of KV cache in language models.",
         "max_tokens": 100
         }'


### PR DESCRIPTION
## Summary

This PR updates quickstart documentation examples to use open Qwen models instead of gated Meta-Llama models, removing the HF_TOKEN dependency and improving the getting started experience.

## Changes

- **share_kv_cache.rst**: Replace `meta-llama/Meta-Llama-3.1-8B-Instruct` with `Qwen/Qwen2.5-7B-Instruct`
- **disaggregated_prefill.rst**: Update to use `Qwen/Qwen2.5-7B-Instruct` and add:
  - Version information (tested with vLLM 0.11.0, LMCache 0.3.9)
  - Fixed port numbers for consistency
  - Added `nixl_backends` configuration
- Add `LMCACHE_USE_EXPERIMENTAL=True` environment variable to all examples
- Remove HF_TOKEN requirements from examples

## Testing

- Tested with vLLM 0.11.0 and LMCache 0.3.9
- Verified all examples work with Qwen/Qwen2.5-7B-Instruct model
- Confirmed no HF_TOKEN authentication needed

## Motivation

The current quickstart examples use gated models (Meta-Llama-3.1-8B-Instruct) that require users to authenticate with HuggingFace tokens, creating friction for new users. Using open Qwen models makes the quickstart more accessible and user-friendly.