### PR TITLE
Adds configuration validation for ports numbers mismatch

### DIFF
--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -70,6 +70,7 @@ class LMCacheWorker:
         self.lmcache_engine = lmcache_engine
         self.worker_id = metadata.worker_id
 
+        self._validate_port_configurations()
         self.context = get_zmq_context()
 
         assert config.controller_pull_url is not None
@@ -124,6 +125,31 @@ class LMCacheWorker:
 
         self.register()
 
+    def _validate_port_configurations(self):
+        """Validate that port configurations have enough ports for the worker_id"""
+        required_ports = (
+            self.worker_id + 1
+        )  # worker_id starts from 0, so need worker_id+1 ports
+
+        # Check all port configurations
+        port_configs = [
+            ("lmcache_worker_ports", self.config.lmcache_worker_ports),
+            ("p2p_init_ports", self.config.p2p_init_ports),
+            ("p2p_lookup_ports", self.config.p2p_lookup_ports),
+        ]
+
+        errors = []
+        for config_name, ports in port_configs:
+            if len(ports) < required_ports:
+                errors.append(
+                    f"• {config_name}: {len(ports)} port(s) configured, "
+                    f"but {required_ports} are required for worker {self.worker_id}"
+                )
+
+        if errors:
+            error_msg = "Port Configuration Errors:\n\n" + "\n".join(errors)
+            raise ValueError(error_msg)
+        
     def register(self):
         """
         Register the lmcache worker with the controller.

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -134,13 +134,20 @@ class LMCacheWorker:
         # Check all port configurations
         port_configs = [
             ("lmcache_worker_ports", self.config.lmcache_worker_ports),
-            ("p2p_init_ports", self.config.p2p_init_ports),
-            ("p2p_lookup_ports", self.config.p2p_lookup_ports),
         ]
+        if self.config.enable_p2p:
+            port_configs.extend(
+                [
+                    ("p2p_init_ports", self.config.p2p_init_ports),
+                    ("p2p_lookup_ports", self.config.p2p_lookup_ports),
+                ]
+            )
 
         errors = []
         for config_name, ports in port_configs:
-            if len(ports) < required_ports:
+            if ports is None:
+                errors.append(f"• {config_name}: is not configured but required.")
+            elif len(ports) < required_ports:
                 errors.append(
                     f"• {config_name}: {len(ports)} port(s) configured, "
                     f"but {required_ports} are required for worker {self.worker_id}"

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -149,7 +149,7 @@ class LMCacheWorker:
         if errors:
             error_msg = "Port Configuration Errors:\n\n" + "\n".join(errors)
             raise ValueError(error_msg)
-        
+
     def register(self):
         """
         Register the lmcache worker with the controller.


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Motivated by https://github.com/LMCache/LMCache/issues/1966#issue-3599840601.  

**Issue**: When tensor_parallel_size is larger than the number of configured ports in the YAML file, workers accessing port lists by index would encounter IndexError without clear guidance. This PR adds configuration validation to provide clear error messages instead of cryptic IndexError, 


