### PR TITLE
[correctness]: fix early alignment of num_computed_tokens

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1518,14 +1518,6 @@ class LMCacheConnectorV1Impl:
             logger.debug(f"Looking up cache for the first time for request {req_id}!")
             self._requests_priority[req_id] = getattr(request, "priority", 0)
 
-            # Align computed tokens once to avoid repeated
-            # chunk-size rounding downstream
-            aligned_num_computed_tokens = (
-                num_computed_tokens
-                // self._lmcache_chunk_size
-                * self._lmcache_chunk_size
-            )
-
             # token_ids = request.prompt_token_ids
             # all token ids covers the preemption case
             token_ids = request.all_token_ids
@@ -1542,11 +1534,21 @@ class LMCacheConnectorV1Impl:
             if self.skip_last_n_tokens > 0:
                 token_ids = token_ids[: -self.skip_last_n_tokens]
 
+            # this rounds down
+            # example diagram: vllm page size = 16, lmcache chunk size = 256 (brackets)
+            # [ vllm page 1 | ... | vllm page 16 ] [ vllm page 17 | vllm page 18 ]
+            # lmcache chunk 1                                     lmcache chunk 2
+            # total tokens = 512 (2 lmcache chunks)
+            # vllm num_computed_tokens = 288 (18 vllm pages)
+            # we can completely skip lmcache chunk 1 but we will still retrieve chunk 2
+            # and overwrite vllm page 17 and 18
+            # the need_to_allocate is 512 - 288 = 224
+            # and not 256 even though we will retrieve 256 tokens from lmcache
             num_external_hit_tokens = self.lookup_client.lookup(
                 token_ids,
                 lookup_id=req_id,
                 request_configs=request_configs,
-                num_computed_tokens=aligned_num_computed_tokens,
+                num_computed_tokens=num_computed_tokens,
             )
 
         if num_external_hit_tokens is None:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1035,9 +1035,10 @@ class LMCacheConnectorV1Impl:
 
                 # Check the result
                 num_retrieved_tokens = ret_token_mask.sum().item()
-                num_expected_tokens = (
-                    lmcache_cached_tokens - request.load_spec.vllm_cached_tokens
-                )
+                # use token_mask to calculate expected tokens, matching what retrieve()
+                # calculates internally as num_required_tokens
+                token_mask_slice = token_mask[:lmcache_cached_tokens]
+                num_expected_tokens = token_mask_slice.sum().item()
                 if num_retrieved_tokens < num_expected_tokens:
                     logger.error(
                         "Request %s"
@@ -1060,7 +1061,6 @@ class LMCacheConnectorV1Impl:
                         slot_mapping[:lmcache_cached_tokens],
                     )
                     self._invalid_block_ids.update(missing_blocks)
-
             self._stats_monitor.update_interval_vllm_hit_tokens(
                 request.load_spec.vllm_cached_tokens
             )
@@ -1109,7 +1109,6 @@ class LMCacheConnectorV1Impl:
         ret_mask_cpu = ret_mask.to(device="cpu", dtype=torch.bool)
 
         if ret_mask_cpu.shape[0] != expected_mask_cpu.shape[0]:
-            logger.debug("expected_mask_cpu.shape[0] != ret_mask_cpu.shape[0]")
             return set()
 
         missing_mask = expected_mask_cpu & ~ret_mask_cpu

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1109,6 +1109,7 @@ class LMCacheConnectorV1Impl:
         ret_mask_cpu = ret_mask.to(device="cpu", dtype=torch.bool)
 
         if ret_mask_cpu.shape[0] != expected_mask_cpu.shape[0]:
+            logger.debug("expected_mask_cpu.shape[0] != ret_mask_cpu.shape[0]")
             return set()
 
         missing_mask = expected_mask_cpu & ~ret_mask_cpu
@@ -1533,15 +1534,16 @@ class LMCacheConnectorV1Impl:
             if self.skip_last_n_tokens > 0:
                 token_ids = token_ids[: -self.skip_last_n_tokens]
 
