### PR TITLE
[refactor] use shapes and dtypes in RemoteMetadata

### DIFF
--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -9,10 +9,16 @@ import struct
 import torch
 
 # First Party
+from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey, LayerCacheEngineKey, parse_cache_key
 from lmcache.v1.memory_management import MemoryFormat
 
+logger = init_logger(__name__)
+
+
 MAX_KEY_LENGTH = 150
+REMOTE_METADATA_FMT: Optional[str] = None
+REMOTE_METADATA_BYTES: Optional[int] = None
 
 
 class ClientCommand(IntEnum):
@@ -68,6 +74,28 @@ INT_TO_LOCATION = {
 }
 
 
+def init_remote_metadata_info(num_groups: int):
+    global REMOTE_METADATA_FMT
+    global REMOTE_METADATA_BYTES
+    # length, fmt, (dtype, shape0, shape1, shape2, shape3) * num_groups
+    fmt_length = 2 + 5 * num_groups
+    REMOTE_METADATA_FMT = "i" * fmt_length
+    REMOTE_METADATA_BYTES = 4 * fmt_length
+    logger.info(
+        "init remote metadata info with groups: %s, "
+        "remote metadata fmt: %s, remote metadata bytes: %s",
+        num_groups,
+        REMOTE_METADATA_FMT,
+        REMOTE_METADATA_BYTES,
+    )
+
+
+def get_remote_metadata_bytes():
+    global REMOTE_METADATA_BYTES
+    assert REMOTE_METADATA_BYTES is not None
+    return REMOTE_METADATA_BYTES
+
+
 @dataclass
 class RemoteMetadata:
     length: int
@@ -86,22 +114,22 @@ class RemoteMetadata:
             params.append(shape[3])
         return params
 
-    def serialize_into(self, buffer, fmt: str):
+    def serialize_into(self, buffer):
+        assert REMOTE_METADATA_FMT is not None
         params = self._prepare_params()
-        assert len(fmt) == len(params)
-        struct.pack_into(fmt, buffer, 0, *params)
+        struct.pack_into(REMOTE_METADATA_FMT, buffer, 0, *params)
 
-    def serialize(self, fmt: str) -> bytes:
+    def serialize(self) -> bytes:
+        assert REMOTE_METADATA_FMT is not None
         params = self._prepare_params()
-        assert len(fmt) == len(params)
-        packed_bytes = struct.pack(fmt, *params)
+        packed_bytes = struct.pack(REMOTE_METADATA_FMT, *params)
         return packed_bytes
 
     @staticmethod
-    def deserialize(s: bytes, fmt: str) -> "RemoteMetadata":
-        # length, fmt, dtype, shape0, shape1, shape2, shape3
-        result = struct.unpack_from(fmt, s)
-        assert len(fmt) == len(result)
+    def deserialize(s: bytes) -> "RemoteMetadata":
+        assert REMOTE_METADATA_FMT is not None
+        # length, fmt, (dtype, shape0, shape1, shape2, shape3) * num_groups
+        result = struct.unpack_from(REMOTE_METADATA_FMT, s)
         length = result[0]
         memory_fmt = MemoryFormat(result[1])
         shapes = []

