### PR TITLE
Introduce Phoenix Storage Backend

### DIFF
--- a/docs/source/kv_cache/storage_backends/phxfs.rst
+++ b/docs/source/kv_cache/storage_backends/phxfs.rst
@@ -1,0 +1,118 @@
+Phoenix Backend
+==================
+
+.. _Phoenix-overview:
+
+Overview
+--------
+
+This backend will work with Phoenix-based filesystem. The `Phoenix <https://github.com/nicexlab/phoenix>`_ is a refactored
+I/O Stack for GPU Direct Storage without Phony Buffers, which has been accepted for `SC'25 <https://dl.acm.org/doi/10.1145/3712285.3759862>`_.
+
+
+Ways to configure LMCache Phoenix Backend
+-----------------------------------------
+
+**1. Environment Variables:**
+
+.. code-block:: bash
+
+    # 256 Tokens per KV Chunk
+    export LMCACHE_CHUNK_SIZE=256
+    # Path to store files
+    export LMCACHE_PHX_PATH="/mnt/phx/cache"
+    # CuFile Buffer Size in MiB
+    export LMCACHE_PHX_BUFFER_SIZE="8192"
+    # Disabling CPU RAM offload is sometimes recommended as the
+    # CPU can get in the way of GPUDirect operations
+    export LMCACHE_LOCAL_CPU=False
+
+**2. Configuration File**:
+
+Passed in through ``LMCACHE_CONFIG_FILE=your-lmcache-config.yaml``
+
+Example ``config.yaml``:
+
+.. code-block:: yaml
+
+    # 256 Tokens per KV Chunk
+    chunk_size: 256
+    # Disable local CPU
+    local_cpu: false
+    # Path to file system of Phoenix-enabled mount
+    phx_path: "/mnt/phx/cache"
+    # CuFile Buffer Size in MiB
+    phx_buffer_size: 8192
+
+
+Phoenix Buffer Size Explanation
+------------------------------
+
+The backend currently pre-registers buffer space to speed up phoenix operations. This buffer space
+is registered in VRAM so options like ``--gpu-memory-utilization`` from ``vllm`` should be considered
+when setting it. For example, a good rule of thumb for H100 which generally has 80GiBs of VRAM would
+be to start with 8GiB and set ``--gpu-memory-utilization 0.85`` and depending on your workflow fine-tune
+it from there.
+
+
+Setup Example
+-------------
+
+.. _phoenix-prerequisites:
+
+**Prerequisites:**
+
+- A Machine with at least one GPU. You can adjust the max model length of your vllm instance depending on your GPU memory.
+
+- A mounted file system. A file system supportings Phoenix will work best.
+
+- Deploy the Python API module of phoenix following the `instructions <https://github.com/nicexlab/phoenix/blob/main/python/README.md>`_.
+
+- vllm and lmcache installed (:doc:`Installation Guide <../../getting_started/installation>`)
+
+- Hugging Face access to ``meta-llama/Llama-3.1-8B-Instruct``
+
+.. code-block:: bash
+
+    export HF_TOKEN=your_hugging_face_token
+
+**Step 1. Check phoenix filesystem:**
+
+To check if the phoenix is ready, use `example` from phoenix project:
+
+.. code-block:: bash
+
+    sudo /path/to/phoenix/build/bin/example
+
+Create a directory under the file systew mount (the name here is arbitrary):
+
+.. code-block:: bash
+
+    mkdir /mnt/phx/cache
+
+**Step 2. Start a vLLM server with file backend enabled:**
+
+Create a an lmcache configuration file called: ``phx-backend.yaml``
+
+.. code-block:: yaml
+
+    local_cpu: false
+    chunk_size: 256
+    phx_path: "/mnt/phx/cache"
+    phx_buffer_size: 8192
+
+If you don't want to use a config file, uncomment the first three environment variables
+and then comment out the ``LMCACHE_CONFIG_FILE`` below:
+
+.. code-block:: bash
+
+    # LMCACHE_LOCAL_CPU=False \
+    # LMCACHE_CHUNK_SIZE=256 \
+    # LMCACHE_PHX_PATH="/mnt/phx/cache" \
+    # LMCACHE_PHX_BUFFER_SIZE=8192 \
+    LMCACHE_CONFIG_FILE="phx-backend.yaml" \
+    vllm serve \
+        meta-llama/Llama-3.1-8B-Instruct \
+        --max-model-len 65536 \
+        --kv-transfer-config \
+        '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'

--- a/docs/source/kv_cache/storage_backends/phxfs.rst
+++ b/docs/source/kv_cache/storage_backends/phxfs.rst
@@ -7,7 +7,7 @@ Overview
 --------
 
 This backend will work with Phoenix-based filesystem. The `Phoenix <https://github.com/nicexlab/phoenix>`_ is a refactored
-I/O Stack for GPU Direct Storage without Phony Buffers, which has been accepted for `SC'25 <https://dl.acm.org/doi/10.1145/3712285.3759862>`_.
+I/O Stack for GPU Direct Storage without Phony Buffers, which has been accepted for `SC'23 <https://dl.acm.org/doi/10.1145/3712285.3759862>`_.
 
 
 Ways to configure LMCache Phoenix Backend
@@ -21,7 +21,7 @@ Ways to configure LMCache Phoenix Backend
     export LMCACHE_CHUNK_SIZE=256
     # Path to store files
     export LMCACHE_PHX_PATH="/mnt/phx/cache"
-    # CuFile Buffer Size in MiB
+    # Phoenix Buffer Size in MiB
     export LMCACHE_PHX_BUFFER_SIZE="8192"
     # Disabling CPU RAM offload is sometimes recommended as the
     # CPU can get in the way of GPUDirect operations
@@ -41,7 +41,7 @@ Example ``config.yaml``:
     local_cpu: false
     # Path to file system of Phoenix-enabled mount
     phx_path: "/mnt/phx/cache"
-    # CuFile Buffer Size in MiB
+    # Phoenix Buffer Size in MiB
     phx_buffer_size: 8192
 
 
@@ -64,7 +64,7 @@ Setup Example
 
 - A Machine with at least one GPU. You can adjust the max model length of your vllm instance depending on your GPU memory.
 
