### PR TITLE
[Bugfix] fix CacheEngineKey.to_string() str fmt type err

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -385,7 +385,7 @@ class CacheEngineKey:
     def to_string(self):
         s = (
             f"{self.fmt}@{self.model_name}@{self.world_size}"
-            f"@{self.worker_id}@{self.chunk_hash:x}@{self._dtype_str}"
+            f"@{self.worker_id}@{self.chunk_hash}@{self._dtype_str}"
         )
         if self.tags is not None and len(self.tags) != 0:
             tags = [f"{k}%{v}" for k, v in self.tags]


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Class `CacheEngineKey` formats key with str template which specifies `chunk_hash` to hex in the `to_string()` function. This may cause an error if `chunk_hash` is a normal string like generated by `sha256_cbor`. Related issue: #2166


**Special notes for your reviewers**:

tiny change

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