-            # example diagram: vllm page size = 16, lmcache chunk size = 256 (brackets)
-            # [ vllm page 1 | ... | vllm page 16 ] [ vllm page 17 | vllm page 18 ]
-            # lmcache chunk 1                                     lmcache chunk 2
-            # total tokens = 512 (2 lmcache chunks)
-            # vllm num_computed_tokens = 288 (18 vllm pages)
-            # we can completely skip lmcache chunk 1 but we will still retrieve chunk 2
-            # and overwrite vllm page 17 and 18
-            # the need_to_allocate is 512 - 288 = 224
-            # and not 256 even though we will retrieve 256 tokens from lmcache
+            # Example (page_size=16, chunk_size=256):
+            #
+            # chunks:  [0..255]                [256..511]
+            # pages:   [0..15]...[240..255]    [256..271][272..287] ...
+            #
+            # num_computed_tokens = 288 => vLLM already has [0..287] (18 pages)
+            # LMCache hit_prefix_tokens = 512 => cache covers [0..511] (2 chunks)
+            #
+            # Skip chunk 1, retrieve chunk 2, overwrite [256..287] (32-token overlap)
+            # Allocate only the truly new tail: 512 - 288 = 224 tokens
             num_external_hit_tokens = self.lookup_client.lookup(
                 token_ids,
                 lookup_id=req_id,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1534,7 +1534,6 @@ class LMCacheConnectorV1Impl:
             if self.skip_last_n_tokens > 0:
                 token_ids = token_ids[: -self.skip_last_n_tokens]
 
-            # this rounds down
             # example diagram: vllm page size = 16, lmcache chunk size = 256 (brackets)
             # [ vllm page 1 | ... | vllm page 16 ] [ vllm page 17 | vllm page 18 ]
             # lmcache chunk 1                                     lmcache chunk 2

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -99,6 +99,7 @@ class LMCacheEngine:
     ):
         logger.info(f"Creating LMCacheEngine with config: {config}")
         self.config = config
+        self.chunk_size = config.chunk_size
         self.metadata = metadata
         self.token_database = token_database
         self.gpu_connector = gpu_connector
@@ -924,6 +925,8 @@ class LMCacheEngine:
 
         :return: An int indicating how many prefix tokens are cached.
         """
+        # NOTE: the return statement is in the finally clause and
+        # subtracts away the overlap from the chunk aligned res
         assert self.storage_manager is not None
 
         if tokens is not None:
@@ -933,10 +936,12 @@ class LMCacheEngine:
             assert hashes is not None
             lookup_request_id = self.stats_monitor.on_lookup_request(sum(offsets))
 
-        # Skip the number of tokens that are already computed (aligned upstream to
-        # chunk size)
-        aligned_computed_tokens = num_computed_tokens
-        res = aligned_computed_tokens
+        aligned_computed_tokens = (
+            num_computed_tokens // self.chunk_size * self.chunk_size
+        )
+        # equivalent to: num_computed_tokens - aligned_computed_tokens
+        overlap = num_computed_tokens % self.chunk_size
+        aligned_res = aligned_computed_tokens
         try:
             chunk_info_iterator = self.token_database.process_tokens(
                 tokens=tokens,
@@ -970,9 +975,9 @@ class LMCacheEngine:
                             )
                             location = next(iter(block_mapping.keys()))
                             self.lookup_pins[lookup_id][location].extend(key_all_layers)
-                        res = end
+                        aligned_res = end
                         continue
-                    return res
+                    break
             else:
                 chunk_info_list = []
                 keys = []
@@ -986,24 +991,28 @@ class LMCacheEngine:
                     # chunk_info[2] is the key
                     keys.append(chunk_info[2])
                 # If no tokens to lookup, return immediately
-                if not keys:
-                    return res
-                # hit chunks by prefix matching
-                hit_chunks, block_mapping = self.storage_manager.batched_contains(
-                    keys, search_range, pin
-                )
-                if pin and block_mapping:
-                    assert lookup_id is not None, (
-                        "lookup_id is required when pin is True"
+                if keys:
+                    # hit chunks by prefix matching
+                    hit_chunks, block_mapping = self.storage_manager.batched_contains(
+                        keys, search_range, pin
                     )
-                    self.lookup_pins[lookup_id] = block_mapping
-                for idx, (start, end, key) in enumerate(chunk_info_list):
-                    if idx < hit_chunks:
-                        res = end
-                        continue
-                    return res
-
-            # all tokens where found, return the maximal end
+                    if pin and block_mapping:
+                        assert lookup_id is not None, (
+                            "lookup_id is required when pin is True"
+                        )
+                        self.lookup_pins[lookup_id] = block_mapping
+                    for idx, (start, end, key) in enumerate(chunk_info_list):
+                        if idx < hit_chunks:
+                            aligned_res = end
+                            continue
+                        break
+            res = aligned_res - overlap
+            if res < 0:
+                logger.warning(
+                    f"cache engine found a negative number of hit tokens: {res}"
+                    "returning 0"
+                )
+                res = 0
             return res
         finally:
             # When num_computed_tokens is greater than a chunk, we skip
@@ -1013,7 +1022,9 @@ class LMCacheEngine:
             # In this case, using res as the number of hit tokens will overcount
             # the number of hit tokens.
             # TODO deprecate this metric and use retrieve metrics instead.
-            self.stats_monitor.on_lookup_finished(lookup_request_id, res)
+            self.stats_monitor.on_lookup_finished(
+                lookup_request_id, max(aligned_res - overlap, 0)
+            )
             # vllm lookup sets pin to True
             if pin:
                 self.storage_manager.touch_cache()

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -925,8 +925,6 @@ class LMCacheEngine:
 
         :return: An int indicating how many prefix tokens are cached.
         """
