### PR TITLE
[2/3]: Secure error handling and resource leaks in S3 Connector

### DIFF
--- a/docs/source/kv_cache/storage_backends/s3.rst
+++ b/docs/source/kv_cache/storage_backends/s3.rst
@@ -17,7 +17,7 @@ Basic S3 Configuration
    blocking_timeout_secs: 100
    extra_config:
      s3_region: "us-east-1"
-     s3_max_io_concurrency: 64
+     s3_num_io_threads: 64
      s3_max_inflight_reqs: 64
 
 S3 Express One Zone
@@ -32,7 +32,7 @@ S3 Express One Zone
    remote_serde: "naive"
    blocking_timeout_secs: 100
    extra_config:
-     s3_max_io_concurrency: 64
+     s3_num_io_threads: 64
      s3_max_inflight_reqs: 64
      s3_prefer_http2: True
      s3_region: "{REGION}"
@@ -53,15 +53,19 @@ CoreWeave (S3-compatible)
    remote_serde: "naive"
    blocking_timeout_secs: 100
    extra_config:
-     s3_max_io_concurrency: 320
+     s3_num_io_threads: 320
      s3_max_inflight_reqs: 320
      s3_prefer_http2: False
      s3_region: "US-WEST-04A"
      s3_enable_s3express: False
      save_chunk_meta: False
      s3_file_prefix: "test-2"
+     disable_tls: True
 
-**Note**: `cwlota.com` is CoreWeave's S3-compatible Cloud Storage that caches for GPU locality. Set `s3_enable_s3express: False` for non-AWS services.
+**Note**: `cwlota.com` is CoreWeave's S3-compatible Cloud Storage that caches for GPU locality. You can set `disable_tls: True` for non-AWS services.
+
+Check out the blog post between LMCache, Cohere, and CoreWeave: https://blog.lmcache.ai/en/2025/10/29/breaking-the-memory-barrier-how-lmcache-and-coreweave-power-efficient-llm-inference-for-cohere/
+
 
 Configuration Parameters
 ------------------------
@@ -75,19 +79,19 @@ S3-Specific (in extra_config)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **s3_region**: AWS region for S3 client (required)
-* **s3_max_io_concurrency**: Max concurrent I/O operations for event loop group (controls AWS CRT threading)
-* **s3_max_inflight_reqs**: Max simultaneous S3 requests (creates this many /dev/shm buffers and semaphore limit)
+* **s3_num_io_threads**: Number of IO threads for the AWS CRT client to spawn. Benefits taper out after exceeding the number of CPU cores.
+* **s3_max_inflight_reqs**: Max simultaneous S3 requests (creates this many `/dev/shm` files/buffers and semaphore limit)
 * **s3_prefer_http2**: Enable HTTP/2 with ALPN negotiation (["h2", "http/1.1"])
 * **s3_enable_s3express**: Enable S3 Express One Zone support in AWS CRT client
 * **s3_file_prefix**: Prefix for S3 object keys (e.g., `cache` becomes `/cache/key_name`). Avoid leading/trailing slashes.
 * **save_chunk_meta**: Whether to save chunk metadata with data (set False for performance)
 
-The effective concurrency is limited by the minimum of `s3_max_io_concurrency` and `s3_max_inflight_reqs`.
+The effective concurrency is limited by `s3_max_inflight_reqs`.
 
 /dev/shm Configuration
 ----------------------
 
-/dev/shm is used as the tmpfs that S3 can use to transfer only into RAM instead of having to touch a block device. 
+/dev/shm is used as the tmpfs that S3 can use to transfer only into RAM (OS page cache mapped to user space with `mmap`) instead of having to touch a block device. This reduces a memory copy.
 
 Memory Requirements and Configuration Calculation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/kv_cache_reuse/remote_backends/s3/example.yaml
+++ b/examples/kv_cache_reuse/remote_backends/s3/example.yaml
@@ -9,7 +9,7 @@ remote_serde: "naive"
 blocking_timeout_secs: 100
 
 extra_config:
