### PR TITLE
Introduce a remote config supplier service

### DIFF
--- a/examples/remote_config_server/README.md
+++ b/examples/remote_config_server/README.md
@@ -1,0 +1,123 @@
+# Remote Config Server Example
+
+This example provides a reference implementation of a remote config server
+that can be used with LMCache's dynamic configuration feature.
+
+## Overview
+
+LMCache supports fetching configuration from a remote config service at startup.
+This allows centralized management of LMCache configurations across multiple workers.
+
+## Configuration Fields
+
+To enable remote configuration, add these fields to your LMCache config file:
+
+```yaml
+# URL of the remote config service
+remote_config_url: "http://localhost:8088/config"
+
+# Optional: Application ID for identifying different applications
+app_id: "my-app-001"
+```
+
+## Protocol Specification
+
+### Request
+
+The LMCache worker sends a **POST** request to the `remote_config_url`:
+
+- **Method**: POST
+- **Query Parameters**: `?appId=<app_id>` (if `app_id` is configured)
+- **Headers**: `Content-Type: application/json`
+- **Body**:
+```json
+{
+    "current_config": {
+        "chunk_size": 256,
+        "local_device": "cpu",
+        ...
+    },
+    "env_variables": {
+        "LMCACHE_CONFIG_FILE": "/path/to/config.yaml",
+        "HOME": "/home/user",
+        ...
+    }
+}
+```
+
+### Response
+
+The config server should return a JSON response:
+
+```json
+{
+  "configs": [
+    {
+      "key": "chunk_size",
+      "override": false,
+      "value": 1024
+    },
+    {
+      "key": "max_local_cpu_size",
+      "override": false,
+      "value": 2
+    },
+    {
+      "key": "lmcache_worker_heartbeat_time",
+      "override": true,
+      "value": "14"
+    },
+    {
+      "key": "extra_config",
+      "override": true,
+      "value": "{\"internal_api_server_access_log\": true, \"internal_api_server_log_level\":\"info\", \"save_only_first_rank\": true, \"first_rank_max_local_cpu_size\": 1.1}"
+    }
+  ]
+}
+```
+
+#### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `configs` | array | List of configuration items to apply |
+| `configs[].key` | string | Configuration key name (must match LMCache config fields) |
+| `configs[].value` | any | Value to set for this configuration |
+| `configs[].override` | boolean | If `true`, always override. If `false`, only apply when current value is `None` |
+
+## Running the Example
+
+1. Install dependencies:
+```bash
+pip install flask
+```
+
+2. Start the config server:
+```bash
+python config_server.py
+```
+
+3. Configure LMCache to use this server:
+```yaml
+# example.yaml
+chunk_size: 256
+local_device: "cpu"
+remote_config_url: "http://localhost:8088/config"
+app_id: "test-app"
+```
+
+4. Start your LMCache-enabled application with the config file.
+
+## Customization
+
+You can customize the `config_server.py` to:
+- Fetch configurations from a database
+- Apply different configs based on `app_id`
+- Implement access control based on environment variables
+- Add logging and monitoring
+
+5. How to test
+
+Start standalone LMCache server to check if the config server and remote config are working properly.
+
+See the document of `standalone_starter` for more details.

--- a/examples/remote_config_server/config_server.py
+++ b/examples/remote_config_server/config_server.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Reference implementation of a remote config server for LMCache.
+
+This is a simple Flask-based config server that demonstrates the protocol
+between LMCache workers and a centralized configuration service.
+
+Usage:
+    python config_server.py [--port PORT] [--host HOST]
+
+The server exposes a single endpoint:
+    POST /config?appId=<app_id>
+
+See README.md for the full protocol specification.
+"""
+
+# Standard
+from typing import Any
+import argparse
+import logging
+
+# Third Party
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Example configuration database
+# In production, this could be fetched from a database, config file, or other service
+CONFIG_DATABASE: dict[str, list[dict[str, Any]]] = {
+    # Default configs applied to all apps
+    "default": [
+        {"key": "chunk_size", "value": 512, "override": False},
+        {"key": "max_local_cpu_size", "value": 1, "override": False},
+    ],
+    # App-specific configs
+    "test-app": [
+        {"key": "chunk_size", "value": 1024, "override": False},
+        {"key": "max_local_cpu_size", "value": 2, "override": False},
+        {"key": "lmcache_worker_heartbeat_time", "value": "14", "override": True},
+        {
+            "key": "extra_config",
+            "value": '{"internal_api_server_access_log": true, '
+            '"internal_api_server_log_level":"info", '
+            '"save_only_first_rank": true, '
+            '"first_rank_max_local_cpu_size": 1.1}',
+            "override": True,
+        },
+    ],
+    "production-app": [
+        {"key": "chunk_size", "value": 2048, "override": True},
+        {"key": "max_local_cpu_size", "value": 100, "override": True},
+    ],
+}
+
+
+def get_configs_for_app(
+    app_id: str | None,
+    current_config: dict[str, Any],
+    env_variables: dict[str, str],
+) -> list[dict[str, Any]]:
+    """
+    Determine which configs to return based on app_id and current state.
+
+    This is where you would implement your custom logic, such as:
+    - Looking up configs from a database
+    - Applying rules based on environment variables
+    - A/B testing different configurations
+    """
+    # Use dict to deduplicate by key, later entries override earlier ones
+    config_map: dict[str, dict[str, Any]] = {}
+
+    # Start with default configs
+    if "default" in CONFIG_DATABASE:
+        for item in CONFIG_DATABASE["default"]:
+            config_map[item["key"]] = item
+
+    # Add app-specific configs (override defaults with same keys)
+    if app_id and app_id in CONFIG_DATABASE:
+        for item in CONFIG_DATABASE[app_id]:
+            config_map[item["key"]] = item
+
+    return list(config_map.values())
+
+
+@app.route("/config", methods=["GET", "POST"])
+def get_config():
+    """
+    Handle config requests from LMCache workers.
+
+    Expected request body:
+    {
+        "current_config": {...},
+        "env_variables": {...}
+    }
+
+    Query parameters:
+    - appId: Optional application identifier
+    """
+    try:
+        # Parse request - supports both JSON body and form data
+        data = request.get_json(silent=True)
+        if data is None:
+            # Fallback to form data or query parameters
+            data = request.form.to_dict() or request.args.to_dict()
+
+        current_config = data.get("current_config", {})
+        env_variables = data.get("env_variables", {})
+        app_id = request.args.get("appId") or data.get("appId")
+
+        logger.info(
+            "Config request received - app_id: %s, current_config keys: %s",
+            app_id,
+            list(current_config.keys()),
+        )
+
+        # Get configs for this app
+        configs = get_configs_for_app(app_id, current_config, env_variables)
+
+        response = {"configs": configs}
+
+        logger.info("Returning %d config items for app_id: %s", len(configs), app_id)
+        return jsonify(response)
+
+    except Exception as e:
+        logger.exception("Error processing config request")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/health", methods=["GET"])
+def health_check():
+    """Health check endpoint."""
+    return jsonify({"status": "healthy"})
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="LMCache Remote Config Server Reference Implementation"
+    )
+    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
+    parser.add_argument("--port", type=int, default=8088, help="Port to listen on")
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+
+    args = parser.parse_args()
+
+    logger.info("Starting config server on %s:%d", args.host, args.port)
+    logger.info("Available app configs: %s", list(CONFIG_DATABASE.keys()))
+
+    app.run(host=args.host, port=args.port, debug=args.debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/remote_config_server/example.yaml
+++ b/examples/remote_config_server/example.yaml
@@ -1,0 +1,15 @@
+# Example LMCache configuration with remote config server
+# See README.md for more details
+
+chunk_size: 256
+local_device: "cpu"
+local_cpu: true
+max_local_cpu_size: 10
+internal_api_server_enabled: true
+internal_api_server_port_start: 9899
+
+# Remote configuration settings
+# The remote config server URL - LMCache will fetch additional configs from here
+remote_config_url: "http://localhost:8088/config"
+# Application ID to identify this LMCache instance
+app_id: "test-app"

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+import json
 import os
 import threading
+import urllib.error
+import urllib.parse
+import urllib.request
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -29,6 +33,153 @@ def is_false(value: str) -> bool:
     return value.lower() in ("false", "0", "no", "n", "off")
 
 
+def _fetch_remote_config(
+    remote_config_url: str,
+    lmcache_app_id: Optional[str],
+    config: LMCacheEngineConfig,
+    timeout: int = 10,
+) -> Optional[dict]:
+    """Fetch configuration from remote config service.
+
+    Args:
+        remote_config_url: URL of the remote config service.
+        lmcache_app_id: Optional app ID to send to the config service.
+        config: Current LMCacheEngineConfig to send to the config service.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed JSON response from the config service, or None if failed.
+    """
+    try:
+        # Build request payload with current config and env variables
+        payload: dict[str, Any] = {
+            "current_config": config.to_dict(),
+            "env_variables": {},
+        }
+
+        # Add lmcache_appId if provided
+        if lmcache_app_id:
+            payload["lmcache_appId"] = lmcache_app_id
+
+        # Collect all environment variables
+        for key, value in os.environ.items():
+            payload["env_variables"][key] = value
+
+        # Prepare and send request
+        request_data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            remote_config_url,
+            data=request_data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            response_data = response.read().decode("utf-8")
+            return json.loads(response_data)
+
+    except urllib.error.URLError as e:
+        logger.warning(f"Failed to fetch remote config from {remote_config_url}: {e}")
+        return None
+    except json.JSONDecodeError as e:
+        logger.warning(f"Failed to parse remote config response: {e}")
+        return None
+    except Exception as e:
+        logger.warning(f"Unexpected error fetching remote config: {e}")
+        return None
+
+
+def _apply_remote_configs(
+    config: LMCacheEngineConfig, remote_response: dict
+) -> LMCacheEngineConfig:
+    """Apply remote configuration to LMCacheEngineConfig.
+
+    This function extracts the 'configs' field from the remote response
+    and applies each config item to the LMCacheEngineConfig instance.
+
+    The expected format of remote_response['configs'] is:
+    [
+        {"override": true, "key": "config_key", "value": "config_value"},
+        ...
+    ]
+
+    Args:
+        config: LMCacheEngineConfig instance to update.
+        remote_response: Response from the remote config service.
+
+    Returns:
+        Updated LMCacheEngineConfig instance.
+    """
+    configs = remote_response.get("configs", [])
+    if not configs:
+        logger.debug("No configs found in remote response")
+        return config
+
+    applied_count = 0
+    for config_item in configs:
+        if not isinstance(config_item, dict):
+            logger.warning(f"Invalid config item format: {config_item}")
+            continue
+
+        key = config_item.get("key")
+        value = config_item.get("value")
+        override = config_item.get("override", True)
+
+        if not key:
+            logger.warning(f"Config item missing 'key': {config_item}")
+            continue
+
+        # Check if the config attribute exists
+        if not hasattr(config, key):
+            # If the key doesn't exist as a direct attribute, try to store it
+            # in extra_config
+            if config.extra_config is None:
+                config.extra_config = {}
+            if override or key not in config.extra_config:
+                config.extra_config[key] = value
+                logger.debug(f"Applied remote config to extra_config: {key}={value}")
+                applied_count += 1
+            continue
+
+        # Get current value
+        current_value = getattr(config, key)
+
+        # Skip if override is False and current value is not None/default
+        if not override and current_value is not None:
+            logger.debug(
+                f"Skipping remote config {key} (override=False, "
+                f"current value={current_value})"
+            )
+            continue
+
+        # Try to convert value to appropriate type
+        try:
+            if current_value is not None and value is not None:
+                # Convert to the same type as current value
+                if isinstance(current_value, bool):
+                    # Handle boolean conversion from string
+                    if isinstance(value, str):
+                        value = value.lower() in ("true", "1", "yes", "y", "on")
+                    else:
+                        value = bool(value)
+                elif isinstance(current_value, int):
+                    value = int(value)
+                elif isinstance(current_value, float):
+                    value = float(value)
+                elif isinstance(current_value, str):
+                    value = str(value)
+                # For list and dict, assume the value is already in correct format
+
+            setattr(config, key, value)
+            logger.info(f"Applied remote config: {key}={value}")
+            applied_count += 1
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Failed to apply remote config {key}={value}: {e}")
+
+    logger.info(f"Applied {applied_count} remote configuration items")
+    return config
+
+
 def lmcache_get_or_create_config() -> LMCacheEngineConfig:
     """Get the LMCache configuration from the environment variable
     `LMCACHE_CONFIG_FILE`. If the environment variable is not set, this
