### PR TITLE
Pass missing save_decode_cache argument

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1767,6 +1767,7 @@ class LMCacheConnectorV1Impl:
                     self._lmcache_chunk_size,
                     load_spec=load_spec,
                     discard_partial_chunks=self._discard_partial_chunks,
+                    save_decode_cache=self._save_decode_cache,
                 )
                 if req_meta is not None:
                     meta.add_request(req_meta)


### PR DESCRIPTION
The vllm version < 0.9.2 branch forgets to pass the save_decode_cache argument to the ReqMeta.from_request_tracker call.