### PR TITLE
[1/3]: Refactor S3 Connector Configuration and Initialization

### DIFF
--- a/docs/source/kv_cache/storage_backends/s3.rst
+++ b/docs/source/kv_cache/storage_backends/s3.rst
@@ -17,7 +17,7 @@ Basic S3 Configuration
    blocking_timeout_secs: 100
    extra_config:
      s3_region: "us-east-1"
-     s3_max_io_concurrency: 64
+     s3_num_io_threads: 64
      s3_max_inflight_reqs: 64
 
 S3 Express One Zone
@@ -32,7 +32,7 @@ S3 Express One Zone
    remote_serde: "naive"
    blocking_timeout_secs: 100
    extra_config:
-     s3_max_io_concurrency: 64
+     s3_num_io_threads: 64
      s3_max_inflight_reqs: 64
      s3_prefer_http2: True
      s3_region: "{REGION}"
@@ -53,15 +53,19 @@ CoreWeave (S3-compatible)
    remote_serde: "naive"
    blocking_timeout_secs: 100
    extra_config:
-     s3_max_io_concurrency: 320
+     s3_num_io_threads: 320
      s3_max_inflight_reqs: 320
      s3_prefer_http2: False
      s3_region: "US-WEST-04A"
      s3_enable_s3express: False
      save_chunk_meta: False
      s3_file_prefix: "test-2"
+     disable_tls: True
 
-**Note**: `cwlota.com` is CoreWeave's S3-compatible Cloud Storage that caches for GPU locality. Set `s3_enable_s3express: False` for non-AWS services.
+**Note**: `cwlota.com` is CoreWeave's S3-compatible Cloud Storage that caches for GPU locality. You can set `disable_tls: True` for non-AWS services.
+
+Check out the blog post between LMCache, Cohere, and CoreWeave: https://blog.lmcache.ai/en/2025/10/29/breaking-the-memory-barrier-how-lmcache-and-coreweave-power-efficient-llm-inference-for-cohere/
+
 
 Configuration Parameters
 ------------------------
@@ -75,19 +79,19 @@ S3-Specific (in extra_config)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **s3_region**: AWS region for S3 client (required)
-* **s3_max_io_concurrency**: Max concurrent I/O operations for event loop group (controls AWS CRT threading)
-* **s3_max_inflight_reqs**: Max simultaneous S3 requests (creates this many /dev/shm buffers and semaphore limit)
+* **s3_num_io_threads**: Number of IO threads for the AWS CRT client to spawn. Benefits taper out after exceeding the number of CPU cores.
+* **s3_max_inflight_reqs**: Max simultaneous S3 requests (creates this many `/dev/shm` files/buffers and semaphore limit)
 * **s3_prefer_http2**: Enable HTTP/2 with ALPN negotiation (["h2", "http/1.1"])
 * **s3_enable_s3express**: Enable S3 Express One Zone support in AWS CRT client
 * **s3_file_prefix**: Prefix for S3 object keys (e.g., `cache` becomes `/cache/key_name`). Avoid leading/trailing slashes.
 * **save_chunk_meta**: Whether to save chunk metadata with data (set False for performance)
 
-The effective concurrency is limited by the minimum of `s3_max_io_concurrency` and `s3_max_inflight_reqs`.
+The effective concurrency is limited by `s3_max_inflight_reqs`.
 
 /dev/shm Configuration
 ----------------------
 
-/dev/shm is used as the tmpfs that S3 can use to transfer only into RAM instead of having to touch a block device. 
+/dev/shm is used as the tmpfs that S3 can use to transfer only into RAM (OS page cache mapped to user space with `mmap`) instead of having to touch a block device. This reduces a memory copy.
 
 Memory Requirements and Configuration Calculation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/kv_cache_reuse/remote_backends/s3/example.yaml
+++ b/examples/kv_cache_reuse/remote_backends/s3/example.yaml
@@ -9,7 +9,7 @@ remote_serde: "naive"
 blocking_timeout_secs: 100
 
 extra_config:
-  s3_max_io_concurrency: 64
+  s3_num_io_threads: 64
   s3_max_inflight_reqs: 64
   s3_prefer_http2: True
   s3_region: "{REGION}"

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -127,6 +127,14 @@ class ConnectorContext:
         self.config = config
         self.metadata = metadata
 
+    def get_full_chunk_size(self) -> int:
+        """
+        return the number of bytes in a full chunk
+        useful for S3Connector where we need to preallocate filesystem buffers
+        in ramfs for zero-copy transfers
+        """
+        return self.local_cpu_backend.get_full_chunk_size()
+
 
 class ConnectorAdapter(ABC):
     """Base class for connector adapters."""

--- a/lmcache/v1/storage_backend/connector/s3_adapter.py
+++ b/lmcache/v1/storage_backend/connector/s3_adapter.py
@@ -23,21 +23,22 @@ class S3ConnectorAdapter(ConnectorAdapter):
         config = context.config
         assert config is not None
 
