### PR TITLE
refactor: Abstract internal_api_server & plugin_launcher to LMCacheEngine

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -19,6 +19,9 @@ logger = init_logger(__name__)
 class LMCacheEngineMetadata:
     """name of the LLM model"""
 
+    ROLE_SCHEDULER = "scheduler"
+    ROLE_WORKER = "worker"
+
     model_name: str
     """ world size when running under a distributed setting """
     world_size: int
@@ -35,9 +38,10 @@ class LMCacheEngineMetadata:
     use_mla: bool = False
     """ the role of the current instance (e.g., 'scheduler', 'worker') """
     role: Optional[str] = None
+    """ the local dp rank """
+    dp_rank_local: int = 0
     """ the first rank of the distributed setting """
-    # TODO(baoloongmao): first_rank should be configurable
-    first_rank = 0
+    first_rank: int = 0
 
     def is_first_rank(self) -> bool:
         """Check if the current worker is the first rank"""

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Optional, Tuple
 import os
 import re
@@ -15,12 +16,16 @@ from lmcache.logging import init_logger
 logger = init_logger(__name__)
 
 
+class Role(str, Enum):
+    """Role enumeration for LMCache instances"""
+
+    SCHEDULER = "scheduler"
+    WORKER = "worker"
+
+
 @dataclass
 class LMCacheEngineMetadata:
     """name of the LLM model"""
-
-    ROLE_SCHEDULER = "scheduler"
-    ROLE_WORKER = "worker"
 
     model_name: str
     """ world size when running under a distributed setting """
@@ -37,7 +42,7 @@ class LMCacheEngineMetadata:
     """ whether use MLA"""
     use_mla: bool = False
     """ the role of the current instance (e.g., 'scheduler', 'worker') """
-    role: str = ""
+    role: Optional[Role] = None
     """ the local dp rank """
     dp_rank_local: int = 0
     """ the first rank of the distributed setting """

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -37,7 +37,7 @@ class LMCacheEngineMetadata:
     """ whether use MLA"""
     use_mla: bool = False
     """ the role of the current instance (e.g., 'scheduler', 'worker') """
-    role: Optional[str] = None
+    role: str = ""
     """ the local dp rank """
     dp_rank_local: int = 0
     """ the first rank of the distributed setting """

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -536,7 +536,7 @@ class LMCacheConnectorV1Impl:
             )
 
             # In case of MLA, the lookup server is only created on worker 0
-            if self.async_loading:
+            if self.async_loading and self.lookup_server is not None:
                 assert isinstance(self.lookup_server, LMCacheAsyncLookupServer)
                 self.lmcache_engine.post_init(async_lookup_server=self.lookup_server)
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -41,7 +41,7 @@ import torch
 
 # First Party
 from lmcache import utils
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheEngineMetadata, Role
 from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
