### PR TITLE
Add k8s example for multi process mode

### DIFF
--- a/docs/source/kv_cache/multiprocess_mode.rst
+++ b/docs/source/kv_cache/multiprocess_mode.rst
@@ -168,7 +168,7 @@ Prerequisites
     kubectl apply -f examples/multi_process/multi_process.yaml
 
 .. note::
-    The default model is ``Qwen/Qwen2.5-1.5B``, which does not require a Hugging Face token. If you want to use a gated model (like Llama), you need to:
+    The default model is ``Qwen/Qwen3-14B``, which does not require a Hugging Face token. If you want to use a gated model (like Llama), you need to:
     
     1. Add a Secret with your Hugging Face token:
     
@@ -228,9 +228,9 @@ Send a test request with repeated prompts:
     curl -X POST http://localhost:8000/v1/completions \
       -H "Content-Type: application/json" \
       -d "{
-        \"model\": \"Qwen/Qwen2.5-1.5B\",
+        \"model\": \"Qwen/Qwen3-14B\",
         \"prompt\": \"$(printf 'Explain the significance of KV cache in language models.%.0s' {1..100})\",
-        \"max_tokens\": 100
+        \"max_tokens\": 10
       }"
 
 On the first request, check LMCache server logs for:

--- a/docs/source/kv_cache/multiprocess_mode.rst
+++ b/docs/source/kv_cache/multiprocess_mode.rst
@@ -140,6 +140,138 @@ Once both containers are running, you can send requests to vLLM the same way as 
         \"max_tokens\": 10
     }"
 
+Kubernetes Deployment
+---------------------
+
+You can deploy LMCache and vLLM on Kubernetes using a sidecar container pattern. This approach is suitable for production deployments where you want to leverage Kubernetes orchestration.
+
+.. note::
+    The Kubernetes deployment requires special configuration due to GPU allocation differences from Docker. Both containers must see all GPUs to avoid device ID mismatches in IPC-based GPU memory operations.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+- Kubernetes cluster with GPU support (NVIDIA GPU Operator installed)
+- At least 4 GPUs per node
+- ``kubectl`` configured to access your cluster
+- Hugging Face token (for gated models like Llama)
+
+**Step 1: Create Namespace**
+
+.. code-block:: bash
+
+    kubectl create namespace multi-process
+
+**Step 2: Configure Hugging Face Token**
+
+Edit ``examples/multi_process/multi_process.yaml`` and replace the placeholder token. The `data` field in the Secret requires the token to be base64 encoded. You can generate it using `echo -n "your_hf_token_here" | base64`.
+
+.. code-block:: yaml
+
+    data:
+      hf_token: YOUR_BASE64_ENCODED_HF_TOKEN_HERE
+
+Alternatively, create the secret separately:
+
+.. code-block:: bash
+
+    kubectl create secret generic vllm-secrets \
+      --from-literal=hf_token=your_hf_token_here \
+      -n multi-process
+
+**Step 3: Deploy the Application**
+
+.. code-block:: bash
+
+    kubectl apply -f examples/multi_process/multi_process.yaml
+
+**Step 4: Monitor Deployment**
+
+Check pod status:
+
+.. code-block:: bash
+
+    kubectl get pods -n multi-process -w
+
+Check LMCache server logs:
+
+.. code-block:: bash
+
+    kubectl logs -n multi-process -l app=multi-process-deployment -c lmcache-server -f
+
+Check vLLM server logs:
+
+.. code-block:: bash
+
+    kubectl logs -n multi-process -l app=multi-process-deployment -c vllm -f
+
+Wait for the pod to be ready (this may take several minutes for model loading).
+
+**Step 5: Send Test Requests**
+
+Forward the port to your local machine:
+
+.. code-block:: bash
+
+    kubectl port-forward -n multi-process deployment/multi-process-deployment 8000:8000
+
+Send a test request with repeated prompts:
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:8000/v1/completions \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"model\": \"meta-llama/Llama-3.1-8B-Instruct\",
+        \"prompt\": \"$(printf 'Explain the significance of KV cache in language models.%.0s' {1..100})\",
+        \"max_tokens\": 10
+      }"
+
+On the first request, check LMCache server logs for:
+
+.. code-block:: text
+
+    [LMCache INFO] Stored X tokens in Y seconds
+
+On subsequent identical requests, you should see:
+
+.. code-block:: text
+
+    [LMCache INFO] Retrieved X tokens in Y seconds
+
+Kubernetes Configuration Notes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Kubernetes deployment differs from Docker in several important ways:
+
+**GPU Allocation:**
+
+- Both containers must see all GPUs via pod-level allocation
+- Uses ``hostIPC: true`` for shared memory access required by IPC operations
+- ``CUDA_VISIBLE_DEVICES`` is set to ``0,1,2,3`` for both containers
+- This avoids device ID mismatches that occur with per-container GPU allocation
+
+**Why LMCache Server Needs GPU Access:**
+
+The LMCache server requires GPU access because it:
+
+- Receives GPU tensor IPC handles from vLLM workers
+- Directly accesses vLLM's GPU memory to perform GPU-to-CPU transfers
+- Uses CUDA operations for efficient memory copying
+
+The term "CPU offloading" refers to where KV cache is **stored** (CPU memory), not where the server runs.
+
+**Health Checks:**
+
+The LMCache server does not have health probes because it uses ZMQ sockets, which don't support standard TCP health checks. The vLLM container will fail to start if LMCache is not working properly.
+
+**Cleanup:**
+
+.. code-block:: bash
+
+    kubectl delete -f examples/multi_process/multi_process.yaml
+    kubectl delete namespace multi-process
+
 Detailed Configuration
 ----------------------
 

