### PR TITLE
[BugFix] TypeError: unsupported operand type(s) for +: 'int' and 'Non…

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1412,7 +1412,7 @@ class LMCacheConnectorV1Impl:
                 req_id,
                 request.num_tokens,
             )
-            return None
+            return 0
 
         # When prompt length is divisible by the block size and all
         # blocks are cached, we need to recompute the last token.


### PR DESCRIPTION
…eType'

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When using the P2P KV cache sharing feature, I encountered this error: TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'. I'm wondering if this is due to an oversight, as the function returns 0 for all other values.

**Special notes for your reviewers**:
[2025-11-26 08:49:10,600] LMCache INFO: Got layout info from controller: ('', '', 0, '') (p2p_backend.py:261:lmcache.v1.storage_backend.p2p_backend)
ERROR 11-26 08:49:10 [core.py:634] EngineCore encountered a fatal error.
ERROR 11-26 08:49:10 [core.py:634] Traceback (most recent call last):
ERROR 11-26 08:49:10 [core.py:634]   File "/workspace/lmcache_test/LMCache/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 625, in run_engine_core
ERROR 11-26 08:49:10 [core.py:634]     engine_core.run_busy_loop()
ERROR 11-26 08:49:10 [core.py:634]   File "/workspace/lmcache_test/LMCache/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 652, in run_busy_loop
ERROR 11-26 08:49:10 [core.py:634]     self._process_engine_step()
ERROR 11-26 08:49:10 [core.py:634]   File "/workspace/lmcache_test/LMCache/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 677, in _process_engine_step
ERROR 11-26 08:49:10 [core.py:634]     outputs, model_executed = self.step_fn()
ERROR 11-26 08:49:10 [core.py:634]                               ^^^^^^^^^^^^^^
ERROR 11-26 08:49:10 [core.py:634]   File "/workspace/lmcache_test/LMCache/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 266, in step
ERROR 11-26 08:49:10 [core.py:634]     scheduler_output = self.scheduler.schedule()
ERROR 11-26 08:49:10 [core.py:634]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-26 08:49:10 [core.py:634]   File "/workspace/lmcache_test/LMCache/.venv/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 390, in schedule
ERROR 11-26 08:49:10 [core.py:634]     num_computed_tokens = (num_new_local_computed_tokens +
ERROR 11-26 08:49:10 [core.py:634]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-26 08:49:10 [core.py:634] TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

**If applicable**:

- [×] this PR contains user facing changes - docs added
- [×] this PR contains unit tests
