### PR TITLE
[feature] Support cleanup on exit for local_disk_backend

### DIFF
--- a/docs/source/kv_cache/storage_backends/local_storage.rst
+++ b/docs/source/kv_cache/storage_backends/local_storage.rst
@@ -30,7 +30,8 @@ Two ways to configure LMCache Disk Offloading:
 
     # Disable page cache
     # This should be turned on for better performance if most local CPU memory is used
-    export LMCACHE_EXTRA_CONFIG='{'use_odirect': True}'
+    # clean_on_exit: (Optional) Whether to clean up local disk cache when the engine closes.
+    export LMCACHE_EXTRA_CONFIG='{"use_odirect": true, "clean_on_exit": true}'
 
 **2. Configuration File**:
 
@@ -47,7 +48,8 @@ Passed in through ``LMCACHE_CONFIG_FILE=your-lmcache-config.yaml``
 
     # Disable page cache
     # This should be turned on for better performance if most local CPU memory is used
-    extra_config: {'use_odirect': True}
+    # clean_on_exit: (Optional) Whether to clean up local disk cache when the engine closes.
+    extra_config: {'use_odirect': True, 'clean_on_exit': True}
 
 Local Storage Explanation:
 --------------------------

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
 import os
@@ -132,10 +132,13 @@ class LocalDiskBackend(StorageBackendInterface):
         stat = os.statvfs(self.path)
         self.os_disk_bs = stat.f_bsize
         self.use_odirect = False
+        self.clean_on_exit = True
 
         if config.extra_config is not None:
             self.use_odirect = config.extra_config.get("use_odirect", False)
+            self.clean_on_exit = config.extra_config.get("clean_on_exit", True)
         logger.info("Using O_DIRECT for disk I/O: %s", self.use_odirect)
+        logger.info("Cleaning up local disk cache on exit: %s", self.clean_on_exit)
 
         self.disk_worker = LocalDiskWorker(loop)
 
@@ -592,8 +595,39 @@ class LocalDiskBackend(StorageBackendInterface):
 
     def get_allocator_backend(self):
         return self.local_cpu_backend
+    
+    def _clear_all(self):
+        """
+        Clear all local files held by the backend during shutdown.
+        """
+        logger.info("Cleaning up local disk cache...")
+        with self.disk_lock:
+            if not self.dict:
+                return
+            
+            paths_to_remove = [meta.path for meta in self.dict.values()]
+            self.dict.clear()
+            self.usage = 0
+
+        def _delete_file(path):
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError as e:
+                logger.warning(f"Failed to delete {path}: {e}")
+
+        try:
+            with ThreadPoolExecutor(max_workers=16) as executor:
+                list(executor.map(_delete_file, paths_to_remove))
+        except Exception as e:
+            logger.error(f"Error during parallel cleanup: {e}")
+        
+        logger.info("Local disk cache cleanup completed.")
 
     def close(self) -> None:
+        if self.clean_on_exit:
+            self._clear_all()
+
         if self.batched_msg_sender is not None:
             self.batched_msg_sender.close()
         self.disk_worker.close()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR implements the cleanup functionality for `local_disk_backend` upon exit as requested in #2273 .

Users can now configure the `clean_on_exit` parameter in `extra_config` to control this cleanup behavior. It is enabled by default.

**Special notes for your reviewers**:
Tested on vLLM **v0.13.0**; two vLLM-side tweaks are needed for LMCache shutdown to run.
- Add the missing shutdown call in LMCacheConnectorV1.
- The vLLM API server only gives EngineCore 5s to clean up before killing the process tree. In my env, LMCacheConnector takes ~6.5s to finish one cleanup run; without extending the timeout, it stops when closing lookup_server.
timeout is a fixed value in vllm:
```python
# vllm/v1/utils.py
def shutdown(procs: list[BaseProcess]):
    # Shutdown the process.
    for proc in procs:
        if proc.is_alive():
            proc.terminate()

    # Allow 5 seconds for remaining procs to terminate.
    deadline = time.monotonic() + 5
```


<details>
<summary>a complete shutdown log</summary>

