### PR TITLE
[Core][Test] Refactor centralized storage to use transfer channel

### DIFF
--- a/lmcache/v1/server/__main__.py
+++ b/lmcache/v1/server/__main__.py
@@ -17,6 +17,9 @@ from lmcache.v1.protocol import (
     ServerReturnCode,
 )
 from lmcache.v1.server.storage_backend import CreateStorageBackend
+from lmcache.v1.transfer_channel.py_socket_channel import (
+    PySocketChannel as TransferChannel,
+)
 
 logger = init_logger(__name__)
 
@@ -31,108 +34,134 @@ class LMCacheServer:
         self.server_socket.bind((host, port))
         self.server_socket.listen()
 
-    def receive_all(self, client_socket, n):
-        data = bytearray()
-        while len(data) < n:
-            packet = client_socket.recv(n - len(data))
-            if not packet:
-                return None
-            data.extend(packet)
-        return data
-
     def handle_client(self, client_socket):
+        # Create a channel for this client connection
+        channel = TransferChannel(
+            async_mode=False,
+            role="receiver",
+            buffer_ptr=0,
+            buffer_size=0,
+            align_bytes=1,
+            tp_rank=0,
+            peer_init_url=None,
+        )
+        # Initialize data socket via base-class API using an fd URL.
+        fd = client_socket.detach()
+        channel.lazy_init_peer_connection(
+            local_id="server",
+            peer_id="client",
+            peer_init_url=f"fd://{fd}",
+        )
+
         try:
             while True:
-                logger.debug("Waiting for command")
-                header = self.receive_all(client_socket, ClientMetaMessage.packlength())
-                if not header:
-                    break
-                meta = ClientMetaMessage.deserialize(header)
-                logger.debug(f"Received command: {meta.command}")
-                match meta.command:
-                    case ClientCommand.PUT:
-                        t0 = time.perf_counter()
-                        s = self.receive_all(client_socket, meta.length)
-                        t1 = time.perf_counter()
-                        self.data_store.put(meta, s)
-                        t2 = time.perf_counter()
-                        logger.debug(
-                            f"Time to receive data: {t1 - t0}, time to store "
-                            f"data: {t2 - t1}"
-                        )
+                try:
+                    logger.debug("Waiting for command")
+                    # Receive header using channel
+                    header_buf = bytearray(ClientMetaMessage.packlength())
+                    recv_count = channel.batched_recv(
+                        [header_buf],
+                        transfer_spec={"size": ClientMetaMessage.packlength()},
+                    )
+                    if recv_count == 0:
+                        break
+                    meta = ClientMetaMessage.deserialize(bytes(header_buf))
+                    logger.debug(f"Received command: {meta.command}")
+                    match meta.command:
+                        case ClientCommand.PUT:
+                            t0 = time.perf_counter()
+                            # Receive data using channel
+                            data_buf = bytearray(meta.length)
+                            recv_count = channel.batched_recv(
+                                [data_buf],
+                                transfer_spec={"size": meta.length},
+                            )
+                            if recv_count == 0:
+                                break
+                            t1 = time.perf_counter()
+                            # Avoid an extra full-payload copy; backend expects
+                            # bytearray.
+                            self.data_store.put(meta, data_buf)
+                            t2 = time.perf_counter()
+                            logger.debug(
+                                f"Time to receive data: {t1 - t0}, time to store "
+                                f"data: {t2 - t1}"
+                            )
 
-                    case ClientCommand.GET:
-                        t0 = time.perf_counter()
-                        lms_memory_obj = self.data_store.get(meta.key)
-                        t1 = time.perf_counter()
-                        if lms_memory_obj is not None:
-                            client_socket.sendall(
-                                ServerMetaMessage(
+                        case ClientCommand.GET:
+                            t0 = time.perf_counter()
+                            lms_memory_obj = self.data_store.get(meta.key)
+                            t1 = time.perf_counter()
+                            if lms_memory_obj is not None:
+                                # Send response using channel
+                                response_meta = ServerMetaMessage(
                                     ServerReturnCode.SUCCESS,
                                     lms_memory_obj.length,
                                     lms_memory_obj.fmt,
                                     lms_memory_obj.dtype,
                                     lms_memory_obj.shape,
-                                ).serialize()
-                            )
-                            t2 = time.perf_counter()
-                            client_socket.sendall(lms_memory_obj.data)
-                            t3 = time.perf_counter()
-                            logger.debug(
-                                f"Time to get data: {t1 - t0}, time to send "
-                                f"meta: {t2 - t1}, time to send data: {t3 - t2}"
-                            )
-                        else:
-                            client_socket.sendall(
-                                ServerMetaMessage(
+                                )
+                                channel.batched_send([response_meta.serialize()])
+                                t2 = time.perf_counter()
+                                channel.batched_send([lms_memory_obj.data])
+                                t3 = time.perf_counter()
+                                logger.debug(
+                                    f"Time to get data: {t1 - t0}, time to send "
+                                    f"meta: {t2 - t1}, time to send data: {t3 - t2}"
+                                )
+                            else:
+                                response_meta = ServerMetaMessage(
                                     ServerReturnCode.FAIL,
                                     0,
                                     MemoryFormat(1),
                                     torch.float16,
                                     torch.Size((0, 0, 0, 0)),
-                                ).serialize()
-                            )
+                                )
+                                channel.batched_send([response_meta.serialize()])
 
-                    case ClientCommand.EXIST:
-                        code = (
-                            ServerReturnCode.SUCCESS
-                            if self.data_store.contains(meta.key)
-                            else ServerReturnCode.FAIL
-                        )
-                        logger.debug(f"Key exists: {code}")
-                        client_socket.sendall(
-                            ServerMetaMessage(
+                        case ClientCommand.EXIST:
+                            code = (
+                                ServerReturnCode.SUCCESS
+                                if self.data_store.contains(meta.key)
+                                else ServerReturnCode.FAIL
+                            )
+                            logger.debug(f"Key exists: {code}")
+                            response_meta = ServerMetaMessage(
                                 code,
                                 0,
                                 MemoryFormat(1),
                                 torch.float16,
                                 torch.Size((0, 0, 0, 0)),
-                            ).serialize()
-                        )
-                    case ClientCommand.HEALTH:
-                        client_socket.sendall(
-                            ServerMetaMessage(
+                            )
+                            channel.batched_send([response_meta.serialize()])
+                        case ClientCommand.HEALTH:
+                            response_meta = ServerMetaMessage(
                                 ServerReturnCode.SUCCESS,
                                 0,
                                 MemoryFormat(1),
                                 torch.float16,
                                 torch.Size((0, 0, 0, 0)),
-                            ).serialize()
-                        )
-                        logger.debug("Health check successful")
+                            )
+                            channel.batched_send([response_meta.serialize()])
+                            logger.debug("Health check successful")
+                except (ConnectionResetError, BrokenPipeError, OSError) as e:
+                    logger.info("Client socket error, closing connection: %s", e)
+                    break
 
                     # TODO(Jiayi): Implement List
                     # case ClientCommand.LIST:
                     #     keys = list(self.data_store.list_keys())
                     #     data = "\n".join(keys).encode()
-                    #     client_socket.sendall(
-                    #         ServerMetaMessage(ServerReturnCode.SUCCESS,
-                    #                           len(data)).serialize())
-                    #     client_socket.sendall(data)
+                    #     response_meta = ServerMetaMessage(
+                    #         ServerReturnCode.SUCCESS,
+                    #         len(data),
+                    #     )
+                    #     channel.batched_send([response_meta.serialize()])
+                    #     channel.batched_send([data])
 
         finally:
             logger.info("Client disconnected")
-            client_socket.close()
+            channel.close()
 
     def run(self):
         logger.info(f"Server started at {self.host}:{self.port}")

--- a/lmcache/v1/storage_backend/connector/lm_connector.py
+++ b/lmcache/v1/storage_backend/connector/lm_connector.py
@@ -2,7 +2,7 @@
 # Standard
 from typing import List, Optional, no_type_check
 import asyncio
-import socket
+import threading
 
 # Third Party
 import torch
@@ -19,6 +19,9 @@ from lmcache.v1.protocol import (
 )
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.transfer_channel.py_socket_channel import (
+    PySocketChannel as TransferChannel,
+)
 
 logger = init_logger(__name__)
 
@@ -41,20 +44,46 @@ class LMCServerConnector(RemoteConnector):
         # However, we use socket here as we need to use the socket.recv_into()
         # to reduce memory copy.
 