--- a/docs/source/kv_cache/multiprocess_mode.rst
+++ b/docs/source/kv_cache/multiprocess_mode.rst
@@ -154,7 +154,6 @@ Prerequisites
 - Kubernetes cluster with GPU support (NVIDIA GPU Operator installed)
 - At least 4 GPUs per node
 - ``kubectl`` configured to access your cluster
-- Hugging Face token (for gated models like Llama)
 
 **Step 1: Create Namespace**
 
@@ -162,30 +161,37 @@ Prerequisites
 
     kubectl create namespace multi-process
 
-**Step 2: Configure Hugging Face Token**
-
-Edit ``examples/multi_process/multi_process.yaml`` and replace the placeholder token. The `data` field in the Secret requires the token to be base64 encoded. You can generate it using `echo -n "your_hf_token_here" | base64`.
-
-.. code-block:: yaml
-
-    data:
-      hf_token: YOUR_BASE64_ENCODED_HF_TOKEN_HERE
-
-Alternatively, create the secret separately:
-
-.. code-block:: bash
-
-    kubectl create secret generic vllm-secrets \
-      --from-literal=hf_token=your_hf_token_here \
-      -n multi-process
-
-**Step 3: Deploy the Application**
+**Step 2: Deploy the Application**
 
 .. code-block:: bash
 
     kubectl apply -f examples/multi_process/multi_process.yaml
 
-**Step 4: Monitor Deployment**
+.. note::
+    The default model is ``Qwen/Qwen2.5-1.5B``, which does not require a Hugging Face token. If you want to use a gated model (like Llama), you need to:
+    
+    1. Add a Secret with your Hugging Face token:
+    
+    .. code-block:: bash
+    
+        kubectl create secret generic vllm-secrets \
+          --from-literal=hf_token=your_hf_token_here \
+          -n multi-process
+    
+    2. Add the HF_TOKEN environment variable to the vLLM container in the YAML:
+    
+    .. code-block:: yaml
+    
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: hf_token
+                name: vllm-secrets
+    
+    3. Update the model name in the args section to your desired gated model.
+
+**Step 3: Monitor Deployment**
 
 Check pod status:
 
@@ -207,7 +213,7 @@ Check vLLM server logs:
 
 Wait for the pod to be ready (this may take several minutes for model loading).
 
-**Step 5: Send Test Requests**
+**Step 4: Send Test Requests**
 
 Forward the port to your local machine:
 
