### PR TITLE
init storage manager after register kv caches

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -752,8 +752,26 @@ class LMCacheConnectorV1Impl:
 
             # In case of MLA, the lookup server is only created on worker 0
             if self.async_loading and self.lookup_server is not None:
-                assert isinstance(self.lookup_server, LMCacheAsyncLookupServer)
-                self.lmcache_engine.post_init(async_lookup_server=self.lookup_server)
+                # if the connector implements `register_kv_caches`, we do not need to
+                # post init the lmcache engine here, do it in `register_kv_caches`.
+                def implements_register_kv_caches():
+                    child_class = self._parent.__class__
+                    parent_class = KVConnectorBase_V1
+                    child_method = getattr(child_class, "register_kv_caches", None)
+                    parent_method = getattr(parent_class, "register_kv_caches", None)
+                    if child_method is None or parent_method is None:
+                        return False
+                    return child_method is not parent_method
+
+                if not implements_register_kv_caches():
+                    logger.warning(
+                        "Please use the latest lmcache connector, otherwise some "
+                        "features may not work, such as DSA with async loading."
+                    )
+                    assert isinstance(self.lookup_server, LMCacheAsyncLookupServer)
+                    self.lmcache_engine.post_init(
+                        async_lookup_server=self.lookup_server
+                    )
 
         self.kv_caches: dict[str, torch.Tensor] = {}
 
@@ -921,6 +939,9 @@ class LMCacheConnectorV1Impl:
             )
             kv_layer_groups_manager.build_kv_layer_groups(self.kv_caches)
 
+    # TODO(chunxiaozheng): in the latest lmcache_connector, we use `register_kv_caches`
+    #  to init self.kv_caches, we keep it in order to be compatible with old versions
+    #  and will be removed in the future.
     @_lmcache_nvtx_annotate
     def _init_kv_caches_from_forward_context(self, forward_context: "ForwardContext"):
         for layer_name in forward_context.no_compile_layers:
@@ -949,7 +970,13 @@ class LMCacheConnectorV1Impl:
         self._build_kv_layer_groups()
         if self.lmcache_engine is not None:
             kvcaches = list(self.kv_caches.values())
-            self.lmcache_engine.post_init(kvcaches=kvcaches)
+            async_lookup_server = None
+            if self.async_loading and self.lookup_server is not None:
+                assert isinstance(self.lookup_server, LMCacheAsyncLookupServer)
+                async_lookup_server = self.lookup_server
+            self.lmcache_engine.post_init(
+                kvcaches=kvcaches, async_lookup_server=async_lookup_server
+            )
 
     @_lmcache_nvtx_annotate
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
@@ -967,6 +994,10 @@ class LMCacheConnectorV1Impl:
         self.current_layer = 0
 
         if len(self.kv_caches) == 0:
+            logger.warning(
+                "Please update LMCacheConnector, "
+                "use register_kv_caches to init kv_caches"
+            )
             self._init_kv_caches_from_forward_context(forward_context)
 
         metadata = self._parent._get_connector_metadata()

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -159,30 +159,7 @@ class LMCacheEngine:
         # the storage_manager
         # if save_only_first_rank is True, only the first rank and
         # lookup server workers will initialize the storage_manager
-        self.storage_manager = None
-        lookup_server_worker_ids = self.config.get_lookup_server_worker_ids(
-            metadata.use_mla, metadata.world_size
-        )
-        if (
-            self.lmcache_worker is not None
-            or self.use_layerwise
-            or not self.save_only_first_rank
-            or self.metadata.is_first_rank()
-            or len(lookup_server_worker_ids) == 0
-            or self.metadata.worker_id in lookup_server_worker_ids
-        ):
-            logger.info(
-                f"Initialize storage manager on rank {self.metadata.worker_id}, "
-                f"use layerwise: {self.use_layerwise},"
-                f"save only first rank: {self.save_only_first_rank}"
-            )
-            self.storage_manager = StorageManager(
-                config,
-                metadata,
-                # self.memory_allocator,
-                event_manager=self.event_manager,
-                lmcache_worker=self.lmcache_worker,
-            )
+        self.storage_manager: Optional[StorageManager] = None
 
         # KV events
         self.kv_events_enabled = False
@@ -239,8 +216,30 @@ class LMCacheEngine:
     def post_init(self, **kwargs) -> None:
         if not self.post_inited:
             logger.info("Post initializing LMCacheEngine")
