### PR TITLE
[CI]: audit connector unit test patch

### DIFF
--- a/examples/kubernetes/health_probe.py
+++ b/examples/kubernetes/health_probe.py
@@ -45,7 +45,7 @@ def main():
                     world_size=0,
                     worker_id=0,
                     chunk_hash="",
-                    kv_dtype=torch.float16,
+                    dtype=torch.float16,
                 ),
                 length=0,
                 fmt=MemoryFormat(1),

--- a/examples/kubernetes/health_probe.py
+++ b/examples/kubernetes/health_probe.py
@@ -44,7 +44,7 @@ def main():
                     model_name="",
                     world_size=0,
                     worker_id=0,
-                    chunk_hash="",
+                    chunk_hash=0,
                     dtype=torch.float16,
                 ),
                 length=0,

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -24,7 +24,7 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 def create_test_key(key_id: str) -> CacheEngineKey:
     """Helper to create a test CacheEngineKey"""
-    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id))
+    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), dtype=torch.uint8)
 
 
 def create_mock_memory_obj(backend: LocalCPUBackend, data: bytes) -> MemoryObj:


### PR DESCRIPTION
This is caused by: 

https://github.com/LMCache/LMCache/pull/1859

which merged without conflicts after more unit tests were added