### PR TITLE
[Controller] Refactor: Combine kv_pool and worker_node

### DIFF
--- a/lmcache/tools/controller_benchmark/benchmark.py
+++ b/lmcache/tools/controller_benchmark/benchmark.py
@@ -19,6 +19,7 @@ import zmq.asyncio
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.cache_controller.message import DeRegisterMsg, RegisterMsg
+from lmcache.v1.cache_controller.utils import KVChunkInfo
 from lmcache.v1.rpc_utils import (
     close_zmq_socket,
     get_zmq_context,
@@ -86,8 +87,8 @@ class ZMQControllerBenchmark:
         self.req_socket: Optional[Any] = None
         self.results = BenchmarkResults()
         self.running = False
-        # Track sequence numbers per (instance_id, worker_id, location)
-        self.sequence_numbers: Dict[Tuple[str, int, str], int] = {}
+        # Track sequence numbers per KVChunkInfo (instance_id, worker_id, location)
+        self.sequence_numbers: Dict[KVChunkInfo, int] = {}
 
         # Track registered workers for cleanup
         self.registered_workers: List[Tuple[str, int, str, int]] = []
@@ -159,7 +160,7 @@ class ZMQControllerBenchmark:
         Get monotonically increasing sequence number for specific
         instance-worker-location
         """
-        key = (instance_id, worker_id, location)
+        key = KVChunkInfo(instance_id, worker_id, location)
         if key not in self.sequence_numbers:
             self.sequence_numbers[key] = 0
         seq = self.sequence_numbers[key]

--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -103,8 +103,8 @@ class LMCacheControllerManager:
                 role=zmq.REP,  # type: ignore[attr-defined]
                 bind_or_connect="bind",
             )
-        self.kv_controller = KVController()
         self.reg_controller = RegistrationController()
+        self.kv_controller = KVController(self.reg_controller.registry)
 
         # Cluster executor
         self.cluster_executor = LMCacheClusterExecutor(

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -184,8 +184,8 @@ class KVController:
             result = self.registry.find_kv(key)
             if result is None:
                 break
-            matched_instance = result[0]
-            matched_location = result[2]
+            matched_instance = result.instance_id
+            matched_location = result.location
             layout_info[matched_instance] = (matched_location, end)
         return LookupRetMsg(layout_info=layout_info, event_id=msg.event_id)
 
@@ -209,9 +209,9 @@ class KVController:
         if result is None:
             return BatchedP2PLookupRetMsg(layout_info=[("", "", 0, "")])
 
-        instance_id = result[0]
-        worker_id = result[1]
-        location = result[2]
+        instance_id = result.instance_id
+        worker_id = result.worker_id
+        location = result.location
         assert self.reg_controller is not None
         peer_init_url = self.reg_controller.get_peer_init_url(instance_id, worker_id)
         assert peer_init_url is not None

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from collections import defaultdict
-from typing import Optional
+from typing import TYPE_CHECKING, Any
 
 # First Party
 from lmcache.logging import init_logger
@@ -27,7 +26,12 @@ from lmcache.v1.cache_controller.message import (
     PinRetMsg,
 )
 from lmcache.v1.cache_controller.observability import PrometheusLogger
+from lmcache.v1.cache_controller.utils import RegistryTree
 from lmcache.v1.token_database import ChunkedTokenDatabase
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.cache_controller.controllers import RegistrationController
 
 logger = init_logger(__name__)
 
@@ -42,61 +46,27 @@ better choice.
 
 
 class KVController:
-    def __init__(self) -> None:
-        # Mapping from `(instance_id, worker_id)` -> [location -> set[chunk_hash]]
-        self.kv_pool: dict[tuple[str, int], dict[str, set[int]]] = defaultdict(
-            lambda: defaultdict(set)
-        )
+    def __init__(self, registry: RegistryTree) -> None:
         # TODO(Jiayi): remove this hardcode
         self.token_database = ChunkedTokenDatabase()
 
         # Track sequence discontinuity count for metrics
         self.seq_discontinuity_count = 0
 
-        self._setup_metrics()
+        self.registry = registry
+        self.cluster_executor: Any = None
 
-    def _setup_metrics(self):
+    def _setup_metrics(self) -> None:
         prometheus_logger = PrometheusLogger.GetInstanceOrNone()
         if prometheus_logger is not None:
+            # TODO(baoloongmao): Cache values for better performance
             prometheus_logger.kv_pool_keys_count.set_function(self._get_kv_pool_size)
             prometheus_logger.kv_op_seq_discontinuity_count.set_function(
                 lambda: self.seq_discontinuity_count
             )
 
     def _get_kv_pool_size(self) -> int:
-        total_size = 0
-        for _, location_kvs in self.kv_pool.items():
-            for _, kvs in location_kvs.items():
-                total_size += len(kvs)
-        return total_size
-
-    def _exists(
-        self,
-        key: int,
-        exclude_instance_id: Optional[str] = None,
-        exclude_location: Optional[str] = None,
-    ) -> Optional[tuple[str, int, str]]:
-        """
-        Check if a key exists in the KV pool.
-
-        :param int key: The key to check.
-
-        :param str exclude_instance_id: The instance ID to exclude.
-
-        :param str exclude_location: The location to exclude.
-
-        :return: A tuple of (instance_id, worker_id, location) if the key exists,
-        None otherwise.
-        """
-        for (instance_id, worker_id), location_kvs in self.kv_pool.items():
-            if exclude_instance_id is not None and instance_id == exclude_instance_id:
-                continue
-            for location, kvs in location_kvs.items():
-                if exclude_location is not None and location == exclude_location:
-                    continue
-                if key in kvs:
-                    return instance_id, worker_id, location
-        return None
+        return self.registry.get_total_kv_count()
 
     def check_sequence_number(self, msg: KVOperationMsg) -> None:
         """
@@ -110,15 +80,11 @@ class KVController:
         location = msg.location
         seq_num = msg.seq_num
 
-        last_seq_num = self.reg_controller.registry.get_seq_num(
-            instance_id, worker_id, location
-        )
+        last_seq_num = self.registry.get_seq_num(instance_id, worker_id, location)
 
         if last_seq_num is None:
             # First message from this source
-            self.reg_controller.registry.update_seq_num(
-                instance_id, worker_id, location, seq_num
-            )
+            self.registry.update_seq_num(instance_id, worker_id, location, seq_num)
             return
 
         expected_seq = last_seq_num + 1
@@ -135,65 +101,71 @@ class KVController:
             )
 
         # Update tracker with current sequence number
