### PR TITLE
[refactor] move get_shapes to LMCacheEngineMetadata

### DIFF
--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -61,6 +61,45 @@ class LMCacheEngineMetadata:
             ]
         return [self.kv_dtype]
 
+    def get_shapes(self, num_tokens: Optional[int] = None) -> list[torch.Size]:
+        """Get the shapes of the KV cache in LMCache"""
+        if num_tokens is None:
+            num_tokens = self.chunk_size
+        if self.kv_layer_groups_manager.kv_layer_groups:
+            shapes = []
+            kv_size = 1 if self.use_mla else 2
+            for group in self.kv_layer_groups_manager.kv_layer_groups:
+                layers = group.num_layers
+                num_heads = 1 if self.use_mla else group.shape[3]
+                hidden_dim_size = num_heads * group.shape[-1]
+                shapes.append(
+                    torch.Size(
+                        [
+                            kv_size,
+                            layers,
+                            num_tokens,
+                            hidden_dim_size,
+                        ]
+                    )
+                )
+            return shapes
+        else:
+            return [
+                torch.Size(
+                    [
+                        self.kv_shape[1],
+                        self.kv_shape[0],
+                        num_tokens,
+                        self.kv_shape[3] * self.kv_shape[4],
+                    ]
+                )
+            ]
+
+    def get_num_groups(self) -> int:
+        if self.kv_layer_groups_manager.kv_layer_groups:
+            return self.kv_layer_groups_manager.num_groups
+        return 1
+
 
 @dataclass
 class LMCacheMemPoolMetadata:

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -69,16 +69,13 @@ class LMCacheEngineMetadata:
             shapes = []
             kv_size = 1 if self.use_mla else 2
             for group in self.kv_layer_groups_manager.kv_layer_groups:
-                layers = group.num_layers
-                num_heads = 1 if self.use_mla else group.shape[3]
-                hidden_dim_size = num_heads * group.shape[-1]
                 shapes.append(
                     torch.Size(
                         [
                             kv_size,
-                            layers,
+                            group.num_layers,
                             num_tokens,
-                            hidden_dim_size,
+                            group.hidden_dim_size,
                         ]
                     )
                 )

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -230,7 +230,10 @@ def get_size_bytes(shapes: list[torch.Size], kv_dtypes: list[torch.dtype]):
     """
     Calculate the size in bytes with the given shapes and dtypes.
     """
-    assert len(shapes) == len(kv_dtypes)
+    assert len(shapes) == len(kv_dtypes), (
+        f"shapes and dtypes must have the same length, "
+        f"but got {len(shapes)} and {len(kv_dtypes)}"
+    )
     return sum(
         shape.numel() * kv_dtype.itemsize
         for shape, kv_dtype in zip(shapes, kv_dtypes, strict=True)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -931,8 +931,6 @@ class LMCacheConnectorV1Impl:
                 self.lmcache_engine.metadata.kv_layer_groups_manager
             )
             kv_layer_groups_manager.build_kv_layer_groups(self.kv_caches)
-            if self.lmcache_engine.gpu_connector is not None:
-                self.lmcache_engine.gpu_connector.init_group_info()
 
     ####################
     # Worker side APIs

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -377,7 +377,7 @@ class LMCacheEngine:
             assert isinstance(key, CacheEngineKey)
             # Allocate the memory object
             num_tokens = end - start
-            kv_shapes = self.gpu_connector.get_shapes(num_tokens)
+            kv_shapes = self.metadata.get_shapes(num_tokens)
             kv_dtypes = self.metadata.get_dtypes()
 
             # TODO (Jiayi): should be batched in the future

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -103,27 +103,10 @@ class GPUConnectorInterface(metaclass=abc.ABCMeta):
         """Get the shape of the data given the number of tokens."""
         raise NotImplementedError
 
-    def get_shapes(self, num_tokens: int) -> list[torch.Size]:
-        """Get the shape of the data given the number of tokens."""
-        return [self.get_shape(num_tokens)]
-
     def initialize_kvcaches_ptr(self, **kwargs):
         """Initialize the kvcaches pointers if not already initialized."""
         if "kvcaches" in kwargs:
             self.kvcaches = kwargs["kvcaches"]
-
-    def init_group_info(self):  # noqa: B027
-        """
-        Initialize the group info.
-
-        By default, the shape and dtype of all layers in the model are the same,
-        but when using deepseek v3.2, DSA adds an indexer layer, which has a
-        different shape and dtype. In this case, it is necessary to use `
-        VLLMPagedMemGPUConnectorV3` and initialize the layers and hidden_dim_size
-        of different groups(all layers in the same group have the same shape and
-        dtype) through this method.
-        """
-        pass
 
 
 class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
@@ -393,8 +376,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.use_gpu = use_gpu
         self.kvcaches: Optional[List[torch.Tensor]] = None
         self.page_buffer_size = 0
-        self.group_layers: Optional[list[int]] = None
-        self.group_hidden_dim_sizes: Optional[list[int]] = None
+
+        self.init = False
         self.group_kv_cache_pointers_on_gpu: Optional[list[torch.Tensor]] = None
         self.group_tmp_buffer: Optional[list[torch.Tensor]] = None
 
@@ -411,23 +394,13 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         assert device is not None
         return cls(metadata, device, use_gpu)
 