-- A mounted file system. A file system supportings Phoenix will work best.
+- A mounted file system. A file system supporting Phoenix will work best.
 
 - Deploy the Python API module of phoenix following the `instructions <https://github.com/nicexlab/phoenix/blob/main/python/README.md>`_.
 
@@ -84,7 +84,7 @@ To check if the phoenix is ready, use `example` from phoenix project:
 
     sudo /path/to/phoenix/build/bin/example
 
-Create a directory under the file systew mount (the name here is arbitrary):
+Create a directory under the file system mount (the name here is arbitrary):
 
 .. code-block:: bash
 
@@ -92,7 +92,7 @@ Create a directory under the file systew mount (the name here is arbitrary):
 
 **Step 2. Start a vLLM server with file backend enabled:**
 
-Create a an lmcache configuration file called: ``phx-backend.yaml``
+Create an lmcache configuration file called: ``phx-backend.yaml``
 
 .. code-block:: yaml
 

--- a/docs/source/kv_cache/storage_backends/phxfs.rst
+++ b/docs/source/kv_cache/storage_backends/phxfs.rst
@@ -7,8 +7,7 @@ Overview
 --------
 
 This backend will work with Phoenix-based filesystem. The `Phoenix <https://github.com/nicexlab/phoenix>`_ is a refactored
-I/O Stack for GPU Direct Storage without Phony Buffers, which has been accepted for `SC'23 <https://dl.acm.org/doi/10.1145/3712285.3759862>`_.
-
+I/O Stack for GPU Direct Storage without Phony Buffers, which has been accepted for `SC <https://dl.acm.org/doi/10.1145/3712285.3759862>`_.
 
 Ways to configure LMCache Phoenix Backend
 -----------------------------------------

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -235,6 +235,12 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": int,
     },
