### PR TITLE
fix: blender error when blend_check_layers is not set

### DIFF
--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -86,7 +86,7 @@ class LMCBlender:
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
 
         check_layers = self.common_metadata.check_layers
-        if check_layers and layer_id in check_layers:
+        if check_layers is not None and layer_id in check_layers:
             diff_k = torch.sum(
                 (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
             )

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -85,7 +85,8 @@ class LMCBlender:
         attn_layer = layer.self_attn
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
 
-        if layer_id in self.common_metadata.check_layers:
+        check_layers = self.common_metadata.check_layers
+        if check_layers and layer_id in check_layers:
             diff_k = torch.sum(
                 (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
             )

--- a/lmcache/v1/compute/blend/metadata.py
+++ b/lmcache/v1/compute/blend/metadata.py
@@ -13,7 +13,7 @@ class LMCBlendCommonMetadata:
     CommonMetadata (fixed hyperparams) for blending operations in LMCache.
     """
 
-    check_layers: List[int]
+    check_layers: Optional[List[int]] = None
     recomp_ratios: Optional[List[float]] = None
     thresholds: Optional[List[float]] = None
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
benchmarks/multi_doc_qa "LMCache with blending" configuration throws error:
```
  File ".../.venv/lib/python3.12/site-packages/lmcache/v1/compute/blend/blender.py", line 88, in process_qkv
    if layer_id in self.common_metadata.check_layers:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

The reason is `LMCacheEngineConfig.blend_check_layers` defaults to `None` but `LMCBlendCommonMetadata.check_layers` expects to be a list. This fix adds `Optional` to `LMCBlendCommonMetadata.check_layers` type hint and checks before using it.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
