### PR TITLE
[Controller] Controller benchmark support multi-process

### DIFF
--- a/lmcache/tools/controller_benchmark/__main__.py
+++ b/lmcache/tools/controller_benchmark/__main__.py
@@ -13,16 +13,144 @@ Test operations:
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from typing import Dict, List
 import argparse
 import asyncio
 import json
+import multiprocessing
+import statistics
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.tools.controller_benchmark.benchmark import ZMQControllerBenchmark
+from lmcache.tools.controller_benchmark.benchmark import (
+    BenchmarkResults,
+    OperationStats,
+    ZMQControllerBenchmark,
+)
 from lmcache.tools.controller_benchmark.config import ZMQBenchmarkConfig
 
 logger = init_logger(__name__)
+
+
+def run_single_process(config: ZMQBenchmarkConfig) -> BenchmarkResults:
+    """Run benchmark in a single process and return results"""
+    benchmark = ZMQControllerBenchmark(config)
+    asyncio.run(benchmark.run_benchmark())
+    benchmark.print_results()
+    return benchmark.get_results()
+
+
+def aggregate_results(
+    results_list: List[BenchmarkResults], operations: Dict[str, float]
+) -> BenchmarkResults:
+    """Aggregate results from multiple processes"""
+    aggregated = BenchmarkResults()
+
+    if not results_list:
+        return aggregated
+
+    # Sum up totals
+    aggregated.total_requests = sum(r.total_requests for r in results_list)
+    aggregated.total_messages = sum(r.total_messages for r in results_list)
+    aggregated.total_time = max(r.total_time for r in results_list)
+    aggregated.overall_rps = sum(r.overall_rps for r in results_list)
+    aggregated.overall_qps = sum(r.overall_qps for r in results_list)
+
+    # Aggregate memory usage
+    for r in results_list:
+        aggregated.memory_usage.extend(r.memory_usage)
+
+    # Aggregate per-operation stats
+    for op_name in operations.keys():
+        op_stats_list = [
+            r.operations[op_name] for r in results_list if op_name in r.operations
+        ]
+        if op_stats_list:
+            # Sum QPS and RPS
+            total_qps = sum(s.qps for s in op_stats_list)
+            total_rps = sum(s.rps for s in op_stats_list)
+
+            # Average latencies (weighted by RPS would be more accurate,
+            # but simple average is acceptable)
+            avg_latencies = [s.avg_latency for s in op_stats_list if s.avg_latency > 0]
+            min_latencies = [s.min_latency for s in op_stats_list if s.min_latency > 0]
+            max_latencies = [s.max_latency for s in op_stats_list if s.max_latency > 0]
+            p95_latencies = [s.p95_latency for s in op_stats_list if s.p95_latency > 0]
+
+            aggregated.operations[op_name] = OperationStats(
+                qps=total_qps,
+                rps=total_rps,
+                avg_latency=(statistics.mean(avg_latencies) if avg_latencies else 0.0),
+                min_latency=min(min_latencies) if min_latencies else 0.0,
+                max_latency=max(max_latencies) if max_latencies else 0.0,
+                p95_latency=(statistics.mean(p95_latencies) if p95_latencies else 0.0),
+                errors=sum(s.errors for s in op_stats_list),
+            )
+
+    return aggregated
+
+
+def print_aggregated_results(
+    results: BenchmarkResults,
+    config: ZMQBenchmarkConfig,
+    num_processes: int,
+):
+    """Print aggregated benchmark results from all processes"""
+    print("\n" + "=" * 80)
+    print(
+        "LMCache Controller ZMQ Benchmark - AGGREGATED RESULTS (%d processes)"
+        % num_processes
+    )
+    print("=" * 80)
+
+    print("\nConfiguration:")
+    print("  Controller URL: %s" % config.controller_pull_url)
+    print("  Duration: %d seconds" % config.duration)
+    print("  Batch Size: %d" % config.batch_size)
+    print("  Operations: %s" % config.operations)
+    print(
+        "  Instances per process: %d, Workers: %d, Locations: %d, Keys: %d"
+        % (
+            config.num_instances,
+            config.num_workers,
+            config.num_locations,
+            config.num_keys,
+        )
+    )
+    print("  Total Instances: %d" % (config.num_instances * num_processes))
+
+    print("\nAggregated Performance:")
+    print("  Total Requests: %d" % results.total_requests)
+    print("  Total Messages: %d" % results.total_messages)
+    print("  Total Time: %.2fs" % results.total_time)
+    print("  Overall RPS (Requests/sec): %.2f" % results.overall_rps)
+    print("  Overall QPS (Messages/sec): %.2f" % results.overall_qps)
+
+    print("\nPer-Operation Performance (Aggregated):")
+    for op_name in config.operations.keys():
+        if op_name in results.operations:
+            stats = results.operations[op_name]
+            print("  %s:" % op_name)
+            print("    RPS (Requests/sec): %.2f" % stats.rps)
+            print("    QPS (Messages/sec): %.2f" % stats.qps)
+            print(
+                "    Latency - Avg: %.3fms, Min: %.3fms, Max: %.3fms, P95: %.3fms"
+                % (
+                    stats.avg_latency * 1000,
+                    stats.min_latency * 1000,
+                    stats.max_latency * 1000,
+                    stats.p95_latency * 1000,
+                )
+            )
+            print("    Errors: %d" % stats.errors)
+
+    print("\nSystem Metrics (All Processes):")
+    if results.memory_usage:
+        avg_memory = statistics.mean(results.memory_usage)
+        max_memory = max(results.memory_usage)
+        print("  Memory Usage - Avg: %.1f%%, Max: %.1f%%" % (avg_memory, max_memory))
+
+    print("=" * 80)
 
 
 def main():