@@ -222,9 +228,9 @@ Send a test request with repeated prompts:
     curl -X POST http://localhost:8000/v1/completions \
       -H "Content-Type: application/json" \
       -d "{
-        \"model\": \"meta-llama/Llama-3.1-8B-Instruct\",
+        \"model\": \"Qwen/Qwen2.5-1.5B\",
         \"prompt\": \"$(printf 'Explain the significance of KV cache in language models.%.0s' {1..100})\",
-        \"max_tokens\": 10
+        \"max_tokens\": 100
       }"
 
 On the first request, check LMCache server logs for:
@@ -246,10 +252,9 @@ The Kubernetes deployment differs from Docker in several important ways:
 
 **GPU Allocation:**
 
-- Both containers must see all GPUs via pod-level allocation
+- GPU resources are allocated at the pod level in Kubernetes, even when specified on a single container
+- All GPUs are automatically visible to all containers in the pod
 - Uses ``hostIPC: true`` for shared memory access required by IPC operations
-- ``CUDA_VISIBLE_DEVICES`` is set to ``0,1,2,3`` for both containers
-- This avoids device ID mismatches that occur with per-container GPU allocation
 
 **Why LMCache Server Needs GPU Access:**
 

--- a/docs/source/kv_cache/multiprocess_mode.rst
+++ b/docs/source/kv_cache/multiprocess_mode.rst
@@ -143,10 +143,10 @@ Once both containers are running, you can send requests to vLLM the same way as 
 Kubernetes Deployment
 ---------------------
 
-You can deploy LMCache and vLLM on Kubernetes using a sidecar container pattern. This approach is suitable for production deployments where you want to leverage Kubernetes orchestration.
+You can deploy LMCache and vLLM on Kubernetes using a DaemonSet pattern. This approach runs one LMCache server per node that can be shared by multiple vLLM pods on the same node, making it suitable for production deployments.
 
 .. note::
-    The Kubernetes deployment requires special configuration due to GPU allocation differences from Docker. Both containers must see all GPUs to avoid device ID mismatches in IPC-based GPU memory operations.
+    The DaemonSet deployment uses ``privileged: true`` to allow LMCache to access GPUs without requesting them as Kubernetes resources. This ensures GPUs remain available for vLLM pods while LMCache can still perform GPU operations.
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -161,11 +161,21 @@ Prerequisites
 
     kubectl create namespace multi-process
 
-**Step 2: Deploy the Application**
+**Step 2: Deploy LMCache DaemonSet**
+
+First, deploy the LMCache server as a DaemonSet (one instance per node):
 
 .. code-block:: bash
 
-    kubectl apply -f examples/multi_process/multi_process.yaml
+    kubectl apply -f examples/multi_process/lmcache-daemonset.yaml
+
+**Step 3: Deploy vLLM Application**
+
+Deploy one or more vLLM instances that will connect to the LMCache DaemonSet:
+
+.. code-block:: bash
+
+    kubectl apply -f examples/multi_process/vllm-deployment.yaml
 
 .. note::
     The default model is ``Qwen/Qwen3-14B``, which does not require a Hugging Face token. If you want to use a gated model (like Llama), you need to:
@@ -191,35 +201,50 @@ Prerequisites
     
     3. Update the model name in the args section to your desired gated model.
 
-**Step 3: Monitor Deployment**
+.. note::
+    Multiple vLLM pods on the same node will automatically connect to the same LMCache DaemonSet instance via ``status.hostIP``.
 
-Check pod status:
+**Step 4: Monitor Deployment**
 
-.. code-block:: bash
-
-    kubectl get pods -n multi-process -w
-
-Check LMCache server logs:
+Check DaemonSet status:
 
 .. code-block:: bash
 
-    kubectl logs -n multi-process -l app=multi-process-deployment -c lmcache-server -f
+    kubectl get daemonset -n multi-process
+    kubectl get pods -n multi-process -l app=lmcache-server
+
+Check vLLM deployment status:
+
+.. code-block:: bash
+
+    kubectl get pods -n multi-process -l app=vllm-deployment -w
 
 Check vLLM server logs:
 
 .. code-block:: bash
 
