### PR TITLE
[UT] Fix test_real_nonexistent_worker UT in TestWorkerInfoAPI

### DIFF
--- a/tests/v1/internal_api_server/test_worker_info_api.py
+++ b/tests/v1/internal_api_server/test_worker_info_api.py
@@ -242,7 +242,7 @@ class TestWorkerInfoAPI:
         assert response.status_code == 404
         data = json.loads(response.text)
         assert "detail" in data
-        assert "Worker ('nonexistent', 999) not found" in data["detail"]
+        assert "nonexistent" in data["detail"] and "999" in data["detail"]
 
     def test_real_nonexistent_instance(self, client_with_real_controller):
         response = client_with_real_controller.get(

--- a/tests/v1/internal_api_server/test_worker_info_api.py
+++ b/tests/v1/internal_api_server/test_worker_info_api.py
@@ -242,7 +242,11 @@ class TestWorkerInfoAPI:
         assert response.status_code == 404
         data = json.loads(response.text)
         assert "detail" in data
-        assert "nonexistent" in data["detail"] and "999" in data["detail"]
+        assert (
+            "not found" in data["detail"]
+            and "nonexistent" in data["detail"]
+            and "999" in data["detail"]
+        )
 
     def test_real_nonexistent_instance(self, client_with_real_controller):
         response = client_with_real_controller.get(


### PR DESCRIPTION
Fix the issue 
```
E assert "Worker ('nonexistent', 999) not found" in 'Worker (nonexistent, 999) not found'
```

I guess the `response.text` is different in different environment, so this PR try to make it passed in MacOS and Ci env.