### PR TITLE
Fix double ref_count_down in redis sentinel connector put

### DIFF
--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -379,8 +379,6 @@ class RedisSentinelConnector(RemoteConnector):
         self.master.set(key_str + "kv_bytes", kv_bytes)
         self.master.set(key_str + "metadata", metadata_bytes)
 
-        memory_obj.ref_count_down()
-
     # TODO
     @no_type_check
     async def list(self) -> List[str]:


### PR DESCRIPTION
Remove redundant memory_obj.ref_count_down() call from RedisSentinelConnector.put() method. The InstrumentedRemoteConnector wrapper already handles reference counting  in its finally block, so the explicit call in RedisSentinelConnector was causing  double decrement.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
