### PR TITLE
[CI|Test] Fix the non-CUDA ut ci failed caused by wrong format of yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: "Run non-CUDA unit tests"
         run: |
-          pytest --ignore=tests/disagg --ignore=tests/v1/test_nixl_storage.py \ 
-          --ignore=tests/v1/multiprocess/test_cache_server.py \
-          --ignore=tests/v1/storage_backend/test_eic.py
+          pytest --ignore=tests/disagg --ignore=tests/v1/test_nixl_storage.py \
+            --ignore=tests/v1/multiprocess/test_cache_server.py \
+            --ignore=tests/v1/storage_backend/test_eic.py
 


### PR DESCRIPTION
As title, this is a urgent fix! This is blocked by https://github.com/LMCache/LMCache/pull/1930

<img width="2294" height="1480" alt="Clipboard_Screenshot_1763946498" src="https://github.com/user-attachments/assets/c42853a2-5b37-4b8c-ba9f-cdf427162068" />
