### PR TITLE
[Core] Use concurrent.futures.as_completed in batched_get_blocking

### DIFF
--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from concurrent.futures import Future, TimeoutError
+from concurrent.futures import Future, TimeoutError, as_completed
 from typing import Any, List, Optional, Sequence, Set
 import asyncio
 import threading
@@ -355,28 +355,36 @@ class RemoteBackend(StorageBackendInterface):
                 asyncio.run_coroutine_threadsafe(self.connection.get(key), self.loop)
                 for key in keys
             ]
-            memory_objs = []
-            failed = False
-            for fut in futures:
-                if not failed:
+            future_to_idx = {fut: i for i, fut in enumerate(futures)}
+            memory_objs = [None] * len(keys)
+            index_failed = len(keys)
+            try:
+                for fut in as_completed(futures, self.blocking_timeout_secs):
+                    index = future_to_idx[fut]
+                    if index > index_failed:
+                        continue
+                    
                     try:
-                        memory_obj = fut.result(self.blocking_timeout_secs)
+                        memory_objs[index] = fut.result()
                     except Exception as e:
-                        failed = True
-                        if isinstance(e, TimeoutError):
-                            logger.warning(
-                                "get blocking timeout, trigger cancel the future task"
-                            )
+                        logger.warning(
+                            f"Error occurred in get_blocking: {e}, returning None"
+                        )
+                        for fut in futures[index:]:
                             fut.cancel()
-                        else:
-                            logger.warning(
-                                f"Error occurred in get_blocking: {e}, returning None"
-                            )
-                        memory_obj = None
-                    memory_objs.append(memory_obj)
-                else:
-                    memory_objs.append(None)
+                        index_failed = index
+
+            except TimeoutError as e:
+                logger.warning(
+                    "get blocking timeout, trigger cancel the future task"
+                )
+                index_failed = memory_objs.index(None)
+                for fut in futures[index_failed:]:
                     fut.cancel()
+
+            if index_failed < len(keys):
+                for i in range(index_failed, len(keys)):
+                    memory_objs[i] = None
 
         t2 = time.perf_counter()
         self.stats_monitor.update_interval_remote_time_to_get_sync((t2 - t1) * 1000)

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -357,6 +357,7 @@ class RemoteBackend(StorageBackendInterface):
             ]
             future_to_idx = {fut: i for i, fut in enumerate(futures)}
             memory_objs = [None] * len(keys)
+            done_objs = [False] * len(keys)
             index_failed = len(keys)
             try:
                 for fut in as_completed(futures, self.blocking_timeout_secs):
@@ -366,6 +367,7 @@ class RemoteBackend(StorageBackendInterface):
                     
                     try:
                         memory_objs[index] = fut.result()
+                        done_objs[index] = True
                     except Exception as e:
                         logger.warning(
                             f"Error occurred in get_blocking: {e}, returning None"
@@ -378,7 +380,7 @@ class RemoteBackend(StorageBackendInterface):
                 logger.warning(
                     "get blocking timeout, trigger cancel the future task"
                 )
-                index_failed = memory_objs.index(None)
+                index_failed = done_objs.index(False)
                 for fut in futures[index_failed:]:
                     fut.cancel()
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Refactors the batched_get_blocking method to use concurrent.futures.as_completed for handling multiple asynchronous get calls. This allows parallel processing of futures, preserves the original order of results, and safely cancels remaining tasks on the first failure or timeout.

**Special notes for your reviewers**:
- The implementation ensures results are returned in the same order as the input keys.
- Timeout and exception handling behavior remains consistent with the previous version.
- Uses memory_objs.index(None) to identify the first failed or incomplete future.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
