### PR TITLE
[refactor] refactor RemoteConnector

### DIFF
--- a/lmcache/v1/check/check_mode_test_remote.py
+++ b/lmcache/v1/check/check_mode_test_remote.py
@@ -59,7 +59,7 @@ def create_test_memory_obj(
         connector = backend.connection
 
     return local_cpu_backend.allocate(
-        connector.meta_shape, connector.meta_dtype, connector.meta_fmt
+        connector.meta_shapes, connector.meta_dtypes, connector.meta_fmt
     )
 
 

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -221,8 +221,6 @@ class ConnectorManager:
             if adapter.can_parse(self.context.url):
                 logger.info(f"Creating connector for URL: {self.context.url}")
                 connector = adapter.create_connector(self.context)
-                logger.info(f"initializing chunk meta for connector: {connector}")
-                connector.init_chunk_meta(self.context.config, self.context.metadata)
                 logger.info(f"post-initializing connector: {connector}")
                 connector.post_init()
                 return connector

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -221,8 +221,6 @@ class ConnectorManager:
             if adapter.can_parse(self.context.url):
                 logger.info(f"Creating connector for URL: {self.context.url}")
                 connector = adapter.create_connector(self.context)
-                logger.info(f"post-initializing connector: {connector}")
-                connector.post_init()
                 return connector
 
         raise ValueError(f"No adapter found for URL: {self.context.url}")

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -35,6 +35,19 @@ class RemoteConnector(metaclass=abc.ABCMeta):
     def __init__(
         self, config: LMCacheEngineConfig, metadata: Optional[LMCacheEngineMetadata]
     ):
+        """
+        Initialize some common attributes, which will be used in the subclasses.
+        - `save_chunk_meta` is a flag to indicate whether to save the chunk meta info.
+        - `meta_shapes` is a list of shapes of lmcache full chunk.
+        - `meta_dtypes` is a list of dtypes of lmcache chunk.
+        - `meta_fmt` is the memory format of the lmcache chunk.
+        - `full_chunk_size` is the size of the lmcache full chunk.
+        - `single_token_size` is the size of a single token.`
+
+        Input:
+            config: the lmcache engine config
+            metadata: the lmcache engine metadata
+        """
         # TODO(chunxiaozheng): support layerwise here
         assert metadata is not None
         self.save_chunk_meta: bool = (

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -32,54 +32,32 @@ class RemoteConnector(metaclass=abc.ABCMeta):
     Interface for remote connector
     """
 
-    save_chunk_meta: bool = True
-    meta_shape: Optional[torch.Size] = None
-    meta_dtype: Optional[torch.dtype] = None
-    meta_fmt: Optional[MemoryFormat] = None
-    full_chunk_size: Optional[int] = None
-    single_token_size: Optional[int] = None
-
-    @NotAudit
-    def init_chunk_meta(
-        self,
-        config: Optional[LMCacheEngineConfig],
-        metadata: Optional[LMCacheEngineMetadata],
-    ) -> None:
-        logger.info("initializing chunk meta for remote connector")
-        # TODO: support layerwise later
-        if (
-            config is None
-            or metadata is None
-            or config.extra_config is None
+    def __init__(
+        self, config: LMCacheEngineConfig, metadata: Optional[LMCacheEngineMetadata]
+    ):
+        # TODO(chunxiaozheng): support layerwise here
+        assert metadata is not None
+        self.save_chunk_meta: bool = (
+            config.extra_config is None
             or config.extra_config.get("save_chunk_meta", True)
             or config.use_layerwise
-        ):
-            return
-
-        self.save_chunk_meta = False
-        self.meta_shape = torch.Size(
-            [
-                metadata.kv_shape[1],
-                metadata.kv_shape[0],
-                metadata.kv_shape[2],
-                metadata.kv_shape[3] * metadata.kv_shape[4],
-            ]
         )
-        self.meta_dtype = metadata.kv_dtype
-        self.meta_fmt = (
+        self.meta_shapes: list[torch.Size] = metadata.get_shapes()
+        self.meta_dtypes: list[torch.dtype] = metadata.get_dtypes()
+        self.meta_fmt: MemoryFormat = (
             MemoryFormat.KV_MLA_FMT if metadata.use_mla else MemoryFormat.KV_2LTD
         )
-        self.full_chunk_size = get_size_bytes([self.meta_shape], [self.meta_dtype])
-        assert self.full_chunk_size is not None
-        assert self.full_chunk_size % metadata.kv_shape[2] == 0
-        self.single_token_size = self.full_chunk_size // metadata.kv_shape[2]
+        self.full_chunk_size: int = get_size_bytes(self.meta_shapes, self.meta_dtypes)
+        assert self.full_chunk_size % metadata.chunk_size == 0
+        self.single_token_size = self.full_chunk_size // metadata.chunk_size
         logger.info(
-            f"init remote connector metadata info, "
-            f"shape: {self.meta_shape}, "
-            f"dtype: {self.meta_dtype}, "
-            f"fmt: {self.meta_fmt}, "
-            f"full chunk size: {self.full_chunk_size}, "
-            f"single token size: {self.single_token_size}"
+            "init remote connector metadata info, shapes: %s, dtypes: %s, "
+            "fmt: %s, full chunk size: %s, single token size: %s",
+            self.meta_shapes,
+            self.meta_dtypes,
+            self.meta_fmt,
+            self.full_chunk_size,
+            self.single_token_size,
         )
 
     @NotAudit

--- a/lmcache/v1/storage_backend/connector/eic_connector.py
+++ b/lmcache/v1/storage_backend/connector/eic_connector.py
@@ -118,6 +118,7 @@ class EICConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         memory_allocator: LocalCPUBackend,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(memory_allocator.config, memory_allocator.metadata)
 
         logger.info("init EICConnector")

--- a/lmcache/v1/storage_backend/connector/eic_connector.py
+++ b/lmcache/v1/storage_backend/connector/eic_connector.py
@@ -118,6 +118,8 @@ class EICConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         memory_allocator: LocalCPUBackend,
     ):
+        super().__init__(memory_allocator.config, memory_allocator.metadata)
+
         logger.info("init EICConnector")
         logger.info(f"try connect to eic: {endpoint}")
 

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -45,6 +45,8 @@ class FSConnector(RemoteConnector):
             local_cpu_backend: Memory allocator interface
             config: Lmcache engine config
         """
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         # Parse comma separated paths
         self.base_paths = (
             [Path(p.strip()) for p in base_paths_str.split(",")]
@@ -76,20 +78,6 @@ class FSConnector(RemoteConnector):
             if config is None
             else config.get_extra_config_value("fs_connector_use_odirect", False)
         )
-
-        logger.info(
-            f"Initialized FSConnector with base paths {self.base_paths}, "
-            f"relative tmp dir: {self.relative_tmp_dir}, "
-            f"read ahead size: {self.read_ahead_size}, "
-            f"use O_DIRECT: {self.use_odirect}"
-        )
-        # Create directories for all paths
-        for path in self.base_paths:
-            path.mkdir(parents=True, exist_ok=True)
-            if self.relative_tmp_dir is not None:
-                (path / self.relative_tmp_dir).mkdir(parents=False, exist_ok=True)
-
-    def post_init(self):
         self.os_disk_bs = 0
         if self.use_odirect:
             # save_chunk_meta is useful if save_unfull_chunk is True, since partial
@@ -105,6 +93,18 @@ class FSConnector(RemoteConnector):
             else:
                 stat = os.statvfs(self.base_paths[0])
                 self.os_disk_bs = stat.f_bsize
+
+        logger.info(
+            f"Initialized FSConnector with base paths {self.base_paths}, "
+            f"relative tmp dir: {self.relative_tmp_dir}, "
+            f"read ahead size: {self.read_ahead_size}, "
+            f"use O_DIRECT: {self.use_odirect}"
+        )
+        # Create directories for all paths
+        for path in self.base_paths:
+            path.mkdir(parents=True, exist_ok=True)
+            if self.relative_tmp_dir is not None:
+                (path / self.relative_tmp_dir).mkdir(parents=False, exist_ok=True)
 
     def _get_base_path(self, key: CacheEngineKey) -> Path:
         """Get file base path for the given key"""
@@ -153,7 +153,7 @@ class FSConnector(RemoteConnector):
         fd = -1
         try:
             memory_obj = self.local_cpu_backend.allocate(
-                self.meta_shape, self.meta_dtype, self.meta_fmt
+                self.meta_shapes, self.meta_dtypes, self.meta_fmt
             )
             if memory_obj is None:
                 logger.debug("Memory allocation failed.")
@@ -223,7 +223,7 @@ class FSConnector(RemoteConnector):
                     )
                 else:
                     memory_obj = self.local_cpu_backend.allocate(
-                        self.meta_shape, self.meta_dtype, self.meta_fmt
+                        self.meta_shapes, self.meta_dtypes, self.meta_fmt
                     )
                 if memory_obj is None:
                     logger.debug("Memory allocation failed during async disk load.")

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -45,6 +45,7 @@ class FSConnector(RemoteConnector):
             local_cpu_backend: Memory allocator interface
             config: Lmcache engine config
         """
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         # Parse comma separated paths

--- a/lmcache/v1/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/v1/storage_backend/connector/infinistore_connector.py
@@ -41,6 +41,8 @@ class InfinistoreConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         memory_allocator: LocalCPUBackend,
     ):
+        super().__init__(memory_allocator.config, memory_allocator.metadata)
+
         config = infinistore.ClientConfig(
             host_addr=host,
             service_port=port,

--- a/lmcache/v1/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/v1/storage_backend/connector/infinistore_connector.py
@@ -41,6 +41,7 @@ class InfinistoreConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         memory_allocator: LocalCPUBackend,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(memory_allocator.config, memory_allocator.metadata)
 
         config = infinistore.ClientConfig(

--- a/lmcache/v1/storage_backend/connector/instrumented_connector.py
+++ b/lmcache/v1/storage_backend/connector/instrumented_connector.py
@@ -129,9 +129,6 @@ class InstrumentedRemoteConnector(RemoteConnector):
     def support_batched_contains(self) -> bool:
         return self._connector.support_batched_contains()
 
-    def init_chunk_meta(self, config, metadata) -> None:
-        return self._connector.init_chunk_meta(config, metadata)
-
     def reshape_partial_chunk(
         self, memory_obj: MemoryObj, bytes_read: int
     ) -> MemoryObj:

--- a/lmcache/v1/storage_backend/connector/lm_connector.py
+++ b/lmcache/v1/storage_backend/connector/lm_connector.py
@@ -40,6 +40,7 @@ class LMCServerConnector(RemoteConnector):
         # than implementations that work with sockets.
         # However, we use socket here as we need to use the socket.recv_into()
         # to reduce memory copy.
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.client_socket.connect((host, port))

--- a/lmcache/v1/storage_backend/connector/lm_connector.py
+++ b/lmcache/v1/storage_backend/connector/lm_connector.py
@@ -40,6 +40,8 @@ class LMCServerConnector(RemoteConnector):
         # than implementations that work with sockets.
         # However, we use socket here as we need to use the socket.recv_into()
         # to reduce memory copy.
+
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -177,6 +177,8 @@ class MockConnector(RemoteConnector):
         read_throughput: GB/s for reading
         write_throughput: GB/s for writing
         """
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -177,6 +177,7 @@ class MockConnector(RemoteConnector):
         read_throughput: GB/s for reading
         write_throughput: GB/s for writing
         """
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         self.loop = loop

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -12,7 +12,6 @@ import os
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
@@ -106,6 +105,8 @@ class MooncakestoreConnector(RemoteConnector):
         local_cpu_backend: LocalCPUBackend,
         lmcache_config: Optional[LMCacheEngineConfig],
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         try:
             # Third Party
             from mooncake.store import (
@@ -223,23 +224,6 @@ class MooncakestoreConnector(RemoteConnector):
 
         logger.info("MooncakeConnector initialized successfully.")
 
-    def init_chunk_meta(
-        self,
-        config: Optional[LMCacheEngineConfig],
-        metadata: Optional[LMCacheEngineMetadata],
-    ) -> None:
-        """Initialize chunk metadata and log the configuration."""
-        super().init_chunk_meta(config, metadata)
-
-        if self.meta_shape and self.meta_dtype and self.meta_fmt:
-            logger.info("MooncakeConnector using optimized mode")
-        else:
-            logger.info("MooncakeConnector using legacy mode")
-            logger.info(
-                "Try setting 'save_chunk_meta' to False in the configuration "
-                "for better performance"
-            )
-
     def _register_cpu_buffer(self):
         """Register CPU buffer for zero-copy operations."""
         try:
@@ -329,11 +313,11 @@ class MooncakestoreConnector(RemoteConnector):
         Zero-copy batch get using batch_get_into when metadata is available locally.
         This is used when save_chunk_meta=False (metadata not stored remotely).
         """
-        if not self.meta_shape or not self.meta_dtype or not self.meta_fmt:
+        if not self.meta_shapes or not self.meta_dtypes or not self.meta_fmt:
             logger.error(
                 f"Metadata required for batch_get_into but not available: "
-                f"meta_shape={self.meta_shape}, "
-                f"meta_dtype={self.meta_dtype}, "
+                f"meta_shapes={self.meta_shapes}, "
+                f"meta_dtypes={self.meta_dtypes}, "
                 f"meta_fmt={self.meta_fmt}"
             )
             return [None] * len(keys)
@@ -350,7 +334,7 @@ class MooncakestoreConnector(RemoteConnector):
 
         for i, _ in enumerate(keys):
             buf = self.local_cpu_backend.allocate(
-                self.meta_shape, self.meta_dtype, self.meta_fmt
+                self.meta_shapes, self.meta_dtypes, self.meta_fmt
             )
             memory_objs.append(buf)
             buf_tensor = buf.tensor

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -105,6 +105,7 @@ class MooncakestoreConnector(RemoteConnector):
         local_cpu_backend: LocalCPUBackend,
         lmcache_config: Optional[LMCacheEngineConfig],
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         try:

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -45,6 +45,7 @@ class RedisConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         # set a large max
@@ -272,6 +273,7 @@ class RedisSentinelConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         # Get service name
@@ -413,6 +415,7 @@ class RedisClusterConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         # Convert hosts_and_ports to startup_nodes format expected by RedisCluster

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -45,6 +45,8 @@ class RedisConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         # set a large max
         self.max_connections = 150
         # redis will crash if we have more than max_connections connections
@@ -270,6 +272,8 @@ class RedisSentinelConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         # Get service name
         match os.environ.get(self.ENV_REDIS_SERVICE_NAME):
             case None:
@@ -409,6 +413,8 @@ class RedisClusterConnector(RemoteConnector):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         # Convert hosts_and_ports to startup_nodes format expected by RedisCluster
         startup_nodes = [ClusterNode(h, p) for (h, p) in hosts_and_ports]
 

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -83,6 +83,7 @@ class S3Connector(RemoteConnector):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         if not s3_endpoint.startswith("s3://"):

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -83,11 +83,12 @@ class S3Connector(RemoteConnector):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         if not s3_endpoint.startswith("s3://"):
             raise ValueError("S3 url must start with 's3://'")
 
-        # post initialized
-        self.s3_part_size = None
+        self.s3_part_size = self.full_chunk_size
 
         self.s3_endpoint = s3_endpoint.removeprefix("s3://")
         self.loop = loop
@@ -163,18 +164,6 @@ class S3Connector(RemoteConnector):
         self.connection_disabled = False
 
         self.pq_executor = AsyncPQExecutor(loop)
-
-    def post_init(self):
-        logger.info("Post-initializing S3 connector")
-
-        if self.s3_part_size is None:
-            # Default to chunk size
-            self.s3_part_size = self.full_chunk_size
-        assert self.s3_part_size == self.full_chunk_size, (
-            "S3 part size must be equal to chunk size in S3Connector"
-        )
-        logger.info(f"s3 connector meta_shape: {self.meta_shape}")
-        logger.info(f"s3 connector meta_dtype: {self.meta_dtype}")
 
     def _format_safe_path(self, key_str: str) -> str:
         """
@@ -368,8 +357,8 @@ class S3Connector(RemoteConnector):
             self.object_size_cache[key_str] = obj_size
 
         memory_obj = self.local_cpu_backend.allocate(
-            self.meta_shape,
-            self.meta_dtype,
+            self.meta_shapes,
+            self.meta_dtypes,
             self.meta_fmt,
         )
 
@@ -463,8 +452,8 @@ class S3Connector(RemoteConnector):
                 self.object_size_cache[key_str] = obj_size
 
             memory_obj = self.local_cpu_backend.allocate(
-                self.meta_shape,
-                self.meta_dtype,
+                self.meta_shapes,
+                self.meta_dtypes,
                 self.meta_fmt,
             )
 

--- a/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_adapter.py
+++ b/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_adapter.py
@@ -148,15 +148,6 @@ class SageMakerHyperPodConnectorAdapter(ConnectorAdapter):
             max_lease_size_mb=max_lease_size_mb,
         )
 
-        # Initialize shared memory connection
-        try:
-            connector.post_init()
-        except Exception as e:
-            logger.error(f"Failed to initialize SageMaker HyperPod connector: {e}")
-            raise RuntimeError(
-                f"SageMaker HyperPod connector initialization failed: {e}"
-            ) from e
-
         logger.info("SageMaker HyperPod connector created successfully")
         return connector
 

--- a/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
+++ b/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
@@ -104,6 +104,7 @@ class SageMakerHyperPodConnector(RemoteConnector):
             streaming PUT requests (default: 64KB)
             **kwargs: Unused legacy parameters (ignored for backward compatibility)
         """
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         # Core configuration
@@ -133,9 +134,11 @@ class SageMakerHyperPodConnector(RemoteConnector):
         self.put_inflight = asyncio.Semaphore(self.max_concurrent_requests)
         self.pq_executor = AsyncPQExecutor(loop)
 
-        # Shared memory (lazy initialized)
+        # Shared memory
         self.shared_memory_obj: Optional[shared_memory.SharedMemory] = None
         self.shared_memory_map: Optional[memoryview] = None
+        if self.shared_memory_name:
+            self._init_shared_memory()
 
         # Observability
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
@@ -156,11 +159,6 @@ class SageMakerHyperPodConnector(RemoteConnector):
             f"bucket={self.bucket_name}, shared_memory={self.shared_memory_name}, "
             f"connections={self.max_connections}, lease_ttl={lease_ttl_s}s"
         )