-        self.reg_controller.registry.update_seq_num(
-            instance_id, worker_id, location, seq_num
-        )
+        self.registry.update_seq_num(instance_id, worker_id, location, seq_num)
 
-    def post_init(self, reg_controller, cluster_executor):
+    def post_init(
+        self, reg_controller: "RegistrationController", cluster_executor: Any
+    ) -> None:
         """
         Post initialization of the KV controller.
         """
         self.reg_controller = reg_controller
         self.cluster_executor = cluster_executor
-
-    async def deregister(self, instance_id: str, worker_id: int) -> None:
-        """
-        Deregister all kv chunks of an instance-worker.
-        """
-        report_id = (instance_id, worker_id)
-        if report_id in self.kv_pool:
-            del self.kv_pool[report_id]
-
-    ############################################################
-    # Process OrchMsg
-    # recv request from user
-    ############################################################
+        self._setup_metrics()
 
     async def clear(self, msg: ClearMsg) -> ClearRetMsg:
         """
         Clear kv chunks of instance-worker(s).
         """
+        assert self.cluster_executor is not None
         return await self.cluster_executor.execute("clear", msg)
 
     async def pin(self, msg: PinMsg) -> PinRetMsg:
         """
         Pin kv chunks of instance-worker(s).
         """
+        assert self.cluster_executor is not None
         return await self.cluster_executor.execute("pin", msg)
 
     async def compress(self, msg: CompressMsg) -> CompressRetMsg:
         """
         Compress kv chunks of instance-worker(s).
         """
