### PR TITLE
(KV-cache calculator) Add MiniMaxAI model configuration to modelconfig.json

### DIFF
--- a/docs/source/_static/modelconfig.json
+++ b/docs/source/_static/modelconfig.json
@@ -11,6 +11,12 @@
         "num_hidden_layers": 80,
         "num_key_value_heads": 8
     },
+    "MiniMaxAI/MiniMax-M2": {
+        "hidden_size": 3072,
+        "num_attention_heads": 48,
+        "num_hidden_layers": 62,
+        "num_key_value_heads": 8
+    },
     "mistralai/Mistral-7B-Instruct-v0.2": {
         "hidden_size": 4096,
         "num_attention_heads": 32,

--- a/examples/kv_cache_calculator/modelconfig.json
+++ b/examples/kv_cache_calculator/modelconfig.json
@@ -11,6 +11,12 @@
         "num_hidden_layers": 80,
         "num_key_value_heads": 8
     },
+    "MiniMaxAI/MiniMax-M2": {
+        "hidden_size": 3072,
+        "num_attention_heads": 48,
+        "num_hidden_layers": 62,
+        "num_key_value_heads": 8
+    },
     "mistralai/Mistral-7B-Instruct-v0.2": {
         "hidden_size": 4096,
         "num_attention_heads": 32,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds config from MiniMaxAI/MiniMax-M2 to the config.json file in kv_cache_calculator

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