```bash
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:09,525] LMCache INFO: Starting LMCacheConnector shutdown... (vllm_v1_adapter.py:1392:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:09,532] LMCache INFO: Closing offload_server... (vllm_v1_adapter.py:1400:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:09,538] LMCache INFO: Closing ZMQOffloadServer... (zmq_server.py:99:lmcache.v1.offload_server.zmq_server)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:09,538] LMCache INFO: ZMQ socket closed (zmq_server.py:105:lmcache.v1.offload_server.zmq_server)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:09,539] LMCache INFO: Waiting for offload server thread to finish... (zmq_server.py:111:lmcache.v1.offload_server.zmq_server)
(APIServer pid=9345) INFO 12-22 07:42:09 [launcher.py:110] Shutting down FastAPI HTTP server.
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,539] LMCache WARNING: Offload server thread did not terminate within timeout. Thread may be stuck in blocking recv(). Proceeding with shutdown anyway. (zmq_server.py:115:lmcache.v1.offload_server.zmq_server)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,539] LMCache INFO: offload_server closed successfully (vllm_v1_adapter.py:1405:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,539] LMCache INFO: Closing runtime_plugin_launcher... (vllm_v1_adapter.py:1400:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,540] LMCache INFO: runtime_plugin_launcher closed successfully (vllm_v1_adapter.py:1405:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,540] LMCache INFO: Closing api_server... (vllm_v1_adapter.py:1400:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,540] LMCache INFO: api_server closed successfully (vllm_v1_adapter.py:1405:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:14,540] LMCache INFO: Closing lookup_server... (vllm_v1_adapter.py:1400:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,095] LMCache INFO: lookup_server closed successfully (vllm_v1_adapter.py:1405:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,095] LMCache INFO: Destroying LMCache engine: vllm-instance (vllm_v1_adapter.py:1442:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,095] LMCache INFO: Destroying LMCacheEngine instance: vllm-instance (cache_engine.py:1831:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Shutting down stats logger... (cache_engine.py:1836:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Shutting down LMCacheStatsLogger... (observability.py:1376:lmcache.observability)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Waiting for stats logger thread to finish (timeout: 5.0s)... (observability.py:1389:lmcache.observability)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Stats logger thread terminated successfully (observability.py:1404:lmcache.observability)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: LMCacheStatsLogger shutdown complete (observability.py:1410:lmcache.observability)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Stats logger shut down successfully (cache_engine.py:1838:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Closing cache engine... (cache_engine.py:1844:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Closing LMCacheEngine... (cache_engine.py:1353:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Closing storage_manager... (cache_engine.py:1364:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Closing StorageManager... (storage_manager.py:1032:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:15,096] LMCache INFO: Closing storage backend: LocalCPUBackend (storage_manager.py:1037:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,097] LMCache INFO: Storage backend LocalCPUBackend closed successfully (storage_manager.py:1039:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,097] LMCache INFO: Closing storage backend: LocalDiskBackend (storage_manager.py:1037:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,098] LMCache INFO: Storage backend LocalDiskBackend closed successfully (storage_manager.py:1039:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,098] LMCache INFO: Stopping event loop... (storage_manager.py:1046:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,098] LMCache INFO: Event loop stop signaled (storage_manager.py:1048:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Waiting for storage manager thread to finish... (storage_manager.py:1054:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Storage manager thread terminated successfully (storage_manager.py:1063:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Storage manager closed. (storage_manager.py:1067:lmcache.v1.storage_backend.storage_manager)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: storage_manager closed successfully (cache_engine.py:1367:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: LMCacheEngine closed. (cache_engine.py:1371:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Cache engine closed successfully (cache_engine.py:1846:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Cleaning up instance dictionaries... (cache_engine.py:1851:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Instance dictionaries cleaned up (cache_engine.py:1856:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Destroying stats monitor... (cache_engine.py:1861:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: Stats monitor destroyed successfully (cache_engine.py:1863:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: LMCacheEngine instance vllm-instance destroyed (cache_engine.py:1867:lmcache.v1.cache_engine)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: LMCache engine destroyed successfully (vllm_v1_adapter.py:1447:lmcache.integration.vllm.vllm_v1_adapter)
(EngineCore_DP0 pid=9495) [2025-12-22 07:42:16,099] LMCache INFO: LMCacheConnector shutdown completed successfully in 6.57s (vllm_v1_adapter.py:1465:lmcache.integration.vllm.vllm_v1_adapter)
```
</details>



**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
