### PR TITLE
Add basic Kubernetes integration tests for LMCache

### DIFF
--- a/tests/k8s/Dockerfile
+++ b/tests/k8s/Dockerfile
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Dockerfile for LMCache K8s Integration Tests
+#
+# This container includes kubectl, AWS CLI, and all Python dependencies needed
+# to run the K8s integration tests out of the box.
+
+FROM python:3.10-slim
+
+# Version pinning for reproducibility
+ARG KUBECTL_VERSION=v1.35.0
+ARG AWSCLI_VERSION=2.32.24
+
+# Install kubectl, AWS CLI, and other dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install kubectl (pinned version)
+RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod +x kubectl \
+    && mv kubectl /usr/local/bin/
+
+# Install AWS CLI v2 (pinned version)
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf aws awscliv2.zip
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy test files
+COPY common.py conftest.py test_integration.py requirements.txt ./
+COPY manifests/ ./manifests/
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Default command runs pytest with verbose output
+CMD ["pytest", "test_integration.py", "-v", "-s"]

--- a/tests/k8s/Dockerfile
+++ b/tests/k8s/Dockerfile
@@ -40,6 +40,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
+ENV RUN_K8S_TESTS=1
 
 # Default command runs pytest with verbose output
 CMD ["pytest", "test_integration.py", "-v", "-s"]

--- a/tests/k8s/README.md
+++ b/tests/k8s/README.md
@@ -2,7 +2,7 @@
 
 Python-based integration tests for LMCache in Kubernetes environments.
 
-> **Note**: These tests are currently for local validation only. K8s cluster integration in CI/CD is not yet available. Once a K8s cluster is configured in CI/CD, these tests can be added to the automated pipeline.
+> **Note**: These tests are skipped in CI by default (require K8s cluster with GPU nodes). Set `RUN_K8S_TESTS=1` to enable them when a K8s cluster is available in CI/CD.
 
 ## Directory Structure
 

--- a/tests/k8s/README.md
+++ b/tests/k8s/README.md
@@ -1,0 +1,115 @@
+# LMCache Kubernetes Integration Tests
+
+Python-based integration tests for LMCache in Kubernetes environments.
+
+> **Note**: These tests are currently for local validation only. K8s cluster integration in CI/CD is not yet available. Once a K8s cluster is configured in CI/CD, these tests can be added to the automated pipeline.
+
+## Directory Structure
+
+```
+tests/k8s/
+├── common.py                    # Shared test utilities and helpers
+├── conftest.py                  # Pytest configuration and markers
+├── test_integration.py          # Main integration test file
+├── Dockerfile                   # Container for running tests
+├── README.md                    # This file
+└── manifests/                   # K8s deployment manifests
+    ├── base.yaml                # Base test manifest
+    └── sagemaker-hyperpod.yaml  # SageMaker HyperPod test manifest
+```
+
+## Test Cases
+
+### Base Integration Test
+Tests basic LMCache functionality with local CPU caching.
+
+**Cluster Requirements:**
+- K8s cluster with GPU nodes
+
+### SageMaker HyperPod Integration Test
+Tests LMCache with SageMaker HyperPod's ai-toolkit shared memory cache.
+
+**Cluster Requirements:**
+- SageMaker HyperPod EKS cluster with GPU nodes
+- Tiered storage enabled (see [AWS documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/managed-tier-checkpointing-setup.html))
+
+## Prerequisites
+
+- Docker
+- kubectl
+- For Amazon EKS clusters: AWS credentials configured (required for authentication)
+
+## Running Tests
+
+### Authenticate with the cluster
+
+For Amazon EKS clusters, configure kubectl:
+```bash
+# Set cluster information
+export AWS_REGION="us-west-2"
+export CLUSTER_NAME="your-cluster-name"
+
+# Configure kubectl for your EKS cluster
+aws eks update-kubeconfig --region $AWS_REGION --name $CLUSTER_NAME
+
+# Verify cluster access
+kubectl cluster-info
+```
+
+### Set environment variables
+
+```bash
+export LMCACHE_IMAGE="lmcache/vllm-openai:latest"  # or your custom image
+```
+
+### Build the test container
+```bash
+docker build --platform linux/amd64 -t lmcache-k8s-tests -f tests/k8s/Dockerfile tests/k8s
+```
+
+### Run all tests
+```bash
+docker run --rm \
+  --platform linux/amd64 \
+  -v ~/.kube:/root/.kube:ro \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd)/test-logs:/logs \
+  -e LMCACHE_IMAGE \
+  lmcache-k8s-tests
+```
+
+### Run specific tests
+```bash
+# Base test
+docker run --rm \
+  --platform linux/amd64 \
+  -v ~/.kube:/root/.kube:ro \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd)/test-logs:/logs \
+  -e LMCACHE_IMAGE \
+  lmcache-k8s-tests pytest -m base -v -s
+
+# SageMaker HyperPod test
+docker run --rm \
+  --platform linux/amd64 \
+  -v ~/.kube:/root/.kube:ro \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd)/test-logs:/logs \
+  -e LMCACHE_IMAGE \
+  lmcache-k8s-tests pytest -m sagemaker_hyperpod -v -s
+```
+
+### Debug mode
+Skip cleanup on failure to inspect resources:
+```bash
+docker run --rm \
+  --platform linux/amd64 \
+  -v ~/.kube:/root/.kube:ro \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd)/test-logs:/logs \
+  -e LMCACHE_IMAGE \
+  -e K8S_SKIP_CLEANUP=1 \
+  lmcache-k8s-tests pytest -m base -v -s
+```
+
+Test logs are saved to `./test-logs/` directory with timestamps for debugging.