--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -71,53 +71,50 @@ INT_TO_LOCATION = {
 @dataclass
 class RemoteMetadata:
     length: int
-    shape: torch.Size
-    dtype: Optional[torch.dtype]
+    shapes: list[torch.Size]
+    dtypes: list[torch.dtype]
     fmt: MemoryFormat
 
-    def serialize_into(self, buffer):
-        assert len(self.shape) == 4, "Shape dimension should be 4"
+    def _prepare_params(self):
+        params = [self.length, int(self.fmt.value)]
+        for shape, dtype in zip(self.shapes, self.dtypes, strict=True):
+            assert len(shape) == 4, "Shape dimension should be 4"
+            params.append(DTYPE_TO_INT[dtype])
+            params.append(shape[0])
+            params.append(shape[1])
+            params.append(shape[2])
+            params.append(shape[3])
+        return params
 
-        struct.pack_into(
-            "iiiiiii",
-            buffer,
-            0,
-            self.length,
-            int(self.fmt.value),
-            DTYPE_TO_INT[self.dtype],
-            self.shape[0],
-            self.shape[1],
-            self.shape[2],
-            self.shape[3],
-        )
+    def serialize_into(self, buffer, fmt: str):
+        params = self._prepare_params()
+        assert len(fmt) == len(params)
+        struct.pack_into(fmt, buffer, 0, *params)
 
-    def serialize(self) -> bytes:
-        # NOTE(Jiayi): 4 is the maximum dimension of memory object.
-        # Pass in shape [x, 0, 0, 0] if it is a bytes memory object
-        assert len(self.shape) == 4, "Shape dimension should be 4"
-
-        packed_bytes = struct.pack(
-            "iiiiiii",
-            self.length,
-            int(self.fmt.value),
-            DTYPE_TO_INT[self.dtype],
-            self.shape[0],
-            self.shape[1],
-            self.shape[2],
-            self.shape[3],
-        )
+    def serialize(self, fmt: str) -> bytes:
+        params = self._prepare_params()
+        assert len(fmt) == len(params)
+        packed_bytes = struct.pack(fmt, *params)
         return packed_bytes
 
     @staticmethod
-    def deserialize(s: bytes) -> "RemoteMetadata":
-        length, fmt, dtype, shape0, shape1, shape2, shape3 = struct.unpack_from(
-            "iiiiiii", s
-        )
+    def deserialize(s: bytes, fmt: str) -> "RemoteMetadata":
+        # length, fmt, dtype, shape0, shape1, shape2, shape3
+        result = struct.unpack_from(fmt, s)
+        assert len(fmt) == len(result)
+        length = result[0]
+        memory_fmt = MemoryFormat(result[1])
+        shapes = []
+        dtypes = []
+        for i in range(2, len(result), 5):
+            shapes.append(torch.Size(result[i + 1 : i + 5]))
+            dtypes.append(INT_TO_DTYPE[result[i]])
+
         return RemoteMetadata(
             length,
-            torch.Size([shape0, shape1, shape2, shape3]),
-            INT_TO_DTYPE[dtype],
-            MemoryFormat(fmt),
+            shapes,
+            dtypes,
+            memory_fmt,
         )
 
 

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -43,6 +43,8 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         - `meta_fmt` is the memory format of the lmcache chunk.
         - `full_chunk_size` is the size of the lmcache full chunk.
         - `single_token_size` is the size of a single token.`
+        - `remote_metadata_fmt` is the format of the remote metadata.
+        - `remote_metadata_bytes` is the size of the remote metadata.
 
         Input:
             config: the lmcache engine config
@@ -63,14 +65,21 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         self.full_chunk_size: int = get_size_bytes(self.meta_shapes, self.meta_dtypes)
         assert self.full_chunk_size % metadata.chunk_size == 0
         self.single_token_size = self.full_chunk_size // metadata.chunk_size
+
+        fmt_length = 2 + metadata.get_num_groups() * 5
+        self.remote_metadata_fmt = "i" * fmt_length
+        self.remote_metadata_bytes = fmt_length * 4
         logger.info(
             "init remote connector metadata info, shapes: %s, dtypes: %s, "
-            "fmt: %s, full chunk size: %s, single token size: %s",
+            "fmt: %s, full chunk size: %s, single token size: %s, "
+            "remote metadata fmt: %s, remote metadata bytes: %s",
             self.meta_shapes,
             self.meta_dtypes,
             self.meta_fmt,
             self.full_chunk_size,
             self.single_token_size,
+            self.remote_metadata_fmt,
+            self.remote_metadata_bytes,
         )
 
     @NotAudit

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -14,6 +14,7 @@ from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.protocol import get_remote_metadata_bytes, init_remote_metadata_info
 
 logger = init_logger(__name__)
 
@@ -43,7 +44,6 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         - `meta_fmt` is the memory format of the lmcache chunk.
         - `full_chunk_size` is the size of the lmcache full chunk.
         - `single_token_size` is the size of a single token.`
-        - `remote_metadata_fmt` is the format of the remote metadata.
         - `remote_metadata_bytes` is the size of the remote metadata.
 
         Input:
@@ -66,19 +66,17 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         assert self.full_chunk_size % metadata.chunk_size == 0
         self.single_token_size = self.full_chunk_size // metadata.chunk_size
 
-        fmt_length = 2 + metadata.get_num_groups() * 5
-        self.remote_metadata_fmt = "i" * fmt_length
-        self.remote_metadata_bytes = fmt_length * 4
+        # init remote metadata info
+        init_remote_metadata_info(metadata.get_num_groups())
+        self.remote_metadata_bytes = get_remote_metadata_bytes()
         logger.info(
-            "init remote connector metadata info, shapes: %s, dtypes: %s, "
-            "fmt: %s, full chunk size: %s, single token size: %s, "
-            "remote metadata fmt: %s, remote metadata bytes: %s",
+            "init remote connector metadata info, shapes: %s, dtypes: %s, fmt: %s, "
+            "full chunk size: %s, single token size: %s, remote metadata bytes: %s",
             self.meta_shapes,
             self.meta_dtypes,
             self.meta_fmt,
             self.full_chunk_size,
             self.single_token_size,
-            self.remote_metadata_fmt,
             self.remote_metadata_bytes,
         )
 

--- a/lmcache/v1/storage_backend/connector/eic_connector.py
+++ b/lmcache/v1/storage_backend/connector/eic_connector.py
@@ -339,9 +339,7 @@ class EICConnector(RemoteConnector):
         perf_timer.stop("eic_mget")
 
         perf_timer.start("serialize")
-        meta = RemoteMetadata.deserialize(
-            meta_bytes[:meta_size], self.remote_metadata_fmt
-        )
+        meta = RemoteMetadata.deserialize(meta_bytes[:meta_size])
         perf_timer.stop("serialize")
 
         perf_timer.stop("total_cost")
@@ -462,7 +460,7 @@ class EICConnector(RemoteConnector):
 
         logger.debug(f"eic meta {key_str} remote_meta{remote_meta}")
 
-        meta_bytes = remote_meta.serialize(self.remote_metadata_fmt)
+        meta_bytes = remote_meta.serialize()
 
         perf_timer.stop("serialize")
 
@@ -549,7 +547,7 @@ class EICConnector(RemoteConnector):
             remote_meta = RemoteMetadata(
                 self.remote_metadata_bytes, kv_shapes, kv_dtypes, memory_format
             )
-            meta_bytes = remote_meta.serialize(self.remote_metadata_fmt)
+            meta_bytes = remote_meta.serialize()
             meta_list.append(meta_bytes)
             meta_ptr = self.bytes_get_ptr(meta_bytes)
             meta_size = len(meta_bytes)

--- a/lmcache/v1/storage_backend/connector/eic_connector.py
+++ b/lmcache/v1/storage_backend/connector/eic_connector.py
@@ -72,9 +72,6 @@ class PerformanceTimer:
         logger.debug(f"== Perf op {self.op} size {self.size} =========")
 
 
-METADATA_BYTES_LEN = 28
-
-
 class FlexibleDRAMMemoryPool:
     def __init__(self, conn):
         self._init = False
@@ -306,7 +303,7 @@ class EICConnector(RemoteConnector):
         # Get Meta: generate meta buffer tensor
         perf_timer.start("alloc_mem")
         meta_key = key_str + "_meta"
-        meta_size = METADATA_BYTES_LEN
+        meta_size = self.remote_metadata_bytes
         meta_bytes = bytearray(meta_size)
         meta_bytes_ptr = self.bytes_get_ptr(meta_bytes)
 
@@ -342,7 +339,9 @@ class EICConnector(RemoteConnector):
         perf_timer.stop("eic_mget")
 
         perf_timer.start("serialize")
-        meta = RemoteMetadata.deserialize(meta_bytes[:meta_size])
+        meta = RemoteMetadata.deserialize(
+            meta_bytes[:meta_size], self.remote_metadata_fmt
+        )
         perf_timer.stop("serialize")
 
         perf_timer.stop("total_cost")
@@ -355,8 +354,8 @@ class EICConnector(RemoteConnector):
         perf_timer.start("total_cost")
         perf_timer.start("alloc_obj")
         memory_obj = self.memory_allocator.allocate(
-            meta.shape,
-            meta.dtype,
+            meta.shapes,
+            meta.dtypes,
             meta.fmt,
         )
         if memory_obj is None:
@@ -441,8 +440,8 @@ class EICConnector(RemoteConnector):
         perf_timer.start("total_cost")
         kv_bytes = memory_obj.byte_array
         kv_tensor = memory_obj.tensor
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
+        kv_shapes = memory_obj.get_shapes()
+        kv_dtypes = memory_obj.get_dtypes()
         memory_format = memory_obj.get_memory_format()
         value_size = memory_obj.get_physical_size()
 
@@ -458,12 +457,12 @@ class EICConnector(RemoteConnector):
 
         # generate meta bytes
         remote_meta = RemoteMetadata(
-            METADATA_BYTES_LEN, kv_shape, kv_dtype, memory_format
+            self.remote_metadata_bytes, kv_shapes, kv_dtypes, memory_format
         )
 
         logger.debug(f"eic meta {key_str} remote_meta{remote_meta}")
 
-        meta_bytes = remote_meta.serialize()
+        meta_bytes = remote_meta.serialize(self.remote_metadata_fmt)
 
         perf_timer.stop("serialize")
 
@@ -540,17 +539,17 @@ class EICConnector(RemoteConnector):
             # Get memory object data
             kv_bytes = memory_obj.byte_array
             kv_tensor = memory_obj.tensor
-            kv_shape = memory_obj.get_shape()
-            kv_dtype = memory_obj.get_dtype()
+            kv_shapes = memory_obj.get_shapes()
+            kv_dtypes = memory_obj.get_dtypes()
             memory_format = memory_obj.get_memory_format()
             if kv_tensor is None:
                 logger.error(f"Memory object tensor is None for key {key_str}")
                 return
 
             remote_meta = RemoteMetadata(
-                METADATA_BYTES_LEN, kv_shape, kv_dtype, memory_format
+                self.remote_metadata_bytes, kv_shapes, kv_dtypes, memory_format
             )
-            meta_bytes = remote_meta.serialize()
+            meta_bytes = remote_meta.serialize(self.remote_metadata_fmt)
             meta_list.append(meta_bytes)
             meta_ptr = self.bytes_get_ptr(meta_bytes)
             meta_size = len(meta_bytes)
@@ -558,8 +557,11 @@ class EICConnector(RemoteConnector):
             data_size = len(kv_bytes)
 
             logger.info(
-                f"eic batched_put {key_str} shape {kv_shape} dtype {kv_dtype}"
-                " fmt {memory_format}"
+                "eic batched_put %s, shapes: %s, dtypes: %s, fmt: %s",
+                key_str,
+                kv_shapes,
+                kv_dtypes,
+                memory_format,
             )
 
             # Add meta key & value

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -20,15 +20,13 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 
-METADATA_BYTES_LEN = 28
-
 
 class FSConnector(RemoteConnector):
     """File system based connector that stores data in local files.
 
     Data is stored in the following format:
     - Each key is stored as a separate file
-    - File content: metadata (METADATA_BYTES_LEN bytes) + serialized data
+    - File content: metadata (remote_metadata_bytes) + serialized data
     """
 
     def __init__(
@@ -210,7 +208,7 @@ class FSConnector(RemoteConnector):
                 if self.save_chunk_meta:
                     # Read metadata buffer first to get shape, dtype, fmt
                     # to be able to allocate memory object for the data and read into it
-                    md_buffer = bytearray(METADATA_BYTES_LEN)
+                    md_buffer = bytearray(self.remote_metadata_bytes)
                     num_read = await f.readinto(md_buffer)
                     if num_read != len(md_buffer):
                         raise RuntimeError(
@@ -218,9 +216,11 @@ class FSConnector(RemoteConnector):
                         )
 
                     # Deserialize metadata and allocate memory
-                    metadata = RemoteMetadata.deserialize(md_buffer)
+                    metadata = RemoteMetadata.deserialize(
+                        md_buffer, self.remote_metadata_fmt
+                    )
                     memory_obj = self.local_cpu_backend.allocate(
-                        metadata.shape, metadata.dtype, metadata.fmt
+                        metadata.shapes, metadata.dtypes, metadata.fmt
                     )
                 else:
                     memory_obj = self.local_cpu_backend.allocate(
@@ -305,8 +305,8 @@ class FSConnector(RemoteConnector):
             metadata = (
                 RemoteMetadata(
                     len(buffer),
-                    memory_obj.get_shape(),
-                    memory_obj.get_dtype(),
+                    memory_obj.get_shapes(),
+                    memory_obj.get_dtypes(),
                     memory_obj.get_memory_format(),
                 )
                 if self.save_chunk_meta
@@ -334,7 +334,7 @@ class FSConnector(RemoteConnector):
                 # Write to file (metadata + data)
                 async with aiofiles.open(temp_path, "wb") as f:
                     if metadata is not None:
-                        await f.write(metadata.serialize())
+                        await f.write(metadata.serialize(self.remote_metadata_fmt))
                     await f.write(buffer)
 
             # Atomically rename temp file to final destination

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -216,9 +216,7 @@ class FSConnector(RemoteConnector):
                         )
 
                     # Deserialize metadata and allocate memory
-                    metadata = RemoteMetadata.deserialize(
-                        md_buffer, self.remote_metadata_fmt
-                    )
+                    metadata = RemoteMetadata.deserialize(md_buffer)
                     memory_obj = self.local_cpu_backend.allocate(
                         metadata.shapes, metadata.dtypes, metadata.fmt
                     )
@@ -334,7 +332,7 @@ class FSConnector(RemoteConnector):
                 # Write to file (metadata + data)
                 async with aiofiles.open(temp_path, "wb") as f:
                     if metadata is not None:
-                        await f.write(metadata.serialize(self.remote_metadata_fmt))
+                        await f.write(metadata.serialize())
                     await f.write(buffer)
 
             # Atomically rename temp file to final destination

--- a/lmcache/v1/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/v1/storage_backend/connector/infinistore_connector.py
@@ -101,7 +101,7 @@ class InfinistoreConnector(RemoteConnector):
             self.recv_queue.put_nowait(buf_idx)
             return None
 
-        metadata = RemoteMetadata.deserialize(buffer, self.remote_metadata_fmt)
+        metadata = RemoteMetadata.deserialize(buffer)
 
         num_elements = reduce(operator.mul, metadata.shapes[0])
         assert len(metadata.dtypes) == 1
@@ -143,7 +143,7 @@ class InfinistoreConnector(RemoteConnector):
 
         RemoteMetadata(
             len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-        ).serialize_into(buffer, self.remote_metadata_fmt)
+        ).serialize_into(buffer)
 
         buffer[METADATA_BYTES_LEN : METADATA_BYTES_LEN + len(kv_bytes)] = kv_bytes
 

--- a/lmcache/v1/storage_backend/connector/infinistore_connector.py
+++ b/lmcache/v1/storage_backend/connector/infinistore_connector.py
@@ -101,20 +101,20 @@ class InfinistoreConnector(RemoteConnector):
             self.recv_queue.put_nowait(buf_idx)
             return None
 
-        metadata = RemoteMetadata.deserialize(buffer)
+        metadata = RemoteMetadata.deserialize(buffer, self.remote_metadata_fmt)
 
-        num_elements = reduce(operator.mul, metadata.shape)
-        assert metadata.dtype is not None
+        num_elements = reduce(operator.mul, metadata.shapes[0])
+        assert len(metadata.dtypes) == 1
         temp_tensor = torch.frombuffer(
             buffer,
-            dtype=metadata.dtype,
+            dtype=metadata.dtypes[0],
             offset=METADATA_BYTES_LEN,
             count=num_elements,
-        ).reshape(metadata.shape)
+        ).reshape(metadata.shapes[0])
 
         memory_obj = self.memory_allocator.allocate(
-            metadata.shape,
-            metadata.dtype,
+            metadata.shapes[0],
+            metadata.dtypes[0],
             metadata.fmt,
         )
 
@@ -134,16 +134,16 @@ class InfinistoreConnector(RemoteConnector):
         key_str = key.to_string()
 
         kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
+        kv_shapes = memory_obj.get_shapes()
+        kv_dtypes = memory_obj.get_dtypes()
         memory_format = memory_obj.get_memory_format()
 
         buf_idx = await self.send_queue.get()
         buffer = self.send_buffers[buf_idx]
 
-        RemoteMetadata(len(kv_bytes), kv_shape, kv_dtype, memory_format).serialize_into(
-            buffer
-        )
+        RemoteMetadata(
+            len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+        ).serialize_into(buffer, self.remote_metadata_fmt)
 
         buffer[METADATA_BYTES_LEN : METADATA_BYTES_LEN + len(kv_bytes)] = kv_bytes
 

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -439,11 +439,11 @@ class MooncakestoreConnector(RemoteConnector):
         if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
             return None
 
-        metadata = RemoteMetadata.deserialize(metadata_bytes)
+        metadata = RemoteMetadata.deserialize(metadata_bytes, self.remote_metadata_fmt)
 
         memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
+            metadata.shapes,
+            metadata.dtypes,
             metadata.fmt,
         )
         assert len(retrieved_view) == metadata.length + METADATA_BYTES_LEN
