### PR TITLE
[BugFix] pd_buffer_size is not divisible by chunk_bytes_size

### DIFF
--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -13,6 +13,7 @@ import zmq
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
+from lmcache.integration.vllm.utils import get_size_bytes
 from lmcache.logging import init_logger
 from lmcache.utils import (
     STR_DTYPE_TO_TORCH_DTYPE,
@@ -220,9 +221,18 @@ class PDBackend(AllocatorBackendInterface):
         logger.info(f"Setting cuda device to {corrected_device} ")
         torch.cuda.set_device(corrected_device)
 
+        # Adjust buffer size to be a multiple of align_bytes
+        align_bytes = get_size_bytes(torch.Size(metadata.kv_shape), metadata.kv_dtype)
+        adjusted_buffer_size = (config.pd_buffer_size // align_bytes) * align_bytes
+        if adjusted_buffer_size != config.pd_buffer_size:
+            logger.info(
+                f"Adjusted pd_buffer_size from {config.pd_buffer_size} "
+                f"to {adjusted_buffer_size} to align with chunk size {align_bytes}"
+            )
+
         paged_mem_allocator = PagedCpuGpuMemoryAllocator()
         paged_mem_allocator.init_gpu_memory_allocator(
-            config.pd_buffer_size,
+            adjusted_buffer_size,
             torch.Size(metadata.kv_shape),
             metadata.kv_dtype,
             MemoryFormat.KV_2LTD,  # TODO: remove this hardcode


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When I used the Disaggregated prefill feature, I encountered the following error: AssertionError: Buffer size 1073741824 must be a multiple of align bytes 29360128 in paged memory allocator.

**Special notes for your reviewers**:
(EngineCore_DP0 pid=2629)   File "/workspace/lmcache_test/LMCache/lmcache/v1/storage_backend/storage_manager.py", line 207, in __init__
(EngineCore_DP0 pid=2629)     CreateStorageBackends(
(EngineCore_DP0 pid=2629)   File "/workspace/lmcache_test/LMCache/lmcache/v1/storage_backend/__init__.py", line 133, in CreateStorageBackends
(EngineCore_DP0 pid=2629)     storage_backends["PDBackend"] = PDBackend(config, metadata)
(EngineCore_DP0 pid=2629)                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2629)   File "/workspace/lmcache_test/LMCache/lmcache/v1/storage_backend/pd_backend.py", line 161, in __init__
(EngineCore_DP0 pid=2629)     self.memory_allocator = self.initialize_allocator(config, metadata)
(EngineCore_DP0 pid=2629)                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2629)   File "/workspace/lmcache_test/LMCache/lmcache/v1/storage_backend/pd_backend.py", line 224, in initialize_allocator
(EngineCore_DP0 pid=2629)     paged_mem_allocator.init_gpu_memory_allocator(
(EngineCore_DP0 pid=2629)   File "/workspace/lmcache_test/LMCache/lmcache/v1/memory_management.py", line 1912, in init_gpu_memory_allocator
(EngineCore_DP0 pid=2629)     self.gpu_allocator = PagedTensorMemoryAllocator(
(EngineCore_DP0 pid=2629)                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2629)   File "/workspace/lmcache_test/LMCache/lmcache/v1/memory_management.py", line 1087, in __init__
(EngineCore_DP0 pid=2629)     assert self.buffer_size % self.align_bytes == 0, (
(EngineCore_DP0 pid=2629)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2629) AssertionError: Buffer size 1073741824 must be a multiple of align bytes 29360128 in paged memory allocator.

**If applicable**:

- [×] this PR contains user facing changes - docs added
- [×] this PR contains unit tests
