### PR TITLE
Handle aborted requests in async lookup client and server.

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1662,8 +1662,9 @@ class LMCacheConnectorV1Impl:
         # Cleanup if request was aborted
         if request.status == RequestStatus.FINISHED_ABORTED and self.async_loading:
             # Cancel any ongoing async lookup and prefetch tasks on workers
+            lookup_id = request.request_id
             self.lookup_client.cancel_lookup(  # type: ignore[attr-defined]
-                request.request_id
+                lookup_id
             )
 
         params = (

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -20,6 +20,7 @@ from vllm.distributed.parallel_state import (
     get_tp_group,
 )
 from vllm.sampling_params import SamplingParams
+from vllm.v1.request import RequestStatus
 
 # First Party
 # Use LMCache's own math utilities instead of vllm's
@@ -1658,6 +1659,11 @@ class LMCacheConnectorV1Impl:
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, Optional[dict[str, Any]]]:
+        # Cleanup if request was aborted
+        if request.status == RequestStatus.FINISHED_ABORTED and self.async_loading:
+            # Cancel any ongoing async lookup and prefetch tasks on workers
+            self.lookup_client.cancel_lookup(request.request_id)
+
         params = (
             request.kv_transfer_params
             if hasattr(request, "kv_transfer_params")

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1662,7 +1662,9 @@ class LMCacheConnectorV1Impl:
         # Cleanup if request was aborted
         if request.status == RequestStatus.FINISHED_ABORTED and self.async_loading:
             # Cancel any ongoing async lookup and prefetch tasks on workers
-            self.lookup_client.cancel_lookup(request.request_id)
+            self.lookup_client.cancel_lookup(  # type: ignore[attr-defined]
+                request.request_id
+            )
 
         params = (
             request.kv_transfer_params

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -26,7 +26,7 @@ from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.event_manager import EventManager, EventType
+from lmcache.v1.event_manager import EventManager, EventStatus, EventType
 from lmcache.v1.gpu_connector import (
     GPUConnectorInterface,
     SGLangLayerwiseGPUConnector,
@@ -933,6 +933,42 @@ class LMCacheEngine:
             ),
             self.storage_manager.loop,
         )
+
+    def cleanup_memory_objs(self, lookup_id: str) -> None:
+        """
+        Cleanup memory objects allocated during prefetch for an aborted lookup.
+
+        Called by the scheduler when it determines that an aborted lookup
+        has finished its prefetch tasks.
+        """
+        try:
+            # Get the completed future from event_manager
+            if (
+                self.event_manager.get_event_status(EventType.LOADING, lookup_id)
+                != EventStatus.DONE
+            ):
+                logger.debug(
+                    f"No completed event found for lookup_id={lookup_id} to clean up."
+                )
+                return
+            future = self.event_manager.pop_event(EventType.LOADING, lookup_id)
+
+            # Get memory objects from the future result
+            memory_objs = future.result()
+            # Flatten nested lists (each backend returns a list of chunks)
+            memory_objs_flat = [mm for m in memory_objs for mm in m]
+
+            # Release each memory object
+            for memory_obj in memory_objs_flat:
+                try:
+                    logger.debug(f"Releasing memory object for lookup_id={lookup_id}")
+                    memory_obj.ref_count_down()
+                except Exception as e:
+                    logger.error(f"Error releasing memory object: {e}")
+        except Exception as e:
+            logger.error(
+                f"Error during cleanup_memory_objs for lookup_id={lookup_id}: {e}"
+            )
 
     # TODO(Jiayi): Need to handle the case where `tokens=None`.
     # In this case, we compress all tokens.

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -948,7 +948,7 @@ class LMCacheEngine:
                 != EventStatus.DONE
             ):
                 logger.debug(
-                    f"No completed event found for lookup_id={lookup_id} to clean up."
+                    "No completed event found for lookup_id=%s to clean up.", lookup_id
                 )
                 return
             future = self.event_manager.pop_event(EventType.LOADING, lookup_id)
@@ -961,7 +961,7 @@ class LMCacheEngine:
             # Release each memory object
             for memory_obj in memory_objs_flat:
                 try:
-                    logger.debug(f"Releasing memory object for lookup_id={lookup_id}")
+                    logger.debug("Releasing memory object for lookup_id=%s", lookup_id)
                     memory_obj.ref_count_down()
                 except Exception as e:
                     logger.error(f"Error releasing memory object: {e}")

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -69,3 +69,12 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
             lookup_id: The lookup ID whose status needs to be cleared.
         """
         return
+
+    def cancel_lookup(self, lookup_id: str) -> None:
+        """
+        Cancel an ongoing lookup and mark it for cleanup.
+
+        Args:
+            lookup_id: The lookup ID to cancel.
+        """
+        return

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -69,12 +69,3 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
             lookup_id: The lookup ID whose status needs to be cleared.
         """
         return
-
-    def cancel_lookup(self, lookup_id: str) -> None:
-        """
-        Cancel an ongoing lookup and mark it for cleanup.
-
-        Args:
-            lookup_id: The lookup ID to cancel.
-        """
-        return

--- a/lmcache/v1/lookup_client/async_lookup_message.py
+++ b/lmcache/v1/lookup_client/async_lookup_message.py
@@ -39,3 +39,12 @@ class LookupResponseMsg(AsyncLookupMsg):
             f"Async lookup response for lookup_id={self.lookup_id} "
             f"with {self.num_hit_tokens} hit tokens"
         )
+
+
+class LookupCleanupMsg(AsyncLookupMsg):
+    """Cleanup message from scheduler to worker to release memory objects"""
+
+    lookup_id: str
+
+    def describe(self) -> str:
+        return f"Cleanup memory for lookup_id={self.lookup_id}"

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -262,16 +262,14 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
 
     def _cleanup_finished_aborted_lookups(self) -> None:
         """Check for finished aborted lookups and send cleanup messages to workers."""
-        with self.lock:
-            finished_lookups = [
-                lookup_id
-                for lookup_id in self.aborted_lookups
-                if self.reqs_status.get(lookup_id) is not None
-            ]
-            if finished_lookups:
-                self.aborted_lookups.difference_update(finished_lookups)
+        finished_lookups = [
+            lookup_id
+            for lookup_id in self.aborted_lookups
+            if self.reqs_status.get(lookup_id) is not None
+        ]
+        if finished_lookups:
+            self.aborted_lookups.difference_update(finished_lookups)
 
-        # Send cleanup messages outside the lock to avoid blocking
         for lookup_id in finished_lookups:
             self._send_cleanup_message(lookup_id)
 

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -262,6 +262,8 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
 
     def _cleanup_finished_aborted_lookups(self) -> None:
         """Check for finished aborted lookups and send cleanup messages to workers."""
+        # A lookup whose status is None is still loading.
+        # We wait for it to finish before cleanup.
         finished_lookups = [
             lookup_id
             for lookup_id in self.aborted_lookups
@@ -269,13 +271,11 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         ]
         if finished_lookups:
             self.aborted_lookups.difference_update(finished_lookups)
-            with self.lock:
-                for lookup_id in finished_lookups:
-                    self.reqs_status.pop(lookup_id, None)
 
         # Tell the server to free the reserved memory buffers for each aborted lookup.
         for lookup_id in finished_lookups:
             self._send_cleanup_message(lookup_id)
+            self.clear_lookup_status(lookup_id)
 
     def _send_cleanup_message(self, lookup_id: str) -> None:
         """Send cleanup message to workers to release memory objects."""

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -273,6 +273,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 for lookup_id in finished_lookups:
                     self.reqs_status.pop(lookup_id, None)
 
+        # Tell the server to free the reserved memory buffers for each aborted lookup.
         for lookup_id in finished_lookups:
             self._send_cleanup_message(lookup_id)
 
@@ -283,7 +284,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
 
         for i in range(self.num_ranks):
             self.push_sockets[i].send(msg_buf, copy=False)
