### PR TITLE
[CI]: fix UT crashing from async PQ executor shutdown (and also new lookup_cache)

### DIFF
--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -75,6 +75,9 @@ class AsyncPQExecutor(BaseJobExecutor):
             return
         self._closed = True
 
+        # Enqueue comparable sentinel tuples with the highest priority value so
+        # that outstanding work drains before shutdown signals are consumed.
+        # Use a very large integer to satisfy the typed queue's expected int priority
         sentinel_priority = 2**31 - 1
 
         # Push sentinel for each worker

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -71,31 +71,30 @@ class AsyncPQExecutor(BaseJobExecutor):
                 self._queue.task_done()
 
     async def _shutdown_async(self, wait: bool = True) -> None:
+        if self._closed:
+            return
         self._closed = True
-        # Enqueue comparable sentinel tuples with the highest priority value so
-        # that outstanding work drains before shutdown signals are consumed.
-        # Use a very large integer to satisfy the typed queue's expected int priority
+
         sentinel_priority = 2**31 - 1
+
+        # Push sentinel for each worker
         for _ in range(self.max_workers):
             await self._queue.put(
                 (sentinel_priority, next(self._counter), _SENTINEL, None, {}, None)
             )
+
         if wait:
+            # Let workers drain tasks
             await self._queue.join()
+
+            # FORCE CANCEL to avoid loop-closing race
+            for fut in self._workers:
+                fut.cancel()
+
             await asyncio.gather(
                 *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
                 return_exceptions=True,
             )
-
-        # Force cancel workers in case they are still blocked on queue.get()
-        for fut in self._workers:
-            fut.cancel()
-
-        # Wait for workers to exit
-        await asyncio.gather(
-            *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
-            return_exceptions=True,
-        )
 
     def shutdown(self, wait: bool = True) -> None:
         future = asyncio.run_coroutine_threadsafe(self._shutdown_async(wait), self.loop)

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -87,6 +87,16 @@ class AsyncPQExecutor(BaseJobExecutor):
                 return_exceptions=True,
             )
 
+        # Force cancel workers in case they are still blocked on queue.get()
+        for fut in self._workers:
+            fut.cancel()
+
+        # Wait for workers to exit
+        await asyncio.gather(
+            *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
+            return_exceptions=True,
+        )
+
     def shutdown(self, wait: bool = True) -> None:
         future = asyncio.run_coroutine_threadsafe(self._shutdown_async(wait), self.loop)
         if wait:

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -17,6 +17,7 @@ class AsyncPQExecutor(BaseJobExecutor):
     def __init__(self, loop: asyncio.AbstractEventLoop, max_workers: int = 4):
         max_size = 0  # infinite
         self.loop = loop
+        # (priority, time_id, fn, args, kwargs, done_future)
         self._queue: asyncio.PriorityQueue[
             tuple[
                 int,
@@ -27,6 +28,7 @@ class AsyncPQExecutor(BaseJobExecutor):
                 asyncio.Future[Any] | None,
             ]
         ] = asyncio.PriorityQueue(maxsize=max_size)
+        # counter breaks ties for equal priority items (FCFS)
         self._counter = itertools.count()
         self.max_workers = max_workers
         # we don't use asyncio.create_task so that PQ executor can be invoked
@@ -122,6 +124,7 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
                 asyncio.Future[Any] | None,
             ]
         ] = asyncio.PriorityQueue(maxsize=max_size)
+        # counter breaks ties for equal priority items (FCFS)
         self._counter = itertools.count()
         self.max_workers = max_workers
         self._workers = []
@@ -164,6 +167,11 @@ class AsyncPQThreadPoolExecutor(AsyncPQExecutor):
             )
         if wait:
             await self._queue.join()
+
+            # FORCE CANCEL to avoid loop-closing race
+            for fut in self._workers:
+                fut.cancel()
+
             await asyncio.gather(
                 *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
                 return_exceptions=True,

--- a/tests/v1/lookup_client/test_lmcache_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_lookup_client.py
@@ -212,7 +212,7 @@ class TestLMCacheLookupClientServer:
 
                 # Test clear lookup status
                 client.clear_lookup_status(lookup_id)
-                assert client.lookup_cache(lookup_id) is None
+                assert client.lookup_cache(lookup_id) == -1
 
                 # Test supports_producer_reuse
                 assert client.supports_producer_reuse() is True


### PR DESCRIPTION
AsyncPQExecutor workers were never force-canceled, so they remained blocked on queue.get() and crashed when pytest closed the event loop.

cause issues such as: 
```text
ERROR    asyncio:base_events.py:1833 Task was destroyed but it is pending!
task: <Task pending name='Task-226' coro=<AsyncPQExecutor._worker() ...>>

ERROR    asyncio:base_events.py:1833 Task was destroyed but it is pending!
task: <Task pending name='Task-227' coro=<AsyncPQExecutor._worker() ...>>

RuntimeWarning: coroutine 'AsyncPQExecutor._worker' was never awaited
Enable tracemalloc to get traceback where the object was allocated.

RuntimeError: Event loop is closed
  File ".../asyncio/queues.py", line 160, in get
      getter.cancel()  # Just in case getter is not done yet.
  File ".../asyncio/base_events.py", line 799, in call_soon
      self._check_closed()
```