### PR TITLE
[bugfix] fix unpin error

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -198,8 +198,10 @@ class LMCacheEngine:
         # NOTE(ApostaC): we haven't support lookup-cache yet
         self.lookup_cache: dict[CacheEngineKey, Any] = {}
 
-        # lookup_id -> [pinned keys]
-        self.lookup_pins: dict[str, list] = defaultdict(list)
+        # lookup_id -> {location -> [pinned keys]}
+        self.lookup_pins: dict[str, dict[str, list]] = defaultdict(
+            lambda: defaultdict(list)
+        )
 
         InitializeUsageContext(config.to_original_config(), metadata)
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
@@ -794,20 +796,22 @@ class LMCacheEngine:
                     # of one layer
                     key_all_layers = key.split_layers(self.num_layers)
 
-                    found = False
-                    for key_single_layer in key_all_layers:
-                        if self.storage_manager.contains(
-                            key_single_layer, search_range, pin
-                        ):
-                            found = True
-                    if found:
+                    hit_chunks, block_mapping = self.storage_manager.batched_contains(
+                        key_all_layers,  # type: ignore
+                        search_range,
+                        pin,
+                    )
+                    # Only all layers are hit and hit in one location,
+                    # we consider this key as a hit
+                    if hit_chunks == self.num_layers and len(block_mapping) == 1:
                         if pin:
                             assert lookup_id is not None, (
                                 "lookup_id is required when pin is True"
                             )
-                            self.lookup_pins[lookup_id].extend(  # type: ignore
-                                key_all_layers
-                            )
+                            for location, keys in block_mapping.items():
+                                self.lookup_pins[lookup_id][location].extend(  # type: ignore
+                                    key_all_layers
+                                )
                         res = end
                         continue
                     return res
@@ -820,16 +824,16 @@ class LMCacheEngine:
                     keys.append(chunk_info[2])
 
                 # hit chunks by prefix matching
-                hit_chunks = self.storage_manager.batched_contains(
+                hit_chunks, block_mapping = self.storage_manager.batched_contains(
                     keys, search_range, pin
                 )
+                if pin and block_mapping:
+                    assert lookup_id is not None, (
+                        "lookup_id is required when pin is True"
+                    )
+                    self.lookup_pins[lookup_id] = block_mapping
                 for idx, (start, end, key) in enumerate(chunk_info_list):
                     if idx < hit_chunks:
-                        if pin:
-                            assert lookup_id is not None, (
-                                "lookup_id is required when pin is True"
-                            )
-                            self.lookup_pins[lookup_id].append(key)
                         res = end
                         continue
                     return res
@@ -858,7 +862,7 @@ class LMCacheEngine:
 
         num_tokens = self.lookup(
             tokens,
-            search_range=old_position,
+            search_range=[old_position],
             lookup_id=event_id,
             pin=True,
         )
@@ -867,7 +871,9 @@ class LMCacheEngine:
             logger.debug("Move is not performed as there are no tokens to move.")
             return 0
 
-        keys = self.lookup_pins[event_id]
+        block_mapping = self.lookup_pins[event_id]
+        assert len(block_mapping) == 1
+        keys = block_mapping[old_position]
 
         memory_objs = self.storage_manager.batched_get(
             keys=keys,
@@ -1018,7 +1024,9 @@ class LMCacheEngine:
             logger.debug("Move is not performed as there are no tokens to move.")
             return 0
 
-        keys = self.lookup_pins[event_id]
+        block_mapping = self.lookup_pins[event_id]
+        assert len(block_mapping) == 1
+        keys = block_mapping[location]
 
         memory_objs = self.storage_manager.batched_get(
             keys=keys,
@@ -1074,7 +1082,9 @@ class LMCacheEngine:
             logger.debug("there are no tokens to decompress.")
             return 0
 
-        keys = self.lookup_pins[event_id]
+        block_mapping = self.lookup_pins[event_id]
+        assert len(block_mapping) == 1
+        keys = block_mapping[location]
 
         compressed_memory_objs = self.storage_manager.batched_get(
             keys=keys,
@@ -1107,8 +1117,8 @@ class LMCacheEngine:
     def lookup_unpin(self, lookup_id: str) -> None:
         if lookup_id in self.lookup_pins:
             assert self.storage_manager is not None
-            self.storage_manager.batched_unpin(self.lookup_pins[lookup_id])
-            del self.lookup_pins[lookup_id]
+            for location, keys in self.lookup_pins.pop(lookup_id).items():
+                self.storage_manager.batched_unpin(keys, [location])
 
     @_lmcache_nvtx_annotate
     def clear(

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -808,10 +808,8 @@ class LMCacheEngine:
                             assert lookup_id is not None, (
                                 "lookup_id is required when pin is True"
                             )
-                            for location, keys in block_mapping.items():
-                                self.lookup_pins[lookup_id][location].extend(  # type: ignore
-                                    key_all_layers
-                                )
+                            location = next(iter(block_mapping.keys()))
+                            self.lookup_pins[lookup_id][location].extend(key_all_layers)
                         res = end
                         continue
                     return res


### PR DESCRIPTION
When storage backends is more than 1, the `lookup` may pin keys in different backends, when `lookup_unpin` is called, we should unpin keys in the backend which the keys has pinned before, rather than unpin all keys in all backends.