### PR TITLE
[Controller] Improve heartbeat to controller logic

### DIFF
--- a/lmcache/tools/controller_benchmark/__main__.py
+++ b/lmcache/tools/controller_benchmark/__main__.py
@@ -257,6 +257,7 @@ def main():
         monitor_ports = json.loads(args.monitor_ports)
         pull_port = monitor_ports.get("pull", 8100)
         reply_port = monitor_ports.get("reply")
+        heartbeat_port = monitor_ports.get("heartbeat")
     except json.JSONDecodeError as e:
         logger.error("Failed to parse monitor-ports JSON: %s", e)
         raise ValueError("Invalid monitor-ports format") from e
@@ -267,6 +268,9 @@ def main():
     )
     controller_pull_url = f"{client_host}:{pull_port}"
     controller_reply_url = f"{client_host}:{reply_port}" if reply_port else None
+    controller_heartbeat_url = (
+        f"{client_host}:{heartbeat_port}" if heartbeat_port else None
+    )
 
     # Parse operations
     operations = {}
@@ -281,6 +285,7 @@ def main():
     base_config_kwargs = {
         "controller_pull_url": controller_pull_url,
         "controller_reply_url": controller_reply_url,
+        "controller_heartbeat_url": controller_heartbeat_url,
         "duration": args.duration,
         "batch_size": args.batch_size,
         "operations": operations,

--- a/lmcache/tools/controller_benchmark/benchmark.py
+++ b/lmcache/tools/controller_benchmark/benchmark.py
@@ -290,7 +290,7 @@ class ZMQControllerBenchmark:
                     # (only if not already configured)
                     if self.heartbeat_url is None and response:
                         self._process_register_response(response)
-                except Exception as e:
+                except (RuntimeError, zmq.ZMQError) as e:
                     logger.error(
                         "Failed to register worker %s-%d: %s", instance, worker, e
                     )
@@ -308,7 +308,7 @@ class ZMQControllerBenchmark:
             if ret_msg.extra_config and "heartbeat_url" in ret_msg.extra_config:
                 self.heartbeat_url = ret_msg.extra_config["heartbeat_url"]
                 logger.info("Got heartbeat_url from register: %s", self.heartbeat_url)
-        except Exception as e:
+        except msgspec.DecodeError as e:
             logger.warning("Failed to decode RegisterRetMsg: %s", e)
 
     def _setup_heartbeat_socket(self):

--- a/lmcache/tools/controller_benchmark/benchmark.py
+++ b/lmcache/tools/controller_benchmark/benchmark.py
@@ -18,7 +18,11 @@ import zmq.asyncio
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.cache_controller.message import DeRegisterMsg, RegisterMsg
+from lmcache.v1.cache_controller.message import (
+    DeRegisterMsg,
+    RegisterMsg,
+    RegisterRetMsg,
+)
 from lmcache.v1.cache_controller.utils import KVChunkInfo
 from lmcache.v1.rpc_utils import (
     close_zmq_socket,
@@ -37,6 +41,7 @@ from .constants import (
     DEFAULT_SEND_TIMEOUT_MS,
 )
 from .handlers import OPERATION_HANDLERS
+from .handlers.base import SocketType
 
 logger = init_logger(__name__)
 
@@ -85,6 +90,8 @@ class ZMQControllerBenchmark:
         self.context: Optional[zmq.asyncio.Context] = None
         self.push_socket: Optional[Any] = None
         self.req_socket: Optional[Any] = None
+        self.heartbeat_socket: Optional[Any] = None
+        self.heartbeat_url: Optional[str] = None
         self.results = BenchmarkResults()
         self.running = False
         # Track sequence numbers per KVChunkInfo (instance_id, worker_id, location)
@@ -136,12 +143,23 @@ class ZMQControllerBenchmark:
             # Give ZMQ time to establish the connection
             time.sleep(0.1)
 
+        # Setup heartbeat socket if configured
+        if self.config.controller_heartbeat_url:
+            self.heartbeat_url = self.config.controller_heartbeat_url
+            self._setup_heartbeat_socket()
+            logger.info(
+                "Connected to heartbeat socket at tcp://%s",
+                self.config.controller_heartbeat_url,
+            )
+
     def cleanup(self):
         """Cleanup ZMQ sockets"""
         if self.push_socket:
             close_zmq_socket(self.push_socket)
         if self.req_socket:
             close_zmq_socket(self.req_socket)
+        if self.heartbeat_socket:
+            close_zmq_socket(self.heartbeat_socket)
         logger.info("ZMQ sockets closed")
 
     def generate_test_data(self) -> TestData:
@@ -243,12 +261,15 @@ class ZMQControllerBenchmark:
             raise
 
     async def register_workers(self, test_data: TestData):
-        """Pre-register all workers before benchmark"""
+        """Pre-register all workers before benchmark using REQ-REP mode"""
         if not self.config.register_first:
             return
 
-        logger.info("Pre-registering workers...")
-        messages = []
+        if self.req_socket is None:
+            logger.warning("REQ socket not initialized, skipping worker registration")
+            return
+
+        logger.info("Pre-registering workers via REQ-REP...")
         for instance in test_data.instances:
             for worker in test_data.workers:
                 ip = "192.168.1.%d" % (worker + 1)
@@ -262,16 +283,71 @@ class ZMQControllerBenchmark:
                     port=port,
                     peer_init_url=peer_init_url,
                 )
-                messages.append(msg)
-                self.registered_workers.append((instance, worker, ip, port))
+                try:
+                    _, response = await self.send_request(msg)
+                    self.registered_workers.append((instance, worker, ip, port))
+                    # Extract heartbeat_url from first successful registration
+                    # (only if not already configured)
+                    if self.heartbeat_url is None and response:
+                        self._process_register_response(response)
+                except Exception as e:
+                    logger.error(
+                        "Failed to register worker %s-%d: %s", instance, worker, e
+                    )
 
-        # Send in batches
-        for i in range(0, len(messages), DEFAULT_BATCH_SEND_SIZE):
-            batch = messages[i : i + DEFAULT_BATCH_SEND_SIZE]
-            await self.send_messages(batch)
-
-        logger.info("Registered %d workers", len(messages))
+        logger.info("Registered %d workers", len(self.registered_workers))
+        # Setup heartbeat socket after getting heartbeat_url (if not already setup)
+        if self.heartbeat_url and self.heartbeat_socket is None:
+            self._setup_heartbeat_socket()
         await asyncio.sleep(0.5)
+
+    def _process_register_response(self, response: bytes):
+        """Process RegisterRetMsg to extract heartbeat_url"""
+        try:
+            ret_msg = msgspec.msgpack.decode(response, type=RegisterRetMsg)
+            if ret_msg.extra_config and "heartbeat_url" in ret_msg.extra_config:
+                self.heartbeat_url = ret_msg.extra_config["heartbeat_url"]
+                logger.info("Got heartbeat_url from register: %s", self.heartbeat_url)
+        except Exception as e:
+            logger.warning("Failed to decode RegisterRetMsg: %s", e)
+
+    def _setup_heartbeat_socket(self):
+        """Setup heartbeat socket after getting heartbeat_url from register"""
+        if not self.heartbeat_url or not self.context:
+            return
+        if self.heartbeat_socket is not None:
+            return  # Already setup
+        self.heartbeat_socket = get_zmq_socket_with_timeout(
+            self.context,
+            self.heartbeat_url,
+            protocol="tcp",
+            role=zmq.REQ,
+            bind_or_connect="connect",
+            recv_timeout_ms=DEFAULT_RECV_TIMEOUT_MS,
+            send_timeout_ms=DEFAULT_SEND_TIMEOUT_MS,
+        )
+
+    async def send_heartbeat(self, message: Any) -> Tuple[float, Any]:
+        """Send heartbeat via dedicated heartbeat socket
+
+        Args:
+            message: HeartbeatMsg to send
+
+        Returns:
+            Tuple of (time taken, response)
+        """
+        if self.heartbeat_socket is None:
+            raise RuntimeError(
+                "Heartbeat socket not initialized. Register first to get heartbeat_url."
+            )
+        start_time = time.time()
+        encoded_msg = msgspec.msgpack.encode(message)
+        try:
+            await self.heartbeat_socket.send(encoded_msg)
+            response = await self.heartbeat_socket.recv()
+            return time.time() - start_time, response
+        except zmq.Again as e:
+            raise RuntimeError("Heartbeat timeout") from e
 
     async def deregister_workers(self):
         """Deregister all workers after benchmark"""
@@ -321,10 +397,13 @@ class ZMQControllerBenchmark:
 
         try:
             msg = handler.create_message(self, test_data)
-            # Check if handler requires REQ-REP pattern
-            if handler.use_req_socket():
+            socket_type = handler.socket_type
+
+            if socket_type == SocketType.HEARTBEAT:
+                latency, _ = await self.send_heartbeat(msg)
+            elif socket_type == SocketType.REQ:
                 latency, _ = await self.send_request(msg)
-            else:
+            else:  # SocketType.PUSH
                 msg_start = time.time()
                 await self.send_messages([msg])
                 latency = time.time() - msg_start

--- a/lmcache/tools/controller_benchmark/config.py
+++ b/lmcache/tools/controller_benchmark/config.py
@@ -19,6 +19,7 @@ class ZMQBenchmarkConfig:
     num_workers: int
     num_locations: int
     num_keys: int
+    controller_heartbeat_url: Optional[str] = None
     num_hashes: int = 100
     operations: Dict[str, float] = field(default_factory=dict)
     heartbeat_interval: float = 1.0

--- a/lmcache/tools/controller_benchmark/handlers/base.py
+++ b/lmcache/tools/controller_benchmark/handlers/base.py
@@ -4,11 +4,20 @@
 
 # Standard
 from abc import ABC, abstractmethod
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     # Local
     from ..benchmark import TestData, ZMQControllerBenchmark
+
+
+class SocketType(Enum):
+    """Socket type for benchmark operations"""
+
+    PUSH = auto()  # PUSH socket for fire-and-forget messages
+    REQ = auto()  # REQ socket for request-reply messages
+    HEARTBEAT = auto()  # Dedicated heartbeat socket
 
 
 class OperationHandler(ABC):
@@ -32,6 +41,7 @@ class OperationHandler(ABC):
         """Get the number of messages in a single operation"""
         pass
 
-    def use_req_socket(self) -> bool:
-        """Whether this operation uses REQ-REP socket"""
-        return False
+    @property
+    def socket_type(self) -> SocketType:
+        """Return the socket type for this operation (default: PUSH)"""
+        return SocketType.PUSH

--- a/lmcache/tools/controller_benchmark/handlers/heartbeat.py
+++ b/lmcache/tools/controller_benchmark/handlers/heartbeat.py
@@ -14,19 +14,19 @@ if TYPE_CHECKING:
     from ..benchmark import TestData, ZMQControllerBenchmark
 
 # Local
-from .base import OperationHandler
+from .base import OperationHandler, SocketType
 
 
 class HeartbeatHandler(OperationHandler):
-    """Handler for heartbeat operations (REQ-REP mode)"""
+    """Handler for heartbeat operations (dedicated heartbeat socket)"""
 
     @property
     def operation_name(self) -> str:
         return "heartbeat"
 
-    def use_req_socket(self) -> bool:
-        """Heartbeat now uses REQ-REP mode"""
-        return True
+    @property
+    def socket_type(self) -> SocketType:
+        return SocketType.HEARTBEAT
 
     def create_message(
         self, benchmark: "ZMQControllerBenchmark", test_data: "TestData"

--- a/lmcache/tools/controller_benchmark/handlers/p2p_lookup.py
+++ b/lmcache/tools/controller_benchmark/handlers/p2p_lookup.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ..benchmark import TestData, ZMQControllerBenchmark
 
 # Local
-from .base import OperationHandler
+from .base import OperationHandler, SocketType
 
 
 class P2PLookupHandler(OperationHandler):
@@ -23,6 +23,10 @@ class P2PLookupHandler(OperationHandler):
     @property
     def operation_name(self) -> str:
         return "p2p_lookup"
+
+    @property
+    def socket_type(self) -> SocketType:
+        return SocketType.REQ
 
     def create_message(
         self, benchmark: "ZMQControllerBenchmark", test_data: "TestData"
@@ -41,7 +45,3 @@ class P2PLookupHandler(OperationHandler):
 
     def get_message_count(self, benchmark: "ZMQControllerBenchmark") -> int:
         return benchmark.config.num_hashes
-
-    def use_req_socket(self) -> bool:
-        """P2P lookup requires REQ-REP pattern"""
-        return True

--- a/lmcache/tools/controller_benchmark/handlers/register.py
+++ b/lmcache/tools/controller_benchmark/handlers/register.py
@@ -14,15 +14,19 @@ if TYPE_CHECKING:
     from ..benchmark import TestData, ZMQControllerBenchmark
 
 # Local
-from .base import OperationHandler
+from .base import OperationHandler, SocketType
 
 
 class RegisterHandler(OperationHandler):
-    """Handler for register operations"""
+    """Handler for register operations (REQ-REP mode)"""
 
     @property
     def operation_name(self) -> str:
         return "register"
+
+    @property
+    def socket_type(self) -> SocketType:
+        return SocketType.REQ
 
     def create_message(
         self, benchmark: "ZMQControllerBenchmark", test_data: "TestData"

--- a/lmcache/v1/api_server/__main__.py
+++ b/lmcache/v1/api_server/__main__.py
@@ -491,6 +491,12 @@ def main():
                     f"{config.controller_host}:"
                     f"{config.controller_monitor_ports['reply']}"
                 ),
+                "heartbeat": (
+                    f"{config.controller_host}:"
+                    f"{config.controller_monitor_ports['heartbeat']}"
+                    if config.controller_monitor_ports.get("heartbeat")
+                    else None
+                ),
             }
         else:
             if args.monitor_port != 9001:  # Only warn if explicitly set
@@ -501,6 +507,7 @@ def main():
             controller_urls = {
                 "pull": f"{config.controller_host}:{args.monitor_port}",
                 "reply": None,
+                "heartbeat": None,
             }
 
         # Use config values for health check and timeout

--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -344,7 +344,12 @@ class LMCacheControllerManager:
                             error=f"Expected HeartbeatMsg, got {type(msg)}"
                         )
                         await socket.send(msgspec.msgpack.encode(err_msg))
-                except Exception as e:
+                except (
+                    json.JSONDecodeError,
+                    msgspec.DecodeError,
+                    msgspec.ValidationError,
+                    zmq.ZMQError,
+                ) as e:
                     logger.error(
                         "Error handling heartbeat request: %s", e, exc_info=True
                     )

--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -20,6 +20,7 @@ from lmcache.v1.cache_controller.observability import (
     SocketType,
 )
 from lmcache.v1.rpc_utils import (
+    get_ip,
     get_zmq_context,
     get_zmq_socket,
 )
@@ -170,7 +171,16 @@ class LMCacheControllerManager:
             # Build extra_config with heartbeat_url if available
             extra_config: dict[str, str] = {}
             if self.controller_urls.get("heartbeat") is not None:
-                extra_config["heartbeat_url"] = self.controller_urls["heartbeat"]
+                # Convert bind address (e.g., "0.0.0.0:8082" or "*:8082")
+                # to a connectable address using actual controller IP
+                heartbeat_bind_url = self.controller_urls["heartbeat"]
+                heartbeat_url = self._convert_bind_to_connect_url(heartbeat_bind_url)
+                extra_config["heartbeat_url"] = heartbeat_url
+                logger.debug(
+                    "Returning heartbeat_url to worker: %s (bind: %s)",
+                    heartbeat_url,
+                    heartbeat_bind_url,
+                )
             ret_msg = await self.reg_controller.register(msg, extra_config)
         elif isinstance(msg, BatchedP2PLookupMsg):
             ret_msg = await self.kv_controller.batched_p2p_lookup(msg)
@@ -247,6 +257,29 @@ class LMCacheControllerManager:
             prometheus_logger.reply_socket_active_requests.set_function(
                 lambda: self.reply_socket_active_requests
             )
+
+    def _convert_bind_to_connect_url(self, bind_url: str) -> str:
+        """Convert a bind address to a connectable address.
+
+        Bind addresses like "0.0.0.0:port" or "*:port" cannot be used
+        by workers to connect. We need to replace them with the actual
+        controller IP address.
+
+        Args:
+            bind_url: The bind URL (e.g., "0.0.0.0:8082" or "*:8082")
+
+        Returns:
+            A connectable URL (e.g., "192.168.1.100:8082")
+        """
+        if ":" not in bind_url:
+            return bind_url
+
+        host, port = bind_url.rsplit(":", 1)
+        # Replace bind-all addresses with actual IP
+        if host in ("0.0.0.0", "*", ""):
+            actual_ip = get_ip()
+            return f"{actual_ip}:{port}"
+        return bind_url
 
     def _check_socket_has_pending(self, socket) -> int:
         """Check if socket has pending messages.

--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -104,6 +104,18 @@ class LMCacheControllerManager:
                 role=zmq.REP,  # type: ignore[attr-defined]
                 bind_or_connect="bind",
             )
+
+        # Dedicated heartbeat socket to avoid blocking from other REQ-REP requests
+        if self.controller_urls.get("heartbeat") is not None:
+            self.controller_heartbeat_socket = get_zmq_socket(
+                self.zmq_context,
+                self.controller_urls["heartbeat"],
+                protocol="tcp",
+                role=zmq.REP,  # type: ignore[attr-defined]
+                bind_or_connect="bind",
+            )
+        else:
+            self.controller_heartbeat_socket = None
         self.reg_controller = RegistrationController()
         self.kv_controller = KVController(self.reg_controller.registry)
 
@@ -154,7 +166,13 @@ class LMCacheControllerManager:
         self, msg: WorkerReqMsg
     ) -> Union[WorkerReqRetMsg, ErrorMsg]:
         ret_msg: Union[WorkerReqRetMsg, ErrorMsg]
-        if isinstance(msg, BatchedP2PLookupMsg):
+        if isinstance(msg, RegisterMsg):
+            # Build extra_config with heartbeat_url if available
+            extra_config: dict[str, str] = {}
+            if self.controller_urls.get("heartbeat") is not None:
+                extra_config["heartbeat_url"] = self.controller_urls["heartbeat"]
+            ret_msg = await self.reg_controller.register(msg, extra_config)
+        elif isinstance(msg, BatchedP2PLookupMsg):
             ret_msg = await self.kv_controller.batched_p2p_lookup(msg)
         elif isinstance(msg, HeartbeatMsg):
             ret_msg = await self.reg_controller.heartbeat(msg)
@@ -298,9 +316,44 @@ class LMCacheControllerManager:
                     err_msg = ErrorMsg(error=str(e))
                     await socket.send(msgspec.msgpack.encode(err_msg))
 
+    async def handle_heartbeat_request(self, socket) -> None:
+        """Handle heartbeat requests on dedicated socket.
+
+        This runs on a separate socket to ensure heartbeats are processed
+        without being blocked by other REQ-REP requests.
+        """
+        while True:
+            part = await socket.recv()
+            with SocketMetricsContext(self, SocketType.REPLY):
+                try:
+                    if part.startswith(b"{"):
+                        msg_dict = json.loads(part)
+                        msg = msgspec.convert(msg_dict, type=Msg)
+                    else:
+                        msg = msgspec.msgpack.decode(part, type=Msg)
+
+                    if isinstance(msg, HeartbeatMsg):
+                        ret_msg = await self.reg_controller.heartbeat(msg)
+                        await socket.send(msgspec.msgpack.encode(ret_msg))
+                    else:
+                        logger.error(
+                            "Unexpected message type on heartbeat socket: %s",
+                            type(msg),
+                        )
+                        err_msg = ErrorMsg(
+                            error=f"Expected HeartbeatMsg, got {type(msg)}"
+                        )
+                        await socket.send(msgspec.msgpack.encode(err_msg))
+                except Exception as e:
+                    logger.error(
+                        "Error handling heartbeat request: %s", e, exc_info=True
+                    )
+                    err_msg = ErrorMsg(error=str(e))
+                    await socket.send(msgspec.msgpack.encode(err_msg))
+
     async def health_check(self):
         while True:
-            time.sleep(self.health_check_interval)
+            await asyncio.sleep(self.health_check_interval)
             worker_infos = self.reg_controller.registry.get_all_worker_infos()
             for worker_info in worker_infos:
                 if (
@@ -329,6 +382,10 @@ class LMCacheControllerManager:
         tasks = []
         if self.controller_urls["reply"] is not None:
             tasks.append(self.handle_batched_req_request(self.controller_reply_socket))
+        if self.controller_heartbeat_socket is not None:
+            tasks.append(
+                self.handle_heartbeat_request(self.controller_heartbeat_socket)
+            )
         tasks.append(self.handle_batched_push_request(self.controller_pull_socket))
         await asyncio.gather(
             *tasks,

--- a/lmcache/v1/cache_controller/controllers/registration_controller.py
+++ b/lmcache/v1/cache_controller/controllers/registration_controller.py
@@ -21,6 +21,7 @@ from lmcache.v1.cache_controller.message import (
     QueryWorkerInfoMsg,
     QueryWorkerInfoRetMsg,
     RegisterMsg,
+    RegisterRetMsg,
 )
 from lmcache.v1.cache_controller.observability import PrometheusLogger
 from lmcache.v1.cache_controller.utils import RegistryTree
@@ -98,9 +99,19 @@ class RegistrationController:
             return QueryInstRetMsg(instance_id=None, event_id=event_id)
         return QueryInstRetMsg(instance_id=instance_node.instance_id, event_id=event_id)
 
-    async def register(self, msg: RegisterMsg) -> None:
+    async def register(
+        self, msg: RegisterMsg, extra_config: Optional[dict[str, str]] = None
+    ) -> RegisterRetMsg:
         """
         Register a new instance-worker connection mapping.
+
+        Args:
+            msg: RegisterMsg from worker
+            extra_config: Optional extra configuration to return to worker,
+                          e.g., {"heartbeat_url": "tcp://...:8082"}
+
+        Returns:
+            RegisterRetMsg with extra_config for worker initialization
         """
         instance_id = msg.instance_id
         worker_id = msg.worker_id
@@ -115,7 +126,7 @@ class RegistrationController:
                 "Instance-worker %s already registered, skip registration",
                 (instance_id, worker_id),
             )
-            return
+            return RegisterRetMsg(extra_config=extra_config or {})
 
         peer_init_url = msg.peer_init_url
         if peer_init_url is None:
@@ -147,6 +158,7 @@ class RegistrationController:
         logger.info(
             "Registered instance-worker %s with URL %s", (instance_id, worker_id), url
         )
+        return RegisterRetMsg(extra_config=extra_config or {})
 
     async def deregister(self, msg: DeRegisterMsg) -> None:
         """

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -40,8 +40,16 @@ class WorkerMsg(MsgBase):
         return ""
 
 
-class RegisterMsg(WorkerMsg):
-    """Message for Registration"""
+"""Worker Request (requiring a reply) Message from LMCache to Controller"""
+
+
+class WorkerReqMsg(MsgBase):
+    def describe(self) -> str:
+        return ""
+
+
+class RegisterMsg(WorkerReqMsg):
+    """Message for Registration (REQ-REP mode)"""
 
     instance_id: str
     worker_id: int
@@ -190,14 +198,6 @@ class FullSyncEndMsg(WorkerMsg):
         )
 
 
