### PR TITLE
[controller] simplify config when p2p is not enabled

### DIFF
--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -219,6 +219,7 @@ class KVController:
                 peer_init_url = self.reg_controller.get_distributed_url(
                     instance_id, worker_id
                 )
+                assert peer_init_url is not None
             num_hit_chunks += 1
 
         return BatchedP2PLookupRetMsg(

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -36,9 +36,10 @@ class RegistrationController:
         self.worker_mapping: dict[str, list[int]] = {}
 
         # Mapping from `(instance_id, worker_id)` -> `distributed_url`
-        # NOTE(Jiayi): `distributed_url` is used for actual KV cache transfer.
-        # It's not the lmcache_worker_url
-        self.distributed_url_mapping: dict[tuple[str, int], str] = {}
+        # NOTE(Jiayi): `distributed_url` is used for actual KV cache transfer(p2p),
+        # It's not the lmcache_worker_url.
+        # if p2p is not used, distributed_url is None
+        self.distributed_url_mapping: dict[tuple[str, int], Optional[str]] = {}
 
         # Mapping from `(instance_id, worker_id)` -> `socket`
         self.socket_mapping: dict[tuple[str, int], zmq.asyncio.Socket] = {}
@@ -73,7 +74,9 @@ class RegistrationController:
         """
         url = self.distributed_url_mapping.get((instance_id, worker_id))
         if url is None:
-            logger.warning(f"Instance-worker {(instance_id, worker_id)} not registered")
+            logger.warning(
+                f"Instance-worker {(instance_id, worker_id)} not registered or P2P is not used"
+            )
         return url
 
     def get_workers(self, instance_id: str) -> list[int]:

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -75,7 +75,8 @@ class RegistrationController:
         url = self.distributed_url_mapping.get((instance_id, worker_id))
         if url is None:
             logger.warning(
-                f"Instance-worker {(instance_id, worker_id)} not registered or P2P is not used"
+                f"Instance-worker {(instance_id, worker_id)} not registered "
+                f"or P2P is not used"
             )
         return url
 

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -38,8 +38,8 @@ class RegistrationController:
         # Mapping from `(instance_id, worker_id)` -> `distributed_url`
         # NOTE(Jiayi): `distributed_url` is used for actual KV cache transfer(p2p),
         # It's not the lmcache_worker_url.
-        # if p2p is not used, distributed_url is None
-        self.distributed_url_mapping: dict[tuple[str, int], Optional[str]] = {}
+        # if p2p is not used, distributed_url is None and not registered.
+        self.distributed_url_mapping: dict[tuple[str, int], str] = {}
 
         # Mapping from `(instance_id, worker_id)` -> `socket`
         self.socket_mapping: dict[tuple[str, int], zmq.asyncio.Socket] = {}
@@ -108,7 +108,13 @@ class RegistrationController:
         port = msg.port
         url = f"{ip}:{port}"
         distributed_url = msg.distributed_url
-        self.distributed_url_mapping[(instance_id, worker_id)] = distributed_url
+        if distributed_url is not None:
+            self.distributed_url_mapping[(instance_id, worker_id)] = distributed_url
+        else:
+            logger.info(
+                f"distributed url of {(instance_id, worker_id)} is None, "
+                f"only register when p2p is used."
+            )
 
         self.instance_mapping[ip] = instance_id
 

--- a/lmcache/v1/cache_controller/executor.py
+++ b/lmcache/v1/cache_controller/executor.py
@@ -310,7 +310,7 @@ class LMCacheClusterExecutor:
                         f"Src worker {src_worker_id} not registered for "
                         f"instance {src_instance_id} or "
                         f"dst worker {dst_worker_id} not registered for "
-                        f"instance {dst_instance_id}"
+                        f"instance {dst_instance_id} or P2P is not enabled."
                     )
                 )
             sockets.append(socket)

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -41,7 +41,8 @@ class RegisterMsg(WorkerMsg):
     worker_id: int
     ip: str
     port: int
-    distributed_url: str  # URL for actual KV cache transfer
+    # URL for actual KV cache transfer, only useful when p2p is enabled
+    distributed_url: Optional[str]
 
     def describe(self) -> str:
         return (

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -9,6 +10,6 @@ class WorkerInfo:
     worker_id: int
     ip: str
     port: int
-    distributed_url: str
+    distributed_url: Optional[str]
     registration_time: float
     last_heartbeat_time: float

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -99,12 +99,11 @@ class LMCacheWorker:
         self.lmcache_worker_ip = get_ip()
         self.lmcache_worker_port = lmcache_worker_port
 
+        self.p2p_init_url = None
         if config.enable_p2p:
             self.p2p_host = config.p2p_host
             self.p2p_init_port = config.p2p_init_ports[self.worker_id]
             self.p2p_init_url = f"{self.p2p_host}:{self.p2p_init_port}"
-        else:
-            self.p2p_init_url = None
 
         self.reply_socket = get_zmq_socket(
             self.context,

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -99,9 +99,12 @@ class LMCacheWorker:
         self.lmcache_worker_ip = get_ip()
         self.lmcache_worker_port = lmcache_worker_port
 
-        self.p2p_host = config.p2p_host
-        self.p2p_init_port = config.p2p_init_ports[self.worker_id]
-        self.p2p_init_url = f"{self.p2p_host}:{self.p2p_init_port}"
+        if config.enable_p2p:
+            self.p2p_host = config.p2p_host
+            self.p2p_init_port = config.p2p_init_ports[self.worker_id]
+            self.p2p_init_url = f"{self.p2p_host}:{self.p2p_init_port}"
+        else:
+            self.p2p_init_url = None
 
         self.reply_socket = get_zmq_socket(
             self.context,


### PR DESCRIPTION
When `P2P` is enabled, the controller must be also enabled. But in some scenarios, we want to enable controller, but not use `P2P`, the `P2P` related configs is not necessary.