### PR TITLE
VLLM LMCache Hang with PD && TP >1

### DIFF
--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -121,80 +121,93 @@ async def lifespan(app: FastAPI):
         and len(alloc_port_list) > global_args.num_decoders
     )
     
-    if init_port_complete_lists:
-        tp_ranks_per_decoder = len(init_port_list) // global_args.num_decoders
-    elif alloc_port_complete_lists:
-        tp_ranks_per_decoder = len(alloc_port_list) // global_args.num_decoders
-    else:
-        tp_ranks_per_decoder = None
+    # Calculate TP ranks from each port list and validate consistency
+    tp_ranks_from_init = (
+        len(init_port_list) // global_args.num_decoders 
+        if init_port_complete_lists else None
+    )
+    tp_ranks_from_alloc = (
+        len(alloc_port_list) // global_args.num_decoders 
+        if alloc_port_complete_lists else None
+    )
+    
+    # Validate that both port lists imply the same TP ranks if both are complete lists
+    if tp_ranks_from_init is not None and tp_ranks_from_alloc is not None:
+        if tp_ranks_from_init != tp_ranks_from_alloc:
+            raise ValueError(
+                f"Inconsistent TP ranks detected. "
+                f"Init ports imply {tp_ranks_from_init} ranks per decoder "
+                f"(based on {len(init_port_list)} ports / {global_args.num_decoders} decoders), "
+                f"while alloc ports imply {tp_ranks_from_alloc} ranks per decoder "
+                f"(based on {len(alloc_port_list)} ports / {global_args.num_decoders} decoders). "
+                f"Please ensure both port lists have the same number of ports per decoder."
+            )
+    
+    # Use the determined TP ranks (prioritize init if both are available)
+    tp_ranks_per_decoder = tp_ranks_from_init or tp_ranks_from_alloc
+
+    def get_decoder_ports(
+        port_list: list[int],
+        port_name: str,
+        decoder_idx: int,
+    ) -> list[int]:
+        """
+        Helper function to get the correct port list for a specific decoder.
+        
+        Args:
+            port_list: The full port list provided via command line
+            port_name: Name of the port type ("init" or "alloc") for error messages
+            decoder_idx: Index of the decoder (0-based)
+            
+        Returns:
+            List of ports assigned to this decoder
+        """
+        port_complete_lists = (
+            len(port_list) % global_args.num_decoders == 0 
+            and len(port_list) > global_args.num_decoders
+        )
+        
+        if incremental_mode:
+            # Incremental mode: add index to each base port for TP ranks
+            # Example: base ports [7300, 7301], decoder 0 -> [7300, 7301], decoder 1 -> [7301, 7302]
+            return [p + decoder_idx for p in port_list]
+        elif port_complete_lists:
+            # Ports are provided as complete lists, split them per decoder
+            # Example: [7300, 7301, 7350, 7351] with num_decoders=2, TP=2
+            #          -> decoder 0: [7300, 7301], decoder 1: [7350, 7351]
+            start_idx = decoder_idx * tp_ranks_per_decoder
+            end_idx = start_idx + tp_ranks_per_decoder
+            return port_list[start_idx:end_idx]
+        elif len(port_list) == global_args.num_decoders:
+            # Base ports provided per decoder
+            # Try to infer TP ranks from the other port list if available
+            if tp_ranks_per_decoder is not None:
+                # Use inferred TP ranks to generate port list
+                base_port = port_list[decoder_idx]
+                return [base_port + j for j in range(tp_ranks_per_decoder)]
+            else:
+                # Cannot determine TP ranks, use single port (will warn if TP > 1)
+                logger.warning(
+                    f"Cannot determine TP ranks for decoder {decoder_idx} {port_name} ports. "
+                    f"Using single port {port_list[decoder_idx]}. "
+                    f"This may cause issues if TP > 1. "
+                    f"Please provide complete port lists: "
+                    f"--decoder-{port_name}-port should have num_decoders * TP_ranks ports "
+                    f"(e.g., for {global_args.num_decoders} decoders with TP=2: "
+                    f"provide {global_args.num_decoders * 2} ports)."
+                )
+                return [port_list[decoder_idx]]
+        else:
+            # Use the provided ports as-is (shared across all decoders)
+            # (suitable when different hosts can reuse same port numbers)
+            return port_list
 
     for i, (host, port) in enumerate(decoder_pairs):
         decoder_base_url = f"http://{host}:{int(port)}"
         decode_client = httpx.AsyncClient(timeout=None, base_url=decoder_base_url)
