### PR TITLE
Refactor Async Lookup Client Message

### DIFF
--- a/lmcache/v1/lookup_client/async_lookup_message.py
+++ b/lmcache/v1/lookup_client/async_lookup_message.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Dict, Optional
+
+# Third Party
+import msgspec
+
+
+class AsyncLookupMsg(msgspec.Struct, tag=True):  # type: ignore
+    """Base class for async lookup messages"""
+
+    def describe(self) -> str:
+        return ""
+
+
+class LookupRequestMsg(AsyncLookupMsg):
+    """Async lookup request message from scheduler to worker"""
+
+    lookup_id: str
+    hashes: list[int]
+    offsets: list[int]
+    request_configs: Optional[Dict[str, str]] = None
+
+    def describe(self) -> str:
+        return (
+            f"Async lookup request for lookup_id={self.lookup_id} "
+            f"with {len(self.hashes)} hashes"
+        )
+
+
+class LookupResponseMsg(AsyncLookupMsg):
+    """Async lookup response message from worker to scheduler"""
+
+    lookup_id: str
+    num_hit_tokens: int
+
+    def describe(self) -> str:
+        return (
+            f"Async lookup response for lookup_id={self.lookup_id} "
+            f"with {self.num_hit_tokens} hit tokens"
+        )

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -191,27 +191,31 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
 
     def process_responses_from_workers(self):
         while self.running:
-            msg_buf = self.pull_socket.recv(copy=False)
-            # Deserialize message using msgspec
-            msg = msgspec.msgpack.decode(msg_buf, type=LookupResponseMsg)
-            lookup_id = msg.lookup_id
-            res = msg.num_hit_tokens
+            try:
+                msg_buf = self.pull_socket.recv(copy=False)
+                # Deserialize message using msgspec
+                msg = msgspec.msgpack.decode(msg_buf, type=LookupResponseMsg)
+                lookup_id = msg.lookup_id
+                res = msg.num_hit_tokens
 
-            with self.lock:
-                if lookup_id not in self.res_for_each_worker:
-                    self.res_for_each_worker[lookup_id] = [res]
-                else:
-                    self.res_for_each_worker[lookup_id].append(res)
-                all_res = self.res_for_each_worker[lookup_id]
+                with self.lock:
+                    if lookup_id not in self.res_for_each_worker:
+                        self.res_for_each_worker[lookup_id] = [res]
+                    else:
+                        self.res_for_each_worker[lookup_id].append(res)
+                    all_res = self.res_for_each_worker[lookup_id]
 
-                if len(all_res) == self.num_ranks:
-                    self.res_for_each_worker.pop(lookup_id)
+                    if len(all_res) == self.num_ranks:
+                        self.res_for_each_worker.pop(lookup_id)
 
-                    # NOTE: it is possible that the number of hit
-                    # tokens is different across (TP and PP) ranks, so we
-                    # can use the minimum value as the number of
-                    # hit tokens.
-                    self.reqs_status[lookup_id] = min(all_res)
+                        # NOTE: it is possible that the number of hit
+                        # tokens is different across (TP and PP) ranks, so we
+                        # can use the minimum value as the number of
+                        # hit tokens.
+                        self.reqs_status[lookup_id] = min(all_res)
+
+            except Exception as e:
+                logger.error(f"Error processing response from worker: {e}")
 
     def clear_lookup_status(self, lookup_id: str) -> None:
         with self.lock:
@@ -281,14 +285,9 @@ class LMCacheAsyncLookupServer:
         while self.running:
             try:
                 msg_buf = self.pull_socket.recv(copy=False)
-                # Deserialize message - could be LookupRequestMsg
-                # Use a union type for decoding
-                # Standard
-                from typing import Union as UnionType
-
                 msg = msgspec.msgpack.decode(
                     msg_buf,
-                    type=UnionType[LookupRequestMsg],
+                    type=Union[LookupRequestMsg],
                 )
 
                 if isinstance(msg, LookupRequestMsg):

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -287,7 +287,7 @@ class LMCacheAsyncLookupServer:
                 msg_buf = self.pull_socket.recv(copy=False)
                 msg = msgspec.msgpack.decode(
                     msg_buf,
-                    type=Union[LookupRequestMsg],
+                    type=LookupRequestMsg,
                 )
 
                 if isinstance(msg, LookupRequestMsg):

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -14,6 +14,10 @@ from lmcache.integration.vllm.utils import create_lmcache_metadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.lookup_client.async_lookup_message import (
+    LookupRequestMsg,
+    LookupResponseMsg,
+)
 from lmcache.v1.rpc_utils import (
     get_zmq_context,
     get_zmq_rpc_path_lmcache,
@@ -50,7 +54,6 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
     ):
         metadata, config = create_lmcache_metadata(vllm_config)
 
-        self.encoder = msgspec.msgpack.Encoder()
         self.ctx = get_zmq_context(use_asyncio=False)
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
@@ -162,42 +165,37 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             elif req_status != -1:
                 return req_status
             self.reqs_status[lookup_id] = None
-        hashes = []
+        hashes: list[int] = []
         offsets = []
         for start, end, hash_val in self.token_database.process_tokens(
             token_ids, make_key=False
         ):
-            hashes.append(hash_val)
+            hashes.append(hash_val)  # type: ignore[arg-type]
             offsets.append(end - start)