@@ -453,14 +453,14 @@ class MooncakestoreConnector(RemoteConnector):
             return None
 
         if memory_obj.tensor is not None:
-            assert metadata.dtype is not None
-            num_elements = reduce(operator.mul, metadata.shape)
+            assert len(metadata.dtypes) == 1
+            num_elements = reduce(operator.mul, metadata.shapes[0])
             temp_tensor = torch.frombuffer(
                 buffer,
-                dtype=metadata.dtype,
+                dtype=metadata.dtypes[0],
                 offset=METADATA_BYTES_LEN,
                 count=num_elements,
-            ).reshape(metadata.shape)
+            ).reshape(metadata.shapes[0])
 
             memory_obj.tensor.copy_(temp_tensor)
             return memory_obj
@@ -589,13 +589,13 @@ class MooncakestoreConnector(RemoteConnector):
         try:
             # Serialize data and metadata
             kv_bytes = memory_obj.byte_array
-            kv_shape = memory_obj.get_shape()
-            kv_dtype = memory_obj.get_dtype()
+            kv_shapes = memory_obj.get_shapes()
+            kv_dtypes = memory_obj.get_dtypes()
             memory_format = memory_obj.get_memory_format()
 
             metadata_bytes = RemoteMetadata(
-                len(kv_bytes), kv_shape, kv_dtype, memory_format
-            ).serialize()
+                len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+            ).serialize(self.remote_metadata_fmt)
             assert len(metadata_bytes) == METADATA_BYTES_LEN
 
             await asyncio.wait_for(

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -439,7 +439,7 @@ class MooncakestoreConnector(RemoteConnector):
         if metadata_bytes is None or len(metadata_bytes) != METADATA_BYTES_LEN:
             return None
 
-        metadata = RemoteMetadata.deserialize(metadata_bytes, self.remote_metadata_fmt)
+        metadata = RemoteMetadata.deserialize(metadata_bytes)
 
         memory_obj = self.local_cpu_backend.allocate(
             metadata.shapes,
@@ -595,7 +595,7 @@ class MooncakestoreConnector(RemoteConnector):
 
             metadata_bytes = RemoteMetadata(
                 len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-            ).serialize(self.remote_metadata_fmt)
+            ).serialize()
             assert len(metadata_bytes) == METADATA_BYTES_LEN
 
             await asyncio.wait_for(

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -84,11 +84,13 @@ class RedisConnector(RemoteConnector):
 
             assert not inspect.isawaitable(metadata_bytes)
 
-            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+            metadata = RemoteMetadata.deserialize(
+                memoryview(metadata_bytes), self.remote_metadata_fmt
+            )
 
             memory_obj = self.local_cpu_backend.allocate(
-                metadata.shape,
-                metadata.dtype,
+                metadata.shapes,
+                metadata.dtypes,
                 metadata.fmt,
             )
             if memory_obj is None:
@@ -163,13 +165,13 @@ class RedisConnector(RemoteConnector):
         # TODO(Jiayi): The following code is ugly.
         # Please use a function like `memory_obj.to_meta()`.
         kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
+        kv_shapes = memory_obj.get_shapes()
+        kv_dtypes = memory_obj.get_dtypes()
         memory_format = memory_obj.get_memory_format()
 
         metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
+            len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+        ).serialize(self.remote_metadata_fmt)
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition
@@ -322,11 +324,11 @@ class RedisSentinelConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(metadata_bytes)
+        metadata = RemoteMetadata.deserialize(metadata_bytes, self.remote_metadata_fmt)
 
         memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
+            metadata.shapes,
+            metadata.dtypes,
             metadata.fmt,
         )
         if memory_obj is None:
@@ -372,13 +374,13 @@ class RedisSentinelConnector(RemoteConnector):
         # TODO(Jiayi): The following code is ugly.
         # Please use a function like `memory_obj.to_meta()`.
         kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
+        kv_shapes = memory_obj.get_shapes()
+        kv_dtypes = memory_obj.get_dtypes()
         memory_format = memory_obj.get_memory_format()
 
         metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
+            len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+        ).serialize(self.remote_metadata_fmt)
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition
@@ -462,11 +464,13 @@ class RedisClusterConnector(RemoteConnector):
 
             assert not inspect.isawaitable(metadata_bytes)
 
-            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+            metadata = RemoteMetadata.deserialize(
+                memoryview(metadata_bytes), self.remote_metadata_fmt
+            )
 
             memory_obj = self.local_cpu_backend.allocate(
-                metadata.shape,
-                metadata.dtype,
+                metadata.shapes,
+                metadata.dtypes,
                 metadata.fmt,
             )
             if memory_obj is None:
@@ -542,13 +546,13 @@ class RedisClusterConnector(RemoteConnector):
         # TODO(Jiayi): The following code is ugly.
         # Please use a function like `memory_obj.to_meta()`.
         kv_bytes = memory_obj.byte_array
-        kv_shape = memory_obj.get_shape()
-        kv_dtype = memory_obj.get_dtype()
+        kv_shapes = memory_obj.get_shapes()
+        kv_dtypes = memory_obj.get_dtypes()
         memory_format = memory_obj.get_memory_format()
 
         metadata_bytes = RemoteMetadata(
-            len(kv_bytes), kv_shape, kv_dtype, memory_format
-        ).serialize()
+            len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+        ).serialize(self.remote_metadata_fmt)
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition

--- a/lmcache/v1/storage_backend/connector/redis_connector.py
+++ b/lmcache/v1/storage_backend/connector/redis_connector.py
@@ -84,9 +84,7 @@ class RedisConnector(RemoteConnector):
 
             assert not inspect.isawaitable(metadata_bytes)
 
-            metadata = RemoteMetadata.deserialize(
-                memoryview(metadata_bytes), self.remote_metadata_fmt
-            )
+            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
             memory_obj = self.local_cpu_backend.allocate(
                 metadata.shapes,
@@ -171,7 +169,7 @@ class RedisConnector(RemoteConnector):
 
         metadata_bytes = RemoteMetadata(
             len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-        ).serialize(self.remote_metadata_fmt)
+        ).serialize()
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition
@@ -324,7 +322,7 @@ class RedisSentinelConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(metadata_bytes, self.remote_metadata_fmt)
+        metadata = RemoteMetadata.deserialize(metadata_bytes)
 
         memory_obj = self.local_cpu_backend.allocate(
             metadata.shapes,
@@ -380,7 +378,7 @@ class RedisSentinelConnector(RemoteConnector):
 
         metadata_bytes = RemoteMetadata(
             len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-        ).serialize(self.remote_metadata_fmt)
+        ).serialize()
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition
@@ -464,9 +462,7 @@ class RedisClusterConnector(RemoteConnector):
 
             assert not inspect.isawaitable(metadata_bytes)
 
