### PR TITLE
auto store remote to local pool

### DIFF
--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -13,6 +13,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 import asyncio
 import functools
@@ -475,6 +476,26 @@ class StorageManager:
         for backend_name, storage_backend in self.get_active_storage_backends(location):
             memory_objs = storage_backend.batched_get_blocking(keys)
             if memory_objs:
+                # Align with single-key `get()` logic:
+                # auto-write remote data to local CPU cache
+                if (
+                    backend_name not in ["LocalCPUBackend", "PDBackend"]
+                    and "LocalCPUBackend" in self.storage_backends
+                    and None not in memory_objs
+                ):
+                    logger.debug(
+                        "Storing %s objects from %s to LocalCPUBackend",
+                        len(keys),
+                        backend_name,
+                    )
+                    local_cpu_backend = self.storage_backends["LocalCPUBackend"]
+                    assert isinstance(local_cpu_backend, LocalCPUBackend)
+                    # Type cast: Safe (we verified no Nones above)
+                    # `batched_submit_put_task` expects list[MemoryObj]
+                    # TODO (lisiG9): Refactor this write-back logic into caching
+                    #  policy module
+                    memory_objs_no_none = cast(List[MemoryObj], memory_objs)
+                    local_cpu_backend.batched_submit_put_task(keys, memory_objs_no_none)
                 return memory_objs
         return None
 


### PR DESCRIPTION
feat: auto-put remote cache to LocalCPUBackend

What this PR does / why we need it:
In the PD-separated with lmcache + Mooncake, data fetched by the D-side from remote sources (e.g., MoonCache) is not automatically stored in the local CPU pool (LocalCPUBackend). This causes repeated remote downloads of the same prefix data during multi-turn dialogues, leading to high latency.

Solution:
Only modify the batched_get function in storage_manager.py
Auto-write fetched data to the local CPU cache when retrieved from remote backends (non-LocalCPUBackend/PDBackend)
Avoid duplicate storage: Leverage existing local cache existence checks, no redundant logic added

Compatibility:
Tested and verified on NVIDIA GPU + Ascend NPU

If applicable:

- [ ] this PR contains user facing changes: No (no new configurations/interfaces added, only underlying logic optimization)
- [ ] this PR contains unit tests: No (manual validation completed; can supplement per project guidelines)