### PR TITLE
Fix LMCache layerwise/blending edge cases and add vLLM patch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Works on Linux NVIDIA GPU platform.
 
 More [detailed installation instructions](https://docs.lmcache.ai/getting_started/installation) are available in the docs, particularly if you are not using the latest stable version of vllm or using another serving engine with different dependencies. Any "undefined symbol" or torch mismatch versions can be resolved in the documentation. 
 
+## Optional vLLM GPU worker patch
+
+Some setups require a small vLLM GPU worker patch for LMCache model tracking.
+After installing vLLM, run this script with the same Python interpreter/venv
+used to launch vLLM:
+
+```bash
+python scripts/patch_vllm_gpu_worker.py
+```
+
+The script creates a `.bak` backup next to the original file and is safe to run
+multiple times. Restart vLLM workers after patching.
+
 ## Getting started
 
 The best way to get started is to checkout the [Quickstart Examples](https://docs.lmcache.ai/getting_started/quickstart/) in the docs.

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -416,6 +416,9 @@ void multi_layer_kv_transfer_templated(
 
   int num_layers = key_value.size(1);
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_origin_elements = key_value.size(3);
   int elements_per_xword = sizeof(T) / key_value.element_size();
   int num_xwords = num_origin_elements / elements_per_xword;
@@ -526,6 +529,9 @@ void multi_layer_kv_transfer_unilateral(
 
   int num_layers = key_value.size(1);
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_origin_elements = key_value.size(3);
   int elements_per_qword = 8 / key_value.element_size();
   int num_qwords = num_origin_elements / elements_per_qword;
@@ -607,6 +613,9 @@ void single_layer_kv_transfer(
   int elements_per_entry = 8 / vllm_key_value_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads;
   int head_size_in_64bit;
   int block_size;
@@ -703,6 +712,9 @@ void load_and_reshape_flash(
   int elements_per_entry = 8 / key_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads = key_cache.size(2);
   int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
 
@@ -752,6 +764,9 @@ void reshape_and_cache_back_flash(
   int elements_per_entry = 8 / key_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads = key_cache.size(2);
   int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
 
@@ -817,6 +832,9 @@ void single_layer_kv_transfer_sgl(
   int elements_per_entry = 8 / sgl_key_cache.element_size();
 
   int num_tokens = slot_mapping.size(0);
+  if (num_tokens == 0) {
+    return;
+  }
   int num_heads = sgl_key_cache.size(2);
   int head_size_in_64bit = sgl_key_cache.size(3) / elements_per_entry;
 

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -309,6 +309,7 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
             kvcaches=self.kvcaches,
             slot_mapping=slot_mapping[:retrieve_token_num],
             sync=False,
+            use_shared_buffer_mapping=False,
         )
 
         next(layerwise_retriever)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1019,6 +1019,12 @@ class LMCacheConnectorV1Impl:
 
         assert len(self.kv_caches) > 0
 
+        if self.current_layer >= self.num_layers:
+            # Handle multiple forward segments (e.g. chunked prefill) in one pass.
+            self._finalize_layerwise_storers("layerwise cycle reset")
+            self.layerwise_storers = []
+            self.current_layer = 0
+
         kvcaches = list(self.kv_caches.values())
         if self.current_layer == 0:
             self.layerwise_storers = []
@@ -1086,6 +1092,18 @@ class LMCacheConnectorV1Impl:
 
         self.current_layer += 1
 
+    def _finalize_layerwise_storers(self, reason: str) -> None:
+        if not self.layerwise_storers:
+            return
+        for layerwise_storer in self.layerwise_storers:
+            try:
+                next(layerwise_storer)
+            except StopIteration:
+                logger.debug(
+                    "Layerwise storer exhausted during %s; skipping final step",
+                    reason,
+                )
+
     @_lmcache_nvtx_annotate
     def wait_for_save(self):
         """Blocking until the KV cache is saved to the connector buffer."""
@@ -1098,8 +1116,9 @@ class LMCacheConnectorV1Impl:
             return
 
         if self.use_layerwise:
-            for layerwise_storer in self.layerwise_storers:
-                next(layerwise_storer)
+            self._finalize_layerwise_storers("wait_for_save")
+            self.layerwise_storers = []
+            self.current_layer = 0
 
             # unpin the kv caches according to req_id
             for request in connector_metadata.requests:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -836,6 +836,7 @@ class LMCacheConnectorV1Impl:
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         sync=sync,
+                        use_shared_buffer_mapping=False,
                     )
                     # NOTE: retrieve for two layers at the first layer
                     next(layerwise_retriever)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -793,24 +793,46 @@ class LMCacheConnectorV1Impl:
             token_mask[:masked_token_count] = False
 
             lmcache_cached_tokens = request.load_spec.lmcache_cached_tokens
+            if lmcache_cached_tokens <= 0:
+                continue
+
+            tokens_to_load = tokens[:lmcache_cached_tokens]
+            mask_to_load = token_mask[:lmcache_cached_tokens]
+            if mask_to_load.numel() == 0 or not mask_to_load.any():
+                logger.debug(
+                    "Skipping LMCache load for request %s: mask excludes all tokens",
+                    request.req_id,
+                )
+                continue
+
             if self.use_layerwise:
                 if idx == last_idx:
                     sync = True
                 else:
                     sync = False
                 # NOTE(Jiayi): Perform blending before layerwise prefix caching
-                if self.enable_blending:
+                should_blend = self.enable_blending and (
+                    int(mask_to_load.sum().item()) >= self.config.blend_min_tokens
+                )
+                if self.enable_blending and not should_blend:
+                    logger.debug(
+                        "Skipping blending for request %s: %d < blend_min_tokens %d",
+                        request.req_id,
+                        int(mask_to_load.sum().item()),
+                        self.config.blend_min_tokens,
+                    )
+                if should_blend:
                     # TODO(Jiayi): Need to make prefix caching and blending compatible
                     self.blender.blend(
-                        tokens[:lmcache_cached_tokens],
-                        token_mask[:lmcache_cached_tokens],
+                        tokens_to_load,
+                        mask_to_load,
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                     )
                 else:
                     layerwise_retriever = self.lmcache_engine.retrieve_layer(
-                        tokens[:lmcache_cached_tokens],
-                        token_mask[:lmcache_cached_tokens],
+                        tokens_to_load,
+                        mask_to_load,
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         sync=sync,

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -2,11 +2,13 @@
 # Standard
 from typing import TYPE_CHECKING
 
-# Third Party
 try:
+    # Third Party
     from vllm.attention import Attention
 except ImportError:
     from vllm.attention.layer import Attention
+
+# Third Party
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 from vllm.vllm_flash_attn import flash_attn_varlen_func, get_scheduler_metadata
 import torch

--- a/lmcache/v1/compute/attention/flash_attn.py
+++ b/lmcache/v1/compute/attention/flash_attn.py
@@ -3,7 +3,10 @@
 from typing import TYPE_CHECKING
 
 # Third Party
-from vllm.attention import Attention
+try:
+    from vllm.attention import Attention
+except ImportError:
+    from vllm.attention.layer import Attention
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 from vllm.vllm_flash_attn import flash_attn_varlen_func, get_scheduler_metadata
 import torch

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -12,7 +12,10 @@ from flashinfer.utils import (
     check_shape_dtype_device,
     device_support_pdl,
 )
-from vllm.attention import Attention
+try:
+    from vllm.attention import Attention
+except ImportError:
+    from vllm.attention.layer import Attention
 from vllm.v1.attention.backends.flashinfer import FlashInferImpl
 import flashinfer
 import torch

--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -12,10 +12,14 @@ from flashinfer.utils import (
     check_shape_dtype_device,
     device_support_pdl,
 )
+
 try:
+    # Third Party
     from vllm.attention import Attention
 except ImportError:
     from vllm.attention.layer import Attention
+
+# Third Party
 from vllm.v1.attention.backends.flashinfer import FlashInferImpl
 import flashinfer
 import torch

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -85,7 +85,10 @@ class LMCBlender:
         attn_layer = layer.self_attn
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
 
-        if layer_id in self.common_metadata.check_layers:
+        if (
+            self.common_metadata.check_layers
+            and layer_id in self.common_metadata.check_layers
+        ):
             diff_k = torch.sum(
                 (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
             )
@@ -158,6 +161,10 @@ class LMCBlender:
         """
         Perform blending for the given tokens.
         """
+
+        if mask is not None and mask.numel() > 0 and not mask.any():
+            logger.debug("Blend skipped: mask excludes all tokens.")
+            return
 
         if isinstance(tokens, list):
             tokens = torch.tensor(tokens).cuda()

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -67,7 +67,6 @@ class LMCBlender:
         attn_metadata: LMCAttnMetadata,
     ):
         logger.debug(f"Blender is processing KV for layer {layer_id}")
-        old_k, old_v = self.gpu_connector.get_kv(layer_id)
 
         if attn_output is None:
             attn_output = torch.empty(
@@ -80,10 +79,19 @@ class LMCBlender:
         if self.metadata.positions is None:
             self.metadata.positions = torch.arange(
                 q.shape[0], device=q.device, dtype=torch.int64
-            )
+        )
         layer = self.layerwise_model.vllm_model.model.layers[layer_id]
         attn_layer = layer.self_attn
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
+
+        try:
+            old_k, old_v = self.gpu_connector.get_kv(layer_id)
+        except ValueError:
+            logger.debug(
+                "Skipping blend for layer %d: KV not loaded into GPU buffer.",
+                layer_id,
+            )
+            return q, k, v, residual, attn_output, attn_metadata
 
         if (
             self.common_metadata.check_layers

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -79,7 +79,7 @@ class LMCBlender:
         if self.metadata.positions is None:
             self.metadata.positions = torch.arange(
                 q.shape[0], device=q.device, dtype=torch.int64
-        )
+            )
         layer = self.layerwise_model.vllm_model.model.layers[layer_id]
         attn_layer = layer.self_attn
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -170,6 +170,20 @@ class LMCBlender:
         Perform blending for the given tokens.
         """
 
+        token_len = len(tokens) if isinstance(tokens, list) else tokens.numel()
+        if token_len == 0:
+            if mask is None or mask.numel() == 0:
+                logger.debug("Blend skipped: empty tokens.")
+                return
+            raise ValueError(
+                f"Mask length {mask.numel()} does not match empty tokens."
+            )
+
+        if mask is not None and mask.numel() != token_len:
+            raise ValueError(
+                f"Mask length {mask.numel()} does not match tokens {token_len}."
+            )
+
         if mask is not None and mask.numel() > 0 and not mask.any():
             logger.debug("Blend skipped: mask excludes all tokens.")
             return

--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -175,9 +175,7 @@ class LMCBlender:
             if mask is None or mask.numel() == 0:
                 logger.debug("Blend skipped: empty tokens.")
                 return
-            raise ValueError(
-                f"Mask length {mask.numel()} does not match empty tokens."
-            )
+            raise ValueError(f"Mask length {mask.numel()} does not match empty tokens.")
 
         if mask is not None and mask.numel() != token_len:
             raise ValueError(

--- a/lmcache/v1/compute/models/base.py
+++ b/lmcache/v1/compute/models/base.py
@@ -40,6 +40,22 @@ class LMCBaseModel(nn.Module, ABC):
         # if we want to make this LMCModel more general.
         self.blender = blender
 
+        embed_fn = getattr(vllm_model, "embed_input_ids", None)
+        if embed_fn is None:
+            get_input_embeddings = getattr(vllm_model, "get_input_embeddings", None)
+            if callable(get_input_embeddings):
+                embed_fn = get_input_embeddings()
+            elif hasattr(vllm_model, "model"):
+                if hasattr(vllm_model.model, "embed_input_ids"):
+                    embed_fn = vllm_model.model.embed_input_ids
+                elif hasattr(vllm_model.model, "embed_tokens"):
+                    embed_fn = vllm_model.model.embed_tokens
+        if embed_fn is None:
+            raise AttributeError(
+                f"Cannot find input embedding function for {type(vllm_model).__name__}."
+            )
+        self._embed_fn = embed_fn
+
         # remove hard code
         rotary_emb = vllm_model.model.layers[0].self_attn.rotary_emb
         head_dim = rotary_emb.head_size
@@ -69,7 +85,7 @@ class LMCBaseModel(nn.Module, ABC):
         input_ids: torch.Tensor,
     ):
         input_ids = input_ids.cuda()
-        hidden_states = self.vllm_model.get_input_embeddings(input_ids)
+        hidden_states = self._embed_fn(input_ids)
         residual = None
 
         attn_output = None

--- a/lmcache/v1/compute/models/utils.py
+++ b/lmcache/v1/compute/models/utils.py
@@ -11,7 +11,25 @@ from lmcache.logging import init_logger
 logger = init_logger(__name__)
 
 
+def _unwrap_vllm_model(vllm_model):
+    for _ in range(4):
+        unwrap = getattr(vllm_model, "unwrap", None)
+        if callable(unwrap):
+            unwrapped = unwrap()
+            if unwrapped is vllm_model:
+                break
+            vllm_model = unwrapped
+            continue
+        runnable = getattr(vllm_model, "runnable", None)
+        if runnable is not None:
+            vllm_model = runnable
+            continue
+        break
+    return vllm_model
+
+
 def infer_model_from_vllm(vllm_model, blender, enable_sparse: bool = False):
+    vllm_model = _unwrap_vllm_model(vllm_model)
     model_name = type(vllm_model).__name__
     if model_name == "LlamaForCausalLM":
         # First Party

--- a/lmcache/v1/compute/positional_encoding.py
+++ b/lmcache/v1/compute/positional_encoding.py
@@ -124,9 +124,7 @@ def _match_rope_cache_device(rope, reference: torch.Tensor) -> None:
         cos_sin_cache.device != reference.device
         or cos_sin_cache.dtype != reference.dtype
     ):
-        rope.cos_sin_cache = cos_sin_cache.to(
-            reference.device, dtype=reference.dtype
-        )
+        rope.cos_sin_cache = cos_sin_cache.to(reference.device, dtype=reference.dtype)
 
 
 def validate_reverse_correctness(rope, reverse_rope, fused_rope, head_size) -> bool:

--- a/lmcache/v1/compute/positional_encoding.py
+++ b/lmcache/v1/compute/positional_encoding.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import Any, Callable, Dict, Optional
+import inspect
 
 # Third Party
 from vllm.model_executor.layers.rotary_embedding import get_rope as vllm_get_rope
@@ -109,6 +110,25 @@ def validate_rope_params(
     return True
 
 
+def _match_rope_cache_device(rope, reference: torch.Tensor) -> None:
+    match = getattr(rope, "_match_cos_sin_cache_dtype", None)
+    if callable(match):
+        match(reference)
+        return
+
+    cos_sin_cache = getattr(rope, "cos_sin_cache", None)
+    if cos_sin_cache is None:
+        return
+
+    if (
+        cos_sin_cache.device != reference.device
+        or cos_sin_cache.dtype != reference.dtype
+    ):
+        rope.cos_sin_cache = cos_sin_cache.to(
+            reference.device, dtype=reference.dtype
+        )
+
+
 def validate_reverse_correctness(rope, reverse_rope, fused_rope, head_size) -> bool:
     hidden_dim = head_size * 8
     num_tokens = 10
@@ -116,6 +136,8 @@ def validate_reverse_correctness(rope, reverse_rope, fused_rope, head_size) -> b
     dumb_q = torch.rand((num_tokens, hidden_dim), device="cuda", dtype=torch.bfloat16)
     dumb_k = torch.rand((num_tokens, hidden_dim), device="cuda", dtype=torch.bfloat16)
     positions = torch.arange(num_tokens, device="cuda")
+
+    _match_rope_cache_device(rope, dumb_q)
 
     q1 = dumb_q.clone()
     k1 = dumb_k.clone()
@@ -171,16 +193,30 @@ def get_fused_rope(
         )
         return None
 
-    rope = vllm_get_rope(
-        head_size,
-        rotary_dim,
-        max_position,
-        base,
-        is_neox_style,
-        rope_scaling,
-        dtype,
-        partial_rotary_factor,
-    )
+    rope_params = {
+        "rope_theta": base,
+        "partial_rotary_factor": partial_rotary_factor,
+    }
+    rope_sig = inspect.signature(vllm_get_rope)
+    if "rope_parameters" in rope_sig.parameters:
+        rope = vllm_get_rope(
+            head_size=head_size,
+            max_position=max_position,
+            is_neox_style=is_neox_style,
+            rope_parameters=rope_params,
+            dtype=dtype,
+        )
+    else:
+        rope = vllm_get_rope(
+            head_size,
+            rotary_dim,
+            max_position,
+            base,
+            is_neox_style,
+            rope_scaling,
+            dtype,
+            partial_rotary_factor,
+        )
 
     reverse_rope = BasicReverseRope(rope, rotary_dim, is_neox_style)
     fused_rope = FusedRope(rope, is_neox_style)

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -754,6 +754,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             self.lmc_model = LMCBlenderBuilder.get(ENGINE_NAME).layerwise_model
             self.fused_rotary_emb = self.lmc_model.fused_rotary_emb
 
+        use_shared_buffer_mapping = kwargs.get("use_shared_buffer_mapping", True)
+        buffer_mapping = self.buffer_mapping if use_shared_buffer_mapping else {}
+
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
 
         self._lazy_initialize_buffer(self.kvcaches)
@@ -770,7 +773,9 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         for start, end in zip(starts, ends, strict=False):
             gap_mask[start - buf_offset : end - buf_offset] = False
 
-        self.current_gap_positions = torch.where(gap_mask)[0]
+        current_gap_positions = torch.where(gap_mask)[0]
+        if use_shared_buffer_mapping:
+            self.current_gap_positions = current_gap_positions
 
         buf_offset = starts[0]
         if self.cache_positions:
@@ -804,14 +809,14 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         for layer_id in range(self.num_layers + 2):
             if layer_id > 1:
                 lmc_ops.single_layer_kv_transfer(
-                    self.buffer_mapping[layer_id - 2].tensor,
+                    buffer_mapping[layer_id - 2].tensor,
                     self.kvcaches[layer_id - 2],
                     slot_mapping_full,
                     False,
                     False,  # shape is [2, num_tokens, hidden_dim]
                     self.vllm_two_major,
                 )
-                del self.buffer_mapping[layer_id - 2]
+                del buffer_mapping[layer_id - 2]
 
                 logger.debug(f"Finished loading layer {layer_id - 2} into paged memory")
 
@@ -835,10 +840,10 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     )
 
                 # gap zeroing after RoPE
-                if self.current_gap_positions.numel():
-                    compute_gpu_buffer_obj.tensor[:, self.current_gap_positions] = 0.0
+                if current_gap_positions.numel():
+                    compute_gpu_buffer_obj.tensor[:, current_gap_positions] = 0.0
 
-                self.buffer_mapping[layer_id - 1] = compute_gpu_buffer_obj
+                buffer_mapping[layer_id - 1] = compute_gpu_buffer_obj
 
                 logger.debug(f"Finished loading layer {layer_id - 1} into buffer")
 
@@ -872,10 +877,16 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         load_gpu_buffer_obj.ref_count_down()
         compute_gpu_buffer_obj.ref_count_down()
 
-        assert len(self.buffer_mapping) == 0, (
-            "There are still layers in the buffer mapping after "
-            "releasing the GPU buffers."
-        )
+        if use_shared_buffer_mapping:
+            assert len(self.buffer_mapping) == 0, (
+                "There are still layers in the buffer mapping after "
+                "releasing the GPU buffers."
+            )
+        else:
+            assert len(buffer_mapping) == 0, (
+                "There are still layers in the buffer mapping after "
+                "releasing the GPU buffers."
+            )
 
         yield
 

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -605,6 +605,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
     ):
         self.hidden_dim_size = hidden_dim_size
         self.num_layers = num_layers
+        self.use_mla = bool(kwargs.get("use_mla", False))
 
         self.kvcaches: Optional[List[torch.Tensor]] = None
 
@@ -662,6 +663,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             use_gpu=use_gpu,
             dtype=metadata.kv_dtype,
             device=device,
+            use_mla=metadata.use_mla,
         )
 
     def _lazy_initialize_buffer(self, kv_caches):
@@ -815,6 +817,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     False,
                     False,  # shape is [2, num_tokens, hidden_dim]
                     self.vllm_two_major,
+                    self.use_mla,
                 )
                 del buffer_mapping[layer_id - 2]
 
@@ -981,6 +984,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     True,
                     False,  # shape is [2, num_tokens, hidden_dim]
                     self.vllm_two_major,
+                    self.use_mla,
                 )
                 for (buf_start, buf_end), memory_obj, old_positions in zip(
                     buf_starts_ends,

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -170,6 +170,13 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
+        if not isinstance(token_ids, list):
+            if isinstance(token_ids, torch.Tensor):
+                token_ids = token_ids.tolist()
+            elif hasattr(token_ids, "tolist"):
+                token_ids = token_ids.tolist()
+            else:
+                token_ids = list(token_ids)
         lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -477,10 +477,9 @@ class SegmentTokenDatabase(TokenDatabase):
                 num_falses = mask.numel() - mask.long().sum().item()
             else:
                 num_falses = 0
-            assert num_falses < len(tokens), (
-                "The number of Falses in the mask shouldn't "
-                "be less than the length of tokens."
-            )
+            if num_falses >= len(tokens):
+                # All tokens are masked out, so nothing to process.
+                return
 
             token_chunks = self._fast_split_by_subtensor(tokens)
             start_idx = 0

--- a/notes/review-2025-12-27.md
+++ b/notes/review-2025-12-27.md
@@ -1,0 +1,12 @@
+# Review Notes - 2025-12-27
+
+Context: LMCache blending changes, positional encoding updates, and related tooling tweaks.
+
+Findings:
+- HIGH: `get_fused_rope` drops `rope_scaling` when using the new `rope_parameters` API. This can produce incorrect RoPE for scaled models. Add `rope_scaling` (and any other required fields) to `rope_params` or keep the old path when scaling is present.
+- MED: `inspect.signature(vllm_get_rope)` is unguarded; if `get_rope` becomes a builtin/pybind function, `inspect.signature` can raise `ValueError` and break blending. Add a try/except and fall back to the legacy path.
+- MED: `LMCBlender.process_qkv` assumes `common_metadata.check_layers` is iterable. Config-only fixes (like `blend_check_layers`) leave other configs vulnerable to `TypeError`. Default to an empty list in code.
+- LOW: `examples/kv_cache_calculator/modelconfig.json` removed GLM entries; the calculator no longer supports those models unless the UI/docs are updated.
+
+Notes:
+- I did not review the full HTML changes in `examples/kv_cache_calculator/kv_cache_calculator.html` beyond the model config update.

--- a/scripts/patch_vllm_gpu_worker.py
+++ b/scripts/patch_vllm_gpu_worker.py
@@ -86,6 +86,11 @@ def _comment_kv_init_in_worker_env(lines: list[str]) -> tuple[list[str], bool]:
         return lines, False
 
     start, end = block
+    if not (0 <= start < end <= len(lines)):
+        raise RuntimeError(
+            "Invalid initialize_from_config range in gpu_worker.py: "
+            f"start={start}, end={end}, total={len(lines)}"
+        )
     changed = False
     for idx in range(start, end):
         line = lines[idx]
@@ -127,10 +132,11 @@ def _patch_initialize_from_config(lines: list[str]) -> tuple[list[str], bool]:
     ensure_line = f"{indent}ensure_kv_transfer_initialized(self.vllm_config)\n"
 
     changed = False
-    if not any(
-        "VLLMModelTracker.register_model(" in lines[idx]
-        for idx in range(start, end)
-    ):
+    has_registration = any(
+        "VLLMModelTracker.register_model(" in line
+        for line in lines[start:end]
+    )
+    if not has_registration:
         lines.insert(ensure_idx, register_line)
         ensure_idx += 1
         end += 1

--- a/scripts/patch_vllm_gpu_worker.py
+++ b/scripts/patch_vllm_gpu_worker.py
@@ -11,15 +11,16 @@ This script:
 It is safe to run multiple times.
 """
 
+# Future
 from __future__ import annotations
 
+# Standard
+from pathlib import Path
 import argparse
 import importlib
 import shutil
 import sys
 import time
-from pathlib import Path
-
 
 _IMPORTS_TO_ADD = [
     "from lmcache.integration.vllm.utils import ENGINE_NAME\n",
@@ -95,9 +96,8 @@ def _comment_kv_init_in_worker_env(lines: list[str]) -> tuple[list[str], bool]:
     for idx in range(start, end):
         line = lines[idx]
         stripped = line.lstrip()
-        if (
-            "ensure_kv_transfer_initialized(" in stripped
-            and not stripped.startswith("#")
+        if "ensure_kv_transfer_initialized(" in stripped and not stripped.startswith(
+            "#"
         ):
             leading = line[: len(line) - len(stripped)]
             lines[idx] = f"{leading}# {stripped}"
@@ -133,8 +133,7 @@ def _patch_initialize_from_config(lines: list[str]) -> tuple[list[str], bool]:
 
     changed = False
     has_registration = any(
-        "VLLMModelTracker.register_model(" in line
-        for line in lines[start:end]
+        "VLLMModelTracker.register_model(" in line for line in lines[start:end]
     )
     if not has_registration:
         lines.insert(ensure_idx, register_line)

--- a/scripts/patch_vllm_gpu_worker.py
+++ b/scripts/patch_vllm_gpu_worker.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Patch vLLM GPU worker for LMCache model tracking.
+
+This script:
+  - locates vllm.v1.worker.gpu_worker via import
+  - applies the LMCache model registration + KV transfer init changes
+  - comments out ensure_kv_transfer_initialized in init_worker_distributed_environment
+  - creates a backup of the original file
+
+It is safe to run multiple times.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import shutil
+import sys
+import time
+from pathlib import Path
+
+
+_IMPORTS_TO_ADD = [
+    "from lmcache.integration.vllm.utils import ENGINE_NAME\n",
+    "from lmcache.v1.compute.models.utils import VLLMModelTracker\n",
+]
+
+
+def _find_module_path(module_name: str) -> Path:
+    module = importlib.import_module(module_name)
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        raise RuntimeError(f"Unable to resolve file path for {module_name}")
+    return Path(module_file).resolve()
+
+
+def _backup_file(path: Path) -> Path:
+    backup = path.with_suffix(path.suffix + ".bak")
+    if backup.exists():
+        backup = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+    shutil.copy2(path, backup)
+    return backup
+
+
+def _find_function_block(lines: list[str], func_name: str) -> tuple[int, int] | None:
+    start = None
+    indent = 0
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith(f"def {func_name}("):
+            start = idx
+            indent = len(line) - len(stripped)
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        stripped = lines[idx].lstrip()
+        if stripped.startswith("def ") and (len(lines[idx]) - len(stripped)) <= indent:
+            end = idx
+            break
+    return start, end
+
+
+def _ensure_imports(lines: list[str]) -> tuple[list[str], bool]:
+    content = "".join(lines)
+    if all(line in content for line in _IMPORTS_TO_ADD):
+        return lines, False
+
+    insert_at = None
+    for idx, line in enumerate(lines):
+        if line.startswith("logger = init_logger("):
+            insert_at = idx
+            break
+    if insert_at is None:
+        insert_at = 0
+
+    new_lines = lines[:insert_at] + _IMPORTS_TO_ADD + lines[insert_at:]
+    return new_lines, True
+
+
+def _comment_kv_init_in_worker_env(lines: list[str]) -> tuple[list[str], bool]:
+    block = _find_function_block(lines, "init_worker_distributed_environment")
+    if block is None:
+        return lines, False
+
+    start, end = block
+    changed = False
+    for idx in range(start, end):
+        line = lines[idx]
+        stripped = line.lstrip()
+        if "ensure_kv_transfer_initialized(" in stripped and not stripped.startswith("#"):
+            leading = line[: len(line) - len(stripped)]
+            lines[idx] = f"{leading}# {stripped}"
+            changed = True
+    return lines, changed
+
+
+def _patch_initialize_from_config(lines: list[str]) -> tuple[list[str], bool]:
+    block = _find_function_block(lines, "initialize_from_config")
+    if block is None:
+        raise RuntimeError("Unable to find initialize_from_config in gpu_worker.py")
+
+    start, end = block
+    ensure_idx = None
+    for idx in range(start, end):
+        if "ensure_kv_transfer_initialized(" in lines[idx]:
+            ensure_idx = idx
+            break
+
+    if ensure_idx is None:
+        raise RuntimeError(
+            "Unable to find ensure_kv_transfer_initialized call "
+            "inside initialize_from_config"
+        )
+
+    indent = lines[ensure_idx][: len(lines[ensure_idx]) - len(lines[ensure_idx].lstrip())]
+    register_line = (
+        f"{indent}VLLMModelTracker.register_model("
+        f"ENGINE_NAME, self.model_runner.model)\n"
+    )
+    ensure_line = f"{indent}ensure_kv_transfer_initialized(self.vllm_config)\n"
+
+    changed = False
+    if not any("VLLMModelTracker.register_model(" in lines[idx] for idx in range(start, end)):
+        lines.insert(ensure_idx, register_line)
+        ensure_idx += 1
+        end += 1
+        changed = True
+
+    if lines[ensure_idx] != ensure_line:
+        lines[ensure_idx] = ensure_line
+        changed = True
+
+    return lines, changed
+
+
+def patch_gpu_worker(path: Path) -> bool:
+    original = path.read_text(encoding="utf-8")
+    lines = original.splitlines(keepends=True)
+    changed = False
+
+    lines, imports_changed = _ensure_imports(lines)
+    changed = changed or imports_changed
+
+    lines, env_changed = _comment_kv_init_in_worker_env(lines)
+    changed = changed or env_changed
+
+    lines, init_changed = _patch_initialize_from_config(lines)
+    changed = changed or init_changed
+
+    if not changed:
+        return False
+
+    _backup_file(path)
+    path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--module",
+        default="vllm.v1.worker.gpu_worker",
+        help="Module path to patch (default: vllm.v1.worker.gpu_worker)",
+    )
+    args = parser.parse_args()
+
+    try:
+        target_path = _find_module_path(args.module)
+    except Exception as exc:
+        print(f"Error locating module {args.module}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        did_patch = patch_gpu_worker(target_path)
+    except Exception as exc:
+        print(f"Error patching {target_path}: {exc}", file=sys.stderr)
+        return 1
+
+    if did_patch:
+        print(f"Patched {target_path}")
+        print("Backup created alongside the original file.")
+    else:
+        print(f"No changes needed in {target_path}")
+
+    print("Restart vLLM workers after patching.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/patch_vllm_gpu_worker.py
+++ b/scripts/patch_vllm_gpu_worker.py
@@ -89,7 +89,10 @@ def _comment_kv_init_in_worker_env(lines: list[str]) -> tuple[list[str], bool]:
     for idx in range(start, end):
         line = lines[idx]
         stripped = line.lstrip()
-        if "ensure_kv_transfer_initialized(" in stripped and not stripped.startswith("#"):
+        if (
+            "ensure_kv_transfer_initialized(" in stripped
+            and not stripped.startswith("#")
+        ):
             leading = line[: len(line) - len(stripped)]
             lines[idx] = f"{leading}# {stripped}"
             changed = True
@@ -114,7 +117,8 @@ def _patch_initialize_from_config(lines: list[str]) -> tuple[list[str], bool]:
             "inside initialize_from_config"
         )
 
-    indent = lines[ensure_idx][: len(lines[ensure_idx]) - len(lines[ensure_idx].lstrip())]
+    line = lines[ensure_idx]
+    indent = line[: len(line) - len(line.lstrip())]
     register_line = (
         f"{indent}VLLMModelTracker.register_model("
         f"ENGINE_NAME, self.model_runner.model)\n"
@@ -122,7 +126,10 @@ def _patch_initialize_from_config(lines: list[str]) -> tuple[list[str], bool]:
     ensure_line = f"{indent}ensure_kv_transfer_initialized(self.vllm_config)\n"
 
     changed = False
-    if not any("VLLMModelTracker.register_model(" in lines[idx] for idx in range(start, end)):
+    if not any(
+        "VLLMModelTracker.register_model(" in lines[idx]
+        for idx in range(start, end)
+    ):
         lines.insert(ensure_idx, register_line)
         ensure_idx += 1
         end += 1

--- a/scripts/patch_vllm_gpu_worker.py
+++ b/scripts/patch_vllm_gpu_worker.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Patch vLLM GPU worker for LMCache model tracking.
 
 This script:

--- a/tests/tools/test_patch_vllm_gpu_worker.py
+++ b/tests/tools/test_patch_vllm_gpu_worker.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Tests for the vLLM GPU worker patch script.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+import importlib.util
+
+# Third Party
+import pytest
+
+
+def _load_patch_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "patch_vllm_gpu_worker.py"
+    spec = importlib.util.spec_from_file_location(
+        "patch_vllm_gpu_worker",
+        script_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sample_gpu_worker_source() -> str:
+    return "\n".join(
+        [
+            "from vllm.logger import init_logger",
+            "",
+            "logger = init_logger(__name__)",
+            "",
+            "def init_worker_distributed_environment(vllm_config):",
+            "    ensure_kv_transfer_initialized(vllm_config)",
+            "",
+            "def initialize_from_config(self):",
+            "    ensure_kv_transfer_initialized(self.vllm_config)",
+            "",
+            "def other(self):",
+            "    pass",
+            "",
+        ]
+    )
+
+
+def test_patch_gpu_worker_idempotent(tmp_path: Path):
+    module = _load_patch_module()
+    worker_path = tmp_path / "gpu_worker.py"
+    worker_path.write_text(_sample_gpu_worker_source(), encoding="utf-8")
+
+    changed = module.patch_gpu_worker(worker_path)
+    assert changed is True
+
+    backup_path = worker_path.with_suffix(".py.bak")
+    assert backup_path.exists()
+
+    patched = worker_path.read_text(encoding="utf-8")
+    assert "from lmcache.integration.vllm.utils import ENGINE_NAME" in patched
+    assert "from lmcache.v1.compute.models.utils import VLLMModelTracker" in patched
+    assert "VLLMModelTracker.register_model(" in patched
+    assert "ensure_kv_transfer_initialized(self.vllm_config)" in patched
+    assert "# ensure_kv_transfer_initialized(vllm_config)" in patched
+
+    changed_again = module.patch_gpu_worker(worker_path)
+    assert changed_again is False

--- a/tests/tools/test_patch_vllm_gpu_worker.py
+++ b/tests/tools/test_patch_vllm_gpu_worker.py
@@ -9,10 +9,6 @@ Tests for the vLLM GPU worker patch script.
 from pathlib import Path
 import importlib.util
 
-# Third Party
-import pytest
-
-
 def _load_patch_module():
     repo_root = Path(__file__).resolve().parents[2]
     script_path = repo_root / "scripts" / "patch_vllm_gpu_worker.py"

--- a/tests/tools/test_patch_vllm_gpu_worker.py
+++ b/tests/tools/test_patch_vllm_gpu_worker.py
@@ -9,6 +9,7 @@ Tests for the vLLM GPU worker patch script.
 from pathlib import Path
 import importlib.util
 
+
 def _load_patch_module():
     repo_root = Path(__file__).resolve().parents[2]
     script_path = repo_root / "scripts" / "patch_vllm_gpu_worker.py"

--- a/tests/v1/test_blender_masks.py
+++ b/tests/v1/test_blender_masks.py
@@ -5,23 +5,27 @@ import pytest
 from lmcache.v1.compute.blend.blender import LMCBlender
 
 
-def _make_blender(num_layers: int = 1):
-    blender = LMCBlender.__new__(LMCBlender)
-    blender.num_layers = num_layers
-    calls: dict[str, object] = {"count": 0, "last": None}
+@pytest.fixture
+def blender_factory():
+    def _make_blender(num_layers: int = 1):
+        blender = LMCBlender.__new__(LMCBlender)
+        blender.num_layers = num_layers
+        calls: dict[str, object] = {"count": 0, "last": None}
 
-    def fake_blend_layer(tokens, mask=None, **kwargs):
-        calls["count"] += 1
-        calls["last"] = (tokens, mask, kwargs)
-        for _ in range(blender.num_layers + 2):
-            yield None
+        def fake_blend_layer(tokens, mask=None, **kwargs):
+            calls["count"] += 1
+            calls["last"] = (tokens, mask, kwargs)
+            for _ in range(blender.num_layers + 2):
+                yield None
 
-    blender.blend_layer = fake_blend_layer
-    return blender, calls
+        blender.blend_layer = fake_blend_layer
+        return blender, calls
+
+    return _make_blender
 
 
-def test_blend_all_true_mask_calls_blend_layer():
-    blender, calls = _make_blender()
+def test_blend_all_true_mask_calls_blend_layer(blender_factory):
+    blender, calls = blender_factory()
     tokens = torch.arange(4, dtype=torch.int64)
     mask = torch.ones(4, dtype=torch.bool)
 
@@ -30,8 +34,8 @@ def test_blend_all_true_mask_calls_blend_layer():
     assert calls["count"] == 1
 
 
-def test_blend_all_false_mask_skips():
-    blender, calls = _make_blender()
+def test_blend_all_false_mask_skips(blender_factory):
+    blender, calls = blender_factory()
     tokens = torch.arange(4, dtype=torch.int64)
     mask = torch.zeros(4, dtype=torch.bool)
 
@@ -40,8 +44,8 @@ def test_blend_all_false_mask_skips():
     assert calls["count"] == 0
 
 
-def test_blend_empty_tokens_skips():
-    blender, calls = _make_blender()
+def test_blend_empty_tokens_skips(blender_factory):
+    blender, calls = blender_factory()
     tokens = torch.tensor([], dtype=torch.int64)
     mask = torch.tensor([], dtype=torch.bool)
 
@@ -50,8 +54,8 @@ def test_blend_empty_tokens_skips():
     assert calls["count"] == 0
 
 
-def test_blend_mask_length_mismatch_raises():
-    blender, _ = _make_blender()
+def test_blend_mask_length_mismatch_raises(blender_factory):
+    blender, _ = blender_factory()
     tokens = torch.arange(4, dtype=torch.int64)
     mask = torch.ones(3, dtype=torch.bool)
 

--- a/tests/v1/test_blender_masks.py
+++ b/tests/v1/test_blender_masks.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-import torch
+# Third Party
 import pytest
+import torch
 
+# First Party
 from lmcache.v1.compute.blend.blender import LMCBlender
 
 
@@ -18,7 +20,7 @@ def blender_factory():
             for _ in range(blender.num_layers + 2):
                 yield None
 
-        blender.blend_layer = fake_blend_layer
+        blender.blend_layer = fake_blend_layer  # type: ignore[method-assign]
         return blender, calls
 
     return _make_blender

--- a/tests/v1/test_blender_masks.py
+++ b/tests/v1/test_blender_masks.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+
+from lmcache.v1.compute.blend.blender import LMCBlender
+
+
+def _make_blender(num_layers: int = 1):
+    blender = LMCBlender.__new__(LMCBlender)
+    blender.num_layers = num_layers
+    calls: dict[str, object] = {"count": 0, "last": None}
+
+    def fake_blend_layer(tokens, mask=None, **kwargs):
+        calls["count"] += 1
+        calls["last"] = (tokens, mask, kwargs)
+        for _ in range(blender.num_layers + 2):
+            yield None
+
+    blender.blend_layer = fake_blend_layer
+    return blender, calls
+
+
+def test_blend_all_true_mask_calls_blend_layer():
+    blender, calls = _make_blender()
+    tokens = torch.arange(4, dtype=torch.int64)
+    mask = torch.ones(4, dtype=torch.bool)
+
+    blender.blend(tokens, mask)
+
+    assert calls["count"] == 1
+
+
+def test_blend_all_false_mask_skips():
+    blender, calls = _make_blender()
+    tokens = torch.arange(4, dtype=torch.int64)
+    mask = torch.zeros(4, dtype=torch.bool)
+
+    blender.blend(tokens, mask)
+
+    assert calls["count"] == 0
+
+
+def test_blend_empty_tokens_skips():
+    blender, calls = _make_blender()
+    tokens = torch.tensor([], dtype=torch.int64)
+    mask = torch.tensor([], dtype=torch.bool)
+
+    blender.blend(tokens, mask)
+
+    assert calls["count"] == 0
+
+
+def test_blend_mask_length_mismatch_raises():
+    blender, _ = _make_blender()
+    tokens = torch.arange(4, dtype=torch.int64)
+    mask = torch.ones(3, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="Mask length"):
+        blender.blend(tokens, mask)

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -688,6 +688,88 @@ def test_layerwise_vllm_buffer_connector_with_gpu(use_gpu):
 
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
+    reason="TODO: Add non-CUDA implementation to VLLMBufferLayerwiseGPUConnector",
+)
+def test_layerwise_buffer_connector_unshared_mapping():
+    # Ensure the GPU buffer can allocate two aligned chunks (2 * 4096 bytes).
+    num_blocks = 16
+    block_size = 16
+    num_layers = 2
+    num_heads = 1
+    head_size = 8
+    device = "cuda"
+    hidden_dim = num_heads * head_size
+    dtype = torch.bfloat16
+
+    num_tokens = 8
+    chunk_size = 4
+
+    kvcaches = [
+        torch.zeros(
+            [2, num_blocks, block_size, num_heads, head_size],
+            dtype=dtype,
+            device=device,
+        )
+        for _ in range(num_layers)
+    ]
+
+    slot_mapping = torch.arange(num_tokens, device=device, dtype=torch.int64)
+
+    connector = VLLMBufferLayerwiseGPUConnector(
+        hidden_dim,
+        num_layers,
+        use_gpu=True,
+        dtype=dtype,
+        device=device,
+    )
+    connector.fused_rotary_emb = lambda old_pos, new_pos, k: k
+
+    allocator = PinMemoryAllocator(1024 * 1024)
+
+    starts = [0, chunk_size]
+    ends = [chunk_size, num_tokens]
+    memory_objs = []
+
+    for start, end in zip(starts, ends, strict=False):
+        shape = connector.get_shape(end - start)
+        layer_objs = []
+        for _ in range(num_layers):
+            mem_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_2TD)
+            assert mem_obj is not None
+            mem_obj.tensor.zero_()
+            mem_obj.metadata.cached_positions = torch.arange(
+                start, end, device=device, dtype=torch.int64
+            )
+            layer_objs.append(mem_obj)
+        memory_objs.append(layer_objs)
+
+    memory_objs = [list(row) for row in zip(*memory_objs, strict=False)]
+
+    mem_obj_consumer = connector.batched_to_gpu(
+        starts,
+        ends,
+        kvcaches=kvcaches,
+        slot_mapping=slot_mapping,
+        use_shared_buffer_mapping=False,
+    )
+    next(mem_obj_consumer)
+    for layer_id in range(num_layers):
+        mem_obj_consumer.send(memory_objs[layer_id])
+    next(mem_obj_consumer)
+
+    assert connector.buffer_mapping == {}
+    assert connector.gpu_buffer_allocator.memcheck()
+
+    for mem_obj_multi_layer in memory_objs:
+        for mem_obj in mem_obj_multi_layer:
+            mem_obj.ref_count_down()
+
+    assert allocator.memcheck()
+    allocator.close()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
 def test_vllm_paged_connector_v2_to_gpu_bench(benchmark):

--- a/tests/v1/test_layerwise_storers.py
+++ b/tests/v1/test_layerwise_storers.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+
+pytest.importorskip("vllm")
+
+# First Party
+from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
+
+
+def _empty_generator():
+    if False:
+        yield None
+
+
+def _one_step_generator():
+    yield None
+
+
+def test_finalize_layerwise_storers_handles_exhausted():
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector.layerwise_storers = [_empty_generator()]
+
+    connector._finalize_layerwise_storers("test")
+
+
+def test_finalize_layerwise_storers_advances_generator():
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    gen = _one_step_generator()
+    connector.layerwise_storers = [gen]
+
+    connector._finalize_layerwise_storers("test")
+
+    with pytest.raises(StopIteration):
+        next(gen)

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -63,6 +63,39 @@ def _slice_kv_at(
     ]
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="TODO: Add non CUDA implementations for CUDA enhanced functions",
+)
+def test_load_and_reshape_flash_empty_slot_mapping():
+    device = "cuda"
+    num_blocks = 4
+    block_size = 16
+    num_layers = 32
+    num_heads = 8
+    head_size = 128
+    dtype = torch.bfloat16
+
+    kv_cache = generate_kv_cache_paged(
+        num_blocks, device, block_size=block_size, dtype=dtype
+    )
+    slot_mapping = torch.empty(0, device=device, dtype=torch.int64)
+
+    key_value = torch.empty(
+        (2, num_layers, 0, num_heads * head_size),
+        device=device,
+        dtype=dtype,
+    )
+
+    lmc_ops.load_and_reshape_flash(
+        key_value,
+        kv_cache[0][0],
+        kv_cache[0][1],
+        slot_mapping,
+        0,
+    )
+
+
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 def test_extract_and_load_back(num_tokens):
     device = "cuda"

--- a/tests/v1/test_rope_cache_device.py
+++ b/tests/v1/test_rope_cache_device.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+# First Party
+from lmcache.v1.compute.positional_encoding import _match_rope_cache_device
+
+
+class _DummyRope:
+    def __init__(self, dtype: torch.dtype):
+        self.cos_sin_cache = torch.zeros((2, 2), dtype=dtype)
+
+
+class _DummyRopeWithMatcher:
+    def __init__(self):
+        self.called = False
+
+    def _match_cos_sin_cache_dtype(self, reference: torch.Tensor) -> None:
+        self.called = True
+
+
+def test_match_rope_cache_device_updates_dtype():
+    rope = _DummyRope(dtype=torch.float16)
+    reference = torch.zeros((2, 2), dtype=torch.float32)
+
+    _match_rope_cache_device(rope, reference)
+
+    assert rope.cos_sin_cache.dtype == reference.dtype
+
+
+def test_match_rope_cache_device_prefers_rope_matcher():
+    rope = _DummyRopeWithMatcher()
+    reference = torch.zeros((2, 2), dtype=torch.float32)
+
+    _match_rope_cache_device(rope, reference)
+
+    assert rope.called is True


### PR DESCRIPTION
# Problem Description

In LMCache with vLLM v1 and layerwise KV transfer + blending:

- ❌ Layerwise save can throw StopIteration during chunked prefill.
- ❌ Zero-token KV transfers can trigger CUDA invalid configuration errors.
- ❌ Blending can fail when a layer KV buffer is missing or the hit is too small.
- ❌ vLLM API changes (model wrappers, rope signature, attention import path) break
LMCache compute.
- ❌ There is no repo-provided, repeatable way to apply the vLLM GPU worker patch.

## Root Cause Analysis

### 1. Workflow

```text
Request → vLLM Scheduler → LMCache Integration → Layerwise storer/save → GPU transfer → Model compute → Blending
```

## 2. Key Code Logic

### Layerwise Save 
`lmcache/integration/vllm/vllm_v1_adapter.py`
  The adapter advances a layerwise generator once per layer. If the generator is already
  exhausted, `next()` raises `StopIteration`.

```python
next(layerwise_storer)
```

### Kernel Launch 
`csrc/mem_kernels.cu`
The CUDA grid size is derived from `num_tokens`. If `num_tokens == 0`, the kernel launch
should be skipped to avoid invalid configuration errors.

```c++
const int num_tokens = slot_mapping.size(0);
// launch grid uses num_tokens
```
### Blending 
`lmcache/v1/gpu_connector.py` + integration
Blending paths assume the layer KV buffer is present and the hit is large enough; missing
buffers or tiny hits can cause invalid accesses or unstable behavior.

### Model / RoPE Handling
`lmcache/v1/compute/models/base.py`, `lmcache/v1/compute/positional_encoding.py`
Embedding lookup and RoPE invocation assume a specific vLLM wrapper and function
signature, which changed across vLLM versions.

### Attention Import
`lmcache/v1/compute/attention/*.py`
vLLM moved attention modules; a direct import can break across versions.

```python
from vllm.attention import Attention
```

## 3. Why These Commits Are Needed
- Layerwise saving is a multi‑stage generator; without explicit finalization it can desync under chunked prefill and crash vLLM.
- Zero‑token save/load is a valid path under skip logic and needs safe no‑op behavior.
- Blending needs to handle missing GPU buffers or tiny hits to avoid invalid accesses and broken outputs.
- vLLM refactors changed wrapper/rope/attention APIs; LMCache must adapt to keep layerwise compute working.
- The vLLM GPU worker patch is required for model registration/kv transfer init and need a reproducible script.

## 4. Fix Solution
- Finalize/reset layerwise storers for chunked prefill and guard wait_for_save.
- Add early returns to CUDA kernels when `num_tokens == 0`.
- Isolate GPU buffer mapping per request; skip blending when KV buffers are missing or hits are too small.
- Unwrap vLLM models before embedding, support new rope signature, and add attention import fallbacks.
- Add `scripts/patch_vllm_gpu_worker.py` plus `README` guidance.


  - [x] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