-        if config.extra_config is not None:
-            # Different parts can be transferred in parallel.
-            self.s3_part_size = config.extra_config.get("s3_part_size", None)
-            self.s3_max_io_concurrency = config.extra_config.get(
-                "s3_max_io_concurrency", 64
-            )
-            self.s3_max_inflight_reqs = config.extra_config.get(
-                "s3_max_inflight_reqs", 64
-            )
-            self.s3_prefer_http2 = config.extra_config.get("s3_prefer_http2", True)
-            self.s3_region = config.extra_config.get("s3_region", None)
-            self.s3_enable_s3express = config.extra_config.get(
-                "s3_enable_s3express", True
-            )
-            self.s3_file_prefix = config.extra_config.get("s3_file_prefix", None)
+        # Get full_chunk_size from context
+        full_chunk_size = context.get_full_chunk_size()
+
+        # Get config from extra_config with defaults
+        extra_config = config.extra_config if config.extra_config is not None else {}
+
+        self.s3_part_size = int(extra_config.get("s3_part_size", full_chunk_size))
+        self.s3_num_io_threads = int(extra_config.get("s3_num_io_threads", 64))
+        self.s3_max_inflight_reqs = int(extra_config.get("s3_max_inflight_reqs", 64))
+        self.s3_prefer_http2 = bool(extra_config.get("s3_prefer_http2", True))
+        self.s3_region = extra_config.get("s3_region", None)
+        assert self.s3_region is not None, "s3_region is required"
+        self.s3_region = str(self.s3_region)
+        self.s3_enable_s3express = bool(extra_config.get("s3_enable_s3express", False))
+        self.s3_file_prefix = extra_config.get("s3_file_prefix", None)
+        self.disable_tls = bool(extra_config.get("disable_tls", False))
 
         logger.info(f"Creating S3 connector for URL: {context.url}")
 
@@ -47,11 +48,13 @@ class S3ConnectorAdapter(ConnectorAdapter):
             s3_endpoint=s3_endpoint,
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
+            full_chunk_size=full_chunk_size,
             s3_part_size=self.s3_part_size,
             s3_file_prefix=self.s3_file_prefix,
-            s3_max_io_concurrency=self.s3_max_io_concurrency,
+            s3_num_io_threads=self.s3_num_io_threads,
             s3_max_inflight_reqs=self.s3_max_inflight_reqs,
             s3_prefer_http2=self.s3_prefer_http2,
             s3_region=self.s3_region,
             s3_enable_s3express=self.s3_enable_s3express,
+            disable_tls=self.disable_tls,
         )

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -39,9 +39,7 @@ class Priorities(IntEnum):
 # `/dev/shm` in `S3Connector`
 # (2) Need to hack amazon python s3 crt library to enable `offset`
 # to achieve zero-copy.
-# (3) Need a job manager so that we can do sth like
-# write priority, read priority, etc.
-# (4) Potentially can drop the semaphore to reduce the complexity.
+# (3) Potentially can drop the semaphore to reduce the complexity.
 # Let crt handle the scheduling.
 
 
@@ -106,13 +104,15 @@ class S3Connector(RemoteConnector):
         s3_endpoint: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
+        full_chunk_size: int,
         s3_part_size: Optional[int],
         s3_file_prefix: Optional[str],
-        s3_max_io_concurrency: int,
+        s3_num_io_threads: int,
         s3_max_inflight_reqs: int,
         s3_prefer_http2: bool,
         s3_region: str,
         s3_enable_s3express: bool,
+        disable_tls: bool,
     ):
         if not s3_endpoint.startswith("s3://"):
             raise ValueError("S3 url must start with 's3://'")
@@ -121,21 +121,23 @@ class S3Connector(RemoteConnector):
         self.s3_prefix = s3_file_prefix
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        self.full_chunk_size = full_chunk_size
 
         self.s3_part_size = s3_part_size
 
         # TODO(Jiayi): Now we only assume S3 part size = chunk size
+        logger.info(f"S3 part size is set to {self.s3_part_size} bytes")
         assert self.s3_part_size == self.full_chunk_size, (
             "S3 part size must be equal to chunk size in S3Connector"
         )
 
-        self.s3_max_io_concurrency = s3_max_io_concurrency
+        self.s3_num_io_threads = s3_num_io_threads
         self.s3_max_inflight_reqs = s3_max_inflight_reqs
         self.s3_prefer_http2 = s3_prefer_http2
         self.s3_region = s3_region
         self.s3_enable_s3express = s3_enable_s3express
 
-        event_loop_group = io.EventLoopGroup(s3_max_io_concurrency)
+        event_loop_group = io.EventLoopGroup(s3_num_io_threads)
         host_resolver = io.DefaultHostResolver(event_loop_group)
         client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
         self.credentials_provider = auth.AwsCredentialsProvider.new_default_chain(
@@ -143,6 +145,7 @@ class S3Connector(RemoteConnector):
         )
 
         tls_opts = None
