### PR TITLE
[Docs][CI/CD] docker build pipeline and docs for lmcache standalone mode

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -73,3 +73,16 @@ jobs:
         run: |
           docker push lmcache/vllm-openai:latest-nightly
           docker push lmcache/vllm-openai:nightly-${{ env.NOW }}
+
+      - name: Build lmcache/standalone container image
+        run: |
+          docker build \
+          --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+          --target lmcache-final \
+          --tag lmcache/standalone:nightly --tag lmcache/standalone:nightly-${{ env.NOW }} \
+          --file docker/Dockerfile.standalone .
+
+      - name: Push lmcache/standalone container image to DockerHub
+        run: |
+          docker push lmcache/standalone:nightly
+          docker push lmcache/standalone:nightly-${{ env.NOW }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -273,3 +273,16 @@ jobs:
               run: |
                 docker push lmcache/vllm-openai:lightweight
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-lightweight
+            
+            - name: Build lmcache/standalone container image
+              run: |
+                docker build \
+                --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+                --target lmcache-final \
+                --tag lmcache/standalone:latest --tag lmcache/standalone:${{ env.LATEST_TAG }} \
+                --file docker/Dockerfile.standalone .
+            
+            - name: Push lmcache/standalone container image to DockerHub
+              run: |
+                docker push lmcache/standalone:latest
+                docker push lmcache/standalone:${{ env.LATEST_TAG }}

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -21,7 +21,8 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
         ccache software-properties-common git curl sudo \
-        python3 python3-dev python3-venv python3-pip tzdata \
+        python3 python3-dev python3-venv tzdata \
+    && rm -rf /var/lib/apt/lists/* \
     && ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/ \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv ~/.local/bin/uv /usr/local/bin/ \
@@ -35,7 +36,7 @@ WORKDIR /workspace
 # Install runtime dependencies
 COPY ./requirements/common.txt common.txt
 COPY ./requirements/cuda.txt cuda.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/uv \
     . /opt/venv/bin/activate && \
     uv pip install -r cuda.txt
 
@@ -59,7 +60,7 @@ ENV MAX_JOBS=${max_jobs}
 ARG nvcc_threads=8
 ENV NVCC_THREADS=$nvcc_threads
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/uv \
     . /opt/venv/bin/activate && \
     uv pip install -r build.txt
 
@@ -84,10 +85,10 @@ FROM base AS lmcache-final
 COPY --from=lmcache-build /workspace/LMCache/dist_lmcache/*.whl /tmp/
 
 # Install LMCache from wheel
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/uv \
     . /opt/venv/bin/activate && \
     uv pip install /tmp/*.whl --verbose && \
-    rm -rf /tmp/*.whl && uv cache clean
+    rm -rf /tmp/*.whl 
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -1,0 +1,96 @@
+# The LMCache Standalone Dockerfile is used to build a LMCache image
+# without vLLM integration.
+
+ARG CUDA_VERSION=12.8
+ARG UBUNTU_VERSION=24.04
+
+#################### BASE BUILD IMAGE ####################
+# Prepare basic build environment
+
+FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS base
+
+ARG CUDA_VERSION
+ARG PYTHON_VERSION=3.12
+ARG UBUNTU_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Install Python and other dependencies
+RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
+    && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ccache software-properties-common git curl sudo \
+        python3 python3-dev python3-venv python3-pip tzdata \
+    && ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/ \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv ~/.local/bin/uv /usr/local/bin/ \
+    && mv ~/.local/bin/uvx /usr/local/bin/ \
+    && uv venv /opt/venv \
+    && . /opt/venv/bin/activate \
+    && python3 --version
+
+WORKDIR /workspace
+
+# Install runtime dependencies
+COPY ./requirements/common.txt common.txt
+COPY ./requirements/cuda.txt cuda.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    . /opt/venv/bin/activate && \
+    uv pip install -r cuda.txt
+
+# CUDA arch list used by torch
+ARG torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0+PTX'
+ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
+
+#################### LMCache Build ##########################
+# Build LMCache wheel
+
+FROM base AS lmcache-build
+
+# install build dependencies
+COPY ./requirements/build.txt build.txt
+
+# Max jobs used by Ninja to build extensions
+ARG max_jobs=2
+ENV MAX_JOBS=${max_jobs}
+
+# Number of threads used by nvcc
+ARG nvcc_threads=8
+ENV NVCC_THREADS=$nvcc_threads
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    . /opt/venv/bin/activate && \
+    uv pip install -r build.txt
+
+ARG LMCACHE_COMMIT_ID=1
+
+COPY . /workspace/LMCache
+WORKDIR /workspace/LMCache
+
+# Build LMCache wheel (don't install yet)
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
+    --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
+    . /opt/venv/bin/activate && \
+    python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
+    python3 setup.py bdist_wheel --dist-dir=dist_lmcache
+
+#################### LMCache Final Image ##########################
+# Clean install of LMCache from wheel
+
+FROM base AS lmcache-final
+
+# Copy the built wheel from build stage
+COPY --from=lmcache-build /workspace/LMCache/dist_lmcache/*.whl /tmp/
+
+# Install LMCache from wheel
+RUN --mount=type=cache,target=/root/.cache/pip \
+    . /opt/venv/bin/activate && \
+    uv pip install /tmp/*.whl --verbose && \
+    rm -rf /tmp/*.whl && uv cache clean
+
+WORKDIR /workspace
+
+# Default shell entrypoint (no vLLM server)
+CMD ["/bin/bash"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,213 @@
+# LMCache Docker Images
+
+This directory contains Dockerfiles for building different LMCache images. Each Dockerfile serves a specific use case depending on your needs.
+
+## Available Dockerfiles
+
+### 1. `Dockerfile` - Full Integration with vLLM
+
+**Image**: `lmcache/vllm-openai:latest`
+
+**Description**: The main Dockerfile that builds LMCache from source and integrates it with vLLM OpenAI server. This is the recommended image for production deployments with full feature support including Prefill-Decode Disaggregation (PD).
+
+**Features**:
+- ✅ LMCache built from source
+- ✅ vLLM integration (nightly or stable)
+- ✅ Full NIXL support for Prefill-Decode Disaggregation
+- ✅ CUDA support
+- ✅ Optimized multi-stage build
+
+**Build Targets**:
+- `image-build`: Builds with vLLM nightly and LMCache from source
+- `image-release`: Uses stable vLLM release and LMCache from PyPI
+
+**Usage**:
+
+```bash
+# Build with nightly vLLM
+docker build \
+  --build-arg CUDA_VERSION=12.8 \
+  --build-arg UBUNTU_VERSION=24.04 \
+  --target image-build \
+  --tag lmcache/vllm-openai:latest \
+  --file docker/Dockerfile .
+
+# Build with stable releases
+docker build \
+  --build-arg CUDA_VERSION=12.8 \
+  --build-arg UBUNTU_VERSION=24.04 \
+  --target image-release \
+  --tag lmcache/vllm-openai:latest \
+  --file docker/Dockerfile .
+```
+
+**Run Example**:
+
+```bash
+export HF_TOKEN=<your_huggingface_token>
+
+docker run --runtime nvidia --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -p 8000:8000 \
+  --ipc=host \
+  lmcache/vllm-openai:latest \
+  serve Qwen/Qwen3-0.6B \
+  --kv-transfer-config \
+  '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+```
+
+---
+
+### 2. `Dockerfile.standalone` - LMCache Only
+
+**Image**: `lmcache/standalone:latest`
+
+**Description**: A standalone Docker image that builds and installs LMCache from source without vLLM. This will be useful when running LMCache in the standalone mode.
+
+**Features**:
+- ✅ LMCache built from source
+- ✅ No vLLM dependency
+- ✅ CUDA support
+
+**Build Target**:
+- `lmcache-final`: Final optimized image with LMCache installed
+
+**Usage**:
+
+```bash
+docker build \
+  --build-arg CUDA_VERSION=12.8 \
+  --build-arg UBUNTU_VERSION=24.04 \
+  --target lmcache-final \
+  --tag lmcache/standalone:latest \
+  --file docker/Dockerfile.standalone .
+```
+
+**Run Example**:
+
+```bash
+# Start an interactive shell
+docker run --runtime nvidia --gpus all -it \
+  lmcache/standalone:latest \
+  /opt/venv/bin/python3 \
+  -m lmcache.v1.multiprocess.server \
+  --cpu-buffer-size 60 \
+  --max-workers 4 \
+  --port 6555
+```
+
+---
+
+### 3. `Dockerfile.lightweight` - Quick Setup
+
+**Image**: `lmcache/vllm-openai:lightweight`
+
+**Description**: A lightweight image that extends the official vLLM image and installs LMCache from PyPI. This is the fastest way to get started but does not include NIXL support.
+
+**Features**:
+- ✅ Based on official `vllm/vllm-openai:latest` image
+- ✅ LMCache installed from PyPI (latest release)
+- ✅ Quick build time
+- ✅ Small image size
+- ❌ No NIXL support (no Prefill-Decode Disaggregation)
+
+**Limitations**:
+- Cannot use Prefill-Decode Disaggregation features
+
+**Usage**:
+
+```bash
+docker build \
+  --tag lmcache/vllm-openai:lightweight \
+  --file docker/Dockerfile.lightweight .
+```
+
+**Run Example**:
+
+```bash
+export HF_TOKEN=<your_huggingface_token>
+
+docker run --runtime nvidia --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  --env "HF_TOKEN=$HF_TOKEN" \
+  -p 8000:8000 \
+  --ipc=host \
+  lmcache/vllm-openai:lightweight \
+  serve Qwen/Qwen3-0.6B \
+  --kv-transfer-config \
+  '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+```
+
+---
+
+## Which Dockerfile Should I Use?
+
+### Use `Dockerfile` if you:
+- Need full LMCache + vLLM integration
+- Want Prefill-Decode Disaggregation support
+- Are deploying to production
+- Need the latest features built from source
+
+### Use `Dockerfile.standalone` if you:
+- Want LMCache without vLLM
+- Need a clean LMCache installation for development
+- Want to integrate LMCache with custom tools
+
+### Use `Dockerfile.lightweight` if you:
+- Prefer stable releases from PyPI
+- Need fast build times
+
+---
+
+## Build Arguments
+
+All Dockerfiles support the following build arguments:
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `CUDA_VERSION` | `12.8` | CUDA version to use |
+| `UBUNTU_VERSION` | `24.04` | Ubuntu base version |
+| `PYTHON_VERSION` | `3.12` | Python version |
+| `max_jobs` | `2` | Max parallel jobs for build |
+| `nvcc_threads` | `8` | Number of nvcc threads |
+| `torch_cuda_arch_list` | `7.0 7.5 8.0 8.6 8.9 9.0 10.0+PTX` | CUDA architectures |
+
+**Example with custom arguments**:
+
+```bash
+docker build \
+  --build-arg CUDA_VERSION=12.4 \
+  --build-arg max_jobs=4 \
+  --build-arg nvcc_threads=16 \
+  --target image-build \
+  --tag lmcache/vllm-openai:cuda12.4 \
+  --file docker/Dockerfile .
+```
+
+---
+
+## Published Images
+
+Pre-built images are available on Docker Hub:
+
+- `lmcache/vllm-openai:latest` - Latest stable release with vLLM
+- `lmcache/vllm-openai:{version}` - Specific version (e.g., `v0.1.0`)
+- `lmcache/vllm-openai:lightweight` - Lightweight version
+- `lmcache/standalone:latest` - Latest standalone release
+- `lmcache/standalone:{version}` - Specific standalone version
+
+```bash
+# Pull pre-built images
+docker pull lmcache/vllm-openai:latest
+docker pull lmcache/standalone:latest
+```
+
+---
+
+## Additional Resources
+
+- [LMCache Documentation](https://docs.lmcache.ai/)
+- [vLLM Documentation](https://docs.vllm.ai/)
+- [Installation Guide](https://docs.lmcache.ai/getting_started/installation.html)
+- [Docker Deployment Guide](https://docs.lmcache.ai/production/docker_deployment.html)
+


### PR DESCRIPTION
# Major changes:

1. Add a new Docker file that only installs LMCache (no vLLM) 
2. Add documents for "how to use Docker to deploy LMCache multi-process mode".
3. Update GitHub Actions to build and publish release and nightly "standalone" LMCache docker images.
4. Added a README.md under `docker/` folder


<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
6. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
