### PR TITLE
[Core][vLLM]: Add KV event generation

### DIFF
--- a/lmcache/integration/vllm/lmcache_connector_v1.py
+++ b/lmcache/integration/vllm/lmcache_connector_v1.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # Standard
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, List, Optional
-import time
+from typing import TYPE_CHECKING, Any, Optional
 
 # Third Party
 from vllm.config import VllmConfig
-from vllm.distributed.kv_events import BlockStored, KVCacheEvent, KVEventBatch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
@@ -14,7 +12,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.outputs import KVConnectorOutput
 import torch
 
 # First Party
@@ -27,25 +24,18 @@ if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.request import Request
 
-
 logger = init_logger(__name__)
 
 
-class LMCacheConnectorV1(KVConnectorBase_V1):
-    def __init__(
-        self,
-        vllm_config: "VllmConfig",
-        role: KVConnectorRole,
-    ):
+class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
+    def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole):
         super().__init__(vllm_config=vllm_config, role=role)
         self._lmcache_engine = LMCacheConnectorV1Impl(vllm_config, role, self)
-
-        self._kv_events: List[KVCacheEvent] = []
 
     # ==============================
     # Worker-side methods
     # ==============================
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         """
         Start loading the KV cache from the connector to vLLM's paged
         KV buffer. This is called from the forward context before the
@@ -80,7 +70,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         layer_name: str,
         kv_layer: torch.Tensor,
         attn_metadata: "AttentionMetadata",
-        **kwargs: Any,
+        **kwargs,
     ) -> None:
         """
         Start saving the a layer of KV cache from vLLM's paged buffer
@@ -110,7 +100,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
 
     def get_finished(
         self, finished_req_ids: set[str]
-    ) -> tuple[set[str] | None, set[str] | None]:
+    ) -> tuple[Optional[set[str]], Optional[set[str]]]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
@@ -124,29 +114,9 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         """
         return self._lmcache_engine.get_finished(finished_req_ids)
 
-    def get_kv_connector_kv_cache_events(self) -> Optional["KVEventBatch"]:
-        """
-        Get the KV connector kv cache events collected during the last interval.
-        """
-        events = self._lmcache_engine.get_kv_events()
-        if not events:
-            return None
-
-        lmcache_kv_events: KVEventBatch | None = None
-        for event in events:
-            if lmcache_kv_events is None:
-                lmcache_kv_events = KVEventBatch(ts=time.time(), events=[])
-            block = BlockStored(
-                block_hashes=event.block_hashes,
-                parent_block_hash=event.parent_block_hash,
-                token_ids=event.token_ids,
-                lora_id=event.lora_id,
-                block_size=event.block_size,
-                medium=event.medium,
-            )
-            lmcache_kv_events.events.append(block)
-
-        return lmcache_kv_events
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Return block IDs that failed to load during the last interval."""
+        return self._lmcache_engine.get_block_ids_with_load_errors()
 
     def shutdown(self):
         """
@@ -163,7 +133,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         self,
         request: "Request",
         num_computed_tokens: int,
-    ) -> tuple[int | None, bool]:
+    ) -> tuple[Optional[int], bool]:
         """
         Get number of new tokens that can be loaded from the
         external KV cache beyond the num_computed_tokens.
@@ -203,30 +173,11 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         """
         return self._lmcache_engine.build_connector_meta(scheduler_output)
 
-    def update_connector_output(self, connector_output: KVConnectorOutput):
-        """
-        Update KVConnector state from worker-side connectors output.
-
-        Args:
-            connector_output (KVConnectorOutput): the worker-side
-                connectors output.
-        """
-        # Get the KV events
-        kv_events = connector_output.kv_cache_events
-        if (
-            not kv_events
-            or not isinstance(kv_events, KVEventBatch)
-            or not kv_events.events
-        ):
-            return
-        self._kv_events.extend(kv_events.events)
-        return
-
     def request_finished(
         self,
         request: "Request",
         block_ids: list[int],
-    ) -> tuple[bool, dict[str, Any] | None]:
+    ) -> tuple[bool, Optional[dict[str, Any]]]:
         """
         Called when a request has finished, before its blocks are freed.
 