-        hash_buf = self.encoder.encode(hashes)
-        offset_buf = self.encoder.encode(offsets)
 
-        lookup_id_buf = lookup_id.encode("utf-8")
-        request_configs_str = ""
-        if request_configs is not None and len(request_configs) != 0:
-            request_configs_str = "@".join(
-                [f"{k}%{v}" for k, v in request_configs.items()]
-            )
-        request_configs_buf = request_configs_str.encode("utf-8")
+        # Create structured message
+        msg = LookupRequestMsg(
+            lookup_id=lookup_id,
+            hashes=hashes,
+            offsets=offsets,
+            request_configs=request_configs,
+        )
 
-        msg_buf = [
-            lookup_id_buf,
-            hash_buf,
-            offset_buf,
-            request_configs_buf,
-        ]
+        # Serialize message using msgspec
+        msg_buf = msgspec.msgpack.encode(msg)
 
         for i in range(self.num_ranks):
-            self.push_sockets[i].send_multipart(msg_buf, copy=False)
+            self.push_sockets[i].send(msg_buf, copy=False)
         time.sleep(self.lookup_backoff_time)
         return None
 
     def process_responses_from_workers(self):
         while self.running:
-            frames = self.pull_socket.recv_multipart(copy=False)
-            assert len(frames) == self.num_parts
-            lookup_id = frames[0].bytes.decode("utf-8")
-            res = int.from_bytes(frames[1], "big")
+            msg_buf = self.pull_socket.recv(copy=False)
+            # Deserialize message using msgspec
+            msg = msgspec.msgpack.decode(msg_buf, type=LookupResponseMsg)
+            lookup_id = msg.lookup_id
+            res = msg.num_hit_tokens
 
             with self.lock:
                 if lookup_id not in self.res_for_each_worker:
@@ -241,7 +239,6 @@ class LMCacheAsyncLookupServer:
     requests using LMCacheEngine."""
 
     def __init__(self, lmcache_engine: LMCacheEngine, vllm_config: "VllmConfig"):
-        self.decoder = msgspec.msgpack.Decoder()
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
@@ -280,46 +277,45 @@ class LMCacheAsyncLookupServer:
         )
         self.thread.start()
 
-        # The four parts are [hash, offset, lookup_id, request_configs]
-        self.num_parts = 4
-
     def process_requests_from_scheduler(self):
         while self.running:
-            frames = self.pull_socket.recv_multipart(copy=False)
-            num_frames = len(frames)
-            assert num_frames % self.num_parts == 0
-            for i in range(0, num_frames, self.num_parts):
-                lookup_id = frames[i].bytes.decode("utf-8")
+            try:
+                msg_buf = self.pull_socket.recv(copy=False)
+                # Deserialize message - could be LookupRequestMsg
+                # Use a union type for decoding
+                # Standard
+                from typing import Union as UnionType
 
-                hash_frame = frames[i + 1]
-                hashes = self.decoder.decode(hash_frame)
-
-                offset_frame = frames[i + 2]
-                offsets = self.decoder.decode(offset_frame)
-
-                request_configs_str = frames[i + 3].bytes.decode("utf-8")
-                request_configs = None
-                if request_configs_str != "":
-                    request_configs = {}
-                    request_configs_list = request_configs_str.split("@")
-                    for kv in request_configs_list:
-                        kvs = kv.split("%", 1)
-                        if len(kvs) != 2:
-                            raise ValueError(f"Unexpected tags_str: {kvs}")
-                        request_configs[kvs[0]] = kvs[1]
-
-                self.lmcache_engine.async_lookup_and_prefetch(
-                    lookup_id=lookup_id,
-                    hashes=hashes,
-                    offsets=offsets,
-                    pin=True,
-                    request_configs=request_configs,
+                msg = msgspec.msgpack.decode(
+                    msg_buf,
+                    type=UnionType[LookupRequestMsg],
                 )
 
+                if isinstance(msg, LookupRequestMsg):
+                    # Handle lookup request
+                    self.lmcache_engine.async_lookup_and_prefetch(
+                        lookup_id=msg.lookup_id,
+                        hashes=msg.hashes,
+                        offsets=msg.offsets,
+                        pin=True,
+                        request_configs=msg.request_configs,
+                    )
+                else:
+                    logger.warning(f"Unknown message type: {type(msg)}")
+
+            except Exception as e:
+                logger.error(f"Error processing request from scheduler: {e}")
+
     def send_response_to_scheduler(self, lookup_id: str, num_hit_tokens: int):
-        lookup_id_buf = lookup_id.encode("utf-8")
-        num_hit_tokens_buf = num_hit_tokens.to_bytes(4, "big")
-        self.push_socket.send_multipart([lookup_id_buf, num_hit_tokens_buf], copy=False)
+        # Create structured response message
+        msg = LookupResponseMsg(
+            lookup_id=lookup_id,
+            num_hit_tokens=num_hit_tokens,
+        )
+
+        # Serialize message using msgspec
+        msg_buf = msgspec.msgpack.encode(msg)
+        self.push_socket.send(msg_buf, copy=False)
 
     def close(self):
         self.running = False


### PR DESCRIPTION
Let's use structured dataclasses instead of a raw list to pass the messages.