@@ -495,7 +495,7 @@ class LMCacheConnectorV1Impl:
             self.lmcache_engine = self._init_lmcache_engine(
                 config,
                 vllm_config,
-                role=LMCacheEngineMetadata.ROLE_SCHEDULER,
+                role=Role.SCHEDULER,
             )
             # Create lookup client using factory
             self.lookup_client = LookupClientFactory.create_lookup_client(
@@ -507,7 +507,7 @@ class LMCacheConnectorV1Impl:
             self.lmcache_engine = self._init_lmcache_engine(
                 config,
                 vllm_config,
-                role=LMCacheEngineMetadata.ROLE_WORKER,
+                role=Role.WORKER,
             )
 
             self.use_layerwise = config.use_layerwise
@@ -590,7 +590,7 @@ class LMCacheConnectorV1Impl:
         self,
         lmcache_config: LMCacheEngineConfig,
         vllm_config: "VllmConfig",
-        role: str,
+        role: Role,
     ) -> LMCacheEngine:
         """Initialize the LMCache engine by the given model config and parallel
         config. This function will check the environment variable
@@ -667,7 +667,7 @@ class LMCacheConnectorV1Impl:
 
         # When use_mla is True, num_kv_head is 1
         hidden_dim_size = num_kv_head * head_size
-        if role == LMCacheEngineMetadata.ROLE_SCHEDULER:
+        if role == Role.SCHEDULER:
             vllm_gpu_connector = None
             # Create a dummy tpg object with broadcast and broadcast_object methods
             tpg = SimpleNamespace()

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -61,13 +61,11 @@ from lmcache.v1.gpu_connector import (
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemLayerwiseGPUConnector,
 )
-from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.lookup_client import LookupClientFactory
 from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
     LMCacheAsyncLookupServer,
 )
 from lmcache.v1.offload_server.zmq_server import ZMQOffloadServer
-from lmcache.v1.plugin.plugin_launcher import PluginLauncher
 
 if TYPE_CHECKING:
     # Third Party
@@ -442,136 +440,6 @@ def _calculate_draft_layers(vllm_config, model_config):
     return num_draft_layers
 
 
-def _init_lmcache_engine(
-    lmcache_config: LMCacheEngineConfig,
-    vllm_config: "VllmConfig",
-    role: str,
-) -> LMCacheEngine:
-    """Initialize the LMCache engine by the given model config and parallel
-    config. This function will check the environment variable
-    `LMCACHE_CONFIG_FILE` to load the configuration file. If that environment
-    variable is not set, this function will return None.
-
-    :param lmcache_config: The LMCache configuration.
-    :type lmcache_config: LMCacheEngineConfig
-    :param vllm_config: The vLLM configuration.
-    :type vllm_config: VllmConfig
-
-    :return: The initialized LMCache engine
-    :rtype: LMCacheEngine
-    """
-    if curr_engine := LMCacheEngineBuilder.get(ENGINE_NAME):
-        return curr_engine
-
-    model_config = vllm_config.model_config
-    parallel_config = vllm_config.parallel_config
-    cache_config = vllm_config.cache_config
-
-    assert isinstance(lmcache_config, LMCacheEngineConfig), (
-        "LMCache v1 configuration is should be passed."
-    )
-
-    kv_dtype = get_kv_cache_torch_dtype(cache_config.cache_dtype, model_config.dtype)
-
-    use_mla = mla_enabled(model_config)
-    if use_mla and (
-        lmcache_config.remote_serde != "naive"
-        and lmcache_config.remote_serde is not None
-    ):
-        raise ValueError("MLA only works with naive serde mode..")
-
-    # construct kv shape (for mem pool)
-    num_layer = model_config.get_num_layers(parallel_config)
-    num_draft_layers = _calculate_draft_layers(vllm_config, model_config)
-    num_layer += num_draft_layers
-    chunk_size = lmcache_config.chunk_size
-    num_kv_head = model_config.get_num_kv_heads(parallel_config)
-    head_size = model_config.get_head_size()
-    kv_shape = (num_layer, 1 if use_mla else 2, chunk_size, num_kv_head, head_size)
-    logger.info(
-        f"use mla: {use_mla}, kv shape: {kv_shape}, num_draft_layers:{num_draft_layers}"
-    )
-
-    # Change current device.
-    num_gpus = torch.cuda.device_count()
-    local_rank = parallel_config.rank % num_gpus
-    torch.cuda.set_device(local_rank)
-    device = torch.device(f"cuda:{local_rank}")
-    metadata = LMCacheEngineMetadata(
-        model_config.model,
-        parallel_config.world_size,
-        parallel_config.rank,
-        "vllm",
-        kv_dtype,
-        kv_shape,
-        use_mla,
-        role,
-    )
-
-    use_gpu = need_gpu_interm_buffer(lmcache_config)
-    vllm_gpu_connector: Optional[GPUConnectorInterface]
-
-    if use_mla and lmcache_config.use_layerwise:
-        raise ValueError("layerwise MLA connector is not supported yet")
-
-    # When use_mla is True, num_kv_head is 1
-    hidden_dim_size = num_kv_head * head_size
-    if role == "scheduler":
-        vllm_gpu_connector = None
-        # Create a dummy tpg object with broadcast and broadcast_object methods
-        tpg = SimpleNamespace()
-        tpg.broadcast = lambda tensor, src: tensor
-        tpg.broadcast_object = lambda obj, src: obj
-    elif lmcache_config.use_layerwise:
-        if lmcache_config.enable_blending:
-            # Use layerwise connector for blending
-            vllm_gpu_connector = VLLMBufferLayerwiseGPUConnector(
-                hidden_dim_size,
-                num_layer,
-                use_gpu=use_gpu,
-                chunk_size=chunk_size,
-                dtype=kv_dtype,
-                device=device,
-            )
-        else:
-            vllm_gpu_connector = VLLMPagedMemLayerwiseGPUConnector(
-                hidden_dim_size,
-                num_layer,
-                use_gpu=use_gpu,
-                chunk_size=chunk_size,
-                dtype=kv_dtype,
-                device=device,
-            )
-        tpg = get_tp_group()
-    else:
-        vllm_gpu_connector = VLLMPagedMemGPUConnectorV2(
-            hidden_dim_size,
-            num_layer,
-            use_gpu=use_gpu,
-            chunk_size=chunk_size,
-            dtype=kv_dtype,
-            device=device,
-            use_mla=use_mla,
-        )
-        tpg = get_tp_group()
-    engine = LMCacheEngineBuilder.get_or_create(
-        ENGINE_NAME,
-        lmcache_config,
-        metadata,
-        vllm_gpu_connector,
-        tpg.broadcast,
-        tpg.broadcast_object,
-    )
-    if role == "scheduler" and lmcache_config.enable_scheduler_bypass_lookup:
-        assert engine.save_only_first_rank or lmcache_config.get_extra_config_value(
-            "remote_enable_mla_worker_id_as0", metadata.use_mla
-        ), (
-            "enable_scheduler_bypass_lookup is only supported with "
-            "save_only_first_rank or remote_enable_mla_worker_id_as0"
-        )
-    return engine
-
-
 @dataclass
 class LMCacheConnectorMetadata(KVConnectorMetadata):
     requests: list[ReqMeta] = field(default_factory=list)
@@ -617,22 +485,18 @@ class LMCacheConnectorV1Impl:
                         )
 
         self.config = config
-
+        self.lmcache_engine: Optional[LMCacheEngine] = None
         self.async_loading = config.enable_async_loading
         self.layerwise_retrievers: list[
             Generator[Optional[torch.Tensor], None, None]
         ] = []
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
         if role == KVConnectorRole.SCHEDULER:
-            self.lmcache_engine: Optional[LMCacheEngine] = None
-            # Check if bypass lookup is enabled for scheduler
-            if config.enable_scheduler_bypass_lookup:
-                # Create LMCacheEngine for scheduler when bypass is enabled
-                self.lmcache_engine = _init_lmcache_engine(
-                    config,
-                    vllm_config,
-                    role="scheduler",
-                )
+            self.lmcache_engine = self._init_lmcache_engine(
+                config,
+                vllm_config,
+                role=LMCacheEngineMetadata.ROLE_SCHEDULER,
+            )
             # Create lookup client using factory
             self.lookup_client = LookupClientFactory.create_lookup_client(
                 vllm_config, config, self.lmcache_engine
@@ -640,10 +504,10 @@ class LMCacheConnectorV1Impl:
             self._unfinished_requests: dict[str, Request] = {}
             self.lmcache_engine = None
         else:
-            self.lmcache_engine = _init_lmcache_engine(
+            self.lmcache_engine = self._init_lmcache_engine(
                 config,
                 vllm_config,
-                role="worker",
+                role=LMCacheEngineMetadata.ROLE_WORKER,
             )
 
             self.use_layerwise = config.use_layerwise
@@ -661,7 +525,6 @@ class LMCacheConnectorV1Impl:
                 )
 
             # Create lookup server using factory
-            assert self.lmcache_engine is not None
             self.lookup_server = LookupClientFactory.create_lookup_server(
                 self.lmcache_engine, vllm_config
             )
@@ -673,7 +536,7 @@ class LMCacheConnectorV1Impl:
             )
 
             # In case of MLA, the lookup server is only created on worker 0
-            if self.async_loading and self.lookup_server is not None:
+            if self.async_loading:
                 assert isinstance(self.lookup_server, LMCacheAsyncLookupServer)
                 self.lmcache_engine.post_init(async_lookup_server=self.lookup_server)
 
@@ -716,31 +579,142 @@ class LMCacheConnectorV1Impl:
         # Track block IDs associated with failed load attempts.
         self._invalid_block_ids: set[int] = set()
 
-        # TODO(baoloongmao): Internal api server & plugin framework support dp > 1
-        if vllm_config.parallel_config.data_parallel_rank_local == 0:
-            # Start internal API server if enabled
-            # The enabled check is in the InternalAPIServer constructor
-            self.api_server = InternalAPIServer(self)
-            self.api_server.start()
-            # Launch plugins
-            self.plugin_launcher = PluginLauncher(
-                self.config,
-                role,
-                self.worker_count,
-                -1
-                if self.lmcache_engine is None  # scheduler side
-                else self.lmcache_engine.metadata.worker_id,
-            )
-            self.plugin_launcher.launch_plugins()
-        else:
-            self.api_server = None  # type: ignore[assignment]
-            self.plugin_launcher = None  # type: ignore[assignment]
         logger.info(
             f"LMCache initialized for role {role} with version {utils.get_version()}, "
             f"vllm version {VLLM_VERSION}, "
             "lmcache cache_engine metadata: "
             f"{getattr(self.lmcache_engine, 'metadata', None)}"
         )
+
+    def _init_lmcache_engine(
+        self,
+        lmcache_config: LMCacheEngineConfig,
+        vllm_config: "VllmConfig",
+        role: str,
+    ) -> LMCacheEngine:
+        """Initialize the LMCache engine by the given model config and parallel
+        config. This function will check the environment variable
+        `LMCACHE_CONFIG_FILE` to load the configuration file. If that environment
+        variable is not set, this function will return None.
+
+        :param lmcache_config: The LMCache configuration.
+        :type lmcache_config: LMCacheEngineConfig
+        :param vllm_config: The vLLM configuration.
+        :type vllm_config: VllmConfig
+        :param lmcache_adapter: The LMCache adapter instance (optional).
+        :type lmcache_adapter: Optional[Any]
+
+        :return: The initialized LMCache engine
+        :rtype: LMCacheEngine
+        """
+        if curr_engine := LMCacheEngineBuilder.get(ENGINE_NAME):
+            return curr_engine
+
+        model_config = vllm_config.model_config
+        parallel_config = vllm_config.parallel_config
+        cache_config = vllm_config.cache_config
+
+        assert isinstance(lmcache_config, LMCacheEngineConfig), (
+            "LMCache v1 configuration is should be passed."
+        )
+
+        kv_dtype = get_kv_cache_torch_dtype(
+            cache_config.cache_dtype, model_config.dtype
+        )
+
+        use_mla = mla_enabled(model_config)
+        if use_mla and (
+            lmcache_config.remote_serde != "naive"
+            and lmcache_config.remote_serde is not None
+        ):
+            raise ValueError("MLA only works with naive serde mode..")
+
+        # construct kv shape (for mem pool)
+        num_layer = model_config.get_num_layers(parallel_config)
+        num_draft_layers = _calculate_draft_layers(vllm_config, model_config)
+        num_layer += num_draft_layers
+        chunk_size = lmcache_config.chunk_size
+        num_kv_head = model_config.get_num_kv_heads(parallel_config)
+        head_size = model_config.get_head_size()
+        kv_shape = (num_layer, 1 if use_mla else 2, chunk_size, num_kv_head, head_size)
+        logger.info(
+            f"use mla: {use_mla}, kv shape: {kv_shape}, "
+            f"num_draft_layers:{num_draft_layers}"
+        )
+
+        # Change current device.
+        num_gpus = torch.cuda.device_count()
+        local_rank = parallel_config.rank % num_gpus
+        torch.cuda.set_device(local_rank)
+        device = torch.device(f"cuda:{local_rank}")
+        metadata = LMCacheEngineMetadata(
+            model_name=model_config.model,
+            world_size=parallel_config.world_size,
+            worker_id=parallel_config.rank,
+            fmt="vllm",
+            kv_dtype=kv_dtype,
+            kv_shape=kv_shape,
+            use_mla=use_mla,
+            role=role,
+            dp_rank_local=vllm_config.parallel_config.data_parallel_rank_local,
+        )
+
+        use_gpu = need_gpu_interm_buffer(lmcache_config)
+        vllm_gpu_connector: Optional[GPUConnectorInterface]
+
+        if use_mla and lmcache_config.use_layerwise:
+            raise ValueError("layerwise MLA connector is not supported yet")
+
+        # When use_mla is True, num_kv_head is 1
+        hidden_dim_size = num_kv_head * head_size
+        if role == LMCacheEngineMetadata.ROLE_SCHEDULER:
+            vllm_gpu_connector = None
+            # Create a dummy tpg object with broadcast and broadcast_object methods
+            tpg = SimpleNamespace()
+            tpg.broadcast = lambda tensor, src: tensor
+            tpg.broadcast_object = lambda obj, src: obj
+        elif lmcache_config.use_layerwise:
+            if lmcache_config.enable_blending:
+                # Use layerwise connector for blending
+                vllm_gpu_connector = VLLMBufferLayerwiseGPUConnector(
+                    hidden_dim_size,
+                    num_layer,
+                    use_gpu=use_gpu,
+                    chunk_size=chunk_size,
+                    dtype=kv_dtype,
+                    device=device,
+                )
+            else:
+                vllm_gpu_connector = VLLMPagedMemLayerwiseGPUConnector(
+                    hidden_dim_size,
+                    num_layer,
+                    use_gpu=use_gpu,
+                    chunk_size=chunk_size,
+                    dtype=kv_dtype,
+                    device=device,
+                )
+            tpg = get_tp_group()
+        else:
+            vllm_gpu_connector = VLLMPagedMemGPUConnectorV2(
+                hidden_dim_size,
+                num_layer,
+                use_gpu=use_gpu,
+                chunk_size=chunk_size,
+                dtype=kv_dtype,
+                device=device,
+                use_mla=use_mla,
+            )
+            tpg = get_tp_group()
+        engine = LMCacheEngineBuilder.get_or_create(
+            ENGINE_NAME,
+            lmcache_config,
+            metadata,
+            vllm_gpu_connector,
+            tpg.broadcast,
+            tpg.broadcast_object,
+            self,
+        )
+        return engine
 
     def get_inference_info(self) -> dict:
         """Get inference information including vLLM config and related details.

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -20,7 +20,7 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheEngineMetadata, Role
 from lmcache.logging import init_logger
 from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