-        self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.client_socket.connect((host, port))
-        # loop.sock_recv_into(sock, buf)
-
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
+        # Create channel for this connection
+        self.channel = TransferChannel(
+            async_mode=True,
+            role="sender",
+            buffer_ptr=0,
+            buffer_size=0,
+            align_bytes=1,
+            tp_rank=0,
+            peer_init_url=None,
+            event_loop=loop,
+        )
+        # Initialize data socket via base-class API using a tcp URL.
+        init_url = f"tcp://{host}:{port}"
+        if loop.is_running() and getattr(loop, "_thread_id", None) not in (
+            None,
+            threading.get_ident(),
+        ):
+            fut = asyncio.run_coroutine_threadsafe(
+                self.channel.async_lazy_init_peer_connection(
+                    local_id="client",
+                    peer_id="server",
+                    peer_init_url=init_url,
+                ),
+                loop,
+            )
+            fut.result()
+        else:
+            # Fallback for cases where we can't block on the event loop thread.
+            self.channel.lazy_init_peer_connection(
+                local_id="client",
+                peer_id="server",
+                peer_init_url=init_url,
+            )
+
         self.async_socket_lock = asyncio.Lock()
 
-    # TODO(Jiayi): This should be an async function
-    def receive_all(self, meta: ServerMetaMessage) -> Optional[MemoryObj]:
-        received = 0
-        n = meta.length
-
+    async def receive_all(self, meta: ServerMetaMessage) -> Optional[MemoryObj]:
         # TODO(Jiayi): Format will be used once we support
         # compressed memory format
         memory_obj = self.local_cpu_backend.allocate(
@@ -66,14 +95,13 @@ class LMCServerConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        buffer = memory_obj.byte_array
-        view = memoryview(buffer)
-
-        while received < n:
-            num_bytes = self.client_socket.recv_into(view[received:], n - received)
-            if num_bytes == 0:
-                return None
-            received += num_bytes
+        # Receive data using channel
+        recv_count = await self.channel.async_batched_recv(
+            [memory_obj],
+            transfer_spec={"size": meta.length},
+        )
+        if recv_count == 0:
+            return None
 
         return memory_obj
 
@@ -81,18 +109,20 @@ class LMCServerConnector(RemoteConnector):
         # logger.debug("Call to exists()!")
 
         async with self.async_socket_lock:
-            self.client_socket.sendall(
-                ClientMetaMessage(
-                    ClientCommand.EXIST,
-                    key,
-                    0,
-                    MemoryFormat(1),
-                    torch.float16,
-                    torch.Size([0, 0, 0, 0]),
-                ).serialize()
+            request = ClientMetaMessage(
+                ClientCommand.EXIST,
+                key,
+                0,
+                MemoryFormat(1),
+                torch.float16,
+                torch.Size([0, 0, 0, 0]),
             )
-
-            response = self.client_socket.recv(ServerMetaMessage.packlength())
+            await self.channel.async_batched_send([request.serialize()])
+            response = await self.channel.async_recv_exactly(
+                ServerMetaMessage.packlength()
+            )
+            if response is None:
+                return False
 
         return ServerMetaMessage.deserialize(response).code == ServerReturnCode.SUCCESS
 
@@ -118,49 +148,45 @@ class LMCServerConnector(RemoteConnector):
         memory_format = memory_obj.get_memory_format()
 
         async with self.async_socket_lock:
-            await self.loop.sock_sendall(
-                self.client_socket,
-                ClientMetaMessage(
-                    ClientCommand.PUT,
-                    key,
-                    len(kv_bytes),
-                    memory_format,
-                    kv_dtype,
-                    kv_shape,
-                ).serialize(),
+            request = ClientMetaMessage(
+                ClientCommand.PUT,
+                key,
+                len(kv_bytes),
+                memory_format,
+                kv_dtype,
+                kv_shape,
             )
-
-            await self.loop.sock_sendall(self.client_socket, kv_bytes)
+            await self.channel.async_batched_send([request.serialize()])
+            await self.channel.async_batched_send([kv_bytes])
 
     # TODO(Jiayi): This should be an async function
     @_lmcache_nvtx_annotate
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        # NOTE(Jiayi): Not using any await in the following as
-        # we don't want to yield control to other tasks which could
-        # sacrifice the performance loading to trade the performance of
-        # saving
+        # IMPORTANT: Keep the socket lock held across the full request/response
+        # (meta + payload). Otherwise concurrent GETs can interleave reads on
+        # the same TCP stream and corrupt framing.
         async with self.async_socket_lock:
-            self.client_socket.sendall(
-                ClientMetaMessage(
-                    ClientCommand.GET,
-                    key,
-                    0,
-                    MemoryFormat(1),
-                    torch.float16,
-                    torch.Size([0, 0, 0, 0]),
-                ).serialize()
+            request = ClientMetaMessage(
+                ClientCommand.GET,
+                key,
+                0,
+                MemoryFormat(1),
+                torch.float16,
+                torch.Size([0, 0, 0, 0]),
             )
+            await self.channel.async_batched_send([request.serialize()])
 
-            data = self.client_socket.recv(ServerMetaMessage.packlength())
+            response = await self.channel.async_recv_exactly(
+                ServerMetaMessage.packlength()
+            )
+            if response is None:
+                return None
 
-        meta = ServerMetaMessage.deserialize(data)
-        if meta.code != ServerReturnCode.SUCCESS:
-            return None
+            meta = ServerMetaMessage.deserialize(response)
+            if meta.code != ServerReturnCode.SUCCESS:
+                return None
 
-        async with self.async_socket_lock:
-            memory_obj = self.receive_all(meta)
-
-        return memory_obj
+            return await self.receive_all(meta)
 
     # TODO
     @no_type_check
@@ -169,5 +195,5 @@ class LMCServerConnector(RemoteConnector):
 
     async def close(self):
         async with self.async_socket_lock:
-            self.client_socket.close()
+            self.channel.close()
         logger.info("Closed the lmserver connection")

--- a/lmcache/v1/transfer_channel/py_socket_channel.py
+++ b/lmcache/v1/transfer_channel/py_socket_channel.py
@@ -8,6 +8,7 @@
 # Standard
 from typing import Optional, Union
 import asyncio
+import socket
 import threading
 import time
 
@@ -17,6 +18,7 @@ import zmq
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.rpc_utils import get_zmq_context, get_zmq_socket
 from lmcache.v1.transfer_channel.abstract import BaseTransferChannel
 from lmcache.v1.transfer_channel.transfer_utils import (
@@ -96,11 +98,36 @@ class PySocketChannel(BaseTransferChannel):
         self.peer_init_url = kwargs["peer_init_url"]
         self.event_loop = kwargs.get("event_loop", None)
 
+        # Data plane: socket for data transfer
+        self.data_socket: Optional[socket.socket] = None
+
         self._init_side_channels()
 
     ############################################################
     # Control plane: Initialization functions
     ############################################################
+
+    def get_local_mem_indices(
+        self, objects: Union[list[bytes], list[MemoryObj]]
+    ) -> list[int]:
+        """Get memory indices from objects"""
+        local_indices: list[int] = []
+        if len(objects) == 0:
+            return local_indices
+
+        if isinstance(objects[0], MemoryObj):
+            for mem_obj in objects:
+                assert isinstance(mem_obj, MemoryObj)
+                local_indices.append(mem_obj.meta.address)
+        elif isinstance(objects[0], bytes):
+            # For bytes, we don't have memory indices
+            local_indices = [0] * len(objects)
+        return local_indices
+
+    def _is_data_socket_url(self, url: str) -> bool:
+        # If it has a scheme, treat it as a data-plane socket URL.
+        # ZMQ init URLs are typically like "host:port" without scheme.
+        return "://" in url
 
     def lazy_init_peer_connection(
         self,
@@ -109,7 +136,17 @@ class PySocketChannel(BaseTransferChannel):
         peer_init_url: str,
         init_side_msg: Optional[InitSideMsgBase] = None,
     ) -> Optional[InitSideRetMsgBase]:
-        raise NotImplementedError("Sync mode not supported in PySocketChannel")
+        # Data-plane init path: accept/connect socket via URL.
+        if self._is_data_socket_url(peer_init_url):
+            self.set_data_socket_from_url(peer_init_url)
+            self.remote_connections[peer_id] = {"peer_init_url": peer_init_url}
+            return None
+
+        # Control-plane ZMQ handshake path is not supported in sync mode.
+        raise NotImplementedError(
+            "Sync ZMQ handshake not supported in PySocketChannel; "
+            "pass a data socket URL like tcp://host:port or fd://<fd>."
+        )
 
     async def async_lazy_init_peer_connection(
         self,
@@ -123,6 +160,47 @@ class PySocketChannel(BaseTransferChannel):
 
         Note: peer_id is expected to be peer_init_url in this implementation.
         """
+        # Data-plane init path: accept/connect socket via URL.
+        if self._is_data_socket_url(peer_init_url):
+            # Prefer non-blocking connect for tcp:// in async mode.
+            if peer_init_url.startswith("tcp://"):
+                hostport = peer_init_url[len("tcp://") :]
+
+                def _parse_host_port(hp: str) -> tuple[str, int]:
+                    if hp.startswith("["):
+                        end = hp.find("]")
+                        if end == -1 or end + 1 >= len(hp) or hp[end + 1] != ":":
+                            raise ValueError(f"Invalid host:port: {hp}")
+                        host = hp[1:end]
+                        port_s = hp[end + 2 :]
+                    else:
+                        if ":" not in hp:
+                            raise ValueError(f"Invalid host:port: {hp}")
+                        host, port_s = hp.rsplit(":", 1)
+                    return host, int(port_s)
+
+                host, port = _parse_host_port(hostport)
+                addrinfos = socket.getaddrinfo(
+                    host,
+                    port,
+                    family=socket.AF_UNSPEC,
+                    type=socket.SOCK_STREAM,
+                )
+                if not addrinfos:
+                    raise OSError(f"Failed to resolve {host}:{port}")
+                family, socktype, proto, _, sockaddr = addrinfos[0]
+                sock = socket.socket(family, socktype, proto)
+                sock.setblocking(False)
+                loop = asyncio.get_running_loop()
+                await loop.sock_connect(sock, sockaddr)
+                self.set_data_socket(sock)
+            else:
+                # fd:// or other supported URL: fall back to sync wrapper.
+                self.set_data_socket_from_url(peer_init_url)
+
+            self.remote_connections[peer_id] = {"peer_init_url": peer_init_url}
+            return None
+
         init_tmp_socket = get_zmq_socket(
             self.zmq_context,
             peer_init_url,
@@ -245,6 +323,369 @@ class PySocketChannel(BaseTransferChannel):
                     await asyncio.sleep(0.01)
 
     ############################################################
+    # Data plane: Utility functions
+    ############################################################
+
+    def set_data_socket(self, sock: socket.socket):
+        """Set the data socket for this channel"""
+        self.data_socket = sock
+
+    def get_data_socket(self) -> Optional[socket.socket]:
+        """Get the data socket"""
+        return self.data_socket
+
+    def set_data_socket_from_url(self, url: str) -> socket.socket:
+        """
+        Create/wrap a TCP socket from a URL and set it as data socket.
+
+        Supported URL formats:
+        - ``tcp://host:port`` or ``host:port``: create a new TCP socket and connect.
+        - ``fd://<int>``: take ownership of an existing file descriptor.
+        """
+
+        def _parse_host_port(hostport: str) -> tuple[str, int]:
+            # Support bracketed IPv6 like "[::1]:1234"
+            if hostport.startswith("["):
+                end = hostport.find("]")
+                if end == -1 or end + 1 >= len(hostport) or hostport[end + 1] != ":":
+                    raise ValueError(f"Invalid host:port: {hostport}")
+                host = hostport[1:end]
+                port_s = hostport[end + 2 :]
+            else:
+                if ":" not in hostport:
+                    raise ValueError(f"Invalid host:port: {hostport}")
+                host, port_s = hostport.rsplit(":", 1)
+            return host, int(port_s)
+
+        if url.startswith("fd://"):
+            fd_str = url[len("fd://") :]
+            fd = int(fd_str)
+            sock = socket.socket(fileno=fd)
+            self.data_socket = sock
+            return sock
+
+        hostport = url[len("tcp://") :] if url.startswith("tcp://") else url
+        host, port = _parse_host_port(hostport)
+
+        addrinfos = socket.getaddrinfo(
+            host,
+            port,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+        )
+        if not addrinfos:
+            raise OSError(f"Failed to resolve {host}:{port}")
+
+        family, socktype, proto, _, sockaddr = addrinfos[0]
+        sock = socket.socket(family, socktype, proto)
+        sock.connect(sockaddr)
+        self.data_socket = sock
+        return sock
+
+    def _receive_all(self, sock: socket.socket, n: int) -> Optional[bytes]:
+        """Receive exactly n bytes from socket"""
+        # NOTE: We intentionally avoid building a bytearray here to match the
+        # connector-side pattern of working with immutable bytes for meta
+        # messages. Payloads should use recv_into into a pre-allocated buffer.
+        chunks: list[bytes] = []
+        remaining = n
+        while remaining > 0:
+            packet = sock.recv(remaining)
+            if not packet:
+                return None
+            chunks.append(packet)
+            remaining -= len(packet)
+        return b"".join(chunks)
+
+    async def _async_receive_all(self, sock: socket.socket, n: int) -> Optional[bytes]:
+        """Async receive exactly n bytes from socket"""
+        chunks: list[bytes] = []
+        remaining = n
+        loop = asyncio.get_running_loop()
+        while remaining > 0:
+            packet = await loop.sock_recv(sock, remaining)
+            if not packet:
+                return None
+            chunks.append(packet)
+            remaining -= len(packet)
+        return b"".join(chunks)
+
+    def recv_exactly(self, n: int) -> Optional[bytes]:
+        """Receive exactly n bytes from the data socket (sync)."""
+        if self.data_socket is None:
+            raise RuntimeError("Data socket not initialized")
+        return self._receive_all(self.data_socket, n)
+
+    async def async_recv_exactly(self, n: int) -> Optional[bytes]:
+        """Receive exactly n bytes from the data socket (async)."""
+        if self.data_socket is None:
+            raise RuntimeError("Data socket not initialized")
+        return await self._async_receive_all(self.data_socket, n)
+
+    ############################################################
+    # Data plane: Send/Recv functions
+    ############################################################
+
+    def batched_send(
+        self,
+        objects: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Send a batch of data through the socket (sync)"""
+        if self.data_socket is None:
+            raise RuntimeError("Data socket not initialized")
+
+        sent_count = 0
+        for obj in objects:
+            if isinstance(obj, (bytes, bytearray, memoryview)):
+                self.data_socket.sendall(obj)
+                sent_count += 1
+            elif isinstance(obj, MemoryObj):
+                # IMPORTANT: MemoryObj.byte_array can be a memoryview (e.g. pinned
+                # memory). Do NOT convert to bytes, otherwise we'd copy payload.
+                self.data_socket.sendall(obj.byte_array)
+                sent_count += 1
+            else:
+                raise ValueError(f"Unsupported object type: {type(obj)}")
+
+        return sent_count
+
+    def batched_recv(
+        self,
+        buffers: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Receive a batch of data through the socket (sync)"""
+        if self.data_socket is None:
+            raise RuntimeError("Data socket not initialized")
+
+        if transfer_spec is None:
+            raise ValueError("transfer_spec is required for recv")
+
+        recv_count = 0
+
+        for buf in buffers:
+            if isinstance(buf, bytearray):
+                # For bytearray, receive directly into the buffer to avoid
+                # allocating a temporary bytes object + copying.
+                size = transfer_spec.get("size", len(buf))
+                view = memoryview(buf)
+                remaining = size
+                offset = 0
+                while remaining > 0:
+                    chunk_size = min(remaining, 65536)
+                    received = self.data_socket.recv_into(
+                        view[offset : offset + chunk_size], chunk_size
+                    )
+                    if received == 0:
+                        return recv_count
+                    offset += received
+                    remaining -= received
+                recv_count += 1
+            elif isinstance(buf, MemoryObj):
+                # For MemoryObj, read into its byte_array
+                size = buf.get_physical_size()
+                byte_array = buf.byte_array
+
+                # Use recv_into to directly read into the buffer
+                if isinstance(byte_array, memoryview):
+                    # Cast memoryview to 'B' (unsigned bytes) format for recv_into
+                    view = byte_array.cast("B")
+                    remaining = size
+                    offset = 0
+                    while remaining > 0:
+                        chunk_size = min(remaining, 65536)  # Read in chunks
+                        view_slice = view[offset : offset + chunk_size]
+                        received = self.data_socket.recv_into(view_slice, chunk_size)
+                        if received == 0:
+                            return recv_count
+                        offset += received
+                        remaining -= received
+                elif isinstance(byte_array, bytearray):
+                    # Direct recv_into for bytearray
+                    remaining = size
+                    offset = 0
+                    while remaining > 0:
+                        chunk_size = min(remaining, 65536)
+                        received = self.data_socket.recv_into(
+                            memoryview(byte_array[offset : offset + chunk_size]),
+                            chunk_size,
+                        )
+                        if received == 0:
+                            return recv_count
+                        offset += received
+                        remaining -= received
+                else:
+                    # Fallback: read into temporary buffer and copy
+                    data = self._receive_all(self.data_socket, size)
+                    if data is None:
+                        break
+                    # For other types, we can't modify directly
+                    raise ValueError(
+                        f"Cannot receive into buffer type: {type(byte_array)}"
+                    )
+                recv_count += 1
+            else:
+                raise ValueError(f"Unsupported buffer type: {type(buf)}")
+
+        return recv_count
+
+    async def async_batched_send(
+        self,
+        objects: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Async send a batch of data through the socket"""
+        if self.data_socket is None:
+            raise RuntimeError("Data socket not initialized")
+
+        loop = asyncio.get_event_loop()
+        sent_count = 0
+
+        for obj in objects:
+            if isinstance(obj, (bytes, bytearray, memoryview)):
+                await loop.sock_sendall(self.data_socket, obj)
+                sent_count += 1
+            elif isinstance(obj, MemoryObj):
+                # IMPORTANT: avoid memoryview->bytes copy
+                await loop.sock_sendall(self.data_socket, obj.byte_array)
+                sent_count += 1
+            else:
+                raise ValueError(f"Unsupported object type: {type(obj)}")
+
+        return sent_count
+
+    async def async_batched_recv(
+        self,
+        buffers: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Async receive a batch of data through the socket"""
+        if self.data_socket is None:
+            raise RuntimeError("Data socket not initialized")
+
+        if transfer_spec is None:
+            raise ValueError("transfer_spec is required for recv")
+
+        recv_count = 0
+        loop = asyncio.get_event_loop()
+
+        for buf in buffers:
+            if isinstance(buf, bytearray):
+                # For bytearray, receive directly into the buffer to avoid
+                # allocating a temporary bytes object + copying.
+                size = transfer_spec.get("size", len(buf))
+                view = memoryview(buf)
+                remaining = size
+                offset = 0
+                while remaining > 0:
+                    chunk_size = min(remaining, 65536)
+                    # asyncio BaseSelectorEventLoop.sock_recv_into(sock, buf)
+                    # reads up to len(buf) bytes; it does NOT take a "nbytes"
+                    # argument in Python 3.12.
+                    received = await loop.sock_recv_into(
+                        self.data_socket,
+                        view[offset : offset + chunk_size],
+                    )
+                    if received == 0:
+                        return recv_count
+                    offset += received
+                    remaining -= received
+                recv_count += 1
+            elif isinstance(buf, MemoryObj):
+                # For MemoryObj, read into its byte_array
+                size = buf.get_physical_size()
+                byte_array = buf.byte_array
+
+                # For async, we need to read in chunks and copy into the buffer
+                if isinstance(byte_array, memoryview):
+                    # Cast to 'B' format for byte operations
+                    view = byte_array.cast("B")
+                    remaining = size
+                    offset = 0
+                    while remaining > 0:
+                        chunk_size = min(remaining, 65536)  # Read in chunks
+                        view_slice = view[offset : offset + chunk_size]
+                        received = await loop.sock_recv_into(
+                            self.data_socket, view_slice
+                        )
+                        if received == 0:
+                            return recv_count
+                        offset += received
+                        remaining -= received
+                    if remaining > 0:
+                        return recv_count  # Incomplete read
+                elif isinstance(byte_array, bytearray):
+                    # For bytearray, read directly
+                    remaining = size
+                    offset = 0
+                    while remaining > 0:
+                        chunk_size = min(remaining, 65536)
+                        received = await loop.sock_recv_into(
+                            self.data_socket,
+                            memoryview(byte_array)[offset : offset + chunk_size],
+                        )
+                        if received == 0:
+                            return recv_count
+                        offset += received
+                        remaining -= received
+                    if remaining > 0:
+                        return recv_count  # Incomplete read
+                else:
+                    # Fallback: read all and try to copy
+                    data = await self._async_receive_all(self.data_socket, size)
+                    if data is None:
+                        break
+                    raise ValueError(
+                        f"Cannot receive into buffer type: {type(byte_array)}"
+                    )
+                recv_count += 1
+            else:
+                raise ValueError(f"Unsupported buffer type: {type(buf)}")
+
+        return recv_count
+
+    ############################################################
+    # Data plane: Read/Write functions
+    ############################################################
+
+    def remote_xfer_handler_exists(self, receiver_or_sender_id: str) -> bool:
+        """Check if remote handler exists"""
+        return self.data_socket is not None and self.data_socket.fileno() != -1
+
+    def batched_write(
+        self,
+        objects: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Write a batch of data through the socket (sync)"""
+        return self.batched_send(objects, transfer_spec)
+
+    def batched_read(
+        self,
+        buffers: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Read a batch of data through the socket (sync)"""
+        return self.batched_recv(buffers, transfer_spec)
+
+    async def async_batched_write(
+        self,
+        objects: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Async write a batch of data through the socket"""
+        return await self.async_batched_send(objects, transfer_spec)
+
+    async def async_batched_read(
+        self,
+        buffers: Union[list[bytes], list[MemoryObj]],
+        transfer_spec: Optional[dict] = None,
+    ) -> int:
+        """Async read a batch of data through the socket"""
+        return await self.async_batched_recv(buffers, transfer_spec)
+
+    ############################################################
     # Cleanup-related functions
     ############################################################
 
@@ -254,7 +695,19 @@ class PySocketChannel(BaseTransferChannel):
         for thread in self.running_threads:
             thread.join()
 
-        if self.side_channel is not None:
-            self.side_channel.close()
+        if self.data_socket is not None:
+            try:
+                self.data_socket.close()
+            except Exception as e:
+                logger.warning(f"Error closing data socket: {e}")
 
-        self.zmq_context.term()
+        if self.side_channel is not None:
+            try:
+                self.side_channel.close()
+            except Exception as e:
+                logger.warning(f"Error closing side channel: {e}")
+
+        # Note: We don't call zmq_context.term() because get_zmq_context()
+        # returns a singleton instance (zmq.Context.instance()) that may be
+        # shared with other parts of the application. Terminating it would
+        # affect all users of the context.

--- a/tests/v1/storage_backend/test_lm_server_connector_channel.py
+++ b/tests/v1/storage_backend/test_lm_server_connector_channel.py
@@ -1,0 +1,1122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import asyncio
+import socket
+import threading
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import MemoryFormat, PinMemoryAllocator
+from lmcache.v1.protocol import (
+    ClientCommand,
+    ClientMetaMessage,
+    ServerMetaMessage,
+    ServerReturnCode,
+)
+from lmcache.v1.server.__main__ import LMCacheServer
+from lmcache.v1.storage_backend.connector.lm_connector import LMCServerConnector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.transfer_channel.py_socket_channel import PySocketChannel
+from tests.v1.utils import (
+    close_asyncio_loop,
+    dumb_cache_engine_key,
+    get_available_port,
+    init_asyncio_loop,
+)
+
+logger = init_logger(__name__)
+
+
+class TestLMCacheServerConnectorChannel:
+    """
+    Test suite for LMCacheServer and LMCServerConnector communication
+    using the refactored transfer channel implementation.
+
+    Tests verify that the refactored code using PySocketChannel
+    maintains the same functionality as the original implementation.
+    """
+
+    @pytest.fixture
+    def server_port(self):
+        """Get an available port for the server."""
+        return get_available_port()
+
+    @pytest.fixture
+    def server(self, server_port):
+        """Create and start a LMCacheServer instance."""
+        host = "127.0.0.1"
+        device = "cpu"
+        server = LMCacheServer(host, server_port, device)
+
+        # Start server in a separate thread
+        server_thread = threading.Thread(target=server.run, daemon=True)
+        server_thread.start()
+
+        # Give server time to start
+        time.sleep(0.2)
+
+        yield server
+
+        # Cleanup
+        try:
+            server.server_socket.close()
+        except Exception:
+            pass
+
+    @pytest.fixture
+    def async_loop(self):
+        """Create an async event loop for testing."""
+        async_loop, async_thread = init_asyncio_loop()
+        yield async_loop
+        close_asyncio_loop(async_loop, async_thread)
+
+    @pytest.fixture
+    def local_cpu_backend(self):
+        """Create a LocalCPUBackend instance for the connector."""
+        # First Party
+        from lmcache.config import LMCacheEngineMetadata
+        from lmcache.v1.config import LMCacheEngineConfig
+
+        config = LMCacheEngineConfig.from_defaults()
+        metadata = LMCacheEngineMetadata(
+            "test_model", 1, 0, "vllm", torch.bfloat16, (4, 2, 256, 8, 128)
+        )
+        backend = LocalCPUBackend(config, metadata, "cpu")
+        yield backend
+        backend.close()
+
+    @pytest.fixture
+    def connector(self, server, server_port, async_loop, local_cpu_backend):
+        """Create a LMCServerConnector instance."""
+        host = "127.0.0.1"
+        # Wait for server to be ready by attempting to connect
+        max_retries = 10
+        retry_delay = 0.1
+        for _ in range(max_retries):
+            try:
+                test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                test_socket.settimeout(0.1)
+                test_socket.connect((host, server_port))
+                test_socket.close()
+                break
+            except (socket.error, OSError):
+                time.sleep(retry_delay)
+        else:
+            raise RuntimeError(
+                f"Server not ready after {max_retries * retry_delay} seconds"
+            )
+
+        connector = LMCServerConnector(host, server_port, async_loop, local_cpu_backend)
+        yield connector
+        # Cleanup
+        try:
+            future = asyncio.run_coroutine_threadsafe(connector.close(), async_loop)
+            future.result(timeout=2)
+        except Exception:
+            pass
+
+    def test_channel_initialization(self, connector):
+        """Test that the connector uses PySocketChannel."""
+        assert hasattr(connector, "channel"), (
+            "Connector should have a channel attribute"
+        )
+        assert isinstance(connector.channel, PySocketChannel), (
+            "Connector should use PySocketChannel"
+        )
+        assert connector.channel.data_socket is not None, (
+            "Channel should have a data socket initialized"
+        )
+
+    def test_put_command(self, server, connector, async_loop):
+        """Test PUT command - server stores data correctly using channel."""
+        key = dumb_cache_engine_key()
+        num_tokens = 256
+        mem_obj_shape = torch.Size([2, 4, num_tokens, 1024])
+        dtype = torch.bfloat16
+
+        # Allocate memory object
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+
+        # Fill with test data
+        torch.manual_seed(42)
+        test_tensor = torch.randint(
+            0, 100, memory_obj.raw_data.shape, dtype=torch.int64
+        )
+        memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+        # Test PUT command
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=5)
+
+        # Verify data was stored by checking if key exists
+        future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+        assert future.result(timeout=5), "Key should exist after PUT command"
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_get_command_success(self, server, connector, async_loop):
+        """Test GET command - server retrieves data correctly using channel."""
+        key = dumb_cache_engine_key()
+        num_tokens = 256
+        mem_obj_shape = torch.Size([2, 4, num_tokens, 1024])
+        dtype = torch.bfloat16
+
+        # Allocate memory object
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+
+        # Fill with test data
+        torch.manual_seed(42)
+        test_tensor = torch.randint(
+            0, 100, memory_obj.raw_data.shape, dtype=torch.int64
+        )
+        memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+        # Store data first
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=5)
+
+        # Test GET command
+        future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+        retrieved_memory_obj = future.result(timeout=5)
+
+        # Verify data was retrieved correctly
+        assert retrieved_memory_obj is not None, (
+            "GET should return data for existing key"
+        )
+        assert retrieved_memory_obj.get_shape() == memory_obj.get_shape()
+        assert retrieved_memory_obj.get_dtype() == memory_obj.get_dtype()
+        assert (
+            retrieved_memory_obj.get_memory_format() == memory_obj.get_memory_format()
+        )
+
+        # Verify data content matches
+        retrieved_tensor = retrieved_memory_obj.tensor
+        original_tensor = memory_obj.tensor
+        assert torch.allclose(retrieved_tensor, original_tensor)
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_get_command_fail(self, server, connector, async_loop):
+        """Test GET command - server returns None for non-existent key."""
+        key = dumb_cache_engine_key()
+
+        # Test GET on non-existent key
+        future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+        retrieved_memory_obj = future.result(timeout=5)
+
+        # Server should return None (FAIL response) for non-existent key
+        assert retrieved_memory_obj is None, (
+            "GET should return None for non-existent key"
+        )
+
+    def test_exist_command_success(self, server, connector, async_loop):
+        """Test EXIST command - server correctly identifies existing key."""
+        key = dumb_cache_engine_key()
+
+        # Key should not exist initially
+        future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+        assert not future.result(timeout=5), "Key should not exist initially"
+
+        # Put data
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=5)
+
+        # Test EXIST command - key should exist now
+        future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+        assert future.result(timeout=5), "Key should exist after PUT"
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_exist_command_fail(self, server, connector, async_loop):
+        """Test EXIST command - server correctly identifies non-existent key."""
+        key = dumb_cache_engine_key()
+
+        # Test EXIST on non-existent key
+        future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+        assert not future.result(timeout=5), (
+            "EXIST should return False for non-existent key"
+        )
+
+    def test_health_command(self, server, server_port):
+        """Test HEALTH command - server responds with success using channel."""
+        host = "127.0.0.1"
+        key = CacheEngineKey(
+            fmt="",
+            model_name="",
+            world_size=0,
+            worker_id=0,
+            chunk_hash=0,
+            dtype=torch.float16,
+        )
+
+        # Create connection and send HEALTH command
+        with socket.create_connection((host, server_port), timeout=5) as s:
+            msg = ClientMetaMessage(
+                ClientCommand.HEALTH,
+                key=key,
+                length=0,
+                fmt=MemoryFormat(1),
+                dtype=torch.float16,
+                shape=torch.Size((0, 0, 0, 0)),
+            )
+            s.sendall(msg.serialize())
+
+            # Receive and parse response
+            resp = s.recv(ServerMetaMessage.packlength())
+            assert resp is not None and len(resp) > 0, (
+                "Server should respond to HEALTH command"
+            )
+
+            # Parse the response message
+            meta = ServerMetaMessage.deserialize(resp)
+
+            # Verify server responded with SUCCESS
+            assert meta.code == ServerReturnCode.SUCCESS, (
+                "HEALTH command should return SUCCESS"
+            )
+
+    def test_channel_data_transfer(self, server, connector, async_loop):
+        """Test that channel correctly transfers data between server and connector."""
+        key = dumb_cache_engine_key()
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Create test data
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+        torch.manual_seed(123)
+        test_tensor = torch.randint(
+            0, 100, memory_obj.raw_data.shape, dtype=torch.int64
+        )
+        memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+        # Put using channel
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=5)
+
+        # Get using channel
+        future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+        retrieved_memory_obj = future.result(timeout=5)
+
+        # Verify channel transferred data correctly
+        assert retrieved_memory_obj is not None
+        assert torch.allclose(retrieved_memory_obj.tensor, memory_obj.tensor)
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_channel_handles_bytearray(self, server, connector, async_loop):
+        """Test that channel correctly handles bytearray data."""
+        key = dumb_cache_engine_key()
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Create memory object with bytearray data
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+
+        # Put and get to verify bytearray handling
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=5)
+
+        future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+        retrieved_memory_obj = future.result(timeout=5)
+
+        assert retrieved_memory_obj is not None
+        assert retrieved_memory_obj.get_shape() == memory_obj.get_shape()
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_multiple_operations(self, server, connector, async_loop):
+        """Test multiple PUT, GET, and EXIST operations using channel."""
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        keys = []
+        memory_objs = []
+
+        # Put multiple keys
+        for i in range(5):
+            key = dumb_cache_engine_key(id=i)
+            keys.append(key)
+            mem_obj_shape = torch.Size([2, 4, 256, 1024])
+            dtype = torch.bfloat16
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+
+            # Fill with unique data
+            torch.manual_seed(i)
+            test_tensor = torch.randint(
+                0, 100, memory_obj.raw_data.shape, dtype=torch.int64
+            )
+            memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            future.result(timeout=5)
+            memory_objs.append(memory_obj)
+
+        # Test EXIST for all keys
+        for key in keys:
+            future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+            assert future.result(timeout=5), f"Key {key} should exist"
+
+        # Test GET for all keys
+        for i, key in enumerate(keys):
+            future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+            retrieved_memory_obj = future.result(timeout=5)
+
+            assert retrieved_memory_obj is not None
+            assert torch.allclose(retrieved_memory_obj.tensor, memory_objs[i].tensor)
+
+        # Cleanup
+        for memory_obj in memory_objs:
+            memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_concurrent_operations(self, server, connector, async_loop):
+        """Test concurrent PUT and GET operations using channel."""
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        keys = []
+        memory_objs = []
+
+        # Create multiple keys
+        for i in range(10):
+            key = dumb_cache_engine_key(id=i)
+            keys.append(key)
+            mem_obj_shape = torch.Size([2, 4, 256, 1024])
+            dtype = torch.bfloat16
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+
+            torch.manual_seed(i)
+            test_tensor = torch.randint(
+                0, 100, memory_obj.raw_data.shape, dtype=torch.int64
+            )
+            memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+            memory_objs.append(memory_obj)
+
+        # Concurrent PUT operations
+        futures = []
+        for key, memory_obj in zip(keys, memory_objs, strict=False):
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            futures.append(future)
+
+        # Wait for all PUTs to complete
+        for future in futures:
+            future.result(timeout=10)
+
+        # Concurrent GET operations
+        get_futures = []
+        for key in keys:
+            future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+            get_futures.append(future)
+
+        # Verify all GETs
+        for i, future in enumerate(get_futures):
+            retrieved_memory_obj = future.result(timeout=10)
+            assert retrieved_memory_obj is not None
+            assert torch.allclose(retrieved_memory_obj.tensor, memory_objs[i].tensor)
+
+        # Cleanup
+        for memory_obj in memory_objs:
+            memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_large_data(self, server, connector, async_loop):
+        """Test PUT and GET with large data using channel."""
+        key = dumb_cache_engine_key()
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+
+        # Create larger memory object
+        mem_obj_shape = torch.Size([2, 4, 2048, 1024])
+        dtype = torch.bfloat16
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+
+        torch.manual_seed(42)
+        test_tensor = torch.randint(
+            0, 100, memory_obj.raw_data.shape, dtype=torch.int64
+        )
+        memory_obj.raw_data.copy_(test_tensor.to(torch.float32).to(dtype))
+
+        # Put large data
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=10)
+
+        # Get large data
+        future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+        retrieved_memory_obj = future.result(timeout=10)
+
+        assert retrieved_memory_obj is not None
+        assert retrieved_memory_obj.get_shape() == memory_obj.get_shape()
+        assert torch.allclose(retrieved_memory_obj.tensor, memory_obj.tensor)
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_channel_close(self, server, connector, async_loop):
+        """Test that channel closes correctly."""
+        # Verify channel is open
+        assert connector.channel.data_socket is not None
+        assert connector.channel.remote_xfer_handler_exists("test")
+
+        # Close connector (which closes channel)
+        future = asyncio.run_coroutine_threadsafe(connector.close(), async_loop)
+        future.result(timeout=2)
+
+        # Channel should be closed
+        assert (
+            connector.channel.data_socket is None
+            or connector.channel.data_socket.fileno() == -1
+        )
+
+    def test_server_uses_channel_per_connection(self, server, server_port):
+        """Test that server creates a new channel for each client connection."""
+        host = "127.0.0.1"
+
+        # Create multiple connections
+        connections = []
+        for _ in range(3):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect((host, server_port))
+            connections.append(sock)
+
+        # Each connection should be handled by server
+        # (We can't directly verify channel creation, but we can verify
+        # connections work)
+        key = CacheEngineKey(
+            fmt="",
+            model_name="",
+            world_size=0,
+            worker_id=0,
+            chunk_hash=0,
+            dtype=torch.float16,
+        )
+
+        for sock in connections:
+            msg = ClientMetaMessage(
+                ClientCommand.HEALTH,
+                key=key,
+                length=0,
+                fmt=MemoryFormat(1),
+                dtype=torch.float16,
+                shape=torch.Size((0, 0, 0, 0)),
+            )
+            sock.sendall(msg.serialize())
+            resp = sock.recv(ServerMetaMessage.packlength())
+            assert resp is not None and len(resp) > 0
+
+        # Cleanup
+        for sock in connections:
+            sock.close()
+
+    def test_channel_async_operations(self, server, connector, async_loop):
+        """Test that channel async operations work correctly."""
+        key = dumb_cache_engine_key()
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Create memory object
+        memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        memory_obj.ref_count_up()
+
+        # Test async send through put (which uses async_batched_send internally)
+        # We don't test async_batched_send directly because it requires following
+        # the protocol (sending proper ClientMetaMessage first)
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result(timeout=5)
+
+        # Test async recv through get (which uses async_batched_recv internally)
+        future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+        retrieved_memory_obj = future.result(timeout=5)
+
+        assert retrieved_memory_obj is not None
+        assert retrieved_memory_obj.get_shape() == memory_obj.get_shape()
+        assert torch.allclose(retrieved_memory_obj.tensor, memory_obj.tensor)
+
+        memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_channel_batched_send_recv_bytearray(self):
+        """Test PySocketChannel batched_send/batched_recv with byte payloads.
+
+        This is a direct unit-level test for the data-plane batch primitives,
+        independent of the LMCache server protocol.
+        """
+        if not hasattr(socket, "socketpair"):
+            pytest.skip("socketpair not supported on this platform")
+
+        a, b = socket.socketpair()
+        try:
+            sender = PySocketChannel.__new__(PySocketChannel)
+            receiver = PySocketChannel.__new__(PySocketChannel)
+            sender.data_socket = a
+            receiver.data_socket = b
+
+            sizes = [1, 7, 4096, 12345]
+            payloads = [bytes([i]) * sz for i, sz in enumerate(sizes, start=1)]
+            buffers = [bytearray(sz) for sz in sizes]
+            total_bytes = sum(sizes)
+
+            t0 = time.perf_counter()
+            sent = sender.batched_send(payloads)
+            t1 = time.perf_counter()
+            recvd = receiver.batched_recv(buffers, transfer_spec={})
+            t2 = time.perf_counter()
+
+            assert sent == len(payloads)
+            assert recvd == len(payloads)
+            assert [bytes(buf) for buf in buffers] == payloads
+
+            send_s = max(t1 - t0, 1e-12)
+            recv_s = max(t2 - t1, 1e-12)
+            total_s = max(t2 - t0, 1e-12)
+            throughput_mib_s = (total_bytes / (1024 * 1024)) / total_s
+
+            print(f"\n{'=' * 100}")
+            print("Batch Transfer Efficiency (PySocketChannel)")
+            print(f"{'=' * 100}")
+            print(
+                f"{'Mode':10s} | {'Msgs':4s} | {'Bytes':10s} | {'Send (ms)':10s} | "
+                f"{'Recv (ms)':10s} | {'Total (ms)':10s} | {'Throughput (MiB/s)':18s}"
+            )
+            print(f"{'-' * 100}")
+            print(
+                f"{'sync':10s} | {len(payloads):4d} | {total_bytes:10d} | "
+                f"{send_s * 1e3:10.3f} | "
+                f"{recv_s * 1e3:10.3f} | {total_s * 1e3:10.3f} | "
+                f"{throughput_mib_s:18.2f}"
+            )
+            print(f"{'=' * 100}\n")
+
+            logger.info(
+                "PySocketChannel batched_send/recv metrics: msgs=%d bytes=%d "
+                "send_ms=%.3f recv_ms=%.3f total_ms=%.3f throughput_MiBps=%.2f",
+                len(payloads),
+                total_bytes,
+                send_s * 1e3,
+                recv_s * 1e3,
+                total_s * 1e3,
+                throughput_mib_s,
+            )
+        finally:
+            a.close()
+            b.close()
+
+    def test_channel_async_batched_send_recv_bytearray(self):
+        """Test PySocketChannel async_batched_send/async_batched_recv with byte
+        payloads.
+        """
+        if not hasattr(socket, "socketpair"):
+            pytest.skip("socketpair not supported on this platform")
+
+        async def _roundtrip():
+            a, b = socket.socketpair()
+            a.setblocking(False)
+            b.setblocking(False)
+            try:
+                sender = PySocketChannel.__new__(PySocketChannel)
+                receiver = PySocketChannel.__new__(PySocketChannel)
+                sender.data_socket = a
+                receiver.data_socket = b
+
+                sizes = [1, 7, 4096, 100000]
+                payloads = [bytes([i]) * sz for i, sz in enumerate(sizes, start=1)]
+                buffers = [bytearray(sz) for sz in sizes]
+                total_bytes = sum(sizes)
+
+                async def _timed_send():
+                    t0 = time.perf_counter()
+                    sent = await sender.async_batched_send(payloads)
+                    t1 = time.perf_counter()
+                    return sent, max(t1 - t0, 1e-12)
+
+                async def _timed_recv():
+                    t0 = time.perf_counter()
+                    recvd = await receiver.async_batched_recv(buffers, transfer_spec={})
+                    t1 = time.perf_counter()
+                    return recvd, max(t1 - t0, 1e-12)
+
+                wall_t0 = time.perf_counter()
+                (sent, send_s), (recvd, recv_s) = await asyncio.gather(
+                    asyncio.create_task(_timed_send()),
+                    asyncio.create_task(_timed_recv()),
+                )
+                wall_t1 = time.perf_counter()
+
+                assert sent == len(payloads)
+                assert recvd == len(payloads)
+                assert [bytes(buf) for buf in buffers] == payloads
+
+                wall_s = max(wall_t1 - wall_t0, 1e-12)
+                throughput_mib_s = (total_bytes / (1024 * 1024)) / wall_s
+
+                print(f"\n{'=' * 100}")
+                print("Batch Transfer Efficiency (PySocketChannel)")
+                print(f"{'=' * 100}")
+                print(
+                    f"{'Mode':10s} | {'Msgs':4s} | {'Bytes':10s} | {'Send (ms)':10s} | "
+                    f"{'Recv (ms)':10s} | {'Wall (ms)':10s} | "
+                    f"{'Throughput (MiB/s)':18s}"
+                )
+                print(f"{'-' * 100}")
+                print(
+                    f"{'async':10s} | {len(payloads):4d} | {total_bytes:10d} | "
+                    f"{send_s * 1e3:10.3f} | "
+                    f"{recv_s * 1e3:10.3f} | {wall_s * 1e3:10.3f} | "
+                    f"{throughput_mib_s:18.2f}"
+                )
+                print(f"{'=' * 100}\n")
+
+                logger.info(
+                    "PySocketChannel async_batched_send/recv metrics: msgs=%d bytes=%d "
+                    "send_ms=%.3f recv_ms=%.3f wall_ms=%.3f throughput_MiBps=%.2f",
+                    len(payloads),
+                    total_bytes,
+                    send_s * 1e3,
+                    recv_s * 1e3,
+                    wall_s * 1e3,
+                    throughput_mib_s,
+                )
+            finally:
+                a.close()
+                b.close()
+
+        asyncio.run(_roundtrip())
+
+    # ========== Performance Measurement Tests ==========
+
+    def test_measure_put_efficiency(self, server, connector, async_loop):
+        """Measure PUT operation efficiency (latency and throughput) using channel."""
+        # Standard
+        import statistics
+
+        num_iterations = 100
+        latencies = []
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Warm-up
+        warmup_key = dumb_cache_engine_key(id=-1)
+        warmup_memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+        warmup_memory_obj.ref_count_up()
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(warmup_key, warmup_memory_obj), async_loop
+        )
+        future.result(timeout=5)
+        warmup_memory_obj.ref_count_down()
+
+        # Measure PUT operations
+        for i in range(num_iterations):
+            key = dumb_cache_engine_key(id=i)
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            future.result(timeout=5)
+            end_time = time.perf_counter()
+
+            latency_ms = (end_time - start_time) * 1000
+            latencies.append(latency_ms)
+            memory_obj.ref_count_down()
+
+        # Calculate statistics
+        avg_latency = statistics.mean(latencies)
+        min_latency = min(latencies)
+        max_latency = max(latencies)
+        median_latency = statistics.median(latencies)
+        p95_latency = statistics.quantiles(latencies, n=20)[18]  # 95th percentile
+        throughput = 1000 / avg_latency if avg_latency > 0 else 0
+
+        # Print results
+        print(f"\n{'=' * 60}")
+        print(f"PUT Operation Performance with Channel (n={num_iterations})")
+        print(f"{'=' * 60}")
+        print(f"Average Latency: {avg_latency:.3f} ms")
+        print(f"Median Latency:  {median_latency:.3f} ms")
+        print(f"Min Latency:     {min_latency:.3f} ms")
+        print(f"Max Latency:     {max_latency:.3f} ms")
+        print(f"P95 Latency:     {p95_latency:.3f} ms")
+        print(f"Throughput:      {throughput:.2f} ops/sec")
+        print(f"{'=' * 60}\n")
+
+        memory_allocator.close()
+
+    def test_measure_get_efficiency(self, server, connector, async_loop):
+        """Measure GET operation efficiency (latency and throughput) using channel."""
+        # Standard
+        import statistics
+
+        num_iterations = 100
+        latencies = []
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Prepare data first
+        keys = []
+        for i in range(num_iterations):
+            key = dumb_cache_engine_key(id=i)
+            keys.append(key)
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            future.result(timeout=5)
+            memory_obj.ref_count_down()
+
+        time.sleep(0.1)  # Small delay to ensure data is stored
+
+        # Warm-up
+        future = asyncio.run_coroutine_threadsafe(connector.get(keys[0]), async_loop)
+        future.result(timeout=5)
+
+        # Measure GET operations
+        for key in keys:
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+            future.result(timeout=5)
+            end_time = time.perf_counter()
+
+            latency_ms = (end_time - start_time) * 1000
+            latencies.append(latency_ms)
+
+        # Calculate statistics
+        avg_latency = statistics.mean(latencies)
+        min_latency = min(latencies)
+        max_latency = max(latencies)
+        median_latency = statistics.median(latencies)
+        p95_latency = statistics.quantiles(latencies, n=20)[18]  # 95th percentile
+        throughput = 1000 / avg_latency if avg_latency > 0 else 0
+
+        # Print results
+        print(f"\n{'=' * 60}")
+        print(f"GET Operation Performance with Channel (n={num_iterations})")
+        print(f"{'=' * 60}")
+        print(f"Average Latency: {avg_latency:.3f} ms")
+        print(f"Median Latency:  {median_latency:.3f} ms")
+        print(f"Min Latency:     {min_latency:.3f} ms")
+        print(f"Max Latency:     {max_latency:.3f} ms")
+        print(f"P95 Latency:     {p95_latency:.3f} ms")
+        print(f"Throughput:      {throughput:.2f} ops/sec")
+        print(f"{'=' * 60}\n")
+
+        memory_allocator.close()
+
+    def test_measure_exist_efficiency(self, server, connector, async_loop):
+        """Measure EXIST operation efficiency (latency and throughput) using channel."""
+        # Standard
+        import statistics
+
+        num_iterations = 100
+        latencies = []
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Prepare data first
+        keys = []
+        for i in range(num_iterations):
+            key = dumb_cache_engine_key(id=i)
+            keys.append(key)
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            future.result(timeout=5)
+            memory_obj.ref_count_down()
+
+        time.sleep(0.1)  # Small delay to ensure data is stored
+
+        # Warm-up
+        future = asyncio.run_coroutine_threadsafe(connector.exists(keys[0]), async_loop)
+        future.result(timeout=5)
+
+        # Measure EXIST operations
+        for key in keys:
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+            future.result(timeout=5)
+            end_time = time.perf_counter()
+
+            latency_ms = (end_time - start_time) * 1000
+            latencies.append(latency_ms)
+
+        # Calculate statistics
+        avg_latency = statistics.mean(latencies)
+        min_latency = min(latencies)
+        max_latency = max(latencies)
+        median_latency = statistics.median(latencies)
+        p95_latency = statistics.quantiles(latencies, n=20)[18]  # 95th percentile
+        throughput = 1000 / avg_latency if avg_latency > 0 else 0
+
+        # Print results
+        print(f"\n{'=' * 60}")
+        print(f"EXIST Operation Performance with Channel (n={num_iterations})")
+        print(f"{'=' * 60}")
+        print(f"Average Latency: {avg_latency:.3f} ms")
+        print(f"Median Latency:  {median_latency:.3f} ms")
+        print(f"Min Latency:     {min_latency:.3f} ms")
+        print(f"Max Latency:     {max_latency:.3f} ms")
+        print(f"P95 Latency:     {p95_latency:.3f} ms")
+        print(f"Throughput:      {throughput:.2f} ops/sec")
+        print(f"{'=' * 60}\n")
+
+        memory_allocator.close()
+
+    def test_measure_health_efficiency(self, server, server_port):
+        """Measure HEALTH command efficiency (latency and throughput) using channel."""
+        # Standard
+        import statistics
+
+        num_iterations = 100
+        latencies = []
+        host = "127.0.0.1"
+        key = CacheEngineKey(
+            fmt="",
+            model_name="",
+            world_size=0,
+            worker_id=0,
+            chunk_hash=0,
+            dtype=torch.float16,
+        )
+
+        # Warm-up
+        with socket.create_connection((host, server_port), timeout=5) as s:
+            msg = ClientMetaMessage(
+                ClientCommand.HEALTH,
+                key=key,
+                length=0,
+                fmt=MemoryFormat(1),
+                dtype=torch.float16,
+                shape=torch.Size((0, 0, 0, 0)),
+            )
+            s.sendall(msg.serialize())
+            s.recv(ServerMetaMessage.packlength())
+
+        # Measure HEALTH operations
+        for _ in range(num_iterations):
+            with socket.create_connection((host, server_port), timeout=5) as s:
+                msg = ClientMetaMessage(
+                    ClientCommand.HEALTH,
+                    key=key,
+                    length=0,
+                    fmt=MemoryFormat(1),
+                    dtype=torch.float16,
+                    shape=torch.Size((0, 0, 0, 0)),
+                )
+                start_time = time.perf_counter()
+                s.sendall(msg.serialize())
+                s.recv(ServerMetaMessage.packlength())
+                end_time = time.perf_counter()
+
+                latency_ms = (end_time - start_time) * 1000
+                latencies.append(latency_ms)
+
+        # Calculate statistics
+        avg_latency = statistics.mean(latencies)
+        min_latency = min(latencies)
+        max_latency = max(latencies)
+        median_latency = statistics.median(latencies)
+        p95_latency = statistics.quantiles(latencies, n=20)[18]  # 95th percentile
+        throughput = 1000 / avg_latency if avg_latency > 0 else 0
+
+        # Print results
+        print(f"\n{'=' * 60}")
+        print(f"HEALTH Operation Performance with Channel (n={num_iterations})")
+        print(f"{'=' * 60}")
+        print(f"Average Latency: {avg_latency:.3f} ms")
+        print(f"Median Latency:  {median_latency:.3f} ms")
+        print(f"Min Latency:     {min_latency:.3f} ms")
+        print(f"Max Latency:     {max_latency:.3f} ms")
+        print(f"P95 Latency:     {p95_latency:.3f} ms")
+        print(f"Throughput:      {throughput:.2f} ops/sec")
+        print(f"{'=' * 60}\n")
+
+    def test_measure_all_operations_efficiency(self, server, connector, async_loop):
+        """Measure efficiency of all operations in a single test using channel."""
+        # Standard
+        import statistics
+
+        num_iterations = 50
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        mem_obj_shape = torch.Size([2, 4, 256, 1024])
+        dtype = torch.bfloat16
+
+        # Prepare data
+        keys = []
+        memory_objs = []
+        for i in range(num_iterations):
+            key = dumb_cache_engine_key(id=i)
+            keys.append(key)
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+            memory_objs.append(memory_obj)
+
+        # Measure PUT
+        put_latencies = []
+        for key, memory_obj in zip(keys, memory_objs, strict=False):
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            future.result(timeout=5)
+            end_time = time.perf_counter()
+            put_latencies.append((end_time - start_time) * 1000)
+
+        time.sleep(0.1)  # Small delay
+
+        # Measure GET
+        get_latencies = []
+        for key in keys:
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+            future.result(timeout=5)
+            end_time = time.perf_counter()
+            get_latencies.append((end_time - start_time) * 1000)
+
+        # Measure EXIST
+        exist_latencies = []
+        for key in keys:
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+            future.result(timeout=5)
+            end_time = time.perf_counter()
+            exist_latencies.append((end_time - start_time) * 1000)
+
+        # Calculate and print statistics
+        def print_stats(op_name, latencies):
+            avg = statistics.mean(latencies)
+            median = statistics.median(latencies)
+            p95 = statistics.quantiles(latencies, n=20)[18]
+            throughput = 1000 / avg if avg > 0 else 0
+            print(
+                f"{op_name:8s} | {avg:8.3f} | {median:8.3f} | {p95:8.3f} | "
+                f"{throughput:10.2f}"
+            )
+
+        print(f"\n{'=' * 70}")
+        print(f"All Operations Performance Summary with Channel (n={num_iterations})")
+        print(f"{'=' * 70}")
+        print(
+            f"{'Operation':8s} | {'Avg (ms)':8s} | "
+            f"{'Median (ms)':8s} | {'P95 (ms)':8s} | "
+            f"{'Throughput (ops/s)':10s}"
+        )
+        print(f"{'-' * 70}")
+        print_stats("PUT", put_latencies)
+        print_stats("GET", get_latencies)
+        print_stats("EXIST", exist_latencies)
+        print(f"{'=' * 70}\n")
+
+        # Cleanup
+        for memory_obj in memory_objs:
+            memory_obj.ref_count_down()
+        memory_allocator.close()
+
+    def test_measure_operation_efficiency_by_data_size(
+        self, server, connector, async_loop
+    ):
+        """Measure operation efficiency for different data sizes using channel."""
+        # Standard
+
+        data_sizes = [
+            (64, "Small"),
+            (256, "Medium"),
+            (1024, "Large"),
+            (2048, "XLarge"),
+        ]
+        memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+        dtype = torch.bfloat16
+
+        print(f"\n{'=' * 100}")
+        print("Operation Efficiency by Data Size (with Channel)")
+        print(f"{'=' * 100}")
+        print(
+            f"{'Shape':30s} | {'PUT (ms)':10s} | {'GET (ms)':10s} | {'EXIST (ms)':10s}"
+        )
+        print(f"{'-' * 100}")
+
+        for num_tokens, size_label in data_sizes:
+            mem_obj_shape = torch.Size([2, 4, num_tokens, 1024])
+            shape_str = str(list(mem_obj_shape))
+            key = dumb_cache_engine_key(id=hash(size_label))
+
+            # Measure PUT
+            memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+            memory_obj.ref_count_up()
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(
+                connector.put(key, memory_obj), async_loop
+            )
+            future.result(timeout=10)
+            put_latency = (time.perf_counter() - start_time) * 1000
+
+            time.sleep(0.1)
+
+            # Measure GET
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(connector.get(key), async_loop)
+            future.result(timeout=10)
+            get_latency = (time.perf_counter() - start_time) * 1000
+
+            # Measure EXIST
+            start_time = time.perf_counter()
+            future = asyncio.run_coroutine_threadsafe(connector.exists(key), async_loop)
+            future.result(timeout=5)
+            exist_latency = (time.perf_counter() - start_time) * 1000
+
+            print(
+                f"{shape_str:30s} | {put_latency:10.3f} | {get_latency:10.3f} | "
+                f"{exist_latency:10.3f}"
+            )
+
+            memory_obj.ref_count_down()
+
+        print(f"{'=' * 100}\n")
+        memory_allocator.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors LMCache’s centralized storage server and connector to use the transfer channel abstraction (via PySocketChannel) instead of ad-hoc Python socket send/recv logic. This removes duplicated networking code, aligns centralized storage with the shared KV-transfer infrastructure, and improves maintainability for future transport/backend extensions.

In addition, this PR adds a unit test suite (TestLMCacheServerConnectorChannel) to validate that the refactor preserves functionality. The tests cover channel initialization and end-to-end correctness for PUT/GET/EXIST/HEALTH, including concurrent operations, large payloads, and direct PySocketChannel batch primitives (batched_send/batched_recv and async variants) using socketpair.

**Special notes for your reviewers**:

	•	Intended as a behavior-preserving refactor: protocol semantics and outcomes remain the same; only the data plane implementation is routed through PySocketChannel.
	•	Tests include both integration-level (server ↔ connector) and unit-level (channel primitives) coverage to reduce regression risk.
	•	Some tests print performance/latency metrics for visibility; they are informational and not used as pass/fail thresholds.
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces custom TCP send/recv framing in the centralized storage server/connector with a new socket-based channel implementation, which could introduce subtle protocol/locking or partial-read bugs under concurrency. Large new integration tests mitigate risk but also increase runtime and rely on timing/threading behavior.
> 
> **Overview**
> **Centralized storage networking is refactored to use the transfer-channel abstraction.** `LMCacheServer` and `LMCServerConnector` now route PUT/GET/EXIST/HEALTH over `PySocketChannel` instead of direct socket `sendall`/`recv`, including per-connection channel setup (`fd://` on the server side, `tcp://` on the client side) and explicit error handling for broken connections.
> 
> **`PySocketChannel` gains a real socket data plane.** It now supports URL-based socket init, exact-length reads, sync/async batched send/recv that use `recv_into` to avoid payload copies, and safer cleanup (closing data/side sockets without terminating the shared ZMQ context).
> 
> **Test coverage is added for end-to-end correctness and channel primitives.** A new test suite exercises connector/server operations (including concurrency and large payloads) and directly validates `PySocketChannel` batch APIs (sync + async), with some tests printing performance metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf1a23059c4cda085931434fd3b383d13ddcaab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->