### PR TITLE
[docs] update stale cache interface readme

### DIFF
--- a/examples/cache_interface/README.md
+++ b/examples/cache_interface/README.md
@@ -1,5 +1,6 @@
 # User Controllable Caching
 This is an example to demonstrate user controllable caching (e.g., specify whether to cache a request or not).
+
 ## Prerequisites
 Your server should have at least 1 GPU.  
 
@@ -9,49 +10,80 @@ This will use the port 8000 for 1 vllm.
 1. Start the vllm engine at port 8000:
 
 ```bash
-CUDA_VISIBLE_DEVICES=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct \
-  --max-model-len 4096 \
-  --gpu-memory-utilization 0.8 \
-  --port 8000 \
-  --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+  --kv-transfer-config '{"kv_connector": "LMCacheConnectorV1","kv_role": "kv_both"}'
 ```
 
+2. Send a request to vllm engine with caching enabled (default behavior):  
 
-
-3. Send a request to vllm engine with `store_cache: True`:  
+**Using `/v1/completions`:**
 ```bash
 curl -X POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
     "prompt": "Explain the significance of KV cache in language models.",
-    "max_tokens": 10,
-    "store_cache": True,
+    "max_tokens": 10
+  }'
+```
+
+**Using `/v1/chat/completions`:**
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "messages": [
+      {"role": "user", "content": "Explain the significance of KV cache in language models."}
+    ],
+    "max_tokens": 10
   }'
 ```
 
 You should be able to see logs indicating the KV cache is stored:
 
 ```plaintext
-DEBUG LMCache: Store skips 0 tokens and then stores 13 tokens [2025-03-02 21:58:55,147]
+INFO: Storing KV cache for 13 out of 13 tokens (skip_leading_tokens=0)
 ```
 
-4. Send request to vllm engine 2:  
+3. Send a request with caching disabled:
+
+**Using `/v1/completions`:**
 ```bash
 curl -X POST http://localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
-    "prompt": "What's the weather today in Chicago?",
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "prompt": "What is the weather today in Chicago?",
     "max_tokens": 10,
-    "store_cache": False,
+    "kv_transfer_params": {
+      "lmcache.skip_save": true
+    }
+  }'
+```
+
+**Using `/v1/chat/completions`:**
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "messages": [
+      {"role": "user", "content": "What'"'"'s the weather today in Chicago?"}
+    ],
+    "max_tokens": 10,
+    "kv_transfer_params": {
+      "lmcache.skip_save": true
+    }
   }'
 ```
 
 You should be able to see logs indicating the KV cache is NOT stored:
 
 ```plaintext
-DEBUG LMCache: User has specified not to store the cache [2025-03-02 21:54:58,380]
+INFO: User has specified not to store the cache (store_cache: false)
 ```
 
-Note that cache is stored by default.
+Note that cache is stored by default. 
+To disable caching, pass `"kv_transfer_params": {"lmcache.skip_save": true}` in your request. 
+This works for both `/v1/completions` and `/v1/chat/completions` endpoints.


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes the `examples/cache_interface/README.md` which had two issues:
1. Step numbering was wrong (1, 3, 4 instead of 1, 2, 3)
2. The `store_cache` field shown in examples doesn't work - vLLM ignores it with warning: `The following fields were present in the request but ignored: {'store_cache'}`

Solution: replaced with the correct `kv_transfer_params.lmcache.skip_save` approach that was added in PR #1574.

Result
- Fix #1792 - this PR fixes the documentation issue. The underlying feature already works via `kv_transfer_params`.
- PR #1816 can be closed as duplicate - the problem was already solved in PR #1574, just the docs were outdated.

**Special notes for your reviewers**:

The `store_cache` top-level field was a v0 API that was never ported to v1. The working approach uses `kv_transfer_params`:
```json
{
 "kv_transfer_params": {
   "lmcache.skip_save": true
 }
}
```

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests