### PR TITLE
[Bugfix|VLLM] Fix issue of 'CachedRequestData' object has no attribute 'resumed_req_ids'

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1632,10 +1632,25 @@ class LMCacheConnectorV1Impl:
             if load_spec is not None:
                 lmcache_cached_tokens = load_spec.lmcache_cached_tokens
 
+            # Handle both old and new versions of CachedRequestData
+            if hasattr(cached_reqs, "resumed_req_ids"):
+                # New version with resumed_req_ids
+                preempted = req_id in cached_reqs.resumed_req_ids
+            elif hasattr(cached_reqs, "resumed_from_preemption"):
+                # Old version with resumed_from_preemption
+                preempted = cached_reqs.resumed_from_preemption[i]
+            else:
+                # Fallback to False if neither attribute exists
+                preempted = False
+                logger.warning(
+                    f"Unable to determine preemption status for request {req_id}, "
+                    f"assuming not preempted"
+                )
+
             request_tracker.update(
                 new_token_ids,
                 new_block_ids,
-                preempted=req_id in cached_reqs.resumed_req_ids,
+                preempted=preempted,
                 lmcache_cached_tokens=lmcache_cached_tokens,
             )
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1640,11 +1640,11 @@ class LMCacheConnectorV1Impl:
                 # Old version with resumed_from_preemption
                 preempted = cached_reqs.resumed_from_preemption[i]
             else:
-                # Fallback to False if neither attribute exists
-                preempted = False
-                logger.warning(
-                    f"Unable to determine preemption status for request {req_id}, "
-                    f"assuming not preempted"
+                # This case should not be reached with supported vLLM versions.
+                # Raising an error is safer than assuming not preempted.
+                raise AttributeError(
+                    f"Unable to determine preemption status for request {req_id}. "
+                    f"This might be due to an unsupported vLLM version."
                 )
 
             request_tracker.update(


### PR DESCRIPTION
After merge #2007 , vllm 0.11.0 cannot work with lmcache trunk

- vLLM output.
```
EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710] EngineCore encountered a fatal error.
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710] Traceback (most recent call last):
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 701, in run_engine_core
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     engine_core.run_busy_loop()
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 728, in run_busy_loop
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     self._process_engine_step()
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 754, in _process_engine_step
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 283, in step
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     scheduler_output = self.scheduler.schedule()
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 606, in schedule
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     meta = self.connector.build_connector_meta(scheduler_output)
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 151, in build_connector_meta
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     return self._lmcache_engine.build_connector_meta(scheduler_output)
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]   File "/apdcephfs_szgm/share_303468461/baoloongmao/remote_dev/lmcache_new/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 1638, in build_connector_meta
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]     preempted=req_id in cached_reqs.resumed_req_ids,
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=982672) ERROR 11-24 21:48:32 [core.py:710] AttributeError: 'CachedRequestData' object has no attribute 'resumed_req_ids'
(Worker_TP0 pid=982885) INFO 11-24 21:48:32 [multiproc_executor.py:558] Parent process exited, terminating worker
(Worker_TP1 pid=982890) INFO 11-24 21:48:32 [multiproc_executor.py:558] Parent process exited, terminating worker
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480] AsyncLLM output_handler failed.
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480] Traceback (most recent call last):
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 439, in output_handler
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480]     outputs = await engine_core.get_output_async()
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 846, in get_output_async
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480]     raise self._format_exception(outputs) from None
(APIServer pid=982314) ERROR 11-24 21:48:32 [async_llm.py:480] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause.
(APIServer pid=982314) INFO:     127.0.0.1:35352 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

- Root cause
vLLM merged the PR 24926 at 2025/10/9([Core][KVConnector] Propagate all tokens on resumed preemptions (#24926) Qier Li* 2025/10/9 14:43) , so the vllm before this version cannot use the head of lmcache dev branch.