-  s3_max_io_concurrency: 64
+  s3_num_io_threads: 64
   s3_max_inflight_reqs: 64
   s3_prefer_http2: True
   s3_region: "{REGION}"

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -799,7 +799,6 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
                     size=block.size - aligned_size,
                 )
             )
-
         # TODO (Jiayi): need a flag to drop these debug ops
         # Update debug status
         self.total_allocated_size += aligned_size

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -127,6 +127,14 @@ class ConnectorContext:
         self.config = config
         self.metadata = metadata
 
+    def get_full_chunk_size(self) -> int:
+        """
+        return the number of bytes in a full chunk
+        useful for S3Connector where we need to preallocate filesystem buffers
+        in ramfs for zero-copy transfers
+        """
+        return self.local_cpu_backend.get_full_chunk_size()
+
 
 class ConnectorAdapter(ABC):
     """Base class for connector adapters."""

--- a/lmcache/v1/storage_backend/connector/s3_adapter.py
+++ b/lmcache/v1/storage_backend/connector/s3_adapter.py
@@ -39,6 +39,10 @@ class S3ConnectorAdapter(ConnectorAdapter):
         self.s3_enable_s3express = bool(extra_config.get("s3_enable_s3express", False))
         self.s3_file_prefix = extra_config.get("s3_file_prefix", None)
         self.disable_tls = bool(extra_config.get("disable_tls", False))
+        if context.metadata is None:
+            raise ValueError("metadata is required for S3Connector")
+        self.meta_shape = context.metadata.kv_shape
+        self.meta_dtype = context.metadata.kv_dtype
 
         logger.info(f"Creating S3 connector for URL: {context.url}")
 
@@ -48,6 +52,8 @@ class S3ConnectorAdapter(ConnectorAdapter):
             s3_endpoint=s3_endpoint,
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
+            meta_shape=self.meta_shape,
+            meta_dtype=self.meta_dtype,
             full_chunk_size=full_chunk_size,
             s3_part_size=self.s3_part_size,
             s3_file_prefix=self.s3_file_prefix,

--- a/lmcache/v1/storage_backend/connector/s3_adapter.py
+++ b/lmcache/v1/storage_backend/connector/s3_adapter.py
@@ -23,21 +23,22 @@ class S3ConnectorAdapter(ConnectorAdapter):
         config = context.config
         assert config is not None
 
-        if config.extra_config is not None:
-            # Different parts can be transferred in parallel.
-            self.s3_part_size = config.extra_config.get("s3_part_size", None)
-            self.s3_max_io_concurrency = config.extra_config.get(
-                "s3_max_io_concurrency", 64
-            )
-            self.s3_max_inflight_reqs = config.extra_config.get(
-                "s3_max_inflight_reqs", 64
-            )
-            self.s3_prefer_http2 = config.extra_config.get("s3_prefer_http2", True)
-            self.s3_region = config.extra_config.get("s3_region", None)
-            self.s3_enable_s3express = config.extra_config.get(
-                "s3_enable_s3express", True
-            )
-            self.s3_file_prefix = config.extra_config.get("s3_file_prefix", None)
+        # Get full_chunk_size from context
+        full_chunk_size = context.get_full_chunk_size()
+
+        # Get config from extra_config with defaults
+        extra_config = config.extra_config if config.extra_config is not None else {}
+
+        self.s3_part_size = int(extra_config.get("s3_part_size", full_chunk_size))
+        self.s3_num_io_threads = int(extra_config.get("s3_num_io_threads", 64))
+        self.s3_max_inflight_reqs = int(extra_config.get("s3_max_inflight_reqs", 64))
+        self.s3_prefer_http2 = bool(extra_config.get("s3_prefer_http2", True))
+        self.s3_region = extra_config.get("s3_region", None)
+        assert self.s3_region is not None, "s3_region is required"
+        self.s3_region = str(self.s3_region)
+        self.s3_enable_s3express = bool(extra_config.get("s3_enable_s3express", False))
+        self.s3_file_prefix = extra_config.get("s3_file_prefix", None)
+        self.disable_tls = bool(extra_config.get("disable_tls", False))
 
         logger.info(f"Creating S3 connector for URL: {context.url}")
 
