### PR TITLE
[FSConnector] support O_DIRECT in fs connector

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -145,6 +145,7 @@ class FSConnector(RemoteConnector):
     def _get_with_odirect(self, file_path: Path) -> Optional[MemoryObj]:
         """Synchronous direct IO read, executed in a thread."""
         try:
+            fd = -1
             memory_obj = self.local_cpu_backend.allocate(
                 self.meta_shape, self.meta_dtype, self.meta_fmt
             )
@@ -176,6 +177,12 @@ class FSConnector(RemoteConnector):
 
         except Exception as e:
             logger.error(f"Failed to read from file {file_path}: {str(e)}")
+            # Make sure fd is closed on error
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except Exception:
+                    pass
             return None
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
@@ -270,7 +277,7 @@ class FSConnector(RemoteConnector):
             if fd >= 0:
                 try:
                     os.close(fd)
-                except Exception:
+                except OSError:
                     pass
             raise
 

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -150,8 +150,8 @@ class FSConnector(RemoteConnector):
 
     def _get_with_odirect(self, file_path: Path) -> Optional[MemoryObj]:
         """Synchronous direct IO read, executed in a thread."""
+        fd = -1
         try:
-            fd = -1
             memory_obj = self.local_cpu_backend.allocate(
                 self.meta_shape, self.meta_dtype, self.meta_fmt
             )
@@ -176,6 +176,9 @@ class FSConnector(RemoteConnector):
             else:
                 fd = os.open(file_path, os.O_RDONLY | os.O_DIRECT)
                 with os.fdopen(fd, "rb", buffering=0) as fdo:
+                    # The fd is now managed by the file object, so we "forget" it
+                    # to prevent closing it in the finally block.
+                    fd = -1
                     num_read = fdo.readinto(buffer)
 
             memory_obj = self.reshape_partial_chunk(memory_obj, num_read)
@@ -183,13 +186,13 @@ class FSConnector(RemoteConnector):
 
         except Exception as e:
             logger.error(f"Failed to read from file {file_path}: {str(e)}")
-            # Make sure fd is closed on error
+            return None
+        finally:
             if fd >= 0:
                 try:
                     os.close(fd)
-                except Exception:
+                except OSError:
                     pass
-            return None
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Get data from file system"""
@@ -273,19 +276,19 @@ class FSConnector(RemoteConnector):
             return None
 
     def _put_with_odirect(self, file_path: Path, buffer: bytes) -> None:
-        fd = os.open(str(file_path), os.O_CREAT | os.O_WRONLY | os.O_DIRECT, 0o644)
+        fd = -1
         try:
+            fd = os.open(str(file_path), os.O_CREAT | os.O_WRONLY | os.O_DIRECT, 0o644)
             os.write(fd, buffer)
-            os.close(fd)
         except Exception as e:
             logger.error(f"Failed to write to file {file_path}: {e}")
-            # Make sure fd is closed on error
+            raise
+        finally:
             if fd >= 0:
                 try:
                     os.close(fd)
                 except OSError:
                     pass
-            raise
 
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """Store data to file system"""

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -71,16 +71,34 @@ class FSConnector(RemoteConnector):
             else config.get_extra_config_value("fs_connector_read_ahead_size", None)
         )
 
+        self.use_odirect = (
+            False
+            if config is None
+            else config.get_extra_config_value("fs_connector_use_odirect", False)
+        )
+
         logger.info(
             f"Initialized FSConnector with base paths {self.base_paths}, "
             f"relative tmp dir: {self.relative_tmp_dir}, "
-            f"read ahead size: {self.read_ahead_size}"
+            f"read ahead size: {self.read_ahead_size}, "
+            f"use O_DIRECT: {self.use_odirect}"
         )
         # Create directories for all paths
         for path in self.base_paths:
             path.mkdir(parents=True, exist_ok=True)
             if self.relative_tmp_dir is not None:
                 (path / self.relative_tmp_dir).mkdir(parents=False, exist_ok=True)
+
+    def post_init(self):
+        self.os_disk_bs = 0
+        if self.use_odirect:
+            # check save_chunk_meta
+            if self.save_chunk_meta:
+                logger.warning("Cannot use O_DIRECT if save_chunk_meta enabled.")
+                self.use_odirect = False
+            else:
+                stat = os.statvfs(self.base_paths[0])
+                self.os_disk_bs = stat.f_bsize
 
     def _get_base_path(self, key: CacheEngineKey) -> Path:
         """Get file base path for the given key"""
@@ -124,9 +142,50 @@ class FSConnector(RemoteConnector):
         file_path = self._get_file_path(key)
         return os.path.exists(file_path)
 
+    def _get_with_odirect(self, file_path: Path) -> Optional[MemoryObj]:
+        """Synchronous direct IO read, executed in a thread."""
+        try:
+            memory_obj = self.local_cpu_backend.allocate(
+                self.meta_shape, self.meta_dtype, self.meta_fmt
+            )
+            if memory_obj is None:
+                logger.debug("Memory allocation failed.")
+                return None
+
+            buffer = memory_obj.byte_array
+            size = len(buffer)
+
+            fblock_aligned = (
+                self.os_disk_bs is not None
+                and self.os_disk_bs > 0
+                and size % self.os_disk_bs == 0
+            )
+            if not fblock_aligned:
+                logger.warning(
+                    f"Cannot use O_DIRECT for {file_path}, size is not aligned."
+                )
+                with open(file_path, "rb") as f:
+                    num_read = f.readinto(buffer)
+            else:
+                fd = os.open(file_path, os.O_RDONLY | os.O_DIRECT)
+                with os.fdopen(fd, "rb", buffering=0) as fdo:
+                    num_read = fdo.readinto(buffer)
+
+            memory_obj = self.reshape_partial_chunk(memory_obj, num_read)
+            return memory_obj
+
+        except Exception as e:
+            logger.error(f"Failed to read from file {file_path}: {str(e)}")
+            return None
+
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Get data from file system"""
         file_path = self._get_file_path(key)
