### PR TITLE
[Controller] Refactor heartbeat from PUSH to REQ-REP mode and supply heartbeat command framework

### DIFF
--- a/lmcache/tools/controller_benchmark/handlers/heartbeat.py
+++ b/lmcache/tools/controller_benchmark/handlers/heartbeat.py
@@ -18,11 +18,15 @@ from .base import OperationHandler
 
 
 class HeartbeatHandler(OperationHandler):
-    """Handler for heartbeat operations"""
+    """Handler for heartbeat operations (REQ-REP mode)"""
 
     @property
     def operation_name(self) -> str:
         return "heartbeat"
+
+    def use_req_socket(self) -> bool:
+        """Heartbeat now uses REQ-REP mode"""
+        return True
 
     def create_message(
         self, benchmark: "ZMQControllerBenchmark", test_data: "TestData"

--- a/lmcache/v1/cache_controller/commands/__init__.py
+++ b/lmcache/v1/cache_controller/commands/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Heartbeat commands module
+
+This module provides the command abstraction for the heartbeat mechanism.
+Commands can be sent from controller to workers through heartbeat responses.
+"""
+
+# First Party
+from lmcache.v1.cache_controller.commands.base import HeartbeatCommand
+from lmcache.v1.cache_controller.commands.full_sync import FullSyncCommand
+
+__all__ = [
+    "HeartbeatCommand",
+    "FullSyncCommand",
+]

--- a/lmcache/v1/cache_controller/commands/base.py
+++ b/lmcache/v1/cache_controller/commands/base.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Base class for heartbeat commands"""
+
+# Standard
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+# Third Party
+import msgspec
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.cache_controller.worker import LMCacheWorker
+
+
+class HeartbeatCommand(msgspec.Struct, tag_field="command_type"):
+    """Base class for heartbeat commands (polymorphic)
+
+    This abstraction allows controller to send various commands to workers
+    through the heartbeat mechanism. Each command type is a subclass with
+    its own specific fields.
+
+    Uses msgspec's tagged union for serialization/deserialization.
+    """
+
+    reason: Optional[str] = None  # Why this command is issued
+    args: Optional[Dict[str, Any]] = None  # Extension arguments for command
+
+    def describe(self) -> str:
+        return f"{self.__class__.__name__}(reason={self.reason}, args={self.args})"
+
+    def execute(self, worker: "LMCacheWorker") -> None:
+        """Execute this command on the worker. Override in subclasses."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__}.execute() not implemented"
+        )

--- a/lmcache/v1/cache_controller/commands/full_sync.py
+++ b/lmcache/v1/cache_controller/commands/full_sync.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Full sync command implementation"""
+
+# Standard
+from typing import TYPE_CHECKING
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.cache_controller.commands.base import HeartbeatCommand
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.cache_controller.worker import LMCacheWorker
+
+logger = init_logger(__name__)
+
+
+class FullSyncCommand(HeartbeatCommand, tag="full_sync"):
+    """Command to request full state synchronization
+
+    Sent when the controller needs the worker to perform a full sync,
+    e.g., after controller restart or worker re-registration.
+    """
+
+    # FullSync-specific fields can be added here, e.g.:
+    # sync_scope: Optional[str] = None  # "all", "metadata", "data"
+    # priority: int = 0  # Sync priority level
+
+    def describe(self) -> str:
+        return f"FullSyncCommand(reason={self.reason}, args={self.args})"
+
+    def execute(self, worker: "LMCacheWorker") -> None:
+        """Trigger full sync on the worker"""
+        # TODO(baoloongmao): Implement full sync logic and turn to freeze mode
+        logger.info(
+            "Received full sync command with reason: %s, args: %s",
+            self.reason,
+            self.args,
+        )

--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Optional
+from typing import Optional, Union
 import asyncio
 import json
 import threading
@@ -136,9 +136,7 @@ class LMCacheControllerManager:
         self._setup_socket_metrics()
 
     async def handle_worker_message(self, msg: WorkerMsg) -> None:
-        if isinstance(msg, HeartbeatMsg):
-            await self.reg_controller.heartbeat(msg)
-        elif isinstance(msg, RegisterMsg):
+        if isinstance(msg, RegisterMsg):
             await self.reg_controller.register(msg)
         elif isinstance(msg, DeRegisterMsg):
             await self.reg_controller.deregister(msg)
@@ -173,9 +171,17 @@ class LMCacheControllerManager:
         else:
             logger.error(f"Unknown worker message type: {msg}")
 
-    async def handle_worker_req_message(self, msg: WorkerReqMsg) -> WorkerReqRetMsg:
+    async def handle_worker_req_message(
+        self, msg: WorkerReqMsg
+    ) -> Union[WorkerReqRetMsg, ErrorMsg]:
+        ret_msg: Union[WorkerReqRetMsg, ErrorMsg]
         if isinstance(msg, BatchedP2PLookupMsg):
             ret_msg = await self.kv_controller.batched_p2p_lookup(msg)
+        elif isinstance(msg, HeartbeatMsg):
+            ret_msg = await self.reg_controller.heartbeat(msg)
+        else:
+            logger.error(f"Unknown worker request message type: {msg}")
+            ret_msg = ErrorMsg(error=f"Unknown message type: {type(msg)}")
         return ret_msg
 
     async def handle_orchestration_message(self, msg: OrchMsg) -> OrchRetMsg:

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -9,11 +9,13 @@ import zmq.asyncio
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.cache_controller.commands import FullSyncCommand, HeartbeatCommand
 from lmcache.v1.cache_controller.message import (
     DeRegisterMsg,
     HealthMsg,
     HealthRetMsg,
     HeartbeatMsg,
+    HeartbeatRetMsg,
     QueryInstMsg,
     QueryInstRetMsg,
     QueryWorkerInfoMsg,
@@ -175,21 +177,37 @@ class RegistrationController:
             msg,
         )
 
-    # TODO: add more worker info in heartbeat
-    async def heartbeat(self, msg: HeartbeatMsg) -> None:
+    async def heartbeat(self, msg: HeartbeatMsg) -> HeartbeatRetMsg:
         """
-        Heartbeat from lmcache worker.
+        Heartbeat from lmcache worker (REQ-REP mode).
+
+        Returns HeartbeatRetMsg with optional commands for the worker to execute.
+        Commands are executed sequentially by the worker.
         """
         instance_id = msg.instance_id
         worker_id = msg.worker_id
         success = self.registry.update_heartbeat(instance_id, worker_id, time.time())
+
+        commands: list[HeartbeatCommand] = []
+
         if not success:
             logger.warning(
                 "%s has not been registered, re-register the worker.",
                 (instance_id, worker_id),
             )
             # re-register the worker
-            await self.register(msg)
+            register_msg = RegisterMsg(
+                instance_id=msg.instance_id,
+                worker_id=msg.worker_id,
+                ip=msg.ip,
+                port=msg.port,
+                peer_init_url=msg.peer_init_url,
+            )
+            await self.register(register_msg)
+            # New worker needs full sync
+            commands.append(FullSyncCommand(reason="worker_re_registered"))
+
+        return HeartbeatRetMsg(commands=commands)
 
     async def query_worker_info(self, msg: QueryWorkerInfoMsg) -> QueryWorkerInfoRetMsg:
         """

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from enum import Enum
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 # Third Party
 import msgspec
 
 # First Party
+from lmcache.v1.cache_controller.commands.base import HeartbeatCommand
+from lmcache.v1.cache_controller.commands.full_sync import FullSyncCommand
 from lmcache.v1.cache_controller.utils import WorkerInfo
+
+# Type alias for all command types - msgspec needs Union for tagged unions
+AnyCommand = Union[FullSyncCommand, HeartbeatCommand]
 
 
 class MsgBase(msgspec.Struct, tag=True):  # type: ignore
@@ -109,15 +114,6 @@ class KVOpEvent(msgspec.Struct):
     seq_num: int
 
 
-class HeartbeatMsg(RegisterMsg):
-    """Message for heartbeat, include register info for re-register"""
-
-    # TODO: add more heartbeat info
-
-    def describe(self) -> str:
-        return f"Heartbeat from instance {self.instance_id}, worker {self.worker_id}"
-
-
 class BatchedKVOperationMsg(WorkerMsg):
     """Batched KV operation message with common fields and lightweight operations
 
@@ -146,6 +142,19 @@ class WorkerReqMsg(MsgBase):
         return ""
 
 
+class HeartbeatMsg(WorkerReqMsg):
+    """Message for heartbeat (REQ-REP mode), include register info for re-register"""
+
+    instance_id: str
+    worker_id: int
+    ip: str
+    port: int
+    peer_init_url: Optional[str]
+
+    def describe(self) -> str:
+        return f"Heartbeat from instance {self.instance_id}, worker {self.worker_id}"
+
+
 class BatchedP2PLookupMsg(WorkerReqMsg):
     """Batched P2P lookup message"""
 
@@ -167,6 +176,31 @@ class BatchedP2PLookupMsg(WorkerReqMsg):
 class WorkerReqRetMsg(MsgBase):
     def describe(self) -> str:
         return ""
+
+
+class HeartbeatRetMsg(WorkerReqRetMsg):
+    """Heartbeat response message with optional commands
+
+    The controller can use this to send commands to workers through
+    the heartbeat mechanism. This provides a general-purpose way to
+    trigger actions on workers without adding new message types.
+
+    The commands field uses msgspec's tagged union for polymorphic
+    serialization - each command subclass is identified by its tag.
+    Commands are executed sequentially by the worker.
+    """
+
+    commands: List[AnyCommand] = []
+
+    def describe(self) -> str:
+        if not self.commands:
+            return "HeartbeatRet (no commands)"
+        cmd_descs = [cmd.describe() for cmd in self.commands]
+        return f"HeartbeatRet commands=[{', '.join(cmd_descs)}]"
+
+    def has_commands(self) -> bool:
+        """Check if there are commands to execute"""
+        return len(self.commands) > 0
 
 
 class BatchedP2PLookupRetMsg(WorkerReqRetMsg):
@@ -639,6 +673,7 @@ Msg = Union[
     QueryInstMsg,
     QueryInstRetMsg,
     HeartbeatMsg,
+    HeartbeatRetMsg,
     BatchedP2PLookupMsg,
     BatchedP2PLookupRetMsg,
     QueryWorkerInfoMsg,

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -25,6 +25,7 @@ from lmcache.v1.cache_controller.message import (
     HealthWorkerMsg,
     HealthWorkerRetMsg,
     HeartbeatMsg,
+    HeartbeatRetMsg,
     MoveWorkerMsg,
     MoveWorkerRetMsg,
     Msg,
@@ -220,6 +221,8 @@ class LMCacheWorker:
     def _create_ret_msg(self, msg: WorkerReqMsg) -> WorkerReqRetMsg:
         if isinstance(msg, BatchedP2PLookupMsg):
             return BatchedP2PLookupRetMsg(layout_info=[("", "", 0, "")])
+        elif isinstance(msg, HeartbeatMsg):
+            return HeartbeatRetMsg()  # No command by default
         else:
             raise ValueError(f"Unknown message type: {type(msg)}")
 
@@ -254,6 +257,11 @@ class LMCacheWorker:
         return batch
 
     async def heartbeat(self):
+        """
+        Send periodic heartbeats to the controller (REQ-REP mode).
+
+        Process any commands received in the heartbeat response.
+        """
         enable_heartbeat = (
             self.config.lmcache_worker_heartbeat_time is not None
             and self.config.lmcache_worker_heartbeat_time > 0
@@ -266,16 +274,57 @@ class LMCacheWorker:
             )
             await asyncio.sleep(self.config.lmcache_worker_heartbeat_delay_time)
             while True:
-                self.put_msg(
-                    HeartbeatMsg(
-                        instance_id=self.lmcache_instance_id,
-                        worker_id=self.worker_id,
-                        ip=self.lmcache_worker_ip,
-                        port=self.lmcache_worker_port,
-                        peer_init_url=self.p2p_init_url,
-                    )
+                # Send heartbeat via REQ-REP and get response
+                heartbeat_msg = HeartbeatMsg(
+                    instance_id=self.lmcache_instance_id,
+                    worker_id=self.worker_id,
+                    ip=self.lmcache_worker_ip,
+                    port=self.lmcache_worker_port,
+                    peer_init_url=self.p2p_init_url,
                 )
+
+                try:
+                    ret_msg = await self.async_put_and_wait_msg(heartbeat_msg)
+
+                    if isinstance(ret_msg, HeartbeatRetMsg):
+                        self._handle_heartbeat_commands(ret_msg)
+                    else:
+                        logger.warning(
+                            "Unexpected heartbeat response type: %s", type(ret_msg)
+                        )
+                except Exception as e:
+                    logger.error("Error during heartbeat: %s", e)
+
                 await asyncio.sleep(self.config.lmcache_worker_heartbeat_time)
+
+    def _handle_heartbeat_commands(self, ret_msg: HeartbeatRetMsg):
+        """
+        Handle commands received in heartbeat response.
+
+        Uses polymorphic dispatch - each command class implements its own
+        execute() method. Commands are executed sequentially.
+        """
+        if not ret_msg.has_commands():
+            return
+
+        for command in ret_msg.commands:
+            logger.info(
+                "Executing heartbeat command: %s",
+                command.describe(),
+            )
+            try:
+                command.execute(self)
+            except NotImplementedError:
+                logger.warning(
+                    "Command %s.execute() not implemented yet",
+                    type(command).__name__,
+                )
+            except Exception as e:
+                logger.error(
+                    "Error executing command %s: %s",
+                    type(command).__name__,
+                    e,
+                )
 
     async def push(self):
         while True:

--- a/tests/tools/test_controller_zmq_benchmark.py
+++ b/tests/tools/test_controller_zmq_benchmark.py
@@ -158,7 +158,7 @@ class TestOperationHandlers:
 
         assert isinstance(msg, HeartbeatMsg)
         assert handler.get_message_count(controller_zmq_benchmark) == 1
-        assert not handler.use_req_socket()
+        assert handler.use_req_socket()
 
     def test_register_handler(self, controller_zmq_benchmark, test_data):
         """Test RegisterHandler functionality"""


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

- HeartbeatMsg now inherits from WorkerReqMsg instead of RegisterMsg
- Added HeartbeatCommand struct for extensible commands
- HeartbeatRetMsg now uses command pattern
- Worker heartbeat handler dispatches commands via _handle_heartbeat_command
- Updated registration_controller heartbeat to return HeartbeatCommand
- Updated benchmark heartbeat handler for command-based response

The command abstraction allows controller to send various commands to workers through the heartbeat mechanism. New commands can be added by extending HeartbeatCommandType enum without changing the message structure.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
