### PR TITLE
[Fix][AsyncLoading] Multi tiered backends discontinuous case

### DIFF
--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -537,6 +537,12 @@ class StorageManager:
         #   cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280, 1536, 1792]
         #   tier_expected_chunks = [3, 2, 2]  # Tier 0: 3, Tier 1: 2, Tier 2: 2
         #
+        #   Chunks:
+        #   [0 1 2 3 4 5 6]
+        #   |-----|          <--- stored in Tier0, tier_expected_chunks[0]==3
+        #         |---|      <--- stored in Tier1, tier_expected_chunks[1]==2
+        #             |---|  <--- stored in Tier2, tier_expected_chunks[2]==2
+        #
         # Case 1: All chunks retrieved successfully
         #   res = [[obj0, obj1, obj2], [obj3, obj4], [obj5, obj6]]
         #   total_retrieved_chunks = 7

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -515,7 +515,8 @@ class StorageManager:
         self,
         task: asyncio.Future,
         lookup_id: str,
-        cum_last_tier_chunk_lengths: list[int],
+        cum_chunk_lengths_total: list[int],
+        tier_expected_chunks: list[int],
     ) -> None:
         """
         Callback function when all prefetch tasks
@@ -526,8 +527,48 @@ class StorageManager:
             EventType.LOADING, lookup_id, status=EventStatus.DONE
         )
         res = task.result()
-        last_tier_retrieved_chunks = len(res[-1])
-        retrieved_length = cum_last_tier_chunk_lengths[last_tier_retrieved_chunks]
+
+        # Calculate total retrieved chunks across all tiers based on actual results
+        # from batched_get_non_blocking, not the batched_async_contains results.
+        # This handles the case where chunks may be evicted between contains check
+        # and actual retrieval.
+        #
+        # Example: chunk_size=256, 7 chunks total (1792 tokens) across 3 tiers
+        #   cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280, 1536, 1792]
+        #   tier_expected_chunks = [3, 2, 2]  # Tier 0: 3, Tier 1: 2, Tier 2: 2
+        #
+        # Case 1: All chunks retrieved successfully
+        #   res = [[obj0, obj1, obj2], [obj3, obj4], [obj5, obj6]]
+        #   total_retrieved_chunks = 7
+        #   retrieved_length = cum_chunk_lengths_total[7] = 1792
+        #
+        # Case 2: Tier 1 only got 1 chunk (eviction), Tier 2 got all 2 chunks
+        #   res = [[obj0, obj1, obj2], [obj3], [obj5, obj6]]
+        #   total_retrieved_chunks = 4 (stop at tier 1, tier 2 chunks ignored)
+        #   retrieved_length = cum_chunk_lengths_total[4] = 1024
+        #   Note: Even though tier 2 successfully retrieved 2 chunks, they are
+        #   not counted because tier 1 has a gap, breaking prefix continuity.
+        #
+        # Case 3: Tier 0 only got 2 chunks (eviction), other tiers got all
+        #   res = [[obj0, obj1], [obj3, obj4], [obj5, obj6]]
+        #   total_retrieved_chunks = 2 (stop at tier 0, all subsequent ignored)
+        #   retrieved_length = cum_chunk_lengths_total[2] = 512
+        total_retrieved_chunks = 0
+        for tier_idx, tier_result in enumerate(res):
+            actual_chunks = len(tier_result)
+            expected_chunks = tier_expected_chunks[tier_idx]
+            total_retrieved_chunks += actual_chunks
+
+            # If a tier retrieved fewer chunks than expected, we stop counting
+            # because subsequent chunks are not contiguous
+            if actual_chunks < expected_chunks:
+                # Release all chunks in subsequent tiers since they won't be used
+                for subsequent_tier in res[tier_idx + 1 :]:
+                    for mem_obj in subsequent_tier:
+                        mem_obj.ref_count_down()
+                break
+
+        retrieved_length = cum_chunk_lengths_total[total_retrieved_chunks]
         logger.info(
             f"Responding to scheduler for lookup id {lookup_id}"
             f" with retrieved length {retrieved_length}"
@@ -547,7 +588,15 @@ class StorageManager:
 
         :param str lookup_id: The unique id (e.g., request id) for the request.
         :param list[CacheEngineKey] keys: The keys to lookup and prefetch.
-        :param list[int] cum_chunk_lengths: The cumulative lengths of the chunks.
+        :param list[int] cum_chunk_lengths: The cumulative token lengths of the chunks.
+            This is a list where cum_chunk_lengths[i] represents the total number of
+            tokens from chunk 0 to chunk i-1 (inclusive).
+            Example: If chunk_size=256 and we have 3 chunks:
+                - chunk 0: 256 tokens (tokens 0-255)
+                - chunk 1: 256 tokens (tokens 256-511)
+                - chunk 2: 128 tokens (tokens 512-639)
+            Then cum_chunk_lengths = [0, 256, 512, 640]
+            Note: len(cum_chunk_lengths) = len(keys) + 1
         :param Optional[list[str]] search_range: The range of storage backends
         to search in. Should be a subset of ["LocalCPUBackend",
         "LocalDiskBackend"] for now. If None, search in all backends.
@@ -568,9 +617,16 @@ class StorageManager:
 
         num_total_chunks = len(keys)
         num_total_hit_chunks = 0
-        num_last_tier_hit_chunks = 0
+        # cum_chunk_lengths_total: A copy of the original cumulative chunk lengths
+        # for all chunks. This is preserved to calculate the final token count
+        # based on the actual retrieved chunks.
+        # Example: If chunk_size=256 and we have 3 chunks with total 640 tokens:
+        #     cum_chunk_lengths_total = [0, 256, 512, 640]
+        # If we retrieve 2 chunks, the retrieved token count is:
+        #     cum_chunk_lengths_total[2] = 512 tokens
         cum_chunk_lengths_total = cum_chunk_lengths[:]
         loading_tasks = []
+        tier_expected_chunks = []
         for backend_name, backend in self.storage_backends.items():
             if search_range and backend_name not in search_range:
                 continue
@@ -579,9 +635,8 @@ class StorageManager:
             if num_hit_chunks == 0:
                 continue
 
-            num_last_tier_hit_chunks = num_hit_chunks
-
             num_total_hit_chunks += num_hit_chunks
+            tier_expected_chunks.append(num_hit_chunks)
 
             assert self.async_serializer is not None, (
                 "Async serializer must be initialized via post_init before using "
@@ -630,9 +685,8 @@ class StorageManager:
             lambda future: self.prefetch_all_done_callback(
                 future,
                 lookup_id,
-                cum_chunk_lengths_total[
-                    num_total_hit_chunks - num_last_tier_hit_chunks :
-                ],
+                cum_chunk_lengths_total,
+                tier_expected_chunks,
             )
         )
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -544,11 +544,19 @@ class StorageManager:
         #             |---|  <--- stored in Tier2, tier_expected_chunks[2]==2
         #
         # Case 1: All chunks retrieved successfully
+        #   [0 1 2 3 4 5 6]
+        #   |-----|          <--- Tier0: retrieved 3 chunks (obj0, obj1, obj2)
+        #         |---|      <--- Tier1: retrieved 2 chunks (obj3, obj4)
+        #             |---|  <--- Tier2: retrieved 2 chunks (obj5, obj6)
         #   res = [[obj0, obj1, obj2], [obj3, obj4], [obj5, obj6]]
         #   total_retrieved_chunks = 7
         #   retrieved_length = cum_chunk_lengths_total[7] = 1792
         #
         # Case 2: Tier 1 only got 1 chunk (eviction), Tier 2 got all 2 chunks
+        #   [0 1 2 3 4 5 6]
+        #   |-----|          <--- Tier0: retrieved 3 chunks (obj0, obj1, obj2)
+        #         |-|X|      <--- Tier1: retrieved 1 chunk (obj3), missing obj4
+        #             |---|  <--- Tier2: retrieved 2 chunks (obj5, obj6) - IGNORED
         #   res = [[obj0, obj1, obj2], [obj3], [obj5, obj6]]
         #   total_retrieved_chunks = 4 (stop at tier 1, tier 2 chunks ignored)
         #   retrieved_length = cum_chunk_lengths_total[4] = 1024
@@ -556,6 +564,10 @@ class StorageManager:
         #   not counted because tier 1 has a gap, breaking prefix continuity.
         #
         # Case 3: Tier 0 only got 2 chunks (eviction), other tiers got all
+        #   [0 1 2 3 4 5 6]
+        #   |---|X|          <--- Tier0: retrieved 2 chunks (obj0, obj1), missing obj2
+        #         |---|      <--- Tier1: retrieved 2 chunks (obj3, obj4) - IGNORED
+        #             |---|  <--- Tier2: retrieved 2 chunks (obj5, obj6) - IGNORED
         #   res = [[obj0, obj1], [obj3, obj4], [obj5, obj6]]
         #   total_retrieved_chunks = 2 (stop at tier 0, all subsequent ignored)
         #   retrieved_length = cum_chunk_lengths_total[2] = 512

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Test cases for StorageManager.
+
+This module tests the critical logic in prefetch_all_done_callback that handles:
+1. Calculating the actual number of retrieved chunks based on batched_get_non_blocking
+   results (not batched_async_contains results)
+2. Handling chunk eviction between contains check and actual retrieval
+3. Ensuring prefix-based continuity: if a tier retrieves fewer chunks than expected,
+   all subsequent tiers are ignored
+4. Properly cleaning up (ref_count_down) memory objects that won't be used due to
+   discontinuity
+
+Key scenarios tested:
+- All chunks retrieved successfully from all tiers
+- Middle tier partial retrieval (subsequent tiers ignored)
+- First tier partial retrieval (all subsequent tiers ignored)
+- Last chunk not being full size
+- Single tier partial retrieval
+"""
+
+# Standard
+import asyncio
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.event_manager import EventManager, EventType
+from lmcache.v1.storage_backend.storage_manager import StorageManager
+
+
+class MockMemoryObj:
+    """Mock MemoryObj for testing."""
+
+    def __init__(self, obj_id: int):
+        self.obj_id = obj_id
+        self.ref_count = 1
+        self.ref_count_down_called = False
+
+    def ref_count_down(self):
+        self.ref_count -= 1
+        self.ref_count_down_called = True
+
+    def __repr__(self):
+        return f"MockMemoryObj(id={self.obj_id}, ref_count={self.ref_count})"
+
+
+class MockAsyncLookupServer:
+    """Mock async lookup server for testing."""
+
+    def __init__(self):
+        self.responses = []
+
+    def send_response_to_scheduler(self, lookup_id: str, retrieved_length: int):
+        self.responses.append((lookup_id, retrieved_length))
+
+
+@pytest.fixture
+def event_manager():
+    """Create an EventManager for testing."""
+    return EventManager()
+
+
+@pytest.fixture
+def storage_manager_config():
+    """Create a test configuration for StorageManager."""
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        local_cpu=False,
+        lmcache_instance_id="test_instance",
+    )
+    return config
+
+
+@pytest.fixture
+def storage_manager_metadata():
+    """Create test metadata for StorageManager."""
+    metadata = LMCacheEngineMetadata(
+        model_name="test_model",
+        world_size=1,
+        worker_id=0,
+        fmt="vllm",
+        kv_dtype=torch.bfloat16,
+        kv_shape=(28, 2, 256, 8, 128),
+        role="scheduler",
+    )
+    return metadata
+
+
+@pytest.fixture
+def storage_manager(storage_manager_config, storage_manager_metadata, event_manager):
+    """Create a StorageManager for testing."""
+    manager = StorageManager(
+        config=storage_manager_config,
+        metadata=storage_manager_metadata,
+        event_manager=event_manager,
+    )
+    # Mock the async lookup server
+    manager.async_lookup_server = MockAsyncLookupServer()
+    yield manager
+    manager.close()
+
+
+class TestStorageManagerPrefetchCallback:
+    """Test cases for StorageManager prefetch_all_done_callback."""
+
+    def test_all_chunks_retrieved_successfully(self, storage_manager):
+        """Test Case 1: All chunks retrieved successfully from all tiers."""
+        # Setup: 5 chunks total (1280 tokens), distributed across 2 tiers
+        # Tier 0: 3 chunks, Tier 1: 2 chunks
+        cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280]
+        tier_expected_chunks = [3, 2]
+
+        # Create mock memory objects for all chunks
+        tier0_objs = [MockMemoryObj(i) for i in range(3)]
+        tier1_objs = [MockMemoryObj(i + 3) for i in range(2)]
+        res = [tier0_objs, tier1_objs]
+
+        # Create a mock future that returns the result
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        future = loop.create_future()
+        future.set_result(res)
+
+        # Register the event before calling callback
+        storage_manager.event_manager.add_event(
+            EventType.LOADING, "test_lookup_1", future
+        )
+
+        # Call the callback
+        storage_manager.prefetch_all_done_callback(
+            future, "test_lookup_1", cum_chunk_lengths_total, tier_expected_chunks
+        )
+        loop.close()
+
+        # Verify: All 5 chunks should be counted, total 1280 tokens
+        assert len(storage_manager.async_lookup_server.responses) == 1
+        lookup_id, retrieved_length = storage_manager.async_lookup_server.responses[0]
+        assert lookup_id == "test_lookup_1"
+        assert retrieved_length == 1280
+
+        # Verify: No memory objects should have ref_count_down called
+        for obj in tier0_objs + tier1_objs:
+            assert not obj.ref_count_down_called
+
+    def test_middle_tier_partial_retrieval(self, storage_manager):
+        """Test Case 2: Middle tier only got partial chunks, subsequent tier ignored."""
+        # Setup: 7 chunks total (1792 tokens), distributed across 3 tiers
+        # Tier 0: 3 chunks, Tier 1: 2 chunks, Tier 2: 2 chunks
+        cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280, 1536, 1792]
+        tier_expected_chunks = [3, 2, 2]
+
+        # Tier 0 got all 3, Tier 1 only got 1 (eviction), Tier 2 got all 2
+        tier0_objs = [MockMemoryObj(i) for i in range(3)]
+        tier1_objs = [MockMemoryObj(i + 3) for i in range(1)]  # Only 1 instead of 2
+        tier2_objs = [MockMemoryObj(i + 5) for i in range(2)]  # Got all 2
+        res = [tier0_objs, tier1_objs, tier2_objs]
+
+        # Create a mock future that returns the result
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        future = loop.create_future()
+        future.set_result(res)
+
+        # Register the event before calling callback
+        storage_manager.event_manager.add_event(
+            EventType.LOADING, "test_lookup_2", future
+        )
+
+        # Call the callback
+        storage_manager.prefetch_all_done_callback(
+            future, "test_lookup_2", cum_chunk_lengths_total, tier_expected_chunks
+        )
+        loop.close()
+
+        # Verify: Only 4 chunks counted (3 from tier0 + 1 from tier1)
+        # Total: 1024 tokens
+        assert len(storage_manager.async_lookup_server.responses) == 1
+        lookup_id, retrieved_length = storage_manager.async_lookup_server.responses[0]
+        assert lookup_id == "test_lookup_2"
+        assert retrieved_length == 1024
+
+        # Verify: Tier 0 and Tier 1 objects should NOT have ref_count_down called
+        for obj in tier0_objs + tier1_objs:
+            assert not obj.ref_count_down_called
+
+        # Verify: All Tier 2 objects should have ref_count_down called
+        for obj in tier2_objs:
+            assert obj.ref_count_down_called
+
+    def test_first_tier_partial_retrieval(self, storage_manager):
+        """
+        Test Case 3: First tier only got partial chunks,
+        all subsequent tiers ignored.
+        """
+        # Setup: 7 chunks total (1792 tokens), distributed across 3 tiers
+        # Tier 0: 3 chunks, Tier 1: 2 chunks, Tier 2: 2 chunks
+        cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280, 1536, 1792]
+        tier_expected_chunks = [3, 2, 2]
+
+        # Tier 0 only got 2 (eviction), Tier 1 got all 2, Tier 2 got all 2
+        tier0_objs = [MockMemoryObj(i) for i in range(2)]  # Only 2 instead of 3
+        tier1_objs = [MockMemoryObj(i + 3) for i in range(2)]  # Got all 2
+        tier2_objs = [MockMemoryObj(i + 5) for i in range(2)]  # Got all 2
+        res = [tier0_objs, tier1_objs, tier2_objs]
+
+        # Create a mock future that returns the result
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        future = loop.create_future()
+        future.set_result(res)
+
+        # Register the event before calling callback
+        storage_manager.event_manager.add_event(
+            EventType.LOADING, "test_lookup_3", future
+        )
+
+        # Call the callback
+        storage_manager.prefetch_all_done_callback(
+            future, "test_lookup_3", cum_chunk_lengths_total, tier_expected_chunks
+        )
+        loop.close()
+
+        # Verify: Only 2 chunks counted (2 from tier0)
+        # Total: 512 tokens
+        assert len(storage_manager.async_lookup_server.responses) == 1
+        lookup_id, retrieved_length = storage_manager.async_lookup_server.responses[0]
+        assert lookup_id == "test_lookup_3"
+        assert retrieved_length == 512
+
+        # Verify: Tier 0 objects should NOT have ref_count_down called
+        for obj in tier0_objs:
+            assert not obj.ref_count_down_called
+
+        # Verify: All Tier 1 and Tier 2 objects should have ref_count_down called
+        for obj in tier1_objs + tier2_objs:
+            assert obj.ref_count_down_called
+
+    def test_last_chunk_not_full(self, storage_manager):
+        """Test with last chunk not being full size."""
+        # Setup: 3 chunks with last chunk only 128 tokens (640 tokens total)
+        # Tier 0: 2 chunks, Tier 1: 1 chunk
+        cum_chunk_lengths_total = [0, 256, 512, 640]  # Last chunk is 128 tokens
+        tier_expected_chunks = [2, 1]
+
+        # All chunks retrieved successfully
+        tier0_objs = [MockMemoryObj(i) for i in range(2)]
+        tier1_objs = [MockMemoryObj(i + 2) for i in range(1)]
+        res = [tier0_objs, tier1_objs]
+
+        # Create a mock future that returns the result
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        future = loop.create_future()
+        future.set_result(res)
+
+        # Register the event before calling callback
+        storage_manager.event_manager.add_event(
+            EventType.LOADING, "test_lookup_4", future
+        )
+
+        # Call the callback
+        storage_manager.prefetch_all_done_callback(
+            future, "test_lookup_4", cum_chunk_lengths_total, tier_expected_chunks
+        )
+        loop.close()
+
+        # Verify: All 3 chunks counted, total 640 tokens
+        assert len(storage_manager.async_lookup_server.responses) == 1
+        lookup_id, retrieved_length = storage_manager.async_lookup_server.responses[0]
+        assert lookup_id == "test_lookup_4"
+        assert retrieved_length == 640
+
+        # Verify: No memory objects should have ref_count_down called
+        for obj in tier0_objs + tier1_objs:
+            assert not obj.ref_count_down_called
+
+    def test_single_tier_partial_retrieval(self, storage_manager):
+        """Test with single tier that only got partial chunks."""
+        # Setup: 5 chunks total (1280 tokens), single tier
+        cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280]
+        tier_expected_chunks = [5]
+
+        # Only got 3 chunks instead of 5
+        tier0_objs = [MockMemoryObj(i) for i in range(3)]
+        res = [tier0_objs]
+
+        # Create a mock future that returns the result
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        future = loop.create_future()
+        future.set_result(res)
+
+        # Register the event before calling callback
+        storage_manager.event_manager.add_event(
+            EventType.LOADING, "test_lookup_5", future
+        )
+
+        # Call the callback
+        storage_manager.prefetch_all_done_callback(
+            future, "test_lookup_5", cum_chunk_lengths_total, tier_expected_chunks
+        )
+        loop.close()
+
+        # Verify: Only 3 chunks counted, total 768 tokens
+        assert len(storage_manager.async_lookup_server.responses) == 1
+        lookup_id, retrieved_length = storage_manager.async_lookup_server.responses[0]
+        assert lookup_id == "test_lookup_5"
+        assert retrieved_length == 768
+
+        # Verify: No memory objects should have ref_count_down called
+        # (no remaining chunks in current tier, no subsequent tiers)
+        for obj in tier0_objs:
+            assert not obj.ref_count_down_called


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixed a corner case for async loading. This change handles the case where chunks may be evicted between contains check and actual retrieval for the middle backend.