+
+        if self.use_odirect and not self.save_chunk_meta:
+            return await self.loop.run_in_executor(
+                None, self._get_with_odirect, file_path
+            )
 
         memory_obj = None
         try:
@@ -200,6 +259,21 @@ class FSConnector(RemoteConnector):
                 memory_obj.ref_count_down()
             return None
 
+    def _put_with_odirect(self, file_path: Path, buffer: bytes) -> None:
+        fd = os.open(str(file_path), os.O_CREAT | os.O_WRONLY | os.O_DIRECT, 0o644)
+        try:
+            os.write(fd, buffer)
+            os.close(fd)
+        except Exception as e:
+            logger.error(f"Failed to write to file {file_path}: {e}")
+            # Make sure fd is closed on error
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except Exception:
+                    pass
+            raise
+
     async def put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """Store data to file system"""
         final_path, temp_path = self._get_file_and_tmp_path(key)
@@ -218,11 +292,29 @@ class FSConnector(RemoteConnector):
                 else None
             )
 
-            # Write to file (metadata + data)
-            async with aiofiles.open(temp_path, "wb") as f:
-                if metadata is not None:
-                    await f.write(metadata.serialize())
-                await f.write(buffer)
+            size = len(buffer)
+            do_use_odirect = self.use_odirect
+            if do_use_odirect:
+                fblock_aligned = self.os_disk_bs > 0 and size % self.os_disk_bs == 0
+                if not fblock_aligned:
+                    logger.warning(
+                        f"Cannot use O_DIRECT for writing size {size}, "
+                        f"which is not aligned to block size {self.os_disk_bs}."
+                    )
+                    do_use_odirect = False
+
+            if do_use_odirect:
+                # Use Direct I/O
+                await self.loop.run_in_executor(
+                    None, self._put_with_odirect, temp_path, buffer
+                )
+            else:
+                # Use standard async I/O
+                # Write to file (metadata + data)
+                async with aiofiles.open(temp_path, "wb") as f:
+                    if metadata is not None:
+                        await f.write(metadata.serialize())
+                    await f.write(buffer)
 
             # Atomically rename temp file to final destination
             await aiofiles.os.replace(temp_path, final_path)

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -92,7 +92,13 @@ class FSConnector(RemoteConnector):
     def post_init(self):
         self.os_disk_bs = 0
         if self.use_odirect:
-            # check save_chunk_meta
+            # save_chunk_meta is useful if save_unfull_chunk is True, since partial
+            # chunk will be saved. When loading partial chunk, we need to know
+            # data size and shape. However, chunk meta is short (28 bytes) which
+            # is not aligned to disk block size (512 or 4096).
+            # Therefore, we disable O_DIRECT if save_chunk_meta is True.
+            # TODO: support O_DIRECT for save_chunk_meta by
+            # padding meta data to 4096.
             if self.save_chunk_meta:
                 logger.warning("Cannot use O_DIRECT if save_chunk_meta enabled.")
                 self.use_odirect = False


### PR DESCRIPTION
**Why**
Without O_DIRECT, data written to filesystem is held in page cache by kernel (in most cases) and is flushed later. Consumption of page cache would results in unpredictable slow down when flushing large amount of dirty page to storage. Some kinds of filesystems could handle direct io in its client but others could not. So I add some code path to enable this with option `fs_connector_use_odirect` 

**What**
To keep code simple, 2 new methods `_put_with_odirect` and `_get_with_odirect` are added. Current put() and get() call the new methods only if O_DIRECT is enabled and size is aligned with block size.
Since chunk meta's size is 28, O_DIRECT will only be effective when save_chunk_meta is set to False.
Read ahead is not implemented in `_get_with_odirect` for now