### PR TITLE
[optimize] do not initialize storage manager in some rank

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -126,13 +126,31 @@ class LMCacheEngine:
         self.async_loading = config.enable_async_loading
         self.event_manager = EventManager()
 
-        self.storage_manager = StorageManager(
-            config,
-            metadata,
-            # self.memory_allocator,
-            event_manager=self.event_manager,
-            lmcache_worker=self.lmcache_worker,
+        # if save_only_first_rank is False, all ranks will initialize
+        # the storage_manager
+        # if save_only_first_rank is True, only the first rank and
+        # lookup server workers will initialize the storage_manager
+        self.storage_manager = None
+        lookup_server_worker_ids = self.config.get_lookup_server_worker_ids(
+            metadata.use_mla, metadata.world_size
         )
+        if (
+            not self.save_only_first_rank
+            or self.metadata.is_first_rank()
+            or len(lookup_server_worker_ids) == 0
+            or self.metadata.worker_id in lookup_server_worker_ids
+        ):
+            logger.info(
+                f"Initialize storage manager on rank {self.metadata.worker_id}, "
+                f"save only first rank: {self.save_only_first_rank}"
+            )
+            self.storage_manager = StorageManager(
+                config,
+                metadata,
+                # self.memory_allocator,
+                event_manager=self.event_manager,
+                lmcache_worker=self.lmcache_worker,
+            )
 
         # HACK: remove this in the future
         # NOTE (Jiayi): This is currently used to support
@@ -175,7 +193,8 @@ class LMCacheEngine:
         if "async_lookup_server" in kwargs:
             self.async_lookup_server = kwargs["async_lookup_server"]
         if not self.post_inited:
-            self.storage_manager.post_init(**kwargs)
+            if self.storage_manager is not None:
+                self.storage_manager.post_init(**kwargs)
             logger.info("Post-initializing LMCacheEngine")
             if self.gpu_connector is not None:
                 self.gpu_connector.initialize_kvcaches_ptr(**kwargs)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -243,9 +243,7 @@ class LMCacheEngine:
             logger.debug(f"rank={self.metadata.worker_id} ignore store")
             return
 
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
 
         if mask is not None:
             num_to_store_tokens = torch.sum(mask).item()
@@ -371,9 +369,7 @@ class LMCacheEngine:
             storage backends. In the last iteration, it puts the memory objects
             of the last layer to the storage backends.
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         assert self.gpu_connector is not None, (
             "gpu_connector is required for store_layer operation"
         )
@@ -553,6 +549,7 @@ class LMCacheEngine:
         # TODO(Jiayi): Need to refactor the `remove_after_retrieve` logic.
         for key, memory_obj, _, _ in reordered_chunks:
             if self.remove_after_retrieve and not self._is_passive():
+                assert self.storage_manager is not None
                 self.storage_manager.remove(key)
             memory_obj.ref_count_down()
 
@@ -603,9 +600,7 @@ class LMCacheEngine:
             last iteration, it moves the memory objects of the last layer to
             the GPU.
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         assert self.gpu_connector is not None, (
             "gpu_connector is required for retrieve_layer operation"
         )
@@ -752,9 +747,7 @@ class LMCacheEngine:
 
         :return: An int indicating how many prefix tokens are cached.
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
 
         if tokens is not None:
             lookup_request_id = self.stats_monitor.on_lookup_request(len(tokens))
@@ -843,9 +836,7 @@ class LMCacheEngine:
         """
         Perform cross-node move of the KV cache.
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
 
         num_tokens = self.lookup(
             tokens,
@@ -918,9 +909,7 @@ class LMCacheEngine:
         (2) sync lookup + async retrieval (e.g., disk)
         (3) async lookup + async retrieval (e.g., p2p)
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
 
         keys: list[CacheEngineKey] = []
         cum_chunk_lengths = [0]
@@ -954,9 +943,7 @@ class LMCacheEngine:
         location: str,
         event_id: str,
     ) -> int:
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         if method not in ["cachegen"]:
             logger.warning(f"Unsupported compression method: {method}.")
             return 0
@@ -1012,9 +999,7 @@ class LMCacheEngine:
         location: str,
         event_id: str,
     ) -> int:
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         if method not in ["cachegen"]:
             logger.warning(f"Unsupported decompression method: {method}.")
             return 0
@@ -1066,9 +1051,7 @@ class LMCacheEngine:
 
     @_lmcache_nvtx_annotate
     def lookup_unpin(self, lookup_id: str) -> None:
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         if lookup_id in self.lookup_pins:
             self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
             del self.lookup_pins[lookup_id]
@@ -1095,9 +1078,7 @@ class LMCacheEngine:
         locations: Optional[List[str]] = None,
         request_configs: Optional[dict] = None,
     ) -> int:
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         assert isinstance(self.storage_manager, StorageManager)
         # Clear all caches if tokens is None
         if tokens is None or len(tokens) == 0:
@@ -1122,9 +1103,7 @@ class LMCacheEngine:
         Check the health of the cache engine.
         return: 0 if healthy, otherwise the error code
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
         return 0 if self.storage_manager.memcheck() else -1
 
     def close(self) -> None:
@@ -1207,9 +1186,7 @@ class LMCacheEngine:
             ret_mask: Output mask updated with cache hit positions
             **kwargs: Additional keyword arguments
         """
-        assert self.storage_manager is not None, (
-            "storage_manager is not initialized"
-        )
+        assert self.storage_manager is not None
 
         tot_kv_size = 0
         # location -> [(CacheEngineKey, start, end)]

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -126,6 +126,10 @@ class LMCacheEngine:
         self.async_loading = config.enable_async_loading
         self.event_manager = EventManager()
 
+        self.use_layerwise = config.use_layerwise
+
+        # TODO: support save_only_first_rank when use layerwise
+        # if use_layerwise is True, all ranks will initialize the storage_manager
         # if save_only_first_rank is False, all ranks will initialize
         # the storage_manager
         # if save_only_first_rank is True, only the first rank and
@@ -135,13 +139,16 @@ class LMCacheEngine:
             metadata.use_mla, metadata.world_size
         )
         if (
-            not self.save_only_first_rank
+            self.lmcache_worker is not None
+            or self.use_layerwise
+            or not self.save_only_first_rank
             or self.metadata.is_first_rank()
             or len(lookup_server_worker_ids) == 0
             or self.metadata.worker_id in lookup_server_worker_ids
         ):
             logger.info(
                 f"Initialize storage manager on rank {self.metadata.worker_id}, "
+                f"use layerwise: {self.use_layerwise},"
                 f"save only first rank: {self.save_only_first_rank}"
             )
             self.storage_manager = StorageManager(
@@ -158,7 +165,6 @@ class LMCacheEngine:
         # at decoder.
         self.remove_after_retrieve = config.enable_pd and config.pd_role == "receiver"
 
-        self.use_layerwise = config.use_layerwise
         self.num_layers = metadata.kv_shape[0]
         self.fmt = None
         if self.use_layerwise:
@@ -236,6 +242,10 @@ class LMCacheEngine:
         if self._is_passive():
             logger.debug(f"rank={self.metadata.worker_id} ignore store")
             return
+
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
 
         if mask is not None:
             num_to_store_tokens = torch.sum(mask).item()
@@ -361,6 +371,9 @@ class LMCacheEngine:
             storage backends. In the last iteration, it puts the memory objects
             of the last layer to the storage backends.
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         assert self.gpu_connector is not None, (
             "gpu_connector is required for store_layer operation"
         )
@@ -590,6 +603,9 @@ class LMCacheEngine:
             last iteration, it moves the memory objects of the last layer to
             the GPU.
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         assert self.gpu_connector is not None, (
             "gpu_connector is required for retrieve_layer operation"
         )
@@ -736,6 +752,9 @@ class LMCacheEngine:
 
         :return: An int indicating how many prefix tokens are cached.
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
 
         if tokens is not None:
             lookup_request_id = self.stats_monitor.on_lookup_request(len(tokens))
@@ -824,6 +843,9 @@ class LMCacheEngine:
         """
         Perform cross-node move of the KV cache.
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
 
         num_tokens = self.lookup(
             tokens,
@@ -896,6 +918,9 @@ class LMCacheEngine:
         (2) sync lookup + async retrieval (e.g., disk)
         (3) async lookup + async retrieval (e.g., p2p)
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
 
         keys: list[CacheEngineKey] = []
         cum_chunk_lengths = [0]
@@ -929,6 +954,9 @@ class LMCacheEngine:
         location: str,
         event_id: str,
     ) -> int:
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         if method not in ["cachegen"]:
             logger.warning(f"Unsupported compression method: {method}.")
             return 0
@@ -984,6 +1012,9 @@ class LMCacheEngine:
         location: str,
         event_id: str,
     ) -> int:
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         if method not in ["cachegen"]:
             logger.warning(f"Unsupported decompression method: {method}.")
             return 0
@@ -1035,6 +1066,9 @@ class LMCacheEngine:
 
     @_lmcache_nvtx_annotate
     def lookup_unpin(self, lookup_id: str) -> None:
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         if lookup_id in self.lookup_pins:
             self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
             del self.lookup_pins[lookup_id]
@@ -1061,6 +1095,9 @@ class LMCacheEngine:
         locations: Optional[List[str]] = None,
         request_configs: Optional[dict] = None,
     ) -> int:
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         assert isinstance(self.storage_manager, StorageManager)
         # Clear all caches if tokens is None
         if tokens is None or len(tokens) == 0:
@@ -1085,6 +1122,9 @@ class LMCacheEngine:
         Check the health of the cache engine.
         return: 0 if healthy, otherwise the error code
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
         return 0 if self.storage_manager.memcheck() else -1
 
     def close(self) -> None:
@@ -1093,7 +1133,8 @@ class LMCacheEngine:
         if self.lmcache_worker is not None:
             self.lmcache_worker.close()
 
-        self.storage_manager.close()
+        if self.storage_manager is not None:
+            self.storage_manager.close()
 
         logger.info("LMCacheEngine closed.")
 
@@ -1166,6 +1207,9 @@ class LMCacheEngine:
             ret_mask: Output mask updated with cache hit positions
             **kwargs: Additional keyword arguments
         """
+        assert self.storage_manager is not None, (
+            "storage_manager is not initialized"
+        )
 
         tot_kv_size = 0
         # location -> [(CacheEngineKey, start, end)]

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1051,8 +1051,8 @@ class LMCacheEngine:
 
     @_lmcache_nvtx_annotate
     def lookup_unpin(self, lookup_id: str) -> None:
-        assert self.storage_manager is not None
         if lookup_id in self.lookup_pins:
+            assert self.storage_manager is not None
             self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
             del self.lookup_pins[lookup_id]
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -51,10 +51,6 @@ class RemoteBackend(StorageBackendInterface):
         self.connection: Optional[RemoteConnector] = None
         self.min_reconnect_interval = 10
         self.failure_time = -1000000.0
-        self.save_only_first_rank = (
-            self.config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
-            and metadata.use_mla
-        )
         self.init_connection()
 
         assert config.remote_serde is not None
@@ -82,15 +78,14 @@ class RemoteBackend(StorageBackendInterface):
 
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
 
-        if self.save_only_first_rank and self.metadata.is_first_rank():
-            # Create RemoteMonitor instance, which initializes the
-            # connection status and active connector dynamically
-            # First Party
-            from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
+        # Create RemoteMonitor instance, which initializes the
+        # connection status and active connector dynamically
+        # First Party
+        from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
 
-            self.remote_monitor = RemoteMonitor(self)
-            # Start the remote monitor thread (if ping is supported)
-            self.remote_monitor.start()
+        self.remote_monitor = RemoteMonitor(self)
+        # Start the remote monitor thread (if ping is supported)
+        self.remote_monitor.start()
 
         self._setup_metrics()
 
@@ -105,13 +100,6 @@ class RemoteBackend(StorageBackendInterface):
         return self.__class__.__name__
 
     def init_connection(self):
-        # If save_only_first_rank is enabled, only the first rank init the connection
-        if self.save_only_first_rank and not self.metadata.is_first_rank():
-            logger.warning(
-                f"Save only first rank is enabled, rank {self.metadata.worker_id} "
-                f"is not the first rank, no need to initialize remote connection"
-            )
-            return
         # Initialize connection
         if self.connection is not None:
             return

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -82,15 +82,15 @@ class RemoteBackend(StorageBackendInterface):
 
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
 
-        # Create RemoteMonitor instance, which initializes the
-        # connection status and active connector dynamically
-        # First Party
-        from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
+        if self.save_only_first_rank and self.metadata.is_first_rank():
+            # Create RemoteMonitor instance, which initializes the
+            # connection status and active connector dynamically
+            # First Party
+            from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
 
-        self.remote_monitor = RemoteMonitor(self)
-
-        # Start the remote monitor thread (if ping is supported)
-        self.remote_monitor.start()
+            self.remote_monitor = RemoteMonitor(self)
+            # Start the remote monitor thread (if ping is supported)
+            self.remote_monitor.start()
 
         self._setup_metrics()
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -109,7 +109,8 @@ class RemoteBackend(StorageBackendInterface):
         if self.save_only_first_rank and not self.metadata.is_first_rank():
             logger.warning(
                 f"Save only first rank is enabled, rank {self.metadata.worker_id} "
-                f"is not the first rank, no need to initialize remote connection")
+                f"is not the first rank, no need to initialize remote connection"
+            )
             return
         # Initialize connection
         if self.connection is not None:

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -84,6 +84,7 @@ class RemoteBackend(StorageBackendInterface):
         from lmcache.v1.storage_backend.remote_monitor import RemoteMonitor
 
         self.remote_monitor = RemoteMonitor(self)
+
         # Start the remote monitor thread (if ping is supported)
         self.remote_monitor.start()
 

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -51,6 +51,10 @@ class RemoteBackend(StorageBackendInterface):
         self.connection: Optional[RemoteConnector] = None
         self.min_reconnect_interval = 10
         self.failure_time = -1000000.0
+        self.save_only_first_rank = (
+            self.config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
+            and metadata.use_mla
+        )
         self.init_connection()
 
         assert config.remote_serde is not None
@@ -101,6 +105,12 @@ class RemoteBackend(StorageBackendInterface):
         return self.__class__.__name__
 
     def init_connection(self):
+        # If save_only_first_rank is enabled, only the first rank init the connection
+        if self.save_only_first_rank and not self.metadata.is_first_rank():
+            logger.warning(
+                f"Save only first rank is enabled, rank {self.metadata.worker_id} "
+                f"is not the first rank, no need to initialize remote connection")
+            return
         # Initialize connection
         if self.connection is not None:
             return


### PR DESCRIPTION
if `save_only_first_rank` is enabled, the first rank will execute put and get task, other ranks retrieve kv cache by broadcast, there is no need to init the storage manager of these ranks.
