### PR TITLE
[controller] remove distributed_url

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -166,12 +166,18 @@ Settings for enabling and configuring peer-to-peer CPU KV cache sharing and glob
    * - enable_p2p
      - LMCACHE_ENABLE_P2P
      - Whether to enable peer-to-peer sharing. Values: true/false. Default: false
-   * - lookup_url
-     - LMCACHE_LOOKUP_URL
-     - URL of the lookup server. Required if enable_p2p is true
-   * - distributed_url
-     - LMCACHE_DISTRIBUTED_URL
-     - URL of the distributed server. Required if enable_p2p is true
+   * - p2p_host
+     - LMCACHE_P2P_HOST
+     - Ip address. Required if enable_p2p is true
+   * - peer_init_ports
+     - LMCACHE_PEER_INIT_PORTS
+     - Ports for p2p peer init. Required if enable_p2p is true
+   * - peer_lookup_ports
+     - LMCACHE_PEER_lookup_PORTS
+     - Ports for p2p peer lookup. Required if enable_p2p is true
+   * - transfer_channel
+     - LMCACHE_TRANSFER_CHANNEL
+     - Such as `nixl`. Required if enable_p2p is true
 
 Controller Configurations
 -------------------------

--- a/docs/source/kv_cache_management/query_worker_info.rst
+++ b/docs/source/kv_cache_management/query_worker_info.rst
@@ -62,7 +62,7 @@ The controller responds with a message similar to:
 
 .. code-block:: text
 
-    {"event_id": "xxx", "worker_infos": [{"instance_id": "lmcache_default_instance", "worker_id": 0, "ip": "127.0.0.1", "port": 8001, "distributed_url": "127.0.0.1:8200", "registration_time": 123456, "last_heartbeat_time": 456789}]}
+    {"event_id": "xxx", "worker_infos": [{"instance_id": "lmcache_default_instance", "worker_id": 0, "ip": "127.0.0.1", "port": 8001, "peer_init_url": "127.0.0.1:8200", "registration_time": 123456, "last_heartbeat_time": 456789}]}
 
 ``worker_infos`` contains the queried worker information.
 returned ``event_id`` can be used to query the status of the operation.

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -216,7 +216,7 @@ class KVController:
             elif instance_id == "":
                 instance_id = matched_kv_chunk_meta.instance_id
                 location = matched_kv_chunk_meta.location
-                peer_init_url = self.reg_controller.get_distributed_url(
+                peer_init_url = self.reg_controller.get_peer_init_url(
                     instance_id, worker_id
                 )
                 assert peer_init_url is not None

--- a/lmcache/v1/cache_controller/executor.py
+++ b/lmcache/v1/cache_controller/executor.py
@@ -300,7 +300,7 @@ class LMCacheClusterExecutor:
             src_worker_ids, dst_worker_ids, strict=False
         ):
             socket = self.reg_controller.get_socket(src_instance_id, src_worker_id)
-            dst_url = self.reg_controller.get_distributed_url(
+            dst_url = self.reg_controller.get_peer_init_url(
                 dst_instance_id, dst_worker_id
             )
 

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -42,14 +42,14 @@ class RegisterMsg(WorkerMsg):
     ip: str
     port: int
     # URL for actual KV cache transfer, only useful when p2p is enabled
-    distributed_url: Optional[str]
+    peer_init_url: Optional[str]
 
     def describe(self) -> str:
         return (
             f"Registering instance {self.instance_id}, "
             f"worker {self.worker_id} "
             f"at {self.ip}:{self.port}"
-            f" with distributed URL {self.distributed_url}"
+            f" with peer init URL {self.peer_init_url}"
         )
 
 

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -10,6 +10,6 @@ class WorkerInfo:
     worker_id: int
     ip: str
     port: int
-    distributed_url: Optional[str]
+    peer_init_url: Optional[str]
     registration_time: float
     last_heartbeat_time: float

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -139,7 +139,7 @@ class LMCacheWorker:
                 worker_id=self.worker_id,
                 ip=self.lmcache_worker_ip,
                 port=self.lmcache_worker_port,
-                distributed_url=self.p2p_init_url,
+                peer_init_url=self.p2p_init_url,
             )
         )
 
@@ -219,7 +219,7 @@ class LMCacheWorker:
                         worker_id=self.worker_id,
                         ip=self.lmcache_worker_ip,
                         port=self.lmcache_worker_port,
-                        distributed_url=self.p2p_init_url,
+                        peer_init_url=self.p2p_init_url,
                     )
                 )
                 await asyncio.sleep(self.config.lmcache_worker_heartbeat_time)

--- a/lmcache/v1/internal_api_server/controller/worker_info_api.py
+++ b/lmcache/v1/internal_api_server/controller/worker_info_api.py
@@ -14,7 +14,7 @@ class WorkerInfoResponse(BaseModel):
     worker_id: int
     ip: str
     port: int
-    distributed_url: Optional[str]
+    peer_init_url: Optional[str]
     registration_time: float
     last_heartbeat_time: float
 
@@ -67,7 +67,7 @@ async def get_workers(
                 worker_id=worker_info.worker_id,
                 ip=worker_info.ip,
                 port=worker_info.port,
-                distributed_url=worker_info.distributed_url,
+                peer_init_url=worker_info.peer_init_url,
                 registration_time=worker_info.registration_time,
                 last_heartbeat_time=worker_info.last_heartbeat_time,
             )
@@ -92,7 +92,7 @@ async def get_workers(
                             worker_id=worker_info.worker_id,
                             ip=worker_info.ip,
                             port=worker_info.port,
-                            distributed_url=worker_info.distributed_url,
+                            peer_init_url=worker_info.peer_init_url,
                             registration_time=worker_info.registration_time,
                             last_heartbeat_time=worker_info.last_heartbeat_time,
                         )
@@ -110,7 +110,7 @@ async def get_workers(
                         worker_id=worker_info.worker_id,
                         ip=worker_info.ip,
                         port=worker_info.port,
-                        distributed_url=worker_info.distributed_url,
+                        peer_init_url=worker_info.peer_init_url,
                         registration_time=worker_info.registration_time,
                         last_heartbeat_time=worker_info.last_heartbeat_time,
                     )


### PR DESCRIPTION
`distributed_url` is `peer_init_url`, remove it can make code more clear.

This PR only **rename** the `distributed_url` to `peer_init_url`, no any other operation!