### PR TITLE
[Bugfix] subtract computed tokens in fast path cache hit

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1380,7 +1380,13 @@ class LMCacheConnectorV1Impl:
 
         # consult the cache before any processing
         if cached_num_hit_toks := self.lookup_client.lookup_cache(lookup_id=req_id):
-            return cached_num_hit_toks
+            need_to_allocate = cached_num_hit_toks - num_computed_tokens
+            if cached_num_hit_toks == request.num_tokens:
+                need_to_allocate -= 1
+            if need_to_allocate < 0:
+                need_to_allocate = 0
+
+            return need_to_allocate
 
         self._requests_priority[req_id] = getattr(request, "priority", 0)
 


### PR DESCRIPTION
fix(adapter): fix incorrect return value in lookup_cache fast path

Previously, the fast path optimization in `get_num_new_matched_tokens` returned the total number of cached tokens directly when a cache hit occurred. It failed to subtract `num_computed_tokens` (locally computed tokens), causing the scheduler to receive an incorrect external token count (e.g., returning 24 instead of 24 - 16 = 8).

This commit fixes the logic by subtracting `num_computed_tokens` from `cached_num_hit_toks` and handling the full-prompt hit edge case, ensuring the returned value represents only the *new* tokens to be allocated.

Fixes mismatch assertion errors in vLLM scheduler during cache hits.