### PR TITLE
[critical patch]: refactor async and sync lookup cache

### DIFF
--- a/docs/source/kv_cache/async_loading.rst
+++ b/docs/source/kv_cache/async_loading.rst
@@ -118,12 +118,10 @@ Limitations
     - ``S3Connector``
     - ``FSConnector``
     - ``RedisConnector/RedisClusterConnector``
-- save_unfull_chunk: Automatically disabled in async mode for correctness in prefix chunking.
 
 Future Work
 -----------
 
 - Introduce a default ``batched_async_contains`` implementation, so all backends can support ``async_loading``.
-- Refactor ``AsyncSerializer`` to support being enabled together with ``save_unfull_chunk`` and ``PDBackend``.
 - Add metrics and observability to track the number of asynchronous lookup requests and the number of occupied ``MemoryObj`` instances.
 - Improve the lookup framework by passing vLLM prefix cache hit tokens so that async lookup can skip loading parts already hit in vLLM.

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1462,33 +1462,38 @@ class LMCacheConnectorV1Impl:
 
         req_id = request.request_id
 
-        # consult the cache before any processing
-        if cached_num_hit_toks := self.lookup_client.lookup_cache(lookup_id=req_id):
-            return cached_num_hit_toks
+        if (
+            num_external_hit_tokens := self.lookup_client.lookup_cache(lookup_id=req_id)
+        ) != -1:
+            logger.debug(
+                f"Found {num_external_hit_tokens} hit tokens for request"
+                f" {req_id} in the lookup cache."
+            )
+        else:
+            logger.debug(f"Looking up cache for the first time for request {req_id}!")
+            self._requests_priority[req_id] = getattr(request, "priority", 0)
 
-        self._requests_priority[req_id] = getattr(request, "priority", 0)
+            # token_ids = request.prompt_token_ids
+            # all token ids covers the preemption case
+            token_ids = request.all_token_ids
 
-        # token_ids = request.prompt_token_ids
-        # all token ids covers the preemption case
-        token_ids = request.all_token_ids
+            # If the request has multimodal hashes, apply them to the token ids
+            mm_hashes, mm_positions = extract_mm_features(request)
+            if mm_hashes and mm_positions:
+                # TODO(Jiayi): Optimize this
+                token_ids = torch.tensor(request.prompt_token_ids)
+                apply_mm_hashes_to_token_ids(token_ids, mm_hashes, mm_positions)
+                token_ids = token_ids.tolist()
 
-        # If the request has multimodal hashes, apply them to the token ids
-        mm_hashes, mm_positions = extract_mm_features(request)
-        if mm_hashes and mm_positions:
-            # TODO(Jiayi): Optimize this
-            token_ids = torch.tensor(request.prompt_token_ids)
-            apply_mm_hashes_to_token_ids(token_ids, mm_hashes, mm_positions)
-            token_ids = token_ids.tolist()
+            request_configs = extract_request_configs(request.sampling_params)
+            if self.skip_last_n_tokens > 0:
+                token_ids = token_ids[: -self.skip_last_n_tokens]
 