--- a/tests/k8s/common.py
+++ b/tests/k8s/common.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Common utilities for K8s integration tests
+"""
+
+# Standard
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+import base64
+import json
+import logging
+import os
+import subprocess
+
+
+# Setup logging
+def setup_logging(log_dir: str = "/logs") -> logging.Logger:
+    """Setup logging to both console and file"""
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = log_path / f"k8s_test_{timestamp}.log"
+
+    logger = logging.getLogger("k8s_test")
+    logger.setLevel(logging.DEBUG)
+
+    # File handler - detailed logs
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(logging.DEBUG)
+    file_formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    file_handler.setFormatter(file_formatter)
+
+    # Console handler - summary only
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_formatter = logging.Formatter("%(levelname)s: %(message)s")
+    console_handler.setFormatter(console_formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
+    logger.info(f"Logging to {log_file}")
+    return logger
+
+
+logger = setup_logging()
+
+
+class K8sTestConfig:
+    """Configuration for K8s integration tests"""
+
+    def __init__(
+        self,
+        namespace: str,
+        deployment_name: str,
+        service_name: str,
+        debug_pod_name: str,
+        timeout: int = 1800,  # 30 minutes for image pull
+        test_timeout: int = 60,
+    ):
+        self.namespace = namespace
+        self.deployment_name = deployment_name
+        self.service_name = service_name
+        self.debug_pod_name = debug_pod_name
+        self.timeout = timeout
+        self.test_timeout = test_timeout
+        self.lmcache_image = os.getenv("LMCACHE_IMAGE")
+        if not self.lmcache_image:
+            raise ValueError(
+                "LMCACHE_IMAGE environment variable must be set. "
+                "Example: export LMCACHE_IMAGE='lmcache/vllm-openai:latest'"
+            )
+        self.hf_token = os.getenv("HF_TOKEN", "")
+        self.skip_cleanup = os.getenv("K8S_SKIP_CLEANUP", "0") == "1"
+
+        logger.info(
+            f"Test configuration: namespace={namespace}, "
+            f"image={self.lmcache_image}, timeout={timeout}s"
+        )
+
+
+class K8sTestHelper:
+    """Helper class for K8s operations"""
+
+    def __init__(self, config: K8sTestConfig):
+        self.config = config
+
+    def run_kubectl(
+        self, args: list[str], check: bool = True
+    ) -> subprocess.CompletedProcess:
+        """Run kubectl command"""
+        cmd = ["kubectl"] + args
+        logger.debug(f"Running: {' '.join(cmd)}")
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.debug(f"Command failed with exit code {result.returncode}")
+            logger.debug(f"stdout: {result.stdout}")
+            logger.debug(f"stderr: {result.stderr}")
+        if check and result.returncode != 0:
+            raise RuntimeError(
+                f"kubectl command failed: {' '.join(cmd)}\n"
+                f"stdout: {result.stdout}\n"
+                f"stderr: {result.stderr}"
+            )
+        return result
+
+    def apply_manifest(self, manifest_content: str) -> None:
+        """Apply K8s manifest"""
+        logger.info("Applying K8s manifest")
+        logger.debug(f"Manifest content:\n{manifest_content}")
+        result = subprocess.run(
+            ["kubectl", "apply", "-f", "-"],
+            input=manifest_content,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.error(f"Failed to apply manifest: {result.stderr}")
+            raise RuntimeError(
+                f"Failed to apply manifest:\n"
+                f"stdout: {result.stdout}\n"
+                f"stderr: {result.stderr}"
+            )
+        logger.info("Manifest applied successfully")
+
+    def wait_for_pod_ready(self, label_selector: str, timeout: int) -> None:
+        """Wait for pod to be ready"""
+        logger.info(
+            f"Waiting for pod with label {label_selector} to be ready "
+            f"(timeout: {timeout}s)"
+        )
+        result = self.run_kubectl(
+            [
+                "wait",
+                "--for=condition=ready",
+                "pod",
+                f"-l{label_selector}",
+                f"-n{self.config.namespace}",
+                f"--timeout={timeout}s",
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.error(f"Pod failed to become ready within {timeout}s")
+            # Get pod status for debugging
+            pod_status = self.run_kubectl(
+                [
+                    "get",
+                    "pods",
+                    "-n",
+                    self.config.namespace,
+                    f"-l{label_selector}",
+                    "-o",
+                    "wide",
+                ],
+                check=False,
+            )
+            pod_describe = self.run_kubectl(
+                [
+                    "describe",
+                    "pods",
+                    "-n",
+                    self.config.namespace,
+                    f"-l{label_selector}",
+                ],
+                check=False,
+            )
+            pod_logs = self.run_kubectl(
+                [
+                    "logs",
+                    "-n",
+                    self.config.namespace,
+                    f"-l{label_selector}",
+                    "--tail=100",
+                    "--all-containers=true",
+                ],
+                check=False,
+            )
+
+            # Log detailed debugging info
+            logger.debug(f"Pod status:\n{pod_status.stdout}")
+            logger.debug(f"Pod describe:\n{pod_describe.stdout}")
+            logger.debug(f"Pod logs:\n{pod_logs.stdout}")
+
+            raise RuntimeError(
+                f"Pod failed to become ready within {timeout}s\n"
+                f"Wait command error:\n{result.stderr}\n\n"
+                f"Pod status:\n{pod_status.stdout}\n\n"
+                f"Pod describe:\n{pod_describe.stdout}\n\n"
+                f"Pod logs (last 100 lines):\n{pod_logs.stdout}\n"
+                f"Pod logs stderr:\n{pod_logs.stderr}"
+            )
+        logger.info("Pod is ready")
+
+    def exec_in_pod(
+        self, pod_name: str, command: list[str]
+    ) -> subprocess.CompletedProcess:
+        """Execute command in pod"""
+        return self.run_kubectl(
+            ["exec", pod_name, "-n", self.config.namespace, "--"] + command
+        )
+
+    def cleanup_resources(self, manifest_content: str) -> None:
+        """Cleanup all test resources using the manifest"""
+        if self.config.skip_cleanup:
+            logger.info("Skipping cleanup (K8S_SKIP_CLEANUP=1)")
+            return
+
+        logger.info("Cleaning up test resources")
+        result = subprocess.run(
+            ["kubectl", "delete", "-f", "-"],
+            input=manifest_content,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                f"Cleanup had errors (this is often normal): {result.stderr}"
+            )
+        logger.info("Cleanup complete")
+
+
+def prepare_manifest(
+    manifest_path: Path,
+    lmcache_image: str,
+    hf_token: str,
+    extra_substitutions: Optional[dict[str, str]] = None,
+) -> str:
+    """
+    Load and prepare K8s manifest with variable substitution
+
+    Args:
+        manifest_path: Path to the manifest YAML file
+        lmcache_image: Container image to use
+        hf_token: HuggingFace token
+        extra_substitutions: Additional key-value pairs for substitution
+
+    Returns:
+        Prepared manifest content with substitutions applied
+    """
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest_content = f.read()
+
+    # Encode HF_TOKEN as base64 for Secret (if present in manifest)
+    if "${HF_TOKEN}" in manifest_content:
+        hf_token_b64 = base64.b64encode(hf_token.encode()).decode()
+        manifest_content = manifest_content.replace("${HF_TOKEN}", hf_token_b64)
+
+    # Substitute image
+    manifest_content = manifest_content.replace("${LMCACHE_IMAGE}", lmcache_image)
+
+    # Apply extra substitutions
+    if extra_substitutions:
+        for key, value in extra_substitutions.items():
+            manifest_content = manifest_content.replace(f"${{{key}}}", value)
+
+    return manifest_content
+
+
+def run_inference_test(
+    helper: K8sTestHelper,
+    service_url: str,
+    model: str,
+    prompt: str = "What is the capital of France?",
+    max_tokens: int = 100,
+) -> dict:
+    """
+    Test inference endpoint from debug pod
+
+    Args:
+        helper: K8s test helper
+        service_url: Service URL to test
+        model: Model name
+        prompt: Inference prompt
+        max_tokens: Maximum tokens to generate
+
+    Returns:
+        Response data as dict
+
+    Raises:
+        AssertionError: If inference test fails
+    """
+    logger.info(f"Testing inference at {service_url}")
+    # Prepare inference request
+    request_data = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0.7,
+    }
+    logger.debug(f"Request data: {json.dumps(request_data, indent=2)}")
+
+    # Send request from debug pod
+    curl_cmd = [
+        "curl",
+        "--max-time",
+        str(helper.config.test_timeout),
+        "-w",
+        "%{http_code}",
+        "-o",
+        "/tmp/response.json",
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        json.dumps(request_data),
+        service_url,
+    ]
+
+    result = helper.exec_in_pod(helper.config.debug_pod_name, curl_cmd)
+    http_status = result.stdout.strip()
+    logger.debug(f"HTTP status: {http_status}")
+
+    # Verify HTTP status
+    if http_status != "200":
+        # Get curl stderr for more details
+        curl_stderr = result.stderr if result.stderr else "No stderr output"
+        logger.error(f"Inference request failed with HTTP {http_status}")
+        logger.debug(f"curl stderr: {curl_stderr}")
+        raise AssertionError(
+            f"Expected HTTP 200, got {http_status}\n"
+            f"curl stderr: {curl_stderr}\n"
+            f"Service URL: {service_url}"
+        )
+
+    # Get response body
+    response_result = helper.exec_in_pod(
+        helper.config.debug_pod_name, ["cat", "/tmp/response.json"]
+    )
+    response_text = response_result.stdout
+    logger.debug(f"Response: {response_text}")
+
+    # Parse and validate response
+    try:
+        response_data = json.loads(response_text)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse response JSON: {e}")
+        raise AssertionError(
+            f"Failed to parse response JSON: {e}\nResponse: {response_text}"
+        ) from e
+
+    # Validate response structure
+    assert "choices" in response_data, "Response missing 'choices' field"
+    assert len(response_data["choices"]) > 0, "Response has no choices"
+    assert "text" in response_data["choices"][0], (
+        "Response missing 'choices[0].text' field"
+    )
+
+    logger.info("Inference test passed")
+    return response_data

--- a/tests/k8s/common.py
+++ b/tests/k8s/common.py
@@ -13,8 +13,18 @@ import logging
 import os
 import subprocess
 
-
 # Setup logging
+_logger: Optional[logging.Logger] = None
+
+
+def get_logger() -> logging.Logger:
+    """Get or create the logger instance"""
+    global _logger
+    if _logger is None:
+        _logger = setup_logging()
+    return _logger
+
+
 def setup_logging(log_dir: str = "/logs") -> logging.Logger:
     """Setup logging to both console and file"""
     log_path = Path(log_dir)
@@ -47,9 +57,6 @@ def setup_logging(log_dir: str = "/logs") -> logging.Logger:
     return logger
 
 
-logger = setup_logging()
-
-
 class K8sTestConfig:
     """Configuration for K8s integration tests"""
 
@@ -77,7 +84,7 @@ class K8sTestConfig:
         self.hf_token = os.getenv("HF_TOKEN", "")
         self.skip_cleanup = os.getenv("K8S_SKIP_CLEANUP", "0") == "1"
 
-        logger.info(
+        get_logger().info(
             f"Test configuration: namespace={namespace}, "
             f"image={self.lmcache_image}, timeout={timeout}s"
         )
@@ -94,7 +101,7 @@ class K8sTestHelper:
     ) -> subprocess.CompletedProcess:
         """Run kubectl command"""
         cmd = ["kubectl"] + args
-        logger.debug(f"Running: {' '.join(cmd)}")
+        get_logger().debug(f"Running: {' '.join(cmd)}")
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -102,9 +109,9 @@ class K8sTestHelper:
             check=False,
         )
         if result.returncode != 0:
-            logger.debug(f"Command failed with exit code {result.returncode}")
-            logger.debug(f"stdout: {result.stdout}")
-            logger.debug(f"stderr: {result.stderr}")
+            get_logger().debug(f"Command failed with exit code {result.returncode}")
+            get_logger().debug(f"stdout: {result.stdout}")
+            get_logger().debug(f"stderr: {result.stderr}")
         if check and result.returncode != 0:
             raise RuntimeError(
                 f"kubectl command failed: {' '.join(cmd)}\n"
@@ -115,8 +122,8 @@ class K8sTestHelper:
 
     def apply_manifest(self, manifest_content: str) -> None:
         """Apply K8s manifest"""
-        logger.info("Applying K8s manifest")
-        logger.debug(f"Manifest content:\n{manifest_content}")
+        get_logger().info("Applying K8s manifest")
+        get_logger().debug(f"Manifest content:\n{manifest_content}")
         result = subprocess.run(
             ["kubectl", "apply", "-f", "-"],
             input=manifest_content,
@@ -125,17 +132,17 @@ class K8sTestHelper:
             check=False,
         )
         if result.returncode != 0:
-            logger.error(f"Failed to apply manifest: {result.stderr}")
+            get_logger().error(f"Failed to apply manifest: {result.stderr}")
             raise RuntimeError(
                 f"Failed to apply manifest:\n"
                 f"stdout: {result.stdout}\n"
                 f"stderr: {result.stderr}"
             )
-        logger.info("Manifest applied successfully")
+        get_logger().info("Manifest applied successfully")
 
     def wait_for_pod_ready(self, label_selector: str, timeout: int) -> None:
         """Wait for pod to be ready"""
-        logger.info(
+        get_logger().info(
             f"Waiting for pod with label {label_selector} to be ready "
             f"(timeout: {timeout}s)"
         )
@@ -151,7 +158,7 @@ class K8sTestHelper:
             check=False,
         )
         if result.returncode != 0:
-            logger.error(f"Pod failed to become ready within {timeout}s")
+            get_logger().error(f"Pod failed to become ready within {timeout}s")
             # Get pod status for debugging
             pod_status = self.run_kubectl(
                 [
@@ -188,9 +195,9 @@ class K8sTestHelper:
             )
 
             # Log detailed debugging info
-            logger.debug(f"Pod status:\n{pod_status.stdout}")
-            logger.debug(f"Pod describe:\n{pod_describe.stdout}")
-            logger.debug(f"Pod logs:\n{pod_logs.stdout}")
+            get_logger().debug(f"Pod status:\n{pod_status.stdout}")
+            get_logger().debug(f"Pod describe:\n{pod_describe.stdout}")
+            get_logger().debug(f"Pod logs:\n{pod_logs.stdout}")
 
             raise RuntimeError(
                 f"Pod failed to become ready within {timeout}s\n"
@@ -200,7 +207,7 @@ class K8sTestHelper:
                 f"Pod logs (last 100 lines):\n{pod_logs.stdout}\n"
                 f"Pod logs stderr:\n{pod_logs.stderr}"
             )
-        logger.info("Pod is ready")
+        get_logger().info("Pod is ready")
 
     def exec_in_pod(
         self, pod_name: str, command: list[str]
@@ -213,10 +220,10 @@ class K8sTestHelper:
     def cleanup_resources(self, manifest_content: str) -> None:
         """Cleanup all test resources using the manifest"""
         if self.config.skip_cleanup:
-            logger.info("Skipping cleanup (K8S_SKIP_CLEANUP=1)")
+            get_logger().info("Skipping cleanup (K8S_SKIP_CLEANUP=1)")
             return
 
-        logger.info("Cleaning up test resources")
+        get_logger().info("Cleaning up test resources")
         result = subprocess.run(
             ["kubectl", "delete", "-f", "-"],
             input=manifest_content,
@@ -225,10 +232,10 @@ class K8sTestHelper:
             check=False,
         )
         if result.returncode != 0:
-            logger.warning(
+            get_logger().warning(
                 f"Cleanup had errors (this is often normal): {result.stderr}"
             )
-        logger.info("Cleanup complete")
+        get_logger().info("Cleanup complete")
 
 
 def prepare_manifest(
@@ -291,7 +298,7 @@ def run_inference_test(
     Raises:
         AssertionError: If inference test fails
     """
-    logger.info(f"Testing inference at {service_url}")
+    get_logger().info(f"Testing inference at {service_url}")
     # Prepare inference request
     request_data = {
         "model": model,
@@ -299,7 +306,7 @@ def run_inference_test(
         "max_tokens": max_tokens,
         "temperature": 0.7,
     }
-    logger.debug(f"Request data: {json.dumps(request_data, indent=2)}")
+    get_logger().debug(f"Request data: {json.dumps(request_data, indent=2)}")
 
     # Send request from debug pod
     curl_cmd = [
@@ -319,14 +326,14 @@ def run_inference_test(
 
     result = helper.exec_in_pod(helper.config.debug_pod_name, curl_cmd)
     http_status = result.stdout.strip()
-    logger.debug(f"HTTP status: {http_status}")
+    get_logger().debug(f"HTTP status: {http_status}")
 
     # Verify HTTP status
     if http_status != "200":
         # Get curl stderr for more details
         curl_stderr = result.stderr if result.stderr else "No stderr output"
-        logger.error(f"Inference request failed with HTTP {http_status}")
-        logger.debug(f"curl stderr: {curl_stderr}")
+        get_logger().error(f"Inference request failed with HTTP {http_status}")
+        get_logger().debug(f"curl stderr: {curl_stderr}")
         raise AssertionError(
             f"Expected HTTP 200, got {http_status}\n"
             f"curl stderr: {curl_stderr}\n"
@@ -338,13 +345,13 @@ def run_inference_test(
         helper.config.debug_pod_name, ["cat", "/tmp/response.json"]
     )
     response_text = response_result.stdout
-    logger.debug(f"Response: {response_text}")
+    get_logger().debug(f"Response: {response_text}")
 
     # Parse and validate response
     try:
         response_data = json.loads(response_text)
     except json.JSONDecodeError as e:
-        logger.error(f"Failed to parse response JSON: {e}")
+        get_logger().error(f"Failed to parse response JSON: {e}")
         raise AssertionError(
             f"Failed to parse response JSON: {e}\nResponse: {response_text}"
         ) from e
@@ -356,5 +363,5 @@ def run_inference_test(
         "Response missing 'choices[0].text' field"
     )
 
-    logger.info("Inference test passed")
+    get_logger().info("Inference test passed")
     return response_data

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Pytest configuration for K8s integration tests
+"""
+
+# Third Party
+
+
+def pytest_configure(config):
+    """Register custom markers"""
+    config.addinivalue_line(
+        "markers", "k8s: mark test as requiring Kubernetes cluster access"
+    )
+    config.addinivalue_line("markers", "integration: mark test as integration test")
+    config.addinivalue_line(
+        "markers", "base: mark test as base integration test (any K8s cluster)"
+    )
+    config.addinivalue_line(
+        "markers",
+        "sagemaker_hyperpod: mark test as requiring SageMaker HyperPod environment",
+    )

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -3,7 +3,11 @@
 Pytest configuration for K8s integration tests
 """
 
+# Standard
+import os
+
 # Third Party
+import pytest
 
 
 def pytest_configure(config):
@@ -19,3 +23,15 @@ def pytest_configure(config):
         "markers",
         "sagemaker_hyperpod: mark test as requiring SageMaker HyperPod environment",
     )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip K8s tests in CI unless explicitly enabled"""
+    # Skip K8s tests in CI by default (unless RUN_K8S_TESTS=1)
+    if os.getenv("RUN_K8S_TESTS") != "1":
+        skip_k8s = pytest.mark.skip(
+            reason="K8s tests require cluster access. Set RUN_K8S_TESTS=1 to run them."
+        )
+        for item in items:
+            if "k8s" in item.keywords:
+                item.add_marker(skip_k8s)

--- a/tests/k8s/manifests/base.yaml
+++ b/tests/k8s/manifests/base.yaml
@@ -1,0 +1,121 @@
+---
+# Base K8s test deployment for LMCache + vLLM
+# This is a minimal configuration for testing basic functionality
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lmcache-base-test
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-config
+  namespace: lmcache-base-test
+data:
+  lmcache.yaml: |
+    local_cpu: true
+    chunk_size: 256
+    max_local_cpu_size: 5
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lmcache-base
+  namespace: lmcache-base-test
+  labels:
+    app: lmcache-base
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lmcache-base
+  template:
+    metadata:
+      labels:
+        app: lmcache-base
+    spec:
+      containers:
+        - name: vllm
+          # Configurable via LMCACHE_IMAGE environment variable
+          # Default: lmcache/vllm-openai:latest
+          image: ${LMCACHE_IMAGE}
+          command:
+            - vllm
+            - serve
+            - Qwen/Qwen3-14B
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "8000"
+            - --max-model-len
+            - "1024"
+            - --enforce-eager
+            - --tensor-parallel-size
+            - "4"
+            - --kv-transfer-config
+            - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: LMCACHE_CONFIG_FILE
+              value: /etc/lmcache/lmcache.yaml
+            - name: LMCACHE_LOG_LEVEL
+              value: "DEBUG"
+            - name: PYTHONHASHSEED
+              value: "0"
+          resources:
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          volumeMounts:
+            - name: lmcache-config
+              mountPath: /etc/lmcache
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 3
+      volumes:
+        - name: lmcache-config
+          configMap:
+            name: lmcache-config
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lmcache-base-test-client
+  namespace: lmcache-base-test
+  labels:
+    app: lmcache-base-test-client
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:latest
+      command:
+        - sleep
+        - "3600"
+  restartPolicy: Never

--- a/tests/k8s/manifests/sagemaker-hyperpod.yaml
+++ b/tests/k8s/manifests/sagemaker-hyperpod.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lmcache-sagemaker-hyperpod-test
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-config
+  namespace: lmcache-sagemaker-hyperpod-test
+data:
+  lmcache.yaml: |
+    chunk_size: 256
+    local_cpu: false
+    remote_url: "sagemaker-hyperpod://$NODE_IP:9200"
+    extra_config:
+      sagemaker_hyperpod_bucket: "lmcache"
+      sagemaker_hyperpod_shared_memory_name: "ai_toolkit_cache"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lmcache-sagemaker-hyperpod
+  namespace: lmcache-sagemaker-hyperpod-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lmcache-sagemaker-hyperpod
+  template:
+    metadata:
+      namespace: lmcache-sagemaker-hyperpod-test
+      labels:
+        app: lmcache-sagemaker-hyperpod
+    spec:
+      containers:
+        - name: vllm
+          image: ${LMCACHE_IMAGE}
+          command:
+            - /opt/venv/bin/vllm
+            - serve
+            - Qwen/Qwen3-14B
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --no-enable-prefix-caching
+            - --max-model-len
+            - "4096"
+            - --tensor-parallel-size
+            - "4"
+            - --kv-transfer-config
+            - '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+          resources:
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: LMCACHE_CONFIG_FILE
+              value: /etc/lmcache/lmcache.yaml
+            - name: LMCACHE_LOG_LEVEL
+              value: "DEBUG"
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: PROMETHEUS_MULTIPROC_DIR
+              value: "/tmp"
+          volumeMounts:
+            - name: lmcache-config
+              mountPath: /etc/lmcache
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: lmcache-config
+          configMap:
+            name: lmcache-config
+        - name: dshm
+          hostPath:
+            path: /dev/shm
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lmcache-sagemaker-hyperpod-test-client
+  namespace: lmcache-sagemaker-hyperpod-test
+  labels:
+    app: lmcache-sagemaker-hyperpod-test-client
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:latest
+      command:
+        - sleep
+        - "3600"
+  restartPolicy: Never

--- a/tests/k8s/requirements.txt
+++ b/tests/k8s/requirements.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Python dependencies for LMCache K8s integration tests
+
+pytest>=7.0.0

--- a/tests/k8s/test_integration.py
+++ b/tests/k8s/test_integration.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Kubernetes Integration Tests for LMCache
+
+This module contains integration tests for LMCache in different K8s environments.
+
+Test Cases:
+- test_base_integration: Base test with local CPU cache (any K8s cluster with GPU)
+- test_sagemaker_hyperpod_integration: SageMaker HyperPod with ai-toolkit shared memory
+
+Prerequisites:
+- kubectl configured with access to a K8s cluster
+- Cluster has GPU nodes available
+
+Environment Variables:
+- LMCACHE_IMAGE: Container image to use (default varies by test)
+- K8S_SKIP_CLEANUP: Set to "1" to skip cleanup on failure (for debugging)
+"""
+
+# Standard
+from pathlib import Path
+import json
+import subprocess
+
+# Third Party
+from common import K8sTestConfig, K8sTestHelper, prepare_manifest, run_inference_test
+import pytest
+
+
+@pytest.fixture(scope="function")
+def check_prerequisites():
+    """Check test prerequisites - fail if not met"""
+    # Check kubectl is available
+    try:
+        subprocess.run(
+            ["kubectl", "version", "--client"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        pytest.fail("kubectl not found. Please install kubectl.")
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"kubectl not configured properly.\nError: {e.stderr}")
+
+    # Check cluster connectivity
+    try:
+        subprocess.run(
+            ["kubectl", "cluster-info"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"Cannot connect to Kubernetes cluster.\n"
+            f"Error: {e.stderr}\n"
+            f"Please ensure kubectl is configured with valid cluster credentials."
+        )
+
+
+def deploy_and_test(
+    config: K8sTestConfig,
+    manifest_path: Path,
+    model: str,
+):
+    """
+    Common deployment and testing logic
+
+    Args:
+        config: K8s test configuration
+        manifest_path: Path to deployment YAML
+        model: Model name for inference test
+    """
+    helper = K8sTestHelper(config)
+    manifest_content = ""
+
+    try:
+        # Load and prepare manifest
+        manifest_content = prepare_manifest(
+            manifest_path, config.lmcache_image, config.hf_token
+        )
+
+        # Apply manifest
+        helper.apply_manifest(manifest_content)
+
+        # Wait for deployment pod to be ready
+        helper.wait_for_pod_ready(f"app={config.deployment_name}", config.timeout)
+
+        # Get pod IP
+        pod_ip_result = helper.run_kubectl(
+            [
+                "get",
+                "pod",
+                "-n",
+                config.namespace,
+                f"-l app={config.deployment_name}",
+                "-o",
+                "jsonpath={.items[0].status.podIP}",
+            ]
+        )
+        pod_ip = pod_ip_result.stdout.strip()
+
+        # Wait for debug pod to be ready
+        helper.wait_for_pod_ready(f"app={config.debug_pod_name}", 60)
+
+        # Use pod IP directly
+        service_url = f"http://{pod_ip}:8000/v1/completions"
+
+        # Test inference
+        response_data = run_inference_test(
+            helper=helper,
+            service_url=service_url,
+            model=model,
+            prompt="What is the capital of France?",
+            max_tokens=100,
+        )
+
+        # Log success
+        print("✅ Inference test passed")
+        print(f"Response: {json.dumps(response_data, indent=2)}")
+
+    finally:
+        # Cleanup
+        helper.cleanup_resources(manifest_content)
+
+
+@pytest.mark.k8s
+@pytest.mark.integration
+@pytest.mark.base
+def test_base_integration(check_prerequisites):
+    """
+    Test LMCache with local CPU cache
+
+    Requirements:
+    - Any K8s cluster with GPU nodes
+    - No special setup required
+
+    Configuration:
+    - Local CPU cache (5GB)
+    - Chunk size: 256 tokens
+    - Model: Qwen/Qwen3-14B
+    - Image: lmcache/vllm-openai:latest
+    """
+    config = K8sTestConfig(
+        namespace="lmcache-base-test",
+        deployment_name="lmcache-base",
+        service_name="lmcache-base",
+        debug_pod_name="lmcache-base-test-client",
+    )
+
+    manifest_path = Path(__file__).parent / "manifests" / "base.yaml"
+
+    deploy_and_test(
+        config=config,
+        manifest_path=manifest_path,
+        model="Qwen/Qwen3-14B",
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.integration
+@pytest.mark.sagemaker_hyperpod
+def test_sagemaker_hyperpod_integration(check_prerequisites):
+    """
+    Test LMCache with SageMaker HyperPod ai-toolkit
+
+    Requirements:
+    - SageMaker HyperPod EKS cluster
+    - ai-toolkit DaemonSet running on GPU nodes
+    - Tiered storage enabled (20% memory allocation)
+    - ai-toolkit shared memory cache at /dev/shm/ai_toolkit_cache
+
+    Configuration:
+    - Remote storage via ai-toolkit shared memory
+    - Chunk size: 256 tokens
+    - Model: Qwen/Qwen3-14B
+    - Image: Custom ECR image with LMCache
+
+    Setup:
+    1. Enable tiered storage on HyperPod cluster:
+       cd cluster-setup && ./enable-tiered-storage.sh
+
+    2. Verify ai-toolkit is running:
+       kubectl get ds -n aws-hyperpod ai-toolkit
+       kubectl get pods -n aws-hyperpod -l app=ai-toolkit
+
+    3. Verify shared memory cache exists:
+       kubectl exec -n aws-hyperpod <ai-toolkit-pod> -- ls -lh /dev/shm/ai_toolkit_cache
+    """
+    config = K8sTestConfig(
+        namespace="lmcache-sagemaker-hyperpod-test",
+        deployment_name="lmcache-sagemaker-hyperpod",
+        service_name="lmcache-sagemaker-hyperpod",
+        debug_pod_name="lmcache-sagemaker-hyperpod-test-client",
+    )
+
+    manifest_path = Path(__file__).parent / "manifests" / "sagemaker-hyperpod.yaml"
+
+    deploy_and_test(
+        config=config,
+        manifest_path=manifest_path,
+        model="Qwen/Qwen3-14B",
+    )
+
+
+if __name__ == "__main__":
+    # Allow running as standalone script
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds basic Kubernetes integration tests for LMCache to validate deployments in K8s environments. Currently includes two fundamental test scenarios with containerized execution for local development.

**Local execution:** These tests can be used for local development before LMCache has k8s cluster. They can be easily integrated into CI/CD when a K8s cluster with GPU nodes is available.

More k8s tests can come later following same style.
