### PR TITLE
Update _get_file_name of fs_connector to support deserialize

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -95,7 +95,7 @@ class FSConnector(RemoteConnector):
         return base_path
 
     def _get_file_name(self, key: CacheEngineKey) -> str:
-        return key.to_string().replace("/", "-") + ".data"
+        return key.to_string().replace("/", "-SEP-") + ".data"
 
     def _get_file_path(self, key: CacheEngineKey) -> Path:
         """Get file path for the given key"""


### PR DESCRIPTION
One line minor change. 
Without this, we cannot deserialize the CacheEngineKey from chunk file name.