### PR TITLE
The port number is incorrect; the correct one is 9100. It's likely a typo.

### DIFF
--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -36,7 +36,7 @@ The disaggregated prefill setup consists of three main components:
 
 1. **Prefiller Server (Port 8100)**: Handles the prefill phase of LLM inference
 2. **Decoder Server (Port 8200)**: Manages the decoding/generation phase
-3. **Proxy Server (Port 9000)**: Coordinates between prefiller and decoder
+3. **Proxy Server (Port 9100)**: Coordinates between prefiller and decoder
 
 Configuration
 -------------

--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -154,7 +154,7 @@ Send requests to the proxy server (port 9000) using either the completions or ch
 
 .. code-block:: bash
 
-    curl http://localhost:9000/v1/completions \
+    curl http://localhost:9100/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
             "model": "meta-llama/Llama-3.1-8B-Instruct",
@@ -168,7 +168,7 @@ You can also test the setup with the following command, which runs vLLM's servin
 
     git clone https://github.com/vllm-project/vllm.git
     cd vllm/benchmarks
-    vllm bench serve --port 9000 --seed $(date +%s) \
+    vllm bench serve --port 9100 --seed $(date +%s) \
         --model meta-llama/Llama-3.1-8B-Instruct \
         --dataset-name random --random-input-len 5000 --random-output-len 200 \
         --num-prompts 50 --burstiness 100 --request-rate 1

--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -150,7 +150,7 @@ Step-by-Step Setup
 Usage
 -----
 
-Send requests to the proxy server (port 9000) using either the completions or chat completions endpoint:
+Send requests to the proxy server (port 9100) using either the completions or chat completions endpoint:
 
 .. code-block:: bash
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The port number for sending requests to the proxy server on the https://docs.lmcache.ai/getting_started/quickstart/disaggregated_prefill.html page is incorrect; the vllm benchmark test below has the same issue.

**Special notes for your reviewers**:

**If applicable**:

- [×] this PR contains user facing changes - docs added
- [×] this PR contains unit tests