@@ -124,7 +124,7 @@ class LMCacheEngine:
         from lmcache.v1.cache_controller import LMCacheWorker
 
         self.lmcache_worker: Optional[LMCacheWorker] = None
-        if self.enable_controller and self.metadata.role != "scheduler":
+        if self.enable_controller and self.metadata.role != Role.SCHEDULER:
             self.lmcache_worker = LMCacheWorker(config, metadata, self)
 
         self.async_loading = config.enable_async_loading
@@ -195,10 +195,7 @@ class LMCacheEngine:
             "force_store_wait", False
         )
 
-        if (
-            metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
-            and config.enable_scheduler_bypass_lookup
-        ):
+        if metadata.role == Role.SCHEDULER and config.enable_scheduler_bypass_lookup:
             assert self.save_only_first_rank or config.get_extra_config_value(
                 "remote_enable_mla_worker_id_as0", metadata.use_mla
             ), (
@@ -238,7 +235,7 @@ class LMCacheEngine:
             gc.disable()
 
     def post_init(self, **kwargs) -> None:
-        assert self.metadata.role != LMCacheEngineMetadata.ROLE_SCHEDULER
+        assert self.metadata.role != Role.SCHEDULER
         if "async_lookup_server" in kwargs:
             self.async_lookup_server = kwargs["async_lookup_server"]
         if not self.post_inited:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -33,6 +33,7 @@ from lmcache.v1.gpu_connector import (
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemLayerwiseGPUConnector,
 )
+from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.memory_management import CuFileMemoryAllocator  # noqa: E501
 from lmcache.v1.memory_management import (  # noqa: E501
     MemoryAllocatorInterface,
@@ -43,6 +44,7 @@ from lmcache.v1.memory_management import (  # noqa: E501
     PagedTensorMemoryAllocator,
     TensorMemoryObj,
 )
+from lmcache.v1.plugin.plugin_launcher import PluginLauncher
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 from lmcache.v1.system_detection import NUMADetector, NUMAMapping
 from lmcache.v1.token_database import (
@@ -89,6 +91,7 @@ class LMCacheEngine:
         gpu_connector: Optional[GPUConnectorInterface],
         broadcast_fn: Callable[[torch.Tensor, int], None],
         broadcast_object_fn: Callable[[Any, int], Any],
+        lmcache_adapter: Optional[Any] = None,
     ):
         logger.info(f"Creating LMCacheEngine with config: {config}")
         self.config = config
@@ -97,6 +100,7 @@ class LMCacheEngine:
         self.gpu_connector = gpu_connector
         self.broadcast_fn = broadcast_fn
         self.broadcast_object_fn = broadcast_object_fn
+        self.lmcache_adapter = lmcache_adapter
         # save_only_first_rank only works when use mla
         self.save_only_first_rank = (
             self.config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
@@ -191,11 +195,50 @@ class LMCacheEngine:
             "force_store_wait", False
         )
 
+        if (
+            metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
+            and config.enable_scheduler_bypass_lookup
+        ):
+            assert self.save_only_first_rank or config.get_extra_config_value(
+                "remote_enable_mla_worker_id_as0", metadata.use_mla
+            ), (
+                "enable_scheduler_bypass_lookup is only supported with "
+                "save_only_first_rank or remote_enable_mla_worker_id_as0"
+            )
+            # Avoid creating storage manager if scheduler with bypass lookup
+            self.storage_manager = None
+        else:
+            self.storage_manager = StorageManager(
+                config,
+                metadata,
+                # self.memory_allocator,
+                event_manager=self.event_manager,
+                lmcache_worker=self.lmcache_worker,
+            )
+
+            # TODO(baoloongmao): Internal api server & plugin framework support dp > 1
+            # TODO(baoloongmao): enable for other fmt
+            if metadata.dp_rank_local == 0 and metadata.fmt == "vllm":
+                # Start internal API server if enabled
+                # The enabled check is in the InternalAPIServer constructor
+                self.api_server = InternalAPIServer(self, lmcache_adapter)
+                self.api_server.start()
+                # Launch plugins
+                self.plugin_launcher = PluginLauncher(
+                    config,
+                    metadata,
+                )
+                self.plugin_launcher.launch_plugins()
+            else:
+                self.api_server = None  # type: ignore[assignment]
+                self.plugin_launcher = None  # type: ignore[assignment]
+
         gc.collect()
         if not config.py_enable_gc:
             gc.disable()
 
     def post_init(self, **kwargs) -> None:
+        assert self.metadata.role != LMCacheEngineMetadata.ROLE_SCHEDULER
         if "async_lookup_server" in kwargs:
             self.async_lookup_server = kwargs["async_lookup_server"]
         if not self.post_inited:
@@ -1467,6 +1510,7 @@ class LMCacheEngineBuilder:
         gpu_connector: Optional[GPUConnectorInterface],
         broadcast_fn: Callable[[torch.Tensor, int], None],
         broadcast_object_fn: Callable[[Any, int], Any],
+        lmcache_adapter: Optional[Any] = None,
     ) -> LMCacheEngine:
         """
         Builds a new LMCacheEngine instance if it doesn't already exist for the
@@ -1489,6 +1533,7 @@ class LMCacheEngineBuilder:
                 gpu_connector,
                 broadcast_fn,
                 broadcast_object_fn,
+                lmcache_adapter,
             )
 
             cls._instances[instance_id] = engine

--- a/lmcache/v1/internal_api_server/api_server.py
+++ b/lmcache/v1/internal_api_server/api_server.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 import asyncio
 import os
 import threading
@@ -13,11 +13,12 @@ import uvicorn
 from lmcache.logging import init_logger
 
 # Local
+from ...config import LMCacheEngineMetadata
 from .api_registry import APIRegistry
 
 if TYPE_CHECKING:
     # First Party
-    from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
+    from lmcache.v1.cache_engine import LMCacheEngine
 
 logger = init_logger(__name__)
 
@@ -29,11 +30,15 @@ registry.register_all_apis()
 
 
 class InternalAPIServer:
-    def __init__(self, lmcache_adapter: "LMCacheConnectorV1Impl"):
-        config = lmcache_adapter.config
-        lmcache_engine = lmcache_adapter.lmcache_engine
+    def __init__(self, lmcache_engine: "LMCacheEngine", lmcache_adapter: Any = None):
         # 0 for scheduler, 1 for worker 0, 2 for worker 1, ...
-        port_offset = 0 if not lmcache_engine else 1 + lmcache_engine.metadata.worker_id
+        config = lmcache_engine.config
+        metadata = lmcache_engine.metadata
+        port_offset = (
+            0
+            if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
+            else 1 + metadata.worker_id
+        )
         self.port = config.internal_api_server_port_start + port_offset
         self.socket_path_prefix = config.internal_api_server_socket_path_prefix
         self.socket_path = (
@@ -84,6 +89,7 @@ class InternalAPIServer:
             uvicorn_config["port"] = self.port
 
         self.server = uvicorn.Server(uvicorn.Config(**uvicorn_config))
+        app.state.lmcache_engine = lmcache_engine
         app.state.lmcache_adapter = lmcache_adapter
 
     async def run(self):

--- a/lmcache/v1/internal_api_server/api_server.py
+++ b/lmcache/v1/internal_api_server/api_server.py
@@ -10,10 +10,10 @@ from fastapi import FastAPI
 import uvicorn
 
 # First Party
+from lmcache.config import Role
 from lmcache.logging import init_logger
 
 # Local
-from ...config import LMCacheEngineMetadata
 from .api_registry import APIRegistry
 
 if TYPE_CHECKING:
@@ -34,11 +34,7 @@ class InternalAPIServer:
         # 0 for scheduler, 1 for worker 0, 2 for worker 1, ...
         config = lmcache_engine.config
         metadata = lmcache_engine.metadata
-        port_offset = (
-            0
-            if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
-            else 1 + metadata.worker_id
-        )
+        port_offset = 0 if metadata.role == Role.SCHEDULER else 1 + metadata.worker_id
         self.port = config.internal_api_server_port_start + port_offset
         self.socket_path_prefix = config.internal_api_server_socket_path_prefix
         self.socket_path = (

--- a/lmcache/v1/internal_api_server/cache_api.py
+++ b/lmcache/v1/internal_api_server/cache_api.py
@@ -53,8 +53,7 @@ async def clear(
         ```
     """
     try:
-        lmcache_adapter = request.app.state.lmcache_adapter
-        lmcache_engine = getattr(lmcache_adapter, "lmcache_engine", None)
+        lmcache_engine = request.app.state.lmcache_engine
         if not lmcache_engine:
             error_info = {
                 "error": "/cache/clear API is unavailable",

--- a/lmcache/v1/internal_api_server/conf_api.py
+++ b/lmcache/v1/internal_api_server/conf_api.py
@@ -27,7 +27,7 @@ def _get_config_dict(
 
 @router.get("/conf")
 async def get_config(request: Request, names: Optional[str] = None):
-    config = request.app.state.lmcache_adapter.config
+    config = request.app.state.lmcache_engine.config
     # Parse query parameter names (comma-separated list of config names)
     keys = names.split(",") if names else None
     config_dict = _get_config_dict(config, keys)
@@ -41,11 +41,7 @@ async def get_metadata(request: Request, names: Optional[str] = None):
     """
     Get metadata of the cache engine
     """
-    lmcache_engine = request.app.state.lmcache_adapter.lmcache_engine
-    if not lmcache_engine:
-        return PlainTextResponse(
-            content="/meta api only work for lmcache_engine", status_code=500
-        )
+    lmcache_engine = request.app.state.lmcache_engine
     metadata = lmcache_engine.metadata
 
     if names:

--- a/lmcache/v1/internal_api_server/run_script_api.py
+++ b/lmcache/v1/internal_api_server/run_script_api.py
@@ -28,7 +28,7 @@ async def run_script(request: Request):
 
     try:
         # Get allowed imports from config
-        config = request.app.state.lmcache_adapter.config
+        config = request.app.state.lmcache_engine.config
         allowed_imports = config.script_allowed_imports or []
 
         # Pre-import allowed modules

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -9,7 +9,7 @@ import subprocess
 import threading
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheEngineMetadata, Role
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 
@@ -21,11 +21,7 @@ class PluginLauncher:
         self.config = config
         self.role = metadata.role
         self.worker_count = metadata.world_size
-        self.worker_id = (
-            -1
-            if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
-            else metadata.worker_id
-        )
+        self.worker_id = -1 if metadata.role == Role.SCHEDULER else metadata.worker_id
         self.plugin_processes: list[Any] = []
         # Register cleanup handler
         atexit.register(self.stop_plugins)
@@ -63,7 +59,8 @@ class PluginLauncher:
 
         # Check role match
         plugin_role = parts[0].upper()
-        if plugin_role != "ALL" and plugin_role != self.role.upper():
+        current_role = self.role.upper() if self.role else ""
+        if plugin_role != "ALL" and plugin_role != current_role:
             logger.info(f"Skipping {file}: requires role {plugin_role}")
             return True
 

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from pathlib import Path
+from typing import Any
 import atexit
 import os
 import shutil
@@ -8,18 +9,24 @@ import subprocess
 import threading
 
 # First Party
+from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
+from lmcache.v1.config import LMCacheEngineConfig
 
 logger = init_logger(__name__)
 
 
 class PluginLauncher:
-    def __init__(self, config, role, worker_count, worker_id):
+    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
         self.config = config
-        self.role = role
-        self.worker_count = worker_count
-        self.worker_id = worker_id
-        self.plugin_processes = []
+        self.role = metadata.role
+        self.worker_count = metadata.world_size
+        self.worker_id = (
+            -1
+            if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
+            else metadata.worker_id,
+        )
+        self.plugin_processes: list[Any] = []
         # Register cleanup handler
         atexit.register(self.stop_plugins)
 
@@ -56,7 +63,7 @@ class PluginLauncher:
 
         # Check role match
         plugin_role = parts[0].upper()
-        if plugin_role != "ALL" and plugin_role != self.role.name:
+        if plugin_role != "ALL" and plugin_role != self.role:
             logger.info(f"Skipping {file}: requires role {plugin_role}")
             return True
 

--- a/lmcache/v1/plugin/plugin_launcher.py
+++ b/lmcache/v1/plugin/plugin_launcher.py
@@ -24,7 +24,7 @@ class PluginLauncher:
         self.worker_id = (
             -1
             if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER
-            else metadata.worker_id,
+            else metadata.worker_id
         )
         self.plugin_processes: list[Any] = []
         # Register cleanup handler
@@ -63,7 +63,7 @@ class PluginLauncher:
 
         # Check role match
         plugin_role = parts[0].upper()
-        if plugin_role != "ALL" and plugin_role != self.role:
+        if plugin_role != "ALL" and plugin_role != self.role.upper():
             logger.info(f"Skipping {file}: requires role {plugin_role}")
             return True
 

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -9,7 +9,7 @@ import importlib  # Added for dynamic import
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheEngineMetadata, Role
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
@@ -37,10 +37,7 @@ def is_cuda_worker(metadata: LMCacheEngineMetadata) -> bool:
     Returns:
         True if the worker is not a scheduler and CUDA is available.
     """
-    return (
-        metadata.role != LMCacheEngineMetadata.ROLE_SCHEDULER
-        and torch.cuda.is_available()
-    )
+    return metadata.role != Role.SCHEDULER and torch.cuda.is_available()
 
 
 def create_dynamic_backends(
@@ -138,7 +135,7 @@ def CreateStorageBackends(
     # NOTE(Jiayi): The local_cpu backend is always created because
     # other backends might need it as a buffer.
     local_cpu_backend: Optional[LocalCPUBackend] = None
-    if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER:
+    if metadata.role == Role.SCHEDULER:
         # For scheduler role, local_cpu_backend is None
         pass
     elif not config.enable_pd or config.local_cpu:

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -37,7 +37,10 @@ def is_cuda_worker(metadata: LMCacheEngineMetadata) -> bool:
     Returns:
         True if the worker is not a scheduler and CUDA is available.
     """
-    return metadata.role != "scheduler" and torch.cuda.is_available()
+    return (
+        metadata.role != LMCacheEngineMetadata.ROLE_SCHEDULER
+        and torch.cuda.is_available()
+    )
 
 
 def create_dynamic_backends(
@@ -135,7 +138,7 @@ def CreateStorageBackends(
     # NOTE(Jiayi): The local_cpu backend is always created because
     # other backends might need it as a buffer.
     local_cpu_backend: Optional[LocalCPUBackend] = None
-    if metadata.role == "scheduler":
+    if metadata.role == LMCacheEngineMetadata.ROLE_SCHEDULER:
         # For scheduler role, local_cpu_backend is None
         pass
     elif not config.enable_pd or config.local_cpu:

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -217,10 +217,10 @@ class StorageManager:
         self.enable_pd = config.enable_pd
 
         self.allocator_backend = None
-        if metadata.role != "scheduler":
+        if metadata.role != LMCacheEngineMetadata.ROLE_SCHEDULER:
             self.allocator_backend = self._get_allocator_backend(config)
-        if config.local_cpu:
-            self.local_cpu_backend = self.storage_backends["LocalCPUBackend"]
+            if config.local_cpu:
+                self.local_cpu_backend = self.storage_backends["LocalCPUBackend"]
 
         self.manager_lock = threading.Lock()
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -19,7 +19,7 @@ import threading
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheEngineMetadata, Role
 from lmcache.logging import init_logger
 from lmcache.observability import PrometheusLogger
 from lmcache.utils import (
@@ -217,7 +217,7 @@ class StorageManager:
         self.enable_pd = config.enable_pd
 
         self.allocator_backend = None
-        if metadata.role != LMCacheEngineMetadata.ROLE_SCHEDULER:
+        if metadata.role != Role.SCHEDULER:
             self.allocator_backend = self._get_allocator_backend(config)
             if config.local_cpu:
                 self.local_cpu_backend = self.storage_backends["LocalCPUBackend"]

--- a/tests/v1/internal_api_server/test_cache_clear.py
+++ b/tests/v1/internal_api_server/test_cache_clear.py
@@ -31,6 +31,7 @@ class TestCacheClearAPI:
     def client_with_adapter(self, mock_lmcache_adapter):
         """Create a test client with mocked adapter."""
         app.state.lmcache_adapter = mock_lmcache_adapter
+        app.state.lmcache_engine = mock_lmcache_adapter.lmcache_engine
         return TestClient(app)
 
     def test_cache_clear_success(self, client_with_adapter, mock_lmcache_adapter):
@@ -118,12 +119,7 @@ class TestCacheClearAPI:
 
     def test_cache_clear_adapter_attribute_error(self):
         """Test cache clear when adapter doesn't have lmcache_engine attribute."""
-
-        # Arrange
-        class AdapterWithoutEngine:
-            pass
-
-        app.state.lmcache_adapter = AdapterWithoutEngine()
+        app.state.lmcache_engine = None
         client = TestClient(app)
         # Act
         response = client.delete("/cache/clear")


### PR DESCRIPTION
This PR aim to abstract some content apart from vllm_v1_adapter into lmcache_engine module to make vllm adapter part as tiny as possible.