### PR TITLE
Add /cache/load-fs-chunks internal API endpoint for load fs chunk into cpu hot cache

### DIFF
--- a/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
+++ b/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Dict, List, Optional
+import asyncio
+import json
+
+# Third Party
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+
+
+class LoadFSChunksRequest(BaseModel):
+    """Request model for loading FS chunks."""
+
+    config_path: str
+    max_chunks: Optional[int] = None
+    max_failed_keys: int = 10
+
+
+router = APIRouter()
+logger = init_logger(__name__)
+
+
+@router.post("/cache/load-fs-chunks")
+async def load_fs_chunks(
+    request: Request,
+    request_body: LoadFSChunksRequest,
+):
+    """
+    Load chunk files from FSConnector into LocalCPUBackend hot cache.
+
+    This endpoint loads all chunk files from the specified FSConnector directory
+    into the LocalCPUBackend's hot cache by:
+    1. Loading configuration from the specified config file
+    2. Initializing RemoteBackend with FSConnector
+    3. Listing all chunk files in the FSConnector directory
+    4. Constructing CacheEngineKey from filenames
+    5. Loading MemoryObj from files and putting into hot cache
+
+    Args:
+        request: The FastAPI request object
+        config_path: Path to the configuration file for RemoteBackend
+        max_chunks: Maximum number of chunks to load (optional, loads all if None)
+
+    Returns:
+        PlainTextResponse: JSON response with loading statistics
+
+    Example:
+        ```bash
+        curl -X POST "http://localhost:8000/cache/load-fs-chunks" \
+             -H "Content-Type: application/json" \
+             -d '{"config_path": "/path/to/config.json", "max_chunks": 100}'
+        ```
+    """
+    lmcache_adapter = request.app.state.lmcache_adapter
+    lmcache_engine = getattr(lmcache_adapter, "lmcache_engine", None)
+
+    if not lmcache_engine:
+        error_info = {
+            "error": "/cache/load-fs-chunks API is unavailable",
+            "message": "LMCache engine not configured.",
+        }
+        return PlainTextResponse(
+            content=json.dumps(error_info, indent=2),
+            media_type="application/json",
+            status_code=503,
+        )
+
+    remote_backend = None
+    try:
+        config = await _load_config_from_file(request_body.config_path)
+        local_cpu_backend = lmcache_engine.storage_manager.allocator_backend
+
+        remote_backend = await _initialize_remote_backend(
+            config,
+            lmcache_engine.metadata,
+            local_cpu_backend,
+            lmcache_engine.storage_manager.loop,
+        )
+
+        result = await _load_chunks_from_fs_connector(
+            remote_backend,
+            local_cpu_backend,
+            request_body.max_chunks,
+            request_body.max_failed_keys,
+        )
+
+        success_info = {
+            "status": "success",
+            "loaded_chunks": result["loaded_chunks"],
+            "total_files": result["total_files"],
+            "failed_keys": result["failed_keys"],
+            "config_path": request_body.config_path,
+        }
+
+        return PlainTextResponse(
+            content=json.dumps(success_info, indent=2),
+            media_type="application/json",
+        )
+
+    except Exception as e:
+        error_info = {
+            "error": "Failed to load chunks from FSConnector",
+            "message": str(e),
+            "config_path": request_body.config_path,
+        }
+        return PlainTextResponse(
+            content=json.dumps(error_info, indent=2),
+            media_type="application/json",
+            status_code=500,
+        )
+    finally:
+        if remote_backend is not None:
+            remote_backend.close()
+
+
+async def _load_config_from_file(config_path: str) -> LMCacheEngineConfig:
+    """Load configuration from yaml file."""
+    try:
+        return LMCacheEngineConfig.from_file(config_path)
+    except Exception as e:
+        logger.error(f"Failed to load config from {config_path}: {e}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid configuration file: {str(e)}"
+        ) from e
+
+
+async def _initialize_remote_backend(
+    config: LMCacheEngineConfig, metadata, local_cpu_backend, loop
+) -> RemoteBackend:
+    """Initialize RemoteBackend with FSConnector."""
+    try:
+        remote_backend = RemoteBackend(
+            config=config,
+            metadata=metadata,
+            loop=loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cpu",
+        )
+        remote_backend.init_connection()
+        return remote_backend
+    except Exception as e:
+        logger.error(f"Failed to initialize RemoteBackend: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to initialize RemoteBackend: {str(e)}"
+        ) from e
+
+
+async def _load_chunks_from_fs_connector(
+    remote_backend: RemoteBackend,
+    local_cpu_backend,
+    max_chunks: Optional[int] = None,
+    max_failed_keys: int = 10,
+) -> Dict:
+    """Load chunks from FSConnector into LocalCPUBackend."""
+    connector = remote_backend.connection
+    if not connector:
+        raise HTTPException(status_code=500, detail="FSConnector not initialized")
+
+    try:
+        chunk_files = await connector.list()
+        total_files = len(chunk_files)
+
+        if max_chunks:
+            chunk_files = chunk_files[:max_chunks]
+
+        logger.info(f"Found {len(chunk_files)} chunk files to load")
+
+        loaded_chunks = 0
+        failed_keys: List[str] = []
+
+        for chunk_filename in chunk_files:
+            try:
+                key_str = chunk_filename.replace("-SEP-", "/")
+                key = CacheEngineKey.from_string(key_str)
+
+                memory_obj = await asyncio.get_event_loop().run_in_executor(
+                    None, remote_backend.get_blocking, key
+                )
+
+                if memory_obj:
+                    local_cpu_backend.submit_put_task(key, memory_obj)
+                    memory_obj.ref_count_down()
+                    loaded_chunks += 1
+
+                    if loaded_chunks % 100 == 0:
+                        logger.info(f"Loaded {loaded_chunks} chunks...")
+                else:
+                    failed_keys.append(key_str)
+                    logger.warning(f"Failed to load chunk: {key_str}")
+
+            except Exception as e:
+                failed_keys.append(chunk_filename)
+                logger.warning(f"Error loading chunk {chunk_filename}: {e}")
+
+        logger.info(
+            f"Successfully loaded {loaded_chunks} chunks from {total_files} files"
+        )
+
+        return {
+            "loaded_chunks": loaded_chunks,
+            "total_files": total_files,
+            "failed_keys": failed_keys[:max_failed_keys],
+        }
+
+    except Exception as e:
+        logger.error(f"Error in chunk loading process: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Chunk loading failed: {str(e)}"
+        ) from e