@@ -71,7 +199,7 @@ def main():
         "--num-instances",
         type=int,
         default=10,
-        help="Number of instances to simulate",
+        help="Number of instances to simulate per process",
     )
 
     parser.add_argument(
@@ -100,6 +228,13 @@ def main():
         type=int,
         default=100,
         help="Number of hashes for P2P lookup operations",
+    )
+
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=1,
+        help="Number of concurrent benchmark processes",
     )
 
     parser.add_argument(
@@ -133,33 +268,74 @@ def main():
             name, percentage = op_str.split(":", 1)
             operations[name.strip()] = float(percentage.strip())
 
-    # Create config
-    config = ZMQBenchmarkConfig(
-        controller_pull_url=controller_pull_url,
-        controller_reply_url=controller_reply_url,
-        duration=args.duration,
-        batch_size=args.batch_size,
-        operations=operations,
-        num_instances=args.num_instances,
-        num_workers=args.num_workers,
-        num_locations=args.num_locations,
-        num_keys=args.num_keys,
-        num_hashes=args.num_hashes,
-        register_first=not args.no_register_first,
-    )
+    num_processes = args.num_processes
 
-    # Run benchmark
-    benchmark = ZMQControllerBenchmark(config)
+    if num_processes == 1:
+        # Single process mode (original behavior)
+        config = ZMQBenchmarkConfig(
+            controller_pull_url=controller_pull_url,
+            controller_reply_url=controller_reply_url,
+            duration=args.duration,
+            batch_size=args.batch_size,
+            operations=operations,
+            num_instances=args.num_instances,
+            num_workers=args.num_workers,
+            num_locations=args.num_locations,
+            num_keys=args.num_keys,
+            num_hashes=args.num_hashes,
+            register_first=not args.no_register_first,
+            num_processes=1,
+            process_id=0,
+        )
 
-    try:
-        asyncio.run(benchmark.run_benchmark())
-        benchmark.print_results()
+        benchmark = ZMQControllerBenchmark(config)
 
-    except KeyboardInterrupt:
-        print("\nBenchmark interrupted by user")
-    except Exception as e:
-        logger.error("Benchmark failed: %s", e)
-        raise e
+        try:
+            asyncio.run(benchmark.run_benchmark())
+            benchmark.print_results()
+        except KeyboardInterrupt:
+            print("\nBenchmark interrupted by user")
+        except Exception as e:
+            logger.error("Benchmark failed: %s", e)
+            raise e
+    else:
+        # Multi-process mode
+        logger.info("Starting multi-process benchmark with %d processes", num_processes)
+
+        # Create configs for each process
+        configs = []
+        for i in range(num_processes):
+            config = ZMQBenchmarkConfig(
+                controller_pull_url=controller_pull_url,
+                controller_reply_url=controller_reply_url,
+                duration=args.duration,
+                batch_size=args.batch_size,
+                operations=operations,
+                num_instances=args.num_instances,
+                num_workers=args.num_workers,
+                num_locations=args.num_locations,
+                num_keys=args.num_keys,
+                num_hashes=args.num_hashes,
+                register_first=not args.no_register_first,
+                num_processes=num_processes,
+                process_id=i,
+            )
+            configs.append(config)
+
+        try:
+            # Use multiprocessing pool to run benchmarks in parallel
+            with multiprocessing.Pool(processes=num_processes) as pool:
+                results_list = pool.map(run_single_process, configs)
+
+            # Aggregate and print combined results
+            aggregated = aggregate_results(results_list, operations)
+            print_aggregated_results(aggregated, configs[0], num_processes)
+
+        except KeyboardInterrupt:
+            print("\nBenchmark interrupted by user")
+        except Exception as e:
+            logger.error("Benchmark failed: %s", e)
+            raise e
 
 
 if __name__ == "__main__":

--- a/lmcache/tools/controller_benchmark/__main__.py
+++ b/lmcache/tools/controller_benchmark/__main__.py
@@ -86,7 +86,11 @@ def aggregate_results(
                 ),
                 min_latency=min(min_latencies) if min_latencies else 0.0,
                 max_latency=max(max_latencies) if max_latencies else 0.0,
-                p95_latency=max(p95_latencies) if p95_latencies else 0.0,
+                p95_latency=(
+                    sum(s.p95_latency * s.rps for s in op_stats_list) / total_rps
+                    if total_rps > 0 and p95_latencies
+                    else 0.0
+                ),
                 errors=sum(s.errors for s in op_stats_list),
             )
 

--- a/lmcache/tools/controller_benchmark/__main__.py
+++ b/lmcache/tools/controller_benchmark/__main__.py
@@ -72,7 +72,6 @@ def aggregate_results(
 
             # Average latencies (weighted by RPS would be more accurate,
             # but simple average is acceptable)
-            avg_latencies = [s.avg_latency for s in op_stats_list if s.avg_latency > 0]
             min_latencies = [s.min_latency for s in op_stats_list if s.min_latency > 0]
             max_latencies = [s.max_latency for s in op_stats_list if s.max_latency > 0]
             p95_latencies = [s.p95_latency for s in op_stats_list if s.p95_latency > 0]
@@ -80,10 +79,14 @@ def aggregate_results(
             aggregated.operations[op_name] = OperationStats(
                 qps=total_qps,
                 rps=total_rps,
-                avg_latency=(statistics.mean(avg_latencies) if avg_latencies else 0.0),
+                avg_latency=(
+                    sum(s.avg_latency * s.rps for s in op_stats_list) / total_rps
+                    if total_rps > 0
+                    else 0.0
+                ),
                 min_latency=min(min_latencies) if min_latencies else 0.0,
                 max_latency=max(max_latencies) if max_latencies else 0.0,
-                p95_latency=(statistics.mean(p95_latencies) if p95_latencies else 0.0),
+                p95_latency=max(p95_latencies) if p95_latencies else 0.0,
                 errors=sum(s.errors for s in op_stats_list),
             )
 
@@ -270,59 +273,36 @@ def main():
 
     num_processes = args.num_processes
 
-    if num_processes == 1:
-        # Single process mode (original behavior)
-        config = ZMQBenchmarkConfig(
-            controller_pull_url=controller_pull_url,
-            controller_reply_url=controller_reply_url,
-            duration=args.duration,
-            batch_size=args.batch_size,
-            operations=operations,
-            num_instances=args.num_instances,
-            num_workers=args.num_workers,
-            num_locations=args.num_locations,
-            num_keys=args.num_keys,
-            num_hashes=args.num_hashes,
-            register_first=not args.no_register_first,
-            num_processes=1,
-            process_id=0,
-        )
+    # Create a base config dict
+    base_config_kwargs = {
+        "controller_pull_url": controller_pull_url,
+        "controller_reply_url": controller_reply_url,
+        "duration": args.duration,
+        "batch_size": args.batch_size,
+        "operations": operations,
+        "num_instances": args.num_instances,
+        "num_workers": args.num_workers,
+        "num_locations": args.num_locations,
+        "num_keys": args.num_keys,
+        "num_hashes": args.num_hashes,
+        "register_first": not args.no_register_first,
+        "num_processes": num_processes,
+    }
 
-        benchmark = ZMQControllerBenchmark(config)
-
-        try:
-            asyncio.run(benchmark.run_benchmark())
-            benchmark.print_results()
-        except KeyboardInterrupt:
-            print("\nBenchmark interrupted by user")
-        except Exception as e:
-            logger.error("Benchmark failed: %s", e)
-            raise e
-    else:
-        # Multi-process mode
-        logger.info("Starting multi-process benchmark with %d processes", num_processes)
-
-        # Create configs for each process
-        configs = []
-        for i in range(num_processes):
-            config = ZMQBenchmarkConfig(
-                controller_pull_url=controller_pull_url,
-                controller_reply_url=controller_reply_url,
-                duration=args.duration,
-                batch_size=args.batch_size,
-                operations=operations,
-                num_instances=args.num_instances,
-                num_workers=args.num_workers,
-                num_locations=args.num_locations,
-                num_keys=args.num_keys,
-                num_hashes=args.num_hashes,
-                register_first=not args.no_register_first,
-                num_processes=num_processes,
-                process_id=i,
+    try:
+        if num_processes == 1:
+            # Single process mode
+            config = ZMQBenchmarkConfig(**base_config_kwargs, process_id=0)
+            run_single_process(config)
+        else:
+            # Multi-process mode
+            logger.info(
+                "Starting multi-process benchmark with %d processes", num_processes
             )
-            configs.append(config)
-
-        try:
+            configs = [
+                ZMQBenchmarkConfig(**base_config_kwargs, process_id=i)
+                for i in range(num_processes)
+            ]
             # Use multiprocessing pool to run benchmarks in parallel
             with multiprocessing.Pool(processes=num_processes) as pool:
                 results_list = pool.map(run_single_process, configs)
@@ -331,11 +311,11 @@ def main():
             aggregated = aggregate_results(results_list, operations)
             print_aggregated_results(aggregated, configs[0], num_processes)
 
-        except KeyboardInterrupt:
-            print("\nBenchmark interrupted by user")
-        except Exception as e:
-            logger.error("Benchmark failed: %s", e)
-            raise e
+    except KeyboardInterrupt:
+        print("\nBenchmark interrupted by user")
+    except Exception as e:
+        logger.error("Benchmark failed: %s", e)
+        raise e
 
 
 if __name__ == "__main__":

--- a/lmcache/tools/controller_benchmark/benchmark.py
+++ b/lmcache/tools/controller_benchmark/benchmark.py
@@ -145,9 +145,17 @@ class ZMQControllerBenchmark:
         logger.info("ZMQ sockets closed")
 
     def generate_test_data(self) -> TestData:
-        """Generate test data based on configuration"""
+        """Generate test data based on configuration
+
+        Each process gets a unique range of instance IDs to avoid conflicts.
+        Format: instance_p{process_id}_{instance_index}
+        """
+        process_id = self.config.process_id
         return TestData(
-            instances=["instance_%d" % i for i in range(self.config.num_instances)],
+            instances=[
+                "instance_p%d_%d" % (process_id, i)
+                for i in range(self.config.num_instances)
+            ],
             workers=list(range(self.config.num_workers)),
             locations=["location_%d" % i for i in range(self.config.num_locations)],
             keys=list(range(self.config.num_keys)),
@@ -445,7 +453,13 @@ class ZMQControllerBenchmark:
     def print_results(self):
         """Print benchmark results"""
         print("\n" + "=" * 80)
-        print("LMCache Controller ZMQ Benchmark Results")
+        if self.config.num_processes > 1:
+            print(
+                "LMCache Controller ZMQ Benchmark Results (Process %d/%d)"
+                % (self.config.process_id + 1, self.config.num_processes)
+            )
+        else:
+            print("LMCache Controller ZMQ Benchmark Results")
         print("=" * 80)
 
         print("\nConfiguration:")
@@ -497,3 +511,7 @@ class ZMQControllerBenchmark:
             )
 
         print("=" * 80)
+
+    def get_results(self) -> BenchmarkResults:
+        """Return benchmark results for aggregation"""
+        return self.results

--- a/lmcache/tools/controller_benchmark/config.py
+++ b/lmcache/tools/controller_benchmark/config.py
@@ -23,6 +23,9 @@ class ZMQBenchmarkConfig:
     operations: Dict[str, float] = field(default_factory=dict)
     heartbeat_interval: float = 1.0
     register_first: bool = True
+    # Multi-process settings
+    num_processes: int = 1
+    process_id: int = 0
 
     def __post_init__(self):
         if not self.operations:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

```shell
python3 -m lmcache.tools.controller_benchmark  \
--monitor-ports  "{\"pull\":7555,\"reply\":7556}" \
--num-instances 50 --num-workers 1 --num-keys 1000000 --batch-size 100 \
--operations "admit:35,evict:29,heartbeat:1,p2p_lookup:35" \
--duration 60 --num-processes 2
```

```yaml
================================================================================
LMCache Controller ZMQ Benchmark Results (Process 1/2)
================================================================================

Configuration:
  Controller URL: 127.0.0.1:7555
  Duration: 60 seconds
  Batch Size: 100
  Operations: {'admit': 35.0, 'evict': 29.0, 'heartbeat': 1.0, 'p2p_lookup': 35.0}
  Instances: 50, Workers: 1, Locations: 1, Keys: 1000000

Overall Performance:
  Total Requests: 172475
  Total Messages: 17076923
  Total Time: 60.00s
  Overall RPS (Requests/sec): 2874.58
  Overall QPS (Messages/sec): 284614.65

Per-Operation Performance:
  admit:
    RPS (Requests/sec): 1006.01
    QPS (Messages/sec): 100601.41
    Latency - Avg: 0.019ms, Min: 0.007ms, Max: 1.928ms, P95: 0.037ms
    Errors: 0
  evict:
    RPS (Requests/sec): 833.46
    QPS (Messages/sec): 83346.45
    Latency - Avg: 0.019ms, Min: 0.007ms, Max: 0.539ms, P95: 0.037ms
    Errors: 0
  heartbeat:
    RPS (Requests/sec): 28.72
    QPS (Messages/sec): 28.72
    Latency - Avg: 0.012ms, Min: 0.002ms, Max: 0.171ms, P95: 0.030ms
    Errors: 0
  p2p_lookup:
    RPS (Requests/sec): 1006.38
    QPS (Messages/sec): 100638.07
    Latency - Avg: 0.768ms, Min: 0.162ms, Max: 11.726ms, P95: 1.677ms
    Errors: 0

System Metrics:
  Memory Usage - Avg: 58.1%, Max: 59.3%
================================================================================

================================================================================
LMCache Controller ZMQ Benchmark Results (Process 2/2)
================================================================================

Configuration:
  Controller URL: 127.0.0.1:7555
  Duration: 60 seconds
  Batch Size: 100
  Operations: {'admit': 35.0, 'evict': 29.0, 'heartbeat': 1.0, 'p2p_lookup': 35.0}
  Instances: 50, Workers: 1, Locations: 1, Keys: 1000000

Overall Performance:
  Total Requests: 172034
  Total Messages: 17033120
  Total Time: 60.00s
  Overall RPS (Requests/sec): 2867.23
  Overall QPS (Messages/sec): 283884.88

Per-Operation Performance:
  admit:
    RPS (Requests/sec): 1003.55
    QPS (Messages/sec): 100354.84
    Latency - Avg: 0.019ms, Min: 0.007ms, Max: 1.278ms, P95: 0.037ms
    Errors: 0
  evict:
    RPS (Requests/sec): 831.43
    QPS (Messages/sec): 83143.20
    Latency - Avg: 0.019ms, Min: 0.007ms, Max: 1.988ms, P95: 0.038ms
    Errors: 0
  heartbeat:
    RPS (Requests/sec): 28.67
    QPS (Messages/sec): 28.67
    Latency - Avg: 0.012ms, Min: 0.002ms, Max: 0.109ms, P95: 0.031ms
    Errors: 0
  p2p_lookup:
    RPS (Requests/sec): 1003.58
    QPS (Messages/sec): 100358.17
    Latency - Avg: 0.770ms, Min: 0.158ms, Max: 11.639ms, P95: 1.714ms
    Errors: 0

System Metrics:
  Memory Usage - Avg: 58.1%, Max: 59.3%
================================================================================

================================================================================
LMCache Controller ZMQ Benchmark - AGGREGATED RESULTS (2 processes)
================================================================================

Configuration:
  Controller URL: 127.0.0.1:7555
  Duration: 60 seconds
  Batch Size: 100
  Operations: {'admit': 35.0, 'evict': 29.0, 'heartbeat': 1.0, 'p2p_lookup': 35.0}
  Instances per process: 50, Workers: 1, Locations: 1, Keys: 1000000
  Total Instances: 100

Aggregated Performance:
  Total Requests: 344509
  Total Messages: 34110043
  Total Time: 60.00s
  Overall RPS (Requests/sec): 5741.80
  Overall QPS (Messages/sec): 568499.53

Per-Operation Performance (Aggregated):
  admit:
    RPS (Requests/sec): 2009.56
    QPS (Messages/sec): 200956.25
    Latency - Avg: 0.019ms, Min: 0.007ms, Max: 1.928ms, P95: 0.037ms
    Errors: 0
  evict:
    RPS (Requests/sec): 1664.90
    QPS (Messages/sec): 166489.65
    Latency - Avg: 0.019ms, Min: 0.007ms, Max: 1.988ms, P95: 0.037ms
    Errors: 0
  heartbeat:
    RPS (Requests/sec): 57.38
    QPS (Messages/sec): 57.38
    Latency - Avg: 0.012ms, Min: 0.002ms, Max: 0.171ms, P95: 0.030ms
    Errors: 0
  p2p_lookup:
    RPS (Requests/sec): 2009.96
    QPS (Messages/sec): 200996.25
    Latency - Avg: 0.769ms, Min: 0.158ms, Max: 11.726ms, P95: 1.696ms
    Errors: 0

System Metrics (All Processes):
  Memory Usage - Avg: 58.1%, Max: 59.3%
```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