-    kubectl logs -n multi-process -l app=multi-process-deployment -c vllm -f
+    kubectl logs -n multi-process -l app=vllm-deployment -f
 
-Wait for the pod to be ready (this may take several minutes for model loading).
+Check LMCache server logs (on the same node as a vLLM pod):
 
-**Step 4: Send Test Requests**
+.. code-block:: bash
+
+    # Get the node where a vLLM pod is running
+    VLLM_NODE=$(kubectl get pod -n multi-process -l app=vllm-deployment -o jsonpath='{.items[0].spec.nodeName}')
+    
+    # Get the LMCache pod on that node and view its logs
+    LMCACHE_POD=$(kubectl get pod -n multi-process -l app=lmcache-server --field-selector spec.nodeName=$VLLM_NODE -o jsonpath='{.items[0].metadata.name}')
+    kubectl logs -n multi-process $LMCACHE_POD -f
+
+Wait for the pods to be ready (this may take several minutes for model loading).
+
+**Step 5: Send Test Requests**
 
 Forward the port to your local machine:
 
 .. code-block:: bash
 
-    kubectl port-forward -n multi-process deployment/multi-process-deployment 8000:8000
+    kubectl port-forward -n multi-process deployment/vllm-deployment 8000:8000
 
 Send a test request with repeated prompts:
 
@@ -248,13 +273,22 @@ On subsequent identical requests, you should see:
 Kubernetes Configuration Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Kubernetes deployment differs from Docker in several important ways:
+The DaemonSet deployment differs from the sidecar pattern in several important ways:
 
-**GPU Allocation:**
+**DaemonSet Architecture:**
 
-- GPU resources are allocated at the pod level in Kubernetes, even when specified on a single container
-- All GPUs are automatically visible to all containers in the pod
-- Uses ``hostIPC: true`` for shared memory access required by IPC operations
+- One LMCache server runs per node (not per pod)
+- Multiple vLLM pods on the same node share the same LMCache instance
+- LMCache uses ``hostNetwork: true`` so vLLM pods can connect via node IP
+- vLLM pods use ``status.hostIP`` to discover the LMCache server on their node
+- Both LMCache and vLLM pods use ``hostIPC: true`` for shared memory IPC communication
+
+**GPU Access Without Resource Requests:**
+
+- LMCache DaemonSet uses ``privileged: true`` to access GPUs
+- GPUs are NOT requested in the DaemonSet resources section
+- This allows GPUs to remain exclusively allocated to vLLM pods
+- LMCache can still perform GPU operations for IPC-based memory transfers
 
 **Why LMCache Server Needs GPU Access:**
 
@@ -267,15 +301,19 @@ The LMCache server requires GPU access because it:
 
 The term "CPU offloading" refers to where KV cache is **stored** (CPU memory), not where the server runs.
 
-**Health Checks:**
+**Advantages of DaemonSet Pattern:**
 
-The LMCache server does not have health probes because it uses ZMQ sockets, which don't support standard TCP health checks. The vLLM container will fail to start if LMCache is not working properly.
+- Resource efficiency: One LMCache server per node instead of per pod
+- Better for multi-tenant scenarios with multiple vLLM deployments
+- Easier to manage and monitor centrally
+- Works with SGLang and other inference engines
 
 **Cleanup:**
 
 .. code-block:: bash
 
-    kubectl delete -f examples/multi_process/multi_process.yaml
+    kubectl delete -f examples/multi_process/vllm-deployment.yaml
+    kubectl delete -f examples/multi_process/lmcache-daemonset.yaml
     kubectl delete namespace multi-process
 
 Detailed Configuration

--- a/docs/source/kv_cache/multiprocess_mode.rst
+++ b/docs/source/kv_cache/multiprocess_mode.rst
@@ -258,6 +258,7 @@ The LMCache server requires GPU access because it:
 - Receives GPU tensor IPC handles from vLLM workers
 - Directly accesses vLLM's GPU memory to perform GPU-to-CPU transfers
 - Uses CUDA operations for efficient memory copying
+- Potentially allocates intermediate GPU buffers
 
 The term "CPU offloading" refers to where KV cache is **stored** (CPU memory), not where the server runs.
 

--- a/docs/source/kv_cache/multiprocess_mode.rst
+++ b/docs/source/kv_cache/multiprocess_mode.rst
@@ -146,7 +146,7 @@ Kubernetes Deployment
 You can deploy LMCache and vLLM on Kubernetes using a DaemonSet pattern. This approach runs one LMCache server per node that can be shared by multiple vLLM pods on the same node, making it suitable for production deployments.
 
 .. note::
-    The DaemonSet deployment uses ``privileged: true`` to allow LMCache to access GPUs without requesting them as Kubernetes resources. This ensures GPUs remain available for vLLM pods while LMCache can still perform GPU operations.
+    The DaemonSet deployment does not request GPU resources, allowing GPUs to remain exclusively allocated to vLLM pods. The NVIDIA container runtime automatically provides GPU access to the LMCache server for IPC-based memory transfers.
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -273,40 +273,38 @@ On subsequent identical requests, you should see:
 Kubernetes Configuration Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The DaemonSet deployment differs from the sidecar pattern in several important ways:
-
 **DaemonSet Architecture:**
 
-- One LMCache server runs per node (not per pod)
-- Multiple vLLM pods on the same node share the same LMCache instance
+- One LMCache server runs per node as a DaemonSet
+- Multiple vLLM pods on the same node can share the same LMCache instance
 - LMCache uses ``hostNetwork: true`` so vLLM pods can connect via node IP
 - vLLM pods use ``status.hostIP`` to discover the LMCache server on their node
-- Both LMCache and vLLM pods use ``hostIPC: true`` for shared memory IPC communication
+- Both containers mount the host's ``/dev/shm`` to enable CUDA IPC memory sharing
 
-**GPU Access Without Resource Requests:**
+**GPU Access:**
 
-- LMCache DaemonSet uses ``privileged: true`` to access GPUs
 - GPUs are NOT requested in the DaemonSet resources section
 - This allows GPUs to remain exclusively allocated to vLLM pods
-- LMCache can still perform GPU operations for IPC-based memory transfers
+- LMCache can still access GPUs for IPC-based memory transfers via the NVIDIA container runtime
 
-**Why LMCache Server Needs GPU Access:**
+.. note::
+    LMCache pods on nodes without GPUs will crash with CUDA initialization errors. This is expected behavior - LMCache only needs to run successfully on GPU nodes where vLLM pods are scheduled.
 
-The LMCache server requires GPU access because it:
+**Minimal Configuration Requirements:**
 
-- Receives GPU tensor IPC handles from vLLM workers
-- Directly accesses vLLM's GPU memory to perform GPU-to-CPU transfers
-- Uses CUDA operations for efficient memory copying
-- Potentially allocates intermediate GPU buffers
+**vLLM Deployment:**
 
-The term "CPU offloading" refers to where KV cache is **stored** (CPU memory), not where the server runs.
+- ``/dev/shm`` hostPath mount (required for CUDA IPC shared memory)
 
-**Advantages of DaemonSet Pattern:**
+**LMCache DaemonSet:**
 
-- Resource efficiency: One LMCache server per node instead of per pod
-- Better for multi-tenant scenarios with multiple vLLM deployments
-- Easier to manage and monitor centrally
-- Works with SGLang and other inference engines
+- ``hostNetwork: true`` (required for vLLM to connect via node IP using ``status.hostIP``)
+- ``/dev/shm`` hostPath mount (required for CUDA IPC shared memory)
+- ``LMCACHE_LOG_LEVEL=DEBUG`` environment variable (optional, for observability)
+
+**Key Insight:**
+
+Mounting the same ``/dev/shm`` from the host in both containers provides the shared memory space needed for CUDA IPC communication. The NVIDIA container runtime (installed via NVIDIA GPU Operator) automatically provides GPU access to the LMCache server.
 
 **Cleanup:**
 