--- a/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
+++ b/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
@@ -25,11 +25,45 @@ class LoadFSChunksRequest(BaseModel):
     max_failed_keys: int = 10
 
 
+class LoadFSChunksResponse(BaseModel):
+    """Response model for load-fs-chunks endpoint."""
+
+    status: str
+    loaded_chunks: int
+    total_files: int
+    failed_keys: List[str]
+    config_path: str
+
+
+class ErrorResponse(BaseModel):
+    """Error response model for load-fs-chunks endpoint."""
+
+    error: str
+    message: str
+    config_path: Optional[str] = None
+
+
 router = APIRouter()
 logger = init_logger(__name__)
 
 
-@router.post("/cache/load-fs-chunks")
+@router.post(
+    "/cache/load-fs-chunks",
+    summary="Load chunks from FSConnector into hot cache",
+    description="""
+    Load chunk files from FSConnector storage into LocalCPUBackend's hot cache.
+    """,
+    responses={
+        200: {
+            "model": LoadFSChunksResponse,
+            "description": "Chunks loaded successfully",
+        },
+        400: {"model": ErrorResponse, "description": "Invalid configuration file"},
+        500: {"model": ErrorResponse, "description": "Internal server error"},
+        503: {"model": ErrorResponse, "description": "LMCache engine not configured"},
+    },
+    tags=["cache-management"],
+)
 async def load_fs_chunks(
     request: Request,
     request_body: LoadFSChunksRequest,
@@ -46,18 +80,47 @@ async def load_fs_chunks(
     5. Loading MemoryObj from files and putting into hot cache
 
     Args:
-        request: The FastAPI request object
-        request_body: Request body containing config_path, max_chunks,
-            and max_failed_keys
+        request: The FastAPI request object containing application state
+        request_body: Request body containing:
+            - config_path: Path to LMCache engine configuration file
+            - max_chunks: Optional limit on number of chunks to load
+            - max_failed_keys: Maximum failed keys to report (default: 10)
 
     Returns:
         PlainTextResponse: JSON response with loading statistics
 
-    Example:
+    Raises:
+        HTTPException: Various error conditions with appropriate status codes
+
+    Example Request:
         ```bash
         curl -X POST "http://localhost:8000/cache/load-fs-chunks" \
              -H "Content-Type: application/json" \
-             -d '{"config_path": "/path/to/config.json", "max_chunks": 100}'
+             -d '{
+                   "config_path": "/path/to/lmcache.yaml", 
+                   "max_chunks": 100,
+                   "max_failed_keys": 10
+                 }'
+        ```
+
+    Example Response (Success):
+        ```json
+        {
+          "status": "success",
+          "loaded_chunks": 95,
+          "total_files": 100,
+          "failed_keys": ["key1", "key2"],
+          "config_path": "/path/to/lmcache.yaml"
+        }
+        ```
+
+    Example Response (Error):
+        ```json
+        {
+          "error": "Failed to load chunks from FSConnector",
+          "message": "Configuration file not found",
+          "config_path": "/path/to/lmcache.yaml"
+        }
         ```
     """
     lmcache_adapter = request.app.state.lmcache_adapter
@@ -109,7 +172,7 @@ async def load_fs_chunks(
     except Exception as e:
         if isinstance(e, HTTPException):
             raise
-        logger.error(f"Unexpected error in load_fs_chunks: {e}", exc_info=True)
+        logger.error("Unexpected error in load_fs_chunks: %s", e, exc_info=True)
         error_info = {
             "error": "Failed to load chunks from FSConnector",
             "message": str(e),
@@ -130,9 +193,9 @@ async def _load_config_from_file(config_path: str) -> LMCacheEngineConfig:
     try:
         return LMCacheEngineConfig.from_file(config_path)
     except Exception as e:
-        logger.error(f"Failed to load config from {config_path}: {e}")
+        logger.error("Failed to load config from %s: %s", config_path, e)
         raise HTTPException(
-            status_code=400, detail=f"Invalid configuration file: {str(e)}"
+            status_code=400, detail="Invalid configuration file: %s" % str(e)
         ) from e
 
 
@@ -151,9 +214,9 @@ async def _initialize_remote_backend(
         remote_backend.init_connection()
         return remote_backend
     except Exception as e:
-        logger.error(f"Failed to initialize RemoteBackend: {e}")
+        logger.error("Failed to initialize RemoteBackend: %s", e)
         raise HTTPException(
-            status_code=500, detail=f"Failed to initialize RemoteBackend: {str(e)}"
+            status_code=500, detail="Failed to initialize RemoteBackend: %s" % str(e)
         ) from e
 
 
@@ -175,7 +238,7 @@ async def _load_chunks_from_fs_connector(
         if max_chunks:
             chunk_files = chunk_files[:max_chunks]
 
-        logger.info("Found {} chunk files to load".format(len(chunk_files)))
+        logger.info("Found %d chunk files to load", len(chunk_files))
 
         loaded_chunks = 0
         failed_keys: List[str] = []
@@ -184,7 +247,25 @@ async def _load_chunks_from_fs_connector(
         semaphore = asyncio.Semaphore(10)
 
         async def process_chunk(chunk_filename: str) -> bool:
-            """Process a single chunk file."""
+            """
+            Process a single chunk file from FSConnector.
+
+            This function is called for each chunk file and performs:
+            - Transforms filename to CacheEngineKey format
+            - Loads MemoryObj data from remote backend
+            - Places chunk into local CPU backend hot cache
+            - Handles errors and tracks failed keys
+
+            Args:
+                chunk_filename: Name of the chunk file from FSConnector
+
+            Returns:
+                bool: True if chunk was successfully loaded, False otherwise
+
+            Note:
+                This function runs with semaphore control to limit concurrency
+                and ensure system stability during bulk loading operations.
+            """
             async with semaphore:
                 key_str = chunk_filename.replace("-SEP-", "/")
                 try:
@@ -197,7 +278,7 @@ async def _load_chunks_from_fs_connector(
 
                     if memory_obj is None:
                         failed_keys.append(key_str)
-                        logger.warning("Failed to load chunk: {}".format(key_str))
+                        logger.warning("Failed to load chunk: %s", key_str)
                         return False
 
                     # Put into local cpu backend and immediately release reference
@@ -207,7 +288,7 @@ async def _load_chunks_from_fs_connector(
 
                 except Exception as e:
                     failed_keys.append(key_str)
-                    logger.warning("Error processing chunk {}: {}".format(key_str, e))
+                    logger.warning("Error processing chunk %s: %s", key_str, e)
                     return False
 
         # Process all chunks concurrently
@@ -218,12 +299,12 @@ async def _load_chunks_from_fs_connector(
         loaded_chunks = sum(1 for result in results if result is True)
 
         if loaded_chunks > 0 and loaded_chunks % 100 == 0:
-            logger.info("Loaded {} chunks...".format(loaded_chunks))
+            logger.info("Loaded %d chunks...", loaded_chunks)
 
         logger.info(
-            "Successfully loaded {} chunks from {} files".format(
-                loaded_chunks, total_files
-            )
+            "Successfully loaded %d chunks from %d files",
+            loaded_chunks,
+            total_files,
         )
 
         return {
@@ -233,7 +314,7 @@ async def _load_chunks_from_fs_connector(
         }
 
     except Exception as e:
-        logger.error("Error in chunk loading process: {}".format(e))
+        logger.error("Error in chunk loading process: %s", e)
         raise HTTPException(
-            status_code=500, detail="Chunk loading failed: {}".format(str(e))
+            status_code=500, detail="Chunk loading failed: %s" % str(e)
         ) from e

--- a/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
+++ b/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
@@ -47,8 +47,8 @@ async def load_fs_chunks(
 
     Args:
         request: The FastAPI request object
-        config_path: Path to the configuration file for RemoteBackend
-        max_chunks: Maximum number of chunks to load (optional, loads all if None)
+        request_body: Request body containing config_path, max_chunks,
+            and max_failed_keys
 
     Returns:
         PlainTextResponse: JSON response with loading statistics
@@ -175,37 +175,55 @@ async def _load_chunks_from_fs_connector(
         if max_chunks:
             chunk_files = chunk_files[:max_chunks]
 
-        logger.info(f"Found {len(chunk_files)} chunk files to load")
+        logger.info("Found {} chunk files to load".format(len(chunk_files)))
 
         loaded_chunks = 0
         failed_keys: List[str] = []
 
-        for chunk_filename in chunk_files:
-            try:
+        # Use semaphore to control concurrency (max 10 concurrent tasks)
+        semaphore = asyncio.Semaphore(10)
+
+        async def process_chunk(chunk_filename: str) -> bool:
+            """Process a single chunk file."""
+            async with semaphore:
                 key_str = chunk_filename.replace("-SEP-", "/")
-                key = CacheEngineKey.from_string(key_str)
+                try:
+                    key = CacheEngineKey.from_string(key_str)
 
-                memory_obj = await asyncio.get_event_loop().run_in_executor(
-                    None, remote_backend.get_blocking, key
-                )
+                    # Get data from remote backend
+                    memory_obj = await asyncio.get_event_loop().run_in_executor(
+                        None, remote_backend.get_blocking, key
+                    )
 
-                if memory_obj:
+                    if memory_obj is None:
+                        failed_keys.append(key_str)
+                        logger.warning("Failed to load chunk: {}".format(key_str))
+                        return False
+
+                    # Put into local cpu backend and immediately release reference
                     local_cpu_backend.submit_put_task(key, memory_obj)
                     memory_obj.ref_count_down()
-                    loaded_chunks += 1
+                    return True
 
-                    if loaded_chunks % 100 == 0:
-                        logger.info(f"Loaded {loaded_chunks} chunks...")
-                else:
+                except Exception as e:
                     failed_keys.append(key_str)
-                    logger.warning(f"Failed to load chunk: {key_str}")
+                    logger.warning("Error processing chunk {}: {}".format(key_str, e))
+                    return False
 
-            except Exception as e:
-                failed_keys.append(chunk_filename)
-                logger.warning(f"Error loading chunk {chunk_filename}: {e}")
+        # Process all chunks concurrently
+        tasks = [process_chunk(chunk_filename) for chunk_filename in chunk_files]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Count successful loads
+        loaded_chunks = sum(1 for result in results if result is True)
+
+        if loaded_chunks > 0 and loaded_chunks % 100 == 0:
+            logger.info("Loaded {} chunks...".format(loaded_chunks))
 
         logger.info(
-            f"Successfully loaded {loaded_chunks} chunks from {total_files} files"
+            "Successfully loaded {} chunks from {} files".format(
+                loaded_chunks, total_files
+            )
         )
 
         return {
@@ -215,7 +233,7 @@ async def _load_chunks_from_fs_connector(
         }
 
     except Exception as e:
-        logger.error(f"Error in chunk loading process: {e}")
+        logger.error("Error in chunk loading process: {}".format(e))
         raise HTTPException(
-            status_code=500, detail=f"Chunk loading failed: {str(e)}"
+            status_code=500, detail="Chunk loading failed: {}".format(str(e))
         ) from e

--- a/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
+++ b/lmcache/v1/internal_api_server/vllm/load_fs_chunks_api.py
@@ -107,6 +107,9 @@ async def load_fs_chunks(
         )
 
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise
+        logger.error(f"Unexpected error in load_fs_chunks: {e}", exc_info=True)
         error_info = {
             "error": "Failed to load chunks from FSConnector",
             "message": str(e),

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import MagicMock
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import threading
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+from lmcache.utils import CacheEngineKey, start_loop_in_thread_with_exceptions
+from lmcache.v1.cache_engine import LMCacheEngine
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.internal_api_server.api_server import app
+from lmcache.v1.memory_management import (
+    AdHocMemoryAllocator,
+    MemoryFormat,
+    MemoryObj,
+)
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+
+
+class TestLoadFSChunksAPI:
+    """Test suite for the /cache/load-fs-chunks API endpoint."""
+
+    @pytest.fixture
+    def temp_fs_path(self):
+        """Create a temporary directory for FSConnector storage."""
+        temp_dir = tempfile.mkdtemp(prefix="lmcache_test_")
+        yield temp_dir
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+
+    @pytest.fixture
+    def async_loop(self):
+        """Create an event loop for async operations."""
+        loop = asyncio.new_event_loop()
+
+        thread = threading.Thread(
+            target=start_loop_in_thread_with_exceptions,
+            args=(loop,),
+            name="test-async-loop",
+        )
+        thread.start()
+
+        yield loop
+
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5.0)
+
+    @pytest.fixture
+    def local_cpu_backend(self):
+        """Create a LocalCPUBackend for testing."""
+        config = LMCacheEngineConfig.from_defaults(chunk_size=256)
+        allocator = AdHocMemoryAllocator(device="cpu")
+        backend = LocalCPUBackend(config, memory_allocator=allocator)
+        yield backend
+        backend.memory_allocator.close()
+
+    @pytest.fixture
+    def test_metadata(self):
+        """Create test metadata."""
+        return LMCacheEngineMetadata(
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            fmt="vllm",
+            kv_dtype=torch.bfloat16,
+            kv_shape=(28, 2, 256, 8, 128),
+        )
+
+    @pytest.fixture
+    def mock_lmcache_adapter(self, local_cpu_backend, test_metadata, async_loop):
+        """Create a mock LMCacheConnectorV1Impl adapter with real backend."""
+        adapter = MagicMock()
+        mock_engine = MagicMock(spec=LMCacheEngine)
+        mock_engine.metadata = test_metadata
+        mock_engine.local_cpu_backend = local_cpu_backend
+
+        # Mock storage_manager with allocator_backend and loop
+        mock_storage_manager = MagicMock()
+        mock_storage_manager.allocator_backend = local_cpu_backend
+        mock_storage_manager.loop = async_loop
+        mock_engine.storage_manager = mock_storage_manager
+
+        adapter.lmcache_engine = mock_engine
+        return adapter
+
+    @pytest.fixture
+    def client_with_adapter(self, mock_lmcache_adapter):
+        """Create a test client with mocked adapter."""
+        app.state.lmcache_adapter = mock_lmcache_adapter
+        return TestClient(app)
+
+    @pytest.fixture
+    def temp_config_file(self, temp_fs_path):
+        """Create a temporary config file for testing."""
+        config_data = {
+            "chunk_size": 256,
+            "local_cpu": True,
+            "max_local_cpu_size": 5.0,
+            "remote_url": f"fs://host:0/{temp_fs_path}",
+            "remote_serde": "naive",
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            temp_path = f.name
+
+        yield temp_path
+
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+    def _create_test_key(self, key_id: int) -> CacheEngineKey:
+        """Create a test CacheEngineKey."""
+        return CacheEngineKey(
+            fmt="vllm",
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            chunk_hash=key_id,
+            dtype=torch.bfloat16,
+        )
+
+    def _create_test_memory_obj(
+        self, shape=(2, 16, 8, 128), dtype=torch.bfloat16
+    ) -> MemoryObj:
+        """Create a test MemoryObj."""
+        allocator = AdHocMemoryAllocator(device="cpu")
+        memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
+        return memory_obj
+
+    def _prepare_test_data(
+        self,
+        temp_fs_path: str,
+        async_loop: asyncio.AbstractEventLoop,
+        local_cpu_backend: LocalCPUBackend,
+        test_metadata: LMCacheEngineMetadata,
+        num_chunks: int = 3,
+    ):
+        """Prepare test data by putting chunks into FSConnector."""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            remote_url=f"fs://host:0/{temp_fs_path}",
+            remote_serde="naive",
+        )
+
+        remote_backend = RemoteBackend(
+            config=config,
+            metadata=test_metadata,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cpu",
+        )
+
+        for i in range(num_chunks):
+            key = self._create_test_key(i)
+            memory_obj = self._create_test_memory_obj()
+            future = remote_backend.submit_put_task(key, memory_obj)
+            if future:
+                future.result(timeout=5.0)
+
+        remote_backend.close()
+        return num_chunks
+
+    def test_load_fs_chunks_success(
+        self,
+        client_with_adapter,
+        mock_lmcache_adapter,
+        temp_config_file,
+        temp_fs_path,
+        async_loop,
+        local_cpu_backend,
+        test_metadata,
+    ):
+        """Test successful load-fs-chunks operation with real FSConnector."""
+        self._prepare_test_data(
+            temp_fs_path, async_loop, local_cpu_backend, test_metadata, num_chunks=3
+        )
+
+        response = client_with_adapter.post(
+            "/cache/load-fs-chunks",
+            json={"config_path": temp_config_file, "max_chunks": 2},
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.text)
+        assert response_data["status"] == "success"
+        assert response_data["loaded_chunks"] == 2
+        assert response_data["total_files"] == 3
+        assert response_data["config_path"] == temp_config_file
+
+    def test_load_fs_chunks_no_engine(self, client_with_adapter, temp_config_file):
+        """Test load-fs-chunks when engine is not configured."""
+        app.state.lmcache_adapter = None
+
+        response = client_with_adapter.post(
+            "/cache/load-fs-chunks", json={"config_path": temp_config_file}
+        )
+
+        assert response.status_code == 503
+        response_data = json.loads(response.text)
+        assert response_data["error"] == "/cache/load-fs-chunks API is unavailable"
+        assert response_data["message"] == "LMCache engine not configured."
+
+    def test_load_fs_chunks_invalid_config(
+        self, client_with_adapter, mock_lmcache_adapter
+    ):
+        """Test load-fs-chunks with invalid config file."""
+        response = client_with_adapter.post(
+            "/cache/load-fs-chunks", json={"config_path": "/nonexistent/config.json"}
+        )
+
+        assert response.status_code == 500
+        response_data = json.loads(response.text)
+        assert "Failed to load chunks from FSConnector" in response_data["error"]
+
+    def test_load_fs_chunks_empty_directory(
+        self,
+        client_with_adapter,
+        mock_lmcache_adapter,
+        temp_config_file,
+        temp_fs_path,
+    ):
+        """Test load-fs-chunks with empty FSConnector directory."""
+        response = client_with_adapter.post(
+            "/cache/load-fs-chunks", json={"config_path": temp_config_file}
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.text)
+        assert response_data["status"] == "success"
+        assert response_data["loaded_chunks"] == 0
+        assert response_data["total_files"] == 0
+
+    def test_load_fs_chunks_all_chunks(
+        self,
+        client_with_adapter,
+        mock_lmcache_adapter,
+        temp_config_file,
+        temp_fs_path,
+        async_loop,
+        local_cpu_backend,
+        test_metadata,
+    ):
+        """Test load-fs-chunks loading all chunks without max_chunks limit."""
+        self._prepare_test_data(
+            temp_fs_path, async_loop, local_cpu_backend, test_metadata, num_chunks=3
+        )
+
+        response = client_with_adapter.post(
+            "/cache/load-fs-chunks", json={"config_path": temp_config_file}
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.text)
+        assert response_data["status"] == "success"
+        assert response_data["loaded_chunks"] == 3
+        assert response_data["total_files"] == 3
+        assert len(response_data["failed_keys"]) == 0

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -12,6 +12,7 @@ import threading
 from fastapi.testclient import TestClient
 import pytest
 import torch
+import yaml
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
@@ -105,14 +106,13 @@ class TestLoadFSChunksAPI:
         """Create a temporary config file for testing."""
         config_data = {
             "chunk_size": 256,
-            "local_cpu": True,
-            "max_local_cpu_size": 5.0,
+            "local_cpu": False,
+            "max_local_cpu_size": 2.0,
             "remote_url": f"fs://host:0/{temp_fs_path}",
-            "remote_serde": "naive",
         }
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump(config_data, f)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config_data, f)
             temp_path = f.name
 
         yield temp_path
@@ -161,15 +161,15 @@ class TestLoadFSChunksAPI:
             local_cpu_backend=local_cpu_backend,
             dst_device="cpu",
         )
-
-        for i in range(num_chunks):
-            key = self._create_test_key(i)
-            memory_obj = self._create_test_memory_obj()
-            future = remote_backend.submit_put_task(key, memory_obj)
-            if future:
-                future.result(timeout=5.0)
-
-        remote_backend.close()
+        try:
+            for i in range(num_chunks):
+                key = self._create_test_key(i)
+                memory_obj = self._create_test_memory_obj()
+                future = remote_backend.submit_put_task(key, memory_obj)
+                if future:
+                    future.result(timeout=5.0)
+        finally:
+            remote_backend.close()
         return num_chunks
 
     def test_load_fs_chunks_success(
@@ -183,8 +183,13 @@ class TestLoadFSChunksAPI:
         test_metadata,
     ):
         """Test successful load-fs-chunks operation with real FSConnector."""
+        num_chunks = 3
         self._prepare_test_data(
-            temp_fs_path, async_loop, local_cpu_backend, test_metadata, num_chunks=3
+            temp_fs_path,
+            async_loop,
+            local_cpu_backend,
+            test_metadata,
+            num_chunks=num_chunks,
         )
 
         response = client_with_adapter.post(
@@ -198,6 +203,8 @@ class TestLoadFSChunksAPI:
         assert response_data["loaded_chunks"] == 2
         assert response_data["total_files"] == 3
         assert response_data["config_path"] == temp_config_file
+
+        self._verify_hot_cache(local_cpu_backend, num_chunks, 2)
 
     def test_load_fs_chunks_no_engine(self, client_with_adapter, temp_config_file):
         """Test load-fs-chunks when engine is not configured."""
@@ -242,6 +249,26 @@ class TestLoadFSChunksAPI:
         assert response_data["loaded_chunks"] == 0
         assert response_data["total_files"] == 0
 
+    def _verify_hot_cache(
+        self, local_cpu_backend: LocalCPUBackend, num_chunks: int, expected_count: int
+    ):
+        """Verify hot cache contains expected memory objects with ref count 1."""
+        with local_cpu_backend.cpu_lock:
+            assert len(local_cpu_backend.hot_cache) == expected_count
+
+            # Check that exactly expected_count keys from total_files
+            # are present in hot cache
+            found_count = 0
+            for i in range(num_chunks):  # total_files is num_chunks
+                key = self._create_test_key(i)
+                if key in local_cpu_backend.hot_cache:
+                    found_count += 1
+                    memory_obj = local_cpu_backend.hot_cache[key]
+                    assert memory_obj.get_ref_count() == 1
+
+            # Verify that we found exactly expected_count keys
+            assert found_count == expected_count
+
     def test_load_fs_chunks_all_chunks(
         self,
         client_with_adapter,
@@ -253,8 +280,13 @@ class TestLoadFSChunksAPI:
         test_metadata,
     ):
         """Test load-fs-chunks loading all chunks without max_chunks limit."""
+        num_chunks = 3
         self._prepare_test_data(
-            temp_fs_path, async_loop, local_cpu_backend, test_metadata, num_chunks=3
+            temp_fs_path,
+            async_loop,
+            local_cpu_backend,
+            test_metadata,
+            num_chunks=num_chunks,
         )
 
         response = client_with_adapter.post(
@@ -267,3 +299,5 @@ class TestLoadFSChunksAPI:
         assert response_data["loaded_chunks"] == 3
         assert response_data["total_files"] == 3
         assert len(response_data["failed_keys"]) == 0
+
+        self._verify_hot_cache(local_cpu_backend, num_chunks, 3)

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -220,9 +220,9 @@ class TestLoadFSChunksAPI:
             "/cache/load-fs-chunks", json={"config_path": "/nonexistent/config.json"}
         )
 
-        assert response.status_code == 500
+        assert response.status_code == 400
         response_data = json.loads(response.text)
-        assert "Failed to load chunks from FSConnector" in response_data["error"]
+        assert "Invalid configuration file" in response_data["detail"]
 
     def test_load_fs_chunks_empty_directory(
         self,


### PR DESCRIPTION
Add internal API endpoint for loading FS chunks into CPU hot cache

## Functionality
- Implements `/cache/load-fs-chunks` API endpoint to load chunk files from FSConnector storage into LocalCPUBackend's hot cache
- Supports configurable limits: max_chunks for batch size control, max_failed_keys for error handling

## Testing
- Unit test suite with pytest fixtures for mock backend and real FSConnector

## Motivation
- Enables warm cache initialization by pre-loading frequently accessed chunks
- Improves cache hit rates by populating hot cache from persistent storage

## Usage Example

```bash
curl -X POST "http://localhost:<Internal_api_port>/cache/load-fs-chunks"
-H "Content-Type: application/json"
-d '{"config_path": "/path/to/config.json", "max_chunks": 100}'
```
