### PR TITLE
[Bugfix] subtract computed tokens in fast path cache hit

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1381,14 +1381,14 @@ class LMCacheConnectorV1Impl:
         # consult the cache before any processing
         if cached_num_hit_toks := self.lookup_client.lookup_cache(lookup_id=req_id):
             need_to_allocate = max(0, cached_num_hit_toks - num_computed_tokens)
-            
+
             if cached_num_hit_toks == request.num_tokens:
                 need_to_allocate = max(0, need_to_allocate - 1)
 
             self.load_specs[req_id] = LoadSpec(
-                vllm_cached_tokens=num_computed_tokens, 
+                vllm_cached_tokens=num_computed_tokens,
                 lmcache_cached_tokens=cached_num_hit_toks,
-                can_load=False, 
+                can_load=False,
             )
 
             return need_to_allocate

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1380,7 +1380,18 @@ class LMCacheConnectorV1Impl:
 
         # consult the cache before any processing
         if cached_num_hit_toks := self.lookup_client.lookup_cache(lookup_id=req_id):
-            return cached_num_hit_toks
+            need_to_allocate = max(0, cached_num_hit_toks - num_computed_tokens)
+            
+            if cached_num_hit_toks == request.num_tokens:
+                need_to_allocate = max(0, need_to_allocate - 1)
+
+            self.load_specs[req_id] = LoadSpec(
+                vllm_cached_tokens=num_computed_tokens, 
+                lmcache_cached_tokens=cached_num_hit_toks,
+                can_load=False, 
+            )
+
+            return need_to_allocate
 
         self._requests_priority[req_id] = getattr(request, "priority", 0)
 


### PR DESCRIPTION
Previously, the fast path optimization in `get_num_new_matched_tokens` returned the total number of cached tokens directly when a cache hit occurred. It failed to subtract `num_computed_tokens` (locally computed tokens), causing the scheduler to receive an incorrect external token count (e.g., returning 24 instead of 24 - 16 = 8).

This commit fixes the logic by subtracting `num_computed_tokens` from `cached_num_hit_toks` and handling the full-prompt hit edge case, ensuring the returned value represents only the *new* tokens to be allocated.

Fixes mismatch assertion errors in vLLM scheduler during cache hits.


```
(Worker_TP1 pid=271088) [2025-11-26 14:10:27,060] LMCache INFO: SiMM exist hit cache! (simm_connector.py:145:lmcache.v1.storage_backend.connector.simm_connector)

(Worker_TP0 pid=271087) [2025-11-26 14:10:27,131] LMCache INFO: SiMM connector using 77.44 ms to batched look up for 1282 chunks, finally found 160 prefix hit chunks. (simm_connector.py:128:lmcache.v1.storage_backend.connector.simm_connector)

(Worker_TP1 pid=271088) [2025-11-26 14:10:27,133] LMCache INFO: SiMM connector using 79.25 ms to batched look up for 1282 chunks, finally found 160 prefix hit chunks. (simm_connector.py:128:lmcache.v1.storage_backend.connector.simm_connector)

(EngineCore_DP0 pid=270952) [2025-11-26 14:10:27,134] LMCache INFO: Reqid: chatcmpl-bc5e1297fe3143eb85f7550b402a32d4, Total tokens 30755, LMCache hit tokens: 3840, need to load: 0 (vllm_v1_adapter.py:1426:lmcache.integration.vllm.vllm_v1_adapter)

(APIServer pid=270811) INFO 11-26 14:10:27 [loggers.py:127] Engine 000: Avg prompt throughput: 6150.6 tokens/s, Avg generation throughput: 19.3 tokens/s, Running: 9 reqs, Waiting: 41 reqs, GPU KV cache usage: 96.8%, Prefix cache hit rate: 7.0%

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710] EngineCore encountered a fatal error.

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710] Traceback (most recent call last):

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 701, in run_engine_core

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     engine_core.run_busy_loop()

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 728, in run_busy_loop

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     self._process_engine_step()

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 754, in _process_engine_step

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     outputs, model_executed = self.step_fn()

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]                               ^^^^^^^^^^^^^^

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 283, in step

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     scheduler_output = self.scheduler.schedule()

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]                        ^^^^^^^^^^^^^^^^^^^^^^^^^

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 490, in schedule

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     self.connector.update_state_after_alloc(

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/opt/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 137, in update_state_after_alloc

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     self._lmcache_engine.update_state_after_alloc(request,

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]   File "/mnt/hisys/kzlin/workflow/LMCache/lmcache/integration/vllm/vllm_v1_adapter.py", line 1504, in update_state_after_alloc

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710]     num_external_tokens

(EngineCore_DP0 pid=270952) ERROR 11-26 14:10:27 [core.py:710] AssertionError: Mismatch in tokens to load: 3840 vs 3840 (tokens in lmcache) - 3840 (tokens in vllm) - 0 (full lmcache hits subtracts last token to recalculate logits) for request chatcmpl-bc5e1297fe3143eb85f7550b402a32d4

(Worker_TP0 pid=271087) INFO 11-26 14:10:27 [multiproc_executor.py:558] Parent process exited, terminating worker

(APIServer pid=270811) ERROR 11-26 14:10:27 [async_llm.py:480] AsyncLLM output_handler failed.

(APIServer pid=270811) ERROR 11-26 14:10:27 [async_llm.py:480] Traceback (most recent call last):

(APIServer pid=270811) ERROR 11-26 14:10:27 [async_llm.py:480]   File "/opt/venv/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 439, in output_handler

(APIServer pid=270811) ERROR 11-26 14:10:27 [async_llm.py:480]     outputs = await engine_core.get_output_async()```