### PR TITLE
[Doc] Remove the explicit usage of the LMCACHE_USE_EXPERIMENTAL

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -63,7 +63,6 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
          max_local_cpu_size: 10  # GB
          EOF
 
-         export LMCACHE_USE_EXPERIMENTAL=True
          export LMCACHE_CONFIG_FILE=$PWD/lmc_config.yaml
 
          python -m sglang.launch_server \

--- a/docs/source/kv_cache/storage_backends/eic.rst
+++ b/docs/source/kv_cache/storage_backends/eic.rst
@@ -21,7 +21,6 @@ You can enable EIC KVCache offload with the official interface, such as
 .. code-block:: bash
 
    export LMCACHE_CONFIG_FILE=/workspace/config/remote-eic.yaml
-   export LMCACHE_USE_EXPERIMENTAL=True
    export VLLM_USE_V1=1
 
    python3 -m vllm.entrypoints.openai.api_server \

--- a/docs/source/kv_cache/storage_backends/redis.rst
+++ b/docs/source/kv_cache/storage_backends/redis.rst
@@ -236,7 +236,6 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     # LMCACHE_REMOTE_URL="redis-sentinel://localhost:26379,localhost:26380,localhost:26381" \
     # LMCACHE_REMOTE_SERDE="naive"
     LMCACHE_CONFIG_FILE="redis-sentinel-offload.yaml" \
-    LMCACHE_USE_EXPERIMENTAL=True \
     vllm serve \
         meta-llama/Llama-3.1-8B-Instruct \
         --max-model-len 16384 \
@@ -262,7 +261,6 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     # LMCACHE_REMOTE_URL="lm://localhost:65432" \
     # LMCACHE_REMOTE_SERDE="naive"
     LMCACHE_CONFIG_FILE="lmcache-server-offload.yaml" \
-    LMCACHE_USE_EXPERIMENTAL=True \
     vllm serve \
         meta-llama/Llama-3.1-8B-Instruct \
         --max-model-len 16384 \


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
To remove the explicit usage of the LMCACHE_USE_EXPERIMENTAL environment variable that remained in the documentation.

Related PR: https://github.com/LMCache/LMCache/pull/1999

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
