### PR TITLE
[Bug][core] make multi_layer_kv_transfer() deal with flashinfer and triton

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -171,17 +171,9 @@ __global__ void single_layer_kv_transfer_kernel(
 
 __device__ __forceinline__ int64_t page_buffer_offset(
     const int k_or_v, const int token_idx, const int scalar_offset,
-    const int scalars_per_token, const int page_buffer_size,
-    const int block_size, const bool vllm_two_major) {
-  if (vllm_two_major) {
-    return k_or_v * page_buffer_size * scalars_per_token +
-           token_idx * scalars_per_token + scalar_offset;
-  }
-  const int block_idx = token_idx / block_size;
-  const int block_offset = token_idx % block_size;
-  return block_idx * (2 * block_size * scalars_per_token) +
-         k_or_v * (block_size * scalars_per_token) +
-         block_offset * scalars_per_token + scalar_offset;
+    const int scalars_per_token, const int page_buffer_size) {
+  return k_or_v * page_buffer_size * scalars_per_token +
+         token_idx * scalars_per_token + scalar_offset;
 }
 
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
@@ -251,24 +243,19 @@ __global__ void single_layer_kv_transfer_sgl_kernel(
 /**
  * Quickly load KV cache between vLLM paged memory and offloading buffer
  * slot_id = slot_mapping[block.x]
- * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][layout],
- * where layout is [2, PAGE_BUFFER_SIZE, scalars_per_token] for vllm_two_major
- * or [num_blocks, 2, block_size, scalars_per_token] for block-major.
+ * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][block.z,
+ * slot_id, thread.x]
  */
 template <typename scalar_t, bool DIRECTION>
 __global__ void load_and_reshape_multi_layer_kernel(
     scalar_t* __restrict__ key_value,           // [2, num_layer, num_tokens,
                                                 // scalars_per_token]
-    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * vLLM KV cache
-                                                // layout:
-                                                // [2, PAGE_BUFFER_SIZE,
-                                                // scalars_per_token] or
-                                                // [num_blocks, 2, block_size,
+    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * [2,
+                                                // PAGE_BUFFER_SIZE,
                                                 // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
     const int scalars_per_token, const int num_tokens, const int num_layers,
-    const int page_buffer_size, const int block_size,
-    const bool vllm_two_major) {
+    const int page_buffer_size) {
   const int token_id = blockIdx.x;
   const int layer_id = blockIdx.y;
   const int k_or_v = blockIdx.z;
@@ -288,9 +275,8 @@ __global__ void load_and_reshape_multi_layer_kernel(
         key_value_offset(k_or_v, layer_id, token_id, i, scalars_per_token,
                          num_tokens, num_layers);
 
-    const int64_t vllm_offset =
-        page_buffer_offset(k_or_v, slot_idx, i, scalars_per_token,
-                           page_buffer_size, block_size, vllm_two_major);
+    const int64_t vllm_offset = page_buffer_offset(
+        k_or_v, slot_idx, i, scalars_per_token, page_buffer_size);
 
     if (DIRECTION)  // 1 is paged buffer to LMCache
       key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
@@ -375,8 +361,7 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  * Processes all the layers at the same time
  *
  * Each layer in vLLM's KV buffer has a shape of
- * [2, PAGE_BUFFER_SIZE, num_heads*head_size] for flash_attn or
- * [PAGE_BUFFER_SIZE, 2, num_heads*head_size] for flashinfer and triton
+ * [2, PAGE_BUFFER_SIZE, num_heads*head_size]
  *
  * Each thread block processes the copy for a token
  * The grid size should be (num_tokens, num_layers, 2)
@@ -397,6 +382,9 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  * LMCache
  */
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> be12a56 (revert mem_kernels.cu to latest base)
 template <typename T>
 void multi_layer_kv_transfer_templated(
     torch::Tensor&
@@ -405,6 +393,7 @@ void multi_layer_kv_transfer_templated(
                     // flash_attn.
                     // [1, num_layer, num_tokens, aligned_head_size]
                     // for MLA.
+<<<<<<< HEAD
 =======
 void multi_layer_kv_transfer(
     torch::Tensor& key_value,  // key/value must be on gpu/pinned cpu.
@@ -413,15 +402,21 @@ void multi_layer_kv_transfer(
                                // attention backend in LMCache [1, num_layer,
                                // num_tokens, aligned_head_size] for MLA.
 >>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
+=======
+>>>>>>> be12a56 (revert mem_kernels.cu to latest base)
 
-    const torch::Tensor& key_value_ptrs,  // [num_layers] * pointers to layers
+    const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> be12a56 (revert mem_kernels.cu to latest base)
     const bool direction, const bool use_mla) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
       get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
+<<<<<<< HEAD
 =======
     const bool direction, const bool use_mla, const bool vllm_two_major,
     const int block_size) {
@@ -429,6 +424,8 @@ void multi_layer_kv_transfer(
   int64_t** page_buffer_ptrs =
       get_kernel_ptr<int64_t*, const torch::Tensor>(key_value_ptrs);
 >>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
+=======
+>>>>>>> be12a56 (revert mem_kernels.cu to latest base)
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
@@ -443,9 +440,6 @@ void multi_layer_kv_transfer(
     k_or_v_size = 1;
   }
 
-  // offset calculation for MLA [num_blocks, block_size, head_size]
-  // is the same as 2-major [2, num_blocks, block_size, ...]
-  const bool use_vllm_two_major = use_mla ? true : vllm_two_major;
   dim3 grid(key_value.size(2), num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
 
@@ -456,17 +450,6 @@ void multi_layer_kv_transfer(
     lmc::load_and_reshape_multi_layer_kernel<T, false>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
 <<<<<<< HEAD
-                                     slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
-=======
-                                     slot_mapping_ptr, num_qwords, num_tokens,
-                                     num_layers, page_buffer_size, block_size,
-                                     use_vllm_two_major);
->>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-  } else {
-    lmc::load_and_reshape_multi_layer_kernel<T, true>
-        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
 <<<<<<< HEAD
                                      slot_mapping_ptr, num_xwords, num_tokens,
                                      num_layers, page_buffer_size);
@@ -475,6 +458,27 @@ void multi_layer_kv_transfer(
                                      num_layers, page_buffer_size, block_size,
                                      use_vllm_two_major);
 >>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
+=======
+                                     slot_mapping_ptr, num_xwords, num_tokens,
+                                     num_layers, page_buffer_size);
+>>>>>>> be12a56 (revert mem_kernels.cu to latest base)
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  } else {
+    lmc::load_and_reshape_multi_layer_kernel<T, true>
+        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+<<<<<<< HEAD
+<<<<<<< HEAD
+                                     slot_mapping_ptr, num_xwords, num_tokens,
+                                     num_layers, page_buffer_size);
+=======
+                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     num_layers, page_buffer_size, block_size,
+                                     use_vllm_two_major);
+>>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
+=======
+                                     slot_mapping_ptr, num_xwords, num_tokens,
+                                     num_layers, page_buffer_size);
+>>>>>>> be12a56 (revert mem_kernels.cu to latest base)
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
@@ -548,7 +552,7 @@ void multi_layer_kv_transfer_unilateral(
   if (use_mla) {
     return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
                                    paged_memory_device, page_buffer_size,
-                                   direction, use_mla, true, 0);
+                                   direction, use_mla);
   }
 
   int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -171,9 +171,17 @@ __global__ void single_layer_kv_transfer_kernel(
 
 __device__ __forceinline__ int64_t page_buffer_offset(
     const int k_or_v, const int token_idx, const int scalar_offset,
-    const int scalars_per_token, const int page_buffer_size) {
-  return k_or_v * page_buffer_size * scalars_per_token +
-         token_idx * scalars_per_token + scalar_offset;
+    const int scalars_per_token, const int page_buffer_size,
+    const int block_size, const bool vllm_two_major) {
+  if (vllm_two_major) {
+    return k_or_v * page_buffer_size * scalars_per_token +
+           token_idx * scalars_per_token + scalar_offset;
+  }
+  const int block_idx = token_idx / block_size;
+  const int block_offset = token_idx % block_size;
+  return block_idx * (2 * block_size * scalars_per_token) +
+         k_or_v * (block_size * scalars_per_token) +
+         block_offset * scalars_per_token + scalar_offset;
 }
 
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
@@ -243,19 +251,24 @@ __global__ void single_layer_kv_transfer_sgl_kernel(
 /**
  * Quickly load KV cache between vLLM paged memory and offloading buffer
  * slot_id = slot_mapping[block.x]
- * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][block.z,
- * slot_id, thread.x]
+ * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][layout],
+ * where layout is [2, PAGE_BUFFER_SIZE, scalars_per_token] for vllm_two_major
+ * or [num_blocks, 2, block_size, scalars_per_token] for block-major.
  */
 template <typename scalar_t, bool DIRECTION>
 __global__ void load_and_reshape_multi_layer_kernel(
     scalar_t* __restrict__ key_value,           // [2, num_layer, num_tokens,
                                                 // scalars_per_token]
-    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * [2,
-                                                // PAGE_BUFFER_SIZE,
+    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * vLLM KV cache
+                                                // layout:
+                                                // [2, PAGE_BUFFER_SIZE,
+                                                // scalars_per_token] or
+                                                // [num_blocks, 2, block_size,
                                                 // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
     const int scalars_per_token, const int num_tokens, const int num_layers,
-    const int page_buffer_size) {
+    const int page_buffer_size, const int block_size,
+    const bool vllm_two_major) {
   const int token_id = blockIdx.x;
   const int layer_id = blockIdx.y;
   const int k_or_v = blockIdx.z;
@@ -275,8 +288,9 @@ __global__ void load_and_reshape_multi_layer_kernel(
         key_value_offset(k_or_v, layer_id, token_id, i, scalars_per_token,
                          num_tokens, num_layers);
 
-    const int64_t vllm_offset = page_buffer_offset(
-        k_or_v, slot_idx, i, scalars_per_token, page_buffer_size);
+    const int64_t vllm_offset =
+        page_buffer_offset(k_or_v, slot_idx, i, scalars_per_token,
+                           page_buffer_size, block_size, vllm_two_major);
 
     if (DIRECTION)  // 1 is paged buffer to LMCache
       key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
@@ -361,7 +375,8 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  * Processes all the layers at the same time
  *
  * Each layer in vLLM's KV buffer has a shape of
- * [2, PAGE_BUFFER_SIZE, num_heads*head_size]
+ * [2, PAGE_BUFFER_SIZE, num_heads*head_size] for flash_attn or
+ * [PAGE_BUFFER_SIZE, 2, num_heads*head_size] for flashinfer and triton
  *
  * Each thread block processes the copy for a token
  * The grid size should be (num_tokens, num_layers, 2)
@@ -381,6 +396,7 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  *  - direction: false  means LMCache to PagedBuffer, true  means PagedBuffer to
  * LMCache
  */
+<<<<<<< HEAD
 template <typename T>
 void multi_layer_kv_transfer_templated(
     torch::Tensor&
@@ -389,14 +405,30 @@ void multi_layer_kv_transfer_templated(
                     // flash_attn.
                     // [1, num_layer, num_tokens, aligned_head_size]
                     // for MLA.
+=======
+void multi_layer_kv_transfer(
+    torch::Tensor& key_value,  // key/value must be on gpu/pinned cpu.
+                               // [2, num_layer, num_tokens,
+                               // num_heads*head_size] for all kinds of
+                               // attention backend in LMCache [1, num_layer,
+                               // num_tokens, aligned_head_size] for MLA.
+>>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
 
-    const torch::Tensor& key_value_ptrs,  // [num_layers]
+    const torch::Tensor& key_value_ptrs,  // [num_layers] * pointers to layers
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
+<<<<<<< HEAD
     const bool direction, const bool use_mla) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
       get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
+=======
+    const bool direction, const bool use_mla, const bool vllm_two_major,
+    const int block_size) {
+  int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
+  int64_t** page_buffer_ptrs =
+      get_kernel_ptr<int64_t*, const torch::Tensor>(key_value_ptrs);
+>>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
@@ -411,6 +443,7 @@ void multi_layer_kv_transfer_templated(
     k_or_v_size = 1;
   }
 
+  const bool use_vllm_two_major = use_mla ? true : vllm_two_major;
   dim3 grid(key_value.size(2), num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
 
@@ -420,14 +453,26 @@ void multi_layer_kv_transfer_templated(
   if (not direction) {
     lmc::load_and_reshape_multi_layer_kernel<T, false>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+<<<<<<< HEAD
                                      slot_mapping_ptr, num_xwords, num_tokens,
                                      num_layers, page_buffer_size);
+=======
+                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     num_layers, page_buffer_size, block_size,
+                                     use_vllm_two_major);
+>>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     lmc::load_and_reshape_multi_layer_kernel<T, true>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
+<<<<<<< HEAD
                                      slot_mapping_ptr, num_xwords, num_tokens,
                                      num_layers, page_buffer_size);
+=======
+                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     num_layers, page_buffer_size, block_size,
+                                     use_vllm_two_major);
+>>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
@@ -501,7 +546,7 @@ void multi_layer_kv_transfer_unilateral(
   if (use_mla) {
     return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
                                    paged_memory_device, page_buffer_size,
-                                   direction, use_mla);
+                                   direction, use_mla, true, 0);
   }
 
   int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -171,9 +171,20 @@ __global__ void single_layer_kv_transfer_kernel(
 
 __device__ __forceinline__ int64_t page_buffer_offset(
     const int k_or_v, const int token_idx, const int scalar_offset,
-    const int scalars_per_token, const int page_buffer_size) {
-  return k_or_v * page_buffer_size * scalars_per_token +
-         token_idx * scalars_per_token + scalar_offset;
+    const int scalars_per_token, const int page_buffer_size,
+    const int block_size, const KVLayout kv_layout) {
+  if (kv_layout == KVLayout::KVFirst) {
+    return k_or_v * page_buffer_size * scalars_per_token +
+           token_idx * scalars_per_token + scalar_offset;
+  }
+  if (kv_layout == KVLayout::BlockFirst) {
+    const int block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int token_offset =
+        block_idx * 2 * block_size + k_or_v * block_size + block_offset;
+    return token_offset * scalars_per_token + scalar_offset;
+  }
+  return token_idx * scalars_per_token + scalar_offset;
 }
 
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
@@ -255,7 +266,8 @@ __global__ void load_and_reshape_multi_layer_kernel(
                                                 // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
     const int scalars_per_token, const int num_tokens, const int num_layers,
-    const int page_buffer_size) {
+    const int page_buffer_size, const int block_size,
+    const KVLayout kv_layout) {
   const int token_id = blockIdx.x;
   const int layer_id = blockIdx.y;
   const int k_or_v = blockIdx.z;
@@ -275,8 +287,9 @@ __global__ void load_and_reshape_multi_layer_kernel(
         key_value_offset(k_or_v, layer_id, token_id, i, scalars_per_token,
                          num_tokens, num_layers);
 
-    const int64_t vllm_offset = page_buffer_offset(
-        k_or_v, slot_idx, i, scalars_per_token, page_buffer_size);
+    const int64_t vllm_offset =
+        page_buffer_offset(k_or_v, slot_idx, i, scalars_per_token,
+                           page_buffer_size, block_size, kv_layout);
 
     if (DIRECTION)  // 1 is paged buffer to LMCache
       key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
@@ -360,8 +373,10 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  * Quickly offload KV cache from vLLM paged memory to the offloading buffer
  * Processes all the layers at the same time
  *
- * Each layer in vLLM's KV buffer has a shape of
- * [2, PAGE_BUFFER_SIZE, num_heads*head_size]
+ * Each layer in vLLM's KV buffer has a layout of either:
+ *  - KVFirst: [2, PAGE_BUFFER_SIZE, num_heads*head_size]
+ *  - BlockFirst: [PAGE_BUFFER_SIZE / block_size, 2, block_size,
+ *    num_heads*head_size]
  *
  * Each thread block processes the copy for a token
  * The grid size should be (num_tokens, num_layers, 2)
@@ -378,54 +393,26 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  * slot_id, thread.x]
  *
  * Param:
- *  - direction: false  means LMCache to PagedBuffer, true  means PagedBuffer to
+ *  - direction: H2D means LMCache to PagedBuffer, D2H means PagedBuffer to
  * LMCache
  */
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> be12a56 (revert mem_kernels.cu to latest base)
 template <typename T>
 void multi_layer_kv_transfer_templated(
-    torch::Tensor&
-        key_value,  // key/value must be on gpu/pinned cpu.
-                    // [2, num_layer, num_tokens, num_heads*head_size] for
-                    // flash_attn.
-                    // [1, num_layer, num_tokens, aligned_head_size]
-                    // for MLA.
-<<<<<<< HEAD
-=======
-void multi_layer_kv_transfer(
     torch::Tensor& key_value,  // key/value must be on gpu/pinned cpu.
                                // [2, num_layer, num_tokens,
-                               // num_heads*head_size] for all kinds of
-                               // attention backend in LMCache [1, num_layer,
+                               // num_heads*head_size] for flash_attn and [2,
+                               // num_layer, num_tokens, num_heads*head_size]
+                               // for flash_infer (layout-aware). [1, num_layer,
                                // num_tokens, aligned_head_size] for MLA.
->>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
-=======
->>>>>>> be12a56 (revert mem_kernels.cu to latest base)
 
     const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> be12a56 (revert mem_kernels.cu to latest base)
-    const bool direction, const bool use_mla) {
+    const TransferDirection direction, const KVLayout kv_layout,
+    const int block_size) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
       get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
-<<<<<<< HEAD
-=======
-    const bool direction, const bool use_mla, const bool vllm_two_major,
-    const int block_size) {
-  int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
-  int64_t** page_buffer_ptrs =
-      get_kernel_ptr<int64_t*, const torch::Tensor>(key_value_ptrs);
->>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
-=======
->>>>>>> be12a56 (revert mem_kernels.cu to latest base)
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
@@ -435,10 +422,7 @@ void multi_layer_kv_transfer(
   int elements_per_xword = sizeof(T) / key_value.element_size();
   int num_xwords = num_origin_elements / elements_per_xword;
 
-  int k_or_v_size = 2;
-  if (use_mla) {
-    k_or_v_size = 1;
-  }
+  int k_or_v_size = kv_layout == KVLayout::MLA ? 1 : 2;
 
   dim3 grid(key_value.size(2), num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
@@ -446,39 +430,18 @@ void multi_layer_kv_transfer(
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  if (not direction) {
+  const bool direction_is_d2h = direction == TransferDirection::D2H;
+  if (!direction_is_d2h) {
     lmc::load_and_reshape_multi_layer_kernel<T, false>
-        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
-<<<<<<< HEAD
-<<<<<<< HEAD
-                                     slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
-=======
-                                     slot_mapping_ptr, num_qwords, num_tokens,
-                                     num_layers, page_buffer_size, block_size,
-                                     use_vllm_two_major);
->>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
-=======
-                                     slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
->>>>>>> be12a56 (revert mem_kernels.cu to latest base)
+        <<<grid, block, 0, stream>>>(
+            key_value_ptr, page_buffer_ptrs, slot_mapping_ptr, num_xwords,
+            num_tokens, num_layers, page_buffer_size, block_size, kv_layout);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     lmc::load_and_reshape_multi_layer_kernel<T, true>
-        <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
-<<<<<<< HEAD
-<<<<<<< HEAD
-                                     slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
-=======
-                                     slot_mapping_ptr, num_qwords, num_tokens,
-                                     num_layers, page_buffer_size, block_size,
-                                     use_vllm_two_major);
->>>>>>> a98c117 (Enable multi_layer_kv_transfer() deal with kv)
-=======
-                                     slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
->>>>>>> be12a56 (revert mem_kernels.cu to latest base)
+        <<<grid, block, 0, stream>>>(
+            key_value_ptr, page_buffer_ptrs, slot_mapping_ptr, num_xwords,
+            num_tokens, num_layers, page_buffer_size, block_size, kv_layout);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
@@ -490,8 +453,9 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& key_value_ptrs,
                              const torch::Tensor& slot_mapping,
                              const torch::Device& paged_memory_device,
-                             const int page_buffer_size, const bool direction,
-                             const bool use_mla) {
+                             const int page_buffer_size,
+                             const TransferDirection direction,
+                             const KVLayout kv_layout, const int block_size) {
   int num_origin_elements = key_value.size(3);
   int copy_size = num_origin_elements * key_value.element_size();
 #ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
@@ -499,7 +463,7 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
     do {                                                                \
       multi_layer_kv_transfer_templated<type>(                          \
           key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
-          page_buffer_size, direction, use_mla);                        \
+          page_buffer_size, direction, kv_layout, block_size);          \
     } while (0)
 #endif
   if (copy_size % 8 == 0) {
@@ -536,7 +500,7 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
  * slot_id, thread.x]
  *
  * Param:
- *  - direction: false  means LMCache to PagedBuffer, true  means PagedBuffer to
+ *  - direction: H2D means LMCache to PagedBuffer, D2H means PagedBuffer to
  * LMCache
  */
 void multi_layer_kv_transfer_unilateral(
@@ -548,11 +512,12 @@ void multi_layer_kv_transfer_unilateral(
     const torch::Tensor& key_value_ptrs,  // [num_layers*2]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
-    const bool direction, const bool use_mla) {
-  if (use_mla) {
+    const TransferDirection direction, const KVLayout kv_layout,
+    const int block_size) {
+  if (kv_layout == KVLayout::MLA) {
     return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
                                    paged_memory_device, page_buffer_size,
-                                   direction, use_mla);
+                                   direction, kv_layout, block_size);
   }
 
   int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
@@ -575,7 +540,8 @@ void multi_layer_kv_transfer_unilateral(
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  if (not direction) {
+  const bool direction_is_d2h = direction == TransferDirection::D2H;
+  if (!direction_is_d2h) {
     lmc::load_and_reshape_multi_layer_kernel_unilateral<int64_t, false>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
                                      slot_mapping_ptr, num_qwords, num_tokens,
@@ -607,25 +573,21 @@ void single_layer_kv_transfer(
     //     vllm_value_cache,  // [num_blocks, block_size, num_heads, head_size]
     //  key_cache/value_cache must be on gpu
     torch::Tensor&
-        vllm_key_value_cache,  // [2, num_blocks, block_size, num_heads,
-                               // head_size] for flash attention
-    // [num_blocks, 2, block_size, num_heads, head_size] for flash infer
-    // [num_blocks, block_size, head_size] for MLA
+        vllm_key_value_cache,  // KV layout:
+                               // KVFirst: [2, num_blocks, block_size,
+                               // num_heads, head_size]
+                               // BlockFirst: [num_blocks, 2, block_size,
+                               // num_heads, head_size]
+                               // MLA: [num_blocks, block_size, head_size]
 
-    torch::Tensor& slot_mapping,  // [num_tokens]
-    const bool direction,    // false: LMCache to PagedBuffer, true: PagedBuffer
-                             // to LMCache
-    const bool token_major,  // true: lmc_key_value_cache is
-                             // [num_tokens, 2, num_heads*head_size]
-                             // false: lmc_key_value_cache is
-                             // [2, num_tokens, num_heads*head_size]
-    const bool vllm_two_major,  // true: vllm_key_value_cache is
-                                // [2, num_blocks, block_size, num_heads,
-                                // head_size]
-                                // false: vllm_key_value_cache is
-                                // [num_blocks, 2, block_size, num_heads,
-                                // head_size]
-    const bool use_mla          // true: use MLA format
+    torch::Tensor& slot_mapping,        // [num_tokens]
+    const TransferDirection direction,  // H2D: LMCache to PagedBuffer, D2H:
+                                        // PagedBuffer to LMCache
+    const bool token_major,             // true: lmc_key_value_cache is
+                                        // [num_tokens, 2, num_heads*head_size]
+                                        // false: lmc_key_value_cache is
+                                        // [2, num_tokens, num_heads*head_size]
+    const KVLayout kv_layout  // KV cache layout (KVFirst/BlockFirst/MLA)
 ) {
   // int64_t* lmc_key_cache_ptr = get_kernel_ptr<int64_t,
   // torch::Tensor>(lmc_key_cache); int64_t* lmc_value_cache_ptr =
@@ -648,7 +610,7 @@ void single_layer_kv_transfer(
   int head_size_in_64bit;
   int block_size;
 
-  if (use_mla) {
+  if (kv_layout == KVLayout::MLA) {
     // MLA format: [num_blocks, block_size, head_size]
     num_heads = 1;
     block_size = vllm_key_value_cache.size(1);
@@ -661,7 +623,7 @@ void single_layer_kv_transfer(
 
   int lmc_stride;
   int lmc_value_offset;
-  if (use_mla) {
+  if (kv_layout == KVLayout::MLA) {
     // MLA format: [num_tokens, aligned_head_size]
     lmc_stride = lmc_key_value_cache.stride(0) / elements_per_entry;
     lmc_value_offset = 0;  // No separate K/V for MLA
@@ -675,12 +637,12 @@ void single_layer_kv_transfer(
 
   int vllm_block_key_stride_in_64bit;
   int vllm_value_offset;
-  if (use_mla) {
+  if (kv_layout == KVLayout::MLA) {
     // MLA format: [num_blocks, block_size, head_size]
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(0) / elements_per_entry;
     vllm_value_offset = 0;  // No separate K/V for MLA
-  } else if (vllm_two_major) {
+  } else if (kv_layout == KVLayout::KVFirst) {
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(1) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(0) / elements_per_entry;
@@ -699,21 +661,22 @@ void single_layer_kv_transfer(
       device_of(vllm_key_value_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  // Dispatch to the appropriate template specialization based on use_mla
-  if (use_mla) {
+  // Dispatch to the appropriate template specialization based on kv_layout
+  const bool direction_is_d2h = direction == TransferDirection::D2H;
+  if (kv_layout == KVLayout::MLA) {
     lmc::single_layer_kv_transfer_kernel<int64_t, true>
         <<<grid, block, 0, stream>>>(
             lmc_key_value_cache_ptr, vllm_key_value_cache_ptr, slot_mapping_ptr,
             vllm_block_key_stride_in_64bit, vllm_value_offset, lmc_stride,
             lmc_value_offset, num_heads, head_size_in_64bit, block_size,
-            direction);
+            direction_is_d2h);
   } else {
     lmc::single_layer_kv_transfer_kernel<int64_t, false>
         <<<grid, block, 0, stream>>>(
             lmc_key_value_cache_ptr, vllm_key_value_cache_ptr, slot_mapping_ptr,
             vllm_block_key_stride_in_64bit, vllm_value_offset, lmc_stride,
             lmc_value_offset, num_heads, head_size_in_64bit, block_size,
-            direction);
+            direction_is_d2h);
   }
 }
 
@@ -829,13 +792,13 @@ void single_layer_kv_transfer_sgl(
     torch::Tensor&
         sgl_value_cache,  // [num_blocks, block_size, num_heads, head_size]
                           // key_cache/value_cache must be on gpu
-    torch::Tensor& slot_mapping,  // [num_tokens]
-    const bool direction,   // false: LMCache to PagedBuffer, true: PagedBuffer
-                            // to LMCache
-    const bool token_major  // true: lmc_key_value_cache is
-                            // [num_tokens, 2, num_heads*head_size]
-                            // false: lmc_key_value_cache is
-                            // [2, num_tokens, num_heads*head_size]
+    torch::Tensor& slot_mapping,        // [num_tokens]
+    const TransferDirection direction,  // H2D: LMCache to PagedBuffer, D2H:
+                                        // PagedBuffer to LMCache
+    const bool token_major              // true: lmc_key_value_cache is
+                                        // [num_tokens, 2, num_heads*head_size]
+                                        // false: lmc_key_value_cache is
+                                        // [2, num_tokens, num_heads*head_size]
 ) {
   // int64_t* lmc_key_cache_ptr = get_kernel_ptr<int64_t,
   // torch::Tensor>(lmc_key_cache); int64_t* lmc_value_cache_ptr =
@@ -877,8 +840,9 @@ void single_layer_kv_transfer_sgl(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(sgl_key_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
+  const bool direction_is_d2h = direction == TransferDirection::D2H;
   lmc::single_layer_kv_transfer_sgl_kernel<int64_t><<<grid, block, 0, stream>>>(
       lmc_key_value_cache_ptr, sgl_key_cache_ptr, sgl_value_cache_ptr,
       slot_mapping_ptr, block_stride_in_64bit, lmc_stride, lmc_value_offset,
-      num_heads, head_size_in_64bit, block_size, direction);
+      num_heads, head_size_in_64bit, block_size, direction_is_d2h);
 }

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -443,6 +443,8 @@ void multi_layer_kv_transfer(
     k_or_v_size = 1;
   }
 
+  // offset calculation for MLA [num_blocks, block_size, head_size]
+  // is the same as 2-major [2, num_blocks, block_size, ...]
   const bool use_vllm_two_major = use_mla ? true : vllm_two_major;
   dim3 grid(key_value.size(2), num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -13,7 +13,8 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& slot_mapping,
                              const torch::Device& paged_memory_device,
                              const int page_buffer_size, const bool direction,
-                             const bool use_mla);
+                             const bool use_mla, const bool vllm_two_major,
+                             const int block_size);
 
 void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -8,31 +8,43 @@
 // #ifndef MEM_KERNELS_CUH
 // #define MEM_KERNELS_CUH
 
+enum class TransferDirection : int {
+  H2D = 0,
+  D2H = 1,
+};
+
+enum class KVLayout : int {
+  KVFirst = 0,
+  BlockFirst = 1,
+  MLA = 2,
+};
+
 void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& key_value_ptrs,
                              const torch::Tensor& slot_mapping,
                              const torch::Device& paged_memory_device,
-                             const int page_buffer_size, const bool direction,
-                             const bool use_mla, const bool vllm_two_major,
-                             const int block_size);
+                             const int page_buffer_size,
+                             const TransferDirection direction,
+                             const KVLayout kv_layout, const int block_size);
 
 void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
-    const int page_buffer_size, const bool direction, const bool use_mla);
+    const int page_buffer_size, const TransferDirection direction,
+    const KVLayout kv_layout, const int block_size);
 
 void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
                               torch::Tensor& vllm_key_value_cache,
-                              torch::Tensor& slot_mapping, const bool direction,
+                              torch::Tensor& slot_mapping,
+                              const TransferDirection direction,
                               const bool token_major = false,
-                              const bool vllm_two_major = false,
-                              const bool use_mla = false);
+                              const KVLayout kv_layout = KVLayout::KVFirst);
 
 void single_layer_kv_transfer_sgl(torch::Tensor& lmc_key_value_cache,
                                   torch::Tensor& sgl_key_cache,
                                   torch::Tensor& sgl_value_cache,
                                   torch::Tensor& slot_mapping,
-                                  const bool direction,
+                                  const TransferDirection direction,
                                   const bool token_major = false);
 
 void load_and_reshape_flash(torch::Tensor& key_value, torch::Tensor& key_cache,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -12,6 +12,15 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(c_ops, m) {
+  py::enum_<TransferDirection>(m, "TransferDirection")
+      .value("H2D", TransferDirection::H2D)
+      .value("D2H", TransferDirection::D2H)
+      .export_values();
+  py::enum_<KVLayout>(m, "KVLayout")
+      .value("KVFirst", KVLayout::KVFirst)
+      .value("BlockFirst", KVLayout::BlockFirst)
+      .value("MLA", KVLayout::MLA)
+      .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -22,6 +22,36 @@ if torch.cuda.is_available():
 logger = init_logger(__name__)
 
 
+def _infer_kv_layout(kv_cache: torch.Tensor, use_mla: bool) -> "lmc_ops.KVLayout":
+    if use_mla:
+        return lmc_ops.KVLayout.MLA
+    if kv_cache.dim() == 5 and kv_cache.shape[0] == 2:
+        return lmc_ops.KVLayout.KVFirst
+    if kv_cache.dim() == 5 and kv_cache.shape[1] == 2:
+        return lmc_ops.KVLayout.BlockFirst
+    raise ValueError(
+        "Unsupported KV cache layout. Expected [2, num_blocks, block_size, "
+        "num_heads, head_size] or [num_blocks, 2, block_size, num_heads, "
+        "head_size] for non-MLA, or [num_blocks, block_size, head_size] for MLA."
+    )
+
+
+def _kv_cache_block_size(kv_cache: torch.Tensor, kv_layout: "lmc_ops.KVLayout") -> int:
+    if kv_layout == lmc_ops.KVLayout.MLA:
+        return kv_cache.shape[1]
+    return kv_cache.shape[2]
+
+
+def _kv_cache_page_buffer_size(
+    kv_cache: torch.Tensor, kv_layout: "lmc_ops.KVLayout"
+) -> int:
+    if kv_layout == lmc_ops.KVLayout.MLA:
+        return kv_cache.shape[0] * kv_cache.shape[1]
+    if kv_layout == lmc_ops.KVLayout.KVFirst:
+        return kv_cache.shape[1] * kv_cache.shape[2]
+    return kv_cache.shape[0] * kv_cache.shape[2]
+
+
 class GPUConnectorInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
@@ -143,7 +173,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
         self.page_buffer_size = 0
         self.block_size = 0
-        self.vllm_two_major = True
+        self.kv_layout: Optional[lmc_ops.KVLayout] = None
 
         self.kvcaches: Optional[List[torch.Tensor]] = None
 
@@ -211,31 +241,9 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.num_layers, dtype=torch.int64, device=self.device
         )
         self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
-        if self.use_mla:
-            # kv_caches[0].shape: [num_pages, page_size, head_size]
-            assert kv_caches[0].dim() == 3
-            self.vllm_two_major = True
-            self.block_size = kv_caches[0].shape[1]
-            self.page_buffer_size = kv_caches[0].shape[0] * self.block_size
-        else:
-            # kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size]
-            # or [num_pages, 2, page_size, num_heads, head_size]
-            assert kv_caches[0].dim() == 5
-            if kv_caches[0].shape[0] == 2:
-                self.vllm_two_major = True
-                num_blocks = kv_caches[0].shape[1]
-                self.block_size = kv_caches[0].shape[2]
-            elif kv_caches[0].shape[1] == 2:
-                self.vllm_two_major = False
-                num_blocks = kv_caches[0].shape[0]
-                self.block_size = kv_caches[0].shape[2]
-            else:
-                raise ValueError(
-                    "The kv_caches should have shape "
-                    "[2, num_blocks, block_size, num_heads, head_size] or "
-                    "[num_blocks, 2, block_size, num_heads, head_size]."
-                )
-            self.page_buffer_size = num_blocks * self.block_size
+        self.kv_layout = _infer_kv_layout(kv_caches[0], self.use_mla)
+        self.block_size = _kv_cache_block_size(kv_caches[0], self.kv_layout)
+        self.page_buffer_size = _kv_cache_page_buffer_size(kv_caches[0], self.kv_layout)
 
         return self.kv_cache_pointers_on_gpu[idx]
 
@@ -291,9 +299,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             slot_mapping[start:end],
             self.device,
             self.page_buffer_size,
-            False,
-            self.use_mla,
-            self.vllm_two_major,
+            lmc_ops.TransferDirection.H2D,
+            self.kv_layout,
             self.block_size,
         )
 
@@ -338,9 +345,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     slot_mapping[start:end],
                     self.kvcaches[0].device,
                     self.page_buffer_size,
-                    True,
-                    self.use_mla,
-                    self.vllm_two_major,
+                    lmc_ops.TransferDirection.D2H,
+                    self.kv_layout,
                     self.block_size,
                 )
             else:
@@ -353,9 +359,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     slot_mapping[start:end],
                     self.kvcaches[0].device,
                     self.page_buffer_size,
-                    True,
-                    self.use_mla,
-                    self.vllm_two_major,
+                    lmc_ops.TransferDirection.D2H,
+                    self.kv_layout,
                     self.block_size,
                 )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
@@ -401,8 +406,6 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.use_gpu = use_gpu
         self.kvcaches: Optional[List[torch.Tensor]] = None
         self.page_buffer_size = 0
-        self.block_size = 0
-        self.vllm_two_major = True
 
         self.init = False
         self.group_kv_cache_pointers_on_gpu: Optional[list[torch.Tensor]] = None
@@ -452,31 +455,11 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
             kv_cache_pointers_on_gpu.copy_(kv_cache_pointers)
             self.group_kv_cache_pointers_on_gpu.append(kv_cache_pointers_on_gpu)
 
-        if self.use_mla:
-            # kvcaches[0].shape: [num_pages, page_size, head_size]
-            assert self.kvcaches[0].dim() == 3
-            self.vllm_two_major = True
-            self.block_size = self.kvcaches[0].shape[1]
-            self.page_buffer_size = self.kvcaches[0].shape[0] * self.block_size
-        else:
-            # kvcaches[0].shape: [2, num_pages, page_size, num_heads, head_size]
-            # or [num_pages, 2, page_size, num_heads, head_size]
-            assert self.kvcaches[0].dim() == 5
-            if self.kvcaches[0].shape[0] == 2:
-                self.vllm_two_major = True
-                num_blocks = self.kvcaches[0].shape[1]
-                self.block_size = self.kvcaches[0].shape[2]
-            elif self.kvcaches[0].shape[1] == 2:
-                self.vllm_two_major = False
-                num_blocks = self.kvcaches[0].shape[0]
-                self.block_size = self.kvcaches[0].shape[2]
-            else:
-                raise ValueError(
-                    "The kv_caches should have shape "
-                    "[2, num_blocks, block_size, num_heads, head_size] or "
-                    "[num_blocks, 2, block_size, num_heads, head_size]."
-                )
-            self.page_buffer_size = num_blocks * self.block_size
+        self.kv_layout = _infer_kv_layout(self.kvcaches[0], self.use_mla)
+        self.block_size = _kv_cache_block_size(self.kvcaches[0], self.kv_layout)
+        self.page_buffer_size = _kv_cache_page_buffer_size(
+            self.kvcaches[0], self.kv_layout
+        )
         self.init = True
         logger.info("init kv cache pointers success in VLLMPagedMemGPUConnectorV3")
 
@@ -504,9 +487,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 slot_mapping[start:end],
                 self.device,
                 self.page_buffer_size,
-                False,
-                self.use_mla,
-                self.vllm_two_major,
+                lmc_ops.TransferDirection.H2D,
+                self.kv_layout,
                 self.block_size,
             )
 
@@ -534,9 +516,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         slot_mapping[start:end],
                         self.device,
                         self.page_buffer_size,
-                        True,
-                        self.use_mla,
-                        self.vllm_two_major,
+                        lmc_ops.TransferDirection.D2H,
+                        self.kv_layout,
                         self.block_size,
                     )
             else:
@@ -552,9 +533,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         slot_mapping[start:end],
                         self.device,
                         self.page_buffer_size,
-                        True,
-                        self.use_mla,
-                        self.vllm_two_major,
+                        lmc_ops.TransferDirection.D2H,
+                        self.kv_layout,
                         self.block_size,
                     )
                     memory_obj_tensor = memory_obj.get_tensor(i)
@@ -621,6 +601,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         self.use_gpu = use_gpu
         self.gpu_buffer_allocator = None
         self.element_size = torch.tensor([], dtype=self.dtype).element_size()
+        self.kv_layout: Optional[lmc_ops.KVLayout] = None
 
     @classmethod
     def from_metadata(
@@ -668,18 +649,13 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            # flash attention: [num_layers, 2, num_blocks, block_size,
-            # num_heads, head_size]
-            # flash infer: [num_layers, num_blocks, 2, block_size, num_heads, head_size]
-            assert kv_caches[0].shape[0] == 2 or kv_caches[0].shape[1] == 2, (
-                "The kv_caches should have shape [num_layers, 2, num_blocks, "
-                "block_size, num_heads, head_size] or "
-                "[num_layers, num_blocks, 2, block_size, num_heads, head_size]"
-            )
+            # flash attention (KVFirst):
+            # [num_layers, 2, num_blocks, block_size, num_heads, head_size]
+            # flash infer (BlockFirst):
+            # [num_layers, num_blocks, 2, block_size, num_heads, head_size]
+            self.kv_layout = _infer_kv_layout(kv_caches[0], use_mla=False)
 
-            self.vllm_two_major = kv_caches[0].shape[0] == 2
-
-            if self.vllm_two_major:
+            if self.kv_layout == lmc_ops.KVLayout.KVFirst:
                 k_cache_shape_per_layer = kv_caches[0][0].shape
             else:
                 k_cache_shape_per_layer = kv_caches[0][:, 0].shape
@@ -797,9 +773,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     self.buffer_mapping[layer_id - 2].tensor,
                     self.kvcaches[layer_id - 2],
                     slot_mapping_full,
-                    False,
+                    lmc_ops.TransferDirection.H2D,
                     False,  # shape is [2, num_tokens, hidden_dim]
-                    self.vllm_two_major,
+                    self.kv_layout,
                 )
                 del self.buffer_mapping[layer_id - 2]
 
@@ -957,9 +933,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     tmp_gpu_buffer_obj.tensor,
                     self.kvcaches[layer_id],
                     slot_mapping_full,
-                    True,
+                    lmc_ops.TransferDirection.D2H,
                     False,  # shape is [2, num_tokens, hidden_dim]
-                    self.vllm_two_major,
+                    self.kv_layout,
                 )
                 for (buf_start, buf_end), memory_obj, old_positions in zip(
                     buf_starts_ends,
@@ -1025,6 +1001,7 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
         self.store_stream = torch.cuda.Stream()
 
         self.use_mla = "use_mla" in kwargs and kwargs["use_mla"]
+        self.kv_layout: Optional[lmc_ops.KVLayout] = None
 
     @classmethod
     def from_metadata(
@@ -1068,8 +1045,11 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
         the gpu buffer size in gpu connector.
         Also, the first request might be a bit slower due to buffer creation.
         """
-        if self.use_gpu and self.gpu_buffer_allocator is None:
-            logger.info("Lazily initializing GPU buffer.")
+        max_tokens = None
+        num_elements = None
+        if self.kv_layout is None or (
+            self.use_gpu and self.gpu_buffer_allocator is None
+        ):
             # NOTE (Jiayi): We use the first layer to determine the gpu buffer size.
             # NOTE (Jiayi): Using the exact number of tokens in the first layer
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
@@ -1084,27 +1064,23 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                 k_cache_shape_per_layer = kv_caches[0].shape
                 max_tokens = k_cache_shape_per_layer[0] * k_cache_shape_per_layer[1]
                 num_elements = k_cache_shape_per_layer.numel()
-                self.vllm_two_major = False  # MLA doesn't need vllm_two_major
+                self.kv_layout = lmc_ops.KVLayout.MLA
             else:
                 # flash attention: [num_layers, 2, num_blocks, block_size,
                 # num_heads, head_size]
                 # flash infer:
                 # [num_layers, num_blocks, 2, block_size, num_heads, head_size]
-                assert kv_caches[0].shape[0] == 2 or kv_caches[0].shape[1] == 2, (
-                    "The kv_caches should have shape [num_layers, 2, num_blocks, "
-                    "block_size, num_heads, head_size] or "
-                    "[num_layers, num_blocks, 2, block_size, num_heads, head_size]"
-                )
+                self.kv_layout = _infer_kv_layout(kv_caches[0], self.use_mla)
 
-                self.vllm_two_major = kv_caches[0].shape[0] == 2
-
-                if self.vllm_two_major:
+                if self.kv_layout == lmc_ops.KVLayout.KVFirst:
                     k_cache_shape_per_layer = kv_caches[0][0].shape
                 else:
                     k_cache_shape_per_layer = kv_caches[0][:, 0].shape
                 max_tokens = k_cache_shape_per_layer[0] * k_cache_shape_per_layer[1]
                 num_elements = k_cache_shape_per_layer.numel() * 2
 
+        if self.use_gpu and self.gpu_buffer_allocator is None:
+            logger.info("Lazily initializing GPU buffer.")
             logger.info(f"Lazily initializing GPU buffer (max tokens={max_tokens}).")
             gpu_buffer_size = num_elements * self.element_size
             self.gpu_buffer_allocator = GPUMemoryAllocator(
@@ -1214,10 +1190,9 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                             memory_obj.tensor,
                             self.kvcaches[layer_id],
                             slot_mapping_full,
-                            False,
+                            lmc_ops.TransferDirection.H2D,
                             True,
-                            self.vllm_two_major,
-                            self.use_mla,
+                            self.kv_layout,
                         )
 
                 if self.use_gpu:
@@ -1225,10 +1200,9 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                         tmp_gpu_buffer_obj.tensor,
                         self.kvcaches[layer_id],
                         slot_mapping_full,
-                        False,
+                        lmc_ops.TransferDirection.H2D,
                         True,
-                        self.vllm_two_major,
-                        self.use_mla,
+                        self.kv_layout,
                     )
         yield
 
@@ -1324,10 +1298,9 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                         tmp_gpu_buffer_obj.tensor,
                         self.kvcaches[layer_id],
                         slot_mapping_full,
+                        lmc_ops.TransferDirection.D2H,
                         True,
-                        True,
-                        self.vllm_two_major,
-                        self.use_mla,
+                        self.kv_layout,
                     )
                 for start, end, memory_obj in zip(
                     starts, ends, memory_objs_layer, strict=False
@@ -1343,10 +1316,9 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                             memory_obj.tensor,
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
+                            lmc_ops.TransferDirection.D2H,
                             True,
-                            True,
-                            self.vllm_two_major,
-                            self.use_mla,
+                            self.kv_layout,
                         )
                     # Set metadata format
                     if self.use_mla:
@@ -1486,8 +1458,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
             slot_mapping[start - offset : end - offset],
             kvcaches[0][0].device,
             self.page_buffer_size,
-            False,
-            self.use_mla,
+            lmc_ops.TransferDirection.H2D,
+            lmc_ops.KVLayout.MLA if self.use_mla else lmc_ops.KVLayout.KVFirst,
+            0,
         )
 
     @_lmcache_nvtx_annotate
@@ -1529,8 +1502,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
                 slot_mapping[start:end],
                 kvcaches[0][0].device,
                 self.page_buffer_size,
-                True,
-                self.use_mla,
+                lmc_ops.TransferDirection.D2H,
+                lmc_ops.KVLayout.MLA if self.use_mla else lmc_ops.KVLayout.KVFirst,
+                0,
             )
         else:
             # kvcaches -> gpu_buffer -> memobj
@@ -1542,8 +1516,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
                 slot_mapping[start:end],
                 kvcaches[0][0].device,
                 self.page_buffer_size,
-                True,
-                self.use_mla,
+                lmc_ops.TransferDirection.D2H,
+                lmc_ops.KVLayout.MLA if self.use_mla else lmc_ops.KVLayout.KVFirst,
+                0,
             )
             memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
@@ -1714,7 +1689,7 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                         self.kvcaches[0][layer_id],
                         self.kvcaches[1][layer_id],
                         slot_mapping[start:end],
-                        False,
+                        lmc_ops.TransferDirection.H2D,
                         True,
                     )
 
@@ -1726,7 +1701,7 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                     self.kvcaches[0][layer_id].view(t, 1, h, d),
                     self.kvcaches[1][layer_id].view(t, 1, h, d),
                     slot_mapping_full,
-                    False,
+                    lmc_ops.TransferDirection.H2D,
                     True,
                 )
 
@@ -1816,7 +1791,7 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                     self.kvcaches[0][layer_id].view(t, 1, h, d),
                     self.kvcaches[1][layer_id].view(t, 1, h, d),
                     slot_mapping_full,
-                    True,
+                    lmc_ops.TransferDirection.D2H,
                     True,
                 )
 
@@ -1839,7 +1814,7 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                         self.kvcaches[0][layer_id],
                         self.kvcaches[1][layer_id],
                         slot_mapping[start:end],
-                        True,
+                        lmc_ops.TransferDirection.D2H,
                         True,
                     )
 

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -142,6 +142,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         # works with a single device?
         self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
         self.page_buffer_size = 0
+        self.block_size = 0
+        self.vllm_two_major = True
 
         self.kvcaches: Optional[List[torch.Tensor]] = None
 
@@ -212,11 +214,28 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         if self.use_mla:
             # kv_caches[0].shape: [num_pages, page_size, head_size]
             assert kv_caches[0].dim() == 3
-            self.page_buffer_size = kv_caches[0].shape[0] * kv_caches[0].shape[1]
+            self.vllm_two_major = True
+            self.block_size = kv_caches[0].shape[1]
+            self.page_buffer_size = kv_caches[0].shape[0] * self.block_size
         else:
             # kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size]
+            # or [num_pages, 2, page_size, num_heads, head_size]
             assert kv_caches[0].dim() == 5
-            self.page_buffer_size = kv_caches[0].shape[1] * kv_caches[0].shape[2]
+            if kv_caches[0].shape[0] == 2:
+                self.vllm_two_major = True
+                num_blocks = kv_caches[0].shape[1]
+                self.block_size = kv_caches[0].shape[2]
+            elif kv_caches[0].shape[1] == 2:
+                self.vllm_two_major = False
+                num_blocks = kv_caches[0].shape[0]
+                self.block_size = kv_caches[0].shape[2]
+            else:
+                raise ValueError(
+                    "The kv_caches should have shape "
+                    "[2, num_blocks, block_size, num_heads, head_size] or "
+                    "[num_blocks, 2, block_size, num_heads, head_size]."
+                )
+            self.page_buffer_size = num_blocks * self.block_size
 
         return self.kv_cache_pointers_on_gpu[idx]
 
@@ -274,6 +293,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.page_buffer_size,
             False,
             self.use_mla,
+            self.vllm_two_major,
+            self.block_size,
         )
 
     @_lmcache_nvtx_annotate
@@ -319,6 +340,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     self.page_buffer_size,
                     True,
                     self.use_mla,
+                    self.vllm_two_major,
+                    self.block_size,
                 )
             else:
                 # kvcaches -> gpu_buffer -> memobj
@@ -332,6 +355,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     self.page_buffer_size,
                     True,
                     self.use_mla,
+                    self.vllm_two_major,
+                    self.block_size,
                 )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
@@ -376,6 +401,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.use_gpu = use_gpu
         self.kvcaches: Optional[List[torch.Tensor]] = None
         self.page_buffer_size = 0
+        self.block_size = 0
+        self.vllm_two_major = True
 
         self.init = False
         self.group_kv_cache_pointers_on_gpu: Optional[list[torch.Tensor]] = None
@@ -428,15 +455,28 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.use_mla:
             # kvcaches[0].shape: [num_pages, page_size, head_size]
             assert self.kvcaches[0].dim() == 3
-            self.page_buffer_size = (
-                self.kvcaches[0].shape[0] * self.kvcaches[0].shape[1]
-            )
+            self.vllm_two_major = True
+            self.block_size = self.kvcaches[0].shape[1]
+            self.page_buffer_size = self.kvcaches[0].shape[0] * self.block_size
         else:
             # kvcaches[0].shape: [2, num_pages, page_size, num_heads, head_size]
+            # or [num_pages, 2, page_size, num_heads, head_size]
             assert self.kvcaches[0].dim() == 5
-            self.page_buffer_size = (
-                self.kvcaches[0].shape[1] * self.kvcaches[0].shape[2]
-            )
+            if self.kvcaches[0].shape[0] == 2:
+                self.vllm_two_major = True
+                num_blocks = self.kvcaches[0].shape[1]
+                self.block_size = self.kvcaches[0].shape[2]
+            elif self.kvcaches[0].shape[1] == 2:
+                self.vllm_two_major = False
+                num_blocks = self.kvcaches[0].shape[0]
+                self.block_size = self.kvcaches[0].shape[2]
+            else:
+                raise ValueError(
+                    "The kv_caches should have shape "
+                    "[2, num_blocks, block_size, num_heads, head_size] or "
+                    "[num_blocks, 2, block_size, num_heads, head_size]."
+                )
+            self.page_buffer_size = num_blocks * self.block_size
         self.init = True
         logger.info("init kv cache pointers success in VLLMPagedMemGPUConnectorV3")
 
@@ -466,6 +506,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 self.page_buffer_size,
                 False,
                 self.use_mla,
+                self.vllm_two_major,
+                self.block_size,
             )
 
     @_lmcache_nvtx_annotate
@@ -494,6 +536,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         self.page_buffer_size,
                         True,
                         self.use_mla,
+                        self.vllm_two_major,
+                        self.block_size,
                     )
             else:
                 # kvcaches -> gpu_buffer -> memobj
@@ -510,6 +554,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         self.page_buffer_size,
                         True,
                         self.use_mla,
+                        self.vllm_two_major,
+                        self.block_size,
                     )
                     memory_obj_tensor = memory_obj.get_tensor(i)
                     assert memory_obj_tensor is not None

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -69,6 +69,7 @@ class GPUCacheContext:
         # MLA shape: [num_blocks, block_size, hidden_dim]
         # MHA shape: [2, num_blocks, block_size, num_heads, head_size]
         self.is_mla_ = self.kv_caches_[0].ndim == 3
+        self.vllm_two_major_ = True
 
         # Shape related
         self.num_layers_ = len(self.kv_caches_)
@@ -77,8 +78,20 @@ class GPUCacheContext:
             self.block_size_ = self.kv_caches_[0].shape[1]
             self.hidden_dim_size_ = self.kv_caches_[0].shape[2]
         else:
-            self.num_blocks_ = self.kv_caches_[0].shape[1]
-            self.block_size_ = self.kv_caches_[0].shape[2]
+            if self.kv_caches_[0].shape[0] == 2:
+                self.vllm_two_major_ = True
+                self.num_blocks_ = self.kv_caches_[0].shape[1]
+                self.block_size_ = self.kv_caches_[0].shape[2]
+            elif self.kv_caches_[0].shape[1] == 2:
+                self.vllm_two_major_ = False
+                self.num_blocks_ = self.kv_caches_[0].shape[0]
+                self.block_size_ = self.kv_caches_[0].shape[2]
+            else:
+                raise ValueError(
+                    "The kv_caches should have shape "
+                    "[2, num_blocks, block_size, num_heads, head_size] or "
+                    "[num_blocks, 2, block_size, num_heads, head_size]."
+                )
             # hidden_dim = num_heads * head_size
             num_heads = self.kv_caches_[0].shape[3]
             head_size = self.kv_caches_[0].shape[4]
@@ -134,6 +147,13 @@ class GPUCacheContext:
         Returns a GPU tensor of the KV cache pointers
         """
         return self.kv_cache_pointers_
+
+    @property
+    def vllm_two_major(self) -> bool:
+        """
+        Returns whether the KV cache uses the [2, num_blocks, ...] layout
+        """
+        return self.vllm_two_major_
 
     @property
     def stream(self) -> torch.cuda.Stream:
@@ -322,6 +342,8 @@ class MPCacheEngine:
                         gpu_context.block_size * gpu_context.num_blocks,
                         True,
                         gpu_context.is_mla,
+                        gpu_context.vllm_two_major,
+                        gpu_context.block_size,
                     )
 
                     assert memory_obj.tensor is not None
@@ -402,6 +424,8 @@ class MPCacheEngine:
                         gpu_context.block_size * gpu_context.num_blocks,
                         False,
                         gpu_context.is_mla,
+                        gpu_context.vllm_two_major,
+                        gpu_context.block_size,
                     )
 
         with (

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -67,8 +67,23 @@ class GPUCacheContext:
 
         # MLA flag
         # MLA shape: [num_blocks, block_size, hidden_dim]
-        # MHA shape: [2, num_blocks, block_size, num_heads, head_size]
+        # MHA shape:
+        #   KVFirst: [2, num_blocks, block_size, num_heads, head_size]
+        #   BlockFirst: [num_blocks, 2, block_size, num_heads, head_size]
         self.is_mla_ = self.kv_caches_[0].ndim == 3
+        if self.is_mla_:
+            self.kv_layout_ = lmc_ops.KVLayout.MLA
+        elif self.kv_caches_[0].shape[0] == 2:
+            self.kv_layout_ = lmc_ops.KVLayout.KVFirst
+        elif self.kv_caches_[0].shape[1] == 2:
+            self.kv_layout_ = lmc_ops.KVLayout.BlockFirst
+        else:
+            raise ValueError(
+                "Unsupported KV cache layout. Expected [2, num_blocks, block_size, "
+                "num_heads, head_size] or [num_blocks, 2, block_size, num_heads, "
+                "head_size] for non-MLA, or [num_blocks, block_size, hidden_dim] "
+                "for MLA."
+            )
 
         # Shape related
         self.num_layers_ = len(self.kv_caches_)
@@ -76,10 +91,16 @@ class GPUCacheContext:
             self.num_blocks_ = self.kv_caches_[0].shape[0]
             self.block_size_ = self.kv_caches_[0].shape[1]
             self.hidden_dim_size_ = self.kv_caches_[0].shape[2]
-        else:
+        elif self.kv_layout_ == lmc_ops.KVLayout.KVFirst:
             self.num_blocks_ = self.kv_caches_[0].shape[1]
             self.block_size_ = self.kv_caches_[0].shape[2]
             # hidden_dim = num_heads * head_size
+            num_heads = self.kv_caches_[0].shape[3]
+            head_size = self.kv_caches_[0].shape[4]
+            self.hidden_dim_size_ = num_heads * head_size
+        else:
+            self.num_blocks_ = self.kv_caches_[0].shape[0]
+            self.block_size_ = self.kv_caches_[0].shape[2]
             num_heads = self.kv_caches_[0].shape[3]
             head_size = self.kv_caches_[0].shape[4]
             self.hidden_dim_size_ = num_heads * head_size
@@ -180,6 +201,13 @@ class GPUCacheContext:
         Returns whether the model uses MLA
         """
         return self.is_mla_
+
+    @property
+    def kv_layout(self) -> "lmc_ops.KVLayout":
+        """
+        Returns the KV cache layout.
+        """
+        return self.kv_layout_
 
     def get_tmp_gpu_buffer(self, num_tokens: int) -> torch.Tensor:
         """
@@ -321,8 +349,8 @@ class MPCacheEngine:
                         gpu_context.device,
                         gpu_context.block_size * gpu_context.num_blocks,
                         lmc_ops.TransferDirection.D2H,
-                        self.kv_layout,
-                        self.block_size,
+                        gpu_context.kv_layout,
+                        gpu_context.block_size,
                     )
 
                     assert memory_obj.tensor is not None
@@ -402,8 +430,8 @@ class MPCacheEngine:
                         gpu_context.device,
                         gpu_context.block_size * gpu_context.num_blocks,
                         lmc_ops.TransferDirection.H2D,
-                        self.kv_layout,
-                        self.block_size,
+                        gpu_context.kv_layout,
+                        gpu_context.block_size,
                     )
 
         with (

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -69,7 +69,6 @@ class GPUCacheContext:
         # MLA shape: [num_blocks, block_size, hidden_dim]
         # MHA shape: [2, num_blocks, block_size, num_heads, head_size]
         self.is_mla_ = self.kv_caches_[0].ndim == 3
-        self.vllm_two_major_ = True
 
         # Shape related
         self.num_layers_ = len(self.kv_caches_)
@@ -78,20 +77,8 @@ class GPUCacheContext:
             self.block_size_ = self.kv_caches_[0].shape[1]
             self.hidden_dim_size_ = self.kv_caches_[0].shape[2]
         else:
-            if self.kv_caches_[0].shape[0] == 2:
-                self.vllm_two_major_ = True
-                self.num_blocks_ = self.kv_caches_[0].shape[1]
-                self.block_size_ = self.kv_caches_[0].shape[2]
-            elif self.kv_caches_[0].shape[1] == 2:
-                self.vllm_two_major_ = False
-                self.num_blocks_ = self.kv_caches_[0].shape[0]
-                self.block_size_ = self.kv_caches_[0].shape[2]
-            else:
-                raise ValueError(
-                    "The kv_caches should have shape "
-                    "[2, num_blocks, block_size, num_heads, head_size] or "
-                    "[num_blocks, 2, block_size, num_heads, head_size]."
-                )
+            self.num_blocks_ = self.kv_caches_[0].shape[1]
+            self.block_size_ = self.kv_caches_[0].shape[2]
             # hidden_dim = num_heads * head_size
             num_heads = self.kv_caches_[0].shape[3]
             head_size = self.kv_caches_[0].shape[4]
@@ -147,13 +134,6 @@ class GPUCacheContext:
         Returns a GPU tensor of the KV cache pointers
         """
         return self.kv_cache_pointers_
-
-    @property
-    def vllm_two_major(self) -> bool:
-        """
-        Returns whether the KV cache uses the [2, num_blocks, ...] layout
-        """
-        return self.vllm_two_major_
 
     @property
     def stream(self) -> torch.cuda.Stream:
@@ -340,10 +320,9 @@ class MPCacheEngine:
                         slot_mapping,
                         gpu_context.device,
                         gpu_context.block_size * gpu_context.num_blocks,
-                        True,
-                        gpu_context.is_mla,
-                        gpu_context.vllm_two_major,
-                        gpu_context.block_size,
+                        lmc_ops.TransferDirection.D2H,
+                        self.kv_layout,
+                        self.block_size,
                     )
 
                     assert memory_obj.tensor is not None
@@ -422,10 +401,9 @@ class MPCacheEngine:
                         slot_mapping,
                         gpu_context.device,
                         gpu_context.block_size * gpu_context.num_blocks,
-                        False,
-                        gpu_context.is_mla,
-                        gpu_context.vllm_two_major,
-                        gpu_context.block_size,
+                        lmc_ops.TransferDirection.H2D,
+                        self.kv_layout,
+                        self.block_size,
                     )
 
         with (

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -239,6 +239,8 @@ def test_multi_layer_kernel(num_tokens):
             page_buffer_size,
             True,
             False,
+            True,
+            block_size,
         )
         memory_obj_new_list.append(memory_obj_new)
 
@@ -274,6 +276,8 @@ def test_multi_layer_kernel(num_tokens):
             page_buffer_size,
             False,
             False,
+            True,
+            block_size,
         )
 
     check_paged_kv_cache_equal(
@@ -357,6 +361,8 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size):
             0,
             True,
             True,
+            True,
+            block_size,
         )
         memory_obj_new_list.append(memory_obj_new)
 
@@ -398,6 +404,8 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size):
             0,
             False,
             True,
+            True,
+            block_size,
         )
 
     for left_kv, right_kv in zip(kv_cache, kv_cache_new, strict=False):

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -46,6 +46,14 @@ def _tuple_kv_to_blob(
     return kv_tensors_flatten
 
 
+def _normalize_kv_cache_layout(kv_cache, kv_layout):
+    if kv_layout == lmc_ops.KVLayout.KVFirst:
+        return kv_cache
+    if kv_layout == lmc_ops.KVLayout.BlockFirst:
+        return [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache]
+    raise ValueError(f"Unsupported kv_layout for normalization: {kv_layout}")
+
+
 def _slice_kv_at(
     start_idx: int,
     kv_tensors: torch.Tensor,
@@ -166,7 +174,11 @@ def test_extract_and_load_back(num_tokens):
 
 
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
-def test_multi_layer_kernel(num_tokens):
+@pytest.mark.parametrize(
+    "kv_layout",
+    [lmc_ops.KVLayout.KVFirst, lmc_ops.KVLayout.BlockFirst],
+)
+def test_multi_layer_kernel(num_tokens, kv_layout):
     device = "cuda"
 
     num_blocks = 1000
@@ -178,6 +190,8 @@ def test_multi_layer_kernel(num_tokens):
     kv_cache = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
+    if kv_layout == lmc_ops.KVLayout.BlockFirst:
+        kv_cache = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache]
     page_buffer_size = num_blocks * block_size
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
@@ -237,9 +251,8 @@ def test_multi_layer_kernel(num_tokens):
             slot_mapping_temp,
             kv_cache[0].device,
             page_buffer_size,
-            True,
-            False,
-            True,
+            lmc_ops.TransferDirection.D2H,
+            kv_layout,
             block_size,
         )
         memory_obj_new_list.append(memory_obj_new)
@@ -259,6 +272,8 @@ def test_multi_layer_kernel(num_tokens):
     kv_cache_new = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
+    if kv_layout == lmc_ops.KVLayout.BlockFirst:
+        kv_cache_new = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache_new]
 
     kv_cache_pointers_new = torch.empty(
         32, dtype=torch.int64, device="cpu", pin_memory=True
@@ -274,15 +289,16 @@ def test_multi_layer_kernel(num_tokens):
             slot_mapping_temp,
             kv_cache_new[0].device,
             page_buffer_size,
-            False,
-            False,
-            True,
+            lmc_ops.TransferDirection.H2D,
+            kv_layout,
             block_size,
         )
 
+    kv_cache_for_check = _normalize_kv_cache_layout(kv_cache, kv_layout)
+    kv_cache_new_for_check = _normalize_kv_cache_layout(kv_cache_new, kv_layout)
     check_paged_kv_cache_equal(
-        kv_cache,
-        kv_cache_new,
+        kv_cache_for_check,
+        kv_cache_new_for_check,
         slot_mapping,
     )
 
@@ -359,9 +375,8 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size):
             slot_mapping_temp,
             kv_cache[0].device,
             0,
-            True,
-            True,
-            True,
+            lmc_ops.TransferDirection.D2H,
+            lmc_ops.KVLayout.MLA,
             block_size,
         )
         memory_obj_new_list.append(memory_obj_new)
@@ -402,9 +417,8 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size):
             slot_mapping_temp,
             kv_cache_new[0].device,
             0,
-            False,
-            True,
-            True,
+            lmc_ops.TransferDirection.H2D,
+            lmc_ops.KVLayout.MLA,
             block_size,
         )
 
@@ -426,7 +440,11 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size):
 
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 @pytest.mark.parametrize("token_major", [True, False])
-def test_single_layer_kernel(num_tokens, token_major):
+@pytest.mark.parametrize(
+    "kv_layout",
+    [lmc_ops.KVLayout.KVFirst, lmc_ops.KVLayout.BlockFirst],
+)
+def test_single_layer_kernel(num_tokens, token_major, kv_layout):
     device = "cuda"
 
     num_layers = 32
@@ -442,6 +460,9 @@ def test_single_layer_kernel(num_tokens, token_major):
     kv_cache_new = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
+    if kv_layout == lmc_ops.KVLayout.BlockFirst:
+        kv_cache = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache]
+        kv_cache_new = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache_new]
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device)
 
@@ -459,23 +480,23 @@ def test_single_layer_kernel(num_tokens, token_major):
             tmp_gpu_buffer,
             kv_cache[layer_id],
             slot_mapping,
-            True,
+            lmc_ops.TransferDirection.D2H,
             token_major,
-            True,
-            False,
+            kv_layout,
         )
         lmc_ops.single_layer_kv_transfer(
             tmp_gpu_buffer,
             kv_cache_new[layer_id],
             slot_mapping,
-            False,
+            lmc_ops.TransferDirection.H2D,
             token_major,
-            True,
-            False,
+            kv_layout,
         )
 
+    kv_cache_for_check = _normalize_kv_cache_layout(kv_cache, kv_layout)
+    kv_cache_new_for_check = _normalize_kv_cache_layout(kv_cache_new, kv_layout)
     check_paged_kv_cache_equal(
-        kv_cache,
-        kv_cache_new,
+        kv_cache_for_check,
+        kv_cache_new_for_check,
         slot_mapping,
     )

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -190,8 +190,12 @@ def test_multi_layer_kernel(num_tokens, kv_layout):
     kv_cache = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
+    # By default kv_cache is generated in KVFirst layout [2, ...]
+    # to test if multi_layer_kv_transfer() can handle BlockFirst layout
+    # Copy it to kv_cache_layout with proper layout
+    kv_cache_layout = kv_cache
     if kv_layout == lmc_ops.KVLayout.BlockFirst:
-        kv_cache = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache]
+        kv_cache_layout = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache]
     page_buffer_size = num_blocks * block_size
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
@@ -213,6 +217,7 @@ def test_multi_layer_kernel(num_tokens, kv_layout):
 
         memory_obj_old = mem_allocator.allocate(mem_obj_shape, dtype)
         for layer_id in range(32):
+            # this function handles default KVFirst layout only
             lmc_ops.load_and_reshape_flash(
                 memory_obj_old.tensor,
                 kv_cache[layer_id][0],
@@ -232,7 +237,7 @@ def test_multi_layer_kernel(num_tokens, kv_layout):
         32, dtype=torch.int64, device="cpu", pin_memory=True
     )
     for i in range(32):
-        kv_cache_pointers[i] = kv_cache[i].data_ptr()
+        kv_cache_pointers[i] = kv_cache_layout[i].data_ptr()
 
     memory_obj_new_list = []
     start_event = torch.cuda.Event(enable_timing=True)
@@ -245,11 +250,12 @@ def test_multi_layer_kernel(num_tokens, kv_layout):
         )
 
         memory_obj_new = mem_allocator.allocate(mem_obj_shape, dtype)
+        # multi_layer_kv_transfer() handles both BlockFirst and KVFirst
         lmc_ops.multi_layer_kv_transfer(
             memory_obj_new.tensor,
             kv_cache_pointers,
             slot_mapping_temp,
-            kv_cache[0].device,
+            kv_cache_layout[0].device,
             page_buffer_size,
             lmc_ops.TransferDirection.D2H,
             kv_layout,
@@ -268,21 +274,26 @@ def test_multi_layer_kernel(num_tokens, kv_layout):
         memory_obj_new_list,
     )
 
-    # Generate new paged kv_cache
+    # Generate new paged kv_cache in KVFirst layout
     kv_cache_new = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
+    # Convert it to kv_cache_new_layout according to kv_layout parameter
+    kv_cache_new_layout = kv_cache_new
     if kv_layout == lmc_ops.KVLayout.BlockFirst:
-        kv_cache_new = [kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache_new]
+        kv_cache_new_layout = [
+            kv.permute(1, 0, 2, 3, 4).contiguous() for kv in kv_cache_new
+        ]
 
     kv_cache_pointers_new = torch.empty(
         32, dtype=torch.int64, device="cpu", pin_memory=True
     )
     for i in range(32):
-        kv_cache_pointers_new[i] = kv_cache_new[i].data_ptr()
+        kv_cache_pointers_new[i] = kv_cache_new_layout[i].data_ptr()
 
     for chunk_id, slot_mapping_temp in enumerate(slot_mapping_chunked):
         memory_obj_new = memory_obj_new_list[chunk_id]
+        # copy memory_obj_new to kv_cache_new_layout
         lmc_ops.multi_layer_kv_transfer(
             memory_obj_new.tensor,
             kv_cache_pointers_new,
@@ -294,10 +305,11 @@ def test_multi_layer_kernel(num_tokens, kv_layout):
             block_size,
         )
 
-    kv_cache_for_check = _normalize_kv_cache_layout(kv_cache, kv_layout)
-    kv_cache_new_for_check = _normalize_kv_cache_layout(kv_cache_new, kv_layout)
+    # Convert kv_cache_new_layout back to KVFirst layout
+    # because check_paged_kv_cache_equal() only handles KVFirst layout
+    kv_cache_new_for_check = _normalize_kv_cache_layout(kv_cache_new_layout, kv_layout)
     check_paged_kv_cache_equal(
-        kv_cache_for_check,
+        kv_cache,
         kv_cache_new_for_check,
         slot_mapping,
     )


### PR DESCRIPTION
**Why**
As described in #2291 ,  `multi_layer_kv_transfer()` in mem_kernels.cu assumed a single vLLM layout and produced incorrect offsets when vLLM uses [num_blocks, 2, block_size, ...]  causing data copy errors with flashinfer or triton
Single-layer transfers `single_layer_kv_transfer()` already had a vllm_two_major flag,  so the multi-layer path and GPU connectors needed the same awareness to handle both layouts correctly.

**What**
- Added `vllm_two_major` and `block_size` parameters to the `multi_layer_kv_transfer` declaration in `csrc/mem_kernels.cuh` and threaded them through the kernel launches in `csrc/mem_kernels.cu`.
- Made `page_buffer_offset` layout-aware by updating its signature and logic to compute offsets for both two-major and block-major layouts, and passed `block_size`/`vllm_two_major` into the `load_and_reshape_multi_layer_kernel`.
- Updated GPU connectors (`VLLMPagedMemGPUConnectorV2`, `VLLMPagedMemGPUConnectorV3`) to detect the vLLM KV cache layout and compute `page_buffer_size` and `block_size`, and pass `self.vllm_two_major`/`self.block_size` into `lmc_ops.multi_layer_kv_transfer` calls.
- Updated `GPUCacheContext` in `lmcache/v1/multiprocess/server.py` to detect layout (`vllm_two_major_`) and pass `vllm_two_major`/`block_size` through the places that call `lmc_ops.multi_layer_kv_transfer`.
- Updated `test_mem_kernels.py` accordingly