-        request_configs = extract_request_configs(request.sampling_params)
-        if self.skip_last_n_tokens > 0:
-            token_ids = token_ids[: -self.skip_last_n_tokens]
-
-        num_external_hit_tokens = self.lookup_client.lookup(
-            token_ids,
-            lookup_id=req_id,
-            request_configs=request_configs,
-        )
+            num_external_hit_tokens = self.lookup_client.lookup(
+                token_ids,
+                lookup_id=req_id,
+                request_configs=request_configs,
+            )
 
         if num_external_hit_tokens is None:
             logger.debug(

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -141,8 +141,6 @@ class RequestTracker:
 
     # The block ids that has been allocated so far
     # NOTE: allocated blocks could be more than the number of tokens
-    # FIXME: need to check whether the block ids will be changed after
-    #        preemption
     allocated_block_ids: list[int]
 
     # The number of tokens that has been saved
@@ -256,6 +254,12 @@ class RequestTracker:
             # reset the number of saved tokens
             self.num_saved_tokens = lmcache_cached_tokens
             # we don't need to extend the token ids in the preempted case
+            # however, it is possible for the scheduled tokens of the request
+            # to be less than the total number of tokens (partial cache hit)
+            # so we may need to truncate
+            self.token_ids = self.token_ids[
+                : lmcache_cached_tokens + len(new_token_ids)
+            ]
         else:
             self.allocated_block_ids.extend(new_block_ids)
             self.token_ids.extend(new_token_ids)
@@ -379,8 +383,10 @@ class ReqMeta:
 
         if len(token_ids) > num_blocks * block_size:
             logger.error(
-                "The number of tokens is more than the number of blocks."
-                "Something might be wrong in scheduling logic!"
+                "The number of tokens is more than the number of blocks"
+                " for request %s. "
+                "Something might be wrong in scheduling logic!",
+                tracker.req_id,
             )
             logger.error(
                 "Num tokens: %d, num blocks: %d, block size: %d",
@@ -1738,6 +1744,16 @@ class LMCacheConnectorV1Impl:
                 raise AttributeError(
                     f"Unable to determine preemption status for request {req_id}. "
                     f"This might be due to an unsupported vLLM version."
+                )
+            if preempted:
+                # num_computed_tokens should be reset to 0 during preemption
+                # and then set to the number of external tokens (from vllm
+                # scheduler's perspective)
+                # this assumption is crucial for the update() call of RequestTracker
+                assert request.num_computed_tokens == lmcache_cached_tokens, (
+                    f"Preempted request {req_id} has "
+                    f"num_computed_tokens {request.num_computed_tokens} "
+                    f"but lmcache_cached_tokens {lmcache_cached_tokens}"
                 )
 
             request_tracker.update(

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1473,6 +1473,8 @@ class LMCacheConnectorV1Impl:
         if (
             num_external_hit_tokens := self.lookup_client.lookup_cache(lookup_id=req_id)
         ) != -1:
+            # -1 means no result cached
+            # None or int means ongoing (async) or cached result
             logger.debug(
                 f"Found {num_external_hit_tokens} hit tokens for request"
                 f" {req_id} in the lookup cache."

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1010,8 +1010,10 @@ class LMCacheConnectorV1Impl:
                 )
                 if num_retrieved_tokens < num_expected_tokens:
                     logger.error(
+                        "Request %s"
                         "The number of retrieved tokens is less than the "
-                        "expected number of tokens! This should not happen!"
+                        "expected number of tokens! This should not happen!",
+                        request.req_id,
                     )
                     logger.error(
                         "Num retrieved tokens: %d, num expected tokens: %d",

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -284,10 +284,10 @@ class LMCacheEngine:
 
         monitor_req_id = self.stats_monitor.on_store_request(num_to_store_tokens)
 
-        starts = []
-        ends = []
-        keys = []
-        memory_objs = []
+        starts: List[int] = []
+        ends: List[int] = []
+        keys: List[CacheEngineKey] = []
+        memory_objs: List[MemoryObj] = []
 
         offload_time = 0.0
         put_time = 0.0
@@ -322,7 +322,9 @@ class LMCacheEngine:
             if memory_obj is None:
                 logger.warning(
                     "Local cpu memory under pressure so"
-                    " choosing to not store the KV cache."
+                    " choosing to store only "
+                    f" {len(memory_objs)}"
+                    " total chunks of KV cache."
                 )
                 break
 
@@ -342,6 +344,8 @@ class LMCacheEngine:
         t = time.perf_counter()
 
         transfer_spec = kwargs.get("transfer_spec", None)
+        # TODO: we implicitly rely on batched_put to call ref_count_down
+        # this management should be done in a cleaner way
         self.storage_manager.batched_put(keys, memory_objs, transfer_spec=transfer_spec)
         put_time += time.perf_counter() - t
 
@@ -563,6 +567,10 @@ class LMCacheEngine:
             _, memory_objs, starts, ends = zip(*reordered_chunks, strict=False)
             self.gpu_connector.batched_to_gpu(
                 list(memory_objs), list(starts), list(ends), **kwargs
+            )
+        else:
+            logger.warning(
+                "No chunks found while retrieving request %s", kwargs["req_id"]
             )
 
         # TODO(Jiayi): Remove the following for loop with batched operations
@@ -1205,7 +1213,11 @@ class LMCacheEngine:
 
         tot_kv_size = 0
         chunks: List[ProcessedChunk] = []
-        future = self.event_manager.pop_event(EventType.LOADING, kwargs["req_id"])
+        try:
+            future = self.event_manager.pop_event(EventType.LOADING, kwargs["req_id"])
+        except Exception as e:
+            logger.error(f"Error popping event for request {kwargs['req_id']}: {e}")
+            return [], 0
 
         memory_objs = future.result()
         memory_objs = [mm for m in memory_objs for mm in m]

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -568,10 +568,6 @@ class LMCacheEngine:
             self.gpu_connector.batched_to_gpu(
                 list(memory_objs), list(starts), list(ends), **kwargs
             )
-        else:
-            logger.warning(
-                "No chunks found while retrieving request %s", kwargs["req_id"]
-            )
 
         # TODO(Jiayi): Remove the following for loop with batched operations
         # TODO(Jiayi): Need to refactor the `remove_after_retrieve` logic.

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1213,14 +1213,14 @@ class LMCacheEngine:
 
         tot_kv_size = 0
         chunks: List[ProcessedChunk] = []
+        future = self.event_manager.pop_event(EventType.LOADING, kwargs["req_id"])
+
         try:
-            future = self.event_manager.pop_event(EventType.LOADING, kwargs["req_id"])
+            memory_objs = future.result()
+            memory_objs = [mm for m in memory_objs for mm in m]
         except Exception as e:
             logger.error(f"Error popping event for request {kwargs['req_id']}: {e}")
             return [], 0
-
-        memory_objs = future.result()
-        memory_objs = [mm for m in memory_objs for mm in m]
 
         # NOTE(Jiayi): here we assume the retrieved memory_objs have
         # the same order as the lookup order.

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -569,14 +569,15 @@ def _create_config_class():
 def _validate_config(self):
     """Validate configuration"""
 
-    # auto-adjust save_unfull_chunk for async loading to prevent CPU fragmentation
-    if self.enable_async_loading:
-        logger.warning(
-            "Automatically setting save_unfull_chunk=False because "
-            "enable_async_loading=True or use_layerwise=True to prevent "
-            "CPU memory fragmentation"
-        )
-        self.save_unfull_chunk = False
+    # needed for the old async serializer implementation
+    # # auto-adjust save_unfull_chunk for async loading to prevent CPU fragmentation
+    # if self.enable_async_loading:
+    #     logger.warning(
+    #         "Automatically setting save_unfull_chunk=False because "
+    #         "enable_async_loading=True or use_layerwise=True to prevent "
+    #         "CPU memory fragmentation"
+    #     )
+    #     self.save_unfull_chunk = False
 
     if self.enable_blending:
         if not self.save_unfull_chunk:

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -20,6 +20,11 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
 
         Args:
             lookup_id: The lookup ID to lookup
+
+        Returns:
+            -1 means not found;
+            None means ongoing; (this semantic is not supported in sync lookup clients)
+            int >= 0 means number of hit tokens
         """
         return None
 
@@ -32,6 +37,8 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
     ) -> Optional[int]:
         """
         Perform lookup for the given token IDs.
+        Should be called for first lookup and pinning. Subsequent lookups for the same
+        request should call lookup_cache instead.
 
         Args:
             token_ids: The token IDs to lookup

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -159,8 +159,12 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             )
 
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
-        with self.lock:
-            return self.reqs_status.get(lookup_id, None)
+        # with self.lock:
+        #     return self.reqs_status.get(lookup_id, None)
+        # NOTE: we cannot implement lookup_cache in async lookup client since
+        # get_num_new_matched_tokens is non-idempotent under repeated calls
+        # w/o calling update_state_after_alloc (None, None, None, ..., hit_tokens)
+        pass
 
     # TODO(Jiayi): Consider batching here
     def lookup(

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -168,9 +168,10 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         self._cleanup_finished_aborted_lookups()
 
         with self.lock:
-            # -1 indicates not found; None indicates ongoing.
-            req_status = self.reqs_status.get(lookup_id, -1)
-            if req_status is None:
+            if (req_status := self.reqs_status.get(lookup_id, -1)) == -1:
+                self.reqs_status[lookup_id] = None
+                self.first_lookup_time[lookup_id] = time.time()
+            elif req_status is None:
                 time.sleep(self.lookup_backoff_time)
                 if (
                     time.time() - self.first_lookup_time[lookup_id]
@@ -187,12 +188,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                     self.first_lookup_time.pop(lookup_id, None)
                     return 0
 
-                return None
-            elif req_status != -1:
-                return req_status
-            self.reqs_status[lookup_id] = None
-        self.first_lookup_time[lookup_id] = time.time()
-        return None
+            return req_status
 
     # TODO(Jiayi): Consider batching here
     def lookup(
@@ -202,7 +198,6 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
         hashes: list[int] = []
-
         offsets = []
         for start, end, hash_val in self.token_database.process_tokens(
             token_ids, make_key=False

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -159,20 +159,11 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             )
 
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
-        # with self.lock:
-        #     return self.reqs_status.get(lookup_id, None)
-        # NOTE: we cannot implement lookup_cache in async lookup client since
-        # get_num_new_matched_tokens is non-idempotent under repeated calls
-        # w/o calling update_state_after_alloc (None, None, None, ..., hit_tokens)
-        pass
-
-    # TODO(Jiayi): Consider batching here
-    def lookup(
-        self,
-        token_ids: Union[torch.Tensor, list[int]],
-        lookup_id: str,
-        request_configs: Optional[dict] = None,
-    ) -> Optional[int]:
+        """
+        -1 means not found;
+        None means ongoing;
+        int >= 0 means number of hit tokens
+        """
         # Check if any aborted lookups are finished, send cleanup messages
         self._cleanup_finished_aborted_lookups()
 
@@ -200,8 +191,16 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             elif req_status != -1:
                 return req_status
             self.reqs_status[lookup_id] = None
-            self.first_lookup_time[lookup_id] = time.time()
+        self.first_lookup_time[lookup_id] = time.time()
+        return None
 
+    # TODO(Jiayi): Consider batching here
+    def lookup(
+        self,
+        token_ids: Union[torch.Tensor, list[int]],
+        lookup_id: str,
+        request_configs: Optional[dict] = None,
+    ) -> Optional[int]:
         hashes: list[int] = []
 
         offsets = []

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -162,7 +162,12 @@ class LMCacheLookupClient(LookupClientInterface):
             self.sockets[rank_idx] = new_socket
 
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
-        return self.reqs_status.get(lookup_id, None)
+        """
+        "-1 means not found;
+        None means ongoing; (this semantic is not supported in sync lookup client)
+        int >= 0 means number of hit tokens
+        """
+        return self.reqs_status.get(lookup_id, -1)
 
     def lookup(
         self,

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -437,6 +437,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
         evict if necessary. Storage manager should always call
         local_cpu_backend.allocate() to get memory objects
         regardless of whether local_cpu is True or False
+
+        busy_loop should only be used for retrieve
+        the reasoning is that:
+
+        1. synchronous case
+        - many stores happen concurrently (if they busy_loop, deadlock happens)
+        - one retrieve at a time (okay to busy loop because stores will clear)
+
+        2. asynchronous case
+        - many stores happen concurrently (if they busy_loop, deadlock happens)
+        - many retrieves happen concurrently
+        (we use the async serializer to handle this)
         """
         logger.debug(
             f"Allocating memory in local cpu backend with busy loop: {busy_loop}"
@@ -529,6 +541,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
         evict if necessary. Storage manager should always call
         local_cpu_backend.allocate() to get memory objects
         regardless of whether local_cpu is True or False
+
+        busy_loop should only be used for retrieve
+        the reasoning is that:
+
+        1. synchronous case
+        - many stores happen concurrently (if they busy_loop, deadlock happens)
+        - one retrieve at a time (okay to busy loop because stores will clear)
+
+        2. asynchronous case
+        - many stores happen concurrently (if they busy_loop, deadlock happens)
+        - many retrieves happen concurrently
+        (we use the async serializer to handle this)
         """
         logger.debug(
             f"Batched allocating memory in local cpu backend"

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -274,9 +274,7 @@ class StorageManager:
             )
             self.async_lookup_server = kwargs.pop("async_lookup_server")
         # PDBackend has't supported calculate_chunk_budget
-        if not self.enable_pd and (
-            self.config.enable_async_loading or self.config.use_layerwise
-        ):
+        if not self.enable_pd and self.config.enable_async_loading:
             assert self.allocator_backend is not None
             self.async_serializer = AsyncSerializer(self.allocator_backend, self.loop)
 
@@ -489,14 +487,7 @@ class StorageManager:
             # Retrieve all chunks for one layer
             backend = self.storage_backends[location]
             # TODO(Jiayi): need to make async loading and layerwise compatible
-            assert self.async_serializer is not None, (
-                "Async serializer must be initialized via post_init before using "
-                "layerwise_batched_get."
-            )
-            coro = self.async_serializer.run(
-                backend.batched_get_non_blocking("fake_lookup_id", keys_multi_chunk),
-                len(keys_multi_chunk),
-            )
+            coro = backend.batched_get_non_blocking("fake_lookup_id", keys_multi_chunk)
             task = asyncio.run_coroutine_threadsafe(coro, self.loop)
             yield task
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Union,
 )
 import asyncio
 import functools
@@ -147,10 +148,12 @@ class WeightedSemaphore:
             self._cond.notify_all()
 
 
-class AsyncSerializer:
+class AsyncMultiSerializer:
     """
     Prevent race conditions where multiple batched_get's cause the local CPU
     backend to allocate memory objects in parallel and get deadlocked.
+    Make the assumption that the save_unfull_chunk is False so that we
+    can assume that we can always use 50% of the given memory
     """
 
     def __init__(
@@ -172,6 +175,29 @@ class AsyncSerializer:
             return await coro_fn
         finally:
             await self._sem.release(num_chunks)
+
+
+class AsyncSingleSerializer:
+    """
+    Prevent race conditions in a naive way by forcing each request that
+    is passed through to be serialized
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self.loop = loop
+        # lazy init in run
+        self.lock: Optional[asyncio.Lock] = None
+
+    async def run(self, coro_fn: Coroutine[Any, Any, Any], *args, **kwargs) -> Any:
+        # we need to lazily initialize the lock to
+        # place it on the calling event loop
+        if self.lock is None:
+            self.lock = asyncio.Lock()
+        async with self.lock:  # type: ignore
+            return await coro_fn
+
+
+AsyncSerializer = Union[AsyncSingleSerializer, AsyncMultiSerializer]
 
 
 # TODO: extend this class to implement caching policies and eviction policies
@@ -268,15 +294,11 @@ class StorageManager:
 
     def post_init(self, **kwargs) -> None:
         if "async_lookup_server" in kwargs:
-            assert not self.config.save_unfull_chunk, (
-                "save_unfull_chunk should be automatically set to False when using "
-                "async loading."
-            )
             self.async_lookup_server = kwargs.pop("async_lookup_server")
         # PDBackend has't supported calculate_chunk_budget
         if not self.enable_pd and self.config.enable_async_loading:
             assert self.allocator_backend is not None
-            self.async_serializer = AsyncSerializer(self.allocator_backend, self.loop)
+            self.async_serializer = AsyncSingleSerializer(self.loop)
 
     def _get_allocator_backend(
         self, config: LMCacheEngineConfig
@@ -653,6 +675,7 @@ class StorageManager:
                 "Async serializer must be initialized via post_init before using "
                 "async_lookup_and_prefetch."
             )
+            # num_hit_chunks is only used for the multi serializer
             get_coro = self.async_serializer.run(
                 backend.batched_get_non_blocking(
                     lookup_id,


### PR DESCRIPTION
# Description
Previously, the preemption refactor (loading KV caches for preempted requests) https://github.com/LMCache/LMCache/pull/2007 broke the async robustness for high concurrency.

In this PR, we
1. refactor `lookup_cache` (THIS ALSO FIXES A BUG IN SYNC CASE WHERE WE PASS BACK A NEGATIVE NUMBER OF TOKENS)
2. fix the `len(tokens) == len(slot_mappings)` assertion error bug
3. change async multi serializer to async single serializer (performance gain is maintained) CRITICAL: releases the `save_unfull_chunk=False` requirement

# A question that we considered: 
should we remove the async serializer abstraction? 

Potential Motivation: we want to support `save_unfull_chunk` which is a forced assumption by the async serializer because it needs to make the strong assumption that 50% of the cpu memory pool is usable

Answer: No, but we should redesign it less greedily. We refactor it to the async single serializer

# Basic reasoning: 

Sync Case: 
- many stores happen at the same time. this is ok because `busy_loop` is false so they will just not store if there is no more space
- one retrieve at a time. this is ok because `busy_loop` will make the retrieve wait for stores to finish

Async Case: 
- same logic for stores
- many retrieves at the same time. we need some sort of serializer here to ensure that all the `busy_loop` True retrieves (we cannot set False or else we might not retrieve what we promised vllm in lookup) don't collide with each other. essentially, they have to lease how many memory chunks (full) that they want to take from the pool
 
 
# Benchmark ran to test the preservation of performance on the single serializer in high concurrency case: 


```yaml
# mock.yaml
chunk_size: 256
local_cpu: False
max_local_cpu_size: 40
save_unfull_chunk: False
enable_async_loading: True
remote_url: "mock://240/?peeking_latency=0&read_throughput=2&write_throughput=2"
remote_serde: "naive"
```


```bash
LMCACHE_LOG_LEVEL=DEBUG \
CUDA_VISIBLE_DEVICES=1 \
PYTHONHASHSEED=0 \
LMCACHE_CONFIG_FILE=mock.yaml \
  vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --kv-transfer-config   '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' \
  --no-enable-prefix-caching > output.log 2>&1
```

```bash
python benchmarks/long_doc_qa/long_doc_qa.py \
      --num-documents 15 \
      --document-length 100000 \
      --output-len 100 \
      --repeat-count 1 \
      --repeat-mode tile \
      --model  meta-llama/Llama-3.1-8B-Instruct \
      --max-inflight-requests 15 \
      --eos-token-id 128001
```


## Multi-Serializer (and had some retrieved less than lookup errors): 
```text
Warmup round mean TTFT: 61.303s
Warmup round time: 116.958s
Warmup round prompt count: 15
Warmup round successful prompt count: 15

=== BENCHMARK RESULTS ===
Query round mean TTFT: 56.426s
Query round time: 100.363s
Query round prompt count: 15
Query round successful prompt count: 15
```

## Single Serializer
```text
Warmup round mean TTFT: 61.002s
Warmup round time: 116.505s
Warmup round prompt count: 15
Warmup round successful prompt count: 15

=== BENCHMARK RESULTS ===
Query round mean TTFT: 47.969s
Query round time: 88.854s
Query round prompt count: 15
Query round successful prompt count: 15
```
