### PR TITLE
[CI/Build] Move /opt/venv/bin to PATH to BASE image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ ARG CUDA_VERSION
 ARG PYTHON_VERSION=3.12
 ARG UBUNTU_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/venv/bin:${PATH}"
 
 # Install Python and other dependencies
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
@@ -68,8 +69,6 @@ ARG nvcc_threads=8
 ENV NVCC_THREADS=$nvcc_threads
 
 ARG VLLM_VERSION=nightly
-
-ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The previous change only fixed for image-build target, which is used for nightly build and local. https://github.com/LMCache/LMCache/pull/1925

We also need to add env var change in image-release target. This issue is still not fixed in v0.3.9post1 without this change.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
