### PR TITLE
Optimize lookups in sync mode by skipping cached chunks.

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1482,6 +1482,11 @@ class LMCacheConnectorV1Impl:
             logger.debug(f"Looking up cache for the first time for request {req_id}!")
             self._requests_priority[req_id] = getattr(request, "priority", 0)
 
+            # Align computed tokens once to avoid repeated chunk-size rounding downstream
+            aligned_num_computed_tokens = (
+                num_computed_tokens // self._lmcache_chunk_size * self._lmcache_chunk_size
+            )
+
             # token_ids = request.prompt_token_ids
             # all token ids covers the preemption case
             token_ids = request.all_token_ids
@@ -1502,7 +1507,7 @@ class LMCacheConnectorV1Impl:
                 token_ids,
                 lookup_id=req_id,
                 request_configs=request_configs,
-                num_computed_tokens=num_computed_tokens,
+                num_computed_tokens=aligned_num_computed_tokens,
             )
 
         if num_external_hit_tokens is None:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1482,7 +1482,8 @@ class LMCacheConnectorV1Impl:
             logger.debug(f"Looking up cache for the first time for request {req_id}!")
             self._requests_priority[req_id] = getattr(request, "priority", 0)
 
-            # Align computed tokens once to avoid repeated chunk-size rounding downstream
+            # Align computed tokens once to avoid repeated
+            # chunk-size rounding downstream
             aligned_num_computed_tokens = (
                 num_computed_tokens
                 // self._lmcache_chunk_size

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1484,7 +1484,9 @@ class LMCacheConnectorV1Impl:
 
             # Align computed tokens once to avoid repeated chunk-size rounding downstream
             aligned_num_computed_tokens = (
-                num_computed_tokens // self._lmcache_chunk_size * self._lmcache_chunk_size
+                num_computed_tokens
+                // self._lmcache_chunk_size
+                * self._lmcache_chunk_size
             )
 
             # token_ids = request.prompt_token_ids

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -409,8 +409,9 @@ class ReqMeta:
         # For load operation: check whether the request is scheduled to load
         if load_spec is not None and load_spec.can_load:
             logger.debug(
-                "Scheduled to load %d tokens for request %s",
+                "Scheduled to load %d tokens (%d cached in vLLM) for request %s",
                 load_spec.lmcache_cached_tokens,
+                load_spec.vllm_cached_tokens,
                 tracker.req_id,
             )
         else:
@@ -1501,6 +1502,7 @@ class LMCacheConnectorV1Impl:
                 token_ids,
                 lookup_id=req_id,
                 request_configs=request_configs,
+                num_computed_tokens=num_computed_tokens,
             )
 
         if num_external_hit_tokens is None:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -786,12 +786,10 @@ class LMCacheEngine:
             assert hashes is not None
             lookup_request_id = self.stats_monitor.on_lookup_request(sum(offsets))
 
