### PR TITLE
[Core][Test] DMA-aware storage backends initialization and automatic LocalCPUBackend staging 

### DIFF
--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -213,6 +213,18 @@ def CreateStorageBackends(
             storage_backends,
         )
 
+    non_dma_backend_names = [
+        name
+        for name, backend in storage_backends.items()
+        if name != "LocalCPUBackend" and not backend.is_using_dma()
+    ]
+
+    if metadata.role != "scheduler" and non_dma_backend_names:
+        assert config.max_local_cpu_size > 0, (
+            "max_local_cpu_size must be greater than 0 "
+            f"because backends {non_dma_backend_names} require CPU memory"
+        )
+
     # Only wrap if audit is enabled in config
     if config.extra_config is not None and config.extra_config.get(
         "audit_backend_enabled", False

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -132,8 +132,9 @@ def CreateStorageBackends(
         storage_backends["PDBackend"] = PDBackend(config, metadata)
 
     # TODO(Jiayi): The hierarchy is fixed for now
-    # NOTE(Jiayi): The local_cpu backend is always created because
-    # other backends might need it as a buffer.
+    # NOTE(Dongjoo): The local_cpu backend is created when:
+    # 1. config.local_cpu=True (explicitly enabled as hot cache)
+    # 2. Other backends need it as staging buffer
     local_cpu_backend: Optional[LocalCPUBackend] = None
     if metadata.role == "scheduler":
         # For scheduler role, local_cpu_backend is None
@@ -148,6 +149,13 @@ def CreateStorageBackends(
             )
             backend_name = str(local_cpu_backend)
             storage_backends[backend_name] = local_cpu_backend
+        elif config.local_cpu:
+            # User explicitly enabled local_cpu but set size to 0
+            raise ValueError(
+                f"config.local_cpu is True but max_local_cpu_size is "
+                f"{config.max_local_cpu_size}. Please set max_local_cpu_size > 0 "
+                f"or disable local_cpu."
+            )
         else:
             logger.info("No cpu memory is allocated as max_local_cpu_size <= 0")
 
@@ -213,17 +221,32 @@ def CreateStorageBackends(
             storage_backends,
         )
 
-    non_dma_backend_names = [
+    # ========== Backend Configuration Validation ==========
+    # Ensure backends that require CPU staging have LocalCPUBackend available
+    backends_requiring_cpu = [
         name
         for name, backend in storage_backends.items()
-        if name != "LocalCPUBackend" and not backend.is_using_dma()
+        if not isinstance(backend, LocalCPUBackend)
+        and backend.requires_local_cpu_staging()
     ]
 
-    if metadata.role != "scheduler" and non_dma_backend_names:
-        assert config.max_local_cpu_size > 0, (
-            "max_local_cpu_size must be greater than 0 "
-            f"because backends {non_dma_backend_names} require CPU memory"
-        )
+    if metadata.role != "scheduler" and backends_requiring_cpu:
+        if "LocalCPUBackend" not in storage_backends:
+            logger.warning(
+                f"Backends {backends_requiring_cpu} require CPU memory for staging, "
+                f"but LocalCPUBackend is not configured. "
+                f"Auto-adjusting max_local_cpu_size to 5 GB. "
+                f"Please explicitly set max_local_cpu_size > 0 in your configuration."
+            )
+            config.max_local_cpu_size = 5
+            local_cpu_backend = LocalCPUBackend(
+                config,
+                metadata,
+                dst_device,
+                lmcache_worker,
+            )
+            backend_name = str(local_cpu_backend)
+            storage_backends[backend_name] = local_cpu_backend
 
     # Only wrap if audit is enabled in config
     if config.extra_config is not None and config.extra_config.get(

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -43,11 +43,15 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
 
         self.dst_device = dst_device
 
-    def is_using_dma(self) -> bool:
+    def requires_local_cpu_staging(self) -> bool:
         """
-        Indicates whether this backend avoids staging through host (CPU) memory.
+        Indicates whether this backend requires staging through LocalCPUBackend.
+
+        Returns:
+            True if this backend needs LocalCPUBackend for data transfer staging.
+            False if this backend can directly access storage (e.g., via DMA).
         """
-        return False
+        return True
 
     @abc.abstractmethod
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -43,6 +43,12 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
 
         self.dst_device = dst_device
 
+    def is_using_dma(self) -> bool:
+        """
+        Indicates whether this backend avoids staging through host (CPU) memory.
+        """
+        return False
+
     @abc.abstractmethod
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         """

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -197,6 +197,9 @@ class GdsBackend(AllocatorBackendInterface):
         self.gds_path = config.gds_path
         self.fstype = get_fstype(config.gds_path)
 
+    def is_using_dma(self) -> bool:
+        return True
+
         # Log the fstype - this is useful in reports and varying optimizations
         # based on the kind of fstype used.
         logger.info(

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -359,8 +359,8 @@ class GdsBackend(AllocatorBackendInterface):
     def __str__(self):
         return self.__class__.__name__
 
-    def is_using_dma(self) -> bool:
-        return True
+    def requires_local_cpu_staging(self) -> bool:
+        return False
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         # TODO: implement pin() semantics

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -197,9 +197,6 @@ class GdsBackend(AllocatorBackendInterface):
         self.gds_path = config.gds_path
         self.fstype = get_fstype(config.gds_path)
 
-    def is_using_dma(self) -> bool:
-        return True
-
         # Log the fstype - this is useful in reports and varying optimizations
         # based on the kind of fstype used.
         logger.info(
@@ -361,6 +358,9 @@ class GdsBackend(AllocatorBackendInterface):
 
     def __str__(self):
         return self.__class__.__name__
+
+    def is_using_dma(self) -> bool:
+        return True
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         # TODO: implement pin() semantics

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -89,7 +89,10 @@ class LocalDiskWorker:
         if self._closed:
             return
         self._closed = True
-        self.executor.shutdown(wait=True)
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            self.executor.shutdown(wait=False)
+        else:
+            self.executor.shutdown(wait=True)
 
 
 class LocalDiskBackend(StorageBackendInterface):

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -168,8 +168,8 @@ class P2PBackend(StorageBackendInterface):
     def __str__(self) -> str:
         return "P2PBackend"
 
-    def is_using_dma(self) -> bool:
-        return True
+    def requires_local_cpu_staging(self) -> bool:
+        return False
 
     async def batched_async_contains(
         self,

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -168,6 +168,9 @@ class P2PBackend(StorageBackendInterface):
     def __str__(self) -> str:
         return "P2PBackend"
 
+    def is_using_dma(self) -> bool:
+        return True
+
     async def batched_async_contains(
         self,
         lookup_id: str,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -226,10 +226,7 @@ class StorageManager:
         self.allocator_backend = None
         if metadata.role != "scheduler":
             self.allocator_backend = self._get_allocator_backend(config)
-        if config.local_cpu and self.local_cpu_backend is None:
-            raise AssertionError(
-                "Local CPU backend is required but missing from storage backends"
-            )
+        # Note: Backend validation is done in CreateStorageBackends
 
         self.manager_lock = threading.Lock()
 
@@ -290,29 +287,43 @@ class StorageManager:
     def _get_allocator_backend(
         self, config: LMCacheEngineConfig
     ) -> AllocatorBackendInterface:
+        """
+        Select an allocator backend with priority:
+        1. PDBackend if enabled
+        2. LocalCPUBackend if available and configured
+        3. Any other AllocatorBackendInterface implementation
+        """
         if self.enable_pd:
             backend = self.storage_backends["PDBackend"]
             assert isinstance(backend, AllocatorBackendInterface)
             return backend
 
-        allocator_backend: Optional[AllocatorBackendInterface] = None
-        local_backend = self.local_cpu_backend
-        if (
-            local_backend is not None
-            and config.max_local_cpu_size > 0
-            and isinstance(local_backend, AllocatorBackendInterface)
-        ):
-            allocator_backend = local_backend
-        else:
-            for backend in self.storage_backends.values():
-                if backend is local_backend:
-                    continue
-                if isinstance(backend, AllocatorBackendInterface):
-                    allocator_backend = backend
-                    break
-        if allocator_backend is None:
-            raise AssertionError("No allocator-capable backend available")
-        return allocator_backend
+        # Build priority list of allocator candidates
+        candidates: list[Optional[AllocatorBackendInterface]] = [
+            (
+                self.local_cpu_backend
+                if isinstance(self.local_cpu_backend, AllocatorBackendInterface)
+                else None
+            )
+        ]
+
+        # Add other allocator backends (excluding LocalCPUBackend)
+        for backend in self.storage_backends.values():
+            if backend != self.local_cpu_backend and isinstance(
+                backend, AllocatorBackendInterface
+            ):
+                candidates.append(backend)
+
+        # Return first available allocator
+        for candidate in candidates:
+            if candidate is not None:
+                return candidate
+
+        raise RuntimeError(
+            "No allocator-capable backend available. "
+            "Please configure at least one backend that implements "
+            "AllocatorBackendInterface."
+        )
 
     @_lmcache_nvtx_annotate
     def allocate(
@@ -442,11 +453,16 @@ class StorageManager:
             memory_obj = backend.get_blocking(key)
             if memory_obj:
                 local_cpu_backend = self.local_cpu_backend
-                if (
-                    backend_name not in ["LocalCPUBackend", "PDBackend"]
-                    and local_cpu_backend is not None
-                ):
-                    local_cpu_backend.submit_put_task(key, memory_obj)
+                # Write-back to LocalCPUBackend for performance optimization
+                if backend_name not in ["LocalCPUBackend", "PDBackend"]:
+                    if local_cpu_backend is not None:
+                        local_cpu_backend.submit_put_task(key, memory_obj)
+                    elif backend.requires_local_cpu_staging():
+                        logger.warning(
+                            f"Backend {backend_name} requires CPU staging but "
+                            f"LocalCPUBackend is not available. This may indicate "
+                            f"a configuration issue."
+                        )
                 return memory_obj
 
         return None

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -216,11 +216,20 @@ class StorageManager:
 
         self.enable_pd = config.enable_pd
 
+        local_cpu_backend = self.storage_backends.get("LocalCPUBackend")
+        self.local_cpu_backend = (
+            local_cpu_backend
+            if isinstance(local_cpu_backend, LocalCPUBackend)
+            else None
+        )
+
         self.allocator_backend = None
         if metadata.role != "scheduler":
             self.allocator_backend = self._get_allocator_backend(config)
-        if config.local_cpu:
-            self.local_cpu_backend = self.storage_backends["LocalCPUBackend"]
+        if config.local_cpu and self.local_cpu_backend is None:
+            raise AssertionError(
+                "Local CPU backend is required but missing from storage backends"
+            )
 
         self.manager_lock = threading.Lock()
 
@@ -282,10 +291,27 @@ class StorageManager:
         self, config: LMCacheEngineConfig
     ) -> AllocatorBackendInterface:
         if self.enable_pd:
-            allocator_backend = self.storage_backends["PDBackend"]
+            backend = self.storage_backends["PDBackend"]
+            assert isinstance(backend, AllocatorBackendInterface)
+            return backend
+
+        allocator_backend: Optional[AllocatorBackendInterface] = None
+        local_backend = self.local_cpu_backend
+        if (
+            local_backend is not None
+            and config.max_local_cpu_size > 0
+            and isinstance(local_backend, AllocatorBackendInterface)
+        ):
+            allocator_backend = local_backend
         else:
-            allocator_backend = self.storage_backends["LocalCPUBackend"]
-        assert isinstance(allocator_backend, AllocatorBackendInterface)
+            for backend in self.storage_backends.values():
+                if backend is local_backend:
+                    continue
+                if isinstance(backend, AllocatorBackendInterface):
+                    allocator_backend = backend
+                    break
+        if allocator_backend is None:
+            raise AssertionError("No allocator-capable backend available")
         return allocator_backend
 
     @_lmcache_nvtx_annotate
@@ -415,12 +441,11 @@ class StorageManager:
             # are allocated by the allocator backend.
             memory_obj = backend.get_blocking(key)
             if memory_obj:
+                local_cpu_backend = self.local_cpu_backend
                 if (
                     backend_name not in ["LocalCPUBackend", "PDBackend"]
-                    and "LocalCPUBackend" in self.storage_backends
+                    and local_cpu_backend is not None
                 ):
-                    local_cpu_backend = self.storage_backends["LocalCPUBackend"]
-                    assert isinstance(local_cpu_backend, LocalCPUBackend)
                     local_cpu_backend.submit_put_task(key, memory_obj)
                 return memory_obj
 

--- a/lmcache/v1/storage_backend/weka_gds_backend.py
+++ b/lmcache/v1/storage_backend/weka_gds_backend.py
@@ -169,8 +169,8 @@ class WekaGdsBackend(AllocatorBackendInterface):
         asyncio.run_coroutine_threadsafe(self._scan_metadata(), self.loop)
         self.save_metadata_tasks: set[asyncio.Task] = set()
 
-    def is_using_dma(self) -> bool:
-        return True
+    def requires_local_cpu_staging(self) -> bool:
+        return False
 
     async def _scan_metadata(self):
         # TODO(Serapheim): even though we only run it once on startup,

--- a/lmcache/v1/storage_backend/weka_gds_backend.py
+++ b/lmcache/v1/storage_backend/weka_gds_backend.py
@@ -169,6 +169,9 @@ class WekaGdsBackend(AllocatorBackendInterface):
         asyncio.run_coroutine_threadsafe(self._scan_metadata(), self.loop)
         self.save_metadata_tasks: set[asyncio.Task] = set()
 
+    def is_using_dma(self) -> bool:
+        return True
+
     async def _scan_metadata(self):
         # TODO(Serapheim): even though we only run it once on startup,
         # this is still not super scalable maybe we need to add metadata

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -504,6 +504,7 @@ def _build_dynamic_backend_config(
 
 
 def test_create_storage_backends_requires_cpu_for_non_dma():
+    """Test that non-DMA backends auto-adjust CPU memory allocation."""
     config = _build_dynamic_backend_config(
         backend_name="NonDma",
         class_name="NonDmaTestBackend",
@@ -514,15 +515,21 @@ def test_create_storage_backends_requires_cpu_for_non_dma():
     metadata.role = "worker"
     loop = asyncio.new_event_loop()
     try:
-        with pytest.raises(AssertionError) as exc_info:
-            CreateStorageBackends(config, metadata, loop)
-        msg = str(exc_info.value)
-        assert "Local CPU cache is disabled" in msg or "max_local_cpu_size" in msg
+        # Should auto-adjust and succeed (no crash)
+        storage_backends = CreateStorageBackends(config, metadata, loop)
+        # Check that config was adjusted
+        assert config.max_local_cpu_size == 5
+        # Check that LocalCPUBackend was created
+        assert "LocalCPUBackend" in storage_backends
+        # Clean up
+        for backend in storage_backends.values():
+            backend.close()
     finally:
         loop.close()
 
 
 def test_create_storage_backends_all_dma_skip_cpu_backend():
+    """Test that DMA-only backends don't require LocalCPUBackend."""
     config = _build_dynamic_backend_config(
         backend_name="DmaOnly",
         class_name="DmaTestBackend",
@@ -535,6 +542,103 @@ def test_create_storage_backends_all_dma_skip_cpu_backend():
     try:
         storage_backends = CreateStorageBackends(config, metadata, loop)
         assert "LocalCPUBackend" not in storage_backends
-        assert storage_backends["DmaOnly"].is_using_dma()
+        assert not storage_backends["DmaOnly"].requires_local_cpu_staging()
+        # Clean up
+        for backend in storage_backends.values():
+            backend.close()
+    finally:
+        loop.close()
+
+
+def test_create_storage_backends_mixed_dma_and_non_dma():
+    """Test mixed DMA and non-DMA backends together."""
+    config = LMCacheEngineConfig.from_defaults()
+    config.local_cpu = False
+    config.max_local_cpu_size = 0.0
+    config.external_backends = ["DmaBackend", "NonDmaBackend"]
+    config.extra_config = {
+        "external_backend.DmaBackend.module_path": "tests.v1.utils",
+        "external_backend.DmaBackend.class_name": "DmaTestBackend",
+        "external_backend.NonDmaBackend.module_path": "tests.v1.utils",
+        "external_backend.NonDmaBackend.class_name": "NonDmaTestBackend",
+    }
+    metadata = dumb_metadata()
+    metadata.role = "worker"
+    loop = asyncio.new_event_loop()
+    try:
+        # Should auto-create LocalCPUBackend for NonDmaBackend
+        storage_backends = CreateStorageBackends(config, metadata, loop)
+        assert "LocalCPUBackend" in storage_backends
+        assert "DmaBackend" in storage_backends
+        assert "NonDmaBackend" in storage_backends
+        assert config.max_local_cpu_size == 5  # Auto-adjusted
+        # Clean up
+        for backend in storage_backends.values():
+            backend.close()
+    finally:
+        loop.close()
+
+
+def test_create_storage_backends_with_local_disk():
+    """Test LocalDiskBackend requires CPU staging."""
+    config = LMCacheEngineConfig.from_defaults()
+    config.local_cpu = True
+    config.local_disk = True
+    config.max_local_disk_size = 1.0
+    config.max_local_cpu_size = 0.1
+    metadata = dumb_metadata()
+    metadata.role = "worker"
+    loop = asyncio.new_event_loop()
+    try:
+        # LocalDiskBackend requires CPU staging, should auto-create LocalCPUBackend
+        storage_backends = CreateStorageBackends(config, metadata, loop)
+        assert "LocalCPUBackend" in storage_backends
+        assert "LocalDiskBackend" in storage_backends
+        # Verify LocalDiskBackend requires staging
+        assert storage_backends["LocalDiskBackend"].requires_local_cpu_staging()
+        # Clean up
+        for backend in storage_backends.values():
+            backend.close()
+    finally:
+        loop.close()
+
+
+def test_create_storage_backends_scheduler_role():
+    """Test that scheduler role doesn't validate CPU requirements."""
+    config = _build_dynamic_backend_config(
+        backend_name="NonDma",
+        class_name="NonDmaTestBackend",
+        local_cpu=False,
+        max_local_cpu_size=0.0,
+    )
+    metadata = dumb_metadata()
+    metadata.role = "scheduler"  # Scheduler role
+    loop = asyncio.new_event_loop()
+    try:
+        # Should succeed without creating LocalCPUBackend
+        storage_backends = CreateStorageBackends(config, metadata, loop)
+        # Scheduler doesn't need LocalCPUBackend even with non-DMA backends
+        assert config.max_local_cpu_size == 0.0  # Not auto-adjusted
+        # Clean up
+        for backend in storage_backends.values():
+            backend.close()
+    finally:
+        loop.close()
+
+
+def test_create_storage_backends_explicit_local_cpu_zero_size():
+    """Test that explicitly enabling local_cpu with zero size raises error."""
+    config = LMCacheEngineConfig.from_defaults()
+    config.local_cpu = True  # Explicitly enabled
+    config.max_local_cpu_size = 0.0  # But zero size
+    metadata = dumb_metadata()
+    metadata.role = "worker"
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            CreateStorageBackends(config, metadata, loop)
+        msg = str(exc_info.value)
+        assert "config.local_cpu is True" in msg
+        assert "max_local_cpu_size" in msg
     finally:
         loop.close()

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import asyncio
 import threading
 
 # Third Party
@@ -9,13 +10,16 @@ import torch
 # First Party
 from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
+from lmcache.v1.cache_controller.message import KVAdmitMsg, KVEvictMsg
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
     AdHocMemoryAllocator,
     MemoryFormat,
     MemoryObj,
 )
+from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from tests.v1.utils import dumb_metadata
 
 
 class MockLookupServer:
@@ -321,8 +325,6 @@ class TestLocalCPUBackend:
 
         # Check that evict message was sent
         assert len(lmcache_worker.messages) == 2  # 1 admit + 1 evict
-        # First Party
-        from lmcache.v1.cache_controller.message import KVAdmitMsg, KVEvictMsg
 
         assert any(isinstance(msg, KVAdmitMsg) for msg in lmcache_worker.messages)
         assert any(isinstance(msg, KVEvictMsg) for msg in lmcache_worker.messages)
@@ -485,3 +487,54 @@ class TestLocalCPUBackend:
         local_cpu_backend.remove(key)
         assert memory_obj.get_ref_count() == initial_ref_count + 1
         local_cpu_backend.memory_allocator.close()
+
+
+def _build_dynamic_backend_config(
+    backend_name: str, class_name: str, *, local_cpu: bool, max_local_cpu_size: float
+) -> LMCacheEngineConfig:
+    config = LMCacheEngineConfig.from_defaults()
+    config.local_cpu = local_cpu
+    config.max_local_cpu_size = max_local_cpu_size
+    config.external_backends = [backend_name]
+    config.extra_config = {
+        f"external_backend.{backend_name}.module_path": "tests.v1.utils",
+        f"external_backend.{backend_name}.class_name": class_name,
+    }
+    return config
+
+
+def test_create_storage_backends_requires_cpu_for_non_dma():
+    config = _build_dynamic_backend_config(
+        backend_name="NonDma",
+        class_name="NonDmaTestBackend",
+        local_cpu=False,
+        max_local_cpu_size=0.0,
+    )
+    metadata = dumb_metadata()
+    metadata.role = "worker"
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(AssertionError) as exc_info:
+            CreateStorageBackends(config, metadata, loop)
+        msg = str(exc_info.value)
+        assert "Local CPU cache is disabled" in msg or "max_local_cpu_size" in msg
+    finally:
+        loop.close()
+
+
+def test_create_storage_backends_all_dma_skip_cpu_backend():
+    config = _build_dynamic_backend_config(
+        backend_name="DmaOnly",
+        class_name="DmaTestBackend",
+        local_cpu=False,
+        max_local_cpu_size=0.0,
+    )
+    metadata = dumb_metadata()
+    metadata.role = "worker"
+    loop = asyncio.new_event_loop()
+    try:
+        storage_backends = CreateStorageBackends(config, metadata, loop)
+        assert "LocalCPUBackend" not in storage_backends
+        assert storage_backends["DmaOnly"].is_using_dma()
+    finally:
+        loop.close()

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from typing import List, Optional, Sequence
 import asyncio
 import random
 import string
@@ -12,6 +13,8 @@ import torch
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 
 
 def recover_engine_states(engine):
@@ -307,3 +310,94 @@ class DummyLMCacheAsyncLookupServer:
         retrieved_length: int,
     ) -> None:
         pass
+
+
+class _BaseTestStorageBackend(StorageBackendInterface):
+    def __init__(
+        self,
+        config=None,
+        metadata=None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        local_cpu_backend=None,
+        dst_device: str = "cpu",
+    ):
+        super().__init__(dst_device=dst_device)
+        self.config = config
+        self.metadata = metadata
+        self.loop = loop
+        self.local_cpu_backend = local_cpu_backend
+
+    def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:  # noqa: ARG002
+        return False
+
+    def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:  # noqa: ARG002
+        return False
+
+    def batched_submit_put_task(
+        self,
+        keys: Sequence[CacheEngineKey],  # noqa: ARG002
+        objs: List[MemoryObj],  # noqa: ARG002
+        transfer_spec=None,  # noqa: ARG002
+    ):
+        return None
+
+    async def async_batched_submit_put_task(
+        self,
+        keys: Sequence[CacheEngineKey],  # noqa: ARG002
+        objs: List[MemoryObj],  # noqa: ARG002
+        transfer_spec=None,  # noqa: ARG002
+    ) -> None:
+        return None
+
+    def get_blocking(
+        self,
+        key: CacheEngineKey,  # noqa: ARG002
+    ) -> Optional[MemoryObj]:
+        return None
+
+    def get_non_blocking(
+        self,
+        key: CacheEngineKey,  # noqa: ARG002
+        location: Optional[str] = None,  # noqa: ARG002
+    ):
+        return None
+
+    async def batched_async_contains(
+        self,
+        lookup_id: str,  # noqa: ARG002
+        keys: List[CacheEngineKey],  # noqa: ARG002
+        pin: bool = False,  # noqa: ARG002
+    ) -> int:
+        return 0
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,  # noqa: ARG002
+        keys: list[CacheEngineKey],  # noqa: ARG002
+        transfer_spec=None,  # noqa: ARG002
+    ) -> list[MemoryObj]:
+        return []
+
+    def pin(self, key: CacheEngineKey) -> bool:  # noqa: ARG002
+        return False
+
+    def unpin(self, key: CacheEngineKey) -> bool:  # noqa: ARG002
+        return False
+
+    def remove(self, key: CacheEngineKey, force: bool = True) -> bool:  # noqa: ARG002
+        return False
+
+    def get_allocator_backend(self):
+        raise NotImplementedError("Test backend does not expose an allocator")
+
+    def close(self) -> None:
+        return None
+
+
+class NonDmaTestBackend(_BaseTestStorageBackend):
+    pass
+
+
+class DmaTestBackend(_BaseTestStorageBackend):
+    def is_using_dma(self) -> bool:
+        return True

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -399,5 +399,5 @@ class NonDmaTestBackend(_BaseTestStorageBackend):
 
 
 class DmaTestBackend(_BaseTestStorageBackend):
-    def is_using_dma(self) -> bool:
-        return True
+    def requires_local_cpu_staging(self) -> bool:
+        return False


### PR DESCRIPTION
Motivated from #1924,
- Today, LocalCPUBackend plays two roles:
1. a hot cache when config.local_cpu is enabled
2. a staging buffer for backends that cannot move data directly btw GPU and storage.

However, Some backends(e.g., GDS / P2P / Weka GDS) do not need CPU staging because they can DMA directly to/from storage.
Other backends do need CPU staging, and LMCache previously asserted that max_local_cpu_size >0 for these configurations, failing fast.

This PR makes "requires CPU staging" an explicit capability of each backend and uses it to
- avoid creating LocalCPUBackend when it is not needed.
- auto-configure a safe default CPU staging buffer when a configuration would otherwise fail.
- Provide clearer validation and logging around misconfigurations.

I added test for each case but need more test in real use case.