### PR TITLE
Mooncake prioritizes obtaining the master address from master_ server_address

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -121,8 +121,9 @@ class MooncakestoreConnector(RemoteConnector):
             else:
                 raise ValueError("MOONCAKE_CONFIG_PATH/lmcache_config must be provided")
 
-            if host != "" and port != 0:
-                self.config.master_server_address = host + ":" + str(port)
+            if not self.config.master_server_address:
+                if host != "" and port != 0:
+                    self.config.master_server_address = host + ":" + str(port)
             if dev_name != "":
                 self.config.device_name = dev_name
             logger.info("Mooncake Configuration loaded. config: %s", self.config)


### PR DESCRIPTION
Previously, in Mooncake connector initialization, the master_server_address was always overwritten by the value parsed from LMCACHE_REMOTE_URL, even if it was explicitly set in LMCACHE_EXTRA_CONFIG. This caused issues in HA mode because master_server_address from the extra config was ignored.

The modification ensures that LMCACHE_REMOTE_URL only sets master_server_address if it is not already configured. This allows master_server_address in LMCACHE_EXTRA_CONFIG to take priority, enabling proper usage of Mooncake HA mode while keeping the remote driver type configurable via LMCACHE_REMOTE_URL.
https://github.com/LMCache/LMCache/issues/1957