-        # Skip the number of tokens that are already computed, align to chunk size
-        skip_n_tokens = (
-            num_computed_tokens // self.config.chunk_size * self.config.chunk_size
-        )
-
-        res = skip_n_tokens
+        # Skip the number of tokens that are already computed (aligned upstream to
+        # chunk size)
+        aligned_computed_tokens = num_computed_tokens
+        res = aligned_computed_tokens
         try:
             chunk_info_iterator = self.token_database.process_tokens(
                 tokens=tokens,
@@ -803,7 +801,7 @@ class LMCacheEngine:
             # TODO: support batched_contains when layerwise is enabled
             if self.use_layerwise:
                 for start, end, key in chunk_info_iterator:
-                    if end <= skip_n_tokens:
+                    if end <= aligned_computed_tokens:
                         continue
                     assert isinstance(key, CacheEngineKey)
 
@@ -834,7 +832,7 @@ class LMCacheEngine:
                 for chunk_info in chunk_info_iterator:
                     assert isinstance(chunk_info[2], CacheEngineKey)
                     start, end, _ = chunk_info
-                    if end <= skip_n_tokens:
+                    if end <= aligned_computed_tokens:
                         continue
                     chunk_info_list.append(chunk_info)
                     keys.append(chunk_info[2])
@@ -861,7 +859,8 @@ class LMCacheEngine:
         finally:
             # When num_computed_tokens is greater than a chunk, we skip
             # some tokens to reduce the number of lookup requests.
-            # It is possible that res = skip_n_tokens and no lookup is performed.
+            # It is possible that res equals aligned_computed_tokens and no lookup is
+            # performed.
             # In this case, using res as the number of hit tokens will overcount
             # the number of hit tokens.
             # TODO deprecate this metric and use retrieve metrics instead.

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -747,6 +747,7 @@ class LMCacheEngine:
         lookup_id: Optional[str] = None,
         pin: bool = False,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
@@ -771,6 +772,9 @@ class LMCacheEngine:
 
         :param Optional[dict] request_configs: the configs of the request.
 
+        :param int num_computed_tokens: Number of leading tokens those are already
+            available in the caller.
+
         :return: An int indicating how many prefix tokens are cached.
         """
         assert self.storage_manager is not None
@@ -782,7 +786,12 @@ class LMCacheEngine:
             assert hashes is not None
             lookup_request_id = self.stats_monitor.on_lookup_request(sum(offsets))
 
-        res = 0
+        # Skip the number of tokens that are already computed, align to chunk size
+        skip_n_tokens = (
+            num_computed_tokens // self.config.chunk_size * self.config.chunk_size
+        )
+
+        res = skip_n_tokens
         try:
             chunk_info_iterator = self.token_database.process_tokens(
                 tokens=tokens,
@@ -794,6 +803,8 @@ class LMCacheEngine:
             # TODO: support batched_contains when layerwise is enabled
             if self.use_layerwise:
                 for start, end, key in chunk_info_iterator:
+                    if end <= skip_n_tokens:
+                        continue
                     assert isinstance(key, CacheEngineKey)
 
                     # TODO(Jiayi): Optimize by checking only the existence of the key
@@ -822,9 +833,14 @@ class LMCacheEngine:
                 keys = []
                 for chunk_info in chunk_info_iterator:
                     assert isinstance(chunk_info[2], CacheEngineKey)
+                    start, end, _ = chunk_info
+                    if end <= skip_n_tokens:
+                        continue
                     chunk_info_list.append(chunk_info)
                     keys.append(chunk_info[2])
-
+                # If no tokens to lookup, return immediately
+                if len(keys) == 0:
+                    return res
                 # hit chunks by prefix matching
                 hit_chunks, block_mapping = self.storage_manager.batched_contains(
                     keys, search_range, pin
@@ -843,6 +859,12 @@ class LMCacheEngine:
             # all tokens where found, return the maximal end
             return res
         finally:
+            # When num_computed_tokens is greater than a chunk, we skip
+            # some tokens to reduce the number of lookup requests.
+            # It is possible that res = skip_n_tokens and no lookup is performed.
+            # In this case, using res as the number of hit tokens will overcount
+            # the number of hit tokens.
+            # TODO deprecate this metric and use retrieve metrics instead.
             self.stats_monitor.on_lookup_finished(lookup_request_id, res)
             # vllm lookup sets pin to True
             if pin:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -835,9 +835,11 @@ class LMCacheEngine:
                     if end <= aligned_computed_tokens:
                         continue
                     chunk_info_list.append(chunk_info)
+                    # chunk_info contains (start, end, key)
+                    # chunk_info[2] is the key
                     keys.append(chunk_info[2])
                 # If no tokens to lookup, return immediately
-                if len(keys) == 0:
+                if not keys:
                     return res
                 # hit chunks by prefix matching
                 hit_chunks, block_mapping = self.storage_manager.batched_contains(

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -34,6 +34,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         """
         Perform lookup for the given token IDs.
@@ -47,6 +48,9 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
 
             request_configs: The configs of the request,
             includes tags and the other configs
+
+            num_computed_tokens: The number of leading tokens that
+            the caller has already computed.
 
         Returns:
             The number of tokens that can be loaded from cache.

--- a/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
+++ b/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
@@ -119,9 +119,15 @@ class ChunkStatisticsLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         start_time = time.time()
-        result = self.actual_lookup_client.lookup(token_ids, lookup_id, request_configs)
+        result = self.actual_lookup_client.lookup(
+            token_ids,
+            lookup_id,
+            request_configs,
+            num_computed_tokens,
+        )
         lookup_elapsed = time.time() - start_time
         with self.lock:
             self.lookup_time += lookup_elapsed

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -14,7 +14,7 @@ logger = init_logger(__name__)
 
 
 """
-HitLimitLookupClient now is used for test, when lookup is called, cal the cache hit,
+HitLimitLookupClient now is used for test, when lookup is called, call the cache hit,
 - if the cache hit <= (1 - hit_miss_ratio), direct return the result
 - if the cache hit > (1 - hit_miss_ratio), re-compute the result by hit_miss_ratio
 """
@@ -41,9 +41,15 @@ class HitLimitLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         # get real hit tokens
-        result = self.actual_lookup_client.lookup(token_ids, lookup_id, request_configs)
+        result = self.actual_lookup_client.lookup(
+            token_ids,
+            lookup_id,
+            request_configs,
+            num_computed_tokens,
+        )
         if result is not None:
             total_tokens_length = len(token_ids)
             assert result <= total_tokens_length

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -14,7 +14,7 @@ logger = init_logger(__name__)
 
 
 """
-HitLimitLookupClient now is used for test, when lookup is called, call the cache hit,
+HitLimitLookupClient now is used for test, when lookup is called, cal the cache hit,
 - if the cache hit <= (1 - hit_miss_ratio), direct return the result
 - if the cache hit > (1 - hit_miss_ratio), re-compute the result by hit_miss_ratio
 """

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -197,7 +197,12 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
+        # TODO(ziruiliu) num_computed_tokens is passed in
+        # Due to complexity in preemption or eviction in async mode
+        # We will handle skipping logic in future.
+
         hashes: list[int] = []
         offsets = []
         for start, end, hash_val in self.token_database.process_tokens(

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -203,7 +203,7 @@ class LMCacheLookupClient(LookupClientInterface):
                 offsets.append(end - start)
             # Return aligned_computed_tokens immediately if there is no token to
             # lookup
-            if len(hashes) == 0:
+            if not hashes:
                 return aligned_computed_tokens
 
             hash_buf = self.encoder.encode(hashes)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -183,7 +183,7 @@ class LMCacheLookupClient(LookupClientInterface):
             request_configs_str = json.dumps(request_configs)
         request_configs_buf = request_configs_str.encode("utf-8")
         num_computed_buf = num_computed_tokens.to_bytes(8, "big", signed=False)
-        skip_n_tokens = 0
+        aligned_computed_tokens = num_computed_tokens  # pre-aligned in adapter
 
         # NOTE(Jiayi): We cannot only send hashes when blending enabled
         # because the blender need the input embedding.
@@ -193,20 +193,18 @@ class LMCacheLookupClient(LookupClientInterface):
 
             # We already have hashes here so we can skip the chunks that are already
             # in GPU cache. Don't pass num_computed_tokens to lookup server.
-            skip_n_tokens = (
-                num_computed_tokens // self.config.chunk_size * self.config.chunk_size
-            )
 
             for start, end, key in self.token_database.process_tokens(
                 token_ids, make_key=False
             ):
-                if end <= skip_n_tokens:
+                if end <= aligned_computed_tokens:
                     continue
                 hashes.append(key)
                 offsets.append(end - start)
-            # Return skip_n_tokens immediately if there is no token to lookup
+            # Return aligned_computed_tokens immediately if there is no token to
+            # lookup
             if len(hashes) == 0:
-                return skip_n_tokens
+                return aligned_computed_tokens
 
             hash_buf = self.encoder.encode(hashes)
             offset_buf = self.encoder.encode(offsets)
@@ -238,7 +236,7 @@ class LMCacheLookupClient(LookupClientInterface):
                 failed_rank = i
                 resp = self.sockets[i].recv()
                 result = int.from_bytes(resp, "big")
-                results.append(result + skip_n_tokens)
+                results.append(result + aligned_computed_tokens)
         except zmq.Again as e:
             logger.error(
                 "Timeout occurred for rank %s, recreating all sockets. Error: %s",

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -175,23 +175,39 @@ class LMCacheLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:
             request_configs_str = json.dumps(request_configs)
         request_configs_buf = request_configs_str.encode("utf-8")
+        num_computed_buf = num_computed_tokens.to_bytes(8, "big", signed=False)
+        skip_n_tokens = 0
 
         # NOTE(Jiayi): We cannot only send hashes when blending enabled
         # because the blender need the input embedding.
         if not self.enable_blending:
             hashes = []
             offsets = []
+
+            # We already have hashes here so we can skip the chunks that are already
+            # in GPU cache. Don't pass num_computed_tokens to lookup server.
+            skip_n_tokens = (
+                num_computed_tokens // self.config.chunk_size * self.config.chunk_size
+            )
+
             for start, end, key in self.token_database.process_tokens(
                 token_ids, make_key=False
             ):
+                if end <= skip_n_tokens:
+                    continue
                 hashes.append(key)
                 offsets.append(end - start)
+            # Return skip_n_tokens immediately if there is no token to lookup
+            if len(hashes) == 0:
+                return skip_n_tokens
+
             hash_buf = self.encoder.encode(hashes)
             offset_buf = self.encoder.encode(offsets)
             msg_buf = [
@@ -205,6 +221,7 @@ class LMCacheLookupClient(LookupClientInterface):
             tokens_buf = self.encoder.encode(token_ids)
             msg_buf = [
                 tokens_buf,
+                num_computed_buf,
                 lookup_id_buf,
                 request_configs_buf,
             ]
@@ -221,7 +238,7 @@ class LMCacheLookupClient(LookupClientInterface):
                 failed_rank = i
                 resp = self.sockets[i].recv()
                 result = int.from_bytes(resp, "big")
-                results.append(result)
+                results.append(result + skip_n_tokens)
         except zmq.Again as e:
             logger.error(
                 "Timeout occurred for rank %s, recreating all sockets. Error: %s",
@@ -332,15 +349,18 @@ class LMCacheLookupServer:
                         lookup_id=lookup_id,
                         pin=True,
                         request_configs=request_configs,
+                        num_computed_tokens=0,
                     )
                 else:
                     token_frames = frames[0]
+                    num_computed_tokens = int.from_bytes(frames[1], "big")
                     tokens = self.decoder.decode(token_frames)
                     result = self.lmcache_engine.lookup(
                         tokens=tokens,
                         lookup_id=lookup_id,
                         pin=True,
                         request_configs=request_configs,
+                        num_computed_tokens=num_computed_tokens,
                     )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -69,20 +69,17 @@ class LMCacheBypassLookupClient(LookupClientInterface):
                 offsets = []
                 # We already have hashes here so we can skip the chunks that are already
                 # in GPU cache. Don't pass num_computed_tokens to engine.
-                skip_n_tokens = (
-                    num_computed_tokens
-                    // self.config.chunk_size
-                    * self.config.chunk_size
-                )
-                result = skip_n_tokens
+                aligned_computed_tokens = num_computed_tokens  # pre-aligned in adapter
+                result = aligned_computed_tokens
                 for start, end, key in self.token_database.process_tokens(
                     token_ids, make_key=False
                 ):
-                    if end <= skip_n_tokens:
+                    if end <= aligned_computed_tokens:
                         continue
                     hashes.append(key)
                     offsets.append(end - start)
-                # Return skip_n_tokens immediately if there is no token to lookup
+                # Return aligned_computed_tokens immediately if there is no token to
+                # lookup
                 if len(hashes) == 0:
                     return result
 

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -80,7 +80,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
                     offsets.append(end - start)
                 # Return aligned_computed_tokens immediately if there is no token to
                 # lookup
-                if len(hashes) == 0:
+                if not hashes:
                     return result
 
                 # Call LMCacheEngine lookup with hashes and offsets

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -74,6 +74,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
                     // self.config.chunk_size
                     * self.config.chunk_size
                 )
+                result = skip_n_tokens
                 for start, end, key in self.token_database.process_tokens(
                     token_ids, make_key=False
                 ):
@@ -83,10 +84,10 @@ class LMCacheBypassLookupClient(LookupClientInterface):
                     offsets.append(end - start)
                 # Return skip_n_tokens immediately if there is no token to lookup
                 if len(hashes) == 0:
-                    return skip_n_tokens
+                    return result
 
                 # Call LMCacheEngine lookup with hashes and offsets
-                result = self.lmcache_engine.lookup(
+                result += self.lmcache_engine.lookup(
                     hashes=hashes,
                     offsets=offsets,
                     lookup_id=lookup_id,

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -60,17 +60,30 @@ class LMCacheBypassLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         try:
             if not self.enable_blending:
                 # Process tokens to get hashes and offsets
                 hashes = []
                 offsets = []
+                # We already have hashes here so we can skip the chunks that are already
+                # in GPU cache. Don't pass num_computed_tokens to engine.
+                skip_n_tokens = (
+                    num_computed_tokens
+                    // self.config.chunk_size
+                    * self.config.chunk_size
+                )
                 for start, end, key in self.token_database.process_tokens(
                     token_ids, make_key=False
                 ):
+                    if end <= skip_n_tokens:
+                        continue
                     hashes.append(key)
                     offsets.append(end - start)
+                # Return skip_n_tokens immediately if there is no token to lookup
+                if len(hashes) == 0:
+                    return skip_n_tokens
 
                 # Call LMCacheEngine lookup with hashes and offsets
                 result = self.lmcache_engine.lookup(
@@ -79,6 +92,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
                     lookup_id=lookup_id,
                     pin=True,
                     request_configs=request_configs,
+                    num_computed_tokens=0,
                 )
             else:
                 # For blending mode, pass tokens directly
@@ -87,6 +101,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
                     lookup_id=lookup_id,
                     pin=True,
                     request_configs=request_configs,
+                    num_computed_tokens=num_computed_tokens,
                 )
 
             return result

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -59,6 +59,7 @@ class MooncakeLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: Optional[str] = None,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         # process token_ids to cacheengine keys
         keys = []

--- a/tests/v1/lookup_client/test_chunk_statistics_lookup_client.py
+++ b/tests/v1/lookup_client/test_chunk_statistics_lookup_client.py
@@ -43,6 +43,7 @@ class MockLookupClient(BaseMockClient):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         self.lookup_calls.append((token_ids, lookup_id, request_configs))
         return len(token_ids) // 2
@@ -54,6 +55,7 @@ class FastMissLookupClient(BaseMockClient):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         time.sleep(0.008)
         return 0


### PR DESCRIPTION
**Why**
Please refer to #1922 , for those kv cache already computed in GPU memory, we do not need to issue lookup to lookup server or cache engine or storage manger.
However, async lookup and prefetch logic is more complex when evction, preemption happened if async taks in still going. So in this PR, we simply focus on optimizing lookup in sync mode

**What**
num_computed_tokens is passed to all types of lookup clients. But only `LMCacheLookupClient` and `LMCacheBypassLookupClient` actually handle this parameter, other types of clients simply ignore or pass down this parameter.
In these two lookup clients, when blending is not enabled, hashes will be generated by token database. Therefore we can simply skip these hashes in lookup client and send rest hashes to cache engine.
If blending is enabled, lookup client pass token ids and num_computed_tokens to cache engine and let cache engine skip chunks when hashes are calculated properly

**Test**
Tested with normal lookup client/server and also LMCacheBypassLookupClient.