-    def init_group_info(self):
+    def _initialize_kv_cache_pointers(self):
+        if self.init:
+            return
         assert self.metadata.kv_layer_groups_manager.kv_layer_groups
-        self.group_layers = []
-        self.group_hidden_dim_sizes = []
-        for group in self.metadata.kv_layer_groups_manager.kv_layer_groups:
-            # init layers
-            self.group_layers.append(group.num_layers)
-
-            # init hidden dim size
-            num_kv_head = 1 if self.metadata.use_mla else group.shape[3]
-            # hidden_dim_size = num_kv_head * head_size
-            hidden_dim_size = num_kv_head * group.shape[-1]
-            self.group_hidden_dim_sizes.append(hidden_dim_size)
-
         if self.use_gpu:
             # init tmp buffer
-            tmp_buf_shapes = self.get_shapes(self.chunk_size)
+            tmp_buf_shapes = self.metadata.get_shapes(self.chunk_size)
             tmp_buf_dtypes = self.metadata.get_dtypes()
             assert len(tmp_buf_shapes) == len(tmp_buf_dtypes)
             self.group_tmp_buffer = [
@@ -436,26 +409,6 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                     tmp_buf_shapes, tmp_buf_dtypes, strict=True
                 )
             ]
-        logger.info("init group info success in VLLMPagedMemGPUConnectorV3")
-
-    def _initialize_kv_cache_pointers(self):
-        if self.group_kv_cache_pointers_on_gpu is not None:
-            return
-        assert self.metadata.kv_layer_groups_manager.kv_layer_groups
-        assert self.group_layers is not None
-        assert self.group_hidden_dim_sizes is not None
-        assert (
-            len(self.group_layers) == self.metadata.kv_layer_groups_manager.num_groups
-        )
-        assert (
-            len(self.group_hidden_dim_sizes)
-            == self.metadata.kv_layer_groups_manager.num_groups
-        )
-        if self.use_gpu:
-            assert (
-                len(self.group_tmp_buffer)
-                == self.metadata.kv_layer_groups_manager.num_groups
-            )
         self.group_kv_cache_pointers_on_gpu = []
         for group in self.metadata.kv_layer_groups_manager.kv_layer_groups:
             # init kv cache pointers
@@ -484,6 +437,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
             self.page_buffer_size = (
                 self.kvcaches[0].shape[1] * self.kvcaches[0].shape[2]
             )
+        self.init = True
         logger.info("init kv cache pointers success in VLLMPagedMemGPUConnectorV3")
 
     @_lmcache_nvtx_annotate
@@ -582,19 +536,6 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
 
     def get_shape(self, num_tokens: int) -> torch.Size:
         raise NotImplementedError
-
-    def get_shapes(self, num_tokens: int) -> list[torch.Size]:
-        shapes = []
-        kv_size = 1 if self.use_mla else 2
-        assert self.group_layers is not None
-        assert self.group_hidden_dim_sizes is not None
-        for num_layers, hidden_dim_size in zip(
-            self.group_layers, self.group_hidden_dim_sizes, strict=True
-        ):
-            shapes.append(
-                torch.Size([kv_size, num_layers, num_tokens, hidden_dim_size])
-            )
-        return shapes
 
 
 class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -57,6 +57,19 @@ class KVLayerGroupInfo:
         """Return the number of layers in this group."""
         return len(self.layer_names)
 
+    @property
+    def hidden_dim_size(self) -> int:
+        """Return the size of the hidden dimension in this group."""
+        # hidden_dim_size = num_heads * head_size
+        if len(self.shape) == 5:
+            # MHA
+            return self.shape[3] * self.shape[4]
+        elif len(self.shape) == 3:
+            # MLA
+            return self.shape[2]
+        else:
+            raise ValueError(f"Invalid shape: {self.shape}")
+
     def contains_layer(self, layer_idx: int) -> bool:
         """Check if a layer index belongs to this group."""
         return layer_idx in self._layer_indices_set

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1930,29 +1930,24 @@ class AdHocMemoryAllocator(MemoryAllocatorInterface):
         """
         Returns a dummy MemoryObj for testing purposes.
         """
-        if isinstance(shapes, torch.Size):
-            shape = shapes
-        elif isinstance(shapes, tuple):
-            shape = torch.Size(shapes)
-        else:
-            shape = shapes[0]
-
-        if isinstance(dtypes, list):
-            dtype = dtypes[0]
-        else:
-            dtype = dtypes
+        shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
+        size = get_size_bytes(shapes, dtypes)
 
         # Return a dummy object with no actual memory allocation
         return TensorMemoryObj(
-            raw_data=torch.empty(shape, dtype=dtype, device=self.device),
+            raw_data=torch.empty(
+                torch.Size([size]), dtype=torch.uint8, device=self.device
+            ),
             metadata=MemoryObjMetadata(
-                shape=shape,
-                dtype=dtype,
+                shape=shapes[0],
+                dtype=dtypes[0],
                 address=0,
                 phy_size=0,
                 ref_count=1,
                 pin_count=0,
                 fmt=fmt,
+                shapes=shapes,
+                dtypes=dtypes,
             ),
             parent_allocator=self,
         )


### PR DESCRIPTION
move `get_shapes` from `gpu_connector` to `metadata`, it is convenient for us to use in other places, such as `LocalCPUBackend` and `RemoteConnector`.
In addition, this can help us remove some methods in `gpu_connector`, such as `init_group_info`.