### PR TITLE
[bugfix] Fix slot_mapping assertion error in v1 adapter for preempted requests

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -266,17 +266,21 @@ class RequestTracker:
             self.allocated_block_ids = new_block_ids
             # reset the number of saved tokens
             self.num_saved_tokens = lmcache_cached_tokens
-            num_computed_tokens = max(lmcache_cached_tokens, vllm_cached_tokens)
-
-            # FIX: For preempted requests, restore token_ids from the full
-            # token list to ensure chunk keys match what was used during
-            # lookup. The lookup uses request.all_token_ids, so we need the
-            # same tokens for retrieve.
-            num_tokens_needed = max(
-                num_computed_tokens + len(new_token_ids),
-                lmcache_cached_tokens,
-            )
+            # vLLM allocates blocks based on vllm_cached_tokens
+            num_computed_tokens = vllm_cached_tokens
+            # Restore token_ids from full token list for preempted requests
+            num_tokens_needed = num_computed_tokens + len(new_token_ids)
             self.token_ids = all_token_ids[:num_tokens_needed]
+
+            logger.debug(
+                f"Preempted request {self.req_id}: "
+                f"vllm_cached={vllm_cached_tokens}, "
+                f"lmcache_cached={lmcache_cached_tokens}, "
+                f"new_tokens={len(new_token_ids)}, "
+                f"num_tokens_needed={num_tokens_needed}, "
+                f"allocated_blocks={len(new_block_ids)}, "
+                f"token_ids_len={len(self.token_ids)}"
+            )
         else:
             self.allocated_block_ids.extend(new_block_ids)
             self.token_ids.extend(new_token_ids)
@@ -376,6 +380,16 @@ class ReqMeta:
         else:
             num_tokens_to_save = input_token_len
 
+        # Cap to allocated block capacity to prevent token_ids/slot_mapping mismatch
+        num_blocks = len(tracker.allocated_block_ids)
+        max_tokens = num_blocks * block_size
+        if num_tokens_to_save > max_tokens:
+            logger.warning(
+                f"Request {tracker.req_id}: num_tokens_to_save ({num_tokens_to_save}) "
+                f"exceeds allocated capacity ({max_tokens}). Capping to {max_tokens}."
+            )
+            num_tokens_to_save = max_tokens
+
         # If we need to save, update the number of saved tokens
         if not skip_save:
             tracker.num_saved_tokens = num_tokens_to_save
@@ -396,9 +410,7 @@ class ReqMeta:
             )
             token_ids = token_ids.tolist()
 