-        # NOTE: the return statement is in the finally clause and
-        # subtracts away the overlap from the chunk aligned res
         assert self.storage_manager is not None
 
         if tokens is not None:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -53,6 +53,7 @@ class LMCacheLookupClient(LookupClientInterface):
         self.encoder = msgspec.msgpack.Encoder()
         self.ctx = get_zmq_context(use_asyncio=False)
         self.config = config
+        self.chunk_size = config.chunk_size
         rpc_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache_rpc_port", 0
         )
@@ -183,7 +184,9 @@ class LMCacheLookupClient(LookupClientInterface):
             request_configs_str = json.dumps(request_configs)
         request_configs_buf = request_configs_str.encode("utf-8")
         num_computed_buf = num_computed_tokens.to_bytes(8, "big", signed=False)
-        aligned_computed_tokens = num_computed_tokens  # pre-aligned in adapter
+        aligned_computed_tokens = (
+            num_computed_tokens // self.chunk_size * self.chunk_size
+        )
 
         # NOTE(Jiayi): We cannot only send hashes when blending enabled
         # because the blender need the input embedding.
@@ -201,10 +204,10 @@ class LMCacheLookupClient(LookupClientInterface):
                     continue
                 hashes.append(key)
                 offsets.append(end - start)
-            # Return aligned_computed_tokens immediately if there is no token to
+            # Return num_computed_tokens immediately if there is no token to
             # lookup
             if not hashes:
-                return aligned_computed_tokens
+                return num_computed_tokens
 
             hash_buf = self.encoder.encode(hashes)
             offset_buf = self.encoder.encode(offsets)


### PR DESCRIPTION
Correctness issues introduced from https://github.com/LMCache/LMCache/pull/2111

Follow-up: PR that will ensure APC + LMCache compatibility


Testing manually: 
```bash
VLLM_SERVER_DEV_MODE=1 \
VLLM_BATCH_INVARIANT=1 \
VLLM_ATTENTION_BACKEND=FLASH_ATTN \
vllm serve meta-llama/Llama-3.2-1B-Instruct \
  --kv-transfer-config \
  '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
```

```bash
CONTEXT="$(
  man bash \
  | col -b \
  | tr -s '[:space:]' ' ' \
  | awk '{
      for (i = 1; i <= NF; i++) {
        printf "%s ", $i
        if (++c == 5000) exit
      }
    }'
)"

HALF_CONTEXT="$(
  man bash \
  | col -b \
  | tr -s '[:space:]' ' ' \
  | awk '{
      for (i = 1; i <= NF; i++) {
        printf "%s ", $i
        if (++c == 2500) exit
      }
    }'
)"

# 1. send curl request with CONTEXT (populates APC and LMCache)
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d "$(jq -n \
    --arg model "meta-llama/Llama-3.2-1B-Instruct" \
    --arg content "$CONTEXT" \
    --argjson max_tokens 100 \
    '{
      model: $model,
      temperature: 0,
      max_tokens: $max_tokens,
      messages: [
        { role: "user", content: $content }
      ]
    }'
  )" | jq -r '.choices[0].message.content'
  
# 2. send clear APC request
curl -X POST "http://localhost:8000/reset_prefix_cache"

# 3. send curl request with HALF_CONTEXT (will populate APC)
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d "$(jq -n \
    --arg model "meta-llama/Llama-3.2-1B-Instruct" \
    --arg content "$HALF_CONTEXT" \
    --argjson max_tokens 100 \
    '{
      model: $model,
      temperature: 0,
      max_tokens: $max_tokens,
      messages: [
        { role: "user", content: $content }
      ]
    }'
  )" | jq -r '.choices[0].message.content'
  
# 4. send curl request with CONTEXT (will half hit APC and half hit LMCache)
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d "$(jq -n \
    --arg model "meta-llama/Llama-3.2-1B-Instruct" \
    --arg content "$CONTEXT" \
    --argjson max_tokens 100 \
    '{
      model: $model,
      temperature: 0,
      max_tokens: $max_tokens,
      messages: [
        { role: "user", content: $content }
      ]
    }'
  )" | jq -r '.choices[0].message.content'
```