+
         if self.s3_prefer_http2:
             # Use HTTP/2 multiplexing if possible.
             tls_ctx = ClientTlsContext(TlsContextOptions())
@@ -152,14 +155,28 @@ class S3Connector(RemoteConnector):
             except Exception:
                 tls_opts = None
 
+        signing_config = None
+        if self.s3_enable_s3express:
+            signing_config = auth.AwsSigningConfig(
+                algorithm=auth.AwsSigningAlgorithm.V4_S3EXPRESS,
+                region=self.s3_region,
+                service="s3",
+                credentials_provider=self.credentials_provider,
+            )
+
+        # turn off TLS for non-AWS services
+        # regular and directory/express buckets both use TLS by default
+        turn_off_tls = (
+            s3.S3RequestTlsMode.DISABLED if disable_tls else s3.S3RequestTlsMode.ENABLED
+        )
         logger.info("Initializing S3 client")
         self.s3_client = s3.S3Client(
             bootstrap=client_bootstrap,
             region=s3_region,
-            credential_provider=self.credentials_provider,
-            enable_s3express=False,  # enable for s3express
+            enable_s3express=s3_enable_s3express,
             tls_connection_options=tls_opts,
-            tls_mode=s3.S3RequestTlsMode.DISABLED,  # only for non-AWS services
+            tls_mode=turn_off_tls,
+            signing_config=signing_config,
         )
 
         # TODO(Jiayi): We need to handle cache consistency issues in a systematic way
@@ -182,13 +199,15 @@ class S3Connector(RemoteConnector):
             "S3 part size must be equal to chunk size in S3Connector"
         )
 
+        # TODO: if two machines on the same node (with the same PYTHONHASHSEED)
+        # are both using the S3 Connector, there may be R/W contention on /dev/shm.
         shm_name_prefix = "my_shm"
         shms = []
         shm_names = []
         mmaps = []
         for i in range(self.s3_max_inflight_reqs):
             shm_name = f"{shm_name_prefix}_{i}"
-
+            # /dev/shm avoids disk (~fs is the page cache)
             shm = tempfile.NamedTemporaryFile(
                 prefix=shm_name, suffix=".part", dir="/dev/shm", delete=False
             )
@@ -196,6 +215,7 @@ class S3Connector(RemoteConnector):
             os.ftruncate(shm.fileno(), self.full_chunk_size)
 
             with open(shm.name, "r+b") as f:
+                # mmap directly maps user space to the /dev/shm
                 mm = mmap.mmap(f.fileno(), self.full_chunk_size)
                 # create a char buffer view over the mmap
                 buf = ctypes.c_char.from_buffer(mm)

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -600,20 +600,12 @@ class LocalCPUBackend(AllocatorBackendInterface):
         self.stats_monitor.update_local_cpu_evict_metrics(evict_keys_count)
         return memory_objs
 
-    def calculate_chunk_budget(self) -> int:
-        """
-        Calculate the maximum number of chunks that can be allocated concurrently
-        without causing memory deadlocks in the async loading system.
-
-        Returns:
-            int: The estimated chunk budget for concurrent allocations
-        """
+    def get_full_chunk_size(self) -> int:
         logger.debug("Attempting to calculate chunk budget for async loading")
         assert self.metadata is not None, (
             "metadata required for chunk budget calculation"
         )
 
-        total_memory = int(self.config.max_local_cpu_size * 1024**3)
         chunk_tokens = self.config.chunk_size
         # already accounted for parallelism
         kv_shape = (
@@ -639,6 +631,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
             f"hidden_dim={hidden_dim}"
         )
         logger.debug(f"Calculated bytes per chunk per rank: {chunk_bytes}")
+        return chunk_bytes
+
+    def calculate_chunk_budget(self) -> int:
+        """
+        Calculate the maximum number of chunks that can be allocated concurrently
+        without causing memory deadlocks in the async loading system.
+
+        Returns:
+            int: The estimated chunk budget for concurrent allocations
+        """
+        total_memory = int(self.config.max_local_cpu_size * 1024**3)
+        chunk_bytes = self.get_full_chunk_size()
         # add alignment overhead
         # (MixedMemoryAllocator uses TensorMemoryAllocator with 4KB alignment)
         assert hasattr(self.memory_allocator, "align_bytes")


### PR DESCRIPTION
FIX https://github.com/LMCache/LMCache/issues/1961 @ksuma2109

This PR fixes the initialization logic and renames / adds some configs such as `num_io_threads` and `disable_tls` and enforcing the `s3_part_size` properly as well as doing type validation.

The follow up PRs are: 
[2/3]: Add proper error validation to the S3Connector
[3/3]: create zero copy semantics (currently there is a copy from `/dev/shm` to cudaHostRegistered memory but we should be able to remove this).