+        assert self.cluster_executor is not None
         return await self.cluster_executor.execute("compress", msg)
 
     async def decompress(self, msg: DecompressMsg) -> DecompressRetMsg:
         """
         Decompress kv chunks of instance-worker(s).
         """
+        assert self.cluster_executor is not None
         return await self.cluster_executor.execute("decompress", msg)
 
     async def move(self, msg: MoveMsg) -> MoveRetMsg:
         """
         Move kv chunks of instance-worker(s).
         """
+        assert self.cluster_executor is not None
         return await self.cluster_executor.execute("move", msg)
 
     async def check_finish(self, msg: CheckFinishMsg) -> CheckFinishRetMsg:
         """
         Check if an event is finished.
         """
+        assert self.cluster_executor is not None
         return await self.cluster_executor.execute("check_finish", msg)
+
+    async def admit(self, msg: KVAdmitMsg) -> None:
+        """
+        Admit a new kv chunk.
+        """
+        self.registry.admit_kv(msg.instance_id, msg.worker_id, msg.location, msg.key)
+
+    async def evict(self, msg: KVEvictMsg) -> None:
+        """
+        Evict a kv chunk.
+        """
+        self.registry.evict_kv(msg.instance_id, msg.worker_id, msg.location, msg.key)
 
     # TODO(Jiayi): The current implementation does not handle
     # the case where the prefix chunks are evicted while the
@@ -209,52 +181,13 @@ class KVController:
         for start, end, key in self.token_database.process_tokens(
             tokens, make_key=False
         ):
-            result = self._exists(key)
+            result = self.registry.find_kv(key)
             if result is None:
                 break
             matched_instance = result[0]
             matched_location = result[2]
             layout_info[matched_instance] = (matched_location, end)
         return LookupRetMsg(layout_info=layout_info, event_id=msg.event_id)
