### PR TITLE
[CI] skip unnecessary comprehensive tests

### DIFF
--- a/.buildkite/pipelines/comprehensive-tests.yml
+++ b/.buildkite/pipelines/comprehensive-tests.yml
@@ -6,6 +6,7 @@ steps:
     key: "test"
     timeout_in_minutes: 60
     commands:
+      - .buildkite/scripts/should-run-comprehensive.sh || exit 0 # Skip comprehensive tests for safe-path-only PRs.
       - chmod +x .buildkite/scripts/vllm-integration-tests.sh
       - BUILD_ID=${BUILDKITE_BUILD_ID} .buildkite/scripts/vllm-integration-tests.sh --hf-token=$HF_TOKEN --server-wait-timeout=240 --configs=.buildkite/cases/comprehensive-cases.txt
       - cat /tmp/build_${BUILDKITE_BUILD_ID}_*.log > build_${BUILDKITE_BUILD_ID}.log

--- a/.buildkite/scripts/should-run-comprehensive.sh
+++ b/.buildkite/scripts/should-run-comprehensive.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decide whether comprehensive tests should run for this build.
+# Exit code semantics:
+#   0 -> run comprehensive tests
+#   1 -> skip comprehensive tests (safe paths only)
+
+# If this isn't a PR build, always run comprehensive tests.
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  exit 0
+fi
+
+# Determine base ref to diff against.
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}"
+BASE_REF="origin/${BASE_BRANCH}"
+
+# Ensure the base ref exists; ignore fetch failures (repo might already have it).
+git fetch origin "${BASE_BRANCH}" >/dev/null 2>&1 || true
+
+# Compute changed files between the base and current HEAD.
+if CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null); then
+  :
+else
+  # Fallback: diff against the previous commit if base ref is unavailable.
+  CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || echo "")
+fi
+
+# If we cannot determine changes, be conservative and run tests.
+if [[ -z "${CHANGED_FILES}" ]]; then
+  exit 0
+fi
+
+# If any changed file is NOT in a safe path, we must run tests.
+for f in ${CHANGED_FILES}; do
+  case "${f}" in
+    docs/*|docs/**) ;;                      # docs
+    *.md|*.rst) ;;                          # markdown / rst anywhere
+    tests/*|tests/**) ;;                    # tests
+    benchmarks/*|benchmarks/**) ;;          # benchmarks
+    tools/*|tools/**) ;;                    # top-level tools
+    lmcache/tools/*|lmcache/tools/**) ;;    # package tools
+    examples/*|examples/**) ;;              # examples
+    asset/*|asset/**) ;;                    # assets
+    *)
+      # Non-safe file touched -> run comprehensive tests.
+      exit 0
+      ;;
+  esac
+done
+
+echo "Docs/tests/benchmarks/tools/examples/assets-only change detected; skipping comprehensive tests."
+exit 1
+

--- a/.buildkite/scripts/should-run-comprehensive.sh
+++ b/.buildkite/scripts/should-run-comprehensive.sh
@@ -19,12 +19,9 @@ BASE_REF="origin/${BASE_BRANCH}"
 git fetch origin "${BASE_BRANCH}" >/dev/null 2>&1 || true
 
 # Compute changed files between the base and current HEAD.
-if CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null); then
-  :
-else
-  # Fallback: diff against the previous commit if base ref is unavailable.
-  CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || echo "")
-fi
+# Compute changed files between the base and current HEAD.
+# If this fails, we will fall back to running the tests (CHANGED_FILES will be empty).
+CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || echo "")
 
 # If we cannot determine changes, be conservative and run tests.
 if [[ -z "${CHANGED_FILES}" ]]; then

--- a/.buildkite/scripts/should-run-comprehensive.sh
+++ b/.buildkite/scripts/should-run-comprehensive.sh
@@ -31,17 +31,46 @@ if [[ -z "${CHANGED_FILES}" ]]; then
   exit 0
 fi
 
+# Track which safe-path categories were touched.
+safe_categories=()
+
+add_safe_category() {
+  local cat="$1"
+  for existing in "${safe_categories[@]}"; do
+    if [[ "$existing" == "$cat" ]]; then
+      return
+    fi
+  done
+  safe_categories+=("$cat")
+}
+
 # If any changed file is NOT in a safe path, we must run tests.
 for f in ${CHANGED_FILES}; do
   case "${f}" in
-    docs/*|docs/**) ;;                      # docs
-    *.md|*.rst) ;;                          # markdown / rst anywhere
-    tests/*|tests/**) ;;                    # tests
-    benchmarks/*|benchmarks/**) ;;          # benchmarks
-    tools/*|tools/**) ;;                    # top-level tools
-    lmcache/tools/*|lmcache/tools/**) ;;    # package tools
-    examples/*|examples/**) ;;              # examples
-    asset/*|asset/**) ;;                    # assets
+    docs/*|docs/**)
+      add_safe_category "docs/"
+      ;;
+    *.md|*.rst)
+      add_safe_category "*.md/*.rst"
+      ;;
+    tests/*|tests/**)
+      add_safe_category "tests/"
+      ;;
+    benchmarks/*|benchmarks/**)
+      add_safe_category "benchmarks/"
+      ;;
+    tools/*|tools/**)
+      add_safe_category "tools/"
+      ;;
+    lmcache/tools/*|lmcache/tools/**)
+      add_safe_category "lmcache/tools/"
+      ;;
+    examples/*|examples/**)
+      add_safe_category "examples/"
+      ;;
+    asset/*|asset/**)
+      add_safe_category "asset/"
+      ;;
     *)
       # Non-safe file touched -> run comprehensive tests.
       exit 0
@@ -49,6 +78,14 @@ for f in ${CHANGED_FILES}; do
   esac
 done
 
-echo "Docs/tests/benchmarks/tools/examples/assets-only change detected; skipping comprehensive tests."
-exit 1
+if ((${#safe_categories[@]} == 0)); then
+  echo "Safe-path-only change detected; skipping comprehensive tests."
+else
+  msg="${safe_categories[0]}"
+  for ((i = 1; i < ${#safe_categories[@]}; i++)); do
+    msg+=", ${safe_categories[i]}"
+  done
+  echo "${msg} change detected; skipping comprehensive tests."
+fi
 
+exit 1

--- a/.buildkite/scripts/should-run-comprehensive.sh
+++ b/.buildkite/scripts/should-run-comprehensive.sh
@@ -42,30 +42,30 @@ add_safe_category() {
 }
 
 # If any changed file is NOT in a safe path, we must run tests.
-for f in ${CHANGED_FILES}; do
-  case "${f}" in
-    docs/*|docs/**)
+while IFS= read -r f; do
+  case "$f" in
+    docs/*)
       add_safe_category "docs/"
       ;;
     *.md|*.rst)
       add_safe_category "*.md/*.rst"
       ;;
-    tests/*|tests/**)
+    tests/*)
       add_safe_category "tests/"
       ;;
-    benchmarks/*|benchmarks/**)
+    benchmarks/*)
       add_safe_category "benchmarks/"
       ;;
-    tools/*|tools/**)
+    tools/*)
       add_safe_category "tools/"
       ;;
-    lmcache/tools/*|lmcache/tools/**)
+    lmcache/tools/*)
       add_safe_category "lmcache/tools/"
       ;;
-    examples/*|examples/**)
+    examples/*)
       add_safe_category "examples/"
       ;;
-    asset/*|asset/**)
+    asset/*)
       add_safe_category "asset/"
       ;;
     *)
@@ -73,16 +73,11 @@ for f in ${CHANGED_FILES}; do
       exit 0
       ;;
   esac
-done
+done <<< "${CHANGED_FILES}"
 
-if ((${#safe_categories[@]} == 0)); then
-  echo "Safe-path-only change detected; skipping comprehensive tests."
-else
-  msg="${safe_categories[0]}"
-  for ((i = 1; i < ${#safe_categories[@]}; i++)); do
-    msg+=", ${safe_categories[i]}"
-  done
-  echo "${msg} change detected; skipping comprehensive tests."
-fi
+# If we reach here, all changes are in safe paths, so safe_categories is not empty.
+# Join the array of categories for a clean log message.
+joined_cats=$(IFS=', '; echo "${safe_categories[*]}")
+echo "${joined_cats} change detected; skipping comprehensive tests."
 
 exit 1

--- a/.buildkite/scripts/should-run-comprehensive.sh
+++ b/.buildkite/scripts/should-run-comprehensive.sh
@@ -54,9 +54,6 @@ while IFS= read -r f; do
     tests/*)
       add_safe_category "tests/"
       ;;
-    benchmarks/*)
-      add_safe_category "benchmarks/"
-      ;;
     tools/*)
       add_safe_category "tools/"
       ;;

--- a/.buildkite/scripts/should-run-comprehensive.sh
+++ b/.buildkite/scripts/should-run-comprehensive.sh
@@ -15,10 +15,11 @@ fi
 BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}"
 BASE_REF="origin/${BASE_BRANCH}"
 
-# Ensure the base ref exists; ignore fetch failures (repo might already have it).
-git fetch origin "${BASE_BRANCH}" >/dev/null 2>&1 || true
+# Ensure the base ref exists; log a warning on fetch failure.
+if ! git fetch origin "${BASE_BRANCH}" >/dev/null 2>&1; then
+  echo "Warning: failed to fetch origin/${BASE_BRANCH}, falling back to local ref for diff." >&2
+fi
 
-# Compute changed files between the base and current HEAD.
 # Compute changed files between the base and current HEAD.
 # If this fails, we will fall back to running the tests (CHANGED_FILES will be empty).
 CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || echo "")


### PR DESCRIPTION
Refs #2180

**What this PR does / why we need it**:

This PR adds a small guard in the buildkite comprehensive tests pipeline so that we can skip running the comprehensive test suite when a PR only touches safe paths that cannot affect runtime behavior.

Specifically, it:
- Adds `.buildkite/scripts/should-run-comprehensive.sh`, which inspects the diff between the PR and its base branch and decides whether comprehensive tests are needed.
- Treats changes under `docs/`, `tests/`, `benchmarks/`, `tools/`, `lmcache/tools/`, `examples/`, `asset/`, and `*.md` / `*.rst` files as safe.
- Updates `.buildkite/pipelines/comprehensive-tests.yml` to call this script at the start of the Comprehensive Tests step and skip the heavy tests if all changes are in safe paths.
- Improves logging so the script reports which safe-path categories were detected when it decides to skip.

This reduces CI time and resource usage for docs- and infra-only PRs, while still running comprehensive tests for any PR that touches core code or configs.

**Special notes for your reviewers**:

- The script is conservative: if it cannot determine the diff or sees any file outside the safe paths, it falls back to running comprehensive tests.
- Locally I verified:
  - On the CI branch (which changes `.buildkite/...`), the script returns `0` (tests run).
  - With only safe-path changes relative to the base, it returns `1` and logs the specific categories detected.
- I’m happy to adjust the safe-path list if there are additional directories you’d like to treat as safe.

**If applicable**:

- [ ] this PR contains user facing changes - docs added  
- [ ] this PR contains unit tests


**Local Tests Evidence**
Test docs/ change PR - Success
<img width="1356" height="474" alt="image" src="https://github.com/user-attachments/assets/f5b99d6d-e3e8-4294-b9c9-81f683302486" />

Test docs/, tests/ change PR - Success
<img width="1352" height="477" alt="image" src="https://github.com/user-attachments/assets/ca78a2b4-0754-4ffb-a419-de7513c135fc" />

Test non-safe PR that shouldn't skip tests - Success
<img width="1356" height="577" alt="image" src="https://github.com/user-attachments/assets/f48551d1-c5b7-4660-9cc0-839d3793304f" />


