### PR TITLE
[core] Support remote cache put and get metrics in sagemaker hyperpod connector

### DIFF
--- a/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
+++ b/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
@@ -6,6 +6,7 @@ from multiprocessing import shared_memory
 from typing import AsyncIterator, List, Optional, Tuple
 import asyncio
 import json
+import time
 import urllib.parse
 
 # Third Party
@@ -14,6 +15,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.protocol import RemoteMetadata
@@ -134,6 +136,9 @@ class SageMakerHyperPodConnector(RemoteConnector):
         # Shared memory (lazy initialized)
         self.shared_memory_obj: Optional[shared_memory.SharedMemory] = None
         self.shared_memory_map: Optional[memoryview] = None
+
+        # Observability
+        self._stats_monitor = LMCStatsMonitor.GetOrCreate()
 
         # Statistics for monitoring
         self.stats = {
@@ -662,12 +667,13 @@ class SageMakerHyperPodConnector(RemoteConnector):
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """
-        Retrieve KV cache data for the given key.
+        Retrieve KV cache data for the given key with metrics reporting.
 
         Flow:
         1. Acquire a new lease
         2. Read from shared memory using lease offsets
         3. Release lease immediately (in finally block)
+        4. Report metrics
 
         Args:
             key: The cache key to retrieve
@@ -675,6 +681,8 @@ class SageMakerHyperPodConnector(RemoteConnector):
         Returns:
             MemoryObj containing the KV cache data, or None if not found
         """
+        begin = time.perf_counter()
+
         lease_info = await self._executor_submit_lease_acquisition(key)
 
         if lease_info is None:
@@ -686,10 +694,20 @@ class SageMakerHyperPodConnector(RemoteConnector):
             memory_obj = self._read_from_shared_memory(key, lease_info)
 
             if memory_obj is not None:
+                end = time.perf_counter()
+                obj_size = memory_obj.get_size()
+
+                # Report metrics for successful get
+                self._stats_monitor.update_interval_remote_time_to_get(
+                    (end - begin) * 1000
+                )
+                self._stats_monitor.update_interval_remote_read_metrics(obj_size)
+
                 self.stats["get_success"] += 1
                 logger.debug(
                     f"GET success: key={key.to_string()}, "
-                    f"shape={memory_obj.get_shape()}"
+                    f"shape={memory_obj.get_shape()}, "
+                    f"size={obj_size / 1e6:.3f} MBytes in {(end - begin) * 1000:.3f}ms"
                 )
             else:
                 self.stats["get_failure"] += 1
@@ -711,7 +729,7 @@ class SageMakerHyperPodConnector(RemoteConnector):
     async def batched_get(
         self, keys: List[CacheEngineKey]
     ) -> List[Optional[MemoryObj]]:
-        """Get multiple keys in parallel."""
+        """Get multiple keys in parallel. Metrics reported per individual get."""
         tasks = [self.get(key) for key in keys]
         return await asyncio.gather(*tasks)
 
@@ -722,7 +740,7 @@ class SageMakerHyperPodConnector(RemoteConnector):
     async def batched_put(
         self, keys: List[CacheEngineKey], memory_objs: List[MemoryObj]
     ):
-        """Store multiple objects in parallel."""
+        """Store multiple objects in parallel. Metrics reported per individual put."""
         await asyncio.gather(
             *(self.put(key, mem) for key, mem in zip(keys, memory_objs, strict=True))
         )
@@ -740,6 +758,8 @@ class SageMakerHyperPodConnector(RemoteConnector):
         """Internal PUT operation - sends data via HTTP streaming."""
         key_str = self._key_to_string(key)
         url = f"{self.base_url}/v1/kv/{self.bucket_name}/{key_str}"
+
+        begin = time.perf_counter()
 
         try:
             # Build streaming payload (header + data)
@@ -760,14 +780,31 @@ class SageMakerHyperPodConnector(RemoteConnector):
                 gate=self.put_inflight,
             )
 
+            end = time.perf_counter()
+
             if result and result["status"] == HTTP_OK:
                 self.stats["put_success"] += 1
+
+                # Report metrics for successful put
+                self._stats_monitor.update_interval_remote_time_to_put(
+                    (end - begin) * 1000
+                )
+                self._stats_monitor.update_interval_remote_write_metrics(payload_len)
+
                 logger.info(
-                    f"PUT success: key={key_str}, size={payload_len / 1024:.2f} KB"
+                    f"PUT success: key={key_str}, size={payload_len / 1024:.2f} KB "
+                    f"in {(end - begin) * 1000:.3f}ms"
                 )
             elif result and result["status"] == HTTP_CONFLICT:
                 # 409 Conflict = key already exists (not an error)
                 self.stats["put_success"] += 1
+
+                # Still report metrics for conflict case
+                self._stats_monitor.update_interval_remote_time_to_put(
+                    (end - begin) * 1000
+                )
+                self._stats_monitor.update_interval_remote_write_metrics(payload_len)
+
                 logger.debug(f"PUT skipped (already exists): key={key_str}")
             else:
                 status = result["status"] if result else "TIMEOUT"


### PR DESCRIPTION
… connector

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The current remote put and get metrics are implemented in instrumented connector, but only works for get() and put() instead of batched functions.

https://github.com/LMCache/LMCache/blob/a64ca32cba3784fa2266b7343c7591ec88d6e277/lmcache/v1/storage_backend/connector/instrumented_connector.py#L37

batched_get() and batched_put() are called when load is high enough. Since batch functions call batch functions in each remote connector, the metric reporting needs to be in remote connector for now unless larger refactoring.

This PR only enables put and get metrics in sagemaker hyperpod connector.

There are two potential TODOs after this:

1. Enable get and put metrics in other remote connectors.
2. Explore larger refactoring to make the logic in instrumented connector.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