-        if incremental_mode:
-            # Incremental mode: add index to each base port for TP ranks
-            # Example: base ports [7300, 7301], decoder 0 -> [7300, 7301], decoder 1 -> [7301, 7302]
-            init_ports = [p + i for p in global_args.decoder_init_port]
-            alloc_ports = [p + i for p in global_args.decoder_alloc_port]
-        elif init_port_complete_lists:
-            # Ports are provided as complete lists, split them per decoder
-            # Example: [7300, 7301, 7350, 7351] with num_decoders=2, TP=2
-            #          -> decoder 0: [7300, 7301], decoder 1: [7350, 7351]
-            start_idx = i * tp_ranks_per_decoder
-            end_idx = start_idx + tp_ranks_per_decoder
-            init_ports = init_port_list[start_idx:end_idx]
-        elif len(init_port_list) == global_args.num_decoders:
-            # Base ports provided per decoder
-            # Try to infer TP ranks by checking if alloc ports have complete lists
-            if alloc_port_complete_lists:
-                # Use alloc ports to infer TP ranks
-                init_base_port = init_port_list[i]
-                init_ports = [init_base_port + j for j in range(tp_ranks_per_decoder)]
-            elif len(alloc_port_list) == global_args.num_decoders and i < len(alloc_port_list) - 1:
-                # Try to infer TP ranks from port spacing between decoders
-                # If decoder ports are spaced consistently, we can infer TP ranks
-                # Example: decoder 0 base=7300, decoder 1 base=7350, spacing=50
-                #          If TP=2, ports should be [7300,7301] and [7350,7351]
-                #          The spacing between decoders (50) suggests TP might be large
-                #          But we can't reliably infer from spacing alone
-                # For now, assume TP=1 if we can't determine
-                init_ports = [init_port_list[i]]
-                logger.warning(
-                    f"Cannot determine TP ranks for decoder {i}. "
-                    f"Using single port {init_port_list[i]}. "
-                    f"This may cause issues if TP > 1. "
-                    f"Please provide complete port lists: "
-                    f"--decoder-init-port should have num_decoders * TP_ranks ports "
-                    f"(e.g., for 2 decoders with TP=2: 7300,7301,7350,7351)."
-                )
-            else:
-                init_ports = [init_port_list[i]]
-                logger.warning(
-                    f"Cannot determine TP ranks for decoder {i}. "
-                    f"Using single port {init_port_list[i]}. "
-                    f"For TP > 1, provide complete port lists."
-                )
-        else:
-            # Use the provided ports as-is (shared across all decoders)
-            # (suitable when different hosts can reuse same port numbers)
-            init_ports = init_port_list
         
