### PR TITLE
Check tool for get kvcaches's checksum

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1232,6 +1232,7 @@ class LMCacheConnectorV1Impl:
                     slot_mapping=slot_mapping,
                     offset=skip_leading_tokens,
                     sync=is_first,
+                    req_id=request.req_id,
                 )
                 self.layerwise_storers.append(layerwise_storer)
                 if is_first:
@@ -1336,6 +1337,7 @@ class LMCacheConnectorV1Impl:
                 offset=skip_leading_tokens,
                 transfer_spec=request.disagg_spec,
                 request_configs=request.request_configs,
+                req_id=request.req_id,
             )
 
             # Update skip_leading_tokens only on last rank to ensure

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -51,6 +51,59 @@ def round_down(x: int, y: int) -> int:
     return (x // y) * y
 
 
+def compress_slot_mapping(slots: List[int]) -> List[List[int]]:
+    """Compress a list of slot indices into ranges.
+
+    Consecutive slots are represented as [start, end] ranges.
+    For example: [1, 2, 3, 4, 5, 9, 10, 11, 12] -> [[1, 5], [9, 12]]
+
+    Args:
+        slots: List of slot indices (can be unsorted).
+
+    Returns:
+        List of [start, end] ranges representing consecutive sequences.
+    """
+    if not slots:
+        return []
+
+    sorted_slots = sorted(slots)
+    ranges: List[List[int]] = []
+    range_start = sorted_slots[0]
+    range_end = sorted_slots[0]
+
+    for slot in sorted_slots[1:]:
+        if slot == range_end + 1:
+            # Extend current range
+            range_end = slot
+        else:
+            # Close current range and start a new one
+            ranges.append([range_start, range_end])
+            range_start = slot
+            range_end = slot
+
+    # Append the last range
+    ranges.append([range_start, range_end])
+    return ranges
+
+
+def decompress_slot_mapping(ranges: List[List[int]]) -> List[int]:
+    """Decompress slot ranges back to a list of slot indices.
+
+    Inverse operation of compress_slot_mapping.
+    For example: [[1, 5], [9, 12]] -> [1, 2, 3, 4, 5, 9, 10, 11, 12]
+
+    Args:
+        ranges: List of [start, end] ranges from compress_slot_mapping.
+
+    Returns:
+        List of slot indices.
+    """
+    slots: List[int] = []
+    for start, end in ranges:
+        slots.extend(range(start, end + 1))
+    return slots
+
+
 try:
     # First Party
     from lmcache import _version  # type: ignore[attr-defined]

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import asyncio
 import hashlib
+import re
 import threading
 import traceback
 
@@ -51,57 +52,174 @@ def round_down(x: int, y: int) -> int:
     return (x // y) * y
 
 
-def compress_slot_mapping(slots: List[int]) -> List[List[int]]:
-    """Compress a list of slot indices into ranges.
+def compress_slot_mapping(slots: list[int]) -> list[Union[int, list[int]]]:
+    """Compress a list of slot indices into ranges while preserving order.
 
-    Consecutive slots are represented as [start, end] ranges.
+    Consecutive slots (3 or more) are represented as [start, end] ranges.
+    Single elements or pairs are kept as individual integers.
     For example: [1, 2, 3, 4, 5, 9, 10, 11, 12] -> [[1, 5], [9, 12]]
+    Order-preserving: [5, 3, 1, 2, 4] -> [5, 3, 1, 2, 4] (no compression)
+    Mixed: [1, 2, 3, 4, 5, 7, 8] -> [[1, 5], 7, 8]
 
     Args:
-        slots: List of slot indices (can be unsorted).
+        slots: List of slot indices (order is preserved).
 
     Returns:
-        List of [start, end] ranges representing consecutive sequences.
+        List of integers or [start, end] ranges. Ranges are only used
+        when there are 3 or more consecutive elements.
     """
     if not slots:
         return []
 
-    sorted_slots = sorted(slots)
-    ranges: List[List[int]] = []
-    range_start = sorted_slots[0]
-    range_end = sorted_slots[0]
+    result: list[Union[int, list[int]]] = []
+    range_start = slots[0]
+    range_end = slots[0]
 
-    for slot in sorted_slots[1:]:
+    for slot in slots[1:]:
         if slot == range_end + 1:
             # Extend current range
             range_end = slot
         else:
             # Close current range and start a new one
-            ranges.append([range_start, range_end])
+            _append_range_or_elements(result, range_start, range_end)
             range_start = slot
             range_end = slot
 
     # Append the last range
-    ranges.append([range_start, range_end])
-    return ranges
+    _append_range_or_elements(result, range_start, range_end)
+    return result
 
 
-def decompress_slot_mapping(ranges: List[List[int]]) -> List[int]:
+def _append_range_or_elements(
+    result: list[Union[int, list[int]]], start: int, end: int
+) -> None:
+    """Helper to append range or individual elements based on length.
+
+    Only compresses to [start, end] if there are 3 or more consecutive elements.
+    """
+    length = end - start + 1
+    if length >= 3:
+        # Compress: 3 or more consecutive elements
+        result.append([start, end])
+    else:
+        # Don't compress: 1 or 2 elements
+        for i in range(start, end + 1):
+            result.append(i)
+
+
+def decompress_slot_mapping(compressed: list[Union[int, list[int]]]) -> list[int]:
     """Decompress slot ranges back to a list of slot indices.
 
     Inverse operation of compress_slot_mapping.
     For example: [[1, 5], [9, 12]] -> [1, 2, 3, 4, 5, 9, 10, 11, 12]
+    Mixed: [[1, 5], 7, 8] -> [1, 2, 3, 4, 5, 7, 8]
 
     Args:
-        ranges: List of [start, end] ranges from compress_slot_mapping.
+        compressed: List of integers or [start, end] ranges from
+            compress_slot_mapping.
 
     Returns:
         List of slot indices.
     """
-    slots: List[int] = []
-    for start, end in ranges:
-        slots.extend(range(start, end + 1))
+    slots: list[int] = []
+    for item in compressed:
+        if isinstance(item, list):
+            start, end = item
+            slots.extend(range(start, end + 1))
+        else:
+            slots.append(item)
     return slots
+
+
+def parse_mixed_slot_mapping(
+    slot_mapping_str: str,
+) -> Tuple[Optional[list[int]], Optional[dict]]:
+    """Parse mixed format slot_mapping string.
+
+    Supports two formats:
+    1. Single numbers: "1,2,3,17,19"
+    2. Range format: "[9,12]" (represents 9,10,11,12)
+    3. Mixed format: "1,2,3,[9,12],17,19" (represents 1,2,3,9,10,11,12,17,19)
+
+    Args:
+        slot_mapping_str: String containing slot mapping information.
+
+    Returns:
+        Tuple of (slot_indices list, error dict).
+        If error dict is not None, slot_indices will be None.
+    """
+    try:
+        # Remove all whitespace
+        clean_str = "".join(slot_mapping_str.split())
+
+        # Split by comma but preserve range expressions
+        parts = []
+        buffer = ""
+        in_brackets = False
+
+        for char in clean_str:
+            if char == "[":
+                if in_brackets:
+                    raise ValueError("Nested brackets not allowed")
+                in_brackets = True
+                buffer += char
+            elif char == "]":
+                if not in_brackets:
+                    raise ValueError("Unmatched closing bracket")
+                in_brackets = False
+                buffer += char
+                parts.append(buffer)
+                buffer = ""
+            elif char == "," and not in_brackets:
+                if buffer:
+                    parts.append(buffer)
+                    buffer = ""
+            else:
+                buffer += char
+
+        # Add the last part if any
+        if buffer:
+            parts.append(buffer)
+
+        if in_brackets:
+            raise ValueError("Unclosed bracket")
+
+        # Parse each part
+        compressed: list[Union[int, list[int]]] = []
+
+        for part in parts:
+            part = part.strip()
+            if not part:
+                continue
+
+            # Check if it's a range format [start,end]
+            range_match = re.match(r"^\[(\d+),(\d+)\]$", part)
+            if range_match:
+                start = int(range_match.group(1))
+                end = int(range_match.group(2))
+                if start > end:
+                    raise ValueError(f"Range start {start} must be <= end {end}")
+                compressed.append([start, end])
+            else:
+                # Single number
+                try:
+                    num = int(part)
+                    compressed.append(num)
+                except ValueError as ve:
+                    raise ValueError(f"Invalid slot format: '{part}'") from ve
+
+        # Decompress to individual slot indices
+        slot_indices = decompress_slot_mapping(compressed)
+        return slot_indices, None
+
+    except Exception as e:
+        return None, {
+            "error": "Invalid slot_mapping format",
+            "message": (
+                f"slot_mapping must be comma-separated integers "
+                f"or ranges like [start,end]: {str(e)}"
+            ),
+        }
 
 
 try:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -335,20 +335,12 @@ class LMCacheEngine:
         )
 
         # KVCache Check logging
-        if self.kvcache_check_log_enabled:
-            slot_mapping = kwargs.get("slot_mapping")
-            if slot_mapping is not None:
-                # Convert slot_mapping to list if it's a tensor
-                slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
-                # slot_mapping_list should not be None when slot_mapping is not None
-                assert slot_mapping_list is not None
-                req_id = kwargs.get("req_id", "unspecified")
-                logger.info(
-                    "[KVCache Check] Store request %s, tokens=%d, slot_mapping: %s",
-                    req_id,
-                    num_to_store_tokens,
-                    compress_slot_mapping(slot_mapping_list),
-                )
+        self._log_kvcache_for_check(
+            operation="Store",
+            kwargs=kwargs,
+            token_count=num_to_store_tokens,
+            require_req_id=False,
+        )
 
         # Check if freeze mode is enabled
         if self.is_frozen():
@@ -506,23 +498,13 @@ class LMCacheEngine:
         else:
             num_to_store_tokens = len(tokens)
 
-        req_id = kwargs.get("req_id", "unspecified")
-
         # KVCache Check logging
-        if self.kvcache_check_log_enabled:
-            slot_mapping = kwargs.get("slot_mapping")
-            if req_id is not None and slot_mapping is not None:
-                # Convert slot_mapping to list if it's a tensor
-                slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
-                # slot_mapping_list should not be None when slot_mapping is not None
-                assert slot_mapping_list is not None
-                logger.info(
-                    "[KVCache Check] Layerwise store request %s, "
-                    "tokens=%d, slot_mapping: %s",
-                    req_id,
-                    num_to_store_tokens,
-                    compress_slot_mapping(slot_mapping_list),
-                )
+        self._log_kvcache_for_check(
+            operation="Layerwise store",
+            kwargs=kwargs,
+            token_count=num_to_store_tokens,
+            require_req_id=True,
+        )
 
         monitor_req_id = self.stats_monitor.on_store_request(num_to_store_tokens)
 
@@ -682,22 +664,13 @@ class LMCacheEngine:
         else:
             num_required_tokens = len(tokens)
 
-        req_id = kwargs.get("req_id", "unspecified")
-
         # KVCache Check logging
-        if self.kvcache_check_log_enabled:
-            slot_mapping = kwargs.get("slot_mapping")
-            if req_id is not None and slot_mapping is not None:
-                # Convert slot_mapping to list if it's a tensor
-                slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
-                # slot_mapping_list should not be None when slot_mapping is not None
-                assert slot_mapping_list is not None
-                logger.info(
-                    "[KVCache Check] retrieve request %s, tokens=%d, slot_mapping: %s",
-                    req_id,
-                    num_required_tokens,
-                    compress_slot_mapping(slot_mapping_list),
-                )
+        self._log_kvcache_for_check(
+            operation="retrieve",
+            kwargs=kwargs,
+            token_count=num_required_tokens,
+            require_req_id=True,
+        )
 
         monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens)
 
@@ -1657,6 +1630,52 @@ class LMCacheEngine:
             return slot_mapping.tolist()
         # At this point, slot_mapping must be List[int]
         return slot_mapping
+
+    def _log_kvcache_for_check(
+        self,
+        operation: str,
+        kwargs: dict,
+        token_count: int,
+        require_req_id: bool = False,
+    ) -> None:
+        """
+        Helper method to log KVCache Check information.
+
+        This method centralizes the KVCache Check logging logic that was
+        duplicated in multiple methods.
+
+        Args:
+            operation: The operation being performed (e.g., "Store", "retrieve")
+            kwargs: The keyword arguments containing slot_mapping and req_id
+            token_count: The number of tokens involved in the operation
+            require_req_id: Whether req_id must be present (default: False)
+        """
+        if not self.kvcache_check_log_enabled:
+            return
+
+        slot_mapping = kwargs.get("slot_mapping")
+        if slot_mapping is None:
+            return
+
+        if require_req_id:
+            req_id = kwargs.get("req_id")
+            if req_id is None:
+                return
+        else:
+            req_id = kwargs.get("req_id", "unspecified")
+
+        # Convert slot_mapping to list if it's a tensor
+        slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
+        # slot_mapping_list should not be None when slot_mapping is not None
+        assert slot_mapping_list is not None
+
+        logger.info(
+            "[KVCache Check] %s request %s, tokens=%d, slot_mapping: %s",
+            operation,
+            req_id,
+            token_count,
+            compress_slot_mapping(slot_mapping_list),
+        )
 
 
 class LMCacheEngineBuilder:

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -29,6 +29,7 @@ from lmcache.utils import (
     CacheEngineKey,
     CacheStoreEvent,
     _lmcache_nvtx_annotate,
+    compress_slot_mapping,
     convert_tokens_to_list,
 )
 from lmcache.v1.config import LMCacheEngineConfig
@@ -228,6 +229,9 @@ class LMCacheEngine:
             "force_store_wait", False
         )
 
+        # Flag to control KVCache Check logging (can be toggled via API)
+        self.kvcache_check_log_enabled = False
+
         gc.collect()
         if not config.py_enable_gc:
             gc.disable()
@@ -329,6 +333,22 @@ class LMCacheEngine:
         assert tokens is not None or hashes is not None, (
             "Either 'tokens' or 'hashes' must be provided."
         )
+
+        # KVCache Check logging
+        if self.kvcache_check_log_enabled:
+            slot_mapping = kwargs.get("slot_mapping")
+            if slot_mapping is not None:
+                # Convert slot_mapping to list if it's a tensor
+                slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
+                # slot_mapping_list should not be None when slot_mapping is not None
+                assert slot_mapping_list is not None
+                req_id = kwargs.get("req_id", "unspecified")
+                logger.info(
+                    "[KVCache Check] Store request %s, tokens=%d, slot_mapping: %s",
+                    req_id,
+                    num_to_store_tokens,
+                    compress_slot_mapping(slot_mapping_list),
+                )
 
         # Check if freeze mode is enabled
         if self.is_frozen():
@@ -485,6 +505,25 @@ class LMCacheEngine:
             num_to_store_tokens = torch.sum(mask).item()
         else:
             num_to_store_tokens = len(tokens)
+
+        req_id = kwargs.get("req_id", "unspecified")
+
+        # KVCache Check logging
+        if self.kvcache_check_log_enabled:
+            slot_mapping = kwargs.get("slot_mapping")
+            if req_id is not None and slot_mapping is not None:
+                # Convert slot_mapping to list if it's a tensor
+                slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
+                # slot_mapping_list should not be None when slot_mapping is not None
+                assert slot_mapping_list is not None
+                logger.info(
+                    "[KVCache Check] Layerwise store request %s, "
+                    "tokens=%d, slot_mapping: %s",
+                    req_id,
+                    num_to_store_tokens,
+                    compress_slot_mapping(slot_mapping_list),
+                )
+
         monitor_req_id = self.stats_monitor.on_store_request(num_to_store_tokens)
 
         # Check if freeze mode is enabled
@@ -642,6 +681,24 @@ class LMCacheEngine:
             num_required_tokens = torch.sum(mask).item()
         else:
             num_required_tokens = len(tokens)
+
+        req_id = kwargs.get("req_id", "unspecified")
+
+        # KVCache Check logging
+        if self.kvcache_check_log_enabled:
+            slot_mapping = kwargs.get("slot_mapping")
+            if req_id is not None and slot_mapping is not None:
+                # Convert slot_mapping to list if it's a tensor
+                slot_mapping_list = self._get_slot_mapping_list(slot_mapping)
+                # slot_mapping_list should not be None when slot_mapping is not None
+                assert slot_mapping_list is not None
+                logger.info(
+                    "[KVCache Check] retrieve request %s, tokens=%d, slot_mapping: %s",
+                    req_id,
+                    num_required_tokens,
+                    compress_slot_mapping(slot_mapping_list),
+                )
+
         monitor_req_id = self.stats_monitor.on_retrieve_request(num_required_tokens)
 
         ret_mask = torch.zeros(len(tokens), dtype=torch.bool, device="cpu")
@@ -1580,6 +1637,26 @@ class LMCacheEngine:
         the data directly, but from the "active" worker (i.e., rank 0 in MLA)
         """
         return self.save_only_first_rank and not self.metadata.is_first_rank()
+
+    def _get_slot_mapping_list(
+        self,
+        slot_mapping: Optional[Union[torch.Tensor, List[int]]],
+    ) -> Optional[List[int]]:
+        """
+        Convert slot_mapping to list if it's a tensor, otherwise return as is.
+
+        :param slot_mapping: The slot_mapping to convert,
+            can be a torch.Tensor or List[int], or None
+        :type slot_mapping: Optional[Union[torch.Tensor, List[int]]]
+        :return: The slot_mapping as a List[int], or None if input is None
+        :rtype: Optional[List[int]]
+        """
+        if slot_mapping is None:
+            return None
+        if isinstance(slot_mapping, torch.Tensor):
+            return slot_mapping.tolist()
+        # At this point, slot_mapping must be List[int]
+        return slot_mapping
 
 
 class LMCacheEngineBuilder:

--- a/lmcache/v1/internal_api_server/vllm/cache_api.py
+++ b/lmcache/v1/internal_api_server/vllm/cache_api.py
@@ -653,7 +653,7 @@ async def retrieve(
     )
 
 
-@router.post("/cache/kvcache/check")
+@router.get("/cache/kvcache/check")
 async def kvcache_check(
     request: Request,
     slot_mapping: Optional[str] = None,
@@ -680,7 +680,7 @@ async def kvcache_check(
     Example:
         ```bash
         # layerwise=false (default): one checksum per chunk (all layers combined)
-        curl -X POST "http://localhost:8000/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
+        curl -X GET "http://localhost:8000/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
         # Response: {
         #   "status": "success",
         #   "slot_mapping_ranges": [[0, 3]],
@@ -691,7 +691,7 @@ async def kvcache_check(
         # }
 
         # layerwise=true: per-layer checksums for each chunk
-        curl -X POST "http://localhost:8000/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2&layerwise=true"
+        curl -X GET "http://localhost:8000/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2&layerwise=true"
         # Response: {
         #   "status": "success",
         #   "slot_mapping_ranges": [[0, 3]],

--- a/lmcache/v1/internal_api_server/vllm/cache_api.py
+++ b/lmcache/v1/internal_api_server/vllm/cache_api.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import Annotated, Any, Callable, List, Optional, Tuple
+import asyncio
 import hashlib
 import json
-import re
 import traceback
 
 # Third Party
@@ -14,7 +14,10 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import compress_slot_mapping, decompress_slot_mapping
+from lmcache.utils import (
+    compress_slot_mapping,
+    parse_mixed_slot_mapping,
+)
 from lmcache.v1.cache_engine import LMCacheEngine
 
 logger = init_logger(__name__)
@@ -56,97 +59,6 @@ def _parse_tokens_from_params(
         return None, {
             "error": "Missing parameters",
             "message": "Must specify either tokens_input or tokens_mock",
-        }
-
-
-def _parse_mixed_slot_mapping(
-    slot_mapping_str: str,
-) -> Tuple[Optional[List[int]], Optional[dict]]:
-    """Parse mixed format slot_mapping string.
-
-    Supports two formats:
-    1. Single numbers: "1,2,3,17,19"
-    2. Range format: "[9,12]" (represents 9,10,11,12)
-    3. Mixed format: "1,2,3,[9,12],17,19" (represents 1,2,3,9,10,11,12,17,19)
-
-    Args:
-        slot_mapping_str: String containing slot mapping information.
-
-    Returns:
-        Tuple of (slot_indices list, error dict).
-        If error dict is not None, slot_indices will be None.
-    """
-    try:
-        # Remove all whitespace
-        clean_str = "".join(slot_mapping_str.split())
-
-        # Split by comma but preserve range expressions
-        parts = []
-        buffer = ""
-        in_brackets = False
-
-        for char in clean_str:
-            if char == "[":
-                if in_brackets:
-                    raise ValueError("Nested brackets not allowed")
-                in_brackets = True
-                buffer += char
-            elif char == "]":
-                if not in_brackets:
-                    raise ValueError("Unmatched closing bracket")
-                in_brackets = False
-                buffer += char
-                parts.append(buffer)
-                buffer = ""
-            elif char == "," and not in_brackets:
-                if buffer:
-                    parts.append(buffer)
-                    buffer = ""
-            else:
-                buffer += char
-
-        # Add the last part if any
-        if buffer:
-            parts.append(buffer)
-
-        if in_brackets:
-            raise ValueError("Unclosed bracket")
-
-        # Parse each part
-        ranges: List[List[int]] = []
-
-        for part in parts:
-            part = part.strip()
-            if not part:
-                continue
-
-            # Check if it's a range format [start,end]
-            range_match = re.match(r"^\[(\d+),(\d+)\]$", part)
-            if range_match:
-                start = int(range_match.group(1))
-                end = int(range_match.group(2))
-                if start > end:
-                    raise ValueError(f"Range start {start} must be <= end {end}")
-                ranges.append([start, end])
-            else:
-                # Single number
-                try:
-                    num = int(part)
-                    ranges.append([num, num])
-                except ValueError as ve:
-                    raise ValueError(f"Invalid slot format: '{part}'") from ve
-
-        # Decompress ranges to individual slot indices
-        slot_indices = decompress_slot_mapping(ranges)
-        return slot_indices, None
-
-    except Exception as e:
-        return None, {
-            "error": "Invalid slot_mapping format",
-            "message": (
-                f"slot_mapping must be comma-separated integers "
-                f"or ranges like [start,end]: {str(e)}"
-            ),
         }
 
 
@@ -727,7 +639,7 @@ async def kvcache_check(
 
         # Parse slot_mapping from mixed format string
         # (supports single numbers and ranges)
-        slot_indices, error_info = _parse_mixed_slot_mapping(slot_mapping)
+        slot_indices, error_info = parse_mixed_slot_mapping(slot_mapping)
         if error_info:
             return _create_error_response(error_info, 400)
 
@@ -794,9 +706,13 @@ async def kvcache_check(
                 400,
             )
 
-        # Get checksums from the adapter
-        checksums_result = compute_kvcache_checksums(
-            lmcache_adapter, slot_indices, chunk_size, layerwise
+        # Get checksums from the adapter asynchronously to not block the loop
+        loop = asyncio.get_running_loop()
+        checksums_result = await loop.run_in_executor(
+            None,  # Uses default ThreadPoolExecutor
+            lambda: compute_kvcache_checksums(
+                lmcache_adapter, slot_indices, chunk_size, layerwise
+            ),
         )
 
         if checksums_result is None:

--- a/lmcache/v1/internal_api_server/vllm/cache_api.py
+++ b/lmcache/v1/internal_api_server/vllm/cache_api.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Annotated, Callable, List, Optional, Tuple
+from typing import Annotated, Any, Callable, List, Optional, Tuple
+import hashlib
 import json
+import re
 import traceback
 
 # Third Party
@@ -12,6 +14,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.utils import compress_slot_mapping, decompress_slot_mapping
 from lmcache.v1.cache_engine import LMCacheEngine
 
 logger = init_logger(__name__)
@@ -53,6 +56,97 @@ def _parse_tokens_from_params(
         return None, {
             "error": "Missing parameters",
             "message": "Must specify either tokens_input or tokens_mock",
+        }
+
+
+def _parse_mixed_slot_mapping(
+    slot_mapping_str: str,
+) -> Tuple[Optional[List[int]], Optional[dict]]:
+    """Parse mixed format slot_mapping string.
+
+    Supports two formats:
+    1. Single numbers: "1,2,3,17,19"
+    2. Range format: "[9,12]" (represents 9,10,11,12)
+    3. Mixed format: "1,2,3,[9,12],17,19" (represents 1,2,3,9,10,11,12,17,19)
+
+    Args:
+        slot_mapping_str: String containing slot mapping information.
+
+    Returns:
+        Tuple of (slot_indices list, error dict).
+        If error dict is not None, slot_indices will be None.
+    """
+    try:
+        # Remove all whitespace
+        clean_str = "".join(slot_mapping_str.split())
+
+        # Split by comma but preserve range expressions
+        parts = []
+        buffer = ""
+        in_brackets = False
+
+        for char in clean_str:
+            if char == "[":
+                if in_brackets:
+                    raise ValueError("Nested brackets not allowed")
+                in_brackets = True
+                buffer += char
+            elif char == "]":
+                if not in_brackets:
+                    raise ValueError("Unmatched closing bracket")
+                in_brackets = False
+                buffer += char
+                parts.append(buffer)
+                buffer = ""
+            elif char == "," and not in_brackets:
+                if buffer:
+                    parts.append(buffer)
+                    buffer = ""
+            else:
+                buffer += char
+
+        # Add the last part if any
+        if buffer:
+            parts.append(buffer)
+
+        if in_brackets:
+            raise ValueError("Unclosed bracket")
+
+        # Parse each part
+        ranges: List[List[int]] = []
+
+        for part in parts:
+            part = part.strip()
+            if not part:
+                continue
+
+            # Check if it's a range format [start,end]
+            range_match = re.match(r"^\[(\d+),(\d+)\]$", part)
+            if range_match:
+                start = int(range_match.group(1))
+                end = int(range_match.group(2))
+                if start > end:
+                    raise ValueError(f"Range start {start} must be <= end {end}")
+                ranges.append([start, end])
+            else:
+                # Single number
+                try:
+                    num = int(part)
+                    ranges.append([num, num])
+                except ValueError as ve:
+                    raise ValueError(f"Invalid slot format: '{part}'") from ve
+
+        # Decompress ranges to individual slot indices
+        slot_indices = decompress_slot_mapping(ranges)
+        return slot_indices, None
+
+    except Exception as e:
+        return None, {
+            "error": "Invalid slot_mapping format",
+            "message": (
+                f"slot_mapping must be comma-separated integers "
+                f"or ranges like [start,end]: {str(e)}"
+            ),
         }
 
 
@@ -122,6 +216,189 @@ def _get_kvcaches_and_device(engine):
             )
 
     return kvcaches, device
+
+
+def _compute_tensor_checksum(tensor: torch.Tensor) -> str:
+    """Compute MD5 checksum of a tensor."""
+    # Move to CPU and convert to bytes for hashing
+    # Handle BFloat16 which is not supported by numpy
+    if tensor.dtype == torch.bfloat16:
+        # Convert bfloat16 to float32 for numpy compatibility
+        tensor = tensor.to(torch.float32)
+
+    tensor_bytes = tensor.detach().cpu().contiguous().numpy().tobytes()
+    return hashlib.md5(tensor_bytes).hexdigest()
+
+
+def _slice_by_slot_dim(
+    kv_at_slots: torch.Tensor, start_idx: int, end_idx: int
+) -> torch.Tensor:
+    """Slice tensor by slot dimension based on tensor ndim."""
+    if kv_at_slots.ndim == 4:
+        # MHA: [2, num_slots, num_heads, head_size]
+        return kv_at_slots[:, start_idx:end_idx, :, :]
+    elif kv_at_slots.ndim == 3:
+        # 4D format: [num_slots, num_heads, head_size]
+        return kv_at_slots[start_idx:end_idx, :, :]
+    else:
+        # MLA: [num_slots, head_size]
+        return kv_at_slots[start_idx:end_idx, :]
+
+
+def _extract_kv_at_slots(
+    kv_tensor: torch.Tensor, slot_tensor: torch.Tensor
+) -> torch.Tensor:
+    """Extract KV data at specified slot positions from kv_tensor.
+
+    Handles different kv_tensor formats:
+    - MHA (5D): [2, num_blocks, block_size, num_heads, head_size]
+    - MLA (3D): [num_blocks, block_size, head_size]
+
+    The slot_mapping is calculated as:
+        slot_idx = block_id * block_size + block_offset
+
+    This means we can reshape the tensor to flatten (num_blocks, block_size)
+    into a single slot dimension and index directly.
+
+    Args:
+        kv_tensor: The KV cache tensor for a single layer.
+        slot_tensor: Tensor of slot indices to extract.
+
+    Returns:
+        Tensor with KV data at the specified slots.
+        - MHA: shape [2, num_slots, num_heads, head_size]
+        - MLA: shape [num_slots, head_size]
+    """
+    ndim = kv_tensor.ndim
+
+    if ndim == 5:
+        # MHA format: [2, num_blocks, block_size, num_heads, head_size]
+        # Reshape to [2, num_blocks * block_size, num_heads, head_size]
+        # then index by slot_tensor on dimension 1
+        kv_2d = 2
+        num_heads = kv_tensor.shape[3]
+        head_size = kv_tensor.shape[4]
+        kv_reshaped = kv_tensor.reshape(kv_2d, -1, num_heads, head_size)
+        return kv_reshaped[:, slot_tensor, :, :]
+    elif ndim == 3:
+        # MLA format: [num_blocks, block_size, head_size]
+        # Reshape to [num_blocks * block_size, head_size]
+        head_size = kv_tensor.shape[2]
+        kv_reshaped = kv_tensor.reshape(-1, head_size)
+        return kv_reshaped[slot_tensor, :]
+    elif ndim == 4:
+        # Alternative format: [num_blocks, block_size, num_heads, head_size]
+        # (used in some test cases)
+        num_heads = kv_tensor.shape[2]
+        head_size = kv_tensor.shape[3]
+        kv_reshaped = kv_tensor.reshape(-1, num_heads, head_size)
+        return kv_reshaped[slot_tensor, :, :]
+    else:
+        # Fallback: try the original approach
+        logger.warning(
+            "Unknown kv_tensor ndim=%d, shape=%s. Using fallback indexing.",
+            ndim,
+            kv_tensor.shape,
+        )
+        return kv_tensor.view(-1, *kv_tensor.shape[2:])[slot_tensor]
+
+
+def compute_kvcache_checksums(
+    lmcache_adapter,
+    slot_indices: list[int],
+    chunk_size: Optional[int] = None,
+    layerwise: bool = False,
+) -> Optional[dict[str, Any]]:
+    """Compute MD5 checksums for kvcaches at specified slot positions.
+
+    This method is used by the kvcache check API to verify that stored
+    and retrieved kvcaches are identical.
+
+    The slot_mapping is calculated in vllm_v1_adapter.py as:
+        slot_idx = block_id * block_size + block_offset
+
+    For vLLM kv_cache formats:
+    - MHA (5D): [2, num_blocks, block_size, num_heads, head_size]
+    - MLA (3D): [num_blocks, block_size, head_size]
+
+    Args:
+        lmcache_adapter: The LMCache adapter containing kv_caches.
+        slot_indices: List of slot indices to compute checksums for.
+        chunk_size: Optional chunk size for computing per-chunk checksums.
+            If provided, will compute checksums for each chunk.
+        layerwise: If True, output per-layer checksums for each chunk.
+            If False (default), output one checksum per chunk (all layers combined).
+
+    Returns:
+        Dictionary containing:
+        - 'chunk_checksums': (if layerwise=True) dict mapping layer names to
+          list of per-chunk checksums
+        - 'chunk_checksums': (if layerwise=False) list of checksums, one per chunk
+          (each checksum covers all layers for that chunk)
+        Returns None if kv_caches is not available.
+    """
+    if not lmcache_adapter.kv_caches:
+        logger.warning("kv_caches is empty, cannot compute checksums")
+        return None
+
+    if chunk_size is None or chunk_size <= 0:
+        return {"chunk_checksums": [], "chunk_size": chunk_size, "num_chunks": 0}
+
+    num_slots = len(slot_indices)
+    num_chunks = (num_slots + chunk_size - 1) // chunk_size
+
+    # Pre-extract all layer data at slot positions
+    layer_data_at_slots: dict[str, torch.Tensor] = {}
+    for layer_name, kv_tensor in lmcache_adapter.kv_caches.items():
+        try:
+            slot_tensor = torch.tensor(
+                slot_indices, dtype=torch.long, device=kv_tensor.device
+            )
+            layer_data_at_slots[layer_name] = _extract_kv_at_slots(
+                kv_tensor, slot_tensor
+            )
+        except Exception as e:
+            logger.error("Failed to extract data for layer %s: %s", layer_name, str(e))
+            layer_data_at_slots[layer_name] = None  # type: ignore
+
+    if layerwise:
+        # Output per-layer checksums for each chunk: {layer_name: [checksum1, ...]}
+        chunk_checksums: dict[str, list[str]] = {}
+        for layer_name, kv_at_slots in layer_data_at_slots.items():
+            if kv_at_slots is None:
+                chunk_checksums[layer_name] = ["error"] * num_chunks
+                continue
+            chunk_checksum_list: list[str] = []
+            for chunk_idx in range(num_chunks):
+                start_idx = chunk_idx * chunk_size
+                end_idx = min(start_idx + chunk_size, num_slots)
+                chunk_data = _slice_by_slot_dim(kv_at_slots, start_idx, end_idx)
+                chunk_checksum_list.append(_compute_tensor_checksum(chunk_data))
+            chunk_checksums[layer_name] = chunk_checksum_list
+        return {
+            "chunk_checksums": chunk_checksums,
+            "chunk_size": chunk_size,
+            "num_chunks": num_chunks,
+        }
+    else:
+        # Output one checksum per chunk (all layers combined): [checksum1, ...]
+        chunk_checksums_list: list[str] = []
+        for chunk_idx in range(num_chunks):
+            start_idx = chunk_idx * chunk_size
+            end_idx = min(start_idx + chunk_size, num_slots)
+            md5_hash = hashlib.md5()
+            for layer_name in sorted(layer_data_at_slots.keys()):
+                kv_at_slots = layer_data_at_slots[layer_name]
+                if kv_at_slots is None:
+                    continue
+                chunk_data = _slice_by_slot_dim(kv_at_slots, start_idx, end_idx)
+                md5_hash.update(_compute_tensor_checksum(chunk_data).encode())
+            chunk_checksums_list.append(md5_hash.hexdigest())
+        return {
+            "chunk_checksums": chunk_checksums_list,
+            "chunk_size": chunk_size,
+            "num_chunks": num_chunks,
+        }
 
 
 @router.delete("/cache/clear")
@@ -303,6 +580,7 @@ async def store(
         )
 
         engine.store(
+            req_id="cache_api_store",
             tokens=token_list,
             slot_mapping=slot_mapping,
             kvcaches=kvcaches,
@@ -356,10 +634,13 @@ async def retrieve(
         slot_mapping = torch.arange(len(token_list), dtype=torch.long, device=device)
 
         logger.debug(
-            f"Retrieving {len(token_list)} tokens with slot_mapping on device {device}"
+            "Retrieving %d tokens with slot_mapping on device %s",
+            len(token_list),
+            device,
         )
 
         ret_mask = engine.retrieve(
+            req_id="cache_api_retrieve",
             tokens=token_list,
             slot_mapping=slot_mapping,
             kvcaches=kvcaches,
@@ -370,3 +651,329 @@ async def retrieve(
     return _execute_cache_operation(
         "retrieve cache", _retrieve_operation, lmcache_engine, tokens
     )
+
+
+@router.post("/cache/kvcache/check")
+async def kvcache_check(
+    request: Request,
+    slot_mapping: Optional[str] = None,
+    chunk_size: Optional[int] = None,
+    layerwise: bool = False,
+):
+    """Compute checksum for kvcaches at specified slot_mapping positions.
+
+    This endpoint is used to verify that stored and retrieved kvcaches are identical.
+
+    Args:
+        request (Request): The FastAPI request object containing application state.
+        slot_mapping (Optional[str], optional): Slot indices in comma-separated format,
+            supports single numbers and range expressions.
+            Examples: "0,1,2,3", "1,2,3,[9,12],17,19". Defaults to None.
+        chunk_size (Optional[int], optional): Chunk size for computing checksums.
+            Each chunk contains `chunk_size` slots. Required parameter.
+        layerwise (bool, optional): If True, output per-layer checksums for each chunk.
+            If False (default), output one checksum per chunk (all layers combined).
+
+    Returns:
+        PlainTextResponse: A JSON response containing checksums.
+
+    Example:
+        ```bash
+        # layerwise=false (default): one checksum per chunk (all layers combined)
+        curl -X POST "http://localhost:8000/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
+        # Response: {
+        #   "status": "success",
+        #   "slot_mapping_ranges": [[0, 3]],
+        #   "chunk_size": 2,
+        #   "num_chunks": 2,
+        #   "chunk_checksums": ["checksum_chunk0", "checksum_chunk1"],
+        #   "layerwise": false
+        # }
+
+        # layerwise=true: per-layer checksums for each chunk
+        curl -X POST "http://localhost:8000/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2&layerwise=true"
+        # Response: {
+        #   "status": "success",
+        #   "slot_mapping_ranges": [[0, 3]],
+        #   "chunk_size": 2,
+        #   "num_chunks": 2,
+        #   "chunk_checksums": {
+        #       "layer_0": ["checksum_chunk0", "checksum_chunk1"],
+        #       "layer_1": ["checksum_chunk0", "checksum_chunk1"],
+        #   },
+        #   "layerwise": true
+        # }
+        ```
+    """
+    try:
+        lmcache_adapter = request.app.state.lmcache_adapter
+        if not lmcache_adapter:
+            return _create_error_response(
+                {
+                    "error": "LMCache adapter unavailable",
+                    "message": "LMCache adapter not configured.",
+                },
+                503,
+            )
+
+        if not slot_mapping:
+            return _create_error_response(
+                {
+                    "error": "Missing parameters",
+                    "message": "slot_mapping parameter is required",
+                },
+                400,
+            )
+
+        # Parse slot_mapping from mixed format string
+        # (supports single numbers and ranges)
+        slot_indices, error_info = _parse_mixed_slot_mapping(slot_mapping)
+        if error_info:
+            return _create_error_response(error_info, 400)
+
+        # slot_indices is guaranteed to be non-None when error_info is None
+        assert slot_indices is not None
+
+        # Validate slot indices are within valid range
+        if lmcache_adapter.kv_caches:
+            # Get the first kv_tensor to check dimensions
+            first_kv_tensor = next(iter(lmcache_adapter.kv_caches.values()))
+            # Calculate total slots: num_blocks * block_size
+            # For different formats:
+            # - MHA (5D): [2, num_blocks, block_size, num_heads, head_size]
+            # - MLA (3D): [num_blocks, block_size, head_size]
+            # - 4D: [num_blocks, block_size, num_heads, head_size]
+            ndim = first_kv_tensor.ndim
+            if ndim == 5:
+                # MHA: [2, num_blocks, block_size, num_heads, head_size]
+                total_slots = first_kv_tensor.shape[1] * first_kv_tensor.shape[2]
+            elif ndim == 3:
+                # MLA: [num_blocks, block_size, head_size]
+                total_slots = first_kv_tensor.shape[0] * first_kv_tensor.shape[1]
+            elif ndim == 4:
+                # 4D: [num_blocks, block_size, num_heads, head_size]
+                total_slots = first_kv_tensor.shape[0] * first_kv_tensor.shape[1]
+            else:
+                # Fallback
+                reshaped = first_kv_tensor.view(-1, *first_kv_tensor.shape[2:])
+                total_slots = reshaped.shape[0]
+
+            # Check each slot index
+            invalid_indices = []
+            for slot_idx in slot_indices:
+                if slot_idx < 0 or slot_idx >= total_slots:
+                    invalid_indices.append(slot_idx)
+
+            if invalid_indices:
+                return _create_error_response(
+                    {
+                        "error": "Invalid slot indices",
+                        "message": (
+                            "Slot indices out of bounds: %s. Valid range: 0 to %d"
+                        )
+                        % (invalid_indices, total_slots - 1),
+                    },
+                    400,
+                )
+        else:
+            return _create_error_response(
+                {
+                    "error": "kv_caches not available",
+                    "message": "kv_caches is empty or not initialized",
+                },
+                404,
+            )
+
+        # Validate chunk_size if provided
+        if chunk_size is not None and chunk_size <= 0:
+            return _create_error_response(
+                {
+                    "error": "Invalid chunk_size",
+                    "message": "chunk_size must be a positive integer",
+                },
+                400,
+            )
+
+        # Get checksums from the adapter
+        checksums_result = compute_kvcache_checksums(
+            lmcache_adapter, slot_indices, chunk_size, layerwise
+        )
+
+        if checksums_result is None:
+            return _create_error_response(
+                {
+                    "error": "Failed to compute checksums",
+                    "message": "kv_caches not available or empty",
+                },
+                500,
+            )
+
+        # Compute slot mapping ranges using compress_slot_mapping
+        slot_mapping_ranges = compress_slot_mapping(slot_indices)
+
+        response_data: dict[str, Any] = {
+            "status": "success",
+            "slot_mapping_ranges": slot_mapping_ranges,
+        }
+
+        # Include chunk checksums
+        response_data["chunk_size"] = checksums_result.get("chunk_size")
+        response_data["num_chunks"] = checksums_result.get("num_chunks")
+        response_data["chunk_checksums"] = checksums_result.get("chunk_checksums")
+        response_data["layerwise"] = layerwise
+
+        return PlainTextResponse(
+            content=json.dumps(response_data, indent=2),
+            media_type="application/json",
+        )
+
+    except Exception as e:
+        logger.error("Failed to compute kvcache checksums: %s", str(e))
+        return _create_error_response(
+            {"error": "Failed to compute checksums", "message": str(e)},
+            500,
+        )
+
+
+@router.post("/cache/kvcache/record_slot")
+async def kvcache_record_slot(
+    request: Request,
+    enabled: Optional[str] = None,
+):
+    """Enable or disable KVCache Check slot_mapping logging.
+
+    This endpoint controls whether the KVCache Check logs (slot_mapping info)
+    are printed when store/retrieve operations are performed.
+
+    Args:
+        request (Request): The FastAPI request object containing application state.
+        enabled (Optional[str], optional): "true" to enable logging, "false" to
+            disable. Defaults to None.
+
+    Returns:
+        PlainTextResponse: A JSON response containing the current logging status.
+
+    Example:
+        ```bash
+        # Enable logging
+        curl -X POST "http://localhost:8000/cache/kvcache/record_slot?enabled=true"
+
+        # Disable logging
+        curl -X POST "http://localhost:8000/cache/kvcache/record_slot?enabled=false"
+
+        # Check current status
+        curl -X POST "http://localhost:8000/cache/kvcache/record_slot"
+        ```
+    """
+    try:
+        lmcache_adapter = request.app.state.lmcache_adapter
+        if not lmcache_adapter:
+            return _create_error_response(
+                {
+                    "error": "LMCache adapter unavailable",
+                    "message": "LMCache adapter not configured.",
+                },
+                503,
+            )
+
+        # Get current status from lmcache_engine
+        lmcache_engine = lmcache_adapter.lmcache_engine
+        current_status = getattr(lmcache_engine, "kvcache_check_log_enabled", False)
+
+        # Update status if enabled parameter is provided
+        if enabled is not None:
+            enabled_lower = enabled.lower()
+            if enabled_lower == "true":
+                lmcache_engine.kvcache_check_log_enabled = True
+                current_status = True
+                logger.info("KVCache Check logging enabled")
+            elif enabled_lower == "false":
+                lmcache_engine.kvcache_check_log_enabled = False
+                current_status = False
+                logger.info("KVCache Check logging disabled")
+            else:
+                return _create_error_response(
+                    {
+                        "error": "Invalid parameter",
+                        "message": "enabled must be 'true' or 'false'",
+                    },
+                    400,
+                )
+
+        response_data = {
+            "status": "success",
+            "kvcache_check_log_enabled": current_status,
+        }
+
+        return PlainTextResponse(
+            content=json.dumps(response_data, indent=2),
+            media_type="application/json",
+        )
+
+    except Exception as e:
+        logger.error("Failed to set kvcache record slot status: %s", str(e))
+        return _create_error_response(
+            {"error": "Failed to set record slot status", "message": str(e)},
+            500,
+        )
+
+
+@router.get("/cache/kvcache/info")
+async def kvcache_info(request: Request):
+    """Get information about the current kvcaches.
+
+    Returns information about the kvcaches structure including layer names,
+    shapes, and device information.
+
+    Args:
+        request (Request): The FastAPI request object containing application state.
+
+    Returns:
+        PlainTextResponse: A JSON response containing kvcache information.
+    """
+    try:
+        lmcache_adapter = request.app.state.lmcache_adapter
+        if not lmcache_adapter:
+            return _create_error_response(
+                {
+                    "error": "LMCache adapter unavailable",
+                    "message": "LMCache adapter not configured.",
+                },
+                503,
+            )
+
+        kv_caches = getattr(lmcache_adapter, "kvcaches", None)
+        if not kv_caches:
+            return _create_error_response(
+                {
+                    "error": "kv_caches not available",
+                    "message": "kv_caches is empty or not initialized",
+                },
+                404,
+            )
+
+        layers_info: dict = {}
+        for layer_name, kv_tensor in kv_caches.items():
+            layers_info[layer_name] = {
+                "shape": list(kv_tensor.shape),
+                "dtype": str(kv_tensor.dtype),
+                "device": str(kv_tensor.device),
+            }
+
+        info = {
+            "status": "success",
+            "num_layers": len(kv_caches),
+            "layers": layers_info,
+        }
+
+        return PlainTextResponse(
+            content=json.dumps(info, indent=2),
+            media_type="application/json",
+        )
+
+    except Exception as e:
+        logger.error("Failed to get kvcache info: %s", str(e))
+        return _create_error_response(
+            {"error": "Failed to get kvcache info", "message": str(e)},
+            500,
+        )

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -363,10 +363,11 @@ class LMCacheStandaloneStarter:
         logger.info("Starting LMCache engine with instance ID: %s", instance_id)
 
         # Generate fixed pattern kvcaches for testing
-        kvcaches = self._generate_fixed_kvcaches(device=self.device)
+        kv_caches = self._generate_fixed_kvcaches(device=self.device)
+        self.kv_caches = kv_caches
 
         # Initialize the engine with kvcaches
-        self.lmcache_engine.post_init(kvcaches=list(kvcaches.values()))
+        self.lmcache_engine.post_init(kvcaches=list(kv_caches.values()))
         logger.info("LMCache engine post-initialized with fixed kvcaches")
 
         # Start internal API server

--- a/tests/v1/internal_api_server/test_kvcache_check_api.py
+++ b/tests/v1/internal_api_server/test_kvcache_check_api.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+import hashlib
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import compress_slot_mapping
+from lmcache.v1.internal_api_server.api_server import app
+
+
+class TestKVCacheCheckAPI:
+    """Test suite for the /kvcache/check API endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def reset_adapter(self):
+        """Reset adapter before each test."""
+        yield
+        app.state.lmcache_adapter = None
+
+    @pytest.fixture
+    def mock_kv_caches(self) -> Dict[str, torch.Tensor]:
+        """Create mock kv_caches tensors for testing."""
+        return {
+            "layer_0": torch.randn(4, 4, 8, 64),
+            "layer_1": torch.randn(4, 4, 8, 64),
+        }
+
+    @pytest.fixture
+    def mock_lmcache_adapter(self, mock_kv_caches):
+        """Create a mock LMCacheConnectorV1Impl adapter."""
+        adapter = MagicMock()
+        adapter.kv_caches = mock_kv_caches
+        adapter.kvcaches = mock_kv_caches  # API uses kvcaches (no underscore)
+
+        # Mock lmcache_engine for record_slot tests
+        mock_engine = MagicMock()
+        mock_engine.kvcache_check_log_enabled = False
+        adapter.lmcache_engine = mock_engine
+
+        def compute_checksums(
+            slot_indices: List[int], chunk_size: Optional[int] = None
+        ) -> Optional[Dict[str, Any]]:
+            if not adapter.kv_caches:
+                return None
+
+            layer_checksums: Dict[str, str] = {}
+            chunk_checksums: Dict[str, List[str]] = {}
+
+            for layer_name, kv_tensor in adapter.kv_caches.items():
+                slot_tensor = torch.tensor(
+                    slot_indices, dtype=torch.long, device=kv_tensor.device
+                )
+                kv_at_slots = kv_tensor.view(-1, *kv_tensor.shape[2:])[slot_tensor]
+                tensor_bytes = kv_at_slots.detach().cpu().contiguous().numpy().tobytes()
+                layer_checksums[layer_name] = hashlib.md5(tensor_bytes).hexdigest()
+
+                if chunk_size and chunk_size > 0:
+                    num_slots = len(slot_indices)
+                    chunk_checksum_list: List[str] = []
+                    for i in range((num_slots + chunk_size - 1) // chunk_size):
+                        chunk_data = kv_at_slots[i * chunk_size : (i + 1) * chunk_size]
+                        chunk_bytes = (
+                            chunk_data.detach().cpu().contiguous().numpy().tobytes()
+                        )
+                        chunk_checksum_list.append(hashlib.md5(chunk_bytes).hexdigest())
+                    chunk_checksums[layer_name] = chunk_checksum_list
+
+            result: Dict[str, Any] = {"layer_checksums": layer_checksums}
+            if chunk_size:
+                result["chunk_checksums"] = chunk_checksums
+                result["chunk_size"] = chunk_size
+                result["num_chunks"] = (
+                    (len(slot_indices) + chunk_size - 1) // chunk_size
+                    if slot_indices
+                    else 0
+                )
+            return result
+
+        adapter.compute_kvcache_checksums = compute_checksums
+        return adapter
+
+    @pytest.fixture
+    def client_with_adapter(self, mock_lmcache_adapter):
+        """Create a test client with mocked adapter."""
+        app.state.lmcache_adapter = mock_lmcache_adapter
+        return TestClient(app)
+
+    # ==========================================================================
+    # Tests for /kvcache/check endpoint
+    # ==========================================================================
+
+    def test_kvcache_check_success_layer_only(self, client_with_adapter):
+        """Test successful kvcache check with layer-level checksums."""
+        response = client_with_adapter.post(
+            "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
+        )
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["status"] == "success"
+        assert "chunk_checksums" in data
+
+    @pytest.mark.parametrize(
+        "url,expected_error",
+        [
+            ("/cache/kvcache/check?slot_mapping=a,b,c", "Invalid slot_mapping format"),
+            (
+                "/cache/kvcache/check?slot_mapping=0,1&chunk_size=0",
+                "Invalid chunk_size",
+            ),
+            (
+                "/cache/kvcache/check?slot_mapping=0,1&chunk_size=-1",
+                "Invalid chunk_size",
+            ),
+        ],
+    )
+    def test_kvcache_check_invalid_params(
+        self, client_with_adapter, url, expected_error
+    ):
+        """Test kvcache check with various invalid parameters."""
+        response = client_with_adapter.post(url)
+        assert response.status_code == 400
+        assert json.loads(response.text)["error"] == expected_error
+
+    @pytest.mark.parametrize(
+        "slots,chunk_size,expected_chunks",
+        [
+            ("0,1,2,3,4,5,6,7", 4, 2),
+            ("0,1,2,3,4,5,6", 3, 3),
+            ("0,1,2,3", 4, 1),
+            ("0,1,2,3", 1, 4),
+        ],
+    )
+    def test_kvcache_check_with_chunk_size(
+        self, client_with_adapter, slots, chunk_size, expected_chunks
+    ):
+        """Test kvcache check with various chunk sizes."""
+        response = client_with_adapter.post(
+            f"/cache/kvcache/check?slot_mapping={slots}&chunk_size={chunk_size}"
+        )
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["num_chunks"] == expected_chunks
+
+    def test_kvcache_check_consistency(self, client_with_adapter):
+        """Test that checksums are consistent across calls."""
+        url = "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
+        data1 = json.loads(client_with_adapter.post(url).text)
+        data2 = json.loads(client_with_adapter.post(url).text)
+        assert data1["chunk_checksums"] == data2["chunk_checksums"]
+
+    # ==========================================================================
+    # Tests for adapter unavailable scenarios
+    # ==========================================================================
+
+    @pytest.mark.parametrize(
+        "method,url",
+        [
+            ("post", "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"),
+            ("get", "/cache/kvcache/info"),
+            ("post", "/cache/kvcache/record_slot?enabled=true"),
+        ],
+    )
+    def test_no_adapter(self, method, url):
+        """Test endpoints when adapter is not available."""
+        app.state.lmcache_adapter = None
+        client = TestClient(app)
+        response = getattr(client, method)(url)
+        assert response.status_code == 503
+        assert json.loads(response.text)["error"] == "LMCache adapter unavailable"
+
+    def test_kvcache_check_empty_kv_caches(self):
+        """Test kvcache check when kv_caches is empty."""
+        adapter = MagicMock()
+        adapter.kv_caches = {}
+        adapter.kvcaches = {}
+        adapter.compute_kvcache_checksums = MagicMock(return_value=None)
+        app.state.lmcache_adapter = adapter
+        response = TestClient(app).post(
+            "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
+        )
+        assert response.status_code == 404
+
+    # ==========================================================================
+    # Tests for /cache/kvcache/info endpoint
+    # ==========================================================================
+
+    def test_kvcache_info_success(self, client_with_adapter):
+        """Test successful kvcache info retrieval."""
+        response = client_with_adapter.get("/cache/kvcache/info")
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["num_layers"] == 2
+        assert "layer_0" in data["layers"]
+
+    def test_kvcache_info_empty(self):
+        """Test kvcache info when kvcaches is empty."""
+        adapter = MagicMock()
+        adapter.kvcaches = {}
+        app.state.lmcache_adapter = adapter
+        response = TestClient(app).get("/cache/kvcache/info")
+        assert response.status_code == 404
+
+    # ==========================================================================
+    # Tests for /cache/kvcache/record_slot endpoint
+    # ==========================================================================
+
+    @pytest.mark.parametrize(
+        "enabled_param,expected_value",
+        [("true", True), ("false", False), ("TRUE", True), ("False", False)],
+    )
+    def test_kvcache_record_slot_toggle(
+        self, client_with_adapter, mock_lmcache_adapter, enabled_param, expected_value
+    ):
+        """Test enabling/disabling KVCache Check logging."""
+        response = client_with_adapter.post(
+            f"/cache/kvcache/record_slot?enabled={enabled_param}"
+        )
+        assert response.status_code == 200
+        assert (
+            mock_lmcache_adapter.lmcache_engine.kvcache_check_log_enabled
+            == expected_value
+        )
+
+    def test_kvcache_record_slot_invalid(self, client_with_adapter):
+        """Test with invalid enabled parameter."""
+        response = client_with_adapter.post(
+            "/cache/kvcache/record_slot?enabled=invalid"
+        )
+        assert response.status_code == 400
+
+
+class TestCompressSlotMapping:
+    """Test suite for the compress_slot_mapping function."""
+
+    @pytest.mark.parametrize(
+        "input_slots,expected",
+        [
+            ([1, 2, 3, 4, 5], [[1, 5]]),
+            ([1, 2, 3, 4, 5, 9, 10, 11, 12], [[1, 5], [9, 12]]),
+            ([1, 3, 5, 7], [[1, 1], [3, 3], [5, 5], [7, 7]]),
+            ([1, 2, 3, 5, 7, 8, 9], [[1, 3], [5, 5], [7, 9]]),
+            ([], []),
+            ([42], [[42, 42]]),
+            ([5, 3, 1, 2, 4, 9, 12, 10, 11], [[1, 5], [9, 12]]),
+            ([0, 1, 2, 100, 101, 102], [[0, 2], [100, 102]]),
+        ],
+    )
+    def test_compress_slot_mapping(self, input_slots, expected):
+        """Test compression of slot mappings."""
+        assert compress_slot_mapping(input_slots) == expected

--- a/tests/v1/internal_api_server/test_kvcache_check_api.py
+++ b/tests/v1/internal_api_server/test_kvcache_check_api.py
@@ -244,12 +244,17 @@ class TestCompressSlotMapping:
         [
             ([1, 2, 3, 4, 5], [[1, 5]]),
             ([1, 2, 3, 4, 5, 9, 10, 11, 12], [[1, 5], [9, 12]]),
-            ([1, 3, 5, 7], [[1, 1], [3, 3], [5, 5], [7, 7]]),
-            ([1, 2, 3, 5, 7, 8, 9], [[1, 3], [5, 5], [7, 9]]),
+            # No consecutive elements, no compression
+            ([1, 3, 5, 7], [1, 3, 5, 7]),
+            # 5 is single, not compressed
+            ([1, 2, 3, 5, 7, 8, 9], [[1, 3], 5, [7, 9]]),
             ([], []),
-            ([42], [[42, 42]]),
-            ([5, 3, 1, 2, 4, 9, 12, 10, 11], [[1, 5], [9, 12]]),
+            ([42], [42]),  # Single element, not compressed
+            # Mixed order
+            ([5, 3, 1, 2, 4, 9, 10, 11, 13], [5, 3, 1, 2, 4, [9, 11], 13]),
             ([0, 1, 2, 100, 101, 102], [[0, 2], [100, 102]]),
+            ([1, 2], [1, 2]),  # Two elements, not compressed
+            ([1, 2, 3], [[1, 3]]),  # Three elements, compressed
         ],
     )
     def test_compress_slot_mapping(self, input_slots, expected):

--- a/tests/v1/internal_api_server/test_kvcache_check_api.py
+++ b/tests/v1/internal_api_server/test_kvcache_check_api.py
@@ -98,7 +98,7 @@ class TestKVCacheCheckAPI:
 
     def test_kvcache_check_success_layer_only(self, client_with_adapter):
         """Test successful kvcache check with layer-level checksums."""
-        response = client_with_adapter.post(
+        response = client_with_adapter.get(
             "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
         )
         assert response.status_code == 200
@@ -124,7 +124,7 @@ class TestKVCacheCheckAPI:
         self, client_with_adapter, url, expected_error
     ):
         """Test kvcache check with various invalid parameters."""
-        response = client_with_adapter.post(url)
+        response = client_with_adapter.get(url)
         assert response.status_code == 400
         assert json.loads(response.text)["error"] == expected_error
 
@@ -141,7 +141,7 @@ class TestKVCacheCheckAPI:
         self, client_with_adapter, slots, chunk_size, expected_chunks
     ):
         """Test kvcache check with various chunk sizes."""
-        response = client_with_adapter.post(
+        response = client_with_adapter.get(
             f"/cache/kvcache/check?slot_mapping={slots}&chunk_size={chunk_size}"
         )
         assert response.status_code == 200
@@ -151,8 +151,8 @@ class TestKVCacheCheckAPI:
     def test_kvcache_check_consistency(self, client_with_adapter):
         """Test that checksums are consistent across calls."""
         url = "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
-        data1 = json.loads(client_with_adapter.post(url).text)
-        data2 = json.loads(client_with_adapter.post(url).text)
+        data1 = json.loads(client_with_adapter.get(url).text)
+        data2 = json.loads(client_with_adapter.get(url).text)
         assert data1["chunk_checksums"] == data2["chunk_checksums"]
 
     # ==========================================================================
@@ -162,7 +162,7 @@ class TestKVCacheCheckAPI:
     @pytest.mark.parametrize(
         "method,url",
         [
-            ("post", "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"),
+            ("get", "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"),
             ("get", "/cache/kvcache/info"),
             ("post", "/cache/kvcache/record_slot?enabled=true"),
         ],
@@ -182,7 +182,7 @@ class TestKVCacheCheckAPI:
         adapter.kvcaches = {}
         adapter.compute_kvcache_checksums = MagicMock(return_value=None)
         app.state.lmcache_adapter = adapter
-        response = TestClient(app).post(
+        response = TestClient(app).get(
             "/cache/kvcache/check?slot_mapping=0,1,2,3&chunk_size=2"
         )
         assert response.status_code == 404


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

```shell

curl -X POST "http://localhost:8080/cache/kvcache/record_slot?enabled=true"
{
  "status": "success",
  "kvcache_check_log_enabled": true
}

(Worker_TP0 pid=2165995) [2025-12-14 23:57:21,238] LMCache INFO: [KVCache Check] Store request chatcmpl-f7643f71a4084d32b729dc7a28c0beb9, tokens=256, slot_mapping: [[384, 639]] (cache_engine.py:316:lmcache.v1.cache_engine)

(Worker_TP0 pid=2165995) [2025-12-14 23:57:42,032] LMCache INFO: [KVCache Check] retrieve request chatcmpl-95025a30c3cb4cc6a4d9274de12af8aa, tokens=256, slot_mapping: [[704, 959]] (cache_engine.py:646:lmcache.v1.cache_engine)
(Worker_TP1 pid=2165996) [2025-12

curl -X GET "http://localhost:8080/cache/kvcache/check?slot_mapping=\[384,639\]&chunk_size=256&layerwise=false"
{
  "status": "success",
  "slot_mapping_ranges": [
    [
      384,
      639
    ]
  ],
  "chunk_size": 256,
  "num_chunks": 1,
  "chunk_checksums": [
    "cf20096459f840c558ffb0986753e8bc"
  ],
  "layerwise": false

 curl -X GET "http://localhost:8080/cache/kvcache/check?slot_mapping=\[704,959\]&chunk_size=256&layerwise=false""
{
  "status": "success",
  "slot_mapping_ranges": [
    [
      704,
      959
    ]
  ],
  "chunk_size": 256,
  "num_chunks": 1,
  "chunk_checksums": [
    "cf20096459f840c558ffb0986753e8bc"
  ],
  "layerwise": false
```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
