### PR TITLE
[optimize] optimize batched contains

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1191,13 +1191,7 @@ class LMCacheEngine:
         assert self.storage_manager is not None
 
         tot_kv_size = 0
-        # location -> [(CacheEngineKey, start, end)]
-        block_mapping: dict[str, list[tuple[CacheEngineKey, int, int]]] = defaultdict(
-            list
-        )
-
         reordered_chunks: List[ProcessedChunk] = []
-
         request_configs = kwargs.get("request_configs")
         if request_configs is not None and len(request_configs) != 0:
             assert isinstance(request_configs, dict)
@@ -1210,43 +1204,28 @@ class LMCacheEngine:
         skip_contains_check = (
             kwargs["skip_contains_check"] if "skip_contains_check" in kwargs else False
         )
-        for start, end, key in self.token_database.process_tokens(
+        chunk_infos = []
+        for chunk_info in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
             request_configs=request_configs,
         ):
-            assert isinstance(key, CacheEngineKey)
+            assert isinstance(chunk_info[2], CacheEngineKey)
+            chunk_infos.append(chunk_info)
 
-            location = None
-            if key in self.lookup_cache:
-                # TODO(Jiayi): we can reduce the number of `contains` calls
-                # by checking the lookup cache first (should be updated in `lookup`)
-                pass
-            else:
-                # NOTE: key should always be in the lookup cache once we support it.
-                # TODO: use lookup_cache to skip the contains
-                if (
-                    skip_contains_check
-                    and len(self.storage_manager.non_allocator_backends) == 1
-                ):
-                    location = self.storage_manager.non_allocator_backends[0]
-                else:
-                    location = self.storage_manager.contains(key)
-                if location is None:
-                    break
-
-                # NOTE: Here we make the assumption that the underlying
-                # storage backend support pin operation, and the memory
-                # object is already pinned in the storage backend.
-                ret_mask[start:end] = True
-
-            assert location is not None
-
-            block_mapping[location].append((key, start, end))
+        # block_mapping: location -> [(start, end, CacheEngineKey)]
+        if (
+            skip_contains_check
+            and len(self.storage_manager.non_allocator_backends) == 1
+        ):
+            location = self.storage_manager.non_allocator_backends[0]
+            block_mapping = {location: chunk_infos}
+        else:
+            block_mapping = self.storage_manager.get_chunk_locations(chunk_infos)
 
         last_failed_block_start = None
         for location, blocks in block_mapping.items():
-            keys = [key for key, _, _ in blocks]
+            keys = [key for _, _, key in blocks]
             memory_objs = self.storage_manager.batched_get(
                 keys=keys,
                 location=location,
@@ -1255,7 +1234,7 @@ class LMCacheEngine:
                 "Failed to get memory objects from storage backend"
             )
 
-            for (key, start, end), memory_obj in zip(blocks, memory_objs, strict=False):
+            for (start, end, key), memory_obj in zip(blocks, memory_objs, strict=False):
                 if memory_obj is None:
                     logger.warning(
                         "The cache block is in the storage, but it can't be retrieved"
@@ -1268,6 +1247,7 @@ class LMCacheEngine:
                     break
                 reordered_chunks.append((key, memory_obj, start, end))
                 tot_kv_size += memory_obj.get_size()
+                ret_mask[start:end] = True
 
         if last_failed_block_start is not None:
             ret_mask[last_failed_block_start:] = False

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1205,15 +1205,15 @@ class LMCacheEngine:
             kwargs["skip_contains_check"] if "skip_contains_check" in kwargs else False
         )
         chunk_infos = []
-        for chunk_info in self.token_database.process_tokens(
+        for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
             request_configs=request_configs,
         ):
-            assert isinstance(chunk_info[2], CacheEngineKey)
-            chunk_infos.append(chunk_info)
+            assert isinstance(key, CacheEngineKey)
+            chunk_infos.append((key, start, end))
 
