### PR TITLE
[Bugfix] Update layerwise-mode cache engine key format

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -132,13 +132,14 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
 
     Args:
         key_str: String in format:
-            fmt@model@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
+            fmt@model@world_size@worker_id@chunk_hash@dtype[@layer_id][@tag%value...]
 
     Returns:
         CacheEngineKey if no layer_id, LayerCacheEngineKey if valid layer_id
     """
+    LAYER_MODE_PART_NUM = 6
     parts = key_str.strip().split("@")
-    if len(parts) >= 6 and parts[5].isdigit():
+    if len(parts) > LAYER_MODE_PART_NUM and parts[LAYER_MODE_PART_NUM].isdigit():
         return LayerCacheEngineKey.from_string(key_str)
     return CacheEngineKey.from_string(key_str)
 
@@ -378,12 +379,19 @@ class LayerCacheEngineKey(CacheEngineKey):
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
+
+        # Handle negative hex numbers in chunk_hash
+        chunk_hash_str = parts[4]
+        if chunk_hash_str.startswith("-"):
+            chunk_hash_str = chunk_hash_str[1:]
+        chunk_hash = int(chunk_hash_str, 16)
+
         return LayerCacheEngineKey(
             parts[0],
             parts[1],
             int(parts[2]),
             int(parts[3]),
-            int(parts[4], 16),
+            chunk_hash,
             STR_DTYPE_TO_TORCH_DTYPE[parts[5]],
             request_configs,
             int(parts[6]),


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Fixes #2135 

**What this PR does / why we need it**:
- The CacheEngineKey format is inconsistent so that LMCache layerwise mode is unable to parse the key.

**Special notes for your reviewers**:
N/A

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