-        logger.debug(f"Sent cleanup message for lookup_id={lookup_id}")
+        logger.debug("Sent cleanup message for lookup_id=%s", lookup_id)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports producer kvcache reuse"""
@@ -349,6 +350,8 @@ class LMCacheAsyncLookupServer:
         while self.running:
             try:
                 msg_buf = self.pull_socket.recv(copy=False)
+                # rely on msgspec to automatically discriminate
+                # between LookupRequestMsg and LookupCleanupMsg
                 msg = msgspec.msgpack.decode(
                     msg_buf,
                     type=Union[LookupRequestMsg, LookupCleanupMsg],
@@ -369,10 +372,10 @@ class LMCacheAsyncLookupServer:
                     self.lmcache_engine.cleanup_memory_objs(msg.lookup_id)
 
                 else:
-                    logger.warning(f"Unknown message type: {type(msg)}")
+                    logger.warning("Unknown message type: %s", type(msg))
 
             except Exception as e:
-                logger.error(f"Error processing request from scheduler: {e}")
+                logger.error("Error processing request from scheduler: %s", e)
 
     def send_response_to_scheduler(self, lookup_id: str, num_hit_tokens: int):
         # Create structured response message

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -269,6 +269,9 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         ]
         if finished_lookups:
             self.aborted_lookups.difference_update(finished_lookups)
+            with self.lock:
+                for lookup_id in finished_lookups:
+                    self.reqs_status.pop(lookup_id, None)
 
         for lookup_id in finished_lookups:
             self._send_cleanup_message(lookup_id)

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -15,6 +15,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
 from lmcache.v1.lookup_client.async_lookup_message import (
+    LookupCleanupMsg,
     LookupRequestMsg,
     LookupResponseMsg,
 )
@@ -140,6 +141,9 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         # The two parts are [lookup_id (i.e., req_id), num_hit_tokens]
         self.num_parts = 2
 
+        # Track lookup_ids that have been aborted for cleanup
+        self.aborted_lookups: set[str] = set()
+
         self.running = True
 
         self.thread = threading.Thread(
@@ -165,6 +169,9 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
+        # Check if any aborted lookups are finished, send cleanup messages
+        self._cleanup_finished_aborted_lookups()
+
         with self.lock:
             # -1 indicates not found; None indicates ongoing.
             req_status = self.reqs_status.get(lookup_id, -1)
@@ -249,6 +256,34 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             self.reqs_status.pop(lookup_id, None)
             self.first_lookup_time.pop(lookup_id, None)
 
+    def cancel_lookup(self, lookup_id: str) -> None:
+        """Mark lookup as aborted. Cleanup will happen after task finishes."""
+        self.aborted_lookups.add(lookup_id)
+
+    def _cleanup_finished_aborted_lookups(self) -> None:
+        """Check for finished aborted lookups and send cleanup messages to workers."""
+        with self.lock:
+            finished_lookups = [
+                lookup_id
+                for lookup_id in self.aborted_lookups
+                if self.reqs_status.get(lookup_id) is not None
+            ]
+            if finished_lookups:
+                self.aborted_lookups.difference_update(finished_lookups)
+
+        # Send cleanup messages outside the lock to avoid blocking
+        for lookup_id in finished_lookups:
+            self._send_cleanup_message(lookup_id)
+
+    def _send_cleanup_message(self, lookup_id: str) -> None:
+        """Send cleanup message to workers to release memory objects."""
+        msg = LookupCleanupMsg(lookup_id=lookup_id)
+        msg_buf = msgspec.msgpack.encode(msg)
+
+        for i in range(self.num_ranks):
+            self.push_sockets[i].send(msg_buf, copy=False)
+        logger.debug(f"Sent cleanup message for lookup_id={lookup_id}")
+
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports producer kvcache reuse"""
         return True
@@ -315,7 +350,7 @@ class LMCacheAsyncLookupServer:
                 msg_buf = self.pull_socket.recv(copy=False)
                 msg = msgspec.msgpack.decode(
                     msg_buf,
-                    type=LookupRequestMsg,
+                    type=Union[LookupRequestMsg, LookupCleanupMsg],
                 )
 
                 if isinstance(msg, LookupRequestMsg):
@@ -327,6 +362,11 @@ class LMCacheAsyncLookupServer:
                         pin=True,
                         request_configs=msg.request_configs,
                     )
+
+                elif isinstance(msg, LookupCleanupMsg):
+                    # Handle cleanup request - release memory objects for aborted lookup
+                    self.lmcache_engine.cleanup_memory_objs(msg.lookup_id)
+
                 else:
                     logger.warning(f"Unknown message type: {type(msg)}")
 


### PR DESCRIPTION
1. The adapter on the scheduler side receives finished requests from the scheduler, and passes the aborted requests to the async lookup client.
2. The async lookup client keeps a record of aborted requests.
3. The async lookup client constantly checks if aborted requests are done loading. Pick those that are done loading and send cleanup messages for them to the async lookup servers.
4. The async lookup servers get the aborted requests and safely count down their memory objects.