--- a/examples/multi_process/lmcache-daemonset.yaml
+++ b/examples/multi_process/lmcache-daemonset.yaml
@@ -39,7 +39,8 @@ spec:
               mountPath: /dev/shm
           resources:
             requests:
-              memory: "10Gi"
+              # 65Gi = 60GB cpu-buffer-size + ~5GB overhead for Python runtime and server operations
+              memory: "65Gi"
               cpu: "4"
             limits:
               memory: "120Gi"

--- a/examples/multi_process/lmcache-daemonset.yaml
+++ b/examples/multi_process/lmcache-daemonset.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lmcache-server
+  namespace: multi-process
+spec:
+  selector:
+    matchLabels:
+      app: lmcache-server
+  template:
+    metadata:
+      labels:
+        app: lmcache-server
+    spec:
+      hostNetwork: true
+      containers:
+        - name: lmcache-server
+          image: lmcache/standalone:nightly
+          command:
+            - /opt/venv/bin/python3
+            - -m
+            - lmcache.v1.multiprocess.server
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "6555"
+            - --cpu-buffer-size
+            - "60"
+            - --max-workers
+            - "4"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "10Gi"
+              cpu: "4"
+            limits:
+              memory: "120Gi"
+              cpu: "8"
+          env:
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+            - name: LMCACHE_LOG_LEVEL
+              value: "DEBUG"

--- a/examples/multi_process/lmcache-daemonset.yaml
+++ b/examples/multi_process/lmcache-daemonset.yaml
@@ -14,6 +14,11 @@ spec:
         app: lmcache-server
     spec:
       hostNetwork: true
+      volumes:
+        - name: dev-shm
+          hostPath:
+            path: /dev/shm
+            type: Directory
       containers:
         - name: lmcache-server
           image: lmcache/standalone:nightly
@@ -29,8 +34,9 @@ spec:
             - "60"
             - --max-workers
             - "4"
-          securityContext:
-            privileged: true
+          volumeMounts:
+            - name: dev-shm
+              mountPath: /dev/shm
           resources:
             requests:
               memory: "10Gi"
@@ -39,7 +45,5 @@ spec:
               memory: "120Gi"
               cpu: "8"
           env:
-            - name: NVIDIA_VISIBLE_DEVICES
-              value: "all"
             - name: LMCACHE_LOG_LEVEL
               value: "DEBUG"

--- a/examples/multi_process/multi_process.yaml
+++ b/examples/multi_process/multi_process.yaml
@@ -1,16 +1,4 @@
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: vllm-secrets
-  namespace: multi-process
-type: Opaque
-data:
-  # Base64 encoded Hugging Face token
-  # Replace with: echo -n "your_hf_token_here" | base64
-  hf_token: YOUR_BASE64_ENCODED_HF_TOKEN_HERE
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,9 +41,6 @@ spec:
           env:
             - name: LMCACHE_LOG_LEVEL
               value: "DEBUG"
-            # Make all GPUs visible to allow for inter-process communication across devices.
-            - name: CUDA_VISIBLE_DEVICES
-              value: "0,1,2,3"
           ports:
             - containerPort: 6555
               name: lmcache
@@ -65,7 +50,7 @@ spec:
         - name: vllm
           image: lmcache/vllm-openai:latest-nightly
           args:
-            - meta-llama/Llama-3.1-8B-Instruct
+            - Qwen/Qwen2.5-1.5B
             - --host
             - "0.0.0.0"
             - --port
@@ -81,7 +66,10 @@ spec:
             - '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.port": 6555}}'
           resources:
             limits:
-              # Allocate all 4 GPUs at pod level
+              # Note: GPU allocation in Kubernetes is pod-level, not container-level.
+              # Even though specified here on the vLLM container, all 4 GPUs are mounted
+              # to the pod's device namespace, making them accessible to ALL containers
+              # (including lmcache-server).
               nvidia.com/gpu: "4"
             requests:
               nvidia.com/gpu: "4"
@@ -96,17 +84,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           env:
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  key: hf_token
-                  name: vllm-secrets
             - name: PYTHONHASHSEED
               value: "0"
             - name: PROMETHEUS_MULTIPROC_DIR
               value: "/tmp"
             - name: LMCACHE_LOG_LEVEL
               value: "DEBUG"
