### PR TITLE
[feature] reduce redundant lookup [2/3]: use key to locate mem obj in async loading

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1220,33 +1220,39 @@ class LMCacheEngine:
         future = self.event_manager.pop_event(EventType.LOADING, kwargs["req_id"])
 
         try:
-            memory_objs = future.result()
-            memory_objs = [mm for m in memory_objs for mm in m]
+            keyed_memory_objs = future.result()
+            memory_obj_map: dict[CacheEngineKey, MemoryObj] = {}
         except Exception as e:
             logger.error(f"Error popping event for request {kwargs['req_id']}: {e}")
             return [], 0
+        
+        for backend_results in keyed_memory_objs:
+            for key, memory_obj in backend_results:
+                memory_obj_map[key] = memory_obj
 
-        # NOTE(Jiayi): here we assume the retrieved memory_objs have
-        # the same order as the lookup order.
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
-        used_indices = set()
+        used_keys: set[CacheEngineKey] = set()
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
             request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)
-            idx = start // self.config.chunk_size
-            memory_obj = memory_objs[idx]
+            memory_obj = memory_obj_map.get(key)
+            if memory_obj is None:
+                # returned chunks are expected to be contiguous.
+                # break at the first missing chunk.
+                break
             chunks.append((key, memory_obj, start, end))
             tot_kv_size += memory_obj.get_size()
             ret_mask[start:end] = True
-            used_indices.add(idx)
+            used_keys.add(key)
 
         # NOTE: free the memory objects that are not hit.
-        for idx, unused_mem_obj in enumerate(memory_objs):
-            if idx not in used_indices:
-                unused_mem_obj.ref_count_down()
+        for backend_results in keyed_memory_objs:
+            for key, unused_mem_obj in backend_results:
+                if key not in used_keys:
+                    unused_mem_obj.ref_count_down()
 
         return chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1219,7 +1219,9 @@ class LMCacheEngine:
         chunks: List[ProcessedChunk] = []
         future = self.event_manager.pop_event(EventType.LOADING, kwargs["req_id"])
 
-        try:
+        # As mentioned in async_lookup_and_prefetch(), the future.result()
+        # is key data pair for each chunk in each tier. So extract the key
+        # and memory object pairs to memory_obj_map        try:
             keyed_memory_objs = future.result()
             memory_obj_map: dict[CacheEngineKey, MemoryObj] = {}
         except Exception as e:
@@ -1249,9 +1251,9 @@ class LMCacheEngine:
             used_keys.add(key)
 
         # NOTE: free the memory objects that are not hit.
-        for key, unused_mem_obj in memory_obj_map.items():
+        for key, mem_obj in memory_obj_map.items():
             if key not in used_keys:
-                unused_mem_obj.ref_count_down()
+                mem_obj.ref_count_down()
 
         return chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1249,10 +1249,9 @@ class LMCacheEngine:
             used_keys.add(key)
 
         # NOTE: free the memory objects that are not hit.
-        for backend_results in keyed_memory_objs:
-            for key, unused_mem_obj in backend_results:
-                if key not in used_keys:
-                    unused_mem_obj.ref_count_down()
+        for key, unused_mem_obj in memory_obj_map.items():
+            if key not in used_keys:
+                unused_mem_obj.ref_count_down()
 
         return chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1221,13 +1221,14 @@ class LMCacheEngine:
 
         # As mentioned in async_lookup_and_prefetch(), the future.result()
         # is key data pair for each chunk in each tier. So extract the key
-        # and memory object pairs to memory_obj_map        try:
+        # and memory object pairs to memory_obj_map
+        try:
             keyed_memory_objs = future.result()
             memory_obj_map: dict[CacheEngineKey, MemoryObj] = {}
         except Exception as e:
             logger.error(f"Error popping event for request {kwargs['req_id']}: {e}")
             return [], 0
-        
+
         for backend_results in keyed_memory_objs:
             for key, memory_obj in backend_results:
                 memory_obj_map[key] = memory_obj

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -659,11 +659,8 @@ class StorageManager:
         #     cum_chunk_lengths_total[2] = 512 tokens
         cum_chunk_lengths_total = cum_chunk_lengths[:]
         loading_tasks = []
-<<<<<<< HEAD
         tier_expected_chunks = []
-=======
         loading_task_keys: list[list[CacheEngineKey]] = []
