### PR TITLE
[bugfix] Fix missing lookup hits with async_loading

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -149,7 +149,8 @@ class LMCacheEngine:
 
         self.async_loading = config.enable_async_loading
         self.event_manager = EventManager()
-
+        InitializeUsageContext(config.to_original_config(), metadata)
+        self.stats_monitor: LMCStatsMonitor = LMCStatsMonitor.GetOrCreate()
         self.use_layerwise = config.use_layerwise
 
         # TODO: support save_only_first_rank when use layerwise
@@ -181,6 +182,7 @@ class LMCacheEngine:
                 # self.memory_allocator,
                 event_manager=self.event_manager,
                 lmcache_worker=self.lmcache_worker,
+                stats_monitor=self.stats_monitor,
             )
 
         # KV events
@@ -1018,9 +1020,18 @@ class LMCacheEngine:
             keys.append(key)
             cum_chunk_lengths.append(end)
 
+        # Track lookup metrics for async path
+        num_requested_tokens = cum_chunk_lengths[-1]
+        lookup_request_id = self.stats_monitor.on_lookup_request(num_requested_tokens)
+
         asyncio.run_coroutine_threadsafe(
             self.storage_manager.async_lookup_and_prefetch(
-                lookup_id, keys, cum_chunk_lengths, search_range, pin
+                lookup_id,
+                keys,
+                cum_chunk_lengths,
+                search_range,
+                pin,
+                lookup_request_id=lookup_request_id,
             ),
             self.storage_manager.loop,
         )

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -24,7 +24,7 @@ import torch
 # First Party
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
-from lmcache.observability import PrometheusLogger
+from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.utils import (
     CacheEngineKey,
     _lmcache_nvtx_annotate,
@@ -212,10 +212,12 @@ class StorageManager:
         metadata: LMCacheEngineMetadata,
         event_manager: EventManager,
         lmcache_worker: Optional["LMCacheWorker"] = None,
+        stats_monitor: Optional[LMCStatsMonitor] = None,
     ):
         self.config = config
         self.metadata = metadata
         self.loop = asyncio.new_event_loop()
+        self.stats_monitor = stats_monitor
 
         self.thread = threading.Thread(
             target=start_loop_in_thread_with_exceptions,
@@ -532,6 +534,7 @@ class StorageManager:
         lookup_id: str,
         cum_chunk_lengths_total: list[int],
         tier_expected_chunks: list[int],
+        lookup_request_id: Optional[int] = None,
     ) -> None:
         """
         Callback function when all prefetch tasks
@@ -606,6 +609,8 @@ class StorageManager:
             f"Responding to scheduler for lookup id {lookup_id}"
             f" with retrieved length {retrieved_length}"
         )
+        if self.stats_monitor is not None and lookup_request_id is not None:
+            self.stats_monitor.on_lookup_finished(lookup_request_id, retrieved_length)
         self.async_lookup_server.send_response_to_scheduler(lookup_id, retrieved_length)
 
     async def async_lookup_and_prefetch(
@@ -615,6 +620,7 @@ class StorageManager:
         cum_chunk_lengths: list[int],
         search_range: Optional[list[str]] = None,
         pin: bool = False,
+        lookup_request_id: Optional[int] = None,
     ) -> None:
         """
         Perform asynchronous lookup and prefetching across all storage backends.
@@ -634,6 +640,7 @@ class StorageManager:
         to search in. Should be a subset of ["LocalCPUBackend",
         "LocalDiskBackend"] for now. If None, search in all backends.
         :param bool pin: Whether to pin the keys.
+        :param Optional[int] lookup_request_id: Stats monitor lookup request id.
         """
 
         # NOTE(Jiayi): Currently, the retrieval pattern is always
@@ -708,6 +715,8 @@ class StorageManager:
 
         # If no chunks were hit across all backends, respond immediately and return.
         if num_total_hit_chunks == 0:
+            if self.stats_monitor is not None and lookup_request_id is not None:
+                self.stats_monitor.on_lookup_finished(lookup_request_id, 0)
             if self.async_lookup_server is not None:
                 self.async_lookup_server.send_response_to_scheduler(lookup_id, 0)
             return
@@ -744,6 +753,7 @@ class StorageManager:
                 lookup_id,
                 cum_chunk_lengths_total,
                 tier_expected_chunks,
+                lookup_request_id,
             )
         )
 

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -851,6 +851,8 @@ def test_paged_prefetch_retrieve(backend, prefetch_from, autorelease_v1):
                 raise TimeoutError(f"Operation timed out after {timeout} seconds.")
             time.sleep(0.1)
     """ Wait until disk load (prefetch) finishes and delete disk cache"""
+    lookup_req_before = engine.stats_monitor.interval_lookup_requests
+    lookup_hits_before = engine.stats_monitor.interval_lookup_hits
     engine.async_lookup_and_prefetch(
         lookup_id=test_lookup_id, tokens=torch.cat([tokens, new_tokens])
     )
@@ -866,6 +868,13 @@ def test_paged_prefetch_retrieve(backend, prefetch_from, autorelease_v1):
                 raise TimeoutError(f"Operation timed out after {timeout} seconds.")
             time.sleep(0.01)
         engine.storage_manager.storage_backends["LocalDiskBackend"].dict.clear()
+
+    assert engine.stats_monitor.interval_lookup_requests == lookup_req_before + 1
+    assert (
+        engine.stats_monitor.interval_lookup_hits
+        == lookup_hits_before + expected_length
+    )
+
     """ test retrieve """
     t4 = time.perf_counter()
 


### PR DESCRIPTION
Fixes #2064

**What this PR does / why we need it**

When `enable_async_loading` is turned on, lookups go through
`LMCacheEngine.async_lookup_and_prefetch`. That async path didn’t call
`LMCStatsMonitor.on_lookup_request/on_lookup_finished`, so those lookups were
missing from the metrics.

This PR:

- Starts lookup metrics in `LMCacheEngine.async_lookup_and_prefetch` and passes
  a `lookup_request_id` into `StorageManager.async_lookup_and_prefetch`.
- Finishes the metrics in the storage manager for both:
  - the zero-hit fast path, and
  - the normal completion callback (using the actual retrieved length).
- Extends `test_paged_prefetch_retrieve` to assert that
  `interval_lookup_requests` and `interval_lookup_hits` increase by the
  expected amounts after async loading.

**Special notes for reviewers**

- Only the async-loading path is touched; sync `lookup` behavior is unchanged.
- `StorageManager` accepts an optional `stats_monitor` so existing call sites
  stay compatible.
- Locally, I ran:
  - `pre-commit run --all-files`: passed
  - `pytest tests/v1/test_cache_engine.py::test_paged_prefetch_retrieve`: passed

**If applicable**

- [ ] this PR contains user facing changes - docs added  
- [x] this PR contains unit tests