-
-    ############################################################
-    # Process KVOperationMsg
-    # we do not need to return anything
-    ############################################################
-
-    async def admit(self, msg: KVAdmitMsg) -> None:
-        """
-        Admit a new kv chunk.
-        """
-        report_id = (msg.instance_id, msg.worker_id)
-        self.kv_pool[report_id][msg.location].add(msg.key)
-
-    async def evict(self, msg: KVEvictMsg) -> None:
-        """
-        Evict a kv chunk.
-        """
-        report_id = (msg.instance_id, msg.worker_id)
-        location = msg.location
-        key = msg.key
-
-        if (
-            report_id not in self.kv_pool
-            or location not in self.kv_pool[report_id]
-            or key not in self.kv_pool[report_id][location]
-        ):
-            return
-
-        self.kv_pool[report_id][location].remove(key)
-        if not self.kv_pool[report_id][location]:
-            del self.kv_pool[report_id][location]
-        if not self.kv_pool[report_id]:
-            del self.kv_pool[report_id]
-
-    ############################################################
-    # Process WorkerReqMsg
-    # we must add try-except block, if any error occurs, we should
-    # return WorkerReqRetMsg, otherwise the worker will hang or timeout.
-    ############################################################
 
     # TODO: improve the matching logic, return multi results
     async def batched_p2p_lookup(
@@ -267,39 +200,32 @@ class KVController:
 
         :return: A BatchedP2PLookupRetMsg containing the lookup results.
         """
-        try:
-            if len(msg.hashes) == 0:
-                return BatchedP2PLookupRetMsg(layout_info=[("", "", 0, "")])
-
-            result = self._exists(msg.hashes[0], msg.instance_id)
-            if result is None:
-                return BatchedP2PLookupRetMsg(layout_info=[("", "", 0, "")])
-
-            instance_id = result[0]
-            worker_id = result[1]
-            location = result[2]
-            peer_init_url = self.reg_controller.get_peer_init_url(
-                instance_id, worker_id
-            )
-            if peer_init_url is None:
-                raise ValueError(
-                    f"Peer init url not found for {instance_id}: {worker_id}"
-                )
-            current_instance_keys = self.kv_pool[(instance_id, worker_id)][location]
-            num_hit_chunks = 0
-            for key in msg.hashes:
-                if key not in current_instance_keys:
-                    break
-                num_hit_chunks += 1
-
-            return BatchedP2PLookupRetMsg(
-                layout_info=[
-                    (instance_id, location, num_hit_chunks, peer_init_url),
-                ]
-            )
-        except KeyError as e:
-            logger.error("Key not found in kv_pool during batched p2p lookup", e)
+        if len(msg.hashes) == 0:
             return BatchedP2PLookupRetMsg(layout_info=[("", "", 0, "")])
-        except Exception as e:
-            logger.error("An unexpected error occurred during batched p2p lookup", e)
+
+        result = self.registry.find_kv(
+            msg.hashes[0], exclude_instance_id=msg.instance_id
+        )
+        if result is None:
             return BatchedP2PLookupRetMsg(layout_info=[("", "", 0, "")])
+
+        instance_id = result[0]
+        worker_id = result[1]
+        location = result[2]
+        assert self.reg_controller is not None
+        peer_init_url = self.reg_controller.get_peer_init_url(instance_id, worker_id)
+        assert peer_init_url is not None
+        current_instance_keys = self.registry.get_worker_kv_keys(
+            instance_id, worker_id, location
+        )
+        num_hit_chunks = 0
+        for key in msg.hashes:
+            if key not in current_instance_keys:
+                break
+            num_hit_chunks += 1
+
+        return BatchedP2PLookupRetMsg(
+            layout_info=[
+                (instance_id, location, num_hit_chunks, peer_init_url),
+            ]
+        )

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -164,7 +164,6 @@ class RegistrationController:
         if worker_node.socket is not None:
             close_zmq_socket(worker_node.socket)
 
-        await self.kv_controller.deregister(instance_id, worker_id)
         logger.info("Deregistered instance-worker %s", (instance_id, worker_id))
 
     async def health(self, msg: HealthMsg) -> HealthRetMsg:

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -32,6 +32,40 @@ class WorkerNode:
     registration_time: float
     last_heartbeat_time: float
     seq_tracker: dict[str, int] = field(default_factory=dict)  # location -> seq_num
+    kv_store: dict[str, set[int]] = field(
+        default_factory=dict
+    )  # location -> set[chunk_hash]
+
+    def admit_kv(self, location: str, key: int) -> None:
+        """Admit a KV chunk to this worker."""
+        if location not in self.kv_store:
+            self.kv_store[location] = set()
+        self.kv_store[location].add(key)
+
+    def evict_kv(self, location: str, key: int) -> bool:
+        """Evict a KV chunk from this worker. Returns True if evicted."""
+        if location not in self.kv_store or key not in self.kv_store[location]:
+            return False
+        self.kv_store[location].remove(key)
+        if not self.kv_store[location]:
+            del self.kv_store[location]
+        return True
+
+    def has_kv(self, location: str, key: int) -> bool:
+        """Check if a KV chunk exists in this worker."""
+        return location in self.kv_store and key in self.kv_store[location]
+
+    def get_kv_keys(self, location: str) -> set[int]:
+        """Get all keys for a location."""
+        return self.kv_store.get(location, set())
+
+    def clear_kv_store(self) -> None:
+        """Clear all KV data for this worker."""
+        self.kv_store.clear()
+
+    def get_kv_count(self) -> int:
+        """Get total count of KV chunks."""
+        return sum(len(keys) for keys in self.kv_store.values())
 
     def to_worker_info(self, instance_id: str) -> WorkerInfo:
         """Convert to WorkerInfo for backward compatibility."""
@@ -223,3 +257,70 @@ class RegistryTree:
         if worker_node is None:
             return None
         return worker_node.seq_tracker.get(location)
+
+    # KV store operations
+    def admit_kv(
+        self, instance_id: str, worker_id: int, location: str, key: int
+    ) -> bool:
+        """Admit a KV chunk. Returns True if successful."""
+        worker_node = self.get_worker(instance_id, worker_id)
+        if worker_node is None:
+            return False
+        worker_node.admit_kv(location, key)
+        return True
+
+    def evict_kv(
+        self, instance_id: str, worker_id: int, location: str, key: int
+    ) -> bool:
+        """Evict a KV chunk. Returns True if successful."""
+        worker_node = self.get_worker(instance_id, worker_id)
+        if worker_node is None:
+            return False
+        return worker_node.evict_kv(location, key)
+
+    def find_kv(
+        self,
+        key: int,
+        exclude_instance_id: Optional[str] = None,
+        exclude_location: Optional[str] = None,
+    ) -> Optional[tuple[str, int, str]]:
+        """
+        Find a KV chunk across all workers.
+
+        Returns: (instance_id, worker_id, location) if found, None otherwise.
+        """
+        for ip_instances in self.instances.values():
+            for instance_id, instance_node in ip_instances.items():
+                if (
+                    exclude_instance_id is not None
+                    and instance_id == exclude_instance_id
+                ):
+                    continue
+                for worker_id, worker_node in instance_node.workers.items():
+                    for location, keys in worker_node.kv_store.items():
+                        if (
+                            exclude_location is not None
+                            and location == exclude_location
+                        ):
+                            continue
+                        if key in keys:
+                            return instance_id, worker_id, location
+        return None
+
+    def get_total_kv_count(self) -> int:
+        """Get total count of KV chunks across all workers."""
+        return sum(
+            worker_node.get_kv_count()
+            for ip_instances in self.instances.values()
+            for instance_node in ip_instances.values()
+            for worker_node in instance_node.workers.values()
+        )
+
+    def get_worker_kv_keys(
+        self, instance_id: str, worker_id: int, location: str
+    ) -> set[int]:
+        """Get all KV keys for a specific worker and location."""
+        worker_node = self.get_worker(instance_id, worker_id)
+        if worker_node is None:
+            return set()
+        return worker_node.get_kv_keys(location)

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -1,10 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import NamedTuple, Optional
 
 # Third Party
 import zmq.asyncio
+
+
+class KVChunkInfo(NamedTuple):
+    """
+    Represents the location information of a KV chunk in the cluster.
+    This class is immutable and can be used as a dictionary key.
+    """
+
+    instance_id: str
+    worker_id: int
+    location: str
 
 
 @dataclass
@@ -283,11 +294,11 @@ class RegistryTree:
         key: int,
         exclude_instance_id: Optional[str] = None,
         exclude_location: Optional[str] = None,
-    ) -> Optional[tuple[str, int, str]]:
+    ) -> Optional[KVChunkInfo]:
         """
         Find a KV chunk across all workers.
 
-        Returns: (instance_id, worker_id, location) if found, None otherwise.
+        Returns: KVChunkInfo if found, None otherwise.
         """
         for ip_instances in self.instances.values():
             for instance_id, instance_node in ip_instances.items():
@@ -304,7 +315,7 @@ class RegistryTree:
                         ):
                             continue
                         if key in keys:
-                            return instance_id, worker_id, location
+                            return KVChunkInfo(instance_id, worker_id, location)
         return None
 
     def get_total_kv_count(self) -> int:


### PR DESCRIPTION
This refactor is a follow-up of #2131

We can remove kv_pool and use the workerNode to keep the keys belong to.