-            metadata = RemoteMetadata.deserialize(
-                memoryview(metadata_bytes), self.remote_metadata_fmt
-            )
+            metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
             memory_obj = self.local_cpu_backend.allocate(
                 metadata.shapes,
@@ -552,7 +548,7 @@ class RedisClusterConnector(RemoteConnector):
 
         metadata_bytes = RemoteMetadata(
             len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-        ).serialize(self.remote_metadata_fmt)
+        ).serialize()
 
         key_str = key.to_string()
         # kv bytes needs to be set first to avoid race condition

--- a/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
+++ b/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
@@ -469,18 +469,18 @@ class SageMakerHyperPodConnector(RemoteConnector):
                 return None
 
             # Parse metadata
-            metadata = RemoteMetadata.deserialize(header)
+            metadata = RemoteMetadata.deserialize(header, self.remote_metadata_fmt)
             if metadata.length <= 0:
                 logger.error(f"Invalid payload length: {metadata.length}")
                 return None
 
             # Restore original shape (remove padding zeros)
-            actual_shape = self._parse_shape(metadata.shape)
+            actual_shape = self._parse_shape(metadata.shapes[0])
 
             # Allocate local CPU memory
             memory_obj = self.local_cpu_backend.allocate(
                 actual_shape,
-                metadata.dtype,
+                metadata.dtypes[0],
                 metadata.fmt,
             )
             if memory_obj is None:
@@ -503,9 +503,11 @@ class SageMakerHyperPodConnector(RemoteConnector):
                 return None
 
             logger.debug(
-                f"Read from shared memory: key={key.to_string()}, "
-                f"shape={actual_shape}, dtype={metadata.dtype},"
-                f"size={metadata.length} bytes"
+                "Read from shared memory: key=%s, shape=%s, dtype=%s, size=%s bytes",
+                key.to_string(),
+                actual_shape,
+                metadata.dtypes[0],
+                metadata.length,
             )
 
             return memory_obj
@@ -828,14 +830,14 @@ class SageMakerHyperPodConnector(RemoteConnector):
 
         metadata = RemoteMetadata(
             kv_len,
-            torch.Size(padded_shape),
-            memory_obj.get_dtype(),
+            [torch.Size(padded_shape)],
+            [memory_obj.get_dtype()],
             memory_obj.get_memory_format(),
         )
 
         # Serialize metadata header
         header = bytearray(METADATA_SIZE_BYTES)
-        metadata.serialize_into(header)
+        metadata.serialize_into(header, self.remote_metadata_fmt)
         header_bytes = bytes(header)
 
         total_len = len(header_bytes) + kv_len

--- a/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
+++ b/lmcache/v1/storage_backend/connector/sagemaker_hyperpod_connector.py
@@ -469,7 +469,7 @@ class SageMakerHyperPodConnector(RemoteConnector):
                 return None
 
             # Parse metadata
-            metadata = RemoteMetadata.deserialize(header, self.remote_metadata_fmt)
+            metadata = RemoteMetadata.deserialize(header)
             if metadata.length <= 0:
                 logger.error(f"Invalid payload length: {metadata.length}")
                 return None
@@ -837,7 +837,7 @@ class SageMakerHyperPodConnector(RemoteConnector):
 
         # Serialize metadata header
         header = bytearray(METADATA_SIZE_BYTES)
-        metadata.serialize_into(header, self.remote_metadata_fmt)
+        metadata.serialize_into(header)
         header_bytes = bytes(header)
 
         total_len = len(header_bytes) + kv_len

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -134,9 +134,7 @@ class ValkeyConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(
-            memoryview(metadata_bytes), self.remote_metadata_fmt
-        )
+        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
         memory_obj = self.local_cpu_backend.allocate(
             metadata.shapes,
@@ -193,7 +191,7 @@ class ValkeyConnector(RemoteConnector):
 
             metadata_bytes = RemoteMetadata(
                 len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-            ).serialize(self.remote_metadata_fmt)
+            ).serialize()
 
             metadata_key, kv_key = self._get_keys(key)
 
@@ -312,9 +310,7 @@ class ValkeyClusterConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(
-            memoryview(metadata_bytes), self.remote_metadata_fmt
-        )
+        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
 
         memory_obj = self.local_cpu_backend.allocate(
             metadata.shapes,
@@ -370,7 +366,7 @@ class ValkeyClusterConnector(RemoteConnector):
 
             metadata_bytes = RemoteMetadata(
                 len(kv_bytes), kv_shapes, kv_dtypes, memory_format
-            ).serialize(self.remote_metadata_fmt)
+            ).serialize()
 
             metadata_key, kv_key = self._get_keys_with_hash_tag(key)
 

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -134,11 +134,13 @@ class ValkeyConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+        metadata = RemoteMetadata.deserialize(
+            memoryview(metadata_bytes), self.remote_metadata_fmt
+        )
 
         memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
+            metadata.shapes,
+            metadata.dtypes,
             metadata.fmt,
         )
         if memory_obj is None:
@@ -185,13 +187,13 @@ class ValkeyConnector(RemoteConnector):
     async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         try:
             kv_bytes = bytes(memory_obj.byte_array)
-            kv_shape = memory_obj.get_shape()
-            kv_dtype = memory_obj.get_dtype()
+            kv_shapes = memory_obj.get_shapes()
+            kv_dtypes = memory_obj.get_dtypes()
             memory_format = memory_obj.get_memory_format()
 
             metadata_bytes = RemoteMetadata(
-                len(kv_bytes), kv_shape, kv_dtype, memory_format
-            ).serialize()
+                len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+            ).serialize(self.remote_metadata_fmt)
 
             metadata_key, kv_key = self._get_keys(key)
 
@@ -310,11 +312,13 @@ class ValkeyClusterConnector(RemoteConnector):
 
         assert not inspect.isawaitable(metadata_bytes)
 
-        metadata = RemoteMetadata.deserialize(memoryview(metadata_bytes))
+        metadata = RemoteMetadata.deserialize(
+            memoryview(metadata_bytes), self.remote_metadata_fmt
+        )
 
         memory_obj = self.local_cpu_backend.allocate(
-            metadata.shape,
-            metadata.dtype,
+            metadata.shapes,
+            metadata.dtypes,
             metadata.fmt,
         )
         if memory_obj is None:
