### PR TITLE
Adapt to Agentic-RL Framework

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -549,10 +549,11 @@ def _init_lmcache_engine(
     local_rank = parallel_config.rank % num_gpus
     torch_dev.set_device(local_rank)
     device = torch.device(f"{dev_name}:{local_rank}")
+    tp_rank = parallel_config.rank % parallel_config.tensor_parallel_size
     metadata = LMCacheEngineMetadata(
         model_config.model,
         parallel_config.world_size,
-        parallel_config.rank,
+        tp_rank,
         "vllm",
         kv_dtype,
         kv_shape,

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -306,8 +306,9 @@ class LMCacheLookupServer:
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
         )
+        tp_rank = vllm_config.parallel_config.rank % vllm_config.parallel_config.tensor_parallel_size
         socket_path = get_zmq_rpc_path_lmcache(
-            vllm_config, "lookup", rpc_port, vllm_config.parallel_config.rank
+            vllm_config, "lookup", rpc_port, tp_rank
         )
         self.socket = get_zmq_socket(
             self.ctx,


### PR DESCRIPTION
**What this PR does / why we need it**:
1. In LMCacheLookupServer, use tp rank to create socket path, otherwise lookup_server won't be able to connect to lookup_client
2. in _init_lmcache_engine, use tp rank to initialize metadata.worker_id, otherwise cache won't be able to reuse between difference inference engine, because in RL Framework parallel_config.rank means global rank.

**Special notes for your reviewers**:
Refs #2203
