### PR TITLE
[docs] Update controllable caching document

### DIFF
--- a/examples/cache_interface/README.md
+++ b/examples/cache_interface/README.md
@@ -40,7 +40,7 @@ You should be able to see logs indicating the KV cache is stored:
 
 4. Send request to vllm engine with `lmcache.skip_save: true` to skip storing the KV cache:
 ```bash
-curl POST http://localhost:8000/v1/completions \
+curl -X POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",

--- a/examples/cache_interface/README.md
+++ b/examples/cache_interface/README.md
@@ -18,40 +18,40 @@ CUDA_VISIBLE_DEVICES=0 LMCACHE_USE_EXPERIMENTAL=True LMCACHE_CONFIG_FILE=example
 
 
 
-3. Send a request to vllm engine with `store_cache: True`:  
+3. Send a request to vllm engine with `lmcache.skip_save: false` to store the KV cache:  
 ```bash
-curl -X POST http://localhost:8000/v1/completions \
+curl POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "prompt": "Explain the significance of KV cache in language models.",
     "max_tokens": 10,
-    "store_cache": True,
+    "kv_transfer_params": {
+      "lmcache.skip_save": false,
+    }
   }'
 ```
 
 You should be able to see logs indicating the KV cache is stored:
 
 ```plaintext
-DEBUG LMCache: Store skips 0 tokens and then stores 13 tokens [2025-03-02 21:58:55,147]
+[2025-11-18 09:11:17,227] LMCache INFO: Storing KV cache for 8 out of 8 tokens (skip_leading_tokens=0) for request cmpl-e184aa1d5d884d5d9a36abb6afcb198e-0 (vllm_v1_adapter.py:1094:lmcache.integration.vllm.vllm_v1_adapter)
 ```
 
-4. Send request to vllm engine 2:  
+4. Send request to vllm engine with `lmcache.skip_save: true` to skip storing the KV cache:
 ```bash
-curl -X POST http://localhost:8000/v1/completions \
+curl POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "prompt": "What's the weather today in Chicago?",
     "max_tokens": 10,
-    "store_cache": False,
+    "kv_transfer_params": {
+      "lmcache.skip_save": true,
+    }
   }'
 ```
 
-You should be able to see logs indicating the KV cache is NOT stored:
-
-```plaintext
-DEBUG LMCache: User has specified not to store the cache [2025-03-02 21:54:58,380]
-```
+If the KV cache is not stored, you will not see any storing logs.
 
 Note that cache is stored by default.

--- a/examples/cache_interface/README.md
+++ b/examples/cache_interface/README.md
@@ -20,7 +20,7 @@ CUDA_VISIBLE_DEVICES=0 LMCACHE_USE_EXPERIMENTAL=True LMCACHE_CONFIG_FILE=example
 
 3. Send a request to vllm engine with `lmcache.skip_save: false` to store the KV cache:  
 ```bash
-curl POST http://localhost:8000/v1/completions \
+curl -X POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This pull request updates the documentation in `examples/cache_interface/README.md` to clarify how to control KV cache storage when sending requests to the vllm engine. Since vllm v1 the previous `store_cache` approach doesn't work anymore, instead it must be done with the `kv_transfer_params` field with the `lmcache.skip_save` parameter.

Documentation improvements for KV cache control:

* Updated request examples to use `kv_transfer_params` with `lmcache.skip_save` instead of `store_cache` for controlling KV cache storage in vllm requests.
* Revised example log output

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
