### PR TITLE
[Core] Add multi-layer transfer kernel for ds v3.2

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -263,7 +263,7 @@ __global__ void load_and_reshape_multi_layer_kernel(
   const int num_threads = blockDim.x;
 
   const int64_t slot_idx = slot_mapping[token_id];
-  int64_t* paged_buffer_ptr = paged_buffer_ptrs[layer_id];
+  scalar_t* paged_buffer_ptr = paged_buffer_ptrs[layer_id];
 
   if (slot_idx < 0) {
     return;
@@ -305,8 +305,8 @@ __global__ void load_and_reshape_multi_layer_kernel_unilateral(
   const int num_threads = blockDim.x;
 
   const int64_t slot_idx = slot_mapping[token_id];
-  int64_t* key_ptr = paged_buffer_ptrs[layer_id];
-  int64_t* value_ptr = paged_buffer_ptrs[layer_id + num_layers];
+  scalar_t* key_ptr = paged_buffer_ptrs[layer_id];
+  scalar_t* value_ptr = paged_buffer_ptrs[layer_id + num_layers];
 
   if (slot_idx < 0) {
     return;
@@ -381,7 +381,8 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  *  - direction: false  means LMCache to PagedBuffer, true  means PagedBuffer to
  * LMCache
  */
-void multi_layer_kv_transfer(
+template <typename T>
+void multi_layer_kv_transfer_templated(
     torch::Tensor&
         key_value,  // key/value must be on gpu/pinned cpu.
                     // [2, num_layer, num_tokens, num_heads*head_size] for
@@ -393,17 +394,17 @@ void multi_layer_kv_transfer(
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
     const bool direction, const bool use_mla) {
-  int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
-  int64_t** page_buffer_ptrs =
-      get_kernel_ptr<int64_t*, const torch::Tensor>(key_value_ptrs);
+  T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
+  T** page_buffer_ptrs =
+      get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
   int num_layers = key_value.size(1);
   int num_tokens = slot_mapping.size(0);
   int num_origin_elements = key_value.size(3);
-  int elements_per_qword = 8 / key_value.element_size();
-  int num_qwords = num_origin_elements / elements_per_qword;
+  int elements_per_xword = sizeof(T) / key_value.element_size();
+  int num_xwords = num_origin_elements / elements_per_xword;
 
   int k_or_v_size = 2;
   if (use_mla) {
@@ -411,24 +412,55 @@ void multi_layer_kv_transfer(
   }
 
   dim3 grid(key_value.size(2), num_layers, k_or_v_size);
-  dim3 block(std::min(num_qwords, 128));
+  dim3 block(std::min(num_xwords, 128));
 
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (not direction) {
-    lmc::load_and_reshape_multi_layer_kernel<int64_t, false>
+    lmc::load_and_reshape_multi_layer_kernel<T, false>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
-                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     slot_mapping_ptr, num_xwords, num_tokens,
                                      num_layers, page_buffer_size);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
-    lmc::load_and_reshape_multi_layer_kernel<int64_t, true>
+    lmc::load_and_reshape_multi_layer_kernel<T, true>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
-                                     slot_mapping_ptr, num_qwords, num_tokens,
+                                     slot_mapping_ptr, num_xwords, num_tokens,
                                      num_layers, page_buffer_size);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
+}
+
+/**
+ * @see multi_layer_kv_transfer_templated
+ */
+void multi_layer_kv_transfer(torch::Tensor& key_value,
+                             const torch::Tensor& key_value_ptrs,
+                             const torch::Tensor& slot_mapping,
+                             const torch::Device& paged_memory_device,
+                             const int page_buffer_size, const bool direction,
+                             const bool use_mla) {
+  int num_origin_elements = key_value.size(3);
+  int copy_size = num_origin_elements * key_value.element_size();
+#ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
+  #define LAUNCH_MULTI_LAYER_KV_TRANSFER(type)                          \
+    do {                                                                \
+      multi_layer_kv_transfer_templated<type>(                          \
+          key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
+          page_buffer_size, direction, use_mla);                        \
+    } while (0)
+#endif
+  if (copy_size % 8 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int64_t);
+  } else if (copy_size % 4 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int32_t);
+  } else if (copy_size % 2 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int16_t);
+  } else {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int8_t);
+  }
+#undef LAUNCH_MULTI_LAYER_KV_TRANSFER
 }
 
 /**

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -186,12 +186,6 @@ def test_multi_layer_kernel(num_tokens):
     pinned_cpu_size = 4 * 1024 * 1024 * 1024  # 4GB
     mem_allocator = PinMemoryAllocator(pinned_cpu_size)
 
-    # lmc_ops.multi_layer_kv_transfer(memory_obj_new.tensor,
-    #                                kv_cache_pointers, # TODO: initialize this
-    #                                slot_mapping_temp,
-    #                                kv_cache[0].device,
-    #                                len(slot_mapping_temp), True)
-
     # layer by layer extract
     memory_obj_old_list = []
     start_event = torch.cuda.Event(enable_timing=True)
@@ -292,17 +286,17 @@ def test_multi_layer_kernel(num_tokens):
 
 
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
-def test_multi_layer_kernel_use_mla(num_tokens):
+@pytest.mark.parametrize("head_size", [576, 66])  # Use 68 for dsv32 (132x int8)
+def test_multi_layer_kernel_use_mla(num_tokens, head_size):
     device = "cuda"
 
     num_blocks = 1000
     block_size = 64
-    head_size = 576
     chunk_size = 256
     dtype = torch.bfloat16
     num_layers = 32
     kv_cache = generate_mla_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, num_layers
+        num_blocks, device, block_size, dtype, num_layers, head_size
     )
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
@@ -385,7 +379,7 @@ def test_multi_layer_kernel_use_mla(num_tokens):
 
     # Generate new paged kv_cache
     kv_cache_new = generate_mla_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, num_layers
+        num_blocks, device, block_size, dtype, num_layers, head_size
     )
 
     kv_cache_pointers_new = torch.empty(

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -173,13 +173,17 @@ def generate_sglang_kv_cache_paged_list_tensors(
 
 
 def generate_mla_kv_cache_paged_list_tensors(
-    num_blocks, device, block_size=64, dtype=torch.bfloat16, num_layers=32
+    num_blocks,
+    device,
+    block_size=64,
+    dtype=torch.bfloat16,
+    num_layers=32,
+    head_size=576,
 ):
     """
     return KV cache of MLA
     """
     ret = []
-    head_size = 576
     shape = [num_blocks, block_size, head_size]
 
     for i in range(num_layers):


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

For ds v3.2, the hidden dim size is 132 * int8 for a single token. However, the current multi-layer transfer requires 8-byte alignment, which causes a correctness issue.

**In this PR**:

We introduced the following things:
1. A unittest to test the case for dsv3.2 (132-byte) copy
2. Make the multi layer kv transfer a templated function that accepts different copy types.

**In the future**:

For dsv32, since a single token's hidden size is very small (132 byte), using a thread-block to copy a single token single layer's KV cache could be inefficient.

We probably want to let a thread block copy the whole "page" to improve the efficiency.


**If applicable**:

- [ ] this PR contains user facing changes - docs added 
- [x] this PR contains unit tests