@@ -360,13 +364,13 @@ class ValkeyClusterConnector(RemoteConnector):
     async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         try:
             kv_bytes = bytes(memory_obj.byte_array)
-            kv_shape = memory_obj.get_shape()
-            kv_dtype = memory_obj.get_dtype()
+            kv_shapes = memory_obj.get_shapes()
+            kv_dtypes = memory_obj.get_dtypes()
             memory_format = memory_obj.get_memory_format()
 
             metadata_bytes = RemoteMetadata(
-                len(kv_bytes), kv_shape, kv_dtype, memory_format
-            ).serialize()
+                len(kv_bytes), kv_shapes, kv_dtypes, memory_format
+            ).serialize(self.remote_metadata_fmt)
 
             metadata_key, kv_key = self._get_keys_with_hash_tag(key)
 

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -375,7 +375,7 @@ def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
         memory_obj.get_dtypes(),
         memory_obj.get_memory_format(),
     )
-    metadata_bytes = meta.serialize("iiiiiii")
+    metadata_bytes = meta.serialize()
 
     # clean up memory object after getting metadata
     memory_obj.ref_count_down()

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -371,11 +371,11 @@ def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
     kv_bytes = memory_obj.byte_array
     meta = RemoteMetadata(
         len(kv_bytes),
-        memory_obj.get_shape(),
-        memory_obj.get_dtype(),
+        memory_obj.get_shapes(),
+        memory_obj.get_dtypes(),
         memory_obj.get_memory_format(),
     )
-    metadata_bytes = meta.serialize()
+    metadata_bytes = meta.serialize("iiiiiii")
 
     # clean up memory object after getting metadata
     memory_obj.ref_count_down()

--- a/tests/v1/test_remote_metadata.py
+++ b/tests/v1/test_remote_metadata.py
@@ -5,7 +5,11 @@ import torch
 
 # First Party
 from lmcache.v1.memory_management import MemoryFormat
-from lmcache.v1.protocol import RemoteMetadata
+from lmcache.v1.protocol import (
+    RemoteMetadata,
+    get_remote_metadata_bytes,
+    init_remote_metadata_info,
+)
 
 
 @pytest.mark.parametrize("num_groups", [1, 2, 3])
@@ -19,6 +23,10 @@ def test_serialize_and_deserialize(num_groups):
 
     shapes = all_shapes[:num_groups]
     dtypes = all_dtypes[:num_groups]
+
+    # init remote metadata
+    init_remote_metadata_info(num_groups)
+
     origin_metadata = RemoteMetadata(
         100,
         shapes,
@@ -26,10 +34,9 @@ def test_serialize_and_deserialize(num_groups):
         MemoryFormat.KV_MLA_FMT,
     )
 
-    fmt = "i" * (2 + num_groups * 5)
-    meta_bytes = origin_metadata.serialize(fmt)
-    assert len(meta_bytes) == (2 + num_groups * 5) * 4
-    new_metadata = RemoteMetadata.deserialize(meta_bytes, fmt)
+    meta_bytes = origin_metadata.serialize()
+    assert len(meta_bytes) == get_remote_metadata_bytes()
+    new_metadata = RemoteMetadata.deserialize(meta_bytes)
     assert origin_metadata.length == new_metadata.length
     assert origin_metadata.shapes == new_metadata.shapes
     assert origin_metadata.dtypes == new_metadata.dtypes

--- a/tests/v1/test_remote_metadata.py
+++ b/tests/v1/test_remote_metadata.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.memory_management import MemoryFormat
+from lmcache.v1.protocol import RemoteMetadata
+
+
+@pytest.mark.parametrize("num_groups", [1, 2, 3])
+def test_serialize_and_deserialize(num_groups):
+    all_shapes = [
+        torch.Size([1, 2, 3, 4]),
+        torch.Size([5, 6, 7, 8]),
+        torch.Size([9, 10, 11, 12]),
+    ]
+    all_dtypes = [torch.uint8, torch.float16, torch.float32]
+
+    shapes = all_shapes[:num_groups]
+    dtypes = all_dtypes[:num_groups]
+    origin_metadata = RemoteMetadata(
+        100,
+        shapes,
+        dtypes,
+        MemoryFormat.KV_MLA_FMT,
+    )
+
+    fmt = "i" * (2 + num_groups * 5)
+    meta_bytes = origin_metadata.serialize(fmt)
+    assert len(meta_bytes) == (2 + num_groups * 5) * 4
+    new_metadata = RemoteMetadata.deserialize(meta_bytes, fmt)
+    assert origin_metadata.length == new_metadata.length
+    assert origin_metadata.shapes == new_metadata.shapes
+    assert origin_metadata.dtypes == new_metadata.dtypes
+    assert origin_metadata.fmt == new_metadata.fmt


### PR DESCRIPTION
use shapes and dtypes in RemoteMetadata