### PR TITLE
Fix LMCache layerwise edge cases and add vLLM patch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ Works on Linux NVIDIA GPU platform.
 
 More [detailed installation instructions](https://docs.lmcache.ai/getting_started/installation) are available in the docs, particularly if you are not using the latest stable version of vllm or using another serving engine with different dependencies. Any "undefined symbol" or torch mismatch versions can be resolved in the documentation. 
 
+## Optional vLLM GPU worker patch
+
+Some setups require a small vLLM GPU worker patch for LMCache model tracking.
+After installing vLLM, run this script with the same Python interpreter/venv
+used to launch vLLM:
+
+```bash
+python scripts/patch_vllm_gpu_worker.py
+```
+
+The script creates a `.bak` backup next to the original file and is safe to run
+multiple times. Restart vLLM workers after patching.
+
 ## Getting started
 
 The best way to get started is to checkout the [Quickstart Examples](https://docs.lmcache.ai/getting_started/quickstart/) in the docs.

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -401,6 +401,9 @@ void multi_layer_kv_transfer(
 
   int num_layers = key_value.size(1);
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_origin_elements = key_value.size(3);
   int elements_per_qword = 8 / key_value.element_size();
   int num_qwords = num_origin_elements / elements_per_qword;
@@ -480,6 +483,9 @@ void multi_layer_kv_transfer_unilateral(
 
   int num_layers = key_value.size(1);
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_origin_elements = key_value.size(3);
   int elements_per_qword = 8 / key_value.element_size();
   int num_qwords = num_origin_elements / elements_per_qword;
@@ -561,6 +567,9 @@ void single_layer_kv_transfer(
   int elements_per_entry = 8 / vllm_key_value_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads;
   int head_size_in_64bit;
   int block_size;
@@ -657,6 +666,9 @@ void load_and_reshape_flash(
   int elements_per_entry = 8 / key_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads = key_cache.size(2);
   int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
 
@@ -706,6 +718,9 @@ void reshape_and_cache_back_flash(
   int elements_per_entry = 8 / key_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads = key_cache.size(2);
   int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
 
@@ -771,6 +786,9 @@ void single_layer_kv_transfer_sgl(
   int elements_per_entry = 8 / sgl_key_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads = sgl_key_cache.size(2);
   int head_size_in_64bit = sgl_key_cache.size(3) / elements_per_entry;
 

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -24,6 +24,7 @@ import zmq.asyncio
 from lmcache.logging import init_logger
 from lmcache.v1.storage_backend.pd_backend import (
     PDMsg,
+    ProxyNotif,
 )
 
 logger = init_logger(__name__)
@@ -233,21 +234,42 @@ run_proxy = True  # Shutdown flag
 async def zmq_pull_server():
     socket = zmq_ctx.socket(zmq.PULL)
     proxy_url = f"{global_args.proxy_host}:{global_args.proxy_port}"
-    socket.bind(f"tcp://{proxy_url}")
-    logger.info(f"ZMQ proxy server started on {proxy_url}")
+    try:
+        socket.bind(f"tcp://{proxy_url}")
+    except Exception:
+        logger.exception("ZMQ proxy server failed to bind on %s", proxy_url)
+        return
+    logger.info("ZMQ proxy server started on %s", proxy_url)
 
     while run_proxy:
         try:
             msg_bytes = await socket.recv()
-            msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
-            req_id = msg.req_id
-            app.state.finished_reqs[req_id] += 1
-            logger.debug(f"Prefill of req {req_id} done.")
         except zmq.Again:
             await asyncio.sleep(0.01)  # Avoid busy loop
-        except Exception as e:
-            print("ZMQ Error:", e)
-            break
+            continue
+        except zmq.ZMQError as exc:
+            if exc.errno in (zmq.ETERM, zmq.ENOTSOCK):
+                break
+            logger.warning("ZMQ recv error: %s", exc)
+            await asyncio.sleep(0.05)
+            continue
+
+        try:
+            msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
+        except msgspec.DecodeError as exc:
+            logger.warning("ZMQ received non-PD message: %s", exc)
+            continue
+        except Exception as exc:
+            logger.exception("ZMQ message decode failed: %s", exc)
+            continue
+
+        if not isinstance(msg, ProxyNotif):
+            logger.debug("ZMQ ignored message type: %s", type(msg).__name__)
+            continue
+
+        req_id = msg.req_id
+        app.state.finished_reqs[req_id] += 1
+        logger.debug("Prefill of req %s done.", req_id)
 
     socket.close()
     logger.info("ZMQ PULL server stopped.")

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -236,7 +236,7 @@ async def zmq_pull_server():
     proxy_url = f"{global_args.proxy_host}:{global_args.proxy_port}"
     try:
         socket.bind(f"tcp://{proxy_url}")
-    except Exception:
+    except zmq.ZMQError:
         logger.exception("ZMQ proxy server failed to bind on %s", proxy_url)
         return
     logger.info("ZMQ proxy server started on %s", proxy_url)

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -24,7 +24,6 @@ import zmq.asyncio
 from lmcache.logging import init_logger
 from lmcache.v1.storage_backend.pd_backend import (
     PDMsg,
-    ProxyNotif,
 )
 
 logger = init_logger(__name__)
@@ -234,42 +233,21 @@ run_proxy = True  # Shutdown flag
 async def zmq_pull_server():
     socket = zmq_ctx.socket(zmq.PULL)
     proxy_url = f"{global_args.proxy_host}:{global_args.proxy_port}"
-    try:
-        socket.bind(f"tcp://{proxy_url}")
-    except Exception:
-        logger.exception("ZMQ proxy server failed to bind on %s", proxy_url)
-        return
-    logger.info("ZMQ proxy server started on %s", proxy_url)
+    socket.bind(f"tcp://{proxy_url}")
+    logger.info(f"ZMQ proxy server started on {proxy_url}")
 
     while run_proxy:
         try:
             msg_bytes = await socket.recv()
+            msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
+            req_id = msg.req_id
+            app.state.finished_reqs[req_id] += 1
+            logger.debug(f"Prefill of req {req_id} done.")
         except zmq.Again:
             await asyncio.sleep(0.01)  # Avoid busy loop
-            continue
-        except zmq.ZMQError as exc:
-            if exc.errno in (zmq.ETERM, zmq.ENOTSOCK):
-                break
-            logger.warning("ZMQ recv error: %s", exc)
-            await asyncio.sleep(0.05)
-            continue
-
-        try:
-            msg = msgspec.msgpack.decode(msg_bytes, type=PDMsg)
-        except msgspec.DecodeError as exc:
-            logger.warning("ZMQ received non-PD message: %s", exc)
-            continue
-        except Exception as exc:
-            logger.exception("ZMQ message decode failed: %s", exc)
-            continue
-
-        if not isinstance(msg, ProxyNotif):
-            logger.debug("ZMQ ignored message type: %s", type(msg).__name__)
-            continue
-
-        req_id = msg.req_id
-        app.state.finished_reqs[req_id] += 1
-        logger.debug("Prefill of req %s done.", req_id)
+        except Exception as e:
+            print("ZMQ Error:", e)
+            break
 
     socket.close()
     logger.info("ZMQ PULL server stopped.")

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -300,6 +300,7 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
             kvcaches=self.kvcaches,
             slot_mapping=slot_mapping[:retrieve_token_num],
             sync=False,
+            use_shared_buffer_mapping=False,
         )
 
         next(layerwise_retriever)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -996,24 +996,46 @@ class LMCacheConnectorV1Impl:
             token_mask[:masked_token_count] = False
 
             lmcache_cached_tokens = request.load_spec.lmcache_cached_tokens
+            if lmcache_cached_tokens <= 0:
+                continue
+
+            tokens_to_load = tokens[:lmcache_cached_tokens]
+            mask_to_load = token_mask[:lmcache_cached_tokens]
+            if mask_to_load.numel() == 0 or not mask_to_load.any():
+                logger.debug(
+                    "Skipping LMCache load for request %s: mask excludes all tokens",
+                    request.req_id,
+                )
+                continue
+
             if self.use_layerwise:
                 if idx == last_idx:
                     sync = True
                 else:
                     sync = False
                 # NOTE(Jiayi): Perform blending before layerwise prefix caching
-                if self.enable_blending:
+                should_blend = self.enable_blending and (
+                    int(mask_to_load.sum().item()) >= self.config.blend_min_tokens
+                )
+                if self.enable_blending and not should_blend:
+                    logger.debug(
+                        "Skipping blending for request %s: %d < blend_min_tokens %d",
+                        request.req_id,
+                        int(mask_to_load.sum().item()),
+                        self.config.blend_min_tokens,
+                    )
+                if should_blend:
                     # TODO(Jiayi): Need to make prefix caching and blending compatible
                     self.blender.blend(
-                        tokens[:lmcache_cached_tokens],
-                        token_mask[:lmcache_cached_tokens],
+                        tokens_to_load,
+                        mask_to_load,
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                     )
                 else:
                     layerwise_retriever = self.lmcache_engine.retrieve_layer(
-                        tokens[:lmcache_cached_tokens],
-                        token_mask[:lmcache_cached_tokens],
+                        tokens_to_load,
+                        mask_to_load,
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         sync=sync,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1223,6 +1223,12 @@ class LMCacheConnectorV1Impl:
 
         assert len(self.kv_caches) > 0
 
+        if self.current_layer >= self.num_layers:
+            # Handle multiple forward segments (e.g. chunked prefill) in one pass.
+            self._finalize_layerwise_storers("layerwise cycle reset")
+            self.layerwise_storers = []
+            self.current_layer = 0
+
         kvcaches = list(self.kv_caches.values())
         if self.current_layer == 0:
             self.layerwise_storers = []
@@ -1290,6 +1296,18 @@ class LMCacheConnectorV1Impl:
 
         self.current_layer += 1
 
+    def _finalize_layerwise_storers(self, reason: str) -> None:
+        if not self.layerwise_storers:
+            return
+        for layerwise_storer in self.layerwise_storers:
+            try:
+                next(layerwise_storer)
+            except StopIteration:
+                logger.debug(
+                    "Layerwise storer exhausted during %s; skipping final step",
+                    reason,
+                )
+
     @_lmcache_nvtx_annotate
     def wait_for_save(self):
         """Blocking until the KV cache is saved to the connector buffer."""
@@ -1302,8 +1320,9 @@ class LMCacheConnectorV1Impl:
             return
 
         if self.use_layerwise:
-            for layerwise_storer in self.layerwise_storers:
-                next(layerwise_storer)
+            self._finalize_layerwise_storers("wait_for_save")
+            self.layerwise_storers = []
+            self.current_layer = 0
 
             # unpin the kv caches according to req_id
             for request in connector_metadata.requests:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1039,6 +1039,7 @@ class LMCacheConnectorV1Impl:
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         sync=sync,
+                        use_shared_buffer_mapping=False,
                     )
                     # NOTE: retrieve for two layers at the first layer
                     next(layerwise_retriever)

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -3,7 +3,10 @@
 from typing import TYPE_CHECKING
 
 # Third Party
-from vllm.attention import Attention
+try:
+    from vllm.attention import Attention
+except ImportError:
+    from vllm.attention.layer import Attention
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 from vllm.vllm_flash_attn import flash_attn_varlen_func, get_scheduler_metadata
 import torch

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -12,7 +12,10 @@ from flashinfer.utils import (
     check_shape_dtype_device,
     device_support_pdl,
 )
-from vllm.attention import Attention
+try:
+    from vllm.attention import Attention
+except ImportError:
+    from vllm.attention.layer import Attention
 from vllm.v1.attention.backends.flashinfer import FlashInferImpl
 import flashinfer
 import torch

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -85,7 +85,10 @@ class LMCBlender:
         attn_layer = layer.self_attn
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
 
-        if layer_id in self.common_metadata.check_layers:
+        if (
+            self.common_metadata.check_layers
+            and layer_id in self.common_metadata.check_layers
+        ):
             diff_k = torch.sum(
                 (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
             )
@@ -158,6 +161,10 @@ class LMCBlender:
         """
         Perform blending for the given tokens.
         """
+
+        if mask is not None and mask.numel() > 0 and not mask.any():
+            logger.debug("Blend skipped: mask excludes all tokens.")
+            return
 
         if isinstance(tokens, list):
             tokens = torch.tensor(tokens).cuda()

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -67,7 +67,6 @@ class LMCBlender:
         attn_metadata: LMCAttnMetadata,
     ):
         logger.debug(f"Blender is processing KV for layer {layer_id}")
-        old_k, old_v = self.gpu_connector.get_kv(layer_id)
 
         if attn_output is None:
             attn_output = torch.empty(
@@ -80,10 +79,19 @@ class LMCBlender:
         if self.metadata.positions is None:
             self.metadata.positions = torch.arange(
                 q.shape[0], device=q.device, dtype=torch.int64
-            )
+        )
         layer = self.layerwise_model.vllm_model.model.layers[layer_id]
         attn_layer = layer.self_attn
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
+
+        try:
+            old_k, old_v = self.gpu_connector.get_kv(layer_id)
+        except ValueError:
+            logger.debug(
+                "Skipping blend for layer %d: KV not loaded into GPU buffer.",
+                layer_id,
+            )
+            return q, k, v, residual, attn_output, attn_metadata
 
         if (
             self.common_metadata.check_layers

--- a/lmcache/v1/compute/models/base.py
+++ b/lmcache/v1/compute/models/base.py
@@ -40,6 +40,22 @@ class LMCBaseModel(nn.Module, ABC):
         # if we want to make this LMCModel more general.
         self.blender = blender
 
+        embed_fn = getattr(vllm_model, "embed_input_ids", None)
+        if embed_fn is None:
+            get_input_embeddings = getattr(vllm_model, "get_input_embeddings", None)
+            if callable(get_input_embeddings):
+                embed_fn = get_input_embeddings()
+            elif hasattr(vllm_model, "model"):
+                if hasattr(vllm_model.model, "embed_input_ids"):
+                    embed_fn = vllm_model.model.embed_input_ids
+                elif hasattr(vllm_model.model, "embed_tokens"):
+                    embed_fn = vllm_model.model.embed_tokens
+        if embed_fn is None:
+            raise AttributeError(
+                f"Cannot find input embedding function for {type(vllm_model).__name__}."
+            )
+        self._embed_fn = embed_fn
+
         # remove hard code
         rotary_emb = vllm_model.model.layers[0].self_attn.rotary_emb
         head_dim = rotary_emb.head_size
@@ -69,7 +85,7 @@ class LMCBaseModel(nn.Module, ABC):
         input_ids: torch.Tensor,
     ):
         input_ids = input_ids.cuda()
-        hidden_states = self.vllm_model.get_input_embeddings(input_ids)
+        hidden_states = self._embed_fn(input_ids)
         residual = None
 
         attn_output = None

--- a/lmcache/v1/compute/models/utils.py
+++ b/lmcache/v1/compute/models/utils.py
@@ -11,7 +11,25 @@ from lmcache.logging import init_logger
 logger = init_logger(__name__)
 
 
+def _unwrap_vllm_model(vllm_model):
+    for _ in range(4):
+        unwrap = getattr(vllm_model, "unwrap", None)
+        if callable(unwrap):
+            unwrapped = unwrap()
+            if unwrapped is vllm_model:
+                break
+            vllm_model = unwrapped
+            continue
+        runnable = getattr(vllm_model, "runnable", None)
+        if runnable is not None:
+            vllm_model = runnable
+            continue
+        break
+    return vllm_model
+
+
 def infer_model_from_vllm(vllm_model, blender, enable_sparse: bool = False):
+    vllm_model = _unwrap_vllm_model(vllm_model)
     model_name = type(vllm_model).__name__
     if model_name == "LlamaForCausalLM":
         # First Party

--- a/lmcache/v1/compute/positional_encoding.py
+++ b/lmcache/v1/compute/positional_encoding.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import Any, Callable, Dict, Optional
+import inspect
 
 # Third Party
 from vllm.model_executor.layers.rotary_embedding import get_rope as vllm_get_rope
@@ -109,6 +110,25 @@ def validate_rope_params(
     return True
 
 
+def _match_rope_cache_device(rope, reference: torch.Tensor) -> None:
+    match = getattr(rope, "_match_cos_sin_cache_dtype", None)
+    if callable(match):
+        match(reference)
+        return
+
+    cos_sin_cache = getattr(rope, "cos_sin_cache", None)
+    if cos_sin_cache is None:
+        return
+
+    if (
+        cos_sin_cache.device != reference.device
+        or cos_sin_cache.dtype != reference.dtype
+    ):
+        rope.cos_sin_cache = cos_sin_cache.to(
+            reference.device, dtype=reference.dtype
+        )
+
+
 def validate_reverse_correctness(rope, reverse_rope, fused_rope, head_size) -> bool:
     hidden_dim = head_size * 8
     num_tokens = 10
@@ -116,6 +136,8 @@ def validate_reverse_correctness(rope, reverse_rope, fused_rope, head_size) -> b
     dumb_q = torch.rand((num_tokens, hidden_dim), device="cuda", dtype=torch.bfloat16)
     dumb_k = torch.rand((num_tokens, hidden_dim), device="cuda", dtype=torch.bfloat16)
     positions = torch.arange(num_tokens, device="cuda")
+
+    _match_rope_cache_device(rope, dumb_q)
 
     q1 = dumb_q.clone()
     k1 = dumb_k.clone()
@@ -171,16 +193,30 @@ def get_fused_rope(
         )
         return None
 
-    rope = vllm_get_rope(
-        head_size,
-        rotary_dim,
-        max_position,
-        base,
-        is_neox_style,
-        rope_scaling,
-        dtype,
-        partial_rotary_factor,
-    )
+    rope_params = {
+        "rope_theta": base,
+        "partial_rotary_factor": partial_rotary_factor,
+    }
+    rope_sig = inspect.signature(vllm_get_rope)
+    if "rope_parameters" in rope_sig.parameters:
+        rope = vllm_get_rope(
+            head_size=head_size,
+            max_position=max_position,
+            is_neox_style=is_neox_style,
+            rope_parameters=rope_params,
+            dtype=dtype,
+        )
+    else:
+        rope = vllm_get_rope(
+            head_size,
+            rotary_dim,
+            max_position,
+            base,
+            is_neox_style,
+            rope_scaling,
+            dtype,
+            partial_rotary_factor,
+        )
 
     reverse_rope = BasicReverseRope(rope, rotary_dim, is_neox_style)
     fused_rope = FusedRope(rope, is_neox_style)

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -608,6 +608,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
     ):
         self.hidden_dim_size = hidden_dim_size
         self.num_layers = num_layers
+        self.use_mla = bool(kwargs.get("use_mla", False))
 
         self.kvcaches: Optional[List[torch.Tensor]] = None
 
@@ -665,6 +666,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             use_gpu=use_gpu,
             dtype=metadata.kv_dtype,
             device=device,
+            use_mla=metadata.use_mla,
         )
 
     def _lazy_initialize_buffer(self, kv_caches):
@@ -818,6 +820,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     False,
                     False,  # shape is [2, num_tokens, hidden_dim]
                     self.vllm_two_major,
+                    self.use_mla,
                 )
                 del buffer_mapping[layer_id - 2]
 
@@ -984,6 +987,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     True,
                     False,  # shape is [2, num_tokens, hidden_dim]
                     self.vllm_two_major,
+                    self.use_mla,
                 )
                 for (buf_start, buf_end), memory_obj, old_positions in zip(
                     buf_starts_ends,

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -757,6 +757,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             self.lmc_model = LMCBlenderBuilder.get(ENGINE_NAME).layerwise_model
             self.fused_rotary_emb = self.lmc_model.fused_rotary_emb
 
+        use_shared_buffer_mapping = kwargs.get("use_shared_buffer_mapping", True)
+        buffer_mapping = self.buffer_mapping if use_shared_buffer_mapping else {}
+
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
 
         self._lazy_initialize_buffer(self.kvcaches)
@@ -773,7 +776,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         for start, end in zip(starts, ends, strict=False):
             gap_mask[start - buf_offset : end - buf_offset] = False
 
-        self.current_gap_positions = torch.where(gap_mask)[0]
+        current_gap_positions = torch.where(gap_mask)[0]
+        if use_shared_buffer_mapping:
+            self.current_gap_positions = current_gap_positions
 
         buf_offset = starts[0]
         if self.cache_positions:
@@ -807,14 +812,14 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         for layer_id in range(self.num_layers + 2):
             if layer_id > 1:
                 lmc_ops.single_layer_kv_transfer(
-                    self.buffer_mapping[layer_id - 2].tensor,
+                    buffer_mapping[layer_id - 2].tensor,
                     self.kvcaches[layer_id - 2],
                     slot_mapping_full,
                     False,
                     False,  # shape is [2, num_tokens, hidden_dim]
                     self.vllm_two_major,
                 )
-                del self.buffer_mapping[layer_id - 2]
+                del buffer_mapping[layer_id - 2]
 
                 logger.debug(f"Finished loading layer {layer_id - 2} into paged memory")
 
@@ -838,10 +843,10 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     )
 
                 # gap zeroing after RoPE
-                if self.current_gap_positions.numel():
-                    compute_gpu_buffer_obj.tensor[:, self.current_gap_positions] = 0.0
+                if current_gap_positions.numel():
+                    compute_gpu_buffer_obj.tensor[:, current_gap_positions] = 0.0
 
-                self.buffer_mapping[layer_id - 1] = compute_gpu_buffer_obj
+                buffer_mapping[layer_id - 1] = compute_gpu_buffer_obj
 
                 logger.debug(f"Finished loading layer {layer_id - 1} into buffer")
 
@@ -875,10 +880,16 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         load_gpu_buffer_obj.ref_count_down()
         compute_gpu_buffer_obj.ref_count_down()
 
-        assert len(self.buffer_mapping) == 0, (
-            "There are still layers in the buffer mapping after "
-            "releasing the GPU buffers."
-        )
+        if use_shared_buffer_mapping:
+            assert len(self.buffer_mapping) == 0, (
+                "There are still layers in the buffer mapping after "
+                "releasing the GPU buffers."
+            )
+        else:
+            assert len(buffer_mapping) == 0, (
+                "There are still layers in the buffer mapping after "
+                "releasing the GPU buffers."
+            )
 
         yield
 

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -177,6 +177,13 @@ class LMCacheLookupClient(LookupClientInterface):
         request_configs: Optional[dict] = None,
         num_computed_tokens: int = 0,
     ) -> Optional[int]:
+        if not isinstance(token_ids, list):
+            if isinstance(token_ids, torch.Tensor):
+                token_ids = token_ids.tolist()
+            elif hasattr(token_ids, "tolist"):
+                token_ids = token_ids.tolist()
+            else:
+                token_ids = list(token_ids)
         lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -477,10 +477,9 @@ class SegmentTokenDatabase(TokenDatabase):
                 num_falses = mask.numel() - mask.long().sum().item()
             else:
                 num_falses = 0
-            assert num_falses < len(tokens), (
-                "The number of Falses in the mask shouldn't "
-                "be less than the length of tokens."
-            )
+            if num_falses >= len(tokens):
+                # All tokens are masked out, so nothing to process.
+                return
 
             token_chunks = self._fast_split_by_subtensor(tokens)
             start_idx = 0

--- a/notes/review-2025-12-27.md
+++ b/notes/review-2025-12-27.md
@@ -1,0 +1,12 @@
+# Review Notes - 2025-12-27
+
+Context: LMCache blending changes, positional encoding updates, and related tooling tweaks.
+
+Findings:
+- HIGH: `get_fused_rope` drops `rope_scaling` when using the new `rope_parameters` API. This can produce incorrect RoPE for scaled models. Add `rope_scaling` (and any other required fields) to `rope_params` or keep the old path when scaling is present.
+- MED: `inspect.signature(vllm_get_rope)` is unguarded; if `get_rope` becomes a builtin/pybind function, `inspect.signature` can raise `ValueError` and break blending. Add a try/except and fall back to the legacy path.
+- MED: `LMCBlender.process_qkv` assumes `common_metadata.check_layers` is iterable. Config-only fixes (like `blend_check_layers`) leave other configs vulnerable to `TypeError`. Default to an empty list in code.
+- LOW: `examples/kv_cache_calculator/modelconfig.json` removed GLM entries; the calculator no longer supports those models unless the UI/docs are updated.
+
+Notes:
+- I did not review the full HTML changes in `examples/kv_cache_calculator/kv_cache_calculator.html` beyond the model config update.

--- a/scripts/patch_vllm_gpu_worker.py
+++ b/scripts/patch_vllm_gpu_worker.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Patch vLLM GPU worker for LMCache model tracking.
+
+This script:
+  - locates vllm.v1.worker.gpu_worker via import
+  - applies the LMCache model registration + KV transfer init changes
+  - comments out ensure_kv_transfer_initialized in init_worker_distributed_environment
+  - creates a backup of the original file
+
+It is safe to run multiple times.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import shutil
+import sys
+import time
+from pathlib import Path
+
+
+_IMPORTS_TO_ADD = [
+    "from lmcache.integration.vllm.utils import ENGINE_NAME\n",
+    "from lmcache.v1.compute.models.utils import VLLMModelTracker\n",
+]
+
+
+def _find_module_path(module_name: str) -> Path:
+    module = importlib.import_module(module_name)
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        raise RuntimeError(f"Unable to resolve file path for {module_name}")
+    return Path(module_file).resolve()
+
+
+def _backup_file(path: Path) -> Path:
+    backup = path.with_suffix(path.suffix + ".bak")
+    if backup.exists():
+        backup = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+    shutil.copy2(path, backup)
+    return backup
+
+
+def _find_function_block(lines: list[str], func_name: str) -> tuple[int, int] | None:
+    start = None
+    indent = 0
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith(f"def {func_name}("):
+            start = idx
+            indent = len(line) - len(stripped)
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        stripped = lines[idx].lstrip()
+        if stripped.startswith("def ") and (len(lines[idx]) - len(stripped)) <= indent:
+            end = idx
+            break
+    return start, end
+
+
+def _ensure_imports(lines: list[str]) -> tuple[list[str], bool]:
+    content = "".join(lines)
+    if all(line in content for line in _IMPORTS_TO_ADD):
+        return lines, False
+
+    insert_at = None
+    for idx, line in enumerate(lines):
+        if line.startswith("logger = init_logger("):
+            insert_at = idx
+            break
+    if insert_at is None:
+        insert_at = 0
+
+    new_lines = lines[:insert_at] + _IMPORTS_TO_ADD + lines[insert_at:]
+    return new_lines, True
+
+
+def _comment_kv_init_in_worker_env(lines: list[str]) -> tuple[list[str], bool]:
+    block = _find_function_block(lines, "init_worker_distributed_environment")
+    if block is None:
+        return lines, False
+
+    start, end = block
+    changed = False
+    for idx in range(start, end):
+        line = lines[idx]
+        stripped = line.lstrip()
+        if "ensure_kv_transfer_initialized(" in stripped and not stripped.startswith("#"):
+            leading = line[: len(line) - len(stripped)]
+            lines[idx] = f"{leading}# {stripped}"
+            changed = True
+    return lines, changed
+
+
+def _patch_initialize_from_config(lines: list[str]) -> tuple[list[str], bool]:
+    block = _find_function_block(lines, "initialize_from_config")
+    if block is None:
+        raise RuntimeError("Unable to find initialize_from_config in gpu_worker.py")
+
+    start, end = block
+    ensure_idx = None
+    for idx in range(start, end):
+        if "ensure_kv_transfer_initialized(" in lines[idx]:
+            ensure_idx = idx
+            break
+
+    if ensure_idx is None:
+        raise RuntimeError(
+            "Unable to find ensure_kv_transfer_initialized call "
+            "inside initialize_from_config"
+        )
+
+    indent = lines[ensure_idx][: len(lines[ensure_idx]) - len(lines[ensure_idx].lstrip())]
+    register_line = (
+        f"{indent}VLLMModelTracker.register_model("
+        f"ENGINE_NAME, self.model_runner.model)\n"
+    )
+    ensure_line = f"{indent}ensure_kv_transfer_initialized(self.vllm_config)\n"
+
+    changed = False
+    if not any("VLLMModelTracker.register_model(" in lines[idx] for idx in range(start, end)):
+        lines.insert(ensure_idx, register_line)
+        ensure_idx += 1
+        end += 1
+        changed = True
+
+    if lines[ensure_idx] != ensure_line:
+        lines[ensure_idx] = ensure_line
+        changed = True
+
+    return lines, changed
+
+
+def patch_gpu_worker(path: Path) -> bool:
+    original = path.read_text(encoding="utf-8")
+    lines = original.splitlines(keepends=True)
+    changed = False
+
+    lines, imports_changed = _ensure_imports(lines)
+    changed = changed or imports_changed
+
+    lines, env_changed = _comment_kv_init_in_worker_env(lines)
+    changed = changed or env_changed
+
+    lines, init_changed = _patch_initialize_from_config(lines)
+    changed = changed or init_changed
+
+    if not changed:
+        return False
+
+    _backup_file(path)
+    path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--module",
+        default="vllm.v1.worker.gpu_worker",
+        help="Module path to patch (default: vllm.v1.worker.gpu_worker)",
+    )
+    args = parser.parse_args()
+
+    try:
+        target_path = _find_module_path(args.module)
+    except Exception as exc:
+        print(f"Error locating module {args.module}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        did_patch = patch_gpu_worker(target_path)
+    except Exception as exc:
+        print(f"Error patching {target_path}: {exc}", file=sys.stderr)
+        return 1
+
+    if did_patch:
+        print(f"Patched {target_path}")
+        print("Backup created alongside the original file.")
+    else:
+        print(f"No changes needed in {target_path}")
+
+    print("Restart vLLM workers after patching.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem Description

In LMCache with vLLM v1 and layerwise KV transfer:

- ❌ Layerwise save can throw StopIteration during chunked prefill.
- ❌ Zero-token KV transfers can trigger CUDA invalid configuration errors.
- ❌ vLLM API changes (model wrappers, rope signature, attention import path) break LMCache compute.
- ❌ There is no repo-provided, repeatable way to apply the vLLM GPU worker patch.

## Root Cause Analysis

### 1. Workflow

```
Request → vLLM Scheduler → LMCache Integration → Layerwise storer/save → GPU transfer → Model compute
```

### 2. Key Code Logic

#### Layerwise save (`lmcache/integration/vllm/vllm_v1_adapter.py`)

```python
next(layerwise_storer)
```

#### Kernel launch (`csrc/mem_kernels.cu`)

```cpp
const int num_tokens = slot_mapping.size(0);
// launch grid uses num_tokens
```

#### Model/rope handling (`lmcache/v1/compute/models/base.py`, `lmcache/v1/compute/positional_encoding.py`)

```python
# embedding lookup assumes a specific method name and rope signature
```

#### Attention import (`lmcache/v1/compute/attention/*.py`)

```python
from vllm.attention import Attention
```

### 3. Root Cause

1) The layerwise storer generator could be exhausted by chunked prefill without being reset, so `wait_for_save` raised `StopIteration`.
2) A zero-token transfer path launched CUDA kernels with a zero-sized grid.
3) vLLM refactors changed wrapper models, rope call signatures, and module paths.
4) Required vLLM GPU worker adjustments were not documented or scripted.

### 4. Fix Solution

1) Reset/finalize layerwise storers for chunked prefill and guard `wait_for_save`.
2) Add early returns to CUDA kernels when `num_tokens == 0`.
3) Unwrap vLLM models before embedding, support new rope signature, and add attention import fallbacks.
4) Add `scripts/patch_vllm_gpu_worker.py` plus README guidance (idempotent, `.bak` backup).

**Special notes for reviewers**:
- The patch script is optional and should be run after installing vLLM; restart workers afterward.
- Tests not run for this PR.
