### PR TITLE
[refactor] unified reconstruct cache engine key

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -298,6 +298,18 @@ class CacheEngineKey:
             request_configs=request_configs,
         )
 
+    def with_new_worker_id(self, new_worker_id: int) -> "CacheEngineKey":
+        # Reconstruct the cache engine key with new worker id
+        return CacheEngineKey(
+            self.fmt,
+            self.model_name,
+            self.world_size,
+            new_worker_id,
+            self.chunk_hash,
+            self.dtype,
+            self.request_configs,
+        )
+
 
 @dataclass(slots=True)
 class LayerCacheEngineKey(CacheEngineKey):

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -136,7 +136,7 @@ class RemoteBackend(StorageBackendInterface):
 
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            key = self._reconstruct_cache_engine_key(key)
+            key = key.with_new_worker_id(0)
 
         try:
             if self.config.extra_config is not None and self.config.extra_config.get(
@@ -172,7 +172,7 @@ class RemoteBackend(StorageBackendInterface):
             return [False] * len(keys)
 
         if self._mla_worker_id_as0_mode:
-            keys = [self._reconstruct_cache_engine_key(key) for key in keys]
+            keys = [key.with_new_worker_id(0) for key in keys]
 
         try:
             return self.connection.batched_contains(keys, stop_after_first_not_exits)
@@ -289,7 +289,7 @@ class RemoteBackend(StorageBackendInterface):
             return None
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            key = self._reconstruct_cache_engine_key(key)
+            key = key.with_new_worker_id(0)
         t1 = time.perf_counter()
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
 
@@ -333,15 +333,13 @@ class RemoteBackend(StorageBackendInterface):
 
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            new_keys = [self._reconstruct_cache_engine_key(key) for key in keys]
-        else:
-            new_keys = keys
+            keys = [key.with_new_worker_id(0) for key in keys]
 
         t1 = time.perf_counter()
         # batched get
         if self.connection.support_batched_get():
             future = asyncio.run_coroutine_threadsafe(
-                self.connection.batched_get(new_keys), self.loop
+                self.connection.batched_get(keys), self.loop
             )
             try:
                 memory_objs = future.result(self.blocking_timeout_secs)
@@ -360,7 +358,7 @@ class RemoteBackend(StorageBackendInterface):
         else:
             futures = [
                 asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
-                for key in new_keys
+                for key in keys
             ]
             memory_objs = []
             failed = False
@@ -418,7 +416,7 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning("Connection is None in batched_async_contains, returning 0")
             return 0
         if self._mla_worker_id_as0_mode:
-            keys = [self._reconstruct_cache_engine_key(key) for key in keys]
+            keys = [key.with_new_worker_id(0) for key in keys]
 
         try:
             assert self.connection.support_batched_async_contains(), (
@@ -500,17 +498,3 @@ class RemoteBackend(StorageBackendInterface):
             logger.info("Remote backend closed.")
         except Exception as e:
             logger.warning(f"Error occurred when closing remote connection: {e}")
-
-    def _reconstruct_cache_engine_key(
-        self, key: CacheEngineKey, new_worker_id: int = 0
-    ) -> CacheEngineKey:
-        # Reconstruct the cache engine key with new worker id
-        return CacheEngineKey(
-            key.fmt,
-            key.model_name,
-            key.world_size,
-            new_worker_id,
-            key.chunk_hash,
-            key.dtype,
-            key.request_configs,
-        )

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -136,15 +136,7 @@ class RemoteBackend(StorageBackendInterface):
 
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            key = CacheEngineKey(
-                key.fmt,
-                key.model_name,
-                key.world_size,
-                0,
-                key.chunk_hash,
-                key.dtype,
-                key.request_configs,
-            )
+            key = self._reconstruct_cache_engine_key(key)
 
         try:
             if self.config.extra_config is not None and self.config.extra_config.get(
@@ -181,14 +173,7 @@ class RemoteBackend(StorageBackendInterface):
 
         if self._mla_worker_id_as0_mode:
             keys = [
-                CacheEngineKey(
-                    key.fmt,
-                    key.model_name,
-                    key.world_size,
-                    0,
-                    key.chunk_hash,
-                    key.request_configs,
-                )
+                self._reconstruct_cache_engine_key(key)
                 for key in keys
             ]
 
@@ -307,15 +292,7 @@ class RemoteBackend(StorageBackendInterface):
             return None
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            key = CacheEngineKey(
-                key.fmt,
-                key.model_name,
-                key.world_size,
-                0,
-                key.chunk_hash,
-                key.dtype,
-                key.request_configs,
-            )
+            key = self._reconstruct_cache_engine_key(key)
         t1 = time.perf_counter()
         future = asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
 
@@ -360,15 +337,7 @@ class RemoteBackend(StorageBackendInterface):
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
             new_keys = [
-                CacheEngineKey(
-                    key.fmt,
-                    key.model_name,
-                    key.world_size,
-                    0,
-                    key.chunk_hash,
-                    key.dtype,
-                    key.request_configs,
-                )
+                self._reconstruct_cache_engine_key(key)
                 for key in keys
             ]
         else:
@@ -456,15 +425,7 @@ class RemoteBackend(StorageBackendInterface):
             return 0
         if self._mla_worker_id_as0_mode:
             keys = [
-                CacheEngineKey(
-                    key.fmt,
-                    key.model_name,
-                    key.world_size,
-                    0,
-                    key.chunk_hash,
-                    key.dtype,
-                    key.request_configs,
-                )
+                self._reconstruct_cache_engine_key(key)
                 for key in keys
             ]
 
@@ -548,3 +509,17 @@ class RemoteBackend(StorageBackendInterface):
             logger.info("Remote backend closed.")
         except Exception as e:
             logger.warning(f"Error occurred when closing remote connection: {e}")
+
+    def _reconstruct_cache_engine_key(
+        self, key: CacheEngineKey, new_worker_id: int = 0
+    ) -> CacheEngineKey:
+        # Reconstruct the cache engine key with new worker id
+        return CacheEngineKey(
+                    key.fmt,
+                    key.model_name,
+                    key.world_size,
+                    new_worker_id,
+                    key.chunk_hash,
+                    key.dtype,
+                    key.request_configs,
+                )

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -172,10 +172,7 @@ class RemoteBackend(StorageBackendInterface):
             return [False] * len(keys)
 
         if self._mla_worker_id_as0_mode:
-            keys = [
-                self._reconstruct_cache_engine_key(key)
-                for key in keys
-            ]
+            keys = [self._reconstruct_cache_engine_key(key) for key in keys]
 
         try:
             return self.connection.batched_contains(keys, stop_after_first_not_exits)
@@ -336,10 +333,7 @@ class RemoteBackend(StorageBackendInterface):
 
         # For MLA worker id as 0 mode, use worker_id 0
         if self._mla_worker_id_as0_mode:
-            new_keys = [
-                self._reconstruct_cache_engine_key(key)
-                for key in keys
-            ]
+            new_keys = [self._reconstruct_cache_engine_key(key) for key in keys]
         else:
             new_keys = keys
 
@@ -424,10 +418,7 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning("Connection is None in batched_async_contains, returning 0")
             return 0
         if self._mla_worker_id_as0_mode:
-            keys = [
-                self._reconstruct_cache_engine_key(key)
-                for key in keys
-            ]
+            keys = [self._reconstruct_cache_engine_key(key) for key in keys]
 
         try:
             assert self.connection.support_batched_async_contains(), (
@@ -515,11 +506,11 @@ class RemoteBackend(StorageBackendInterface):
     ) -> CacheEngineKey:
         # Reconstruct the cache engine key with new worker id
         return CacheEngineKey(
-                    key.fmt,
-                    key.model_name,
-                    key.world_size,
-                    new_worker_id,
-                    key.chunk_hash,
-                    key.dtype,
-                    key.request_configs,
-                )
+            key.fmt,
+            key.model_name,
+            key.world_size,
+            new_worker_id,
+            key.chunk_hash,
+            key.dtype,
+            key.request_configs,
+        )


### PR DESCRIPTION
unified reconstruct cache engine key, there are tow main benfits:
1. The code is clearer;
2. Prevent missing modifications, which will result in some bugs. such as the following case:

#1854 add the following code to reconstruct the `CacheEngineKey`
```
        if self._mla_worker_id_as0_mode:
            keys = [
                CacheEngineKey(
                    key.fmt,
                    key.model_name,
                    key.world_size,
                    0,
                    key.chunk_hash,
                    key.request_configs,
                )
                for key in keys
            ]
```
#1859 add `dtype` in `CacheEngineKey`, but misses the modification here.