-        if alloc_port_complete_lists:
-            start_idx = i * tp_ranks_per_decoder
-            end_idx = start_idx + tp_ranks_per_decoder
-            alloc_ports = alloc_port_list[start_idx:end_idx]
-        elif len(alloc_port_list) == global_args.num_decoders:
-            if init_port_complete_lists:
-                alloc_base_port = alloc_port_list[i]
-                alloc_ports = [alloc_base_port + j for j in range(tp_ranks_per_decoder)]
-            else:
-                logger.warning(
-                    f"Cannot determine TP ranks for decoder {i} alloc ports. "
-                    f"Using single port {alloc_port_list[i]}."
-                )
-                alloc_ports = [alloc_port_list[i]]
-        else:
-            alloc_ports = alloc_port_list
+        init_ports = get_decoder_ports(init_port_list, "init", i)
+        alloc_ports = get_decoder_ports(alloc_port_list, "alloc", i)
 
         app.state.decode_clients.append(
             ClientInfo(

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -97,18 +97,104 @@ async def lifespan(app: FastAPI):
     incremental_mode = (
         len(dec_hosts) == 1 and len(dec_ports) == 1 and global_args.num_decoders > 1
     )
+    
+    # Check if init/alloc ports are provided per decoder or as a single shared list
+    # Strategy 1: If the number is num_decoders * TP_ranks, split them per decoder
+    #   Example: --decoder-init-port 7300,7301,7350,7351 with num_decoders=2
+    #            -> decoder 0: [7300, 7301], decoder 1: [7350, 7351]
+    # Strategy 2: If the number matches num_decoders, treat as base ports (incremental per decoder)
+    #   Example: --decoder-init-port 7300,7350 with num_decoders=2
+    #            -> decoder 0: [7300, ...], decoder 1: [7350, ...]
+    #            But this requires TP ranks info, so we'll use incremental mode logic
+    # Strategy 3: Otherwise, use as shared list for all decoders
+    init_port_list = list(global_args.decoder_init_port)
+    alloc_port_list = list(global_args.decoder_alloc_port)
+    
+    # Check if ports are provided as complete lists (num_decoders * TP_ranks)
+    # This is the preferred way when TP > 1
+    init_port_complete_lists = (
+        len(init_port_list) % global_args.num_decoders == 0 
+        and len(init_port_list) > global_args.num_decoders
+    )
+    alloc_port_complete_lists = (
+        len(alloc_port_list) % global_args.num_decoders == 0 
+        and len(alloc_port_list) > global_args.num_decoders
+    )
+    
+    if init_port_complete_lists:
+        tp_ranks_per_decoder = len(init_port_list) // global_args.num_decoders
+    elif alloc_port_complete_lists:
+        tp_ranks_per_decoder = len(alloc_port_list) // global_args.num_decoders
+    else:
+        tp_ranks_per_decoder = None
 
     for i, (host, port) in enumerate(decoder_pairs):
         decoder_base_url = f"http://{host}:{int(port)}"
         decode_client = httpx.AsyncClient(timeout=None, base_url=decoder_base_url)
         if incremental_mode:
+            # Incremental mode: add index to each base port for TP ranks
+            # Example: base ports [7300, 7301], decoder 0 -> [7300, 7301], decoder 1 -> [7301, 7302]
             init_ports = [p + i for p in global_args.decoder_init_port]
             alloc_ports = [p + i for p in global_args.decoder_alloc_port]
+        elif init_port_complete_lists:
+            # Ports are provided as complete lists, split them per decoder
+            # Example: [7300, 7301, 7350, 7351] with num_decoders=2, TP=2
+            #          -> decoder 0: [7300, 7301], decoder 1: [7350, 7351]
+            start_idx = i * tp_ranks_per_decoder
+            end_idx = start_idx + tp_ranks_per_decoder
+            init_ports = init_port_list[start_idx:end_idx]
+        elif len(init_port_list) == global_args.num_decoders:
+            # Base ports provided per decoder
+            # Try to infer TP ranks by checking if alloc ports have complete lists
+            if alloc_port_complete_lists:
+                # Use alloc ports to infer TP ranks
+                init_base_port = init_port_list[i]
+                init_ports = [init_base_port + j for j in range(tp_ranks_per_decoder)]
+            elif len(alloc_port_list) == global_args.num_decoders and i < len(alloc_port_list) - 1:
+                # Try to infer TP ranks from port spacing between decoders
+                # If decoder ports are spaced consistently, we can infer TP ranks
+                # Example: decoder 0 base=7300, decoder 1 base=7350, spacing=50
+                #          If TP=2, ports should be [7300,7301] and [7350,7351]
+                #          The spacing between decoders (50) suggests TP might be large
+                #          But we can't reliably infer from spacing alone
+                # For now, assume TP=1 if we can't determine
+                init_ports = [init_port_list[i]]
+                logger.warning(
+                    f"Cannot determine TP ranks for decoder {i}. "
+                    f"Using single port {init_port_list[i]}. "
+                    f"This may cause issues if TP > 1. "
+                    f"Please provide complete port lists: "
+                    f"--decoder-init-port should have num_decoders * TP_ranks ports "
+                    f"(e.g., for 2 decoders with TP=2: 7300,7301,7350,7351)."
+                )
+            else:
+                init_ports = [init_port_list[i]]
+                logger.warning(
+                    f"Cannot determine TP ranks for decoder {i}. "
+                    f"Using single port {init_port_list[i]}. "
+                    f"For TP > 1, provide complete port lists."
+                )
         else:
-            # Use the provided ports as-is
+            # Use the provided ports as-is (shared across all decoders)
             # (suitable when different hosts can reuse same port numbers)
-            init_ports = list(global_args.decoder_init_port)
-            alloc_ports = list(global_args.decoder_alloc_port)
+            init_ports = init_port_list
+        
+        if alloc_port_complete_lists:
+            start_idx = i * tp_ranks_per_decoder
+            end_idx = start_idx + tp_ranks_per_decoder
+            alloc_ports = alloc_port_list[start_idx:end_idx]
+        elif len(alloc_port_list) == global_args.num_decoders:
+            if init_port_complete_lists:
+                alloc_base_port = alloc_port_list[i]
+                alloc_ports = [alloc_base_port + j for j in range(tp_ranks_per_decoder)]
+            else:
+                logger.warning(
+                    f"Cannot determine TP ranks for decoder {i} alloc ports. "
+                    f"Using single port {alloc_port_list[i]}."
+                )
+                alloc_ports = [alloc_port_list[i]]
+        else:
+            alloc_ports = alloc_port_list
 
         app.state.decode_clients.append(
             ClientInfo(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
see: #2144 
## Problem Description
In PD disaggregation mode:
- ✅ **1P1D TP=2**: Works correctly
- ❌ **1P2D TP=2**: vLLM worker returns the first token and then hangs
- ❌ **2P2D TP=2**: vLLM worker returns the first token and then hangs

## Root Cause Analysis

### 1. Workflow

```
User Request → Proxy Server
          ↓
    Select Prefiller (round-robin)
          ↓
    Select Decoder (round-robin)
          ↓
    Send disagg_spec (contains receiver_init_port and receiver_alloc_port lists)
          ↓
    Prefiller processes prefill, sends ProxyNotif notification when complete
          ↓
    Proxy waits for all notifications to arrive (wait_decode_kv_ready)
          ↓
    Start streaming decode response
```

### 2. Key Code Logic

#### Proxy Server Side (`disagg_proxy_server.py`)

**Select Decoder and Set Ports:**
```python
# Line 395: Select decoder (round-robin)
decode_client = round_robin_pick_client(app.state.decode_clients, counter)

# Line 397-402: Set disagg_spec
disagg_spec = {
    "req_id": req_id,
    "receiver_host": decode_client.host,
    "receiver_init_port": decode_client.init_port,  # Port list
    "receiver_alloc_port": decode_client.alloc_port, # Port list
}
num_tp_rank = len(decode_client.init_port)  # Number of TP ranks

# Line 454: Wait for all notifications
await wait_decode_kv_ready(req_id, num_tp_rank)
```

**Wait for Notifications Function:**
```python
# Line 366-370
async def wait_decode_kv_ready(req_id: str, num_tp_rank: int):
    while app.state.finished_reqs[req_id] < num_tp_rank:
        await asyncio.sleep(0.0001)  # Wait for num_tp_rank notifications
    app.state.finished_reqs.pop(req_id)
```

#### Prefiller Side (`pd_backend.py`)

**Each TP Rank Sends Notification:**
```python
# Line 379-380: Each TP rank uses corresponding port
receiver_init_port = transfer_spec.receiver_init_port[self.tp_rank]
receiver_alloc_port = transfer_spec.receiver_alloc_port[self.tp_rank]

# Line 430-434: Send notification when is_last_prefill=True
if transfer_spec.is_last_prefill:
    notif_msg = ProxyNotif(req_id=transfer_spec.req_id)
    notif_msg_bytes = msgspec.msgpack.encode(notif_msg)
    self.proxy_side_channel.send(notif_msg_bytes)
```

### 3. Root Cause

#### Original Bug Code Logic (Before Fix)

When user provides:
```bash
--decoder-init-port 7300,7350    # 2 ports
--decoder-alloc-port 7400,7450   # 2 ports
--num-decoders 2
```

**Original code would:**
```python
# Not in incremental_mode (because 2 ports provided)
for i, (host, port) in enumerate(decoder_pairs):
    # decoder 0: init_ports = [7300, 7350]  ❌ Wrong!
    # decoder 1: init_ports = [7300, 7350]  ❌ Wrong! (same)
    init_ports = list(global_args.decoder_init_port)  # [7300, 7350]
    alloc_ports = list(global_args.decoder_alloc_port)  # [7400, 7450]
```

**Should be:**
```python
# decoder 0: init_ports = [7300, 7301]  ✅ TP=2
# decoder 1: init_ports = [7350, 7351]  ✅ TP=2
```

#### Problem Scenario Analysis

**Scenario 1: 1P1D TP=2 (Works Correctly) ✅**

```
Request → Proxy → Prefiller 1 → Decoder 1
                         ↓
                    Prefiller has TP=2
                    Sends 2 notifications
                         ↓
            Proxy waits for 2 notifications (num_tp_rank=2)
                    ✅ Receives 2 notifications
                         ↓
                    Continues decode
```

**Scenario 2: 1P2D TP=2 (Hangs) ❌**

```
Request 1 → Proxy → Prefiller 1 → Decoder 1 (selected)
                           ↓
                      Prefiller 1 has TP=2
                      Sends 2 notifications
                           ↓
              Proxy waits for notifications (num_tp_rank=?)
                      
Problem:
- If init_port incorrectly configured as [7300, 7350], num_tp_rank = 2
- But Decoder 1's actual ports are [7300, 7301]
- Prefiller 1 tries to connect to wrong ports, possibly:
  1. Connecting to wrong decoder (port 7350 belongs to Decoder 2)
  2. Or connection fails
  3. Causing notifications to not be sent correctly
- Proxy waits forever for enough notifications → HANG
```

**Scenario 3: 2P2D TP=2 (Hangs) ❌**

Similar issue, but:
- Multiple prefillers may be assigned to different decoders
- If port configuration is wrong, prefillers cannot connect correctly to corresponding decoders
- Leading to notification count mismatch

### 4. Why Does 1P1D Work Correctly?

In 1P1D scenario:
- Only 1 decoder, all prefillers connect to it
- Even if port configuration is wrong, with only one decoder, connection errors have less impact
- Or incremental_mode is used, ports auto-increment, avoiding the error

### 5. Fix Solution

The fixed code will:
1. **Detect Complete Port Lists**: If port count = `num_decoders * TP_ranks`, automatically split
   ```python
   # User provides: --decoder-init-port 7300,7301,7350,7351
   # Automatically splits to:
   # decoder 0: [7300, 7301]
   # decoder 1: [7350, 7351]
   ```

2. **Support Base Port Mode**: If only base ports provided, infer TP ranks from alloc ports

3. **Improved Error Messages**: When TP ranks cannot be determined, provide clear error messages

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
