### PR TITLE
[bugfix] Remote Connector should raise exception while read bytes is 0

### DIFF
--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -90,7 +90,8 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         assert self.full_chunk_size is not None
         assert self.single_token_size is not None
         if (
-            bytes_read % self.single_token_size != 0
+            bytes_read == 0
+            or bytes_read % self.single_token_size != 0
             or bytes_read > self.full_chunk_size
         ):
             raise ValueError(


### PR DESCRIPTION
In our test scenario, the distributed fs use async write, when the fs process crashed, which may produce some error files, the size is 0, if read from these error files, `bytes_read` is `0`, which will result in torch error. 
Therefore, we must check the `bytes_read` is not `0`, and promptly throw out exceptions.