-            # See all 4 GPUs and use all for TP=4
-            - name: CUDA_VISIBLE_DEVICES
-              value: "0,1,2,3"

--- a/examples/multi_process/multi_process.yaml
+++ b/examples/multi_process/multi_process.yaml
@@ -50,7 +50,7 @@ spec:
         - name: vllm
           image: lmcache/vllm-openai:latest-nightly
           args:
-            - Qwen/Qwen2.5-1.5B
+            - Qwen/Qwen3-14B
             - --host
             - "0.0.0.0"
             - --port

--- a/examples/multi_process/multi_process.yaml
+++ b/examples/multi_process/multi_process.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vllm-secrets
+  namespace: multi-process
+type: Opaque
+data:
+  # Base64 encoded Hugging Face token
+  # Replace with: echo -n "your_hf_token_here" | base64
+  hf_token: YOUR_BASE64_ENCODED_HF_TOKEN_HERE
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-process-deployment
+  namespace: multi-process
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multi-process-deployment
+  template:
+    metadata:
+      labels:
+        app: multi-process-deployment
+    spec:
+      hostIPC: true
+      containers:
+        # Sidecar container: LMCache server. The vLLM container will wait for it to be ready.
+        - name: lmcache-server
+          image: lmcache/standalone:nightly
+          command:
+            - /opt/venv/bin/python3
+            - -m
+            - lmcache.v1.multiprocess.server
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "6555"
+            - --cpu-buffer-size
+            - "60"
+            - --max-workers
+            - "4"
+          resources:
+            requests:
+              memory: "10Gi"
+              cpu: "4"
+            limits:
+              memory: "120Gi"
+              cpu: "8"
+          env:
+            - name: LMCACHE_LOG_LEVEL
+              value: "DEBUG"
+            # Make all GPUs visible to allow for inter-process communication across devices.
+            - name: CUDA_VISIBLE_DEVICES
+              value: "0,1,2,3"
+          ports:
+            - containerPort: 6555
+              name: lmcache
+              protocol: TCP
+
+        # Main container: vLLM
+        - name: vllm
+          image: lmcache/vllm-openai:latest-nightly
+          args:
+            - meta-llama/Llama-3.1-8B-Instruct
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
+            - --no-enable-prefix-caching
+            - --max-model-len
+            - "32768"
+            - --gpu-memory-utilization
+            - "0.85"
+            - --tensor-parallel-size
+            - "4"
+            - --kv-transfer-config
+            - '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.port": 6555}}'
+          resources:
+            limits:
+              # Allocate all 4 GPUs at pod level
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: hf_token
+                  name: vllm-secrets
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: PROMETHEUS_MULTIPROC_DIR
+              value: "/tmp"
+            - name: LMCACHE_LOG_LEVEL
+              value: "DEBUG"
+            # See all 4 GPUs and use all for TP=4
+            - name: CUDA_VISIBLE_DEVICES
+              value: "0,1,2,3"

--- a/examples/multi_process/vllm-deployment.yaml
+++ b/examples/multi_process/vllm-deployment.yaml
@@ -14,25 +14,38 @@ spec:
       labels:
         app: vllm-deployment
     spec:
-      hostIPC: true
+      volumes:
+        - name: dshm
+          hostPath:
+            path: /dev/shm
+            type: Directory
       containers:
         - name: vllm
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
           image: lmcache/vllm-openai:latest-nightly
-          args:
-            - Qwen/Qwen3-14B
-            - --host
-            - "0.0.0.0"
-            - --port
-            - "8000"
-            - --no-enable-prefix-caching
-            - --max-model-len
-            - "32768"
-            - --gpu-memory-utilization
-            - "0.85"
-            - --tensor-parallel-size
-            - "4"
-            - --kv-transfer-config
-            - '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.port": 6555}}'
+          command:
+            - /bin/bash
+            - -c
+            - |
+              vllm serve Qwen/Qwen3-14B \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --no-enable-prefix-caching \
+                --max-model-len 32768 \
+                --gpu-memory-utilization 0.85 \
+                --tensor-parallel-size 4 \
+                --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"tcp://${HOST_IP}\", \"lmcache.mp.port\": 6555}}"
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: PROMETHEUS_MULTIPROC_DIR
+              value: "/tmp"
           resources:
             limits:
               nvidia.com/gpu: "4"
