### PR TITLE
[Bugfix]: part of the kv get operation fails mem not free

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1319,6 +1319,12 @@ class LMCacheEngine:
                 reordered_chunks.append((key, memory_obj, start, end))
                 tot_kv_size += memory_obj.get_size()
                 ret_mask[start:end] = True
+                if last_failed_block_start is not None:
+                    for (key, start, end), memory_obj in zip(
+                        blocks, memory_objs, strict=False
+                    ):
+                        if memory_obj is not None and start >= last_failed_block_start:
+                            memory_obj.ref_count_down()
 
         if last_failed_block_start is not None:
             ret_mask[last_failed_block_start:] = False

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1304,7 +1304,7 @@ class LMCacheEngine:
             assert memory_objs is not None, (
                 "Failed to get memory objects from storage backend"
             )
-
+            retrieval_failed = False
             for (key, start, end), memory_obj in zip(blocks, memory_objs, strict=False):
                 if memory_obj is None:
                     logger.warning(
@@ -1315,16 +1315,14 @@ class LMCacheEngine:
                         or last_failed_block_start < start
                     ):
                         last_failed_block_start = start
-                    break
-                reordered_chunks.append((key, memory_obj, start, end))
-                tot_kv_size += memory_obj.get_size()
-                ret_mask[start:end] = True
-                if last_failed_block_start is not None:
-                    for (key, start, end), memory_obj in zip(
-                        blocks, memory_objs, strict=False
-                    ):
-                        if memory_obj is not None and start >= last_failed_block_start:
-                            memory_obj.ref_count_down()
+                        retrieval_failed = True
+                if memory_obj:
+                    if retrieval_failed:
+                        memory_obj.ref_count_up()
+                    elif memory_obj:
+                        reordered_chunks.append((key, memory_obj, start, end))
+                        tot_kv_size += memory_obj.get_size()
+                        ret_mask[start:end] = True
 
         if last_failed_block_start is not None:
             ret_mask[last_failed_block_start:] = False


### PR DESCRIPTION
**Describe the bug**
release: v0.3.10
When part of the kv get operation fails, it will cause an OOM

for detail [#2170](https://github.com/LMCache/LMCache/issues/2170)