@@ -238,14 +189,3 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             returned by the engine.
         """
         return self._lmcache_engine.request_finished(request, block_ids)
-
-    def take_events(self) -> Iterable["KVCacheEvent"]:
-        """
-        Take the KV cache events from the connector.
-
-        Yields:
-            New KV cache events since the last call.
-        """
-        if self._kv_events is not None:
-            yield from self._kv_events
-            self._kv_events.clear()

--- a/lmcache/integration/vllm/lmcache_connector_v1.py
+++ b/lmcache/integration/vllm/lmcache_connector_v1.py
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections.abc import Iterable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, List, Optional
+import time
 
 # Third Party
 from vllm.config import VllmConfig
-from vllm.distributed.kv_events import BlockStored, KVCacheEvent
+from vllm.distributed.kv_events import BlockStored, KVCacheEvent, KVEventBatch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
@@ -28,52 +27,11 @@ if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.request import Request
 
+
 logger = init_logger(__name__)
 
 
-@dataclass
-class LMCacheKVEvents(KVConnectorStats):
-    """
-    Maintain a list of KV events from worker to scheduler
-    """
-
-    def aggregate(self, other: "KVConnectorStats") -> "LMCacheKVEvents":
-        if not other and not isinstance(other, LMCacheKVEvents):
-            raise TypeError("Can only aggregate with another LMCacheKVEvents")
-
-        if other.is_empty():
-            return self
-
-        if self.is_empty():
-            self.data["kv_events"] = []
-
-        other_events = other.get_kv_events()
-        for other_event in other_events:
-            self.data["kv_events"].append(other_event)
-
-        return self
-
-    def reset(self):
-        self.data.clear()
-
-    def reduce(self) -> dict[str, List[BlockStored]]:
-        return self.data
-
-    def add_kv_event(self, event: BlockStored):
-        if self.is_empty():
-            self.data["kv_events"] = []
-        self.data["kv_events"].append(event)
-
-    def get_kv_events(self) -> Optional[List[BlockStored]]:
-        if self.is_empty():
-            return None
-        return self.data["kv_events"]
-
-    def is_empty(self) -> bool:
-        return not self.data or self.data.get("kv_events", 0) == 0
-
-
-class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
+class LMCacheConnectorV1(KVConnectorBase_V1):
     def __init__(
         self,
         vllm_config: "VllmConfig",
@@ -166,18 +124,18 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         """
         return self._lmcache_engine.get_finished(finished_req_ids)
 
-    def get_kv_connector_stats(self) -> Optional["KVConnectorStats"]:
+    def get_kv_connector_kv_cache_events(self) -> Optional["KVEventBatch"]:
         """
-        Get the KV connector stats collected during the last interval.
+        Get the KV connector kv cache events collected during the last interval.
         """
         events = self._lmcache_engine.get_kv_events()
         if not events:
             return None
 
-        lmcache_kv_events: LMCacheKVEvents | None = None
+        lmcache_kv_events: KVEventBatch | None = None
         for event in events:
             if lmcache_kv_events is None:
-                lmcache_kv_events = LMCacheKVEvents()
+                lmcache_kv_events = KVEventBatch(ts=time.time(), events=[])
             block = BlockStored(
                 block_hashes=event.block_hashes,
                 parent_block_hash=event.parent_block_hash,
@@ -186,7 +144,7 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
                 block_size=event.block_size,
                 medium=event.medium,
             )
-            lmcache_kv_events.add_kv_event(block)
+            lmcache_kv_events.events.append(block)
 
         return lmcache_kv_events
 
