### PR TITLE
[refactor]use list to process shape and dtype

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -228,9 +228,10 @@ def extract_mm_features(
 
 def get_size_bytes(shapes: list[torch.Size], kv_dtypes: list[torch.dtype]):
     """
-    Calculate the size in bytes with the given shape and dtype.
+    Calculate the size in bytes with the given shapes and dtypes.
     """
-    size_in_bytes = 0
-    for shape, kv_dtype in zip(shapes, kv_dtypes, strict=False):
-        size_in_bytes += shape.numel() * kv_dtype.itemsize
-    return size_in_bytes
+    assert len(shapes) == len(kv_dtypes)
+    return sum(
+        shape.numel() * kv_dtype.itemsize
+        for shape, kv_dtype in zip(shapes, kv_dtypes, strict=False)
+    )

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -226,8 +226,11 @@ def extract_mm_features(
         return ([], [])
 
 
-def get_size_bytes(shape: torch.Size, kv_dtype: torch.dtype):
+def get_size_bytes(shapes: list[torch.Size], kv_dtypes: list[torch.dtype]):
     """
     Calculate the size in bytes with the given shape and dtype.
     """
-    return shape.numel() * kv_dtype.itemsize
+    size_in_bytes = 0
+    for shape, kv_dtype in zip(shapes, kv_dtypes, strict=False):
+        size_in_bytes += shape.numel() * kv_dtype.itemsize
+    return size_in_bytes

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1581,8 +1581,8 @@ class LMCacheEngineBuilder:
 
             return PagedTensorMemoryAllocator(
                 buffer,
-                torch.Size(metadata.kv_shape),
-                metadata.kv_dtype,
+                [torch.Size(metadata.kv_shape)],
+                [metadata.kv_dtype],
                 MemoryFormat.KV_2LTD,
             )
 

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -66,8 +66,8 @@ def create_test_memory_obj_for_storage_manager(
     kv_2ltd_shape = torch.Size([kv_dim, num_layers, num_tokens, hidden_dim])
 
     memory_obj = storage_manager.allocate(
-        shape=kv_2ltd_shape,
-        dtype=metadata.kv_dtype,
+        kv_2ltd_shape,
+        metadata.kv_dtype,
         fmt=MemoryFormat.KV_2LTD,
         eviction=True,
         busy_loop=False,

--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -393,12 +393,12 @@ class LazyMixedMemoryAllocator(MixedMemoryAllocator):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
-        result = super().allocate(shape, dtype, fmt, allocator_type)
+        result = super().allocate(shapes, dtypes, fmt, allocator_type)
         if result and fmt != MemoryFormat.BINARY_BUFFER:
             self._check_and_trigger_expansion()
         return result
@@ -406,13 +406,15 @@ class LazyMixedMemoryAllocator(MixedMemoryAllocator):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
-        result = super().batched_allocate(shape, dtype, batch_size, fmt, allocator_type)
+        result = super().batched_allocate(
+            shapes, dtypes, batch_size, fmt, allocator_type
+        )
         if result and fmt != MemoryFormat.BINARY_BUFFER:
             self._check_and_trigger_expansion()
         return result

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -751,10 +751,10 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def _Compute_raw_size(shapes: list[torch.Size], dtypes: list[torch.dtype]) -> int:
         assert len(shapes) == len(dtypes)
-        raw_size = 0
-        for shape, dtype in zip(shapes, dtypes, strict=False):
-            raw_size += shape.numel() * dtype.itemsize
-        return raw_size
+        return sum(
+            shape.numel() * dtype.itemsize
+            for shape, dtype in zip(shapes, dtypes, strict=False)
+        )
 
     @staticmethod
     @_lmcache_nvtx_annotate

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -725,6 +725,27 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
         """
         return True
 
+    # TODO(chunxiaozheng): remove if after all params replaced by shapes/dtypes
+    def _adapt_shapes_and_dtypes(
+        self,
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+    ) -> Tuple[list[torch.Size], list[torch.dtype]]:
+        if isinstance(shapes, torch.Size):
+            shapes = [shapes]
+        elif isinstance(shapes, tuple):
+            shapes = [torch.Size(shapes)]
+
+        if isinstance(dtypes, torch.dtype):
+            dtypes = [dtypes]
+
+        assert len(shapes) == len(dtypes), (
+            f"shapes and dtypes must have the same length, "
+            f"got {len(shapes)} and {len(dtypes)}, "
+            f"shapes: {shapes}, dtypes: {dtypes}"
+        )
+        return shapes, dtypes
+
 
 class TensorMemoryAllocator(MemoryAllocatorInterface):
     """
@@ -816,13 +837,7 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[TensorMemoryObj]:
-        if isinstance(shapes, torch.Size):
-            shapes = [shapes]
-        elif isinstance(shapes, tuple):
-            shapes = [torch.Size(shapes)]
-        if isinstance(dtypes, torch.dtype):
-            dtypes = [dtypes]
-        assert len(shapes) == len(dtypes)
+        shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
 
         # Calculate the size of the tensor
         raw_size = TensorMemoryAllocator._Compute_raw_size(shapes, dtypes)
@@ -896,13 +911,7 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         """
         Batched allocate tensor memory objs with equal sizes.
         """
-        if isinstance(shapes, torch.Size):
-            shapes = [shapes]
-        elif isinstance(shapes, tuple):
-            shapes = [torch.Size(shapes)]
-        if isinstance(dtypes, torch.dtype):
-            dtypes = [dtypes]
-        assert len(shapes) == len(dtypes)
+        shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
 
         # Calculate the size of the tensor
         unit_raw_size = TensorMemoryAllocator._Compute_raw_size(shapes, dtypes)
@@ -1180,13 +1189,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[TensorMemoryObj]:
-        if isinstance(shapes, torch.Size):
-            shapes = [shapes]
-        elif isinstance(shapes, tuple):
-            shapes = [torch.Size(shapes)]
-        if isinstance(dtypes, torch.dtype):
-            dtypes = [dtypes]
-        assert len(shapes) == len(dtypes)
+        shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
 
         try:
             free_block = self.free_blocks.popleft()
@@ -1234,13 +1237,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         """
         Batched allocate tensor memory objs with pre-defined equal sizes.
         """
-        if isinstance(shapes, torch.Size):
-            shapes = [shapes]
-        elif isinstance(shapes, tuple):
-            shapes = [torch.Size(shapes)]
-        if isinstance(dtypes, torch.dtype):
-            dtypes = [dtypes]
-        assert len(shapes) == len(dtypes)
+        shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
 
         allocated_blocks: list[TensorMemoryObj] = []
         for i in range(batch_size):

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -209,6 +209,20 @@ class MemoryObj(metaclass=abc.ABCMeta):
         return None
 
     @abc.abstractmethod
+    def get_shapes(self) -> list[torch.Size]:
+        """
+        Get the shapes of the MemoryObj.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_dtypes(self) -> list[torch.dtype]:
+        """
+        Get the dtypes of the MemoryObj.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def get_memory_format(self) -> MemoryFormat:
         """
         Get the memory format of the MemoryObj.
@@ -410,6 +424,14 @@ class TensorMemoryObj(MemoryObj):
     def get_dtype(self) -> torch.dtype:
         return self.meta.dtype
 
+    def get_shapes(self) -> list[torch.Size]:
+        assert self.meta.shapes is not None
+        return self.meta.shapes
+
+    def get_dtypes(self) -> list[torch.dtype]:
+        assert self.meta.dtypes is not None
+        return self.meta.dtypes
+
     def get_memory_format(self) -> MemoryFormat:
         with self.lock:
             return self.meta.fmt
@@ -562,6 +584,12 @@ class BytesBufferMemoryObj(MemoryObj):
 
     def get_dtype(self) -> Optional[torch.dtype]:
         return None
+
+    def get_shapes(self) -> list[torch.Size]:
+        return [self.get_shape()]
+
+    def get_dtypes(self) -> list[torch.dtype]:
+        return []
 
     def get_memory_format(self) -> MemoryFormat:
         return self.metadata.fmt

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -112,23 +112,37 @@ class MemoryObjMetadata:
     # Positions when the cache is stored
     cached_positions: Optional[torch.Tensor] = None
 
+    # shapes and dtypes should be used in the future
+    shapes: Optional[list[torch.Size]] = None
+    dtypes: Optional[list[torch.dtype]] = None
+
     def to_dict(self):
         # Note(Kuntai): this is used for serializing MemoryObjMetadata via
         # msgpack.
         return {
             "__type__": "MemoryObjMetadata",
             "shape": list(self.shape),  # torch.Size -> list
-            "dtype": str(self.dtype) if self.dtype is not None else None,
+            "dtype": str(self.dtype) if self.dtype else None,
             "address": self.address,
             "phy_size": self.phy_size,
             "ref_count": self.ref_count,
             "fmt": self.fmt.value,
+            "shapes": [list(shape) for shape in self.shapes] if self.shapes else None,
+            "dtypes": [str(dtype) for dtype in self.dtypes] if self.dtypes else None,
         }
 
     @staticmethod
     def from_dict(d):
         dtype_str = d["dtype"]
         dtype = getattr(torch, dtype_str.replace("torch.", "")) if dtype_str else None
+        shapes_list = d["shapes"]
+        shapes = [torch.Size(s) for s in shapes_list] if shapes_list else None
+        dtypes_list = d["dtypes"]
+        dtypes = (
+            [getattr(torch, d_str.replace("torch.", "")) for d_str in dtypes_list]
+            if dtypes_list
+            else None
+        )
         return MemoryObjMetadata(
             shape=torch.Size(d["shape"]),
             dtype=dtype,
@@ -136,6 +150,8 @@ class MemoryObjMetadata:
             phy_size=d["phy_size"],
             ref_count=d["ref_count"],
             fmt=MemoryFormat(d["fmt"]),
+            shapes=shapes,
+            dtypes=dtypes,
         )
 
     def get_size(self) -> int:
@@ -620,16 +636,16 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
         """
         Allocates the memory to hold a tensor of the given shape.
 
-        :param torch.Size shape: The shape of the tensor to allocate.
-        :param torch.dtype dtype: The dtype of the tensor to allocate.
+        :param torch.Size shapes: The shape of the tensor to allocate.
+        :param torch.dtype dtypes: The dtype of the tensor to allocate.
         :param MemoryFormat fmt: The format of the memory to allocate.
 
         :return: A MemoryObj wrapping the allocated memory. Returns
@@ -642,8 +658,8 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
@@ -651,12 +667,12 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
         """
         Batched allocate the memory to hold a tensor of the given shape.
 
-        :param torch.Size shape: The shape of the tensor to allocate.
-        :param torch.dtype dtype: The dtype of the tensor to allocate.
+        :param torch.Size shapes: The shape of the tensor to allocate.
+        :param torch.dtype dtypes: The dtype of the tensor to allocate.
         :param int batch_size: The number of tensors to allocate.
         :param MemoryFormat fmt: The format of the memory to allocate.
 
-        :return: A lisf of MemoryObjs wrapping the allocated memory.
+        :return: A list of MemoryObjs wrapping the allocated memory.
             Returns None if the allocation failed.
 
         :rtype: Optional[List[MemoryObj]]
@@ -733,8 +749,12 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
 
     @staticmethod
     @_lmcache_nvtx_annotate
-    def _Compute_raw_size(shape: torch.Size, dtype: torch.dtype) -> int:
-        return shape.numel() * dtype.itemsize
+    def _Compute_raw_size(shapes: list[torch.Size], dtypes: list[torch.dtype]) -> int:
+        assert len(shapes) == len(dtypes)
+        raw_size = 0
+        for shape, dtype in zip(shapes, dtypes, strict=False):
+            raw_size += shape.numel() * dtype.itemsize
+        return raw_size
 
     @staticmethod
     @_lmcache_nvtx_annotate
@@ -791,17 +811,21 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[TensorMemoryObj]:
-        if not isinstance(shape, torch.Size):
-            shape = torch.Size(shape)
+        if isinstance(shapes, torch.Size):
+            shapes = [shapes]
+        elif isinstance(shapes, tuple):
+            shapes = [torch.Size(shapes)]
+        if isinstance(dtypes, torch.dtype):
+            dtypes = [dtypes]
+        assert len(shapes) == len(dtypes)
 
-        assert dtype is not None, "dtype must be specified"
         # Calculate the size of the tensor
-        raw_size = TensorMemoryAllocator._Compute_raw_size(shape, dtype)
+        raw_size = TensorMemoryAllocator._Compute_raw_size(shapes, dtypes)
         if raw_size % self.align_bytes != 0:
             aligned_size = TensorMemoryAllocator._Compute_aligned_size(
                 raw_size, self.align_bytes
@@ -816,7 +840,7 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         else:
             logger.debug(
                 f"Failed to allocate memory for "
-                f"tensor({shape}, {dtype}) because "
+                f"tensor({shapes}, {dtypes}) because "
                 "no memory is available"
             )
             return None
@@ -843,7 +867,15 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         return TensorMemoryObj(
             raw_data=raw_data,
             metadata=MemoryObjMetadata(
-                shape, dtype, block.start, aligned_size, 1, 0, fmt
+                shapes[0],
+                dtypes[0],
+                block.start,
+                aligned_size,
+                1,
+                0,
+                fmt,
+                shapes=shapes,
+                dtypes=dtypes,
             ),
             parent_allocator=self,
         )
@@ -855,8 +887,8 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -864,13 +896,16 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         """
         Batched allocate tensor memory objs with equal sizes.
         """
-        if not isinstance(shape, torch.Size):
-            shape = torch.Size(shape)
-
-        assert dtype is not None, "dtype must be specified"
+        if isinstance(shapes, torch.Size):
+            shapes = [shapes]
+        elif isinstance(shapes, tuple):
+            shapes = [torch.Size(shapes)]
+        if isinstance(dtypes, torch.dtype):
+            dtypes = [dtypes]
+        assert len(shapes) == len(dtypes)
 
         # Calculate the size of the tensor
-        unit_raw_size = TensorMemoryAllocator._Compute_raw_size(shape, dtype)
+        unit_raw_size = TensorMemoryAllocator._Compute_raw_size(shapes, dtypes)
 
         if unit_raw_size % self.align_bytes != 0:
             unit_aligned_size = TensorMemoryAllocator._Compute_aligned_size(
@@ -888,7 +923,7 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         else:
             logger.debug(
                 f"Failed to batched allocate memory for "
-                f"{batch_size} tensor({shape}, {dtype}) because "
+                f"{batch_size} tensor({shapes}, {dtypes}) because "
                 "no memory is available"
             )
             return None
@@ -922,7 +957,15 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
                 TensorMemoryObj(
                     raw_data=raw_data,
                     metadata=MemoryObjMetadata(
-                        shape, dtype, temp_start, unit_aligned_size, 1, 0, fmt
+                        shapes[0],
+                        dtypes[0],
+                        temp_start,
+                        unit_aligned_size,
+                        1,
+                        0,
+                        fmt,
+                        shapes=shapes,
+                        dtypes=dtypes,
                     ),
                     parent_allocator=self,
                 )
@@ -1068,20 +1111,20 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     def __init__(
         self,
         tensor: torch.Tensor,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: list[torch.Size],
+        dtypes: list[torch.dtype],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
     ):
         self.buffer = tensor.view(torch.uint8).flatten()
         self.buffer_size = self.buffer.numel() * self.buffer.element_size()
         self.buffer_ptr = self.buffer.data_ptr()
 
-        self.shape = shape
-        self.dtype = dtype
+        self.shapes = shapes
+        self.dtypes = dtypes
         self.fmt = fmt
 
         # full chunk size bytes
-        self.align_bytes = get_size_bytes(shape, dtype)
+        self.align_bytes = get_size_bytes(shapes, dtypes)
 
         assert self.buffer_size % self.align_bytes == 0, (
             f"Buffer size {self.buffer_size} must be a"
@@ -1101,13 +1144,15 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
             # NOTE: the last unfull chunk's shape needs to be
             # adjusted during allocation.
             metadata = MemoryObjMetadata(
-                self.shape,
-                self.dtype,
+                self.shapes[0],
+                self.dtypes[0],
                 idx,
                 self.align_bytes,  # 1 page
                 1,  # ref_count=1
                 0,  # pin_count=0
                 self.fmt,
+                shapes=self.shapes,
+                dtypes=self.dtypes,
             )
             mem_obj = TensorMemoryObj(
                 raw_data=buf,
@@ -1130,33 +1175,39 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[TensorMemoryObj]:
-        if not isinstance(shape, torch.Size):
-            shape = torch.Size(shape)
-
-        assert dtype is not None, "dtype must be specified"
+        if isinstance(shapes, torch.Size):
+            shapes = [shapes]
+        elif isinstance(shapes, tuple):
+            shapes = [torch.Size(shapes)]
+        if isinstance(dtypes, torch.dtype):
+            dtypes = [dtypes]
+        assert len(shapes) == len(dtypes)
 
         try:
             free_block = self.free_blocks.popleft()
         except IndexError:
             logger.debug(
                 f"Failed to allocate memory for "
-                f"tensor({shape}, {dtype}) because "
+                f"tensor({shapes}, {dtypes}) because "
                 "no free blocks is available"
             )
             return None
 
         # TODO (Jiayi): This is a bit redundant.
-        free_block.meta.shape = shape
+        free_block.meta.shape = shapes[0]
+        free_block.meta.dtype = dtypes[0]
+        free_block.meta.shapes = shapes
+        free_block.meta.dtypes = dtypes
         free_block.meta.fmt = fmt
         free_block.meta.ref_count = 1
 
-        if shape != self.shape:
-            size_in_bytes = get_size_bytes(shape, dtype)
+        if shapes != self.shapes:
+            size_in_bytes = get_size_bytes(shapes, dtypes)
             free_block.raw_data = free_block.raw_data[:size_in_bytes]
 
         # TODO (Jiayi): need a flag to drop these debug ops
@@ -1174,8 +1225,8 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1183,10 +1234,13 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         """
         Batched allocate tensor memory objs with pre-defined equal sizes.
         """
-        if not isinstance(shape, torch.Size):
-            shape = torch.Size(shape)
-
-        assert dtype is not None, "dtype must be specified"
+        if isinstance(shapes, torch.Size):
+            shapes = [shapes]
+        elif isinstance(shapes, tuple):
+            shapes = [torch.Size(shapes)]
+        if isinstance(dtypes, torch.dtype):
+            dtypes = [dtypes]
+        assert len(shapes) == len(dtypes)
 
         allocated_blocks: list[TensorMemoryObj] = []
         for i in range(batch_size):
@@ -1195,7 +1249,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
             except IndexError:
                 logger.debug(
                     f"Failed to allocate memory for "
-                    f"tensor({shape}, {dtype}) because "
+                    f"tensor({shapes}, {dtypes}) because "
                     "no free blocks is available"
                 )
                 self.batched_free(allocated_blocks, update_stats=False)
@@ -1203,12 +1257,15 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
 
             # FIXME: think about whether pareant_allocator
             # should be updated here.
-            free_block.meta.shape = shape
+            free_block.meta.shape = shapes[0]
+            free_block.meta.dtype = dtypes[0]
+            free_block.meta.shapes = shapes
+            free_block.meta.dtypes = dtypes
             free_block.meta.fmt = fmt
             free_block.meta.ref_count = 1
 
-            if shape != self.shape:
-                size_in_bytes = get_size_bytes(shape, dtype)
+            if shapes != self.shapes:
+                size_in_bytes = get_size_bytes(shapes, dtypes)
                 free_block.raw_data = free_block.raw_data[:size_in_bytes]
 
             allocated_blocks.append(free_block)
@@ -1229,7 +1286,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     def free(self, memory_obj: TensorMemoryObj, allocator_type: Optional[str] = None):
         if not memory_obj.is_valid():
             return
-        if memory_obj.meta.shape != self.shape:
+        if memory_obj.meta.shapes != self.shapes:
             page_idx = memory_obj.meta.address
             memory_obj.raw_data = self.paged_buffers[page_idx]
 
@@ -1264,7 +1321,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
                 logger.warning("Trying to free an invalidated MemoryObj")
                 continue
             # memory_obj.invalidate()
-            if memory_obj.meta.shape != self.shape:
+            if memory_obj.meta.shapes != self.shapes:
                 page_idx = memory_obj.meta.address
                 memory_obj.raw_data = self.paged_buffers[page_idx]
 
@@ -1326,25 +1383,31 @@ class BufferAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.BINARY_BUFFER,
         allocator_type: Optional[str] = None,
     ) -> BytesBufferMemoryObj:
-        n = shape[0]
+        if isinstance(shapes, list):
+            n = shapes[0][0]
+        else:
+            n = shapes[0]
         byte_array = bytearray(n)
         return BytesBufferMemoryObj(byte_array)
 
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.BINARY_BUFFER,
         allocator_type: Optional[str] = None,
     ) -> List[BytesBufferMemoryObj]:
-        n = shape[0]
+        if isinstance(shapes, list):
+            n = shapes[0][0]
+        else:
+            n = shapes[0]
         # TODO(Jiayi): Optimize the following loop.
         byte_arrays = [bytearray(n) for _ in range(batch_size)]
         return [BytesBufferMemoryObj(byte_array) for byte_array in byte_arrays]
@@ -1378,17 +1441,17 @@ class HostMemoryAllocator(MemoryAllocatorInterface):
 
         self.allocator: MemoryAllocatorInterface
         if use_paging:
-            assert "shape" in kwargs, (
-                "shape must be specified for paged memory allocator"
+            assert "shapes" in kwargs, (
+                "shapes must be specified for paged memory allocator"
             )
-            assert "dtype" in kwargs, (
-                "dtype must be specified for paged memory allocator"
+            assert "dtypes" in kwargs, (
+                "dtypes must be specified for paged memory allocator"
             )
             assert "fmt" in kwargs, "fmt must be specified for paged memory allocator"
             self.allocator = PagedTensorMemoryAllocator(
                 tensor=buffer,
-                shape=kwargs["shape"],
-                dtype=kwargs["dtype"],
+                shapes=kwargs["shapes"],
+                dtypes=kwargs["dtypes"],
                 fmt=kwargs["fmt"],
             )
         else:
@@ -1399,26 +1462,26 @@ class HostMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
         with self.host_mem_lock:
-            return self.allocator.allocate(shape, dtype, fmt, str(self))
+            return self.allocator.allocate(shapes, dtypes, fmt, str(self))
 
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
         with self.host_mem_lock:
             return self.allocator.batched_allocate(
-                shape, dtype, batch_size, fmt, str(self)
+                shapes, dtypes, batch_size, fmt, str(self)
             )
 
     @_lmcache_nvtx_annotate
@@ -1463,17 +1526,17 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
 
         self.allocator: MemoryAllocatorInterface
         if use_paging:
-            assert "shape" in kwargs, (
-                "shape must be specified for paged memory allocator"
+            assert "shapes" in kwargs, (
+                "shapes must be specified for paged memory allocator"
             )
-            assert "dtype" in kwargs, (
-                "dtype must be specified for paged memory allocator"
+            assert "dtypes" in kwargs, (
+                "dtypes must be specified for paged memory allocator"
             )
             assert "fmt" in kwargs, "fmt must be specified for paged memory allocator"
             self.allocator = PagedTensorMemoryAllocator(
                 tensor=self.buffer,
-                shape=kwargs["shape"],
-                dtype=kwargs["dtype"],
+                shapes=kwargs["shapes"],
+                dtypes=kwargs["dtypes"],
                 fmt=kwargs["fmt"],
             )
         else:
@@ -1484,26 +1547,26 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
         with self.host_mem_lock:
-            return self.allocator.allocate(shape, dtype, fmt, str(self))
+            return self.allocator.allocate(shapes, dtypes, fmt, str(self))
 
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
         with self.host_mem_lock:
             return self.allocator.batched_allocate(
-                shape, dtype, batch_size, fmt, str(self)
+                shapes, dtypes, batch_size, fmt, str(self)
             )
 
     @_lmcache_nvtx_annotate
@@ -1559,17 +1622,17 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
 
         self.pin_allocator: MemoryAllocatorInterface
         if use_paging:
-            assert "shape" in kwargs, (
-                "shape must be specified for paged memory allocator"
+            assert "shapes" in kwargs, (
+                "shapes must be specified for paged memory allocator"
             )
-            assert "dtype" in kwargs, (
-                "dtype must be specified for paged memory allocator"
+            assert "dtypes" in kwargs, (
+                "dtypes must be specified for paged memory allocator"
             )
             assert "fmt" in kwargs, "fmt must be specified for paged memory allocator"
             self.pin_allocator = PagedTensorMemoryAllocator(
                 tensor=self.buffer,
-                shape=kwargs["shape"],
-                dtype=kwargs["dtype"],
+                shapes=kwargs["shapes"],
+                dtypes=kwargs["dtypes"],
                 fmt=kwargs["fmt"],
             )
         else:
@@ -1584,13 +1647,13 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
         if fmt == MemoryFormat.BINARY_BUFFER:
-            return self.buffer_allocator.allocate(shape, dtype, fmt)
+            return self.buffer_allocator.allocate(shapes, dtypes, fmt)
         elif fmt in [
             MemoryFormat.KV_2LTD,
             MemoryFormat.KV_2TD,
@@ -1598,21 +1661,23 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
             MemoryFormat.KV_MLA_FMT,
         ]:
             with self.host_mem_lock:
-                return self.pin_allocator.allocate(shape, dtype, fmt, str(self))
+                return self.pin_allocator.allocate(shapes, dtypes, fmt, str(self))
         else:
             raise ValueError(f"Unsupported memory format: {fmt}")
 
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
         if fmt == MemoryFormat.BINARY_BUFFER:
-            return self.buffer_allocator.batched_allocate(shape, dtype, batch_size, fmt)
+            return self.buffer_allocator.batched_allocate(
+                shapes, dtypes, batch_size, fmt
+            )
         elif fmt in [
             MemoryFormat.KV_2LTD,
             MemoryFormat.KV_2TD,
@@ -1621,7 +1686,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
         ]:
             with self.host_mem_lock:
                 return self.pin_allocator.batched_allocate(
-                    shape, dtype, batch_size, fmt, str(self)
+                    shapes, dtypes, batch_size, fmt, str(self)
                 )
         else:
             raise ValueError(f"Unsupported memory format: {fmt}")
@@ -1706,17 +1771,17 @@ class GPUMemoryAllocator(MemoryAllocatorInterface):
 
         self.allocator: MemoryAllocatorInterface
         if use_paging:
-            assert "shape" in kwargs, (
-                "shape must be specified for paged memory allocator"
+            assert "shapes" in kwargs, (
+                "shapes must be specified for paged memory allocator"
             )
-            assert "dtype" in kwargs, (
-                "dtype must be specified for paged memory allocator"
+            assert "dtypes" in kwargs, (
+                "dtypes must be specified for paged memory allocator"
             )
             assert "fmt" in kwargs, "fmt must be specified for paged memory allocator"
             self.allocator = PagedTensorMemoryAllocator(
                 tensor=self.tensor,
-                shape=kwargs["shape"],
-                dtype=kwargs["dtype"],
+                shapes=kwargs["shapes"],
+                dtypes=kwargs["dtypes"],
                 fmt=kwargs["fmt"],
             )
         else:
@@ -1730,26 +1795,26 @@ class GPUMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
         with self.device_mem_lock:
-            return self.allocator.allocate(shape, dtype, fmt, str(self))
+            return self.allocator.allocate(shapes, dtypes, fmt, str(self))
 
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
         with self.device_mem_lock:
             return self.allocator.batched_allocate(
-                shape, dtype, batch_size, fmt, str(self)
+                shapes, dtypes, batch_size, fmt, str(self)
             )
 
     def free(self, memory_obj: MemoryObj, allocator_type: Optional[str] = None):
@@ -1791,18 +1856,25 @@ class AdHocMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
         """
         Returns a dummy MemoryObj for testing purposes.
         """
-        if not isinstance(shape, torch.Size):
-            shape = torch.Size(shape)
+        if isinstance(shapes, torch.Size):
+            shape = shapes
+        elif isinstance(shapes, tuple):
+            shape = torch.Size(shapes)
+        else:
+            shape = shapes[0]
 
-        assert dtype is not None, "dtype must be specified"
+        if isinstance(dtypes, list):
+            dtype = dtypes[0]
+        else:
+            dtype = dtypes
 
         # Return a dummy object with no actual memory allocation
         return TensorMemoryObj(
@@ -1822,8 +1894,8 @@ class AdHocMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1898,8 +1970,8 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
     def init_gpu_memory_allocator(
         self,
         size: int,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: list[torch.Size],
+        dtypes: list[torch.dtype],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         device: str = "cuda",
     ):
@@ -1910,54 +1982,54 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
         )
         self.gpu_allocator = PagedTensorMemoryAllocator(
             self.gpu_buffer,
-            shape,
-            dtype,
+            shapes,
+            dtypes,
             fmt,
         )
 
     def init_cpu_memory_allocator(
         self,
         size: int,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: list[torch.Size],
+        dtypes: list[torch.dtype],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         numa_mapping: Optional[NUMAMapping] = None,
     ):
         self.cpu_buffer = _allocate_cpu_memory(size, numa_mapping)
         self.cpu_allocator = PagedTensorMemoryAllocator(
             self.cpu_buffer,
-            shape,
-            dtype,
+            shapes,
+            dtypes,
             fmt,
         )
         self.align_bytes = self.cpu_allocator.align_bytes
 
     def allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = "cpu",
     ) -> Optional[MemoryObj]:
         if allocator_type == "gpu":
-            return self.gpu_allocator.allocate(shape, dtype, fmt)
+            return self.gpu_allocator.allocate(shapes, dtypes, fmt)
         elif allocator_type == "cpu":
-            return self.cpu_allocator.allocate(shape, dtype, fmt)
+            return self.cpu_allocator.allocate(shapes, dtypes, fmt)
         else:
             raise ValueError(f"Unsupported allocator type: {allocator_type}")
 
     def batched_allocate(
         self,
-        shape: Union[torch.Size, Tuple[int, ...]],
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = "gpu",
     ) -> Optional[List[MemoryObj]]:
         if allocator_type == "gpu":
-            return self.gpu_allocator.batched_allocate(shape, dtype, batch_size, fmt)
+            return self.gpu_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
         elif allocator_type == "cpu":
-            return self.cpu_allocator.batched_allocate(shape, dtype, batch_size, fmt)
+            return self.cpu_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
         else:
             raise ValueError(f"Unsupported allocator type: {allocator_type}")
 

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -313,8 +313,8 @@ class AllocatorBackendInterface(StorageBackendInterface):
     @abc.abstractmethod
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
         busy_loop: bool = True,
@@ -322,8 +322,10 @@ class AllocatorBackendInterface(StorageBackendInterface):
         """
         Allocates memory in the backend to hold a tensor of the given shape.
 
-        :param torch.Size shape: The shape of the tensor to allocate.
-        :param torch.dtype dtype: The dtype of the tensor to allocate.
+        :param Union[torch.Size, list[torch.Size]] shapes:
+            The shape of the tensor to allocate.
+        :param Union[torch.dtype, list[torch.dtype]] dtypes:
+            The dtype of the tensor to allocate.
         :param MemoryFormat fmt: The format of the memory to allocate.
         :param bool eviction: whether to enable eviction when allocating.
         :param bool busy_loop: whether to enable a busy loop to wait
@@ -340,8 +342,8 @@ class AllocatorBackendInterface(StorageBackendInterface):
     @abc.abstractmethod
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
@@ -352,8 +354,10 @@ class AllocatorBackendInterface(StorageBackendInterface):
         in a batched manner. The allocated memory objects will have the same
         shape, dtype, and format.
 
-        :param torch.Size shape: The shape of the tensor to allocate.
-        :param torch.dtype dtype: The dtype of the tensor to allocate.
+        :param Union[torch.Size, list[torch.Size]] shapes:
+            The shape of the tensor to allocate.
+        :param Union[torch.dtype, list[torch.dtype]] dtypes:
+            The dtype of the tensor to allocate.
         :param int batch_size: The number of memory objects to allocate.
         :param MemoryFormat fmt: The format of the memory to allocate.
         :param bool eviction: whether to enable eviction when allocating.

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -69,7 +69,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         self.meta_fmt = (
             MemoryFormat.KV_MLA_FMT if metadata.use_mla else MemoryFormat.KV_2LTD
         )
-        self.full_chunk_size = get_size_bytes(self.meta_shape, self.meta_dtype)
+        self.full_chunk_size = get_size_bytes([self.meta_shape], [self.meta_dtype])
         assert self.full_chunk_size is not None
         assert self.full_chunk_size % metadata.kv_shape[2] == 0
         self.single_token_size = self.full_chunk_size // metadata.kv_shape[2]

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -729,8 +729,8 @@ class GdsBackend(AllocatorBackendInterface):
 
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
         busy_loop: bool = True,
@@ -740,12 +740,12 @@ class GdsBackend(AllocatorBackendInterface):
         if eviction:
             logger.warning("GDS Backend does not support eviction")
 
-        return self.memory_allocator.allocate(shape, dtype, fmt)
+        return self.memory_allocator.allocate(shapes, dtypes, fmt)
 
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
@@ -756,7 +756,7 @@ class GdsBackend(AllocatorBackendInterface):
         if eviction:
             logger.warning("GDS Backend does not support eviction")
 
-        return self.memory_allocator.batched_allocate(shape, dtype, batch_size, fmt)
+        return self.memory_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
 
     def get_allocator_backend(self):
         return self

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from concurrent.futures import Future
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union
 import threading
 import time
 
@@ -367,7 +367,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 ]
             )
             paged_mem_allocator = PagedCpuGpuMemoryAllocator()
-            chunk_size_bytes = get_size_bytes(new_shape, metadata.kv_dtype)
+            chunk_size_bytes = get_size_bytes([new_shape], [metadata.kv_dtype])
             origin_cpu_size_bytes = int(cpu_size * 1024**3)
             align_cpu_size_bytes = (
                 origin_cpu_size_bytes // chunk_size_bytes * chunk_size_bytes
@@ -378,8 +378,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
             )
             paged_mem_allocator.init_cpu_memory_allocator(
                 align_cpu_size_bytes,
-                shape=new_shape,
-                dtype=metadata.kv_dtype,
+                shapes=[new_shape],
+                dtypes=[metadata.kv_dtype],
                 fmt=MemoryFormat.KV_2LTD,  # TODO: remove this hardcode
                 numa_mapping=numa_mapping,
             )
@@ -425,8 +425,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: Optional[MemoryFormat] = None,
         eviction: bool = True,
         busy_loop: bool = True,
@@ -461,7 +461,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
             else:
                 fmt = MemoryFormat.KV_2LTD
 
-        memory_obj = self.memory_allocator.allocate(shape, dtype, fmt)
+        memory_obj = self.memory_allocator.allocate(shapes, dtypes, fmt)
         if memory_obj is not None or not eviction:
             return memory_obj
 
@@ -512,7 +512,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 # do not hold the lock during sleep
                 time.sleep(time_to_wait)
 
-            memory_obj = self.memory_allocator.allocate(shape, dtype, fmt)
+            memory_obj = self.memory_allocator.allocate(shapes, dtypes, fmt)
             if memory_obj is not None:
                 break
 
@@ -528,8 +528,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: Optional[MemoryFormat] = None,
         eviction: bool = True,
@@ -567,7 +567,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 fmt = MemoryFormat.KV_2LTD
 
         memory_objs = self.memory_allocator.batched_allocate(
-            shape, dtype, batch_size, fmt
+            shapes, dtypes, batch_size, fmt
         )
 
         if memory_objs is not None or not eviction:
@@ -637,7 +637,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 time.sleep(time_to_wait)
 
             memory_objs = self.memory_allocator.batched_allocate(
-                shape, dtype, batch_size, fmt
+                shapes, dtypes, batch_size, fmt
             )
             if memory_objs:
                 break

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -16,7 +16,7 @@
 # Standard
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, List, Optional, Sequence, Set, cast
+from typing import Any, List, Optional, Sequence, Set, Union, cast
 import asyncio
 import os
 import threading
@@ -629,8 +629,8 @@ class NixlStorageBackend(AllocatorBackendInterface):
 
         return PagedTensorMemoryAllocator(
             self.buffer,
-            torch.Size(metadata.kv_shape),
-            metadata.kv_dtype,
+            [torch.Size(metadata.kv_shape)],
+            [metadata.kv_dtype],
             MemoryFormat.KV_2LTD,
         )
 
@@ -639,8 +639,8 @@ class NixlStorageBackend(AllocatorBackendInterface):
 
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
         busy_loop: bool = True,
@@ -648,12 +648,12 @@ class NixlStorageBackend(AllocatorBackendInterface):
         if busy_loop:
             logger.warning("NixlStorageBackend does not support busy loop for now")
 
-        return self.memory_allocator.allocate(shape, dtype, fmt)
+        return self.memory_allocator.allocate(shapes, dtypes, fmt)
 
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
@@ -662,7 +662,7 @@ class NixlStorageBackend(AllocatorBackendInterface):
         if busy_loop:
             logger.warning("NixlStorageBackend does not support busy loop for now")
 
-        return self.memory_allocator.batched_allocate(shape, dtype, batch_size, fmt)
+        return self.memory_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
 
     def get_allocator_backend(self):
         return self

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -209,7 +209,7 @@ class P2PBackend(StorageBackendInterface):
         assert isinstance(self.memory_allocator, PagedCpuGpuMemoryAllocator)
 
         self.dtype = metadata.kv_dtype
-        self.full_size_shape = list(self.memory_allocator.cpu_allocator.shape)
+        self.full_size_shape = list(self.memory_allocator.cpu_allocator.shapes[0])
         self.fmt: MemoryFormat = (
             MemoryFormat.KV_MLA_FMT if metadata.use_mla else MemoryFormat.KV_2LTD
         )

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -223,8 +223,8 @@ class PDBackend(AllocatorBackendInterface):
         paged_mem_allocator = PagedCpuGpuMemoryAllocator()
         paged_mem_allocator.init_gpu_memory_allocator(
             config.pd_buffer_size,
-            torch.Size(metadata.kv_shape),
-            metadata.kv_dtype,
+            [torch.Size(metadata.kv_shape)],
+            [metadata.kv_dtype],
             MemoryFormat.KV_2LTD,  # TODO: remove this hardcode
             corrected_device,
         )
@@ -239,8 +239,8 @@ class PDBackend(AllocatorBackendInterface):
 
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
         busy_loop: bool = True,
@@ -249,15 +249,15 @@ class PDBackend(AllocatorBackendInterface):
             fmt = MemoryFormat.KV_2LTD
         # NOTE: no eviction and busy_loop in PD
         return self.memory_allocator.allocate(
-            shape=shape, dtype=dtype, fmt=fmt, allocator_type="gpu"
+            shapes, dtypes, fmt=fmt, allocator_type="gpu"
         )
 
     # TODO(Jiayi): Please implement batched allocate to reduce memory
     # allocation overhead.
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: Optional[torch.dtype],
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
@@ -266,7 +266,7 @@ class PDBackend(AllocatorBackendInterface):
         if fmt is None:
             fmt = MemoryFormat.KV_2LTD
         return self.memory_allocator.batched_allocate(
-            shape, dtype, batch_size, fmt, allocator_type="gpu"
+            shapes, dtypes, batch_size, fmt, allocator_type="gpu"
         )
 
     # NOTE(Jiayi): If two requests have overlapped keys, will

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -86,8 +86,8 @@ def allocate_and_copy_objects(
         if allocator_backend.contains(key):
             continue
         memory_obj = allocator_backend.allocate(
-            shape=src_memory_obj.get_shape(),
-            dtype=src_memory_obj.get_dtype(),
+            src_memory_obj.get_shape(),
+            src_memory_obj.get_dtype(),
             fmt=src_memory_obj.meta.fmt,
             eviction=True,
             busy_loop=False,
@@ -313,8 +313,8 @@ class StorageManager:
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction=True,
         busy_loop=True,
@@ -327,14 +327,14 @@ class StorageManager:
         # disk in a similar way as CPU.
         assert self.allocator_backend is not None
         return self.allocator_backend.allocate(
-            shape, dtype, fmt, eviction=eviction, busy_loop=busy_loop
+            shapes, dtypes, fmt, eviction=eviction, busy_loop=busy_loop
         )
 
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction=True,
@@ -349,7 +349,7 @@ class StorageManager:
         if self.allocator_backend is None:
             raise RuntimeError("Allocator backend not available for scheduler role")
         return self.allocator_backend.batched_allocate(
-            shape, dtype, batch_size, fmt, eviction=eviction, busy_loop=busy_loop
+            shapes, dtypes, batch_size, fmt, eviction=eviction, busy_loop=busy_loop
         )
 
     def put(

--- a/lmcache/v1/storage_backend/weka_gds_backend.py
+++ b/lmcache/v1/storage_backend/weka_gds_backend.py
@@ -2,7 +2,7 @@
 # Standard
 from collections import OrderedDict
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple, Union
 import asyncio
 import ctypes
 import os
@@ -578,8 +578,8 @@ class WekaGdsBackend(AllocatorBackendInterface):
 
     def allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
         busy_loop: bool = True,
@@ -589,12 +589,12 @@ class WekaGdsBackend(AllocatorBackendInterface):
         if eviction:
             logger.warning("Weka Backend does not support eviction")
 
-        return self.memory_allocator.allocate(shape, dtype, fmt)
+        return self.memory_allocator.allocate(shapes, dtypes, fmt)
 
     def batched_allocate(
         self,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         eviction: bool = True,
@@ -605,7 +605,7 @@ class WekaGdsBackend(AllocatorBackendInterface):
         if eviction:
             logger.warning("Weka Backend does not support eviction")
 
-        return self.memory_allocator.batched_allocate(shape, dtype, batch_size, fmt)
+        return self.memory_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
 
     def close(self) -> None:
         self.memory_allocator.close()

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -36,8 +36,8 @@ def create_mock_memory_obj(backend: LocalCPUBackend, data: bytes) -> MemoryObj:
         tensor = torch.tensor([0], dtype=torch.uint8)
 
     memory_obj = backend.allocate(
-        shape=tensor.shape,
-        dtype=tensor.dtype,
+        shapes=[tensor.shape],
+        dtypes=[tensor.dtype],
         fmt=MemoryFormat.KV_2LTD,
     )
 

--- a/tests/v1/storage_backend/test_p2p_backend_with_controller.py
+++ b/tests/v1/storage_backend/test_p2p_backend_with_controller.py
@@ -263,8 +263,8 @@ def cpu_allocator():
     allocator = PagedCpuGpuMemoryAllocator()
     allocator.init_cpu_memory_allocator(
         size=1120 * 1024 * 1024,
-        shape=torch.Size([28, 2, 256, 8, 128]),
-        dtype=torch.bfloat16,
+        shapes=[torch.Size([28, 2, 256, 8, 128])],
+        dtypes=[torch.bfloat16],
         fmt=MemoryFormat.KV_2LTD,
     )
     try:
@@ -281,8 +281,8 @@ def local_cpu_backend():
         allocator = PagedCpuGpuMemoryAllocator()
         allocator.init_cpu_memory_allocator(
             size=1120 * 1024 * 1024,
-            shape=torch.Size([28, 2, 256, 8, 128]),
-            dtype=torch.bfloat16,
+            shapes=[torch.Size([28, 2, 256, 8, 128])],
+            dtypes=[torch.bfloat16],
             fmt=MemoryFormat.KV_2LTD,
         )
         return LocalCPUBackend(config=config, memory_allocator=allocator)

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -44,7 +44,7 @@ def test_lm_connector(url, autorelease_v1, lmserver_v1_process):
     assert not future.result()
 
     num_tokens = 1000
-    mem_obj_shape = [2, 32, num_tokens, 1024]
+    mem_obj_shape = (2, 32, num_tokens, 1024)
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -204,7 +204,7 @@ def test_redis_connector(url, autorelease_v1):
 
     # Test 2: Create and store test data
     num_tokens = 1000
-    mem_obj_shape = [2, 32, num_tokens, 1024]
+    mem_obj_shape = (2, 32, num_tokens, 1024)
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -271,7 +271,7 @@ def test_redis_sentinel_connector(url, autorelease_v1):
 
     # Test 2: Create and store test data
     num_tokens = 1000
-    mem_obj_shape = [2, 32, num_tokens, 1024]
+    mem_obj_shape = (2, 32, num_tokens, 1024)
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -333,7 +333,7 @@ def test_redis_cluster_connector(url, autorelease_v1):
 
     # Test 2: Create and store test data
     num_tokens = 1000
-    mem_obj_shape = [2, 32, num_tokens, 1024]
+    mem_obj_shape = (2, 32, num_tokens, 1024)
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -372,7 +372,7 @@ def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
 
     random_key = dumb_cache_engine_key()
     # build a small mem obj to get correct metadata bytes
-    memory_obj = memory_allocator.allocate([2, 32, 8, 64], torch.bfloat16)
+    memory_obj = memory_allocator.allocate((2, 32, 8, 64), torch.bfloat16)
     kv_bytes = memory_obj.byte_array
     meta = RemoteMetadata(
         len(kv_bytes),

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -44,7 +44,7 @@ def test_lm_connector(url, autorelease_v1, lmserver_v1_process):
     assert not future.result()
 
     num_tokens = 1000
-    mem_obj_shape = (2, 32, num_tokens, 1024)
+    mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -121,11 +121,13 @@ def test_fs_connector(autorelease_v1, full_chunk, save_chunk_meta, use_mla):
         # Test 2: Create and store test data
         # The size of the full chunk is 256.
         # If test unfull chunk, use 100 (<256) to allocate memory_obj.
-        memory_obj_shape = (
-            kv_shape[1],
-            kv_shape[0],
-            kv_shape[2] if full_chunk else 100,
-            kv_shape[3] * kv_shape[4],
+        memory_obj_shape = torch.Size(
+            [
+                kv_shape[1],
+                kv_shape[0],
+                kv_shape[2] if full_chunk else 100,
+                kv_shape[3] * kv_shape[4],
+            ]
         )
         memory_obj = memory_allocator.allocate(memory_obj_shape, dtype)
         memory_obj.ref_count_up()
@@ -204,7 +206,7 @@ def test_redis_connector(url, autorelease_v1):
 
     # Test 2: Create and store test data
     num_tokens = 1000
-    mem_obj_shape = (2, 32, num_tokens, 1024)
+    mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -271,7 +273,7 @@ def test_redis_sentinel_connector(url, autorelease_v1):
 
     # Test 2: Create and store test data
     num_tokens = 1000
-    mem_obj_shape = (2, 32, num_tokens, 1024)
+    mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -333,7 +335,7 @@ def test_redis_cluster_connector(url, autorelease_v1):
 
     # Test 2: Create and store test data
     num_tokens = 1000
-    mem_obj_shape = (2, 32, num_tokens, 1024)
+    mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
     memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
@@ -372,7 +374,7 @@ def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
 
     random_key = dumb_cache_engine_key()
     # build a small mem obj to get correct metadata bytes
-    memory_obj = memory_allocator.allocate((2, 32, 8, 64), torch.bfloat16)
+    memory_obj = memory_allocator.allocate(torch.Size([2, 32, 8, 64]), torch.bfloat16)
     kv_bytes = memory_obj.byte_array
     meta = RemoteMetadata(
         len(kv_bytes),

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -52,17 +52,17 @@ def patch_pin_allocator():
         self.buffer = torch.empty(size, dtype=torch.uint8, pin_memory=True)
 
         if use_paging:
-            assert "shape" in kwargs, (
-                "shape must be specified for paged memory allocator"
+            assert "shapes" in kwargs, (
+                "shapes must be specified for paged memory allocator"
             )
-            assert "dtype" in kwargs, (
-                "dtype must be specified for paged memory allocator"
+            assert "dtypes" in kwargs, (
+                "dtypes must be specified for paged memory allocator"
             )
             assert "fmt" in kwargs, "fmt must be specified for paged memory allocator"
             self.allocator = PagedTensorMemoryAllocator(
                 tensor=self.buffer,
-                shape=kwargs["shape"],
-                dtype=kwargs["dtype"],
+                shapes=kwargs["shapes"],
+                dtypes=kwargs["dtypes"],
                 fmt=kwargs["fmt"],
             )
         else:

--- a/tests/v1/test_lazy_memory_allocator.py
+++ b/tests/v1/test_lazy_memory_allocator.py
@@ -122,7 +122,7 @@ class TestLazyMemoryAllocator:
         allocator = self._create_allocator()
         try:
             mem_obj = allocator.allocate(
-                torch.Size([1024]), None, MemoryFormat.BINARY_BUFFER
+                torch.Size([1024]), [], MemoryFormat.BINARY_BUFFER
             )
             assert mem_obj and mem_obj.get_memory_format() == MemoryFormat.BINARY_BUFFER
             mem_obj.ref_count_down()

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -94,7 +94,7 @@ def test_extract_and_load_back(num_tokens):
     kv_blob = _tuple_kv_to_blob(kv_tuple_list)
     kv_chunked = _slice_kv_at(0, kv_blob, chunk_size)
     for chunk_id, chunk in enumerate(kv_chunked):
-        mem_obj_shape = [2, 32, chunk.shape[2], num_heads * head_size]
+        mem_obj_shape = torch.Size([2, 32, chunk.shape[2], num_heads * head_size])
 
         memory_obj_old = mem_allocator.allocate(mem_obj_shape, dtype)
         chunk = chunk.contiguous()
@@ -118,7 +118,9 @@ def test_extract_and_load_back(num_tokens):
     start_event.record()
     slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
     for chunk_id, slot_mapping_temp in enumerate(slot_mapping_chunked):
-        mem_obj_shape = [2, 32, len(slot_mapping_temp), num_heads * head_size]
+        mem_obj_shape = torch.Size(
+            [2, 32, len(slot_mapping_temp), num_heads * head_size]
+        )
 
         memory_obj_new = mem_allocator.allocate(mem_obj_shape, dtype)
         for layer_id in range(32):
@@ -197,7 +199,9 @@ def test_multi_layer_kernel(num_tokens):
     start_event.record()
     slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
     for chunk_id, slot_mapping_temp in enumerate(slot_mapping_chunked):
-        mem_obj_shape = [2, 32, len(slot_mapping_temp), num_heads * head_size]
+        mem_obj_shape = torch.Size(
+            [2, 32, len(slot_mapping_temp), num_heads * head_size]
+        )
 
         memory_obj_old = mem_allocator.allocate(mem_obj_shape, dtype)
         for layer_id in range(32):
@@ -228,7 +232,9 @@ def test_multi_layer_kernel(num_tokens):
     start_event.record()
     slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
     for chunk_id, slot_mapping_temp in enumerate(slot_mapping_chunked):
-        mem_obj_shape = [2, 32, len(slot_mapping_temp), num_heads * head_size]
+        mem_obj_shape = torch.Size(
+            [2, 32, len(slot_mapping_temp), num_heads * head_size]
+        )
 
         memory_obj_new = mem_allocator.allocate(mem_obj_shape, dtype)
         lmc_ops.multi_layer_kv_transfer(
@@ -312,7 +318,7 @@ def test_multi_layer_kernel_use_mla(num_tokens):
     start_event.record()
     slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
     for chunk_id, slot_mapping_temp in enumerate(slot_mapping_chunked):
-        mem_obj_shape = [1, num_layers, len(slot_mapping_temp), head_size]
+        mem_obj_shape = torch.Size([1, num_layers, len(slot_mapping_temp), head_size])
         memory_obj_old = mem_allocator.allocate(mem_obj_shape, dtype)
 
         for layer_id in range(num_layers):
@@ -346,7 +352,7 @@ def test_multi_layer_kernel_use_mla(num_tokens):
     start_event.record()
     slot_mapping_chunked = torch.split(slot_mapping, chunk_size)
     for chunk_id, slot_mapping_temp in enumerate(slot_mapping_chunked):
-        mem_obj_shape = [1, num_layers, len(slot_mapping_temp), head_size]
+        mem_obj_shape = torch.Size([1, num_layers, len(slot_mapping_temp), head_size])
 
         memory_obj_new = mem_allocator.allocate(mem_obj_shape, dtype)
         lmc_ops.multi_layer_kv_transfer(

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -9,6 +9,7 @@ from lmcache.v1.memory_management import (
     GPUMemoryAllocator,
     HostMemoryAllocator,
     MemoryFormat,
+    MemoryObjMetadata,
     MixedMemoryAllocator,
     PagedTensorMemoryAllocator,
     PinMemoryAllocator,
@@ -18,22 +19,25 @@ from lmcache.v1.memory_management import (
 
 def check_allocator(allocator, max_size):
     # 512 * 512 * 4 = 1MB
-    data1 = allocator.allocate([512, 512], torch.float)
+    shape1 = torch.Size([512, 512])
+    data1 = allocator.allocate(shape1, torch.float)
     assert data1 is not None
     assert data1.tensor.dtype == torch.float
-    assert data1.tensor.shape == (512, 512)
+    assert data1.tensor.shape == shape1
 
     # 1024 * 1024 * 2 = 2MB
-    data2 = allocator.allocate([1024, 1024], dtype=torch.bfloat16)
+    shape2 = torch.Size([1024, 1024])
+    data2 = allocator.allocate(shape2, torch.bfloat16)
     assert data2 is not None
     assert data2.tensor.dtype == torch.bfloat16
-    assert data2.tensor.shape == (1024, 1024)
+    assert data2.tensor.shape == shape2
 
     # 2048 * 2048 * 1 = 4MB
-    data3 = allocator.allocate([2048, 2048], dtype=torch.int8)
+    shape3 = torch.Size([2048, 2048])
+    data3 = allocator.allocate(shape3, torch.int8)
     assert data3 is not None
     assert data3.tensor.dtype == torch.int8
-    assert data3.tensor.shape == (2048, 2048)
+    assert data3.tensor.shape == shape3
 
     allocator.free(data2)
     assert data2.tensor is None
@@ -45,12 +49,15 @@ def check_allocator(allocator, max_size):
 
     allocator.free(data2)  # This should not crash
 
-    data4 = allocator.allocate([3, 5, 7], dtype=torch.half)
+    shape4 = torch.Size([3, 5, 7])
+    data4 = allocator.allocate(shape4, torch.half)
     assert data4 is not None
     assert data4.tensor.dtype == torch.half
-    assert data4.tensor.shape == (3, 5, 7)
+    assert data4.tensor.shape == shape4
 
-    data_fail = allocator.allocate([max_size], dtype=torch.float)  # This should fail
+    data_fail = allocator.allocate(
+        torch.Size([max_size]), torch.float
+    )  # This should fail
     assert data_fail is None
 
     assert allocator.memcheck()
@@ -118,7 +125,7 @@ def test_tensor_allocator(use_paging):
         dtype = torch.bfloat16
         fmt = MemoryFormat.KV_2LTD
         num_pages = 64
-        allocator = PagedTensorMemoryAllocator(tensor_buffer, shape, dtype, fmt)
+        allocator = PagedTensorMemoryAllocator(tensor_buffer, [shape], [dtype], fmt)
         check_paged_allocator(allocator, shape, dtype, fmt, num_pages)
     else:
         allocator = TensorMemoryAllocator(tensor_buffer)
@@ -151,7 +158,7 @@ def test_device_allocators(alloc_cls, use_paging):
     fmt = MemoryFormat.KV_2LTD
 
     allocator = alloc_cls(
-        total_size, use_paging=use_paging, shape=shape, dtype=dtype, fmt=fmt
+        total_size, use_paging=use_paging, shapes=[shape], dtypes=[dtype], fmt=fmt
     )
 
     if use_paging:
@@ -176,10 +183,11 @@ def test_inplace_modification(alloc_cls):
     total_size = 1024 * 1024
     allocator = alloc_cls(total_size)
 
-    data = allocator.allocate([4096], torch.float)
+    shape = torch.Size([4096])
+    data = allocator.allocate(shape, torch.float)
     assert data is not None
     assert data.tensor.dtype == torch.float
-    assert data.tensor.shape == (4096,)
+    assert data.tensor.shape == shape
 
     data.tensor.fill_(1.0)
     assert torch.all(data.tensor == 1.0)
@@ -202,12 +210,14 @@ def test_inplace_modification(alloc_cls):
 def test_boundary_alloc(alloc_cls):
     total_size = 1 << 25
     allocator = alloc_cls(total_size)
-    data1 = allocator.allocate([512, 10], torch.float)
-    allocator.allocate([512, 10], torch.float)
+
+    shape = torch.Size([512, 10])
+    data1 = allocator.allocate(shape, torch.float)
+    allocator.allocate(shape, torch.float)
     allocator.free(data1)
 
     # `FreeBlock` with size 0 shouldn't exist in the allocator
-    allocator.allocate([512, 10], torch.float)
+    allocator.allocate(shape, torch.float)
 
     if isinstance(allocator, MixedMemoryAllocator):
         assert len(allocator.pin_allocator.explicit_list) == 1
@@ -230,8 +240,9 @@ def test_batched_alloc(alloc_cls):
     total_size = 32 * 100 * 2 * 1024 * 2
     batch_size = 32
     allocator = alloc_cls(total_size)
+    shape = torch.Size([100, 2, 1024])
     objs = allocator.batched_allocate(
-        [100, 2, 1024], torch.bfloat16, batch_size, MemoryFormat.KV_T2D
+        shape, torch.bfloat16, batch_size, MemoryFormat.KV_T2D
     )
 
     assert len(objs) == batch_size
@@ -239,7 +250,7 @@ def test_batched_alloc(alloc_cls):
         assert obj is not None
         assert obj.tensor is not None
         assert obj.tensor.dtype == torch.bfloat16
-        assert obj.tensor.shape == (100, 2, 1024)
+        assert obj.tensor.shape == shape
     allocator.batched_free(objs)
 
     if isinstance(allocator, MixedMemoryAllocator):
@@ -259,8 +270,9 @@ def test_batched_alloc(alloc_cls):
 def test_mixed_alloc(alloc_cls):
     total_size = 1 << 25
     allocator = alloc_cls(total_size)
-    data1 = allocator.allocate([512, 0], None, MemoryFormat.BINARY_BUFFER)
-    allocator.allocate([512, 10], torch.float)
+    shape = torch.Size([512, 10])
+    data1 = allocator.allocate(shape, [], MemoryFormat.BINARY_BUFFER)
+    allocator.allocate(shape, torch.float)
     allocator.free(data1)
 
     assert len(allocator.pin_allocator.explicit_list) == 1
@@ -270,3 +282,45 @@ def test_mixed_alloc(alloc_cls):
     assert len(data1.byte_array) == 512
 
     allocator.close()
+
+
+def test_memory_obj_metadata_to_and_from_dict():
+    shape1 = torch.Size([128, 10])
+    dtype1 = torch.float
+    shape2 = torch.Size([256, 10])
+    dtype2 = torch.uint8
+    shapes = [shape1, shape2]
+    dtypes = [dtype1, dtype2]
+    metadata1 = MemoryObjMetadata(
+        shape=shape1,
+        dtype=dtype1,
+        address=0,
+        phy_size=0,
+        ref_count=0,
+        pin_count=0,
+        fmt=MemoryFormat.KV_T2D,
+    )
+    dict1 = metadata1.to_dict()
+    metadata_from_dict_1 = MemoryObjMetadata.from_dict(dict1)
+    assert metadata_from_dict_1.shape == shape1
+    assert metadata_from_dict_1.dtype == dtype1
+    assert metadata_from_dict_1.shapes is None
+    assert metadata_from_dict_1.dtypes is None
+
+    metadata2 = MemoryObjMetadata(
+        shape=shape1,
+        dtype=dtype1,
+        address=0,
+        phy_size=0,
+        ref_count=0,
+        pin_count=0,
+        fmt=MemoryFormat.KV_T2D,
+        shapes=shapes,
+        dtypes=dtypes,
+    )
+    dict2 = metadata2.to_dict()
+    metadata_from_dict_2 = MemoryObjMetadata.from_dict(dict2)
+    assert metadata_from_dict_2.shape == shape1
+    assert metadata_from_dict_2.dtype == dtype1
+    assert metadata_from_dict_2.shapes == shapes
+    assert metadata_from_dict_2.dtypes == dtypes


### PR DESCRIPTION
refactor `allocate` related methods, use `list[torch.Size]` and `list[torch.dtype]` rather than `torch.Size` or `torch.dtype`