@@ -48,10 +61,3 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          env:
-            - name: PYTHONHASHSEED
-              value: "0"
-            - name: PROMETHEUS_MULTIPROC_DIR
-              value: "/tmp"
-            - name: LMCACHE_LOG_LEVEL
-              value: "DEBUG"

--- a/examples/multi_process/vllm-deployment.yaml
+++ b/examples/multi_process/vllm-deployment.yaml
@@ -2,51 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: multi-process-deployment
+  name: vllm-deployment
   namespace: multi-process
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: multi-process-deployment
+      app: vllm-deployment
   template:
     metadata:
       labels:
-        app: multi-process-deployment
+        app: vllm-deployment
     spec:
       hostIPC: true
       containers:
-        # Sidecar container: LMCache server. The vLLM container will wait for it to be ready.
-        - name: lmcache-server
-          image: lmcache/standalone:nightly
-          command:
-            - /opt/venv/bin/python3
-            - -m
-            - lmcache.v1.multiprocess.server
-            - --host
-            - "0.0.0.0"
-            - --port
-            - "6555"
-            - --cpu-buffer-size
-            - "60"
-            - --max-workers
-            - "4"
-          resources:
-            requests:
-              memory: "10Gi"
-              cpu: "4"
-            limits:
-              memory: "120Gi"
-              cpu: "8"
-          env:
-            - name: LMCACHE_LOG_LEVEL
-              value: "DEBUG"
-          ports:
-            - containerPort: 6555
-              name: lmcache
-              protocol: TCP
-
-        # Main container: vLLM
         - name: vllm
           image: lmcache/vllm-openai:latest-nightly
           args:
@@ -66,10 +35,6 @@ spec:
             - '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.port": 6555}}'
           resources:
             limits:
-              # Note: GPU allocation in Kubernetes is pod-level, not container-level.
-              # Even though specified here on the vLLM container, all 4 GPUs are mounted
-              # to the pod's device namespace, making them accessible to ALL containers
-              # (including lmcache-server).
               nvidia.com/gpu: "4"
             requests:
               nvidia.com/gpu: "4"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Kubernetes deployment example for LMCache multi-process mode with vLLM using a sidecar container pattern.

The existing documentation only covers local and Docker deployments. This PR adds:
- Working Kubernetes YAML configuration (`examples/multi_process/multi_process.yaml`)
- Comprehensive Kubernetes deployment section in the multi-process mode documentation
- Step-by-step deployment, testing, and troubleshooting instructions

**Special notes for your reviewers**:

**Key differences from Docker deployment:**

Kubernetes requires special configuration due to GPU allocation model differences:

1. **Pod-level GPU allocation**: Both containers must see all 4 GPUs (via `CUDA_VISIBLE_DEVICES=0,1,2,3`) to avoid device ID mismatches
2. **hostIPC: true**: Required for IPC-based GPU memory sharing between containers
3. **GPU requirement for LMCache server**: The server needs GPU access to perform IPC-based GPU-to-CPU memory transfers (not just CPU-only as the name "CPU offloading" might suggest)

**Configuration details:**
- Uses `lmcache/standalone:nightly` and `lmcache/vllm-openai:latest-nightly` images
- Allocates 4 GPUs per pod (shared between containers)
- LMCache server: 60GB CPU buffer, 4 worker threads
- vLLM: TP=4, max-model-len=32768, gpu-memory-utilization=0.85
- Tested with Llama-3.1-8B-Instruct model

**Testing performed:**
- Deployed on Kubernetes cluster with 4 GPUs per node
- Verified KV cache registration and unregistration in logs
- Confirmed KV cache offloading (store) and retrieval on repeated requests

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests