### PR TITLE
[Bugfix]: eic memory free and async memory get

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1229,6 +1229,8 @@ class LMCacheEngine:
         ):
             assert isinstance(key, CacheEngineKey)
             idx = start // self.config.chunk_size
+            if idx >= len(memory_objs) or memory_objs[idx] is None:
+                break
             memory_obj = memory_objs[idx]
             chunks.append((key, memory_obj, start, end))
             tot_kv_size += memory_obj.get_size()

--- a/lmcache/v1/storage_backend/connector/eic_connector.py
+++ b/lmcache/v1/storage_backend/connector/eic_connector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from enum import IntEnum, auto
-from typing import List, Optional, Union, no_type_check
+from typing import List, Optional, Union, cast, no_type_check
 import asyncio
 import ctypes
 import os
@@ -712,15 +712,15 @@ class EICConnector(RemoteConnector):
         lookup_id: str,
         keys: List[CacheEngineKey],
     ) -> List[MemoryObj]:
-        # calling self.get will create a circular dependency
         results = await asyncio.gather(*(self._get(key) for key in keys))
-        # Stop at first None, return only elements before None
-        result_list = []
-        for r in results:
-            if r is None:
-                break
-            result_list.append(r)
-        return result_list
+        first_none_idx = results.index(None) if None in results else None
+        if first_none_idx is None:
+            return cast(List[MemoryObj], results)
+        for obj in results[first_none_idx + 1 :]:
+            if obj is not None:
+                obj.ref_count_down()
+
+        return cast(List[MemoryObj], results[:first_none_idx])
 
     async def batched_get_non_blocking(
         self,

--- a/lmcache/v1/storage_backend/connector/eic_connector.py
+++ b/lmcache/v1/storage_backend/connector/eic_connector.py
@@ -325,12 +325,12 @@ class EICConnector(RemoteConnector):
             if err_code == eic.StatusCode.KEY_NOT_EXIST:
                 logger.debug(
                     f"eic mget meta {key_str} failed, status_code {status_code}"
-                    " err_code {err_code}"
+                    f" err_code {err_code}"
                 )
             else:
                 logger.error(
                     f"eic mget meta {key_str} failed, status_code {status_code}"
-                    " err_code {err_code}"
+                    f" err_code {err_code}"
                 )
             return None
         else:
@@ -359,7 +359,7 @@ class EICConnector(RemoteConnector):
         if memory_obj is None:
             logger.error(
                 f"fail to allocate memory during remote receive key {key_str} length"
-                " {meta.length}"
+                f" {meta.length}"
             )
             return None
         perf_timer.stop("alloc_obj")
@@ -389,8 +389,10 @@ class EICConnector(RemoteConnector):
         if status_code != eic.StatusCode.SUCCESS or err_code != eic.StatusCode.SUCCESS:
             logger.error(
                 f"eic mget data {key_str} failed, status_code {status_code}"
-                " err_code {err_code}"
+                f" err_code {err_code}"
             )
+            # eic has fill some data to data_ptr
+            memory_obj.ref_count_down()
             return None
         else:
             logger.debug(f"eic mget data {key_str} success")
@@ -475,7 +477,7 @@ class EICConnector(RemoteConnector):
 
         logger.debug(
             f"eic put {key_str} meta ptr {meta_ptr} len {meta_size} data ptr {data_ptr}"
-            " len {data_size}"
+            f" len {data_size}"
         )
 
         perf_timer.start("eic_mset")
@@ -556,7 +558,7 @@ class EICConnector(RemoteConnector):
 
             logger.info(
                 f"eic batched_put {key_str} shape {kv_shape} dtype {kv_dtype}"
-                " fmt {memory_format}"
+                f" fmt {memory_format}"
             )
 
             # Add meta key & value
@@ -655,7 +657,7 @@ class EICConnector(RemoteConnector):
             if status_code != eic.StatusCode.SUCCESS:
                 logger.debug(
                     f"eic batched_async_contains {key.to_string()} miss,"
-                    " err_code {status_code}"
+                    f" err_code {status_code}"
                 )
                 break
             num_hit_counts += 1
@@ -712,7 +714,13 @@ class EICConnector(RemoteConnector):
     ) -> List[MemoryObj]:
         # calling self.get will create a circular dependency
         results = await asyncio.gather(*(self._get(key) for key in keys))
-        return [r for r in results if r is not None]
+        # Stop at first None, return only elements before None
+        result_list = []
+        for r in results:
+            if r is None:
+                break
+            result_list.append(r)
+        return result_list
 
     async def batched_get_non_blocking(
         self,


### PR DESCRIPTION
**What this PR does / why we need it:**
use async mode `batched_get_non_blocking` need return correct index mem.


<img width="1420" height="998" alt="image" src="https://github.com/user-attachments/assets/9bf4d8da-016a-4944-8f7f-93a735537069" />

maybe redis connecor is error
<img width="1608" height="432" alt="image" src="https://github.com/user-attachments/assets/c63a8670-cc8b-460c-bbc6-040a3978dcd6" />

