### PR TITLE
[BugFix] The variable name is incorrect. The prefiller configuration …

### DIFF
--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -54,7 +54,7 @@ Configuration
        pd_proxy_host: "localhost" # Host where proxy server is running
        pd_proxy_port: 7500        # Port where proxy server is listening
        pd_buffer_size: 1073741824  # 1GB buffer for KV cache transfer
-       nixl_buffer_device: "cuda"   # Use GPU memory for buffer
+       pd_buffer_device: "cuda"   # Use GPU memory for buffer
 
 2. **Decoder Server Configuration** (``lmcache-decoder-config.yaml``):
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The variable name is incorrect. The prefiller configuration for "Disaggregated prefill" should be "pd_buffer_device" instead of "nixl_buffer_device".

**Special notes for your reviewers**:
in v1/config.py 602-617 line:
    if self.enable_pd:
        assert self.pd_role is not None
        assert self.pd_buffer_size is not None
        assert self.pd_buffer_device is not None

        assert self.remote_url is None, "PD only supports remote_url=None"
        assert self.save_decode_cache is False, (
            "PD only supports save_decode_cache=False"
        )
        assert self.enable_p2p is False, "PD only supports enable_p2p=False"

**If applicable**:

- [√] this PR contains user facing changes - docs added
- [×] this PR contains unit tests