-        # block_mapping: location -> [(start, end, CacheEngineKey)]
+        # block_mapping: location -> [(CacheEngineKey, start, end)]
         if (
             skip_contains_check
             and len(self.storage_manager.non_allocator_backends) == 1
@@ -1221,11 +1221,11 @@ class LMCacheEngine:
             location = self.storage_manager.non_allocator_backends[0]
             block_mapping = {location: chunk_infos}
         else:
-            block_mapping = self.storage_manager.get_chunk_locations(chunk_infos)
+            block_mapping = self.storage_manager.get_block_mapping(chunk_infos)
 
         last_failed_block_start = None
         for location, blocks in block_mapping.items():
-            keys = [key for _, _, key in blocks]
+            keys = [key for key, _, _ in blocks]
             memory_objs = self.storage_manager.batched_get(
                 keys=keys,
                 location=location,
@@ -1234,7 +1234,7 @@ class LMCacheEngine:
                 "Failed to get memory objects from storage backend"
             )
 
-            for (start, end, key), memory_obj in zip(blocks, memory_objs, strict=False):
+            for (key, start, end), memory_obj in zip(blocks, memory_objs, strict=False):
                 if memory_obj is None:
                     logger.warning(
                         "The cache block is in the storage, but it can't be retrieved"

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -801,14 +801,12 @@ class LMCacheEngine:
                     chunk_info_list.append(chunk_info)
                     keys.append(chunk_info[2])
 
-                batched_contains_res = self.storage_manager.batched_contains(
-                    keys, search_range, pin, True
+                # hit chunks by prefix matching
+                hit_chunks = self.storage_manager.batched_contains(
+                    keys, search_range, pin
                 )
-                assert len(batched_contains_res) == len(chunk_info_list)
-                for (start, end, key), exists in zip(
-                    chunk_info_list, batched_contains_res, strict=False
-                ):
-                    if exists:
+                for idx, (start, end, key) in enumerate(chunk_info_list):
+                    if idx < hit_chunks:
                         if pin:
                             assert lookup_id is not None, (
                                 "lookup_id is required when pin is True"

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -256,9 +256,6 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def support_batched_contains(self) -> bool:
-        return False
-
     def batched_contains(
         self,
         keys: List[CacheEngineKey],
@@ -279,7 +276,16 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
 
         :return: Return a bool list, True if the key exists, False otherwise.
         """
-        raise NotImplementedError
+        results = []
+        for key in keys:
+            if self.contains(key, pin):
+                results.append(True)
+            else:
+                if stop_after_first_not_exits:
+                    results.extend([False] * (len(keys) - len(results)))
+                    break
+                results.append(False)
+        return results
 
 
 class AllocatorBackendInterface(StorageBackendInterface):

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -260,8 +260,7 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
         self,
         keys: List[CacheEngineKey],
         pin: bool = False,
-        stop_after_first_not_exits: bool = True,
-    ) -> List[bool]:
+    ) -> int:
         """
         Check whether the keys are in the storage backend.
 
@@ -271,21 +270,14 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
             If True, the corresponding KV cache will be
             pinned in the storage backend.
 
-        :param bool stop_after_first_not_exits: Stop when find the first not exists key,
-        all subsequent results will return False directly.
-
-        :return: Return a bool list, True if the key exists, False otherwise.
+        :return: Return hit chunks by prefix match.
         """
-        results = []
+        hit_chunks = 0
         for key in keys:
-            if self.contains(key, pin):
-                results.append(True)
-            else:
-                if stop_after_first_not_exits:
-                    results.extend([False] * (len(keys) - len(results)))
-                    break
-                results.append(False)
-        return results
+            if not self.contains(key, pin):
+                break
+            hit_chunks += 1
+        return hit_chunks
 
 
 class AllocatorBackendInterface(StorageBackendInterface):

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -334,18 +334,13 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    def batched_contains(
-        self, keys: List[CacheEngineKey], stop_after_first_not_exits: bool = True
-    ) -> List[bool]:
+    def batched_contains(self, keys: List[CacheEngineKey]) -> int:
         """
         Batched contains.
 
         :param List[CacheEngineKey] keys: The keys to check.
 
-        :param bool stop_after_first_not_exits: Stop when find the first not exists key,
-        all subsequent results will return False directly.
-
-        :return: Return a bool list, True if the key exists, False otherwise.
+        :return: Return hit chunks by prefix match.
         """
         raise NotImplementedError
 

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -123,10 +123,8 @@ class InstrumentedRemoteConnector(RemoteConnector):
     def remove_sync(self, key: CacheEngineKey) -> bool:
         return self._connector.remove_sync(key)
 
-    def batched_contains(
-        self, keys: List[CacheEngineKey], stop_after_first_not_exits: bool = True
-    ) -> List[bool]:
-        return self._connector.batched_contains(keys, stop_after_first_not_exits)
+    def batched_contains(self, keys: List[CacheEngineKey]) -> int:
+        return self._connector.batched_contains(keys)
 
     def support_batched_contains(self) -> bool:
         return self._connector.support_batched_contains()

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -154,11 +154,6 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning("Returning False")
             return False
 
-    def support_batched_contains(self) -> bool:
-        return (
-            self.connection is not None and self.connection.support_batched_contains()
-        )
-
     def batched_contains(
         self,
         keys: List[CacheEngineKey],
@@ -170,6 +165,9 @@ class RemoteBackend(StorageBackendInterface):
                 "Connection is None in batched_contains, returning all False"
             )
             return [False] * len(keys)
+
+        if not self.connection.support_batched_contains():
+            return super().batched_contains(keys, pin, stop_after_first_not_exits)
 
         if self._mla_worker_id_as0_mode:
             keys = [key.with_new_worker_id(0) for key in keys]

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -160,9 +160,7 @@ class RemoteBackend(StorageBackendInterface):
         pin: bool = False,
     ) -> int:
         if self.connection is None:
-            logger.warning(
-                "Connection is None in batched_contains, returning 0"
-            )
+            logger.warning("Connection is None in batched_contains, returning 0")
             return 0
 
         if not self.connection.support_batched_contains():

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -158,25 +158,24 @@ class RemoteBackend(StorageBackendInterface):
         self,
         keys: List[CacheEngineKey],
         pin: bool = False,
-        stop_after_first_not_exits: bool = True,
-    ) -> List[bool]:
+    ) -> int:
         if self.connection is None:
             logger.warning(
-                "Connection is None in batched_contains, returning all False"
+                "Connection is None in batched_contains, returning 0"
             )
-            return [False] * len(keys)
+            return 0
 
         if not self.connection.support_batched_contains():
-            return super().batched_contains(keys, pin, stop_after_first_not_exits)
+            return super().batched_contains(keys, pin)
 
         if self._mla_worker_id_as0_mode:
             keys = [key.with_new_worker_id(0) for key in keys]
 
         try:
-            return self.connection.batched_contains(keys, stop_after_first_not_exits)
+            return self.connection.batched_contains(keys)
         except Exception as e:
             logger.warning(f"Remote connection failed in batched_contains: {e}")
-            return [False] * len(keys)
+            return 0
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
         with self.lock:

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -821,9 +821,6 @@ class StorageManager:
             if total_hit_chunks == total_keys:
                 break
             keys = keys[hit_chunks:]
-        assert total_hit_chunks == total_keys, (
-            f"Expected {total_keys} hit chunks, got {total_hit_chunks}"
-        )
         return block_mapping
 
     def touch_cache(self):

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Coroutine,
+    Dict,
     Generator,
     List,
     Optional,
@@ -779,7 +780,20 @@ class StorageManager:
 
         return total_hit_chunks
 
-    def get_block_mapping(self, chunk_infos: List[Tuple[CacheEngineKey, int, int]]):
+    def get_block_mapping(
+        self,
+        chunk_infos: List[Tuple[CacheEngineKey, int, int]]
+    ) -> Dict[str, List[Tuple[CacheEngineKey, int, int]]]:
+        """
+        Get block mapping for the given chunk infos, works by prefix match.
+
+        :param List[Tuple[CacheEngineKey, int, int]] chunk_infos:
+        List of chunk infos, each tuple contains (key, begin, end)
+
+        :return: Dict[str, List[Tuple[CacheEngineKey, int, int]]]:
+        Block mapping for the given chunk infos, each key is the backend name,
+        each value is a list of chunk infos in the backend.
+        """
         keys = [chunk_info[0] for chunk_info in chunk_infos]
         total_keys = len(keys)
         block_mapping = {}

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
 )
 import asyncio
 import functools
@@ -799,6 +800,27 @@ class StorageManager:
             keys = keys[hit_chunks:]
 
         return [True] * total_hit_chunks + [False] * (total_keys - total_hit_chunks)
+
+    def get_chunk_locations(self, chunk_infos: List[Tuple[int, int, CacheEngineKey]]):
+        keys = [chunk_info[2] for chunk_info in chunk_infos]
+        total_keys = len(keys)
+        block_mapping = {}
+        total_hit_chunks = 0
+        for backend_name, backend in self.storage_backends.items():
+            results = backend.batched_contains(keys)
+            try:
+                hit_chunks = results.index(False)
+            except ValueError:
+                hit_chunks = len(results)
+            if hit_chunks == 0:
+                continue
+            block_mapping[backend_name] = chunk_infos[total_hit_chunks : total_hit_chunks + hit_chunks]
+            total_hit_chunks += hit_chunks
+            if total_hit_chunks == total_keys:
+                break
+            keys = keys[hit_chunks:]
+        assert total_hit_chunks == total_keys, f"Expected {total_keys} hit chunks, got {total_hit_chunks}"
+        return block_mapping
 
     def touch_cache(self):
         for backend_name, backend in self.storage_backends.items():

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -766,42 +766,29 @@ class StorageManager:
 
         return: True if the key exists in the specified storage backends else False.
         """
+        if len(self.non_allocator_backends) == 1 and (search_range is None or self.non_allocator_backends[0] in search_range):
+            backend_name = self.non_allocator_backends[0]
+            return self.storage_backends[backend_name].batched_contains(keys, pin, stop_after_first_not_exits)
 
-        # TODO: Only single-layer batched_contains is supported currently.
-        # Only allocate backend is LocalCPUBackend and do not enable hot cache,
-        # check another backend is supported batched_contains
-        if (
-            len(self.storage_backends) == 2
-            and not self.config.enable_pd
-            and not self.config.local_cpu
-            and (search_range is None or len(search_range) == 1)
-        ):
-            for backend_name, backend in self.storage_backends.items():
-                if backend_name == "LocalCPUBackend":
-                    continue
-                if (
-                    search_range is None or search_range[0] == backend_name
-                ) and backend.support_batched_contains():
-                    return backend.batched_contains(
-                        keys, pin, stop_after_first_not_exits
-                    )
+        total_keys = len(keys)
+        total_hit_chunks = 0
+        for backend_name, backend in self.storage_backends.items():
+            if search_range and backend_name not in search_range:
+                continue
 
-        # default implementation
-        contains_res = []
-        for key in keys:
-            res = self.contains(key, search_range, pin)
-            if res is not None:
-                contains_res.append(True)
-            else:
-                if stop_after_first_not_exits:
-                    # fill the contains_res with None
-                    current_len = len(contains_res)
-                    contains_res.extend([False] * (len(keys) - current_len))
-                    break
-                else:
-                    contains_res.append(False)
+            results = backend.batched_contains(keys, pin, stop_after_first_not_exits)
+            try:
+                hit_chunks = results.index(False)
+            except ValueError:
+                hit_chunks = len(results)
+            if hit_chunks == 0:
+                continue
+            total_hit_chunks += hit_chunks
+            if total_hit_chunks == total_keys:
+                break
+            keys = keys[hit_chunks:]
 
-        return contains_res
+        return [True] * total_hit_chunks + [False] * (total_keys - total_hit_chunks)
 
     def touch_cache(self):
         for backend_name, backend in self.storage_backends.items():

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -737,9 +737,11 @@ class StorageManager:
 
             # NOTE(Jiayi): We do not pin for PDBackend
             if backend_name == "PDBackend":
-                pin = False
+                pin_in_backend = False
+            else:
+                pin_in_backend = pin
 
-            if backend.contains(key, pin):
+            if backend.contains(key, pin_in_backend):
                 return backend_name
 
         return None
@@ -770,7 +772,13 @@ class StorageManager:
             if search_range and backend_name not in search_range:
                 continue
 
-            hit_chunks = backend.batched_contains(keys, pin)
+            # NOTE(Jiayi): We do not pin for PDBackend
+            if backend_name == "PDBackend":
+                pin_in_backend = False
+            else:
+                pin_in_backend = pin
+
+            hit_chunks = backend.batched_contains(keys, pin_in_backend)
             if hit_chunks == 0:
                 continue
             total_hit_chunks += hit_chunks

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -766,9 +766,13 @@ class StorageManager:
 
         return: True if the key exists in the specified storage backends else False.
         """
-        if len(self.non_allocator_backends) == 1 and (search_range is None or self.non_allocator_backends[0] in search_range):
+        if len(self.non_allocator_backends) == 1 and (
+            search_range is None or self.non_allocator_backends[0] in search_range
+        ):
             backend_name = self.non_allocator_backends[0]
-            return self.storage_backends[backend_name].batched_contains(keys, pin, stop_after_first_not_exits)
+            return self.storage_backends[backend_name].batched_contains(
+                keys, pin, stop_after_first_not_exits
+            )
 
         total_keys = len(keys)
         total_hit_chunks = 0

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -748,8 +748,7 @@ class StorageManager:
         keys: List[CacheEngineKey],
         search_range: Optional[List[str]] = None,
         pin: bool = False,
-        stop_after_first_not_exits: bool = True,
-    ) -> List[bool]:
+    ) -> int:
         """
         Check whether the key exists in the storage backend.
 
@@ -762,36 +761,15 @@ class StorageManager:
 
         :param bool pin: Whether to pin the key.
 
-        :param bool stop_after_first_not_exits: Stop when find the first not exists key,
-        all subsequent results will return False directly.
-
-        return: True if the key exists in the specified storage backends else False.
+        return: Return hit chunks by prefix match.
         """
-        if not stop_after_first_not_exits:
-            # The new optimized logic only works for prefix-based lookups.
-            # For the general case where we don't stop at the first miss,
-            # we must check each key across all specified backends.
-            return [self.contains(key, search_range, pin) is not None for key in keys]
-
-        if len(self.non_allocator_backends) == 1 and (
-            search_range is None or self.non_allocator_backends[0] in search_range
-        ):
-            backend_name = self.non_allocator_backends[0]
-            return self.storage_backends[backend_name].batched_contains(
-                keys, pin, stop_after_first_not_exits
-            )
-
         total_keys = len(keys)
         total_hit_chunks = 0
         for backend_name, backend in self.storage_backends.items():
             if search_range and backend_name not in search_range:
                 continue
 
-            results = backend.batched_contains(keys, pin, stop_after_first_not_exits)
-            try:
-                hit_chunks = results.index(False)
-            except ValueError:
-                hit_chunks = len(results)
+            hit_chunks = backend.batched_contains(keys, pin)
             if hit_chunks == 0:
                 continue
             total_hit_chunks += hit_chunks
@@ -799,7 +777,7 @@ class StorageManager:
                 break
             keys = keys[hit_chunks:]
 
-        return [True] * total_hit_chunks + [False] * (total_keys - total_hit_chunks)
+        return total_hit_chunks
 
     def get_block_mapping(self, chunk_infos: List[Tuple[CacheEngineKey, int, int]]):
         keys = [chunk_info[0] for chunk_info in chunk_infos]
@@ -807,11 +785,7 @@ class StorageManager:
         block_mapping = {}
         total_hit_chunks = 0
         for backend_name, backend in self.storage_backends.items():
-            results = backend.batched_contains(keys)
-            try:
-                hit_chunks = results.index(False)
-            except ValueError:
-                hit_chunks = len(results)
+            hit_chunks = backend.batched_contains(keys)
             if hit_chunks == 0:
                 continue
             block_mapping[backend_name] = chunk_infos[

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -766,6 +766,12 @@ class StorageManager:
 
         return: True if the key exists in the specified storage backends else False.
         """
+        if not stop_after_first_not_exits:
+            # The new optimized logic only works for prefix-based lookups.
+            # For the general case where we don't stop at the first miss,
+            # we must check each key across all specified backends.
+            return [self.contains(key, search_range, pin) is not None for key in keys]
+
         if len(self.non_allocator_backends) == 1 and (
             search_range is None or self.non_allocator_backends[0] in search_range
         ):

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -801,8 +801,8 @@ class StorageManager:
 
         return [True] * total_hit_chunks + [False] * (total_keys - total_hit_chunks)
 
-    def get_chunk_locations(self, chunk_infos: List[Tuple[int, int, CacheEngineKey]]):
-        keys = [chunk_info[2] for chunk_info in chunk_infos]
+    def get_block_mapping(self, chunk_infos: List[Tuple[CacheEngineKey, int, int]]):
+        keys = [chunk_info[0] for chunk_info in chunk_infos]
         total_keys = len(keys)
         block_mapping = {}
         total_hit_chunks = 0
@@ -814,12 +814,16 @@ class StorageManager:
                 hit_chunks = len(results)
             if hit_chunks == 0:
                 continue
-            block_mapping[backend_name] = chunk_infos[total_hit_chunks : total_hit_chunks + hit_chunks]
+            block_mapping[backend_name] = chunk_infos[
+                total_hit_chunks : total_hit_chunks + hit_chunks
+            ]
             total_hit_chunks += hit_chunks
             if total_hit_chunks == total_keys:
                 break
             keys = keys[hit_chunks:]
-        assert total_hit_chunks == total_keys, f"Expected {total_keys} hit chunks, got {total_hit_chunks}"
+        assert total_hit_chunks == total_keys, (
+            f"Expected {total_keys} hit chunks, got {total_hit_chunks}"
+        )
         return block_mapping
 
     def touch_cache(self):

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -781,8 +781,7 @@ class StorageManager:
         return total_hit_chunks
 
     def get_block_mapping(
-        self,
-        chunk_infos: List[Tuple[CacheEngineKey, int, int]]
+        self, chunk_infos: List[Tuple[CacheEngineKey, int, int]]
     ) -> Dict[str, List[Tuple[CacheEngineKey, int, int]]]:
         """
         Get block mapping for the given chunk infos, works by prefix match.


### PR DESCRIPTION
Make `batched_contains` works for prefix-based lookups.

if keys list is `[key1, key2, key3, key4, key5]`, currents backends include `[backend1, backend2, backend3]`

1. the batched_contains will search `backend1` first, and find `key1`, `key2`
2. then search `backend2`, and find `key3`, `key4`
3. finally search `backend3`
