### PR TITLE
fix format error and typo

### DIFF
--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -174,11 +174,13 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                     time.time() - self.first_lookup_time[lookup_id]
                 ) * 1000 > self.timeout_ms:
                     logger.warning(
-                        "Request %s is still waiting for async lookup",
-                        "after %d seconds, returning 0 lmcache cached tokens",
-                        "so vllm can recompute",
+                        (
+                            "Request %s is still waiting for async lookup "
+                            "after %d seconds, returning 0 lmcache cached tokens "
+                            "so vllm can recompute"
+                        ),
                         lookup_id,
-                        self.timeout_ms,
+                        self.timeout_ms // 1000,
                     )
                     self.first_lookup_time.pop(lookup_id, None)
                     return 0


### PR DESCRIPTION
The multi-line string needs to be wrapped in parentheses if we use the % format.
Otherwise, it errors like this.
Also, the number in ms should be divided by 1000. Fix the typo.

TypeError: not all arguments converted during string formatting
(EngineCore_DP0 pid=607072)   File "/root/vllm-lmcache/LMCache/lmcache/v1/lookup_client/lmcache_async_lookup_client.py", line 176, in lookup
(EngineCore_DP0 pid=607072)     logger.warning(
(EngineCore_DP0 pid=607072) Message: 'Request %s is still waiting for async lookup'
(EngineCore_DP0 pid=607072) Arguments: ('after %d seconds, returning 0 lmcache cached tokens', 'so vllm can recompute', 'chatcmpl-55fb505003354be7a6d4185f2205235f', 3000)