-
-    def post_init(self):
-        """Initialize shared memory connection after construction."""
-        if self.shared_memory_name:
-            self._init_shared_memory()
 
     def _init_shared_memory(self):
         """Initialize shared memory connection to ai-toolkit daemon."""

--- a/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
+++ b/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
@@ -104,7 +104,7 @@ class SageMakerHyperPodConnector(RemoteConnector):
             streaming PUT requests (default: 64KB)
             **kwargs: Unused legacy parameters (ignored for backward compatibility)
         """
-        super().__init__()
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         # Core configuration
         self.base_url = sagemaker_hyperpod_url.rstrip("/")

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -46,6 +46,7 @@ class ValkeyConnector(RemoteConnector):
         password: str,
         database_id: Optional[int] = None,
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         if ":" in url:
@@ -233,6 +234,7 @@ class ValkeyClusterConnector(RemoteConnector):
         password: str,
         hosts_and_ports: Optional[List[Tuple[str, int]]],
     ):
+        # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
         self.loop = loop

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -46,6 +46,8 @@ class ValkeyConnector(RemoteConnector):
         password: str,
         database_id: Optional[int] = None,
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         if ":" in url:
             host, port_str = url.split(":", 1)
             port = int(port_str)
@@ -231,6 +233,8 @@ class ValkeyClusterConnector(RemoteConnector):
         password: str,
         hosts_and_ports: Optional[List[Tuple[str, int]]],
     ):
+        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
         self.executor = AsyncPQExecutor(loop)

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -58,11 +58,11 @@ class TestLoadFSChunksAPI:
         thread.join(timeout=5.0)
 
     @pytest.fixture
-    def local_cpu_backend(self):
+    def local_cpu_backend(self, test_metadata):
         """Create a LocalCPUBackend for testing."""
         config = LMCacheEngineConfig.from_defaults(chunk_size=256)
         allocator = AdHocMemoryAllocator(device="cpu")
-        backend = LocalCPUBackend(config, memory_allocator=allocator)
+        backend = LocalCPUBackend(config, test_metadata, memory_allocator=allocator)
         yield backend
         backend.memory_allocator.close()
 

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
@@ -78,8 +79,16 @@ def local_cpu_backend():
         remote_url="mock://test",
         extra_config={},
     )
+    metadata = LMCacheEngineMetadata(
+        model_name="test_model",
+        world_size=1,
+        worker_id=0,
+        fmt="vllm",
+        kv_dtype=torch.bfloat16,
+        kv_shape=(64, 2, 1, 8, 128),
+    )
     allocator = AdHocMemoryAllocator(device="cpu")
-    return LocalCPUBackend(config=config, memory_allocator=allocator)
+    return LocalCPUBackend(config=config, metadata=metadata, memory_allocator=allocator)
 
 
 @pytest.fixture
@@ -468,16 +477,11 @@ class TestAuditConnector:
         log_capture.clear()
 
         audit.post_init()
-        audit.init_chunk_meta(None, None)
 
         print("\nAfter @NotAudit methods:")
         print(log_capture.get_logs())
 
-        operation_logs = [
-            r
-            for r in log_capture.get_records()
-            if "POST_INIT" in r.msg or "INIT_CHUNK_META" in r.msg
-        ]
+        operation_logs = [r for r in log_capture.get_records() if "POST_INIT" in r.msg]
         operation_logs = [r for r in operation_logs if "SUCCESS" in r.msg]
         assert len(operation_logs) == 0, (
             f"@NotAudit methods should not generate operation audit logs. "

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -97,7 +97,8 @@ def async_loop():
 def local_cpu_backend(memory_allocator):
     """Create a LocalCPUBackend for testing."""
     config = LMCacheEngineConfig.from_legacy(chunk_size=256)
-    return LocalCPUBackend(config, memory_allocator=memory_allocator)
+    metadata = create_test_metadata()
+    return LocalCPUBackend(config, metadata, memory_allocator=memory_allocator)
 
 
 @pytest.fixture
@@ -286,6 +287,7 @@ class TestFSConnector:
         # Create new backend instance and verify data persists
         new_local_cpu_backend = LocalCPUBackend(
             LMCacheEngineConfig.from_legacy(chunk_size=256),
+            local_cpu_backend.metadata,
             memory_allocator=local_cpu_backend.memory_allocator,
         )
         new_backend = RemoteBackend(

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -13,6 +13,7 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PinMemoryAllocator
 from lmcache.v1.protocol import RemoteMetadata
+from lmcache.v1.storage_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.connector import CreateConnector
 
 # Local
@@ -37,7 +38,8 @@ def test_lm_connector(url, autorelease_v1, lmserver_v1_process):
 
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
-    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+    local_cpu_backend = _create_local_cpu_backend(memory_allocator, False)
+    connector = autorelease_v1(CreateConnector(url, async_loop, local_cpu_backend))
 
     random_key = dumb_cache_engine_key()
     future = asyncio.run_coroutine_threadsafe(connector.exists(random_key), async_loop)
@@ -46,7 +48,7 @@ def test_lm_connector(url, autorelease_v1, lmserver_v1_process):
     num_tokens = 1000
     mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
-    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj = local_cpu_backend.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
 
     torch.manual_seed(42)
@@ -71,8 +73,7 @@ def test_lm_connector(url, autorelease_v1, lmserver_v1_process):
     )
 
     close_asyncio_loop(async_loop, async_thread)
-
-    memory_allocator.close()
+    local_cpu_backend.close()
 
 
 @pytest.mark.parametrize("full_chunk", [True, False])
@@ -98,17 +99,9 @@ def test_fs_connector(autorelease_v1, full_chunk, save_chunk_meta, use_mla):
         config = LMCacheEngineConfig.from_defaults(
             extra_config={"save_chunk_meta": save_chunk_meta}
         )
-        metadata = LMCacheEngineMetadata(
-            "deepseek/DeepSeek-R1",
-            1,
-            0,
-            "vllm",
-            dtype,
-            kv_shape,
-            use_mla,
-        )
+        local_cpu_backend = _create_local_cpu_backend(memory_allocator, use_mla, config)
         connector = autorelease_v1(
-            CreateConnector(url, async_loop, memory_allocator, config, metadata)
+            CreateConnector(url, async_loop, local_cpu_backend, config)
         )
         random_key = dumb_cache_engine_key()
 
@@ -129,7 +122,7 @@ def test_fs_connector(autorelease_v1, full_chunk, save_chunk_meta, use_mla):
                 kv_shape[3] * kv_shape[4],
             ]
         )
-        memory_obj = memory_allocator.allocate(memory_obj_shape, dtype)
+        memory_obj = local_cpu_backend.allocate(memory_obj_shape, dtype)
         memory_obj.ref_count_up()
         # Fill with deterministic test data
         torch.manual_seed(42)
@@ -173,8 +166,7 @@ def test_fs_connector(autorelease_v1, full_chunk, save_chunk_meta, use_mla):
         assert files[0].stat().st_size == expected_file_size
 
         close_asyncio_loop(async_loop, async_thread)
-
-        memory_allocator.close()
+        local_cpu_backend.close()
 
 
 @pytest.mark.parametrize(
@@ -196,7 +188,8 @@ def test_redis_connector(url, autorelease_v1):
 
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
-    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+    local_cpu_backend = _create_local_cpu_backend(memory_allocator, False)
+    connector = autorelease_v1(CreateConnector(url, async_loop, local_cpu_backend))
 
     random_key = dumb_cache_engine_key()
 
@@ -208,7 +201,7 @@ def test_redis_connector(url, autorelease_v1):
     num_tokens = 1000
     mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
-    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj = local_cpu_backend.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
 
     torch.manual_seed(42)
@@ -236,8 +229,7 @@ def test_redis_connector(url, autorelease_v1):
     )
 
     close_asyncio_loop(async_loop, async_thread)
-
-    memory_allocator.close()
+    local_cpu_backend.close()
 
 
 @pytest.mark.parametrize(
@@ -263,7 +255,8 @@ def test_redis_sentinel_connector(url, autorelease_v1):
 
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
-    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+    local_cpu_backend = _create_local_cpu_backend(memory_allocator, False)
+    connector = autorelease_v1(CreateConnector(url, async_loop, local_cpu_backend))
 
     random_key = dumb_cache_engine_key()
 
@@ -275,7 +268,7 @@ def test_redis_sentinel_connector(url, autorelease_v1):
     num_tokens = 1000
     mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
-    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj = local_cpu_backend.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
 
     # Fill with deterministic test data for Redis Sentinel test
@@ -298,8 +291,7 @@ def test_redis_sentinel_connector(url, autorelease_v1):
     future.result()
 
     close_asyncio_loop(async_loop, async_thread)
-
-    memory_allocator.close()
+    local_cpu_backend.close()
 
 
 REDIS_CLUSTER_URLS = [
@@ -324,8 +316,8 @@ def test_redis_cluster_connector(url, autorelease_v1):
 
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
-
-    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+    local_cpu_backend = _create_local_cpu_backend(memory_allocator, False)
+    connector = autorelease_v1(CreateConnector(url, async_loop, local_cpu_backend))
 
     random_key = dumb_cache_engine_key()
 
@@ -337,7 +329,7 @@ def test_redis_cluster_connector(url, autorelease_v1):
     num_tokens = 1000
     mem_obj_shape = torch.Size([2, 32, num_tokens, 1024])
     dtype = torch.bfloat16
-    memory_obj = memory_allocator.allocate(mem_obj_shape, dtype)
+    memory_obj = local_cpu_backend.allocate(mem_obj_shape, dtype)
     memory_obj.ref_count_up()
 
     # Fill with deterministic test data
@@ -363,18 +355,19 @@ def test_redis_cluster_connector(url, autorelease_v1):
     check_mem_obj_equal([retrieved_memory_obj], [memory_obj])
 
     close_asyncio_loop(async_loop, async_thread)
-    memory_allocator.close()
+    local_cpu_backend.close()
 
 
 @pytest.mark.parametrize("url", REDIS_CLUSTER_URLS)
 def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
-    connector = autorelease_v1(CreateConnector(url, async_loop, memory_allocator))
+    local_cpu_backend = _create_local_cpu_backend(memory_allocator, False)
+    connector = autorelease_v1(CreateConnector(url, async_loop, local_cpu_backend))
 
     random_key = dumb_cache_engine_key()
     # build a small mem obj to get correct metadata bytes
-    memory_obj = memory_allocator.allocate(torch.Size([2, 32, 8, 64]), torch.bfloat16)
+    memory_obj = local_cpu_backend.allocate(torch.Size([2, 32, 8, 64]), torch.bfloat16)
     kv_bytes = memory_obj.byte_array
     meta = RemoteMetadata(
         len(kv_bytes),
@@ -399,4 +392,28 @@ def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
     assert not future.result()
 
     close_asyncio_loop(async_loop, async_thread)
-    memory_allocator.close()
+    local_cpu_backend.close()
+
+
+def _get_metadata(use_mla: bool):
+    kv_shape = (32, 1 if use_mla else 2, 256, 1 if use_mla else 8, 128)
+    dtype = torch.bfloat16
+    metadata = LMCacheEngineMetadata(
+        "deepseek/DeepSeek-R1",
+        1,
+        0,
+        "vllm",
+        dtype,
+        kv_shape,
+        use_mla,
+    )
+    return metadata
+
+
+def _create_local_cpu_backend(memory_allocator, use_mla, config=None):
+    if config is None:
+        config = LMCacheEngineConfig.from_defaults()
+    metadata = _get_metadata(use_mla)
+    return LocalCPUBackend(
+        config=config, metadata=metadata, memory_allocator=memory_allocator
+    )

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -64,7 +64,7 @@ def test_remote_mla_worker_id_as0(mock_stream):
         model_name="test-model",
         fmt="vllm",
         kv_dtype=torch.float16,
-        kv_shape=(2, 32, 1000, 1024, 1),
+        kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
         world_size=4,
         worker_id=2,
@@ -73,7 +73,7 @@ def test_remote_mla_worker_id_as0(mock_stream):
         model_name="test-model",
         fmt="vllm",
         kv_dtype=torch.float16,
-        kv_shape=(1, 32, 1, 1024, 1),
+        kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
         world_size=4,
         worker_id=0,
@@ -84,7 +84,9 @@ def test_remote_mla_worker_id_as0(mock_stream):
     from lmcache.v1.memory_management import AdHocMemoryAllocator
 
     pin_allocator = AdHocMemoryAllocator()
-    local_cpu_backend = LocalCPUBackend(config, memory_allocator=pin_allocator)
+    local_cpu_backend = LocalCPUBackend(
+        config, metadata, memory_allocator=pin_allocator
+    )
 
     loop = asyncio.new_event_loop()
     backend = RemoteBackend(
@@ -109,11 +111,14 @@ def test_remote_mla_worker_id_as0(mock_stream):
         dtype=torch.float32,
     )
 
+    local_cpu_backend0 = LocalCPUBackend(
+        config, metadata0, memory_allocator=pin_allocator
+    )
     backend0 = RemoteBackend(
         config=config,
         metadata=metadata0,
         loop=loop,
-        local_cpu_backend=local_cpu_backend,
+        local_cpu_backend=local_cpu_backend0,
     )
     backend0.connection = backend.connection
     # Create key


### PR DESCRIPTION
refactor `RemoteConnector`, reference to https://github.com/LMCache/LMCache/pull/2266#discussion_r2644457897, I first refactor the `RemoteConnector`, move the attribute to `__init__` method, and rename `shape`, `dtype` to `shapes`, `dtypes`