### PR TITLE
Fix AttributeError in layerwise mode during full cache hit

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -670,6 +670,9 @@ class LMCacheConnectorV1Impl:
         self.layerwise_retrievers: list[
             Generator[Optional[torch.Tensor], None, None]
         ] = []
+        self.layerwise_storers: list[
+            Generator[Optional[torch.Tensor], None, None]
+        ] = []
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.lmcache_engine_metadata: LMCacheEngineMetadata
         if role == KVConnectorRole.SCHEDULER:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -670,9 +670,7 @@ class LMCacheConnectorV1Impl:
         self.layerwise_retrievers: list[
             Generator[Optional[torch.Tensor], None, None]
         ] = []
-        self.layerwise_storers: list[
-            Generator[Optional[torch.Tensor], None, None]
-        ] = []
+        self.layerwise_storers: list[Generator[Optional[torch.Tensor], None, None]] = []
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.lmcache_engine_metadata: LMCacheEngineMetadata
         if role == KVConnectorRole.SCHEDULER:


### PR DESCRIPTION
Description This PR fixes an AttributeError that occurs when running vLLM with LMCacheConnectorV1 in layerwise mode during a full cache hit.

The Issue When a request is fully satisfied by the remote cache (full hit), the save_kv_layer method is never called. Currently, self.layerwise_storers is only initialized inside save_kv_layer. Consequently, when wait_for_save() is called later, it crashes trying to access self.layerwise_storers.

The Fix I have initialized self.layerwise_storers as an empty list in the __init__ method of LMCacheConnectorV1Impl. This ensures the attribute always exists, preventing the crash even when the save phase is skipped.

Related Issue Fixes the crash reported in: https://github.com/vllm-project/vllm/issues/29840

Verification

Validated that self.layerwise_storers is correctly initialized.

The server no longer crashes on full cache hits in layerwise mode.