@@ -254,14 +212,14 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
                 connectors output.
         """
         # Get the KV events
-        kv_events = connector_output.kv_connector_stats
+        kv_events = connector_output.kv_cache_events
         if (
             not kv_events
-            or not isinstance(kv_events, LMCacheKVEvents)
-            or kv_events.is_empty()
+            or not isinstance(kv_events, KVEventBatch)
+            or not kv_events.events
         ):
             return
-        self._kv_events = kv_events.get_kv_events()
+        self._kv_events.extend(kv_events.events)
         return
 
     def request_finished(
@@ -291,9 +249,3 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         if self._kv_events is not None:
             yield from self._kv_events
             self._kv_events.clear()
-
-    @classmethod
-    def build_kv_connector_stats(
-        cls, data: dict[str, Any] | None = None
-    ) -> KVConnectorStats | None:
-        return LMCacheKVEvents(data=data) if data is not None else LMCacheKVEvents()

--- a/lmcache/integration/vllm/lmcache_connector_v1.py
+++ b/lmcache/integration/vllm/lmcache_connector_v1.py
@@ -1,17 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
-
 # Standard
-from typing import TYPE_CHECKING, Any, Optional
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, List, Optional
 
 # Third Party
 from vllm.config import VllmConfig
+from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
 import torch
 
 # First Party
@@ -27,15 +31,63 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+@dataclass
+class LMCacheKVEvents(KVConnectorStats):
+    """
+    Maintain a list of KV events from worker to scheduler
+    """
+
+    def aggregate(self, other: "KVConnectorStats") -> "LMCacheKVEvents":
+        if not other and not isinstance(other, LMCacheKVEvents):
+            raise TypeError("Can only aggregate with another LMCacheKVEvents")
+
+        if other.is_empty():
+            return self
+
+        if self.is_empty():
+            self.data["kv_events"] = []
+
+        other_events = other.get_kv_events()
+        for other_event in other_events:
+            self.data["kv_events"].append(other_event)
+
+        return self
+
+    def reset(self):
+        self.data.clear()
+
+    def reduce(self) -> dict[str, List[BlockStored]]:
+        return self.data
+
+    def add_kv_event(self, event: BlockStored):
+        if self.is_empty():
+            self.data["kv_events"] = []
+        self.data["kv_events"].append(event)
+
+    def get_kv_events(self) -> Optional[List[BlockStored]]:
+        if self.is_empty():
+            return None
+        return self.data["kv_events"]
+
+    def is_empty(self) -> bool:
+        return not self.data or self.data.get("kv_events", 0) == 0
+
+
 class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
-    def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole):
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+    ):
         super().__init__(vllm_config=vllm_config, role=role)
         self._lmcache_engine = LMCacheConnectorV1Impl(vllm_config, role, self)
+
+        self._kv_events: List[KVCacheEvent] = []
 
     # ==============================
     # Worker-side methods
     # ==============================
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
         """
         Start loading the KV cache from the connector to vLLM's paged
         KV buffer. This is called from the forward context before the
@@ -70,7 +122,7 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         layer_name: str,
         kv_layer: torch.Tensor,
         attn_metadata: "AttentionMetadata",
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         Start saving the a layer of KV cache from vLLM's paged buffer
@@ -100,7 +152,7 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
 
     def get_finished(
         self, finished_req_ids: set[str]
-    ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+    ) -> tuple[set[str] | None, set[str] | None]:
         """
         Notifies worker-side connector ids of requests that have
         finished generating tokens.
@@ -114,9 +166,29 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         """
         return self._lmcache_engine.get_finished(finished_req_ids)
 
-    def get_block_ids_with_load_errors(self) -> set[int]:
-        """Return block IDs that failed to load during the last interval."""
-        return self._lmcache_engine.get_block_ids_with_load_errors()
+    def get_kv_connector_stats(self) -> Optional["KVConnectorStats"]:
+        """
+        Get the KV connector stats collected during the last interval.
+        """
+        events = self._lmcache_engine.get_kv_events()
+        if not events:
+            return None
+
+        lmcache_kv_events: LMCacheKVEvents | None = None
+        for event in events:
+            if lmcache_kv_events is None:
+                lmcache_kv_events = LMCacheKVEvents()
+            block = BlockStored(
+                block_hashes=event.block_hashes,
+                parent_block_hash=event.parent_block_hash,
+                token_ids=event.token_ids,
+                lora_id=event.lora_id,
+                block_size=event.block_size,
+                medium=event.medium,
+            )
+            lmcache_kv_events.add_kv_event(block)
+
+        return lmcache_kv_events
 
     def shutdown(self):
         """
@@ -133,7 +205,7 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         self,
         request: "Request",
         num_computed_tokens: int,
-    ) -> tuple[Optional[int], bool]:
+    ) -> tuple[int | None, bool]:
         """
         Get number of new tokens that can be loaded from the
         external KV cache beyond the num_computed_tokens.
@@ -173,11 +245,30 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
         """
         return self._lmcache_engine.build_connector_meta(scheduler_output)
 
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        """
+        Update KVConnector state from worker-side connectors output.
+
+        Args:
+            connector_output (KVConnectorOutput): the worker-side
+                connectors output.
+        """
+        # Get the KV events
+        kv_events = connector_output.kv_connector_stats
+        if (
+            not kv_events
+            or not isinstance(kv_events, LMCacheKVEvents)
+            or kv_events.is_empty()
+        ):
+            return
+        self._kv_events = kv_events.get_kv_events()
+        return
+
     def request_finished(
         self,
         request: "Request",
         block_ids: list[int],
-    ) -> tuple[bool, Optional[dict[str, Any]]]:
+    ) -> tuple[bool, dict[str, Any] | None]:
         """
         Called when a request has finished, before its blocks are freed.
 