@@ -47,11 +48,13 @@ class S3ConnectorAdapter(ConnectorAdapter):
             s3_endpoint=s3_endpoint,
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
+            full_chunk_size=full_chunk_size,
             s3_part_size=self.s3_part_size,
             s3_file_prefix=self.s3_file_prefix,
-            s3_max_io_concurrency=self.s3_max_io_concurrency,
+            s3_num_io_threads=self.s3_num_io_threads,
             s3_max_inflight_reqs=self.s3_max_inflight_reqs,
             s3_prefer_http2=self.s3_prefer_http2,
             s3_region=self.s3_region,
             s3_enable_s3express=self.s3_enable_s3express,
+            disable_tls=self.disable_tls,
         )

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -446,7 +446,7 @@ class S3Connector(RemoteConnector):
     def on_get_done(
         self,
         obj_size: int,
-        memory_obj: Union[MemoryObj, None],
+        memory_obj: Optional[MemoryObj],
         shm: Union[int, None],
         recv_path: str,
         _: asyncio.Future,

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -2,7 +2,7 @@
 # Standard
 from enum import IntEnum, auto
 from functools import partial
-from typing import List, Optional
+from typing import List, Optional, Union
 from urllib.parse import quote as url_quote
 import asyncio
 import ctypes
@@ -33,16 +33,11 @@ class Priorities(IntEnum):
     PUT = auto()
 
 
-# TODO(Jiayi): Some pending problems.
-# (1) We might need a filesystem-like allocator.
-# This could be useful for local disk `LocalDiskBackend` and
-# `/dev/shm` in `S3Connector`
-# (2) Need to hack amazon python s3 crt library to enable `offset`
-# to achieve zero-copy.
-# (3) Potentially can drop the semaphore to reduce the complexity.
-# Let crt handle the scheduling.
-
-
+# TODO: for true zero-copy, we need to register the local
+# cpu backend with /dev/shm as well as cudaHostRegister
+# ctrl + f for `ctypes.memmove`
+# to find where the memcpy is happening right now
+# after that optimization, we can remove this adhoc manager
 class AdhocSharedMemoryManager:
     """
     A shared memory manager that allocates shared memory buffers
@@ -380,7 +375,6 @@ class S3Connector(RemoteConnector):
             client=self.s3_client,
             type=s3.S3RequestType.GET_OBJECT,
             request=req,
-            operation_name="GetObject",
             recv_filepath=recv_path,
             credential_provider=self.credentials_provider,
             region=self.s3_region,
@@ -408,7 +402,6 @@ class S3Connector(RemoteConnector):
             self.meta_dtype,
             self.meta_fmt,
         )
-
         # TODO(Jiayi): Please support this
         assert obj_size == memory_obj.get_size(), (
             "Saving unfull chunk is not supported in S3Connector."
@@ -423,38 +416,44 @@ class S3Connector(RemoteConnector):
             recv_path=recv_path,
         )
 
-        await asyncio.wrap_future(s3_req.finished_future)
+        try:
+            # use blocking_timeout_sec in config to control the timeout
+            await asyncio.wrap_future(s3_req.finished_future)
 
-        dst_ptr = memory_obj.data_ptr
-        ctypes.memmove(dst_ptr, shm, obj_size)
-
-        self.adhoc_shm_manager.free(recv_path, shm)
-
-        self.inflight_sema.release()
-
-        return memory_obj
+            dst_ptr = memory_obj.data_ptr
+            # TODO: optimize this
+            ctypes.memmove(dst_ptr, shm, obj_size)
+            return memory_obj
+        except Exception as e:
+            logger.error(f"Failed to download {key_str} from S3: {e}")
+            self.adhoc_shm_manager.free(recv_path, shm)
+            return None
+        finally:
+            self.inflight_sema.release()
+            self.adhoc_shm_manager.free(recv_path, shm)
 
     # this callback allows us to safely have multiple calls to batched_get
     # since we release the semaphores 1-by-1
     def on_get_done(
         self,
         obj_size: int,
-        memory_obj: MemoryObj,
-        shm: int,
+        memory_obj: Union[MemoryObj, None],
+        shm: Union[int, None],
         recv_path: str,
-        fut: asyncio.Future,
+        _: asyncio.Future,
     ):
         try:
             if memory_obj is None or shm is None:
                 return None
 
             dst_ptr = memory_obj.data_ptr
+            # TODO: optimize this
             ctypes.memmove(dst_ptr, shm, obj_size)
 
-            self.adhoc_shm_manager.free(recv_path, shm)
         except Exception as e:
             logger.error(f"on_get_done failed for {recv_path}: {e}")
         finally:
+            self.adhoc_shm_manager.free(recv_path, shm)
             self.inflight_sema.release()
 
     async def batched_get(
@@ -505,7 +504,7 @@ class S3Connector(RemoteConnector):
                 "Saving unfull chunk is not supported in S3Connector."
             )
 
-            # freeing is done in on_get_done callback
+            # sema release and freeing is done in on_get_done callback
             recv_path, shm = self.adhoc_shm_manager.allocate()
             s3_req = self._s3_download(
                 key_str=key_str,
@@ -546,7 +545,6 @@ class S3Connector(RemoteConnector):
             client=self.s3_client,
             type=s3.S3RequestType.PUT_OBJECT,
             request=req,
-            operation_name="PutObject",
             send_filepath=send_path,
             credential_provider=self.credentials_provider,
             region=self.s3_region,
@@ -572,6 +570,7 @@ class S3Connector(RemoteConnector):
 
         try:
             buffer_ptr = memory_obj.data_ptr
+            # TODO: optimize this
             ctypes.memmove(shm, buffer_ptr, memory_obj.get_physical_size())
             logger.debug("Data copy to S3 buffer completed")
 
@@ -582,7 +581,6 @@ class S3Connector(RemoteConnector):
             logger.debug(f"Uploaded {key_str} to S3 successfully")
         except Exception as e:
             logger.error(f"Failed to upload {key_str} to S3: {e}")
-            raise
         finally:
             self.inflight_sema.release()
             self.adhoc_shm_manager.free(send_path, shm)

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -14,6 +14,7 @@ import tempfile
 from awscrt import auth, io, s3
 from awscrt.http import HttpHeaders, HttpRequest
 from awscrt.io import ClientTlsContext, TlsConnectionOptions, TlsContextOptions
+import torch
 
 # First Party
 from lmcache.logging import init_logger
@@ -99,6 +100,8 @@ class S3Connector(RemoteConnector):
         s3_endpoint: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
+        meta_shape: torch.Size,
+        meta_dtype: torch.dtype,
         full_chunk_size: int,
         s3_part_size: Optional[int],
         s3_file_prefix: Optional[str],
@@ -109,6 +112,11 @@ class S3Connector(RemoteConnector):
         s3_enable_s3express: bool,
         disable_tls: bool,
     ):
+        # TODO: these can be removed after we support unfull_chunk
+        # full_chunk_size
+        # meta_shape (need to store the chunk meta in s3 probably)
+        # meta_dtype (need to store the chunk meta in s3 probably)
+
         if not s3_endpoint.startswith("s3://"):
             raise ValueError("S3 url must start with 's3://'")
 
@@ -138,6 +146,9 @@ class S3Connector(RemoteConnector):
         self.credentials_provider = auth.AwsCredentialsProvider.new_default_chain(
             client_bootstrap
         )
+
+        self.meta_shape = meta_shape
+        self.meta_dtype = meta_dtype
 
         tls_opts = None
 
@@ -329,7 +340,6 @@ class S3Connector(RemoteConnector):
             return 0
         return got["len"] if got["len"] is not None else 0
 
-    # TODO(Jiayi): implement real async
     async def exists(self, key: CacheEngineKey) -> bool:
         return self.exists_sync(key)
 
@@ -426,7 +436,6 @@ class S3Connector(RemoteConnector):
             return memory_obj
         except Exception as e:
             logger.error(f"Failed to download {key_str} from S3: {e}")
-            self.adhoc_shm_manager.free(recv_path, shm)
             return None
         finally:
             self.inflight_sema.release()
@@ -486,7 +495,6 @@ class S3Connector(RemoteConnector):
                 self.object_size_cache[key_str] = obj_size
 
             await self.inflight_sema.acquire()
-
             memory_obj = self.local_cpu_backend.allocate(
                 self.meta_shape,
                 self.meta_dtype,

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -39,9 +39,7 @@ class Priorities(IntEnum):
 # `/dev/shm` in `S3Connector`
 # (2) Need to hack amazon python s3 crt library to enable `offset`
 # to achieve zero-copy.
-# (3) Need a job manager so that we can do sth like
-# write priority, read priority, etc.
-# (4) Potentially can drop the semaphore to reduce the complexity.
+# (3) Potentially can drop the semaphore to reduce the complexity.
 # Let crt handle the scheduling.
 
 
@@ -106,13 +104,15 @@ class S3Connector(RemoteConnector):
         s3_endpoint: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
+        full_chunk_size: int,
         s3_part_size: Optional[int],
         s3_file_prefix: Optional[str],
-        s3_max_io_concurrency: int,
+        s3_num_io_threads: int,
         s3_max_inflight_reqs: int,
         s3_prefer_http2: bool,
         s3_region: str,
         s3_enable_s3express: bool,
+        disable_tls: bool,
     ):
         if not s3_endpoint.startswith("s3://"):
             raise ValueError("S3 url must start with 's3://'")
@@ -121,21 +121,23 @@ class S3Connector(RemoteConnector):
         self.s3_prefix = s3_file_prefix
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
+        self.full_chunk_size = full_chunk_size
 
         self.s3_part_size = s3_part_size
 
         # TODO(Jiayi): Now we only assume S3 part size = chunk size
+        logger.info(f"S3 part size is set to {self.s3_part_size} bytes")
         assert self.s3_part_size == self.full_chunk_size, (
             "S3 part size must be equal to chunk size in S3Connector"
         )
 
-        self.s3_max_io_concurrency = s3_max_io_concurrency
+        self.s3_num_io_threads = s3_num_io_threads
         self.s3_max_inflight_reqs = s3_max_inflight_reqs
         self.s3_prefer_http2 = s3_prefer_http2
         self.s3_region = s3_region
         self.s3_enable_s3express = s3_enable_s3express
 
-        event_loop_group = io.EventLoopGroup(s3_max_io_concurrency)
+        event_loop_group = io.EventLoopGroup(s3_num_io_threads)
         host_resolver = io.DefaultHostResolver(event_loop_group)
         client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
         self.credentials_provider = auth.AwsCredentialsProvider.new_default_chain(
@@ -143,6 +145,7 @@ class S3Connector(RemoteConnector):
         )
 
         tls_opts = None
+
         if self.s3_prefer_http2:
             # Use HTTP/2 multiplexing if possible.
             tls_ctx = ClientTlsContext(TlsContextOptions())
@@ -152,14 +155,28 @@ class S3Connector(RemoteConnector):
             except Exception:
                 tls_opts = None
 
+        signing_config = None
+        if self.s3_enable_s3express:
+            signing_config = auth.AwsSigningConfig(
+                algorithm=auth.AwsSigningAlgorithm.V4_S3EXPRESS,
+                region=self.s3_region,
+                service="s3",
+                credentials_provider=self.credentials_provider,
+            )
+
+        # turn off TLS for non-AWS services
+        # regular and directory/express buckets both use TLS by default
+        turn_off_tls = (
+            s3.S3RequestTlsMode.DISABLED if disable_tls else s3.S3RequestTlsMode.ENABLED
+        )
         logger.info("Initializing S3 client")
         self.s3_client = s3.S3Client(
             bootstrap=client_bootstrap,
             region=s3_region,
-            credential_provider=self.credentials_provider,
-            enable_s3express=False,  # enable for s3express
+            enable_s3express=s3_enable_s3express,
             tls_connection_options=tls_opts,
-            tls_mode=s3.S3RequestTlsMode.DISABLED,  # only for non-AWS services
+            tls_mode=turn_off_tls,
+            signing_config=signing_config,
         )
 
         # TODO(Jiayi): We need to handle cache consistency issues in a systematic way
@@ -182,13 +199,15 @@ class S3Connector(RemoteConnector):
             "S3 part size must be equal to chunk size in S3Connector"
         )
 
+        # TODO: if two machines on the same node (with the same PYTHONHASHSEED)
+        # are both using the S3 Connector, there may be R/W contention on /dev/shm.
         shm_name_prefix = "my_shm"
         shms = []
         shm_names = []
         mmaps = []
         for i in range(self.s3_max_inflight_reqs):
             shm_name = f"{shm_name_prefix}_{i}"
-
+            # /dev/shm avoids disk (~fs is the page cache)
             shm = tempfile.NamedTemporaryFile(
                 prefix=shm_name, suffix=".part", dir="/dev/shm", delete=False
             )
@@ -196,6 +215,7 @@ class S3Connector(RemoteConnector):
             os.ftruncate(shm.fileno(), self.full_chunk_size)
 
             with open(shm.name, "r+b") as f:
+                # mmap directly maps user space to the /dev/shm
                 mm = mmap.mmap(f.fileno(), self.full_chunk_size)
                 # create a char buffer view over the mmap
                 buf = ctypes.c_char.from_buffer(mm)

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -600,20 +600,12 @@ class LocalCPUBackend(AllocatorBackendInterface):
         self.stats_monitor.update_local_cpu_evict_metrics(evict_keys_count)
         return memory_objs
 
-    def calculate_chunk_budget(self) -> int:
-        """
-        Calculate the maximum number of chunks that can be allocated concurrently
-        without causing memory deadlocks in the async loading system.
-
-        Returns:
-            int: The estimated chunk budget for concurrent allocations
-        """
+    def get_full_chunk_size(self) -> int:
         logger.debug("Attempting to calculate chunk budget for async loading")
         assert self.metadata is not None, (
             "metadata required for chunk budget calculation"
         )
 
-        total_memory = int(self.config.max_local_cpu_size * 1024**3)
         chunk_tokens = self.config.chunk_size
         # already accounted for parallelism
         kv_shape = (
@@ -639,6 +631,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
             f"hidden_dim={hidden_dim}"
         )
         logger.debug(f"Calculated bytes per chunk per rank: {chunk_bytes}")
+        return chunk_bytes
+
+    def calculate_chunk_budget(self) -> int:
+        """
+        Calculate the maximum number of chunks that can be allocated concurrently
+        without causing memory deadlocks in the async loading system.
+
+        Returns:
+            int: The estimated chunk budget for concurrent allocations
+        """
+        total_memory = int(self.config.max_local_cpu_size * 1024**3)
+        chunk_bytes = self.get_full_chunk_size()
         # add alignment overhead
         # (MixedMemoryAllocator uses TensorMemoryAllocator with 4KB alignment)
         assert hasattr(self.memory_allocator, "align_bytes")


### PR DESCRIPTION
Follow up to:  https://github.com/LMCache/LMCache/pull/2044

[3/3]: Register Local CPU Backend with `/dev/shm`


UPDATE: the memmove from /dev/shm to local cpu backend only takes ~0.02 seconds, which is not worth the refactor