-        num_blocks = len(tracker.allocated_block_ids)
-
-        if len(token_ids) > num_blocks * block_size:
+        if len(token_ids) > max_tokens:
             logger.error(
                 "The number of tokens is more than the number of blocks"
                 " for request %s. "
@@ -1859,18 +1871,6 @@ class LMCacheConnectorV1Impl:
             if preempted:
                 assert load_spec is not None, (
                     f"Request {req_id} is preempted but was not given a load spec"
-                )
-                # num_computed_tokens should be reset to 0 during preemption
-                # and then set to the number of already cached tokens (maxxing
-                # prefix caching and lmcache)
-                # this assumption is crucial for the update() call of RequestTracker
-                assert request.num_computed_tokens == max(
-                    lmcache_cached_tokens, load_spec.vllm_cached_tokens
-                ), (
-                    f"Preempted request {req_id} has "
-                    f"num_computed_tokens {request.num_computed_tokens} "
-                    "but max(lmcache_cached_tokens, vllm_cached_tokens) = "
-                    f"{max(lmcache_cached_tokens, vllm_cached_tokens)}"
                 )
 
             # Pass all_token_ids for preempted requests to restore


### PR DESCRIPTION
Fixes #2327 

## What this PR does / why we need it

This PR fixes a critical bug in the vLLM v1 adapter that causes worker crashes with `AssertionError: assert len(slot_mapping) == len(token_ids)` when handling large context requests (~64K tokens) under concurrent load. The bug was introduced in v0.3.11 by commit 0a1e001f and manifests as pod crashes in production deployments.

## Root Cause Analysis

The assertion error occurs when `slot_mapping` (derived from allocated blocks) has a different length than `token_ids`. Through extensive debugging and binary search, we identified two root causes:

### Issue 1: Mismatch Between LMCache and vLLM Cached Token Counts

When a request is preempted and resumed, vLLM and LMCache may have cached different amounts of tokens:
- `vllm_cached_tokens`: Tokens in vLLM's local KV cache
- `lmcache_cached_tokens`: Tokens stored in LMCache's cache

By some reason, these values can differ, with `lmcache_cached_tokens > vllm_cached_tokens` in some cases.

**The Problem:**

vLLM's scheduler allocates memory blocks based on `vllm_cached_tokens`:
```
allocated_blocks = (vllm_cached_tokens + new_tokens) / block_size
```

The original code calculated `num_computed_tokens` using the maximum:
```python
num_computed_tokens = max(lmcache_cached_tokens, vllm_cached_tokens)
```

This creates a mismatch when `lmcache_cached_tokens > vllm_cached_tokens`:

**Example:**
- `vllm_cached_tokens = 44,944` → vLLM allocates blocks for 44,944 + 2,042 = 46,986 tokens
- `lmcache_cached_tokens = 45,000` (larger by some reason)
- `new_token_ids = 2,042`

Using `max()`:
- `num_computed_tokens = max(45,000, 44,944) = 45,000`
- `num_tokens_needed = 45,000 + 2,042 = 47,042`
- But vLLM only allocated blocks for 46,986 tokens
- When creating `slot_mapping` from allocated blocks: 46,986 slots
- But `token_ids` has 47,042 tokens
- **Assertion fails**: `assert len(slot_mapping) == len(token_ids)`

**The Fix:**

Since vLLM's scheduler has already made the block allocation decision based on `vllm_cached_tokens`, the adapter must use the same value:

```python
# vLLM allocates blocks based on vllm_cached_tokens
num_computed_tokens = vllm_cached_tokens
```

This ensures `num_tokens_needed` always matches vLLM's actual block allocation.

### Issue 2: Token Count Exceeding Allocated Block Capacity

In `from_request_tracker()`, `num_tokens_to_save` is calculated from `input_token_len`:
```python
if not is_last_prefill or discard_partial_chunks:
    num_tokens_to_save = (input_token_len // chunk_size) * chunk_size
else:
    num_tokens_to_save = input_token_len
```

This value can exceed the allocated block capacity (`num_blocks * block_size`), causing the assertion error.

**When does this happen?**

During preemption with reduced block allocation:
1. A request initially has many tokens (e.g., 43,008 tokens)
2. The request is preempted
3. Upon resumption, vLLM allocates fewer blocks (e.g., 2,576 blocks × 16 = 41,216 tokens)
4. But `input_token_len` is still 43,008 (the full token count)
5. `num_tokens_to_save = 43,008` exceeds allocated capacity of 41,216

**The Fix:**

Cap `num_tokens_to_save` to the allocated block capacity:

```python
# Cap to allocated block capacity to prevent token_ids/slot_mapping mismatch
num_blocks = len(tracker.allocated_block_ids)
max_tokens = num_blocks * block_size
if num_tokens_to_save > max_tokens:
    logger.warning(
        f"Request {tracker.req_id}: num_tokens_to_save ({num_tokens_to_save}) "
        f"exceeds allocated capacity ({max_tokens}). Capping to {max_tokens}."
    )
    num_tokens_to_save = max_tokens
```

This ensures we never try to save more tokens than we have allocated space for.

## Changes Made

1. **`RequestTracker.update()`**: Use `vllm_cached_tokens` instead of `max(lmcache_cached_tokens, vllm_cached_tokens)` to match vLLM's block allocation. Add debug logging for preempted requests.

2. **`ReqMeta.from_request_tracker()`**: Cap `num_tokens_to_save` to allocated block capacity to prevent exceeding available space.

3. **`LMCacheConnectorV1Impl`**: Remove incorrect assertion about `request.num_computed_tokens`.

## Testing

**Validation Environment**:
- 40 replicas on ml.g5.24xlarge (4 GPUs each)
- Model: `meta-llama/Llama-3.1-8B-Instruct`
- Config: `--enable-prefix-caching --max-model-len 70000 --tensor-parallel-size 4`
- Load: 100 concurrent requests with ~64K context

**Results**:
- **Before fix**: Multiple pods crashed within 5-10 minutes with assertion errors
- **After fix**: All 40 pods ran successfully for 6+ hours with no assertion errors or crashes
- **Baseline validation**: Deployed latest dev branch without fixes and confirmed the bug is reproducible

## Special notes for your reviewers

## If applicable

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Note: This is a critical bug fix for production stability. Unit tests would require mocking vLLM's scheduler behavior, which is complex. The fix has been validated in production with 40 replicas under heavy load.