-"""Worker Request (requiring an reply) Message from LMcache to Controller"""
-
-
-class WorkerReqMsg(MsgBase):
-    def describe(self) -> str:
-        return ""
-
-
 class HeartbeatMsg(WorkerReqMsg):
     """Message for heartbeat (REQ-REP mode), include register info for re-register"""
 
@@ -270,6 +270,21 @@ class FullSyncStatusMsg(WorkerReqMsg):
 class WorkerReqRetMsg(MsgBase):
     def describe(self) -> str:
         return ""
+
+
+class RegisterRetMsg(WorkerReqRetMsg):
+    """Register response message with controller configuration
+
+    Returns configuration information that the worker needs for initialization,
+    such as dedicated heartbeat URL.
+    """
+
+    # Extra configuration from controller to worker
+    # e.g., {"heartbeat_url": "tcp://...:8082"}
+    extra_config: dict[str, str] = {}
+
+    def describe(self) -> str:
+        return f"RegisterRet extra_config={self.extra_config}"
 
 
 class HeartbeatRetMsg(WorkerReqRetMsg):
@@ -760,6 +775,7 @@ class ErrorMsg(WorkerReqRetMsg):
 
 Msg = Union[
     RegisterMsg,
+    RegisterRetMsg,
     DeRegisterMsg,
     KVAdmitMsg,
     KVEvictMsg,

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -7,6 +7,7 @@ import threading
 # Third Party
 import msgspec
 import zmq
+import zmq.asyncio
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
@@ -36,6 +37,7 @@ from lmcache.v1.cache_controller.message import (
     PinWorkerMsg,
     PinWorkerRetMsg,
     RegisterMsg,
+    RegisterRetMsg,
     WorkerMsg,
     WorkerReqMsg,
     WorkerReqRetMsg,
@@ -106,6 +108,11 @@ class LMCacheWorker:
             self.controller_rep_url = config.controller_reply_url
             self._create_req_socket()
 
+        # Heartbeat socket will be created dynamically after register
+        # based on heartbeat_url returned from controller
+        self.heartbeat_socket: Optional[zmq.asyncio.Socket] = None
+        self.controller_heartbeat_url: Optional[str] = None
+
         lmcache_worker_ids = config.get_lmcache_worker_ids(
             metadata.use_mla, metadata.world_size
         )
@@ -153,22 +160,54 @@ class LMCacheWorker:
 
     def register(self):
         """
-        Register the lmcache worker with the controller.
+        Register the lmcache worker with the controller via REQ-REP.
+
+        This method sends a RegisterMsg and waits for RegisterRetMsg
+        which contains extra_config (e.g., heartbeat_url).
         """
         assert self.lmcache_instance_id is not None
         logger.info(
-            "Registering lmcache instance-worker: "
-            f"{(self.lmcache_instance_id, self.worker_id)}"
+            "Registering lmcache instance-worker: %s",
+            (self.lmcache_instance_id, self.worker_id),
         )
-        self.put_msg(
-            RegisterMsg(
-                instance_id=self.lmcache_instance_id,
-                worker_id=self.worker_id,
-                ip=self.lmcache_worker_ip,
-                port=self.lmcache_worker_port,
-                peer_init_url=self.p2p_init_url,
+
+        register_msg = RegisterMsg(
+            instance_id=self.lmcache_instance_id,
+            worker_id=self.worker_id,
+            ip=self.lmcache_worker_ip,
+            port=self.lmcache_worker_port,
+            peer_init_url=self.p2p_init_url,
+        )
+
+        # Send via REQ socket and wait for response
+        try:
+            self.req_socket.send(
+                msgspec.msgpack.encode(register_msg), flags=zmq.NOBLOCK
             )
-        )
+            # Use sync recv since we're not in async context
+            serialized_ret_msg = self.req_socket.recv()
+            ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
+
+            if isinstance(ret_msg, RegisterRetMsg):
+                self._process_register_response(ret_msg)
+            else:
+                logger.warning("Unexpected register response type: %s", type(ret_msg))
+        except zmq.ZMQError as e:
+            logger.error("Failed to register with controller: %s", e)
+            raise
+
+    def _process_register_response(self, ret_msg: RegisterRetMsg):
+        """Process RegisterRetMsg and initialize components based on extra_config."""
+        extra_config = ret_msg.extra_config
+
+        # Initialize heartbeat socket if heartbeat_url is provided
+        heartbeat_url = extra_config.get("heartbeat_url")
+        if heartbeat_url:
+            logger.info("Received heartbeat_url from controller: %s", heartbeat_url)
+            self.controller_heartbeat_url = heartbeat_url
+            self._create_heartbeat_socket()
+        else:
+            logger.info("No dedicated heartbeat_url provided by controller")
 
     def deregister(self):
         """
@@ -218,6 +257,24 @@ class LMCacheWorker:
             self.socket_recv_timeout_ms,
             self.socket_send_timeout_ms,
         )
+
+    def _create_heartbeat_socket(self):
+        self.heartbeat_socket = get_zmq_socket_with_timeout(
+            self.context,
+            self.controller_heartbeat_url,
+            "tcp",
+            zmq.REQ,  # type: ignore[attr-defined]
+            "connect",
+            self.socket_recv_timeout_ms,
+            self.socket_send_timeout_ms,
+        )
+
+    def _recreate_heartbeat_socket(self):
+        try:
+            self.heartbeat_socket.close(linger=0)
+        except Exception as e:
+            logger.error("Error closing heartbeat socket: %s", e)
+        self._create_heartbeat_socket()
 
     def _recreate_req_socket(self):
         try:
@@ -298,25 +355,56 @@ class LMCacheWorker:
                 break
         return batch
 
+    async def _send_heartbeat_msg(self, msg: HeartbeatMsg) -> HeartbeatRetMsg:
+        """
+        Send heartbeat message via dedicated heartbeat socket.
+        This is separate from async_put_and_wait_msg to avoid socket contention.
+        """
+        if self.heartbeat_socket is None:
+            logger.warning("Heartbeat socket is not initialized")
+            return HeartbeatRetMsg()
+        try:
+            self.heartbeat_socket.send(msgspec.msgpack.encode(msg))
+            serialized_ret_msg = await self.heartbeat_socket.recv()
+            ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
+            return ret_msg
+        except zmq.Again as e:
+            logger.error("Heartbeat timeout occurred, recreating socket. Error: %s", e)
+            self._recreate_heartbeat_socket()
+            return HeartbeatRetMsg()
+        except zmq.ZMQError as e:
+            logger.error(
+                "Heartbeat ZMQ error occurred, recreating socket. Error: %s", e
+            )
+            self._recreate_heartbeat_socket()
+            return HeartbeatRetMsg()
+        except Exception as e:
+            logger.error("Error happens in heartbeat socket. Error: %s", e)
+            return HeartbeatRetMsg()
+
     async def heartbeat(self):
         """
         Send periodic heartbeats to the controller (REQ-REP mode).
 
         Process any commands received in the heartbeat response.
+        Uses dedicated heartbeat socket to avoid blocking from other requests.
         """
         enable_heartbeat = (
             self.config.lmcache_worker_heartbeat_time is not None
             and self.config.lmcache_worker_heartbeat_time > 0
+            and self.heartbeat_socket is not None
         )
         if enable_heartbeat:
             logger.info(
-                f"Start heartbeat in {self.lmcache_instance_id} : {self.worker_id}, "
-                f"delay time: {self.config.lmcache_worker_heartbeat_delay_time}s, "
-                f"heartbeat time: {self.config.lmcache_worker_heartbeat_time}s"
+                "Start heartbeat in %s : %s, delay time: %ss, heartbeat time: %ss",
+                self.lmcache_instance_id,
+                self.worker_id,
+                self.config.lmcache_worker_heartbeat_delay_time,
+                self.config.lmcache_worker_heartbeat_time,
             )
             await asyncio.sleep(self.config.lmcache_worker_heartbeat_delay_time)
             while True:
-                # Send heartbeat via REQ-REP and get response
+                # Send heartbeat via dedicated heartbeat socket
                 heartbeat_msg = HeartbeatMsg(
                     instance_id=self.lmcache_instance_id,
                     worker_id=self.worker_id,
@@ -326,7 +414,7 @@ class LMCacheWorker:
                 )
 
                 try:
-                    ret_msg = await self.async_put_and_wait_msg(heartbeat_msg)
+                    ret_msg = await self._send_heartbeat_msg(heartbeat_msg)
 
                     if isinstance(ret_msg, HeartbeatRetMsg):
                         self._handle_heartbeat_commands(ret_msg)

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -156,9 +156,7 @@ class LMCacheWorker:
         # Full sync sender (initialized lazily when needed)
         self._full_sync_sender: Optional["FullSyncSender"] = None
 
-        self.register()
-
-    def register(self):
+    async def register(self):
         """
         Register the lmcache worker with the controller via REQ-REP.
 
@@ -181,11 +179,10 @@ class LMCacheWorker:
 
         # Send via REQ socket and wait for response
         try:
-            self.req_socket.send(
+            await self.req_socket.send(
                 msgspec.msgpack.encode(register_msg), flags=zmq.NOBLOCK
             )
-            # Use sync recv since we're not in async context
-            serialized_ret_msg = self.req_socket.recv()
+            serialized_ret_msg = await self.req_socket.recv()
             ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
 
             if isinstance(ret_msg, RegisterRetMsg):
@@ -364,7 +361,7 @@ class LMCacheWorker:
             logger.warning("Heartbeat socket is not initialized")
             return HeartbeatRetMsg()
         try:
-            self.heartbeat_socket.send(msgspec.msgpack.encode(msg))
+            await self.heartbeat_socket.send(msgspec.msgpack.encode(msg))
             serialized_ret_msg = await self.heartbeat_socket.recv()
             ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
             return ret_msg
@@ -379,7 +376,9 @@ class LMCacheWorker:
             self._recreate_heartbeat_socket()
             return HeartbeatRetMsg()
         except Exception as e:
-            logger.error("Error happens in heartbeat socket. Error: %s", e)
+            logger.error(
+                "Error happens in heartbeat socket. Error: %s", e, exc_info=True
+            )
             return HeartbeatRetMsg()
 
     async def heartbeat(self):
@@ -574,6 +573,9 @@ class LMCacheWorker:
 
     async def start_all(self):
         try:
+            # Register first to get heartbeat_url before starting heartbeat task
+            await self.register()
+
             logger.info(
                 f"Starting lmcache worker {self.worker_id}"
                 f"for instance {self.lmcache_instance_id}"

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -256,6 +256,13 @@ class LMCacheWorker:
         )
 
     def _create_heartbeat_socket(self):
+        logger.info(
+            "Creating heartbeat socket to connect to: %s, "
+            "recv_timeout: %dms, send_timeout: %dms",
+            self.controller_heartbeat_url,
+            self.socket_recv_timeout_ms,
+            self.socket_send_timeout_ms,
+        )
         self.heartbeat_socket = get_zmq_socket_with_timeout(
             self.context,
             self.controller_heartbeat_url,
@@ -366,7 +373,13 @@ class LMCacheWorker:
             ret_msg = msgspec.msgpack.decode(serialized_ret_msg, type=Msg)
             return ret_msg
         except zmq.Again as e:
-            logger.error("Heartbeat timeout occurred, recreating socket. Error: %s", e)
+            logger.error(
+                "Heartbeat timeout occurred, recreating socket. "
+                "Error: %s, heartbeat_url: %s, recv_timeout: %dms",
+                e,
+                self.controller_heartbeat_url,
+                self.socket_recv_timeout_ms,
+            )
             self._recreate_heartbeat_socket()
             return HeartbeatRetMsg()
         except zmq.ZMQError as e:
@@ -394,6 +407,7 @@ class LMCacheWorker:
             and self.heartbeat_socket is not None
         )
         if enable_heartbeat:
+            await asyncio.sleep(self.config.lmcache_worker_heartbeat_delay_time)
             logger.info(
                 "Start heartbeat in %s : %s, delay time: %ss, heartbeat time: %ss",
                 self.lmcache_instance_id,
@@ -401,7 +415,6 @@ class LMCacheWorker:
                 self.config.lmcache_worker_heartbeat_delay_time,
                 self.config.lmcache_worker_heartbeat_time,
             )
-            await asyncio.sleep(self.config.lmcache_worker_heartbeat_delay_time)
             while True:
                 # Send heartbeat via dedicated heartbeat socket
                 heartbeat_msg = HeartbeatMsg(

--- a/tests/tools/test_controller_zmq_benchmark.py
+++ b/tests/tools/test_controller_zmq_benchmark.py
@@ -18,7 +18,10 @@ from lmcache.tools.controller_benchmark.benchmark import ZMQControllerBenchmark
 from lmcache.tools.controller_benchmark.config import ZMQBenchmarkConfig
 from lmcache.tools.controller_benchmark.handlers import OPERATION_HANDLERS
 from lmcache.tools.controller_benchmark.handlers.admit import AdmitHandler
-from lmcache.tools.controller_benchmark.handlers.base import OperationHandler
+from lmcache.tools.controller_benchmark.handlers.base import (
+    OperationHandler,
+    SocketType,
+)
 from lmcache.tools.controller_benchmark.handlers.deregister import DeregisterHandler
 from lmcache.tools.controller_benchmark.handlers.evict import EvictHandler
 from lmcache.tools.controller_benchmark.handlers.heartbeat import HeartbeatHandler
@@ -135,7 +138,7 @@ class TestOperationHandlers:
             handler.get_message_count(controller_zmq_benchmark)
             == controller_zmq_benchmark.config.batch_size
         )
-        assert not handler.use_req_socket()
+        assert handler.socket_type == SocketType.PUSH
 
     def test_evict_handler(self, controller_zmq_benchmark, test_data):
         """Test EvictHandler functionality"""
@@ -149,7 +152,7 @@ class TestOperationHandlers:
             handler.get_message_count(controller_zmq_benchmark)
             == controller_zmq_benchmark.config.batch_size
         )
-        assert not handler.use_req_socket()
+        assert handler.socket_type == SocketType.PUSH
 
     def test_heartbeat_handler(self, controller_zmq_benchmark, test_data):
         """Test HeartbeatHandler functionality"""
@@ -158,7 +161,7 @@ class TestOperationHandlers:
 
         assert isinstance(msg, HeartbeatMsg)
         assert handler.get_message_count(controller_zmq_benchmark) == 1
-        assert handler.use_req_socket()
+        assert handler.socket_type == SocketType.HEARTBEAT
 
     def test_register_handler(self, controller_zmq_benchmark, test_data):
         """Test RegisterHandler functionality"""
@@ -167,7 +170,7 @@ class TestOperationHandlers:
 
         assert isinstance(msg, RegisterMsg)
         assert handler.get_message_count(controller_zmq_benchmark) == 1
-        assert not handler.use_req_socket()
+        assert handler.socket_type == SocketType.REQ
 
     def test_deregister_handler(self, controller_zmq_benchmark, test_data):
         """Test DeregisterHandler functionality"""
@@ -176,7 +179,7 @@ class TestOperationHandlers:
 
         assert isinstance(msg, DeRegisterMsg)
         assert handler.get_message_count(controller_zmq_benchmark) == 1
-        assert not handler.use_req_socket()
+        assert handler.socket_type == SocketType.PUSH
 
     def test_p2p_lookup_handler(self, controller_zmq_benchmark, test_data):
         """Test P2PLookupHandler functionality"""
@@ -189,7 +192,7 @@ class TestOperationHandlers:
             handler.get_message_count(controller_zmq_benchmark)
             == controller_zmq_benchmark.config.num_hashes
         )
-        assert handler.use_req_socket()
+        assert handler.socket_type == SocketType.REQ
 
     def test_operation_handler_registry(self):
         """Test operation handler registry"""

--- a/tests/v1/internal_api_server/test_worker_info_api.py
+++ b/tests/v1/internal_api_server/test_worker_info_api.py
@@ -14,7 +14,7 @@ import zmq
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.cache_controller.controller_manager import LMCacheControllerManager
-from lmcache.v1.cache_controller.message import HeartbeatMsg, RegisterMsg
+from lmcache.v1.cache_controller.message import HeartbeatMsg, Msg, RegisterMsg
 from lmcache.v1.internal_api_server.api_server import app
 from lmcache.v1.rpc_utils import get_zmq_context, get_zmq_socket
 
@@ -29,15 +29,17 @@ class TestWorkerInfoAPI:
 
     @pytest.fixture
     def zmq_context(self):
-        return get_zmq_context()
+        return get_zmq_context(use_asyncio=False)
 
     @pytest.fixture
     def controller_urls(self):
         pull_port = get_available_port()
         reply_port = get_available_port()
+        heartbeat_port = get_available_port()
         return {
             "pull": f"127.0.0.1:{pull_port}",
             "reply": f"127.0.0.1:{reply_port}",
+            "heartbeat": f"127.0.0.1:{heartbeat_port}",
         }
 
     @pytest.fixture
@@ -76,6 +78,32 @@ class TestWorkerInfoAPI:
         socket.close()
 
     @pytest.fixture
+    def req_socket(self, zmq_context, controller_urls):
+        """REQ socket for register operations (REQ-REP mode)"""
+        socket = get_zmq_socket(
+            zmq_context,
+            controller_urls["reply"],
+            protocol="tcp",
+            role=zmq.REQ,
+            bind_or_connect="connect",
+        )
+        yield socket
+        socket.close()
+
+    @pytest.fixture
+    def heartbeat_socket(self, zmq_context, controller_urls):
+        """REQ socket for heartbeat operations"""
+        socket = get_zmq_socket(
+            zmq_context,
+            controller_urls["heartbeat"],
+            protocol="tcp",
+            role=zmq.REQ,
+            bind_or_connect="connect",
+        )
+        yield socket
+        socket.close()
+
+    @pytest.fixture
     def client_with_real_controller(self, real_controller_manager):
         app.state.lmcache_controller_manager = real_controller_manager
         return TestClient(app)
@@ -85,8 +113,13 @@ class TestWorkerInfoAPI:
         app.state.lmcache_controller_manager = None
         return TestClient(app)
 
-    def _send_message(self, worker_socket, msg_type, instance_id, worker_id, ip, port):
-        """Send message to controller via ZMQ"""
+    def _send_message(self, socket, msg_type, instance_id, worker_id, ip, port):
+        """Send message to controller via ZMQ
+
+        For register: uses REQ socket (REQ-REP mode), returns response
+        For heartbeat: uses REQ socket (dedicated heartbeat socket)
+        For others: uses PUSH socket (fire-and-forget)
+        """
         msg_classes = {
             "register": RegisterMsg,
             "heartbeat": HeartbeatMsg,
@@ -105,7 +138,15 @@ class TestWorkerInfoAPI:
         )
 
         message_data = msgspec.msgpack.encode(msg)
-        worker_socket.send(message_data)
+
+        # REQ-REP mode for register and heartbeat
+        if msg_type in ("register", "heartbeat"):
+            socket.send(message_data)
+            response = socket.recv()
+            return msgspec.msgpack.decode(response, type=Msg)
+        else:
+            socket.send(message_data)
+            return None
 
     def _wait_for_workers(self, client, expected_count, timeout=5):
         """Wait for expected number of workers to be registered"""
@@ -161,25 +202,25 @@ class TestWorkerInfoAPI:
         return data
 
     def test_real_worker_registration_and_query(
-        self, client_with_real_controller, worker_socket
+        self, client_with_real_controller, req_socket, heartbeat_socket
     ):
-        # Register workers via real ZMQ communication
-        self._send_message(worker_socket, "register", "instance1", 0, "127.0.0.1", 8000)
-        self._send_message(worker_socket, "register", "instance1", 1, "127.0.0.1", 8001)
-        self._send_message(worker_socket, "register", "instance2", 0, "127.0.0.2", 8002)
+        # Register workers via REQ-REP communication
+        self._send_message(req_socket, "register", "instance1", 0, "127.0.0.1", 8000)
+        self._send_message(req_socket, "register", "instance1", 1, "127.0.0.1", 8001)
+        self._send_message(req_socket, "register", "instance2", 0, "127.0.0.2", 8002)
 
         # Wait for workers to be registered
         self._wait_for_workers(client_with_real_controller, 3)
 
         # Send heartbeats to update last_heartbeat_time
         self._send_message(
-            worker_socket, "heartbeat", "instance1", 0, "127.0.0.1", 8000
+            heartbeat_socket, "heartbeat", "instance1", 0, "127.0.0.1", 8000
         )
         self._send_message(
-            worker_socket, "heartbeat", "instance1", 1, "127.0.0.1", 8001
+            heartbeat_socket, "heartbeat", "instance1", 1, "127.0.0.1", 8001
         )
         self._send_message(
-            worker_socket, "heartbeat", "instance2", 0, "127.0.0.2", 8002
+            heartbeat_socket, "heartbeat", "instance2", 0, "127.0.0.2", 8002
         )
 
         # Test getting all workers
@@ -197,9 +238,9 @@ class TestWorkerInfoAPI:
             assert worker["registration_time"] == pytest.approx(time.time(), abs=2)
             assert worker["last_heartbeat_time"] == pytest.approx(time.time(), abs=2)
 
-    def test_real_workers_by_instance(self, client_with_real_controller, worker_socket):
-        self._send_message(worker_socket, "register", "instance1", 0, "127.0.0.1", 8000)
-        self._send_message(worker_socket, "register", "instance2", 0, "127.0.0.2", 8002)
+    def test_real_workers_by_instance(self, client_with_real_controller, req_socket):
+        self._send_message(req_socket, "register", "instance1", 0, "127.0.0.1", 8000)
+        self._send_message(req_socket, "register", "instance2", 0, "127.0.0.2", 8002)
 
         # Wait for workers to be registered
         self._wait_for_workers(client_with_real_controller, 2)
@@ -215,11 +256,11 @@ class TestWorkerInfoAPI:
         assert workers[0]["worker_id"] == 0
 
     def test_real_specific_worker_query(
-        self, client_with_real_controller, worker_socket
+        self, client_with_real_controller, req_socket, heartbeat_socket
     ):
-        self._send_message(worker_socket, "register", "instance1", 0, "127.0.0.1", 8000)
+        self._send_message(req_socket, "register", "instance1", 0, "127.0.0.1", 8000)
         self._send_message(
-            worker_socket, "heartbeat", "instance1", 0, "127.0.0.1", 8000
+            heartbeat_socket, "heartbeat", "instance1", 0, "127.0.0.1", 8000
         )
 
         # Wait for worker to be available


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Before this PR, recent changes to the LMCache Controller introduced a critical issue where heartbeat and p2P lookup operations were executed in different threads/async tasks while sharing the same ZMQ REQ socket. This violated ZMQ's REQ-REP pattern requirement that mandates strict `send() -> recv()` ordering within a single thread.

This PR added dedicated heartbeat socket to solve this issue.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
