### PR TITLE
[bugfix][controller] Fix remove while iteration issue within the method deregister

### DIFF
--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -139,14 +139,21 @@ class KVController:
         """
         Deregister all kv chunks of an instance-worker.
         """
-        for key in self.kv_pool:
-            self.kv_pool[key] = [
+        keys_to_delete = []
+        for key, metadata_list in self.kv_pool.items():
+            # Filter in-place by modifying the list
+            metadata_list[:] = [
                 m
-                for m in self.kv_pool[key]
+                for m in metadata_list
                 if not (m.instance_id == instance_id and m.worker_id == worker_id)
             ]
-            if not self.kv_pool[key]:
-                del self.kv_pool[key]
+            # Mark key for deletion if list becomes empty
+            if not metadata_list:
+                keys_to_delete.append(key)
+
+        # Delete empty keys (safe after iteration)
+        for key in keys_to_delete:
+            del self.kv_pool[key]
 
     # TODO(Jiayi): The current implementation does not handle
     # the case where the prefix chunks are evicted while the

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -142,7 +142,7 @@ class KVController:
         keys_to_delete = []
         for key, metadata_list in self.kv_pool.items():
             # Filter in-place by modifying the list
-            metadata_list[:] = [
+            filtered_metadata_list = [
                 m
                 for m in metadata_list
                 if not (m.instance_id == instance_id and m.worker_id == worker_id)

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -148,7 +148,7 @@ class KVController:
                 if not (m.instance_id == instance_id and m.worker_id == worker_id)
             ]
             # Mark key for deletion if list becomes empty
-            if not metadata_list:
+            if not filtered_metadata_list:
                 keys_to_delete.append(key)
 
         # Delete empty keys (safe after iteration)


### PR DESCRIPTION
An obviously issue, fix it.

Issue: Python didn't support remove element while iteration.

The following is a small prototype,
```python
#!/usr/bin/env python3
"""Minimal script to reproduce dictionary iteration bug"""

# Buggy version - will raise RuntimeError
kv_pool = {100: [1, 2], 200: [3], 300: [4, 5]}

print("Before:", kv_pool)
try:
    for key in kv_pool:
        if key == 200:
            del kv_pool[key]  # ❌ RuntimeError!
except RuntimeError as e:
    print(f"✗ Error: {e}")

# Fixed version - works correctly
kv_pool = {100: [1, 2], 200: [3], 300: [4, 5]}
keys_to_delete = []
for key in list(kv_pool.keys()):
    if key == 200:
        keys_to_delete.append(key)

for key in keys_to_delete:
    del kv_pool[key]

print("✓ Fixed version works! After:", kv_pool)

```

The output is:
```
Before: {100: [1, 2], 200: [3], 300: [4, 5]}
✗ Error: dictionary changed size during iteration
✓ Fixed version works! After: {100: [1, 2], 300: [4, 5]}

```