### PR TITLE
[chore] auto model detection when running long doc qa

### DIFF
--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -423,6 +423,11 @@ async def main(args):
         timeout=None,
     )
     model = args.model
+    if model == "auto":
+        print("Auto-selecting model...", end=" ")
+        models = (await client.models.list(),)
+        model = models[0].data[0].id
+        print(f"selected model: {model}")
 
     pre_warmup_prompts = [str(i) + "xx" + " ".join(["hi"] * 1000) for i in range(5)]
 
@@ -605,8 +610,9 @@ def create_argument_parser():
     parser.add_argument(
         "--model",
         type=str,
-        default="meta-llama/Llama-3.1-8B-Instruct",
-        help="Model name",
+        default="auto",
+        help="Model name, can be set to 'auto' if the "
+        "endpoint support openai api /models",
     )
 
     parser.add_argument(


### PR DESCRIPTION
Add `auto` in long doc qa benchmark to automatically detect the model name

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
