### PR TITLE
[InternalApi] Support config import module for the run_script api

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -401,6 +401,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": False,
         "env_converter": _to_bool,
     },
+    "script_allowed_imports": {
+        "type": Optional[list[str]],
+        "default": None,
+        "env_converter": _to_str_list,
+    },
 }
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add configured import modules to the restricted_globals to allow run script with those modules.