@@ -36,6 +187,11 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
 
     This function is thread-safe and implements singleton pattern,
     ensuring the configuration is loaded only once.
+
+    After loading the configuration, if 'remote_config_url' is configured,
+    this function will attempt to fetch additional configuration from the
+    remote config service. The current config and LMCACHE environment
+    variables will be sent to the service, along with 'lmcache_appId' if set.
     """
     global _config_instance
 
@@ -59,6 +215,27 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
                     _config_instance = LMCacheEngineConfig.from_file(config_file)
                     # Update config from environment variables
                     _config_instance.update_config_from_env()
+
+                # Fetch and apply remote configuration if configured
+                remote_config_url = _config_instance.remote_config_url
+                if remote_config_url:
+                    logger.info(
+                        f"Fetching remote configuration from {remote_config_url}"
+                    )
+                    lmcache_app_id = _config_instance.lmcache_appId
+                    remote_response = _fetch_remote_config(
+                        remote_config_url, lmcache_app_id, _config_instance
+                    )
+                    if remote_response:
+                        _config_instance = _apply_remote_configs(
+                            _config_instance, remote_response
+                        )
+                    else:
+                        logger.warning(
+                            "Failed to fetch remote configuration from %s. "
+                            "Using local configuration only.",
+                            remote_config_url,
+                        )
     return _config_instance
 
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Any, Optional, Tuple
-import json
+from typing import TYPE_CHECKING, Optional, Tuple
 import os
 import threading
-import urllib.error
-import urllib.parse
-import urllib.request
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -18,7 +14,8 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.config import LMCacheEngineConfig, _validate_and_set_config_value
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config_base import apply_remote_configs, fetch_remote_config
 
 logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
@@ -31,126 +28,6 @@ _config_lock = threading.Lock()
 def is_false(value: str) -> bool:
     """Check if the given string value is equivalent to 'false'."""
     return value.lower() in ("false", "0", "no", "n", "off")
-
-
-def _fetch_remote_config(
-    remote_config_url: str,
-    lmcache_app_id: Optional[str],
-    config: LMCacheEngineConfig,
-    timeout: int = 10,
-) -> Optional[dict]:
-    """Fetch configuration from remote config service.
-
-    Args:
-        remote_config_url: URL of the remote config service.
-        lmcache_app_id: Optional app ID to send to the config service.
-        config: Current LMCacheEngineConfig to send to the config service.
-        timeout: Request timeout in seconds.
-
-    Returns:
-        Parsed JSON response from the config service, or None if failed.
-    """
-    try:
-        # Build request payload with current config and env variables
-        payload: dict[str, Any] = {
-            "current_config": config.to_dict(),
-            "env_variables": {},
-        }
-
-        # Add lmcache_appId if provided
-        if lmcache_app_id:
-            remote_config_url = f"{remote_config_url}?appId={lmcache_app_id}"
-
-        # Collect all environment variables
-        for key, value in os.environ.items():
-            payload["env_variables"][key] = value
-
-        # Prepare and send request
-        request_data = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            remote_config_url,
-            data=request_data,
-            headers={"Content-Type": "application/json"},
-            method="GET",
-        )
-
-        with urllib.request.urlopen(req, timeout=timeout) as response:
-            response_data = response.read().decode("utf-8")
-            return json.loads(response_data)
-
-    except urllib.error.URLError as e:
-        logger.warning(f"Failed to fetch remote config from {remote_config_url}: {e}")
-        return None
-    except json.JSONDecodeError as e:
-        logger.warning(f"Failed to parse remote config response: {e}")
-        return None
-    except Exception as e:
-        logger.warning(f"Unexpected error fetching remote config: {e}")
-        return None
-
-
-def _apply_remote_configs(
-    config: LMCacheEngineConfig, remote_response: dict
-) -> LMCacheEngineConfig:
-    """Apply remote configuration to LMCacheEngineConfig.
-
-    This function extracts the 'configs' field from the remote response
-    and applies each config item to the LMCacheEngineConfig instance.
-
-    The expected format of remote_response['configs'] is:
-    [
-        {"override": true, "key": "config_key", "value": "config_value"},
-        ...
-    ]
-
-    Args:
-        config: LMCacheEngineConfig instance to update.
-        remote_response: Response from the remote config service.
-
-    Returns:
-        Updated LMCacheEngineConfig instance.
-    """
-    configs = remote_response.get("configs", [])
-    if not configs:
-        logger.info("No configs found in remote response")
-        return config
-
-    applied_count = 0
-    for config_item in configs:
-        if not isinstance(config_item, dict):
-            logger.warning(f"Invalid config item format: {config_item}")
-            continue
-
-        key = config_item.get("key")
-        value = config_item.get("value")
-        override = config_item.get("override", True)
-
-        if not key:
-            logger.warning(f"Config item missing 'key': {config_item}")
-            continue
-
-        # Get current value
-        current_value = getattr(config, key)
-
-        # Skip if override is False and current value is not None/default
-        if not override and current_value is not None:
-            logger.info(
-                f"Skipping remote config {key} (override=False, "
-                f"current value={current_value})"
-            )
-            continue
-
-        # Try to convert value to appropriate type
-        if _validate_and_set_config_value(config, key, value):
-            logger.info(f"Applied remote config: {key}={value}")
-            applied_count += 1
-        else:
-            logger.warning(
-                f"Failed to apply remote config {key}={value}. Using default value."
-            )
-
-    logger.info(f"Applied {applied_count} remote configuration items")
-    return config
 
 
 def lmcache_get_or_create_config() -> LMCacheEngineConfig:
@@ -196,11 +73,11 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
                         "Fetching remote configuration from %s", remote_config_url
                     )
                     lmcache_app_id = _config_instance.lmcache_app_id
-                    remote_response = _fetch_remote_config(
+                    remote_response = fetch_remote_config(
                         remote_config_url, lmcache_app_id, _config_instance
                     )
                     if remote_response:
-                        _config_instance = _apply_remote_configs(
+                        _config_instance = apply_remote_configs(
                             _config_instance, remote_response
                         )
                     else:

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -72,9 +72,9 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
                     logger.info(
                         "Fetching remote configuration from %s", remote_config_url
                     )
-                    lmcache_app_id = _config_instance.lmcache_app_id
+                    app_id = _config_instance.app_id
                     remote_response = fetch_remote_config(
-                        remote_config_url, lmcache_app_id, _config_instance
+                        remote_config_url, app_id, _config_instance
                     )
                     if remote_response:
                         _config_instance = apply_remote_configs(

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -59,7 +59,7 @@ def _fetch_remote_config(
 
         # Add lmcache_appId if provided
         if lmcache_app_id:
-            payload["appId"] = lmcache_app_id
+            remote_config_url = f"{remote_config_url}?appId={lmcache_app_id}"
 
         # Collect all environment variables
         for key, value in os.environ.items():
@@ -71,7 +71,7 @@ def _fetch_remote_config(
             remote_config_url,
             data=request_data,
             headers={"Content-Type": "application/json"},
-            method="POST",
+            method="GET",
         )
 
         with urllib.request.urlopen(req, timeout=timeout) as response:
@@ -127,18 +127,6 @@ def _apply_remote_configs(
 
         if not key:
             logger.warning(f"Config item missing 'key': {config_item}")
-            continue
-
-        # Check if the config attribute exists
-        if not hasattr(config, key):
-            # If the key doesn't exist as a direct attribute, try to store it
-            # in extra_config
-            if config.extra_config is None:
-                config.extra_config = {}
-            if override or key not in config.extra_config:
-                config.extra_config[key] = value
-                logger.info(f"Applied remote config to extra_config: {key}={value}")
-                applied_count += 1
             continue
 
         # Get current value

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -18,7 +18,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config import LMCacheEngineConfig, _validate_and_set_config_value
 
 logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
@@ -59,7 +59,7 @@ def _fetch_remote_config(
 
         # Add lmcache_appId if provided
         if lmcache_app_id:
-            payload["lmcache_appId"] = lmcache_app_id
+            payload["appId"] = lmcache_app_id
 
         # Collect all environment variables
         for key, value in os.environ.items():
@@ -112,7 +112,7 @@ def _apply_remote_configs(
     """
     configs = remote_response.get("configs", [])
     if not configs:
-        logger.debug("No configs found in remote response")
+        logger.info("No configs found in remote response")
         return config
 
     applied_count = 0
@@ -137,7 +137,7 @@ def _apply_remote_configs(
                 config.extra_config = {}
             if override or key not in config.extra_config:
                 config.extra_config[key] = value
-                logger.debug(f"Applied remote config to extra_config: {key}={value}")
+                logger.info(f"Applied remote config to extra_config: {key}={value}")
                 applied_count += 1
             continue
 
@@ -146,35 +146,20 @@ def _apply_remote_configs(
 
         # Skip if override is False and current value is not None/default
         if not override and current_value is not None:
-            logger.debug(
+            logger.info(
                 f"Skipping remote config {key} (override=False, "
                 f"current value={current_value})"
             )
             continue
 
         # Try to convert value to appropriate type
-        try:
-            if current_value is not None and value is not None:
-                # Convert to the same type as current value
-                if isinstance(current_value, bool):
-                    # Handle boolean conversion from string
-                    if isinstance(value, str):
-                        value = value.lower() in ("true", "1", "yes", "y", "on")
-                    else:
-                        value = bool(value)
-                elif isinstance(current_value, int):
-                    value = int(value)
-                elif isinstance(current_value, float):
-                    value = float(value)
-                elif isinstance(current_value, str):
-                    value = str(value)
-                # For list and dict, assume the value is already in correct format
-
-            setattr(config, key, value)
+        if _validate_and_set_config_value(config, key, value):
             logger.info(f"Applied remote config: {key}={value}")
             applied_count += 1
-        except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to apply remote config {key}={value}: {e}")
+        else:
+            logger.warning(
+                f"Failed to apply remote config {key}={value}. Using default value."
+            )
 
     logger.info(f"Applied {applied_count} remote configuration items")
     return config
@@ -220,9 +205,9 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
                 remote_config_url = _config_instance.remote_config_url
                 if remote_config_url:
                     logger.info(
-                        f"Fetching remote configuration from {remote_config_url}"
+                        "Fetching remote configuration from %s", remote_config_url
                     )
-                    lmcache_app_id = _config_instance.lmcache_appId
+                    lmcache_app_id = _config_instance.lmcache_app_id
                     remote_response = _fetch_remote_config(
                         remote_config_url, lmcache_app_id, _config_instance
                     )

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -41,7 +41,7 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
     After loading the configuration, if 'remote_config_url' is configured,
     this function will attempt to fetch additional configuration from the
     remote config service. The current config and LMCACHE environment
-    variables will be sent to the service, along with 'lmcache_appId' if set.
+    variables will be sent to the service, along with 'appid' if set.
     """
     global _config_instance
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -58,7 +58,8 @@ from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.utils import CacheStoreEvent, _lmcache_nvtx_annotate
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.compute.blend import LMCBlenderBuilder
-from lmcache.v1.config import LMCacheEngineConfig, _validate_and_set_config_value
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config_base import validate_and_set_config_value
 from lmcache.v1.gpu_connector import (
     GPUConnectorInterface,
     VLLMBufferLayerwiseGPUConnector,
@@ -678,7 +679,7 @@ class LMCacheConnectorV1Impl:
             for key, value in kv_connector_extra_config.items():
                 if key.startswith("lmcache."):
                     config_key = key[8:]  # Remove "lmcache." prefix
-                    if _validate_and_set_config_value(config, config_key, value):
+                    if validate_and_set_config_value(config, config_key, value):
                         logger.info(
                             f"Updated config {config_key} from vLLM "
                             f"extra config: {value}"

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -471,7 +471,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
             "fetch additional configuration from this URL at startup."
         ),
     },
-    "lmcache_appId": {
+    "lmcache_app_id": {
         "type": Optional[str],
         "default": None,
         "env_converter": str,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -471,7 +471,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
             "fetch additional configuration from this URL at startup."
         ),
     },
-    "lmcache_app_id": {
+    "app_id": {
         "type": Optional[str],
         "default": None,
         "env_converter": str,

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -711,28 +711,6 @@ def _update_config_from_env(self):
     return self
 
 
-def _validate_and_set_config_value(config, config_key, value):
-    """Validate and set configuration value"""
-    if not hasattr(config, config_key):
-        logger.warning("Config key '%s' does not exist in configuration", config_key)
-        return False
-
-    try:
-        # Convert string to dict for extra_config
-        if config_key == "extra_config" and isinstance(value, str):
-            value = json.loads(value) if value else None
-        setattr(config, config_key, value)
-        return True
-    except Exception as e:
-        logger.error(
-            "Failed to set config item '%s' with value %s: %s",
-            config_key,
-            value,
-            e,
-        )
-        return False
-
-
 # Create configuration class using the base utility
 LMCacheEngineConfig = create_config_class(
     config_name="LMCacheEngineConfig",

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -714,15 +714,21 @@ def _update_config_from_env(self):
 def _validate_and_set_config_value(config, config_key, value):
     """Validate and set configuration value"""
     if not hasattr(config, config_key):
-        logger.warning(f"Config key '{config_key}' does not exist in configuration")
+        logger.warning("Config key '%s' does not exist in configuration", config_key)
         return False
 
     try:
+        # Convert string to dict for extra_config
+        if config_key == "extra_config" and isinstance(value, str):
+            value = json.loads(value) if value else None
         setattr(config, config_key, value)
         return True
     except Exception as e:
         logger.error(
-            f"Failed to set config item '{config_key}' with value {value}: {e}"
+            "Failed to set config item '%s' with value %s: %s",
+            config_key,
+            value,
+            e,
         )
         return False
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -461,6 +461,26 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
             "interval to detect and handle timeouts. Default is 30 seconds."
         ),
     },
+    # Remote configuration service
+    "remote_config_url": {
+        "type": Optional[str],
+        "default": None,
+        "env_converter": str,
+        "description": (
+            "URL of the remote configuration service. When set, LMCache will "
+            "fetch additional configuration from this URL at startup."
+        ),
+    },
+    "lmcache_appId": {
+        "type": Optional[str],
+        "default": None,
+        "env_converter": str,
+        "description": (
+            "Application ID to send to the remote configuration service. "
+            "If not set, the remote service may infer it from current config "
+            "and environment variables."
+        ),
+    },
 }
 
 

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -14,11 +14,10 @@ import json
 import os
 import re
 import threading
-import urllib.error
-import urllib.request
 import uuid
 
 # Third Party
+import requests
 import yaml
 
 # First Party
@@ -612,6 +611,13 @@ def fetch_remote_config(
 ) -> Optional[dict]:
     """Fetch configuration from remote config service.
 
+    The config server protocol:
+    - Request: POST with JSON body containing 'current_config' and 'env_variables'
+    - Query parameter: 'appId' if app_id is provided
+    - Response: JSON with 'configs' array, each item has 'key', 'value', 'override'
+
+    See examples/remote_config_server/ for a reference implementation.
+
     Args:
         remote_config_url: URL of the remote config service.
         app_id: Optional app ID to send to the config service.
@@ -625,31 +631,24 @@ def fetch_remote_config(
         # Build request payload with current config and env variables
         payload: dict[str, Any] = {
             "current_config": config.to_dict(),
-            "env_variables": {},
+            "env_variables": {k: v for k, v in os.environ.items()},
         }
 
-        # Add lmcache_appId if provided
-        if app_id:
-            remote_config_url = "%s?appId=%s" % (remote_config_url, app_id)
+        # Build URL with app_id query parameter if provided
+        params = {"appId": app_id} if app_id else None
 
-        # Collect all environment variables
-        for key, value in os.environ.items():
-            payload["env_variables"][key] = value
-
-        # Prepare and send request
-        request_data = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
+        # Send POST request with JSON payload
+        response = requests.get(
             remote_config_url,
-            data=request_data,
+            json=payload,
+            params=params,
             headers={"Content-Type": "application/json"},
-            method="GET",
+            timeout=timeout,
         )
+        response.raise_for_status()
+        return response.json()
 
-        with urllib.request.urlopen(req, timeout=timeout) as response:
-            response_data = response.read().decode("utf-8")
-            return json.loads(response_data)
-
-    except urllib.error.URLError as e:
+    except requests.RequestException as e:
         logger.warning(
             "Failed to fetch remote config from %s: %s", remote_config_url, e
         )

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -727,20 +727,8 @@ def apply_remote_configs(config: Any, remote_response: dict) -> Any:
             logger.warning("Config item missing 'key': %s", config_item)
             continue
 
-        # Get current value
-        current_value = getattr(config, key)
-
-        # Skip if override is False and current value is not None/default
-        if not override and current_value is not None:
-            logger.info(
-                "Skipping remote config %s (override=False, current value=%s)",
-                key,
-                current_value,
-            )
-            continue
-
         # Try to convert value to appropriate type
-        if validate_and_set_config_value(config, key, value):
+        if validate_and_set_config_value(config, key, value, override=override):
             logger.info("Applied remote config: %s=%s", key, value)
             applied_count += 1
         else:

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -223,6 +223,11 @@ def create_config_class(
 
     def _post_init(self):
         """Post-initialization setup"""
+        # Initialize user-set keys tracking set
+        # This tracks which config keys were explicitly set by user
+        # (via file, env vars, or overrides) vs. using default values
+        if not hasattr(self, "_user_set_keys"):
+            object.__setattr__(self, "_user_set_keys", set())
         # Generate instance ID if not set
         if not hasattr(self, "lmcache_instance_id"):
             self.lmcache_instance_id = f"{config_name.lower()}_{uuid.uuid4().hex}"
@@ -252,6 +257,7 @@ def create_config_class(
         )
 
         config_values = {}
+        user_set_keys = set()  # Track keys explicitly set by user
         for name, config in config_definitions.items():
             if name in resolved_config:
                 try:
@@ -261,6 +267,7 @@ def create_config_class(
                     config_values[name] = _apply_env_converter_safely(
                         config_definitions, name, value
                     )
+                    user_set_keys.add(name)  # Mark as user-set
                 except (ValueError, json.JSONDecodeError) as e:
                     raw_value_for_log = resolved_config.get(name, "unknown value")
                     log_message = (
@@ -279,6 +286,8 @@ def create_config_class(
                 )
 
         instance = cls(**config_values)
+        # Store user-set keys in the instance
+        object.__setattr__(instance, "_user_set_keys", user_set_keys)
         return instance
 
     def _from_file(cls, file_path: str):
@@ -296,27 +305,41 @@ def create_config_class(
         )
 
         config_values = {}
+        user_set_keys = set()  # Track keys explicitly set by user
         for name, config in config_definitions.items():
-            value = resolved_config.get(name, config["default"])
+            if name in resolved_config:
+                value = resolved_config[name]
+                user_set_keys.add(name)  # Mark as user-set
+            else:
+                value = config["default"]
             # Apply env_converter safely regardless of whether value is None or not
             config_values[name] = _apply_env_converter_safely(
                 config_definitions, name, value
             )
 
         instance = cls(**config_values)
+        # Store user-set keys in the instance
+        object.__setattr__(instance, "_user_set_keys", user_set_keys)
         return instance
 
     def _from_defaults(cls, **kwargs):
         """Create configuration from defaults"""
         config_values = {}
+        user_set_keys = set()  # Track keys explicitly set by user
         for name, config in config_definitions.items():
-            value = kwargs.get(name, config["default"])
+            if name in kwargs:
+                value = kwargs[name]
+                user_set_keys.add(name)  # Mark as user-set
+            else:
+                value = config["default"]
             # Apply env_converter safely regardless of whether value is None or not
             config_values[name] = _apply_env_converter_safely(
                 config_definitions, name, value
             )
 
         instance = cls(**config_values)
+        # Store user-set keys in the instance
+        object.__setattr__(instance, "_user_set_keys", user_set_keys)
         return instance
 
     def _update_config_from_env(self):
@@ -343,6 +366,10 @@ def create_config_class(
             deprecated_configs,
         )
 
+        # Ensure _user_set_keys exists
+        if not hasattr(self, "_user_set_keys"):
+            object.__setattr__(self, "_user_set_keys", set())
+
         # Update config object
         for name, config in config_definitions.items():
             if name in resolved_config:
@@ -351,6 +378,8 @@ def create_config_class(
                     value = _parse_quoted_string(raw_value)
                     converted_value = config["env_converter"](value)
                     setattr(self, name, converted_value)
+                    # Mark as user-set
+                    self._user_set_keys.add(name)
                 except (ValueError, json.JSONDecodeError) as e:
                     raw_value_for_log = resolved_config.get(name, "unknown value")
                     log_message = (
@@ -371,12 +400,19 @@ def create_config_class(
             deprecated_configs,
         )
         config_values = {}
+        user_set_keys = set()  # Track keys explicitly set by user
         for name, config in config_definitions.items():
-            value = resolved_config.get(name, config["default"])
+            if name in resolved_config:
+                value = resolved_config[name]
+                user_set_keys.add(name)  # Mark as user-set
+            else:
+                value = config["default"]
             if value is not None:
                 value = config["env_converter"](value)
             config_values[name] = value
         instance = cls(**config_values)
+        # Store user-set keys in the instance
+        object.__setattr__(instance, "_user_set_keys", user_set_keys)
         return instance
 
     def _to_dict(self):
@@ -588,9 +624,11 @@ def validate_and_set_config_value(config, config_key, value, override: bool = Tr
         config: Configuration object to update.
         config_key: The configuration key to set.
         value: The value to set.
-        override: If True, completely replace the value. If False and the key is
-            'extra_config', merge with existing dict (new values take precedence
-            for conflicting keys). Default is True.
+        override: If True, completely replace the value. If False:
+            - For 'extra_config': merge with existing dict (new values take
+              precedence for conflicting keys).
+            - For other keys: skip if current value is not None.
+            Default is True.
 
     Returns:
         True if the value was set successfully, False otherwise.
@@ -618,6 +656,18 @@ def validate_and_set_config_value(config, config_key, value, override: bool = Tr
             # If current value is None or not a dict, just set the new value
             setattr(config, config_key, value)
             return True
+
+        # For non-extra_config keys: skip if override is False and key was user-set
+        if not override:
+            user_set_keys: set[str] = getattr(config, "_user_set_keys", set())
+            if config_key in user_set_keys:
+                current_value = getattr(config, config_key, None)
+                logger.info(
+                    "Skipping config %s (override=False, user-set value=%s)",
+                    config_key,
+                    current_value,
+                )
+                return True  # Return True as this is expected behavior, not an error
 
         setattr(config, config_key, value)
         return True

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -581,8 +581,20 @@ def parse_command_line_extra_params(extra_args: list[str]) -> dict[str, Any]:
     return params
 
 
-def validate_and_set_config_value(config, config_key, value):
-    """Validate and set configuration value."""
+def validate_and_set_config_value(config, config_key, value, override: bool = True):
+    """Validate and set configuration value.
+
+    Args:
+        config: Configuration object to update.
+        config_key: The configuration key to set.
+        value: The value to set.
+        override: If True, completely replace the value. If False and the key is
+            'extra_config', merge with existing dict (new values take precedence
+            for conflicting keys). Default is True.
+
+    Returns:
+        True if the value was set successfully, False otherwise.
+    """
     if not hasattr(config, config_key):
         logger.warning("Config key '%s' does not exist in configuration", config_key)
         return False
@@ -591,6 +603,22 @@ def validate_and_set_config_value(config, config_key, value):
         # Convert string to dict for extra_config
         if config_key == "extra_config" and isinstance(value, str):
             value = json.loads(value) if value else None
+
+        # Handle partial merge for extra_config when override is False
+        if config_key == "extra_config" and not override:
+            current_value = getattr(config, config_key, None)
+            if current_value is not None and isinstance(current_value, dict):
+                if value is not None and isinstance(value, dict):
+                    # Merge: current values are preserved, new values override conflicts
+                    merged_value = {**current_value, **value}
+                    setattr(config, config_key, merged_value)
+                    return True
+                # If new value is None or not a dict, keep current value
+                return True
+            # If current value is None or not a dict, just set the new value
+            setattr(config, config_key, value)
+            return True
+
         setattr(config, config_key, value)
         return True
     except Exception as e:

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -606,7 +606,7 @@ def validate_and_set_config_value(config, config_key, value):
 
 def fetch_remote_config(
     remote_config_url: str,
-    lmcache_app_id: Optional[str],
+    app_id: Optional[str],
     config: Any,
     timeout: int = 10,
 ) -> Optional[dict]:
@@ -614,7 +614,7 @@ def fetch_remote_config(
 
     Args:
         remote_config_url: URL of the remote config service.
-        lmcache_app_id: Optional app ID to send to the config service.
+        app_id: Optional app ID to send to the config service.
         config: Current LMCacheEngineConfig to send to the config service.
         timeout: Request timeout in seconds.
 
@@ -629,8 +629,8 @@ def fetch_remote_config(
         }
 
         # Add lmcache_appId if provided
-        if lmcache_app_id:
-            remote_config_url = "%s?appId=%s" % (remote_config_url, lmcache_app_id)
+        if app_id:
+            remote_config_url = "%s?appId=%s" % (remote_config_url, app_id)
 
         # Collect all environment variables
         for key, value in os.environ.items():

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -14,6 +14,8 @@ import json
 import os
 import re
 import threading
+import urllib.error
+import urllib.request
 import uuid
 
 # Third Party
@@ -578,3 +580,148 @@ def parse_command_line_extra_params(extra_args: list[str]) -> dict[str, Any]:
                 params[key] = value  # type: ignore[assignment]
             logger.info("Extra parameter: %s = %s", key, params[key])
     return params
+
+
+def validate_and_set_config_value(config, config_key, value):
+    """Validate and set configuration value."""
+    if not hasattr(config, config_key):
+        logger.warning("Config key '%s' does not exist in configuration", config_key)
+        return False
+
+    try:
+        # Convert string to dict for extra_config
+        if config_key == "extra_config" and isinstance(value, str):
+            value = json.loads(value) if value else None
+        setattr(config, config_key, value)
+        return True
+    except Exception as e:
+        logger.error(
+            "Failed to set config item '%s' with value %s: %s",
+            config_key,
+            value,
+            e,
+        )
+        return False
+
+
+def fetch_remote_config(
+    remote_config_url: str,
+    lmcache_app_id: Optional[str],
+    config: Any,
+    timeout: int = 10,
+) -> Optional[dict]:
+    """Fetch configuration from remote config service.
+
+    Args:
+        remote_config_url: URL of the remote config service.
+        lmcache_app_id: Optional app ID to send to the config service.
+        config: Current LMCacheEngineConfig to send to the config service.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed JSON response from the config service, or None if failed.
+    """
+    try:
+        # Build request payload with current config and env variables
+        payload: dict[str, Any] = {
+            "current_config": config.to_dict(),
+            "env_variables": {},
+        }
+
+        # Add lmcache_appId if provided
+        if lmcache_app_id:
+            remote_config_url = "%s?appId=%s" % (remote_config_url, lmcache_app_id)
+
+        # Collect all environment variables
+        for key, value in os.environ.items():
+            payload["env_variables"][key] = value
+
+        # Prepare and send request
+        request_data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            remote_config_url,
+            data=request_data,
+            headers={"Content-Type": "application/json"},
+            method="GET",
+        )
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            response_data = response.read().decode("utf-8")
+            return json.loads(response_data)
+
+    except urllib.error.URLError as e:
+        logger.warning(
+            "Failed to fetch remote config from %s: %s", remote_config_url, e
+        )
+        return None
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse remote config response: %s", e)
+        return None
+    except Exception as e:
+        logger.warning("Unexpected error fetching remote config: %s", e)
+        return None
+
+
+def apply_remote_configs(config: Any, remote_response: dict) -> Any:
+    """Apply remote configuration to LMCacheEngineConfig.
+
+    This function extracts the 'configs' field from the remote response
+    and applies each config item to the LMCacheEngineConfig instance.
+
+    The expected format of remote_response['configs'] is:
+    [
+        {"override": true, "key": "config_key", "value": "config_value"},
+        ...
+    ]
+
+    Args:
+        config: LMCacheEngineConfig instance to update.
+        remote_response: Response from the remote config service.
+
+    Returns:
+        Updated LMCacheEngineConfig instance.
+    """
+    configs = remote_response.get("configs", [])
+    if not configs:
+        logger.info("No configs found in remote response")
+        return config
+
+    applied_count = 0
+    for config_item in configs:
+        if not isinstance(config_item, dict):
+            logger.warning("Invalid config item format: %s", config_item)
+            continue
+
+        key = config_item.get("key")
+        value = config_item.get("value")
+        override = config_item.get("override", True)
+
+        if not key:
+            logger.warning("Config item missing 'key': %s", config_item)
+            continue
+
+        # Get current value
+        current_value = getattr(config, key)
+
+        # Skip if override is False and current value is not None/default
+        if not override and current_value is not None:
+            logger.info(
+                "Skipping remote config %s (override=False, current value=%s)",
+                key,
+                current_value,
+            )
+            continue
+
+        # Try to convert value to appropriate type
+        if validate_and_set_config_value(config, key, value):
+            logger.info("Applied remote config: %s=%s", key, value)
+            applied_count += 1
+        else:
+            logger.warning(
+                "Failed to apply remote config %s=%s. Using default value.",
+                key,
+                value,
+            )
+
+    logger.info("Applied %d remote configuration items", applied_count)
+    return config

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -25,7 +25,7 @@ import torch
 
 # First Party
 from lmcache.config import LMCacheEngineMetadata
-from lmcache.integration.vllm.utils import get_size_bytes
+from lmcache.integration.vllm.utils import get_size_bytes, lmcache_get_or_create_config
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
@@ -573,7 +573,7 @@ def main():
     logger.info("=" * 80)
 
     try:
-        config_path = args.config or os.getenv("LMCACHE_CONFIG_FILE")
+        config_path = args.config
         if config_path:
             logger.info("Loading LMCache config file: %s", config_path)
             config = LMCacheEngineConfig.from_file(config_path)
@@ -581,7 +581,7 @@ def main():
             config.update_config_from_env()
         else:
             logger.info("No config file specified, loading from environment variables.")
-            config = LMCacheEngineConfig.from_env()
+            config = lmcache_get_or_create_config()
         # Override with any extra command-line parameters
         if args.extra_params:
             override_config_from_dict(config, args.extra_params)

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -278,6 +278,71 @@ class TestValidateAndSetConfigValue:
         # Original value should be preserved on error
         assert config.extra_config == original_config
 
+    def test_set_basic_config_override_false_skip_when_user_set(self):
+        """Test override=False skips setting value for user-set config keys."""
+        # Create config with user-set chunk_size
+        config = LMCacheEngineConfig.from_defaults(chunk_size=256)
+        # Verify chunk_size is marked as user-set
+        assert "chunk_size" in config._user_set_keys
+
+        result = validate_and_set_config_value(
+            config, "chunk_size", 512, override=False
+        )
+        assert result is True
+        # Value should not be changed because override=False and key is user-set
+        assert config.chunk_size == 256
+
+    def test_set_basic_config_override_false_set_when_not_user_set(self):
+        """Test override=False sets value for non-user-set keys (default values)."""
+        config = LMCacheEngineConfig.from_defaults()
+        # chunk_size has default value 256, not user-set
+        assert "chunk_size" not in config._user_set_keys
+        assert config.chunk_size == 256  # Default value
+
+        result = validate_and_set_config_value(
+            config, "chunk_size", 512, override=False
+        )
+        assert result is True
+        # Value should be set because key is not user-set (just default)
+        assert config.chunk_size == 512
+
+    def test_set_basic_config_override_false_with_none_default(self):
+        """Test override=False sets value for None default keys when not user-set."""
+        config = LMCacheEngineConfig.from_defaults()
+        assert config.remote_url is None  # Default is None
+        assert "remote_url" not in config._user_set_keys
+
+        result = validate_and_set_config_value(
+            config, "remote_url", "http://example.com", override=False
+        )
+        assert result is True
+        # Value should be set because key is not user-set
+        assert config.remote_url == "http://example.com"
+
+    def test_set_basic_config_override_false_skip_user_set_none(self):
+        """Test override=False skips even if user explicitly set value to None."""
+        # User explicitly sets remote_url to None
+        config = LMCacheEngineConfig.from_defaults(remote_url=None)
+        assert "remote_url" in config._user_set_keys
+        assert config.remote_url is None
+
+        result = validate_and_set_config_value(
+            config, "remote_url", "http://example.com", override=False
+        )
+        assert result is True
+        # Value should NOT be changed because key is user-set (even though it's None)
+        assert config.remote_url is None
+
+    def test_set_basic_config_override_true_always_sets(self):
+        """Test that override=True always sets the value regardless of current value."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.chunk_size = 256
+
+        result = validate_and_set_config_value(config, "chunk_size", 512, override=True)
+        assert result is True
+        # Value should be changed because override=True
+        assert config.chunk_size == 512
+
 
 class TestApplyRemoteConfigs:
     """Test cases for apply_remote_configs function with override parameter."""
@@ -293,16 +358,30 @@ class TestApplyRemoteConfigs:
         apply_remote_configs(config, remote_response)
         assert config.chunk_size == 512
 
-    def test_apply_remote_configs_override_false_basic(self):
-        """Test override=False for basic config - value should still be set."""
-        config = LMCacheEngineConfig.from_defaults()
-        config.chunk_size = 256
+    def test_apply_remote_configs_override_false_basic_skip(self):
+        """Test override=False for basic config - skip if user-set."""
+        # Create config with user-set chunk_size
+        config = LMCacheEngineConfig.from_defaults(chunk_size=256)
+        assert "chunk_size" in config._user_set_keys
 
         remote_response = {
             "configs": [{"key": "chunk_size", "value": 512, "override": False}]
         }
         apply_remote_configs(config, remote_response)
-        # For non-extra_config keys, override=False still sets the value
+        # For user-set keys, override=False should skip
+        assert config.chunk_size == 256  # Original user-set value preserved
+
+    def test_apply_remote_configs_override_false_basic_set_when_default(self):
+        """Test override=False for basic config - set value if using default."""
+        config = LMCacheEngineConfig.from_defaults()
+        assert "chunk_size" not in config._user_set_keys
+        assert config.chunk_size == 256  # Default value
+
+        remote_response = {
+            "configs": [{"key": "chunk_size", "value": 512, "override": False}]
+        }
+        apply_remote_configs(config, remote_response)
+        # For non-user-set keys, override=False should set value
         assert config.chunk_size == 512
 
     def test_apply_remote_configs_extra_config_override_true(self):
@@ -424,3 +503,104 @@ class TestApplyRemoteConfigs:
         # Should not raise, just log warning
         result = apply_remote_configs(config, remote_response)
         assert result is config  # Returns the config object
+
+
+class TestUserSetKeysTracking:
+    """Test cases for _user_set_keys tracking functionality."""
+
+    def test_from_defaults_no_kwargs_empty_user_set_keys(self):
+        """Test that from_defaults without kwargs has empty _user_set_keys."""
+        config = LMCacheEngineConfig.from_defaults()
+        assert hasattr(config, "_user_set_keys")
+        assert len(config._user_set_keys) == 0
+
+    def test_from_defaults_with_kwargs_tracks_user_set_keys(self):
+        """Test that from_defaults with kwargs tracks user-set keys."""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=512,
+            remote_url="http://example.com",
+        )
+        assert "chunk_size" in config._user_set_keys
+        assert "remote_url" in config._user_set_keys
+        # Other keys should not be in _user_set_keys
+        assert "local_cpu" not in config._user_set_keys
+
+    def test_from_defaults_user_set_same_as_default(self):
+        """Test that user-set value same as default is still tracked."""
+        # Default chunk_size is 256
+        config = LMCacheEngineConfig.from_defaults(chunk_size=256)
+        # Even though value is same as default, it's user-set
+        assert "chunk_size" in config._user_set_keys
+        assert config.chunk_size == 256
+
+    def test_from_env_tracks_env_set_keys(self):
+        """Test that from_env tracks keys set via environment variables."""
+        os.environ["LMCACHE_CHUNK_SIZE"] = "1024"
+        os.environ["LMCACHE_REMOTE_URL"] = "http://env.example.com"
+        try:
+            config = LMCacheEngineConfig.from_env()
+            assert "chunk_size" in config._user_set_keys
+            assert "remote_url" in config._user_set_keys
+            assert config.chunk_size == 1024
+            assert config.remote_url == "http://env.example.com"
+        finally:
+            del os.environ["LMCACHE_CHUNK_SIZE"]
+            del os.environ["LMCACHE_REMOTE_URL"]
+
+    def test_update_config_from_env_adds_to_user_set_keys(self):
+        """Test that update_config_from_env adds newly set keys to _user_set_keys."""
+        config = LMCacheEngineConfig.from_defaults()
+        assert "chunk_size" not in config._user_set_keys
+
+        os.environ["LMCACHE_CHUNK_SIZE"] = "2048"
+        try:
+            config.update_config_from_env()
+            assert "chunk_size" in config._user_set_keys
+            assert config.chunk_size == 2048
+        finally:
+            del os.environ["LMCACHE_CHUNK_SIZE"]
+
+    def test_from_file_tracks_file_set_keys(self):
+        """Test that from_file tracks keys set in config file."""
+        config = LMCacheEngineConfig.from_file(BASE_DIR / "data/test_config.yaml")
+        # Keys in the config file should be in _user_set_keys
+        assert "extra_config" in config._user_set_keys
+
+    def test_from_dict_tracks_dict_set_keys(self):
+        """Test that from_dict tracks keys set in dictionary."""
+        config_dict = {
+            "chunk_size": 512,
+            "remote_url": "http://dict.example.com",
+        }
+        config = LMCacheEngineConfig.from_dict(config_dict)
+        assert "chunk_size" in config._user_set_keys
+        assert "remote_url" in config._user_set_keys
+        assert "local_cpu" not in config._user_set_keys
+
+    def test_override_false_respects_user_set_for_non_none_defaults(self):
+        """Test override=False respects user-set keys even for non-None defaults."""
+        # chunk_size has default 256 (not None)
+        # User explicitly sets it to 512
+        config = LMCacheEngineConfig.from_defaults(chunk_size=512)
+        assert config.chunk_size == 512
+        assert "chunk_size" in config._user_set_keys
+
+        # Remote config tries to set it with override=False
+        result = validate_and_set_config_value(
+            config, "chunk_size", 1024, override=False
+        )
+        assert result is True
+        # Value should NOT change because user set it
+        assert config.chunk_size == 512
+
+    def test_override_true_ignores_user_set_keys(self):
+        """Test that override=True changes value even if user-set."""
+        config = LMCacheEngineConfig.from_defaults(chunk_size=512)
+        assert "chunk_size" in config._user_set_keys
+
+        result = validate_and_set_config_value(
+            config, "chunk_size", 1024, override=True
+        )
+        assert result is True
+        # Value SHOULD change because override=True
+        assert config.chunk_size == 1024

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -8,7 +8,7 @@ import pytest
 
 # First Party
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.config_base import validate_and_set_config_value
+from lmcache.v1.config_base import apply_remote_configs, validate_and_set_config_value
 
 BASE_DIR = Path(__file__).parent
 
@@ -277,3 +277,150 @@ class TestValidateAndSetConfigValue:
         assert result is False
         # Original value should be preserved on error
         assert config.extra_config == original_config
+
+
+class TestApplyRemoteConfigs:
+    """Test cases for apply_remote_configs function with override parameter."""
+
+    def test_apply_remote_configs_override_true(self):
+        """Test that override=True completely replaces the config value."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.chunk_size = 256
+
+        remote_response = {
+            "configs": [{"key": "chunk_size", "value": 512, "override": True}]
+        }
+        apply_remote_configs(config, remote_response)
+        assert config.chunk_size == 512
+
+    def test_apply_remote_configs_override_false_basic(self):
+        """Test override=False for basic config - value should still be set."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.chunk_size = 256
+
+        remote_response = {
+            "configs": [{"key": "chunk_size", "value": 512, "override": False}]
+        }
+        apply_remote_configs(config, remote_response)
+        # For non-extra_config keys, override=False still sets the value
+        assert config.chunk_size == 512
+
+    def test_apply_remote_configs_extra_config_override_true(self):
+        """Test override=True completely replaces extra_config."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1", "key2": "value2"}
+
+        remote_response = {
+            "configs": [
+                {"key": "extra_config", "value": {"key3": "value3"}, "override": True}
+            ]
+        }
+        apply_remote_configs(config, remote_response)
+        assert config.extra_config == {"key3": "value3"}
+        assert "key1" not in config.extra_config
+        assert "key2" not in config.extra_config
+
+    def test_apply_remote_configs_extra_config_override_false_merge(self):
+        """Test override=False merges extra_config dictionaries."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1", "key2": "value2"}
+
+        remote_response = {
+            "configs": [
+                {
+                    "key": "extra_config",
+                    "value": {"key2": "new_value2", "key3": "value3"},
+                    "override": False,
+                }
+            ]
+        }
+        apply_remote_configs(config, remote_response)
+        # key1 should be preserved
+        assert config.extra_config["key1"] == "value1"
+        # key2 should be updated (new values take precedence)
+        assert config.extra_config["key2"] == "new_value2"
+        # key3 should be added
+        assert config.extra_config["key3"] == "value3"
+
+    def test_apply_remote_configs_extra_config_override_false_current_none(self):
+        """Test override=False when current extra_config is None."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = None
+
+        remote_response = {
+            "configs": [
+                {"key": "extra_config", "value": {"key1": "value1"}, "override": False}
+            ]
+        }
+        apply_remote_configs(config, remote_response)
+        assert config.extra_config == {"key1": "value1"}
+
+    def test_apply_remote_configs_default_override_is_true(self):
+        """Test that default override behavior is True when not specified."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1"}
+
+        # No 'override' key in config item, should default to True
+        remote_response = {
+            "configs": [{"key": "extra_config", "value": {"key2": "value2"}}]
+        }
+        apply_remote_configs(config, remote_response)
+        # Should completely replace
+        assert config.extra_config == {"key2": "value2"}
+        assert "key1" not in config.extra_config
+
+    def test_apply_remote_configs_multiple_items_mixed_override(self):
+        """Test applying multiple config items with different override settings."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.chunk_size = 256
+        config.extra_config = {"existing": "value"}
+
+        remote_response = {
+            "configs": [
+                {"key": "chunk_size", "value": 512, "override": True},
+                {
+                    "key": "extra_config",
+                    "value": {"new": "data"},
+                    "override": False,
+                },
+            ]
+        }
+        apply_remote_configs(config, remote_response)
+        assert config.chunk_size == 512
+        assert config.extra_config["existing"] == "value"
+        assert config.extra_config["new"] == "data"
+
+    def test_apply_remote_configs_empty_configs(self):
+        """Test applying empty configs list."""
+        config = LMCacheEngineConfig.from_defaults()
+        original_chunk_size = config.chunk_size
+
+        remote_response = {"configs": []}
+        apply_remote_configs(config, remote_response)
+        assert config.chunk_size == original_chunk_size
+
+    def test_apply_remote_configs_invalid_config_item(self):
+        """Test that invalid config items are skipped."""
+        config = LMCacheEngineConfig.from_defaults()
+        remote_response = {
+            "configs": [
+                "invalid_item",  # Not a dict
+                {"value": 512},  # Missing 'key'
+                {"key": "chunk_size", "value": 1024, "override": True},  # Valid
+            ]
+        }
+        apply_remote_configs(config, remote_response)
+        assert config.chunk_size == 1024
+
+    def test_apply_remote_configs_nonexistent_key(self):
+        """Test applying config with non-existent key."""
+        config = LMCacheEngineConfig.from_defaults()
+
+        remote_response = {
+            "configs": [
+                {"key": "nonexistent_key", "value": "some_value", "override": True}
+            ]
+        }
+        # Should not raise, just log warning
+        result = apply_remote_configs(config, remote_response)
+        assert result is config  # Returns the config object

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -8,6 +8,7 @@ import pytest
 
 # First Party
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config_base import validate_and_set_config_value
 
 BASE_DIR = Path(__file__).parent
 
@@ -136,3 +137,143 @@ def test_get_lookup_server_worker_ids(use_mla):
     assert lookup_server_worker_ids == [0, 3, 6]
 
     del os.environ["LMCACHE_LOOKUP_SERVER_WORKER_IDS"]
+
+
+class TestValidateAndSetConfigValue:
+    """Test cases for validate_and_set_config_value function."""
+
+    def test_set_basic_config_value(self):
+        """Test setting a basic configuration value."""
+        config = LMCacheEngineConfig.from_defaults()
+        result = validate_and_set_config_value(config, "chunk_size", 512)
+        assert result is True
+        assert config.chunk_size == 512
+
+    def test_set_nonexistent_key(self):
+        """Test setting a non-existent configuration key."""
+        config = LMCacheEngineConfig.from_defaults()
+        result = validate_and_set_config_value(config, "nonexistent_key", "value")
+        assert result is False
+
+    def test_set_extra_config_with_dict(self):
+        """Test setting extra_config with a dictionary value."""
+        config = LMCacheEngineConfig.from_defaults()
+        new_config = {"key1": "value1", "key2": "value2"}
+        result = validate_and_set_config_value(config, "extra_config", new_config)
+        assert result is True
+        assert config.extra_config == new_config
+
+    def test_set_extra_config_with_json_string(self):
+        """Test setting extra_config with a JSON string value."""
+        config = LMCacheEngineConfig.from_defaults()
+        json_str = '{"key1": "value1", "key2": "value2"}'
+        result = validate_and_set_config_value(config, "extra_config", json_str)
+        assert result is True
+        assert config.extra_config == {"key1": "value1", "key2": "value2"}
+
+    def test_set_extra_config_override_true(self):
+        """Test that override=True completely replaces extra_config."""
+        config = LMCacheEngineConfig.from_defaults()
+        # Set initial value
+        config.extra_config = {"key1": "value1", "key2": "value2"}
+
+        # Override with new value
+        new_config = {"key3": "value3"}
+        result = validate_and_set_config_value(
+            config, "extra_config", new_config, override=True
+        )
+        assert result is True
+        assert config.extra_config == {"key3": "value3"}
+        assert "key1" not in config.extra_config
+        assert "key2" not in config.extra_config
+
+    def test_set_extra_config_override_false_merge(self):
+        """Test that override=False merges extra_config dictionaries."""
+        config = LMCacheEngineConfig.from_defaults()
+        # Set initial value
+        config.extra_config = {"key1": "value1", "key2": "value2"}
+
+        # Merge with new value (override=False)
+        new_config = {"key2": "new_value2", "key3": "value3"}
+        result = validate_and_set_config_value(
+            config, "extra_config", new_config, override=False
+        )
+        assert result is True
+        # key1 should be preserved
+        assert config.extra_config["key1"] == "value1"
+        # key2 should be updated
+        assert config.extra_config["key2"] == "new_value2"
+        # key3 should be added
+        assert config.extra_config["key3"] == "value3"
+
+    def test_set_extra_config_override_false_with_json_string(self):
+        """Test merge with JSON string input when override=False."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"existing_key": "existing_value"}
+
+        json_str = '{"new_key": "new_value"}'
+        result = validate_and_set_config_value(
+            config, "extra_config", json_str, override=False
+        )
+        assert result is True
+        assert config.extra_config["existing_key"] == "existing_value"
+        assert config.extra_config["new_key"] == "new_value"
+
+    def test_set_extra_config_override_false_current_none(self):
+        """Test override=False when current extra_config is None."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = None
+
+        new_config = {"key1": "value1"}
+        result = validate_and_set_config_value(
+            config, "extra_config", new_config, override=False
+        )
+        assert result is True
+        assert config.extra_config == {"key1": "value1"}
+
+    def test_set_extra_config_override_false_new_value_none(self):
+        """Test override=False when new value is None, should keep current."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1"}
+
+        result = validate_and_set_config_value(
+            config, "extra_config", None, override=False
+        )
+        assert result is True
+        assert config.extra_config == {"key1": "value1"}
+
+    def test_set_extra_config_override_false_empty_string(self):
+        """Test override=False when new value is empty string."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1"}
+
+        result = validate_and_set_config_value(
+            config, "extra_config", "", override=False
+        )
+        assert result is True
+        # Empty string converts to None, so current value should be kept
+        assert config.extra_config == {"key1": "value1"}
+
+    def test_set_extra_config_default_override_is_true(self):
+        """Test that default behavior is override=True."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1"}
+
+        new_config = {"key2": "value2"}
+        # Don't pass override parameter, should default to True
+        result = validate_and_set_config_value(config, "extra_config", new_config)
+        assert result is True
+        # Should completely replace
+        assert config.extra_config == {"key2": "value2"}
+        assert "key1" not in config.extra_config
+
+    def test_set_extra_config_invalid_json_string(self):
+        """Test setting extra_config with invalid JSON string."""
+        config = LMCacheEngineConfig.from_defaults()
+        config.extra_config = {"key1": "value1"}
+        original_config = config.extra_config.copy()
+
+        result = validate_and_set_config_value(config, "extra_config", "invalid_json{")
+        assert result is False
+        # Original value should be preserved on error
+        assert config.extra_config == original_config


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

With this PR, we can obtain config from remote config server, thus, we can change backend or remote connector without modify lmcache.

**Special notes for your reviewers**:
A simple config.
```yaml
chunk_size: 256
local_device: "cpu"
local_cpu: True
max_local_cpu_size: 10
remote_config_url: "http://<LMCache_CONFIG_ADDR>/hcfs_adapter/get_plugin/"
lmcache_app_id: "lmcache_config_001"
```

The config server should reply config json.

E.g.
```json
{"configs":[{"override":true,"key":"lmcache_worker_heartbeat_time","value":"14"},{"override":false,"key":"extra_config","value":"{\"internal_api_server_access_log\": true, \"internal_api_server_log_level\":\"info\", \"save_only_first_rank\": true, \"first_rank_max_local_cpu_size\": 1.1}"}],"createUser":"","maintainer":""}
```

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