@@ -189,3 +280,20 @@ class LMCacheConnectorV1Dynamic(KVConnectorBase_V1):
             returned by the engine.
         """
         return self._lmcache_engine.request_finished(request, block_ids)
+
+    def take_events(self) -> Iterable["KVCacheEvent"]:
+        """
+        Take the KV cache events from the connector.
+
+        Yields:
+            New KV cache events since the last call.
+        """
+        if self._kv_events is not None:
+            yield from self._kv_events
+            self._kv_events.clear()
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return LMCacheKVEvents(data=data) if data is not None else LMCacheKVEvents()

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
@@ -54,7 +55,7 @@ from lmcache.integration.vllm.utils import (
 )
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
-from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.utils import CacheStoreEvent, _lmcache_nvtx_annotate
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig, _validate_and_set_config_value
@@ -1809,3 +1810,9 @@ class LMCacheConnectorV1Impl:
             }
 
         return False, return_params
+
+    @_lmcache_nvtx_annotate
+    def get_kv_events(self) -> Iterable[CacheStoreEvent]:
+        if self.lmcache_engine is not None:
+            return self.lmcache_engine.get_kv_events()
+        return []

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -76,14 +76,11 @@ def convert_tokens_to_list(
     if tokens is None:
         return []
 
-    if isinstance(tokens, torch.Tensor) and tokens.is_cuda:
-        return tokens.detach().cpu().tolist()[token_start : token_end + 1]
-    else:
-        return (
-            tokens.tolist()[token_start : token_end + 1]
-            if isinstance(tokens, torch.Tensor)
-            else tokens[token_start : token_end + 1]
-        )
+    return (
+        tokens.tolist()[token_start : token_end + 1]
+        if isinstance(tokens, torch.Tensor)
+        else tokens[token_start : token_end + 1]
+    )
 
 
 @dataclass

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -68,6 +68,24 @@ def get_version():
     return f"{version_display}-{commit_id_display}"
 
 
+def convert_tokens_to_list(
+    tokens: Optional[Union[torch.Tensor, list[int]]], token_start: int, token_end: int
+) -> List[int]:
+    """Convert tokens to a list.
+    token_start and token_end delineate tokens to convert"""
+    if tokens is None:
+        return []
+
+    if isinstance(tokens, torch.Tensor) and tokens.is_cuda:
+        return tokens.detach().cpu().tolist()[token_start : token_end + 1]
+    else:
+        return (
+            tokens.tolist()[token_start : token_end + 1]
+            if isinstance(tokens, torch.Tensor)
+            else tokens[token_start : token_end + 1]
+        )
+
+
 @dataclass
 class DiskCacheMetadata:
     path: str

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -390,6 +390,16 @@ class LayerCacheEngineKey(CacheEngineKey):
         )
 
 
+@dataclass
+class CacheStoreEvent:
+    block_hashes: list[int]
+    parent_block_hash: int | None
+    token_ids: list[int]
+    block_size: int
+    lora_id: int | None
+    medium: str | None
+
+
 ##### NVTX annotation #####
 _NVTX_COLORS = ["green", "blue", "purple", "rapids"]
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -25,7 +25,12 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
-from lmcache.utils import CacheEngineKey, CacheStoreEvent, _lmcache_nvtx_annotate
+from lmcache.utils import (
+    CacheEngineKey,
+    CacheStoreEvent,
+    _lmcache_nvtx_annotate,
+    convert_tokens_to_list,
+)
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventStatus, EventType
 from lmcache.v1.gpu_connector import (
@@ -359,14 +364,11 @@ class LMCacheEngine:
                     medium="cpu",
                 )
                 if tokens is not None:
-                    if isinstance(tokens, torch.Tensor) and tokens.is_cuda:
-                        stored_event.token_ids = tokens.detach().cpu().tolist()
-                    else:
-                        stored_event.token_ids = (
-                            tokens.tolist()[start : end + 1]
-                            if isinstance(tokens, torch.Tensor)
-                            else tokens[start : end + 1]
-                        )
+                    stored_event.token_ids = convert_tokens_to_list(
+                        tokens,
+                        start,
+                        end,
+                    )
                     if isinstance(tokens, torch.Tensor):
                         stored_event.medium = tokens.device
                 elif hashes is not None:
@@ -503,14 +505,11 @@ class LMCacheEngine:
                     medium="cpu",
                 )
                 if tokens is not None:
-                    if isinstance(tokens, torch.Tensor) and tokens.is_cuda:
-                        stored_event.token_ids = tokens.detach().cpu().tolist()
-                    else:
-                        stored_event.token_ids = (
-                            tokens.tolist()[start : end + 1]
-                            if isinstance(tokens, torch.Tensor)
-                            else tokens[start : end + 1]
-                        )
+                    stored_event.token_ids = convert_tokens_to_list(
+                        tokens,
+                        start,
+                        end,
+                    )
                     if isinstance(tokens, torch.Tensor):
                         stored_event.medium = tokens.device
                 logger.debug(

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1194,11 +1194,11 @@ class LMCacheEngine:
 
     @_lmcache_nvtx_annotate
     def get_kv_events(self) -> Iterable[CacheStoreEvent]:
-        if not self.kv_events_enabled or not self.kv_events:
-            yield from []
-        else:
-            yield from self.kv_events
-            self.kv_events.clear()
+        if self.kv_events_enabled and self.kv_events:
+            events = self.kv_events
+            self.kv_events = []
+            return events
+        return []
 
     def _clear(
         self,

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -499,7 +499,7 @@ class LMCacheEngine:
                     lora_id=None,
                     medium="GPU",
                 )
-                logger.info(
+                logger.debug(
                     f"Added kv cache event '{stored_event}' to kv cache events queue"
                 )
                 self.kv_events.append(stored_event)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -366,7 +366,7 @@ class LMCacheEngine:
                     )
                 elif hashes is not None:
                     stored_event.token_ids = hashes[start : end + 1]
-                logger.info(
+                logger.debug(
                     f"Added kv cache event '{stored_event}' to kv cache events queue"
                 )
                 self.kv_events.append(stored_event)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -356,14 +356,19 @@ class LMCacheEngine:
                     token_ids=[],
                     block_size=num_tokens,
                     lora_id=None,
-                    medium="GPU",
+                    medium="cpu",
                 )
                 if tokens is not None:
-                    stored_event.token_ids = (
-                        tokens.tolist()[start : end + 1]
-                        if isinstance(tokens, torch.Tensor)
-                        else tokens[start : end + 1]
-                    )
+                    if isinstance(tokens, torch.Tensor) and tokens.is_cuda:
+                        stored_event.token_ids = tokens.detach().cpu().tolist()
+                    else:
+                        stored_event.token_ids = (
+                            tokens.tolist()[start : end + 1]
+                            if isinstance(tokens, torch.Tensor)
+                            else tokens[start : end + 1]
+                        )
+                    if isinstance(tokens, torch.Tensor):
+                        stored_event.medium = tokens.device
                 elif hashes is not None:
                     stored_event.token_ids = hashes[start : end + 1]
                 logger.debug(
@@ -492,13 +497,22 @@ class LMCacheEngine:
                 stored_event = CacheStoreEvent(
                     block_hashes=[key.chunk_hash],
                     parent_block_hash=None if start == 0 else prev_key,
-                    token_ids=tokens.tolist()[start : end + 1]
-                    if isinstance(tokens, torch.Tensor)
-                    else tokens[start : end + 1],
+                    token_ids=[],
                     block_size=num_tokens,
                     lora_id=None,
-                    medium="GPU",
+                    medium="cpu",
                 )
+                if tokens is not None:
+                    if isinstance(tokens, torch.Tensor) and tokens.is_cuda:
+                        stored_event.token_ids = tokens.detach().cpu().tolist()
+                    else:
+                        stored_event.token_ids = (
+                            tokens.tolist()[start : end + 1]
+                            if isinstance(tokens, torch.Tensor)
+                            else tokens[start : end + 1]
+                        )
+                    if isinstance(tokens, torch.Tensor):
+                        stored_event.medium = tokens.device
                 logger.debug(
                     f"Added kv cache event '{stored_event}' to kv cache events queue"
                 )
@@ -1194,8 +1208,7 @@ class LMCacheEngine:
 
     @_lmcache_nvtx_annotate
     def get_kv_events(self) -> Iterable[CacheStoreEvent]:
-        if self.kv_events_enabled and self.kv_events:
-            events = self.kv_events
+        if self.kv_events_enabled and (events := self.kv_events):
             self.kv_events = []
             return events
         return []

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -351,9 +351,7 @@ class LMCacheEngine:
             # Create KV event
             if self.kv_events_enabled:
                 stored_event = CacheStoreEvent(
-                    block_hashes=[hash(key)]
-                    if isinstance(key, CacheEngineKey)
-                    else [key],
+                    block_hashes=[key.chunk_hash],
                     parent_block_hash=None if start == 0 else prev_key,
                     token_ids=[],
                     block_size=num_tokens,
@@ -372,7 +370,7 @@ class LMCacheEngine:
                     f"Added kv cache event '{stored_event}' to kv cache events queue"
                 )
                 self.kv_events.append(stored_event)
-                prev_key = hash(key) if isinstance(key, CacheEngineKey) else key
+                prev_key = key.chunk_hash
 
         # memory_objs might be empty, directly return to avoid sending tokens
         if not memory_objs:
@@ -492,9 +490,7 @@ class LMCacheEngine:
             # Create KV event
             if self.kv_events_enabled and tokens is not None:
                 stored_event = CacheStoreEvent(
-                    block_hashes=[hash(key)]
-                    if isinstance(key, CacheEngineKey)
-                    else [key],
+                    block_hashes=[key.chunk_hash],
                     parent_block_hash=None if start == 0 else prev_key,
                     token_ids=tokens.tolist()[start : end + 1]
                     if isinstance(tokens, torch.Tensor)
@@ -507,7 +503,7 @@ class LMCacheEngine:
                     f"Added kv cache event '{stored_event}' to kv cache events queue"
                 )
                 self.kv_events.append(stored_event)
-                prev_key = hash(key) if isinstance(key, CacheEngineKey) else key
+                prev_key = key.chunk_hash
 
         if keys:
             # Transpose the keys and memory objects into layer major format

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections import defaultdict
+from collections.abc import Iterable
 from typing import (
     Any,
     Callable,
@@ -24,7 +25,7 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
-from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
+from lmcache.utils import CacheEngineKey, CacheStoreEvent, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventStatus, EventType
 from lmcache.v1.gpu_connector import (
@@ -177,6 +178,15 @@ class LMCacheEngine:
                 lmcache_worker=self.lmcache_worker,
             )
 
+        # KV events
+        self.kv_events_enabled = False
+        self.kv_events_enabled = config.enable_kv_events
+        if self.kv_events_enabled:
+            self.kv_events: List[CacheStoreEvent] = []
+            logger.info("KV events are enabled.")
+        else:
+            logger.info("KV events are disabled.")
+
         # HACK: remove this in the future
         # NOTE (Jiayi): This is currently used to support
         # dropping the kv cache from the buffer in PD backend
@@ -301,6 +311,7 @@ class LMCacheEngine:
         if request_configs is not None and len(request_configs) != 0:
             assert isinstance(request_configs, dict)
 
+        prev_key = 0
         for start, end, key in self.token_database.process_tokens(
             tokens,
             hashes,
@@ -336,6 +347,32 @@ class LMCacheEngine:
             memory_objs.append(memory_obj)
             tot_kv_size += memory_obj.get_size()
             tot_token_num += num_tokens
+
+            # Create KV event
+            if self.kv_events_enabled:
+                stored_event = CacheStoreEvent(
+                    block_hashes=[hash(key)]
+                    if isinstance(key, CacheEngineKey)
+                    else [key],
+                    parent_block_hash=None if start == 0 else prev_key,
+                    token_ids=[],
+                    block_size=num_tokens,
+                    lora_id=None,
+                    medium="GPU",
+                )
+                if tokens is not None:
+                    stored_event.token_ids = (
+                        tokens.tolist()[start : end + 1]
+                        if isinstance(tokens, torch.Tensor)
+                        else tokens[start : end + 1]
+                    )
+                elif hashes is not None:
+                    stored_event.token_ids = hashes[start : end + 1]
+                logger.info(
+                    f"Added kv cache event '{stored_event}' to kv cache events queue"
+                )
+                self.kv_events.append(stored_event)
+                prev_key = hash(key) if isinstance(key, CacheEngineKey) else key
 
         # memory_objs might be empty, directly return to avoid sending tokens
         if not memory_objs:
@@ -416,6 +453,7 @@ class LMCacheEngine:
         if request_configs is not None and len(request_configs) != 0:
             assert isinstance(request_configs, dict)
 
+        prev_key = 0
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens, mask=mask, request_configs=request_configs
         ):
@@ -450,6 +488,26 @@ class LMCacheEngine:
             keys.append(keys_multi_layer)
             memory_objs.append(memory_objs_multi_layer)
             tot_token_num += num_tokens
+
+            # Create KV event
+            if self.kv_events_enabled and tokens is not None:
+                stored_event = CacheStoreEvent(
+                    block_hashes=[hash(key)]
+                    if isinstance(key, CacheEngineKey)
+                    else [key],
+                    parent_block_hash=None if start == 0 else prev_key,
+                    token_ids=tokens.tolist()[start : end + 1]
+                    if isinstance(tokens, torch.Tensor)
+                    else tokens[start : end + 1],
+                    block_size=num_tokens,
+                    lora_id=None,
+                    medium="GPU",
+                )
+                logger.info(
+                    f"Added kv cache event '{stored_event}' to kv cache events queue"
+                )
+                self.kv_events.append(stored_event)
+                prev_key = hash(key) if isinstance(key, CacheEngineKey) else key
 
         if keys:
             # Transpose the keys and memory objects into layer major format
@@ -1137,6 +1195,14 @@ class LMCacheEngine:
             else:
                 return 0
         return self._clear(tokens, locations, request_configs)
+
+    @_lmcache_nvtx_annotate
+    def get_kv_events(self) -> Iterable[CacheStoreEvent]:
+        if not self.kv_events_enabled or not self.kv_events:
+            yield from []
+        else:
+            yield from self.kv_events
+            self.kv_events.clear()
 
     def _clear(
         self,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -498,6 +498,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": "memory_bloom_filter",
         "env_converter": str,
         "description": "Recording strategy: memory_bloom_filter or file_hash.",
+    # KV events configuration
+    "enable_kv_events": {
+        "type": bool,
+        "default": False,
+        "env_converter": _to_bool,
     },
 }
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -498,6 +498,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": "memory_bloom_filter",
         "env_converter": str,
         "description": "Recording strategy: memory_bloom_filter or file_hash.",
+    },
     # KV events configuration
     "enable_kv_events": {
         "type": bool,


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This commit adds generation of kv events. It creates the events during LMCache storage operations and stores them in the cache engine. The vLLM model runner and scheduler processes then handle the events and the events are finally published by the vLLM scheduler process.

The overall data flow is as follows:
- Model runner process calls connector `get_kv_connector_kv_events` method which calls cache_engine to return the events
- Model runner process sends the information to the scheduler process via `KVConnectorOutput` class
- Scheduler process calls connector `update_connector_output` method and the connector gets access to events in scheduler side now
- Scheduler calls connector `take_events` method, and the connector returns the latest events to be published by the scheduler

This PR is based on the vLLM RFC [[RFC]: KV-Cache Interoperability API Standardization ](https://github.com/vllm-project/vllm/issues/20492) which proposes "formalizing KV Events as the public contract for any component emitting or consuming KV-Cache lifecycle events - including external indexers, routers, and engines". 

Fixes #1846

**Special notes for your reviewers**:

- The configuration is defined in  `lmcache/v1/config.py`. Please note that KV events are disabled by default. Need to set `enable_kv_events` to `True` for events to be generated.
- Example of the command for vLLM to publish events is as follows: `LMCACHE_CONFIG_FILE=lmcache_config.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct -kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' --disable-log-requests --no-enable-prefix-caching --kv-events-config '{"enable_kv_cache_events": "True", "publisher": "zmq", "topic": "kv-events"}'`. **Note:** You need to build vLLM PR https://github.com/vllm-project/vllm/pull/28309 and run that version of vLLM to pickup the changes so that the events work end to end. A good command to build vLLM Python only (and it only takes seconds) is as follows: `VLLM_USE_PRECOMPILED=1 uv pip install --editable . --extra-index-url https://download.pytorch.org/whl/cu129 --index-strategy unsafe-best-match --prerelease=allow`. 
- Consumer code to test the events being published can be referenced in: https://docs.vllm.ai/en/stable/examples/online_serving/kv_events_subscriber.html
- Currently, events only being generated for storage and not eviction

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

**Additional comment:**

A big thank you to @ApostaC for pointing me towards using the vLLM runner and scheduler flow to handle the event publishing and therefore simplify the solution as compared to #1843 