->>>>>>> 4c57cb6 (locate mem obj by key instead of index in async loading)
         for backend_name, backend in self.storage_backends.items():
             if search_range and backend_name not in search_range:
                 continue

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -659,7 +659,11 @@ class StorageManager:
         #     cum_chunk_lengths_total[2] = 512 tokens
         cum_chunk_lengths_total = cum_chunk_lengths[:]
         loading_tasks = []
+<<<<<<< HEAD
         tier_expected_chunks = []
+=======
+        loading_task_keys: list[list[CacheEngineKey]] = []
+>>>>>>> 4c57cb6 (locate mem obj by key instead of index in async loading)
         for backend_name, backend in self.storage_backends.items():
             if search_range and backend_name not in search_range:
                 continue
@@ -671,6 +675,9 @@ class StorageManager:
             num_total_hit_chunks += num_hit_chunks
             tier_expected_chunks.append(num_hit_chunks)
 
+            backend_keys = keys[:num_hit_chunks]
+            loading_task_keys.append(backend_keys)
+
             assert self.async_serializer is not None, (
                 "Async serializer must be initialized via post_init before using "
                 "async_lookup_and_prefetch."
@@ -679,7 +686,7 @@ class StorageManager:
             get_coro = self.async_serializer.run(
                 backend.batched_get_non_blocking(
                     lookup_id,
-                    keys[:num_hit_chunks],
+                    backend_keys,
                     {"cum_chunk_lengths": cum_chunk_lengths[: num_hit_chunks + 1]},
                 ),
                 num_hit_chunks,
@@ -707,7 +714,14 @@ class StorageManager:
                 self.async_lookup_server.send_response_to_scheduler(lookup_id, 0)
             return
 
-        all_done = asyncio.gather(*loading_tasks)
+        async def gather_with_keys() -> list[list[tuple[CacheEngineKey, MemoryObj]]]:
+            loading_results = await asyncio.gather(*loading_tasks)
+            return [
+                list(zip(keys, results))
+                for keys, results in zip(loading_task_keys, loading_results)
+            ]
+
+        all_done = asyncio.create_task(gather_with_keys())
         # Register the event before adding the callback to avoid race conditions
         self.event_manager.add_event(
             EventType.LOADING,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -660,6 +660,7 @@ class StorageManager:
         cum_chunk_lengths_total = cum_chunk_lengths[:]
         loading_tasks = []
         tier_expected_chunks = []
+        # we also keep track of the keys for each tier and each chunk
         loading_task_keys: list[list[CacheEngineKey]] = []
         for backend_name, backend in self.storage_backends.items():
             if search_range and backend_name not in search_range:
@@ -711,6 +712,15 @@ class StorageManager:
                 self.async_lookup_server.send_response_to_scheduler(lookup_id, 0)
             return
 
+        # gather_with_keys() here make a pair of (key, memory_obj) for each chunk
+        # in each tier. The all_done result's layout is like following and
+        # will be processed in _async_process_tokens_internal()
+        # Tier 0:
+        #  Tuple(loading_task_keys[0][0] : MemoryObj0)
+        #  Tuple(loading_task_keys[0][1] : MemoryObj1)
+        # Tier 1:
+        #  Tuple(loading_task_keys[1][0] : MemoryObj2)
+        #  Tuple(loading_task_keys[1][1] : MemoryObj3)
         async def gather_with_keys() -> list[list[tuple[CacheEngineKey, MemoryObj]]]:
             loading_results = await asyncio.gather(*loading_tasks)
             return [

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -717,8 +717,10 @@ class StorageManager:
         async def gather_with_keys() -> list[list[tuple[CacheEngineKey, MemoryObj]]]:
             loading_results = await asyncio.gather(*loading_tasks)
             return [
-                list(zip(keys, results))
-                for keys, results in zip(loading_task_keys, loading_results)
+                list(zip(keys, results, strict=False))
+                for keys, results in zip(
+                    loading_task_keys, loading_results, strict=False
+                )
             ]
 
         all_done = asyncio.create_task(gather_with_keys())


### PR DESCRIPTION
**Why**
As decribed in comment https://github.com/LMCache/LMCache/pull/1867#issuecomment-3444784949. 
In current `_async_process_tokens_internal`, prefetched memory objects were only returned as an index-ordered list, making it impossible for downstream consumers to reconcile those buffers with their originating cache keys when merging data from other sources, e.g. GPU cache.
Aligning the async path with the synchronous lookup flow lets the storage manager remain the single authority over prefetched memory, preventing mismatches and simplifying future feature work.

**What**
Captured the CacheEngineKey for every async prefetch request and propagated those keys alongside the fetched memory objects so callers can map results deterministically.