Example: chunk_size=256, 7 chunks total (1792 tokens) across 3 tiers
   cum_chunk_lengths_total = [0, 256, 512, 768, 1024, 1280, 1536, 1792]
   tier_expected_chunks = [3, 2, 2]  # Tier 0: 3, Tier 1: 2, Tier 2: 2

Case 1: All chunks retrieved successfully
   res = [[obj0, obj1, obj2], [obj3, obj4], [obj5, obj6]]
   total_retrieved_chunks = 7
   retrieved_length = cum_chunk_lengths_total[7] = 1792

 Case 2: Tier 1 only got 1 chunk (eviction), Tier 2 got all 2 chunks
   res = [[obj0, obj1, obj2], [obj3], [obj5, obj6]]
   total_retrieved_chunks = 4 (stop at tier 1, tier 2 chunks ignored)
   retrieved_length = cum_chunk_lengths_total[4] = 1024
   Note: Even though tier 2 successfully retrieved 2 chunks, they are
   not counted because tier 1 has a gap, breaking prefix continuity.

 Case 3: Tier 0 only got 2 chunks (eviction), other tiers got all
   res = [[obj0, obj1], [obj3, obj4], [obj5, obj6]]
   total_retrieved_chunks = 2 (stop at tier 0, all subsequent ignored)
   retrieved_length = cum_chunk_lengths_total[2] = 512