+    "phx_path": {"type": Optional[str], "default": None, "env_converter": str},
+    "phx_buffer_size": {
+        "type": Optional[int],
+        "default": None,
+        "env_converter": int,
+    },
     # Other configurations
     # (Deprecated) The url of the actual remote lmcache instance for auditing.
     # Please use extra_config['audit_actual_remote_url'] instead.

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -14,6 +14,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.gds_backend import GdsBackend
+from lmcache.v1.storage_backend.phxfs_backend import PhxfsBackend
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 from lmcache.v1.storage_backend.p2p_backend import P2PBackend
@@ -184,6 +185,10 @@ def CreateStorageBackends(
     if config.gds_path is not None:
         gds_backend = GdsBackend(config, metadata, loop, dst_device)
         storage_backends[str(gds_backend)] = gds_backend
+    elif config.phx_path is not None:
+        phxfs_backend = PhxfsBackend(config, metadata, loop, dst_device)
+        storage_backends[str(phxfs_backend)] = phxfs_backend
+
     if config.remote_url is not None:
         remote_backend = RemoteBackend(
             config,

--- a/lmcache/v1/storage_backend/phxfs_backend.py
+++ b/lmcache/v1/storage_backend/phxfs_backend.py
@@ -1,0 +1,879 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import copy
+from collections import OrderedDict
+from concurrent.futures import Future
+from typing import Any, List, Optional, Sequence, Tuple, Union
+import asyncio
+import ctypes
+import json
+import mmap
+import os
+import random
+import string
+import struct
+import threading
+import time
+
+# Third Party
+import aiofile
+import numpy as np
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import (
+    GPUMemoryAllocator,
+    MemoryFormat,
+    MemoryObj,
+)
+from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+logger = init_logger(__name__)
+
+_METADATA_FILE_SUFFIX = ".metadata"
+_DATA_FILE_SUFFIX = ".kvcache.safetensors"
+_FULL_SUFFIX_LENGTH = len(_DATA_FILE_SUFFIX + _METADATA_FILE_SUFFIX)  # 29 characters
+_METADATA_VERSION = 1
+_METADATA_MAX_SIZE = 4096  # reserve 4K for metadata.
+# TODO: It is possible to read this 4KB block without triggering read-ahead by
+# various means.
+
+class PhxfsMemoryAllocator(GPUMemoryAllocator):
+    def __init__(self, size: int, device=None):
+        # HACK(Jiayi): cufile import is buggy on some hardware
+        # (e.g., without GPUDirect), so it's temporarily put here.
+        # Third Party
+        from phxfs.phxfs_bind import phxfs_regmem, phxfs_deregmem
+
+        self.phxfsBufDeReg = phxfs_deregmem
+        if device is None:
+            # TODO(Serapheim): Ideally we'd get the device from the upper
+            # layer - for now just use the current device.
+            if torch.cuda.is_available():
+                device = f"cuda:{torch.cuda.current_device()}"
+            else:
+                device = "cpu:0"
+        super().__init__(size, device, align_bytes=4096)
+        self.size = size
+        self.device_id = get_device_id(device)
+        self.base_pointer = self.tensor.data_ptr()
+        void_ptr = ctypes.c_void_p()
+        host_ptr = ctypes.POINTER(ctypes.c_void_p)(void_ptr)
+        phxfs_regmem(self.device_id, ctypes.c_void_p(self.base_pointer), ctypes.c_size_t(self.size), host_ptr)
+        self.host_ptr = void_ptr
+
+    def __del__(self):
+        self.phxfsBufDeReg(self.device_id, ctypes.c_void_p(self.base_pointer), ctypes.c_size_t(self.size))
+
+    def __str__(self):
+        return "PhxfsMemoryAllocator"
+
+class UnsupportedMetadataVersion(Exception):
+    pass
+
+
+torch_dtypes = {
+    torch.half: "F16",
+    torch.bfloat16: "BF16",
+    torch.float32: "F32",
+    torch.float64: "F64",
+    torch.uint8: "U8",
+    torch.uint16: "U16",
+    torch.uint32: "U32",
+    torch.uint64: "U64",
+    torch.int8: "I8",
+    torch.int16: "I16",
+    torch.int32: "I32",
+    torch.int64: "I64",
+    torch.float8_e4m3fn: "F8E4M3FN",
+    torch.float8_e5m2: "F8E5M2",
+}
+
+
+torch_dtypes_inverse = dict([(v, k) for k, v in torch_dtypes.items()])
+
+
+def get_device_id(dest_device="cuda"):
+    device_idx = 0
+    vec = dest_device.split(":")
+    if len(vec) == 2:
+        device_idx = int(vec[1])
+
+    device_list = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
+    return int(device_list.split(",")[device_idx])
+
+def get_fstype(path):
+    with open("/proc/mounts", "r") as f:
+        lines = f.readlines()
+
+    # Find the best matching mount point
+    best_match = ""
+    best_fstype = ""
+    for line in lines:
+        parts = line.split()
+        if len(parts) >= 3:
+            _, mount_point, fstype = parts[0], parts[1], parts[2]
+            if path.startswith(mount_point) and len(mount_point) > len(best_match):
+                best_match = mount_point
+                best_fstype = fstype
+
+    if not best_fstype:
+        raise RuntimeError(f"Unable to detect fstype for {path}")
+
+    return best_fstype
+
+
+def pack_metadata(tensor, fmt: MemoryFormat, **extra_metadata) -> bytes:
+    if tensor.dtype not in torch_dtypes:
+        raise RuntimeError(f"unhandled dtype {tensor.dtype}")
+
+    # Metadata
+    data_size = tensor.numel() * tensor.element_size()
+    tensor_meta = {
+        "dtype": torch_dtypes[tensor.dtype],
+        "shape": list(tensor.size()),
+        "data_offsets": [0, data_size],
+        "fmt": fmt.value,
+        "__metadata__": extra_metadata,
+    }
+    meta = {"kvcache": tensor_meta}
+    str_meta = json.dumps(meta).encode("utf-8")
+    meta_len = len(str_meta)
+    assert meta_len <= _METADATA_MAX_SIZE - 8
+
+    # Align to _METADATA_MAX_SIZE - 8
+    str_meta += b" " * (_METADATA_MAX_SIZE - 8 - meta_len)
+
+    # Pack it all up so it is sized _METADATA_MAX_SIZE exactly.
+    return struct.pack("<Q", len(str_meta)) + str_meta
+
+
+def unpack_metadata(buffer: bytes):
+    meta_len = struct.unpack("<Q", buffer[:8])[0]
+
+    str_meta = buffer[8 : 8 + meta_len]
+    json_meta = str_meta.rstrip(b" ")
+
+    meta = json.loads(json_meta.decode("utf-8"))
+    tensor_meta = meta["kvcache"]
+
+    shape = tensor_meta["shape"]
+    dtype_str = tensor_meta["dtype"]
+    data_offsets = tensor_meta["data_offsets"]
+    fmt = MemoryFormat(tensor_meta["fmt"])
+
+    nbytes = data_offsets[1] - data_offsets[0]
+    dtype = torch_dtypes_inverse[dtype_str]
+
+    return torch.Size(shape), dtype, nbytes, fmt, tensor_meta["__metadata__"]
+
+
+def rand_suffix(rand, n: int):
+    return "".join(
+        rand.choice(string.ascii_uppercase + string.digits) for _ in range(n)
+    )
+
+
+async def save_metadata(path: str, tmp: str, metadata: bytes):
+    tmp_path = path + tmp
+    async with aiofile.async_open(tmp_path, "wb") as f:
+        await f.write(metadata)
+    os.rename(tmp_path, path)
+
+
+def get_extra_config_bool(key, config: LMCacheEngineConfig) -> bool | None:
+    value = config.extra_config.get(key, None)
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        bool_value = value.lower() == "true"
+    elif value in [False, True]:
+        bool_value = value
+    else:
+        raise RuntimeError(f"Invalid value `{value}` for `{key}` in extra_config")
+
+    logger.info(f"Getting {key} = {bool_value} from extra_config")
+    return bool_value
+
+
+class PhxfsBackend(AllocatorBackendInterface):
+    """
+    Originally based on the open sourced WekaPhxfsBackend, this is a backend that
+    leverages NVIDIA's cuFile API to issue GDS requests directly to the
+    GDS-supported remote filesystem.  In order to use it, users need to specify
+    `phx_path` and `cufile_buffer_size` in their LMCache config.
+
+    Cache Directory Structure created by this Backend:
+    /{phx_path}/{first_level}/{second_level}/{data & metadata} This structure
+    is semi-arbitrary. We create two levels in the directory hierarchy to
+    parallelize loading the data during initialization in the Python code.
+
+    NOTE: If GPUDirect is not supported on that other filesystem, then CuFile will
+    fall back to POSIX I/O.
+    """
+
+    def __init__(
+        self,
+        config: LMCacheEngineConfig,
+        metadata: LMCacheEngineMetadata,
+        loop: asyncio.AbstractEventLoop,
+        dst_device: str = "cuda",
+    ):
+        assert dst_device.startswith("cuda")
+        super().__init__(dst_device=dst_device)
+
+        self.config = config
+        self.loop = loop
+        self.dst_device = dst_device
+        self.device_id = get_device_id(dst_device)
+
+        assert config.phx_path is not None, "Need to specify phx_path for PhxfsBackend"
+        self.phx_path = config.phx_path
+        self.fstype = get_fstype(config.phx_path)
+
+        # Log the fstype - this is useful in reports and varying optimizations
+        # based on the kind of fstype used.
+        logger.info(
+            f"Phxfs backend using fstype '{self.fstype}' on path '{self.phx_path}'"
+        )
+
+        assert self.fstype not in ["tmpfs", "overlayfs"], "Unsupported fstype"
+
+        logger.info("Using phxfs")
+        # HACK(Jiayi): cufile import is buggy on some hardware
+        # (e.g., without GPUDirect), so it's temporarily put here.
+        # Third Party
+        import phxfs
+
+        self.cudart = None
+        self.phxfs = phxfs
+
+        self._phxfs_driver = self.phxfs.PhxfsDriver(self.device_id)
+
+        self.memory_allocator = self.initialize_allocator(config, metadata)
+        
+        self.use_direct_io = True
+        if config.extra_config is not None:
+            use_direct_io = get_extra_config_bool("use_direct_io", config)
+            assert use_direct_io, "Phxfs only support direct io mode"
+
+        if not os.path.exists(self.phx_path):
+            os.makedirs(self.phx_path, exist_ok=True)
+
+        self.stats = None  # TODO: plug into LMCache Statistics
+
+        self.hot_lock = threading.Lock()
+        self.hot_cache: OrderedDict[CacheEngineKey, DiskCacheMetadata] = OrderedDict()
+        self.metadata_dirs: set[str] = set()
+
+        self.put_lock = threading.Lock()
+        self.put_tasks: set[CacheEngineKey] = set()
+
+        self.rand = random.Random(self.dst_device)
+
+        if hasattr(self.memory_allocator, "base_pointer"):
+            logger.debug(f"Using base pointer {self.memory_allocator.base_pointer}")
+            self.phxfs_base_pointer = self.memory_allocator.base_pointer
+        else:
+            logger.info("No base pointer found, cufile will use bounce buffers")
+            self.phxfs_base_pointer = None
+        asyncio.run_coroutine_threadsafe(self._scan_metadata(), self.loop)
+        self.save_metadata_tasks: set[asyncio.Task] = set()
+
+    async def _scan_metadata(self):
+        # TODO: even though we only run it once on startup, this is still
+        # not super scalable - test whether Rust code will be faster here, or
+        # whether we can serialize meta-data in groups for faster loading.
+        tasks = []
+        start = time.perf_counter()
+        with os.scandir(self.phx_path) as it:
+            for entry in it:
+                if not entry.is_dir():
+                    continue
+                l1_dir = os.path.basename(entry.name)
+                if len(l1_dir) != 2:
+                    continue
+                tasks.append(
+                    asyncio.to_thread(
+                        self._scan_metadata_subdir,
+                        os.path.join(self.phx_path, l1_dir),
+                        l1_dir,
+                    )
+                )
+        # TODO: If Python 3.11+, can we use TaskGroup instead?
+        await asyncio.gather(*tasks)
+        end = time.perf_counter()
+        logger.info(
+            f"Read {len(self.hot_cache)} cache entries from persistent "
+            f"storage in {end - start:.2f} seconds"
+        )
+
+    def _scan_metadata_subdir(self, path, l1_dir):
+        target_suffix = _DATA_FILE_SUFFIX + _METADATA_FILE_SUFFIX
+        with os.scandir(path) as it:
+            for entry in it:
+                if not entry.is_dir():
+                    continue
+                l2_dir = os.path.basename(entry.name)
+                if len(l2_dir) != 2:
+                    continue
+                with os.scandir(os.path.join(path, l2_dir)) as it2:
+                    for fentry in it2:
+                        if not fentry.is_file():
+                            continue
+                        if not fentry.name.endswith(target_suffix):
+                            continue
+                        filename = os.path.basename(fentry.name)
+                        key_str = filename[:-_FULL_SUFFIX_LENGTH].replace("_", "/")
+                        try:
+                            key = CacheEngineKey.from_string(key_str)
+                        except ValueError as e:
+                            logger.error(
+                                f"Filename {filename} can't be converted "
+                                f"back into cache key: {e}"
+                            )
+                            continue
+                        try:
+                            self._read_metadata(key, fentry.path, l1_dir + l2_dir)
+                        except UnsupportedMetadataVersion:
+                            logger.error(
+                                "Unsupported metadata version for "
+                                f"{fentry.path}, ignoring"
+                            )
+
+    def _read_metadata(self, key, filename, subdir_key):
+        with open(filename, "rb") as f:
+            buf = f.read(_METADATA_MAX_SIZE)
+
+        shape, dtype, size, fmt, extra_metadata = unpack_metadata(buf)
+        if extra_metadata["lmcache_version"] != str(_METADATA_VERSION):
+            raise RuntimeError("unhandled lmcache metadata")
+        logger.debug(
+            f"Read metadata for {key} from {filename}: "
+            f"shape={shape}, dtype={dtype}, size={size}, fmt={fmt}, "
+            f"extra_metadata={extra_metadata}"
+        )
+        # TODO(extra_metadata)
+        # TODO(Jiayi): need to support `cached_positions`.
+        # Currently we just fill it as None.
+        metadata = DiskCacheMetadata(
+            filename.removesuffix(_METADATA_FILE_SUFFIX),
+            size,
+            shape,
+            dtype,
+            None,
+            fmt,
+        )
+        with self.hot_lock:
+            self.metadata_dirs.add(subdir_key)
+            self.hot_cache[key] = metadata
+        return metadata
+
+    def __str__(self):
+        return self.__class__.__name__
+
+    def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
+        # TODO: implement pin() semantics
+        with self.hot_lock:
+            res = key in self.hot_cache
+        if res:
+            return True
+        if self._try_to_read_metadata(key):
+            return True
+        return False
+
+    def _try_to_read_metadata(self, key: CacheEngineKey) -> Optional[DiskCacheMetadata]:
+        path, subdir_key, _, _ = self._key_to_path(key)
+        path += _METADATA_FILE_SUFFIX
+        if os.path.exists(path):
+            try:
+                return self._read_metadata(key, path, subdir_key)
+            except UnsupportedMetadataVersion:
+                logger.error(f"Unsupported metadata version for {path}, ignoring")
+        return None
+
+    def _key_to_path(
+        self,
+        key: CacheEngineKey,
+    ) -> Tuple[str, str, str, str]:
+        hash = str(key.chunk_hash)
+        l1_dir = hash[:2]
+        l2_dir = hash[2:4]
+        key_str = key.to_string()
+        assert "_" not in key_str, "key string should not contain `_`"
+        return (
+            os.path.join(
+                self.phx_path,
+                l1_dir,
+                l2_dir,
+                key_str.replace("/", "_") + _DATA_FILE_SUFFIX,
+            ),
+            l1_dir + l2_dir,
+            l1_dir,
+            l2_dir,
+        )
+
+    def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
+        with self.put_lock:
+            return key in self.put_tasks
+
+    def submit_put_task(self, key: CacheEngineKey, memory_obj: MemoryObj) -> Future:
+        assert memory_obj.tensor is not None
+        memory_obj.ref_count_up()
+
+        with self.put_lock:
+            self.put_tasks.add(key)
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._async_save_bytes_to_disk(key, memory_obj), self.loop
+        )
+        return future
+
+    def batched_submit_put_task(
+        self,
+        keys: Sequence[CacheEngineKey],
+        memory_objs: List[MemoryObj],
+        transfer_spec: Any = None,
+    ) -> Union[List[Future], None]:
+        futures = []
+        for key, memory_obj in zip(keys, memory_objs, strict=False):
+            future = self.submit_put_task(key, memory_obj)
+            futures.append(future)
+        return futures
+
+    async def _async_save_bytes_to_disk(
+        self,
+        key: CacheEngineKey,
+        memory_obj: MemoryObj,
+    ) -> None:
+        """
+        Convert KV to bytes and async store bytes to disk.
+        """
+        kv_chunk = memory_obj.tensor
+        assert kv_chunk is not None
+        path, subdir_key, l1_dir, l2_dir = self._key_to_path(key)
+        # TODO: maybe remove `metadata_dirs` and insert mkdir calls
+        # only for the case where creating the CuFile fails on ENOENT. It
+        # also makes the code more resilient to out-of-band deletions
+        if subdir_key not in self.metadata_dirs:
+            os.makedirs(os.path.join(self.phx_path, l1_dir, l2_dir), exist_ok=True)
+            self.metadata_dirs.add(subdir_key)
+        tmp = ".tmp" + rand_suffix(self.rand, 8)
+        fmt = memory_obj.metadata.fmt
+        metadata = await asyncio.to_thread(
+            self._save_gds,
+            path,
+            tmp,
+            kv_chunk,
+            fmt,
+            self.phxfs_base_pointer,
+            memory_obj.metadata.address,
+        )
+
+        logger.debug(
+            f"Saved {kv_chunk.numel()} elements of {kv_chunk.dtype} "
+            f"to {path} with metadata {metadata}")
+
+        self.insert_key(key, memory_obj)
+        memory_obj.ref_count_down()
+
+        task = asyncio.create_task(
+            save_metadata(path + _METADATA_FILE_SUFFIX, tmp, metadata)
+        )
+        self.save_metadata_tasks.add(task)
+        task.add_done_callback(self.save_metadata_tasks.discard)
+        with self.put_lock:
+            self.put_tasks.discard(key)
+
+    def insert_key(self, key: CacheEngineKey, memory_obj: MemoryObj) -> None:
+        path, _, _, _ = self._key_to_path(key)
+        size = memory_obj.get_physical_size()
+        shape = memory_obj.metadata.shape
+        dtype = memory_obj.metadata.dtype
+        fmt = memory_obj.metadata.fmt
+        with self.hot_lock:
+            # TODO(Jiayi): need to support `cached_positions`.
+            self.hot_cache[key] = DiskCacheMetadata(path, size, shape, dtype, None, fmt)
+
+    def submit_prefetch_task(
+        self,
+        key: CacheEngineKey,
+    ) -> bool:
+        # with self.hot_lock:
+        #     entry = self.hot_cache.get(key)
+        # if entry is None:
+        #     return None
+
+        # path = entry.path
+        # dtype = entry.dtype
+        # shape = entry.shape
+        # fmt = entry.fmt
+        # assert dtype is not None
+        # assert shape is not None
+        # assert fmt is not None
+        # return asyncio.run_coroutine_threadsafe(
+        #     self._async_load_bytes_from_disk(key, path, dtype, shape，fmt), self.loop
+        # )
+
+        # TODO(Jiayi): Need to modify this when prefetch interface is determined.
+
+        # TODO(Jiayi): add `test_gds_backend_sanity` back after implementing this
+        return False
+
+    async def _async_load_bytes_from_disk(
+        self,
+        key: CacheEngineKey,
+        path: str,
+        dtype: torch.dtype,
+        shape: torch.Size,
+        fmt: MemoryFormat,
+    ) -> Optional[MemoryObj]:
+        return self._load_bytes_from_disk_with_allocation(
+            key, path, dtype, shape, fmt=fmt
+        )
+
+    def get_blocking(
+        self,
+        key: CacheEngineKey,
+    ) -> Optional[MemoryObj]:
+        with self.hot_lock:
+            entry = self.hot_cache.get(key)
+        if entry is None:
+            return None
+
+        path = entry.path
+        dtype = entry.dtype
+        shape = entry.shape
+        fmt = entry.fmt
+        logger.warning(entry)
+        assert dtype is not None
+        assert shape is not None
+        assert fmt is not None
+        return self._load_bytes_from_disk_with_allocation(
+            key, path, dtype=dtype, shape=shape, fmt=fmt
+        )
+
+    def _load_bytes_from_disk_with_allocation(
+        self,
+        key: CacheEngineKey,
+        path: str,
+        dtype: torch.dtype,
+        shape: torch.Size,
+        fmt: MemoryFormat,
+    ) -> Optional[MemoryObj]:
+        """
+        Load byte array from disk by first allocating memory, then loading.
+
+        Args:
+            key: Cache key for error handling
+            path: File path to load from
+            dtype: Data type for memory allocation
+            shape: Shape for memory allocation
+
+        Returns:
+            A new memory object with loaded data, or None if allocation or
+            loading failed
+        """
+        memory_obj = self.memory_allocator.allocate(shape, dtype, fmt=fmt)
+        if memory_obj is None:
+            logger.debug("Memory allocation failed during sync disk load.")
+            return None
+        assert memory_obj.tensor is not None
+        assert memory_obj.tensor.is_cuda
+        assert torch.device(self.dst_device) == torch.device(memory_obj.tensor.device)
+
+        return self._load_bytes_from_disk_with_memory(key, path, memory_obj)
+
+    def _load_bytes_from_disk_with_memory(
+        self,
+        key: CacheEngineKey,
+        path: str,
+        memory_obj: Optional[MemoryObj],
+    ) -> Optional[MemoryObj]:
+        """
+        Load byte array from disk into a pre-allocated memory object.
+
+        Args:
+            key: Cache key for error handling
+            path: File path to load from
+            memory_obj: Pre-allocated memory object to load data into
+
+        Returns:
+            The memory object with loaded data, or None if loading failed
+        """
+        if memory_obj is None or memory_obj.tensor is None:
+            return None
+        assert memory_obj.tensor.is_cuda
+        assert torch.device(self.dst_device) == torch.device(memory_obj.tensor.device)
+
+        offset = _METADATA_MAX_SIZE
+        if self.phxfs_base_pointer is None:
+            addr = ctypes.c_void_p(memory_obj.tensor.data_ptr())
+            dev_offset = 0
+        else:
+            addr = ctypes.c_void_p(self.phxfs_base_pointer)
+            dev_offset = memory_obj.metadata.address
+        ret = self._load_gds(path, offset, addr, memory_obj.get_size(), dev_offset)
+        if ret != memory_obj.get_size():
+            if ret < 0:
+                logger.error(
+                    f"Error loading {path}: ret: {ret} removing entry from cache"
+                )
+                with self.hot_lock:
+                    self.hot_cache.pop(key)
+            else:
+                # TODO: we should probably count errors and
+                # remove the entry if it's a persistent problem.
+                logger.error(
+                    f"Error loading {path}: got only {ret} bytes "
+                    f"out of {memory_obj.get_size()}, ignoring"
+                )
+            memory_obj.ref_count_down()
+            return None
+        return memory_obj
+
+    def get_non_blocking(
+        self,
+        key: CacheEngineKey,
+        location: Optional[str] = None,
+    ) -> Optional[Future]:
+        # TODO: Using a dummy wrapper around prefetch for now.
+        if not self.submit_prefetch_task(key):
+            return None
+        return Future()
+
+    def batched_get_blocking(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> List[Optional[MemoryObj]]:
+        return super().batched_get_blocking(keys)
+
+    def _batched_get_blocking_by_thread_pool_impl(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> list[MemoryObj | None]:
+        paths: list[str | None] = []
+        dtypes: list[torch.dtype | None] = []
+        shapes: list[torch.Size | None] = []
+        with self.hot_lock:
+            for key in keys:
+                entry = self.hot_cache.get(key)
+                if entry is None:
+                    logger.error(f"Lookup failed during get_blocking for {key}")
+                    paths.append(None)
+                    dtypes.append(None)
+                    shapes.append(None)
+                    continue
+                paths.append(entry.path)
+                dtypes.append(entry.dtype)
+                shapes.append(entry.shape)
+
+        memory_objs: list[MemoryObj | None] = []
+        gds_reads, gds_read_bytes = 0, 0
+        for dtype, shape, path in zip(dtypes, shapes, paths, strict=True):
+            if path is None:
+                memory_objs.append(None)
+                continue
+            memory_obj = self.memory_allocator.allocate(shape, dtype)
+            if memory_obj is None:
+                logger.error(f"Memory allocation failed during get_blocking for {path}")
+            else:
+                gds_reads += 1
+                gds_read_bytes += memory_obj.get_size()
+            memory_objs.append(memory_obj)
+
+        start_time = time.perf_counter()
+        assert self._thread_pool is not None
+        results = list(
+            self._thread_pool.map(
+                self._load_bytes_from_disk_with_memory, keys, paths, memory_objs
+            )
+        )
+        total_time = time.perf_counter() - start_time
+        logger.info(
+            f"Time taken for batched_get_blocking: {total_time:.3f}s |"
+            f" {gds_read_bytes / 1024 / 1024}MiB | {gds_reads} ops."
+        )
+        return results
+
+    @_lmcache_nvtx_annotate
+    @torch.inference_mode()
+    def _save_gds(
+        self,
+        path: str,
+        tmp: str,
+        kv_chunk: torch.Tensor,
+        fmt: MemoryFormat,
+        base_pointer: int,
+        device_offset: int,
+    ):
+        if base_pointer is None:
+            addr = ctypes.c_void_p(kv_chunk.data_ptr())
+            dev_offset = 0
+        else:
+            addr = ctypes.c_void_p(base_pointer)
+            dev_offset = device_offset
+        tmp_path = path + tmp
+        offset = _METADATA_MAX_SIZE
+        # TODO: We can add the chunk's metadata here, e.g. Tensor parallelism shard
+        # and pipeline parallelism index.
+        metadata = pack_metadata(
+            kv_chunk, fmt=fmt, lmcache_version=str(_METADATA_VERSION)
+        )
+        try:
+            with open(tmp_path, "wb") as f:
+                f.write(metadata)
+            if self.phxfs:
+                with self.phxfs.Phxfs(
+                    tmp_path, "r+", use_direct_io=self.use_direct_io, device_id = self.device_id
+                ) as f:
+                    f.write(
+                        addr, kv_chunk.nbytes, file_offset=offset, dev_offset=dev_offset
+                    )
+            elif self.cudart:
+                # mmap the file
+                fd = os.open(tmp_path, os.O_RDWR)
+                nbytes = kv_chunk.nbytes
+                os.ftruncate(fd, nbytes + offset)
+                mm = mmap.mmap(
+                    fd, nbytes + offset, prot=mmap.PROT_WRITE, flags=mmap.MAP_SHARED
+                )
+                os.close(fd)
+
+                # get mapped file address
+                arr = np.frombuffer(mm, dtype=np.uint8)
+                buf_addr = arr.__array_interface__["data"][0]
+
+                assert addr.value is not None
+                res = self.cudart.cudaMemcpy(
+                    ctypes.c_void_p(buf_addr + offset),
+                    ctypes.c_void_p(int(addr.value) + device_offset),
+                    ctypes.c_size_t(nbytes),
+                    ctypes.c_int(2),
+                )
+                if res:
+                    raise RuntimeError(f"cudaMemcpy failed {res}")
+                del arr
+                mm.close()
+
+        except Exception as e:
+            logger.error(f"Error saving {tmp_path}: {e}", exc_info=True)
+            raise e
+        os.rename(tmp_path, path)
+        return metadata
+
+    def _load_gds(
+        self,
+        phx_path: str,
+        file_offset: int,
+        gpu_pointer: ctypes.c_void_p,
+        size_in_bytes: int,
+        dev_offset: int,
+    ) -> int:
+        # Read data from disk into a GPU buffer
+        if self.phxfs:
+            with self.phxfs.Phxfs(
+                phx_path, "r", use_direct_io=self.use_direct_io, device_id=self.device_id
+            ) as f:
+                return f.read(
+                    gpu_pointer,
+                    size_in_bytes,
+                    file_offset=file_offset,
+                    dev_offset=dev_offset,
+                )
+        elif self.cudart:
+            fd = os.open(phx_path, os.O_RDONLY)
+            file_size = os.fstat(fd).st_size
+            mm = mmap.mmap(
+                fd,
+                file_size,
+                prot=mmap.PROT_READ,
+                flags=mmap.MAP_PRIVATE | mmap.MAP_POPULATE,  # type: ignore [attr-defined]
+            )
+            os.close(fd)
+
+            arr = np.frombuffer(mm, dtype=np.uint8)
+            addr = arr.__array_interface__["data"][0]
+
+            assert gpu_pointer.value is not None
+            res = self.cudart.cudaMemcpy(
+                ctypes.c_void_p(int(gpu_pointer.value) + dev_offset),
+                ctypes.c_void_p(addr + file_offset),
+                ctypes.c_size_t(size_in_bytes),
+                ctypes.c_int(1),
+            )
+
+            if res != 0:
+                raise RuntimeError(f"cudaMemcpy failed with code {res}")
+            del arr
+            mm.close()
+            return size_in_bytes
+        else:
+            raise RuntimeError(
+                "Both cufile and cudart are None, this should not happen"
+            )
+
+    def pin(self, key: CacheEngineKey) -> bool:
+        # NOTE (ApostaC): Since gds doesn't have eviction now, we don't need
+        # to implement pin and unpin
+        return False
+
+    def unpin(self, key: CacheEngineKey) -> bool:
+        # NOTE (ApostaC): Since gds doesn't have eviction now, we don't need
+        # to implement pin and unpin
+        return False
+
+    def remove(self, key: CacheEngineKey, force: bool = True):
+        raise NotImplementedError("Remote backend does not support remove now.")
+
+    def initialize_allocator(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata
+     ) -> PhxfsMemoryAllocator:
+        assert config.phx_buffer_size is not None
+        return PhxfsMemoryAllocator(config.phx_buffer_size * 1024**2, device=self.dst_device)
+
+    def allocate(
+        self,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[MemoryObj]:
+        if busy_loop:
+            logger.warning("Phxfs backend does not support allocation with busy loop")
+        if eviction:
+            logger.warning("Phxfs backend does not support eviction")
+
+        return self.memory_allocator.allocate(shapes, dtypes, fmt)
+
+    def batched_allocate(
+        self,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+        batch_size: int,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        eviction: bool = True,
+        busy_loop: bool = True,
+    ) -> Optional[list[MemoryObj]]:
+        if busy_loop:
+            logger.warning("Phxfs backend does not support allocation with busy loop")
+        if eviction:
+            logger.warning("Phxfs backend does not support eviction")
+
+        return self.memory_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
+
+    def get_allocator_backend(self):
+        return self
+
+    def get_memory_allocator(self):
+        return self.memory_allocator
+
+    def close(self) -> None:
+        self.memory_allocator.close()
+        logger.info("Phxfs backend closed.")

--- a/lmcache/v1/storage_backend/phxfs_backend.py
+++ b/lmcache/v1/storage_backend/phxfs_backend.py
@@ -45,9 +45,6 @@ _METADATA_MAX_SIZE = 4096  # reserve 4K for metadata.
 
 class PhxfsMemoryAllocator(GPUMemoryAllocator):
     def __init__(self, size: int, device=None):
-        # HACK(Jiayi): cufile import is buggy on some hardware
-        # (e.g., without GPUDirect), so it's temporarily put here.
-        # Third Party
         from phxfs.phxfs_bind import phxfs_regmem, phxfs_deregmem
 
         self.phxfsBufDeReg = phxfs_deregmem
@@ -204,18 +201,14 @@ def get_extra_config_bool(key, config: LMCacheEngineConfig) -> bool | None:
 
 class PhxfsBackend(AllocatorBackendInterface):
     """
-    Originally based on the open sourced WekaPhxfsBackend, this is a backend that
-    leverages NVIDIA's cuFile API to issue GDS requests directly to the
-    GDS-supported remote filesystem.  In order to use it, users need to specify
-    `phx_path` and `cufile_buffer_size` in their LMCache config.
-
+    The PhxfsBackend references GDSBackend. In order to use it, users need to specify
+    `phx_path` and `phx_buffer_size` in their LMCache config.
     Cache Directory Structure created by this Backend:
     /{phx_path}/{first_level}/{second_level}/{data & metadata} This structure
     is semi-arbitrary. We create two levels in the directory hierarchy to
     parallelize loading the data during initialization in the Python code.
 
-    NOTE: If GPUDirect is not supported on that other filesystem, then CuFile will
-    fall back to POSIX I/O.
+    NOTE: The phoenix should support on that filesystem.
     """
 
     def __init__(
@@ -246,8 +239,7 @@ class PhxfsBackend(AllocatorBackendInterface):
         assert self.fstype not in ["tmpfs", "overlayfs"], "Unsupported fstype"
 
         logger.info("Using phxfs")
-        # HACK(Jiayi): cufile import is buggy on some hardware
-        # (e.g., without GPUDirect), so it's temporarily put here.
+
         # Third Party
         import phxfs
 
@@ -281,7 +273,7 @@ class PhxfsBackend(AllocatorBackendInterface):
             logger.debug(f"Using base pointer {self.memory_allocator.base_pointer}")
             self.phxfs_base_pointer = self.memory_allocator.base_pointer
         else:
-            logger.info("No base pointer found, cufile will use bounce buffers")
+            logger.info("No base pointer found, phoenix will use bounce buffers")
             self.phxfs_base_pointer = None
         asyncio.run_coroutine_threadsafe(self._scan_metadata(), self.loop)
         self.save_metadata_tasks: set[asyncio.Task] = set()
@@ -459,7 +451,7 @@ class PhxfsBackend(AllocatorBackendInterface):
         assert kv_chunk is not None
         path, subdir_key, l1_dir, l2_dir = self._key_to_path(key)
         # TODO: maybe remove `metadata_dirs` and insert mkdir calls
-        # only for the case where creating the CuFile fails on ENOENT. It
+        # only for the case where creating the phoenix fails on ENOENT. It
         # also makes the code more resilient to out-of-band deletions
         if subdir_key not in self.metadata_dirs:
             os.makedirs(os.path.join(self.phx_path, l1_dir, l2_dir), exist_ok=True)
@@ -467,7 +459,7 @@ class PhxfsBackend(AllocatorBackendInterface):
         tmp = ".tmp" + rand_suffix(self.rand, 8)
         fmt = memory_obj.metadata.fmt
         metadata = await asyncio.to_thread(
-            self._save_gds,
+            self._save_phxfs,
             path,
             tmp,
             kv_chunk,
@@ -505,25 +497,6 @@ class PhxfsBackend(AllocatorBackendInterface):
         self,
         key: CacheEngineKey,
     ) -> bool:
-        # with self.hot_lock:
-        #     entry = self.hot_cache.get(key)
-        # if entry is None:
-        #     return None
-
-        # path = entry.path
-        # dtype = entry.dtype
-        # shape = entry.shape
-        # fmt = entry.fmt
-        # assert dtype is not None
-        # assert shape is not None
-        # assert fmt is not None
-        # return asyncio.run_coroutine_threadsafe(
-        #     self._async_load_bytes_from_disk(key, path, dtype, shape，fmt), self.loop
-        # )
-
-        # TODO(Jiayi): Need to modify this when prefetch interface is determined.
-
-        # TODO(Jiayi): add `test_gds_backend_sanity` back after implementing this
         return False
 
     async def _async_load_bytes_from_disk(
@@ -551,7 +524,7 @@ class PhxfsBackend(AllocatorBackendInterface):
         dtype = entry.dtype
         shape = entry.shape
         fmt = entry.fmt
-        logger.warning(entry)
+        logger.debug(entry)
         assert dtype is not None
         assert shape is not None
         assert fmt is not None
@@ -619,7 +592,7 @@ class PhxfsBackend(AllocatorBackendInterface):
         else:
             addr = ctypes.c_void_p(self.phxfs_base_pointer)
             dev_offset = memory_obj.metadata.address
-        ret = self._load_gds(path, offset, addr, memory_obj.get_size(), dev_offset)
+        ret = self._load_phxfs(path, offset, addr, memory_obj.get_size(), dev_offset)
         if ret != memory_obj.get_size():
             if ret < 0:
                 logger.error(
@@ -675,7 +648,7 @@ class PhxfsBackend(AllocatorBackendInterface):
                 shapes.append(entry.shape)
 
         memory_objs: list[MemoryObj | None] = []
-        gds_reads, gds_read_bytes = 0, 0
+        phxfs_reads, phxfs_read_bytes = 0, 0
         for dtype, shape, path in zip(dtypes, shapes, paths, strict=True):
             if path is None:
                 memory_objs.append(None)
@@ -684,27 +657,21 @@ class PhxfsBackend(AllocatorBackendInterface):
             if memory_obj is None:
                 logger.error(f"Memory allocation failed during get_blocking for {path}")
             else:
-                gds_reads += 1
-                gds_read_bytes += memory_obj.get_size()
+                phxfs_reads += 1
+                phxfs_read_bytes += memory_obj.get_size()
             memory_objs.append(memory_obj)
 
         start_time = time.perf_counter()
-        assert self._thread_pool is not None
-        results = list(
-            self._thread_pool.map(
-                self._load_bytes_from_disk_with_memory, keys, paths, memory_objs
-            )
-        )
         total_time = time.perf_counter() - start_time
         logger.info(
             f"Time taken for batched_get_blocking: {total_time:.3f}s |"
-            f" {gds_read_bytes / 1024 / 1024}MiB | {gds_reads} ops."
+            f" {phxfs_read_bytes / 1024 / 1024}MiB | {phxfs_reads} ops."
         )
         return results
 
     @_lmcache_nvtx_annotate
     @torch.inference_mode()
-    def _save_gds(
+    def _save_phxfs(
         self,
         path: str,
         tmp: str,
@@ -768,7 +735,7 @@ class PhxfsBackend(AllocatorBackendInterface):
         os.rename(tmp_path, path)
         return metadata
 
-    def _load_gds(
+    def _load_phxfs(
         self,
         phx_path: str,
         file_offset: int,
@@ -816,21 +783,21 @@ class PhxfsBackend(AllocatorBackendInterface):
             return size_in_bytes
         else:
             raise RuntimeError(
-                "Both cufile and cudart are None, this should not happen"
+                "Both phoenix and cudart are None, this should not happen"
             )
 
     def pin(self, key: CacheEngineKey) -> bool:
-        # NOTE (ApostaC): Since gds doesn't have eviction now, we don't need
+        # NOTE (ApostaC): Since phoenix doesn't have eviction now, we don't need
         # to implement pin and unpin
         return False
 
     def unpin(self, key: CacheEngineKey) -> bool:
-        # NOTE (ApostaC): Since gds doesn't have eviction now, we don't need
+        # NOTE (ApostaC): Since phoenix doesn't have eviction now, we don't need
         # to implement pin and unpin
         return False
 
     def remove(self, key: CacheEngineKey, force: bool = True):
-        raise NotImplementedError("Remote backend does not support remove now.")
+        raise NotImplementedError("PhxfsBackend does not support remove now.")
 
     def initialize_allocator(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata
      ) -> PhxfsMemoryAllocator:


### PR DESCRIPTION
Add a storage backend of [Phoenix](https://github.com/nicexlab/phoenix), which is a refactored I/O Stack for GPU Direct Storage without Phony Buffer. This backend implementation integrates with Phoenix, supporting the offloading of the KV-cache via Phoenix. Compared to GDS, Phoenix offers a significant performance improvement. The paper was published in [sc'25](https://dl.acm.org/doi/10.1145/3712285.3759862). Evaluation shows that compared to the state-of-the-art GDS I/O stack, Phoenix reduces the average software processing overhead along the critical I/O path by 70.3%, and improves the small-size I/O performance (e.g., for KV-cache) and large file loading performance (e.g., for checkpoints) by 2.29× and 4.11×, respectively.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Implements the issue  #2304 and enriched high-performance storage backend. 

The total token throughput(tok/s) of vllm end-to-end benchmark test in H20 GPU show:
  | gds | phxfs
-- | -- | --
First time | 8239 | 8261.41
All cached | 20612.82 | 34498.65


Server command:  
LMCACHE_CONFIG_FILE="/data/phxfs.conf" LMCACHE_USE_EXPERIMENTAL=True VLLM_USE_V1=1 CUDA_VISIBLE_DEVICES=0 nohup vllm serve /data/Qwen3-8B/ --enable-reasoning --reasoning-parser deepseek_r1 --max-model-len 12288 --port 8022 --gpu-memory-utilization 0.85 -tp 1 --enforce-eager --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' --no-enable-prefix-caching

Client command:
python /root/vllm/benchmarks/benchmark_serving.py --model /data/Qwen3-8B/ --backend vllm --dataset-name sonnet --dataset-path /root/vllm/benchmarks/sonnet.txt --host 127.0.0.1 --port 8022 --max-concurrency 64 --num-prompts 128 --sonnet-output-len 20


**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
