### PR TITLE
[Refactor] Refactor the type hints of the caching policies

### DIFF
--- a/lmcache/v1/storage_backend/cache_policy/base_policy.py
+++ b/lmcache/v1/storage_backend/cache_policy/base_policy.py
@@ -1,22 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections.abc import MutableMapping
-from typing import Any, Generic, TypeVar
+from typing import Generic, TypeVar
 import abc
 
-# First Party
-from lmcache.utils import CacheEngineKey
-
-TCache = TypeVar("TCache", bound=MutableMapping[CacheEngineKey, Any])
+KeyType = TypeVar("KeyType")
+MapType = TypeVar("MapType", bound=MutableMapping)
 
 
-class BaseCachePolicy(Generic[TCache], metaclass=abc.ABCMeta):
+class BaseCachePolicy(Generic[KeyType, MapType], metaclass=abc.ABCMeta):
     """
     Interface for cache policy.
     """
 
     @abc.abstractmethod
-    def init_mutable_mapping(self) -> TCache:
+    def init_mutable_mapping(self) -> MapType:
         """
         Initialize a mutable mapping for cache storage.
 
@@ -29,14 +27,14 @@ class BaseCachePolicy(Generic[TCache], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def update_on_hit(
         self,
-        key: CacheEngineKey,
-        cache_dict: TCache,
+        key: KeyType,
+        cache_dict: MapType,
     ) -> None:
         """
         Update cache_dict and internal states when a cache is used
 
         Input:
-            key: a CacheEngineKey
+            key: an object of KeyType
             cache_dict: a dict consists of current cache
         """
         raise NotImplementedError
@@ -45,13 +43,13 @@ class BaseCachePolicy(Generic[TCache], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def update_on_put(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         """
         Update cache_dict and internal states when a cache is stored
 
         Input:
-            key: a CacheEngineKey
+            key: an object of KeyType
         """
         raise NotImplementedError
 
@@ -59,13 +57,13 @@ class BaseCachePolicy(Generic[TCache], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def update_on_force_evict(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         """
         Update internal states when a cache is force evicted
 
         Input:
-            key: a CacheEngineKey
+            key: an object of KeyType
         """
         raise NotImplementedError
 
@@ -73,9 +71,9 @@ class BaseCachePolicy(Generic[TCache], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_evict_candidates(
         self,
-        cache_dict: TCache,
+        cache_dict: MapType,
         num_candidates: int = 1,
-    ) -> list[CacheEngineKey]:
+    ) -> list[KeyType]:
         """
         Evict cache when a new cache comes and the storage is full
 
@@ -84,6 +82,6 @@ class BaseCachePolicy(Generic[TCache], metaclass=abc.ABCMeta):
             num_candidates: number of candidates to be evicted
 
         Return:
-            return a list of CacheEngineKeys
+            return a list of keys to be evicted
         """
         raise NotImplementedError

--- a/lmcache/v1/storage_backend/cache_policy/fifo.py
+++ b/lmcache/v1/storage_backend/cache_policy/fifo.py
@@ -8,10 +8,8 @@ from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy,
 
 logger = init_logger(__name__)
 
-MapType = dict[KeyType, Any]
 
-
-class FIFOCachePolicy(BaseCachePolicy[KeyType, MapType]):
+class FIFOCachePolicy(BaseCachePolicy[KeyType, dict[KeyType, Any]]):
     """
     FIFO cache policy.
     """

--- a/lmcache/v1/storage_backend/cache_policy/fifo.py
+++ b/lmcache/v1/storage_backend/cache_policy/fifo.py
@@ -4,13 +4,14 @@ from typing import Any
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey
-from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy
+from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy, KeyType
 
 logger = init_logger(__name__)
 
+MapType = dict[KeyType, Any]
 
-class FIFOCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
+
+class FIFOCachePolicy(BaseCachePolicy[KeyType, MapType]):
     """
     FIFO cache policy.
     """
@@ -18,26 +19,26 @@ class FIFOCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
     def __init__(self):
         logger.info("Initializing FIFOCachePolicy")
 
-    def init_mutable_mapping(self) -> dict[CacheEngineKey, Any]:
+    def init_mutable_mapping(self) -> dict[KeyType, Any]:
         # NOTE(Jiayi): python dict maintains insertion order.
         return {}
 
     def update_on_hit(
         self,
-        key: CacheEngineKey,
-        cache_dict: dict[CacheEngineKey, Any],
+        key: KeyType,
+        cache_dict: dict[KeyType, Any],
     ) -> None:
         pass
 
     def update_on_put(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         pass
 
     def update_on_force_evict(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         pass
 
@@ -45,9 +46,9 @@ class FIFOCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
     # of returned keys mignt be smaller than num_candidates.
     def get_evict_candidates(
         self,
-        cache_dict: dict[CacheEngineKey, Any],
+        cache_dict: dict[KeyType, Any],
         num_candidates: int = 1,
-    ) -> list[CacheEngineKey]:
+    ) -> list[KeyType]:
         evict_keys = []
         for key, cache in cache_dict.items():
             if not cache.can_evict:

--- a/lmcache/v1/storage_backend/cache_policy/lfu.py
+++ b/lmcache/v1/storage_backend/cache_policy/lfu.py
@@ -12,10 +12,8 @@ from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy,
 
 logger = init_logger(__name__)
 
-MapType = dict[KeyType, Any]
 
-
-class LFUCachePolicy(BaseCachePolicy[KeyType, MapType]):
+class LFUCachePolicy(BaseCachePolicy[KeyType, dict[KeyType, Any]]):
     """
     LFU cache policy.
     """

--- a/lmcache/v1/storage_backend/cache_policy/lfu.py
+++ b/lmcache/v1/storage_backend/cache_policy/lfu.py
@@ -8,13 +8,14 @@ from sortedcontainers import SortedDict
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey
-from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy
+from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy, KeyType
 
 logger = init_logger(__name__)
 
+MapType = dict[KeyType, Any]
 
-class LFUCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
+
+class LFUCachePolicy(BaseCachePolicy[KeyType, MapType]):
     """
     LFU cache policy.
     """
@@ -33,13 +34,13 @@ class LFUCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
 
         logger.info("Initializing LFUCachePolicy")
 
-    def init_mutable_mapping(self) -> dict[CacheEngineKey, Any]:
+    def init_mutable_mapping(self) -> dict[KeyType, Any]:
         return {}
 
     def update_on_hit(
         self,
-        key: CacheEngineKey,
-        cache_dict: dict[CacheEngineKey, Any],
+        key: KeyType,
+        cache_dict: dict[KeyType, Any],
     ) -> None:
         curr_freq = self.key_to_freq[key]
         self.freq_to_keys[curr_freq].pop(key)
@@ -56,7 +57,7 @@ class LFUCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
 
     def update_on_put(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         # Initialize the frequency for the new key.
         self.key_to_freq[key] = 1
@@ -67,7 +68,7 @@ class LFUCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
 
     def update_on_force_evict(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         freq = self.key_to_freq.pop(key, None)
         if not freq:
@@ -80,9 +81,9 @@ class LFUCachePolicy(BaseCachePolicy[dict[CacheEngineKey, Any]]):
     # of returned keys mignt be smaller than num_candidates.
     def get_evict_candidates(
         self,
-        cache_dict: dict[CacheEngineKey, Any],
+        cache_dict: dict[KeyType, Any],
         num_candidates: int = 1,
-    ) -> list[CacheEngineKey]:
+    ) -> list[KeyType]:
         evict_keys = []
         evict_freqs = []
         for curr_min_freq, fifo_keys in self.freq_to_keys.items():

--- a/lmcache/v1/storage_backend/cache_policy/lru.py
+++ b/lmcache/v1/storage_backend/cache_policy/lru.py
@@ -9,10 +9,8 @@ from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy,
 
 logger = init_logger(__name__)
 
-MapType = OrderedDict[KeyType, Any]
 
-
-class LRUCachePolicy(BaseCachePolicy[KeyType, MapType]):
+class LRUCachePolicy(BaseCachePolicy[KeyType, OrderedDict[KeyType, Any]]):
     """
     LRU cache policy.
     """

--- a/lmcache/v1/storage_backend/cache_policy/lru.py
+++ b/lmcache/v1/storage_backend/cache_policy/lru.py
@@ -5,13 +5,14 @@ from typing import Any
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey
-from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy
+from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy, KeyType
 
 logger = init_logger(__name__)
 
+MapType = OrderedDict[KeyType, Any]
 
-class LRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
+
+class LRUCachePolicy(BaseCachePolicy[KeyType, MapType]):
     """
     LRU cache policy.
     """
@@ -19,26 +20,26 @@ class LRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
     def __init__(self):
         logger.info("Initializing LRUCachePolicy")
 
-    def init_mutable_mapping(self) -> OrderedDict[CacheEngineKey, Any]:
+    def init_mutable_mapping(self) -> OrderedDict[KeyType, Any]:
         return OrderedDict()
 
     def update_on_hit(
         self,
-        key: CacheEngineKey,
-        cache_dict: OrderedDict[CacheEngineKey, Any],
+        key: KeyType,
+        cache_dict: OrderedDict[KeyType, Any],
     ) -> None:
         cache_dict.move_to_end(key)
 
     def update_on_put(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         # No action needed for LRU on put, as the key is already at the end.
         pass
 
     def update_on_force_evict(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         pass
 
@@ -46,9 +47,9 @@ class LRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
     # of returned keys mignt be smaller than num_candidates.
     def get_evict_candidates(
         self,
-        cache_dict: OrderedDict[CacheEngineKey, Any],
+        cache_dict: OrderedDict[KeyType, Any],
         num_candidates: int = 1,
-    ) -> list[CacheEngineKey]:
+    ) -> list[KeyType]:
         evict_keys = []
         for key, cache in cache_dict.items():
             if not cache.can_evict:

--- a/lmcache/v1/storage_backend/cache_policy/lru.py
+++ b/lmcache/v1/storage_backend/cache_policy/lru.py
@@ -20,16 +20,20 @@ class LRUCachePolicy(BaseCachePolicy[KeyType, OrderedDict[KeyType, Any]]):
 
     def __init__(self):
         logger.info("Initializing LRUCachePolicy")
-        self.chunk_hash_to_init_timestamp: Dict[int, float] = {}
+        self.chunk_hash_to_init_timestamp: Dict[Any, float] = {}
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.max_num_chunk_hash = 12500000
 
     def init_mutable_mapping(self) -> OrderedDict[KeyType, Any]:
         return OrderedDict()
 
-    def update_chunk_hash_dict(self, key: CacheEngineKey) -> None:
+    def update_chunk_hash_dict(self, key: KeyType) -> None:
         curr_time = time.time()
-        key_hash = key.chunk_hash
+        # HACK: doing type conversion here
+        key_hash: Any = key
+        if isinstance(key, CacheEngineKey):
+            key_hash = key.chunk_hash
+
         if init_timestamp := self.chunk_hash_to_init_timestamp.get(key_hash, None):
             time_interval = curr_time - init_timestamp
             self.stats_monitor.on_chunk_reuse(time_interval)

--- a/lmcache/v1/storage_backend/cache_policy/mru.py
+++ b/lmcache/v1/storage_backend/cache_policy/mru.py
@@ -9,10 +9,8 @@ from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy,
 
 logger = init_logger(__name__)
 
-MapType = OrderedDict[KeyType, Any]
 
-
-class MRUCachePolicy(BaseCachePolicy[KeyType, MapType]):
+class MRUCachePolicy(BaseCachePolicy[KeyType, OrderedDict[KeyType, Any]]):
     """
     MRU cache policy.
     """

--- a/lmcache/v1/storage_backend/cache_policy/mru.py
+++ b/lmcache/v1/storage_backend/cache_policy/mru.py
@@ -5,13 +5,14 @@ from typing import Any
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey
-from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy
+from lmcache.v1.storage_backend.cache_policy.base_policy import BaseCachePolicy, KeyType
 
 logger = init_logger(__name__)
 
+MapType = OrderedDict[KeyType, Any]
 
-class MRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
+
+class MRUCachePolicy(BaseCachePolicy[KeyType, MapType]):
     """
     MRU cache policy.
     """
@@ -19,27 +20,27 @@ class MRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
     def __init__(self):
         logger.info("Initializing MRUCachePolicy")
 
-    def init_mutable_mapping(self) -> OrderedDict[CacheEngineKey, Any]:
+    def init_mutable_mapping(self) -> OrderedDict[KeyType, Any]:
         return OrderedDict()
 
     def update_on_hit(
         self,
-        key: CacheEngineKey,
-        cache_dict: OrderedDict[CacheEngineKey, Any],
+        key: KeyType,
+        cache_dict: OrderedDict[KeyType, Any],
     ) -> None:
         # since MRU evicts from the back, the logic is same as LRU.
         cache_dict.move_to_end(key, last=True)
 
     def update_on_put(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         # No action needed for MRU on put, as the key is already at the back.
         pass
 
     def update_on_force_evict(
         self,
-        key: CacheEngineKey,
+        key: KeyType,
     ) -> None:
         pass
 
@@ -47,9 +48,9 @@ class MRUCachePolicy(BaseCachePolicy[OrderedDict[CacheEngineKey, Any]]):
     # of returned keys mignt be smaller than num_candidates.
     def get_evict_candidates(
         self,
-        cache_dict: OrderedDict[CacheEngineKey, Any],
+        cache_dict: OrderedDict[KeyType, Any],
         num_candidates: int = 1,
-    ) -> list[CacheEngineKey]:
+    ) -> list[KeyType]:
         evict_keys = []
         # Since the most recent object is at the end, we reverse the order here
         for key, cache in reversed(cache_dict.items()):


### PR DESCRIPTION
# Summary

Previously, the CachePolicy classes assumes the use of `CacheEngineKey` in the function signature.
This PR removes the assumption and introduces a generic type variable called `KeyType`.

This will be used to support multi-process mode, since we have a different key type there.

**This PR does not contain any functional changes to the code.**