-            if self.storage_manager is not None:
-                self.storage_manager.post_init(**kwargs)
+            lookup_server_worker_ids = self.config.get_lookup_server_worker_ids(
+                self.metadata.use_mla, self.metadata.world_size
+            )
+            if (
+                self.lmcache_worker is not None
+                or self.use_layerwise
+                or not self.save_only_first_rank
+                or self.metadata.is_first_rank()
+                or len(lookup_server_worker_ids) == 0
+                or self.metadata.worker_id in lookup_server_worker_ids
+            ):
+                logger.info(
+                    f"Initialize storage manager on rank {self.metadata.worker_id}, "
+                    f"use layerwise: {self.use_layerwise},"
+                    f"save only first rank: {self.save_only_first_rank}"
+                )
+                async_lookup_server = kwargs.get("async_lookup_server", None)
+                self.storage_manager = StorageManager(
+                    self.config,
+                    self.metadata,
+                    event_manager=self.event_manager,
+                    lmcache_worker=self.lmcache_worker,
+                    async_lookup_server=async_lookup_server,
+                )
             if self.gpu_connector is not None:
                 self.gpu_connector.initialize_kvcaches_ptr(**kwargs)
             self.post_inited = True

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -212,6 +212,7 @@ class StorageManager:
         metadata: LMCacheEngineMetadata,
         event_manager: EventManager,
         lmcache_worker: Optional["LMCacheWorker"] = None,
+        async_lookup_server: Optional["LMCacheAsyncLookupServer"] = None,
     ):
         self.config = config
         self.metadata = metadata
@@ -258,7 +259,9 @@ class StorageManager:
 
         self.event_manager = event_manager
 
-        self.async_lookup_server: Optional["LMCacheAsyncLookupServer"] = None
+        self.async_lookup_server: Optional["LMCacheAsyncLookupServer"] = (
+            async_lookup_server
+        )
         self.async_serializer: Optional[AsyncSerializer] = None
 
         # The cuda stream for internal copies during put
@@ -270,6 +273,10 @@ class StorageManager:
         # freeze mode: only use local_cpu backend for retrieval
         self._freeze = False
         self._freeze_lock = threading.RLock()
+
+        if not self.enable_pd and self.config.enable_async_loading:
+            assert self.allocator_backend is not None
+            self.async_serializer = AsyncSingleSerializer(self.loop)
 
         self._setup_metrics()
 
@@ -295,14 +302,6 @@ class StorageManager:
                     EventType.LOADING, s
                 )
             )
-
-    def post_init(self, **kwargs) -> None:
-        if "async_lookup_server" in kwargs:
-            self.async_lookup_server = kwargs.pop("async_lookup_server")
-        # PDBackend has't supported calculate_chunk_budget
-        if not self.enable_pd and self.config.enable_async_loading:
-            assert self.allocator_backend is not None
-            self.async_serializer = AsyncSingleSerializer(self.loop)
 
     def _get_allocator_backend(
         self, config: LMCacheEngineConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import torch
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
-from lmcache.v1.cache_engine import LMCacheEngineBuilder
+from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.memory_management import MixedMemoryAllocator
 
 # This is to mock the constructor and destructor of
@@ -435,6 +435,8 @@ def autorelease_v1(request):
     objects = []
 
     def _factory(obj):
+        if isinstance(obj, LMCacheEngine):
+            obj.post_init()
         objects.append(obj)
         return obj
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -434,9 +434,9 @@ def autorelease(request):
 def autorelease_v1(request):
     objects = []
 
-    def _factory(obj):
+    def _factory(obj, **kwargs):
         if isinstance(obj, LMCacheEngine):
-            obj.post_init()
+            obj.post_init(**kwargs)
         objects.append(obj)
         return obj
 

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -894,6 +894,7 @@ def test_paged_prefetch_retrieve(
         save_unfull_chunk=save_unfull_chunk,
     )
 
+    async_lookup_server = DummyLMCacheAsyncLookupServer()
     engine = autorelease_v1(
         LMCacheEngineBuilder.get_or_create(
             "test",
@@ -902,10 +903,10 @@ def test_paged_prefetch_retrieve(
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
-        )
+        ),
+        async_lookup_server=async_lookup_server,
     )
-    async_lookup_server = DummyLMCacheAsyncLookupServer()
-    engine.post_init(async_lookup_server=async_lookup_server)
+
     """ test store """
     t1 = time.perf_counter()
     engine.store(tokens, kvcaches=kv_cache, slot_mapping=slot_mapping)


### PR DESCRIPTION
init storage manager after register kv caches.
In DeepDeek V3.2, only after register kv caches, we can get all shapes and dtypes from kv caches, and then we can post init the lmcache engine to create `StorageManager`.