### PR TITLE
[Core] rust raw block mp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ lmcache/experimental/tests
 
 # Ignore all log files
 *.log
+# Rust build outputs
+**/target/
+**/Cargo.lock

--- a/lmcache/v1/multiprocess/__init__.py
+++ b/lmcache/v1/multiprocess/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+LMCache Multi-process Mode
+
+This module provides the multi-process mode for LMCache, allowing vLLM instances
+to connect to a separate LMCache server process for KV cache management.
+"""
+
+# First Party
+from lmcache.v1.multiprocess.mp_metadata import (
+    create_mp_server_metadata,
+    create_mp_server_metadata_from_gpu_context,
+)
+from lmcache.v1.multiprocess.mp_storage_manager import MPStorageManager
+
+__all__ = [
+    "create_mp_server_metadata",
+    "create_mp_server_metadata_from_gpu_context",
+    "MPStorageManager",
+]

--- a/lmcache/v1/multiprocess/mp_metadata.py
+++ b/lmcache/v1/multiprocess/mp_metadata.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MP Server Metadata Utilities
+
+Provides utilities for creating LMCacheEngineMetadata for the MP server.
+The MP server runs as a single process managing storage for all TP workers,
+so it uses world_size=1 regardless of the vLLM tensor parallel configuration.
+"""
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+
+
+def create_mp_server_metadata(
+    model_name: str,
+    num_layers: int,
+    hidden_dim: int,
+    kv_dtype: torch.dtype,
+    chunk_size: int = 256,
+    use_mla: bool = False,
+) -> LMCacheEngineMetadata:
+    """
+    Create LMCacheEngineMetadata for the MP server.
+
+    The MP server is a single process that manages storage for all TP workers.
+    Therefore, it uses world_size=1 to allow storage backends like
+    RustRawBlockBackend that don't support TP > 1.
+
+    Args:
+        model_name: Name of the model being served
+        num_layers: Number of layers in the model
+        hidden_dim: Hidden dimension size (num_heads * head_size)
+        kv_dtype: Data type for KV cache tensors
+        chunk_size: LMCache chunk size in tokens
+        use_mla: Whether the model uses Multi-head Latent Attention
+
+    Returns:
+        LMCacheEngineMetadata configured for MP server
+    """
+    kv_size = 1 if use_mla else 2
+    fmt = "KV_MLA_FMT" if use_mla else "KV_2LTD"
+
+    return LMCacheEngineMetadata(
+        model_name=model_name,
+        world_size=1,  # Single process manages storage
+        worker_id=0,
+        fmt=fmt,
+        kv_dtype=kv_dtype,
+        kv_shape=(num_layers, kv_size, chunk_size, 1, hidden_dim),
+        use_mla=use_mla,
+        role="mp_server",
+        chunk_size=chunk_size,
+    )
+
+
+def create_mp_server_metadata_from_gpu_context(
+    model_name: str,
+    num_layers: int,
+    hidden_dim: int,
+    kv_dtype: torch.dtype,
+    chunk_size: int,
+    is_mla: bool,
+) -> LMCacheEngineMetadata:
+    """
+    Create LMCacheEngineMetadata from GPU context information.
+
+    This is called when the first vLLM instance registers its KV cache
+    with the MP server.
+
+    Args:
+        model_name: Name of the model
+        num_layers: Number of layers from GPUCacheContext
+        hidden_dim: Hidden dimension from GPUCacheContext
+        kv_dtype: KV cache dtype from GPUCacheContext
+        chunk_size: LMCache chunk size
+        is_mla: Whether model uses MLA from GPUCacheContext
+
+    Returns:
+        LMCacheEngineMetadata configured for MP server
+    """
+    return create_mp_server_metadata(
+        model_name=model_name,
+        num_layers=num_layers,
+        hidden_dim=hidden_dim,
+        kv_dtype=kv_dtype,
+        chunk_size=chunk_size,
+        use_mla=is_mla,
+    )

--- a/lmcache/v1/multiprocess/mp_storage_manager.py
+++ b/lmcache/v1/multiprocess/mp_storage_manager.py
@@ -7,7 +7,8 @@ from collections.abc import Hashable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import compress
-from typing import Any, Generic, Iterator, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Generic, Iterator, Optional, TypeVar, Union
+import asyncio
 import threading
 import time
 
@@ -16,10 +17,16 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj, MixedMemoryAllocator
 from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
 from lmcache.v1.storage_backend.cache_policy.lru import LRUCachePolicy
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.config import LMCacheEngineMetadata
+    from lmcache.v1.config import LMCacheEngineConfig
+    from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 
 logger = init_logger(__name__)
 
@@ -184,11 +191,20 @@ class LRUCachePolicyWithLock(LRUCachePolicy[IPCCacheEngineKey]):
 
 
 class MPStorageManager:
-    def __init__(self, cpu_buffer_size: float):
+    def __init__(
+        self,
+        cpu_buffer_size: float,
+        config: Optional["LMCacheEngineConfig"] = None,
+        metadata: Optional["LMCacheEngineMetadata"] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ):
         """
         Args:
             cpu_buffer_size: the total size (in GB) of CPU memory buffer
                 to be used for storage
+            config: Optional LMCache config for L2 storage plugins
+            metadata: Optional metadata for L2 storage operations
+            loop: Optional asyncio event loop for async L2 operations
         """
         # Lock manager for locking memory objects
         # TODO: have separate lock manager for different storage backends
@@ -222,6 +238,153 @@ class MPStorageManager:
         # 1. allocator lock
         # 2. buffer lock
         # To avoid potential deadlock
+
+        # Optional L2 storage backends (raw block, disk, etc.)
+        self._config = config
+        self._metadata = metadata
+        self._loop = loop
+        self._l2_backends: OrderedDict[str, "StorageBackendInterface"] = OrderedDict()
+        self._l2_index: set[IPCCacheEngineKey] = set()
+        self._l2_index_lock = threading.Lock()
+
+        # Initialize L2 backends if config is provided
+        if config is not None and metadata is not None:
+            self._init_l2_backends()
+
+    def _init_l2_backends(self) -> None:
+        """Initialize L2 storage backends from config."""
+        if self._config is None or self._metadata is None:
+            return
+
+        # First Party
+        from lmcache.v1.storage_backend import CreateStorageBackends
+        from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+        try:
+            assert self._loop is not None
+            backends = CreateStorageBackends(
+                config=self._config,
+                metadata=self._metadata,
+                loop=self._loop,
+                dst_device="cpu",
+                lmcache_worker=None,
+            )
+
+            # Separate L2 backends (exclude LocalCPUBackend)
+            for name, backend in backends.items():
+                if not isinstance(backend, LocalCPUBackend):
+                    self._l2_backends[name] = backend
+
+            if self._l2_backends:
+                logger.info(
+                    "MPStorageManager: L2 backends initialized: %s",
+                    list(self._l2_backends.keys()),
+                )
+        except Exception as e:
+            logger.warning("Failed to initialize L2 backends: %s", e)
+
+    def _ipc_key_to_cache_key(
+        self,
+        ipc_key: IPCCacheEngineKey,
+    ) -> CacheEngineKey:
+        """Convert IPCCacheEngineKey to CacheEngineKey for storage backends."""
+        chunk_hash_int = int.from_bytes(
+            ipc_key.chunk_hash, byteorder="big", signed=True
+        )
+        fmt = self._metadata.fmt if self._metadata else "vllm"
+        dtype = self._metadata.kv_dtype if self._metadata else torch.bfloat16
+        return CacheEngineKey(
+            fmt=fmt,
+            model_name=ipc_key.model_name,
+            world_size=ipc_key.world_size,
+            worker_id=ipc_key.worker_id,
+            chunk_hash=chunk_hash_int,
+            dtype=dtype,
+        )
+
+    def _evict_to_l2(self, key: IPCCacheEngineKey, obj: MemoryObj) -> None:
+        """Evict a memory object to L2 storage."""
+        if not self._l2_backends:
+            return
+
+        cache_key = self._ipc_key_to_cache_key(key)
+
+        for name, backend in self._l2_backends.items():
+            try:
+                backend.batched_submit_put_task([cache_key], [obj])
+                with self._l2_index_lock:
+                    self._l2_index.add(key)
+                break
+            except Exception as e:
+                logger.warning("Failed to evict to L2 backend %s: %s", name, e)
+
+    def _store_to_l2_async(
+        self, key_obj_dict: dict[IPCCacheEngineKey, MemoryObj]
+    ) -> None:
+        """Asynchronously store committed objects to L2."""
+        if not self._l2_backends:
+            return
+
+        cache_keys = []
+        objs = []
+
+        for ipc_key, obj in key_obj_dict.items():
+            cache_key = self._ipc_key_to_cache_key(ipc_key)
+            cache_keys.append(cache_key)
+            objs.append(obj)
+
+        for name, backend in self._l2_backends.items():
+            try:
+                backend.batched_submit_put_task(cache_keys, objs)
+                with self._l2_index_lock:
+                    for ipc_key in key_obj_dict.keys():
+                        self._l2_index.add(ipc_key)
+                break
+            except Exception as e:
+                logger.warning("Failed to store to L2 backend %s: %s", name, e)
+
+    def _lookup_in_l2(self, keys: list[IPCCacheEngineKey]) -> int:
+        """Check how many consecutive keys exist in L2."""
+        if not self._l2_backends:
+            return 0
+
+        cache_keys = [self._ipc_key_to_cache_key(k) for k in keys]
+
+        for name, backend in self._l2_backends.items():
+            try:
+                hit_count = backend.batched_contains(cache_keys)
+                if hit_count > 0:
+                    return hit_count
+            except Exception as e:
+                logger.warning("L2 lookup failed for %s: %s", name, e)
+
+        return 0
+
+    def _load_from_l2(self, keys: list[IPCCacheEngineKey]) -> list[Optional[MemoryObj]]:
+        """Load memory objects from L2 storage."""
+        if not self._l2_backends:
+            return [None] * len(keys)
+
+        cache_keys = [self._ipc_key_to_cache_key(k) for k in keys]
+
+        for name, backend in self._l2_backends.items():
+            try:
+                objs = backend.batched_get_blocking(cache_keys)
+                if objs and any(o is not None for o in objs):
+                    logger.info("Loaded %d objects from L2 backend %s", len(objs), name)
+                    return objs
+            except Exception as e:
+                logger.warning("L2 load failed for %s: %s", name, e)
+
+        return [None] * len(keys)
+
+    def has_l2_storage(self) -> bool:
+        """Check if L2 storage is configured."""
+        return len(self._l2_backends) > 0
+
+    def get_l2_backend_names(self) -> list[str]:
+        """Get names of configured L2 backends."""
+        return list(self._l2_backends.keys())
 
     def _allocate_new_reserve_handle(self) -> ReserveHandle:
         """Allocate a new reserve handle in a thread-safe manner."""
@@ -353,11 +516,14 @@ class MPStorageManager:
 
                 for key in candidates:
                     obj = self._commited_memory_objects.pop(key)
+                    # Evict to L2 before freeing (if L2 is configured)
+                    self._evict_to_l2(key, obj)
                     obj.ref_count_down()
 
                 logger.info(
-                    "Recycled %d committed memory objects to free up space.",
+                    "Recycled %d committed memory objects to free up space%s.",
                     len(candidates),
+                    " (evicted to L2)" if self._l2_backends else "",
                 )
 
                 # Try to allocate again
@@ -401,6 +567,10 @@ class MPStorageManager:
                 self._cache_policy.update_on_put(key)
                 self._reserved_keys.remove(key)
 
+        # Async store to L2 for persistence (if L2 is configured)
+        if self._l2_backends and reserved_dict:
+            self._store_to_l2_async(reserved_dict)
+
     @_lmcache_nvtx_annotate
     def lookup(
         self,
@@ -414,7 +584,7 @@ class MPStorageManager:
         Returns:
             int: the total number of found keys (prefix matching)
         """
-        # TODO: implement LOCK mechanism
+        # Check L1 (CPU memory) first
         found_count = 0
         with self._buffer_lock:
             for key in keys:
@@ -423,6 +593,29 @@ class MPStorageManager:
                     self._obj_lock_manager.lock(key)
                 else:
                     break
+
+        if found_count == len(keys):
+            return found_count
+
+        # Check L2 for remaining keys (if L2 is configured)
+        if self._l2_backends:
+            remaining_keys = keys[found_count:]
+            l2_hits = self._lookup_in_l2(remaining_keys)
+
+            if l2_hits > 0:
+                # Load from L2 to L1 and lock
+                keys_to_load = remaining_keys[:l2_hits]
+                loaded = self._load_from_l2(keys_to_load)
+
+                with self._buffer_lock:
+                    for key, obj in zip(keys_to_load, loaded, strict=False):
+                        if obj is not None:
+                            self._commited_memory_objects[key] = obj
+                            self._obj_lock_manager.lock(key)
+                            found_count += 1
+                        else:
+                            break
+
         return found_count
 
     @_lmcache_nvtx_annotate
@@ -505,6 +698,15 @@ class MPStorageManager:
         """
         Release the resources held by the storage manager.
         """
+        # Close L2 backends first
+        for name, backend in self._l2_backends.items():
+            try:
+                backend.close()
+                logger.info("Closed L2 backend: %s", name)
+            except Exception as e:
+                logger.warning("Error closing L2 backend %s: %s", name, e)
+
+        # Close L1 memory allocator
         self._memory_allocator.close()
 
     def memcheck(self):
@@ -538,3 +740,7 @@ class MPStorageManager:
             )
             self._reserved_memory_object_pools.clear()
             self._reserved_keys.clear()
+
+        # Clear L2 index
+        with self._l2_index_lock:
+            self._l2_index.clear()

--- a/lmcache/v1/multiprocess/mp_storage_manager.py
+++ b/lmcache/v1/multiprocess/mp_storage_manager.py
@@ -291,8 +291,9 @@ class MPStorageManager:
         chunk_hash_int = int.from_bytes(
             ipc_key.chunk_hash, byteorder="big", signed=True
         )
-        fmt = self._metadata.fmt if self._metadata else "vllm"
-        dtype = self._metadata.kv_dtype if self._metadata else torch.bfloat16
+        assert self._metadata is not None, "L2 storage operations require metadata."
+        fmt = self._metadata.fmt
+        dtype = self._metadata.kv_dtype
         return CacheEngineKey(
             fmt=fmt,
             model_name=ipc_key.model_name,
@@ -371,7 +372,10 @@ class MPStorageManager:
             try:
                 objs = backend.batched_get_blocking(cache_keys)
                 if objs and any(o is not None for o in objs):
-                    logger.info("Loaded %d objects from L2 backend %s", len(objs), name)
+                    loaded_count = sum(1 for o in objs if o is not None)
+                    logger.info(
+                        "Loaded %d objects from L2 backend %s", loaded_count, name
+                    )
                     return objs
             except Exception as e:
                 logger.warning("L2 load failed for %s: %s", name, e)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -11,8 +11,10 @@
 ###
 
 # Standard
+from typing import Optional
 import argparse
 import array
+import asyncio
 import threading
 import time
 
@@ -24,8 +26,12 @@ import zmq
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey, KVCache
+from lmcache.v1.multiprocess.mp_metadata import (
+    create_mp_server_metadata_from_gpu_context,
+)
 from lmcache.v1.multiprocess.mp_storage_manager import MPStorageManager
 from lmcache.v1.multiprocess.mq import MessageQueueServer
 from lmcache.v1.multiprocess.protocol import (
@@ -206,7 +212,12 @@ class GPUCacheContext:
 
 
 class MPCacheEngine:
-    def __init__(self, chunk_size: int = 256, cpu_buffer_size: float = 5.0):
+    def __init__(
+        self,
+        chunk_size: int = 256,
+        cpu_buffer_size: float = 5.0,
+        config: Optional[LMCacheEngineConfig] = None,
+    ):
         # GPU ID -> KV cache tensors
         self.gpu_contexts: dict[int, GPUCacheContext] = {}
 
@@ -216,8 +227,74 @@ class MPCacheEngine:
         # thread lock to avoid tmp buffer conflicts
         self.lock = threading.Lock()
 
-        # storage manager
-        self.storage_manager = MPStorageManager(cpu_buffer_size)
+        # Store config for deferred storage manager initialization
+        self._config = config
+        self._cpu_buffer_size = cpu_buffer_size
+
+        # Event loop for async storage operations (if L2 configured)
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_thread: Optional[threading.Thread] = None
+        if config is not None:
+            self._loop = asyncio.new_event_loop()
+            self._loop_thread = threading.Thread(
+                target=self._run_event_loop, daemon=True
+            )
+            self._loop_thread.start()
+
+        # Storage manager (created after first GPU context registers, for metadata)
+        self._storage_manager: Optional[MPStorageManager] = None
+
+        if config is not None:
+            logger.info(
+                "MPCacheEngine initialized with L2 storage plugins: %s",
+                config.storage_plugins or "none",
+            )
+
+    def _run_event_loop(self):
+        """Run the event loop in a background thread."""
+        if self._loop:
+            asyncio.set_event_loop(self._loop)
+            self._loop.run_forever()
+
+    def _initialize_storage_manager(self, gpu_context: GPUCacheContext) -> None:
+        """Initialize storage manager after first GPU context registers."""
+        if self._storage_manager is not None:
+            return
+
+        metadata = None
+        if self._config is not None:
+            # Create metadata from GPU context for L2 storage
+            metadata = create_mp_server_metadata_from_gpu_context(
+                model_name="mp_server_model",
+                num_layers=gpu_context.num_layers,
+                hidden_dim=gpu_context.hidden_dim_size,
+                kv_dtype=gpu_context.dtype,
+                chunk_size=self.chunk_size,
+                is_mla=gpu_context.is_mla,
+            )
+
+        self._storage_manager = MPStorageManager(
+            cpu_buffer_size=self._cpu_buffer_size,
+            config=self._config,
+            metadata=metadata,
+            loop=self._loop,
+        )
+
+        if self._config is not None and self._storage_manager.has_l2_storage():
+            logger.info(
+                "MPCacheEngine storage manager initialized with L2 backends: %s",
+                self._storage_manager.get_l2_backend_names(),
+            )
+
+    @property
+    def storage_manager(self) -> MPStorageManager:
+        """Get storage manager (lazy initialization)."""
+        if self._storage_manager is None:
+            # Create basic storage manager without L2 support
+            self._storage_manager = MPStorageManager(
+                cpu_buffer_size=self._cpu_buffer_size,
+            )
+        return self._storage_manager
 
     def register_kv_cache(self, instance_id: int, kv_caches: KVCache) -> None:
         """
@@ -229,6 +306,10 @@ class MPCacheEngine:
         """
         gpu_context = GPUCacheContext(kv_caches)
         self.gpu_contexts[instance_id] = gpu_context
+
+        # Initialize storage manager with metadata from first GPU context
+        self._initialize_storage_manager(gpu_context)
+
         logger.info(
             "Registered KV cache for GPU ID %d with %d layers",
             instance_id,
@@ -492,6 +573,99 @@ class MPCacheEngine:
             self.storage_manager.memcheck()
 
 
+def create_config_from_args(args) -> Optional[LMCacheEngineConfig]:
+    """
+    Create LMCacheEngineConfig from server CLI arguments.
+
+    Returns None if no storage plugins are configured (CPU-only mode).
+    Returns config if storage plugins are configured (L2 storage enabled).
+    """
+    # If config file is provided, use it
+    if hasattr(args, "config_file") and args.config_file:
+        config = LMCacheEngineConfig.from_file(args.config_file)
+        logger.info("Loaded config from file: %s", args.config_file)
+        return config
+
+    # Check if any storage plugin is requested via CLI
+    has_raw_block = hasattr(args, "raw_block_device") and args.raw_block_device
+    has_local_disk = hasattr(args, "local_disk") and args.local_disk
+
+    if not has_raw_block and not has_local_disk:
+        # No storage plugins, use legacy MPCacheEngine
+        return None
+
+    # Build config from CLI args
+    extra_config = {}
+    storage_plugins = []
+
+    if has_raw_block:
+        storage_plugins.append("raw_block")
+        module_path = "lmcache.v1.storage_backend.plugins.rust_raw_block_backend"
+        extra_config.update(
+            {
+                "storage_plugin.raw_block.module_path": module_path,
+                "storage_plugin.raw_block.class_name": "RustRawBlockBackend",
+                "rust_raw_block.device_path": args.raw_block_device,
+                "rust_raw_block.use_odirect": getattr(args, "enable_odirect", False),
+                "rust_raw_block.manifest_write_interval": 1,
+            }
+        )
+        if hasattr(args, "raw_block_capacity_gb") and args.raw_block_capacity_gb > 0:
+            extra_config["rust_raw_block.capacity_bytes"] = int(
+                args.raw_block_capacity_gb * (1 << 30)
+            )
+        logger.info(
+            "Configured Raw Block backend: device=%s, odirect=%s",
+            args.raw_block_device,
+            getattr(args, "enable_odirect", False),
+        )
+
+    if has_local_disk:
+        storage_plugins.append("local_disk")
+        extra_config.update(
+            {
+                "local_disk": args.local_disk,
+                "max_local_disk_size": getattr(args, "max_local_disk_size", 100.0),
+            }
+        )
+        logger.info("Configured Local Disk backend: path=%s", args.local_disk)
+
+    # Create config
+    config = LMCacheEngineConfig(
+        chunk_size=args.chunk_size,
+        local_cpu=True,
+        max_local_cpu_size=args.cpu_buffer_size,
+        storage_plugins=storage_plugins if storage_plugins else None,
+        extra_config=extra_config if extra_config else None,
+    )
+
+    return config
+
+
+def create_cache_engine(args) -> MPCacheEngine:
+    """
+    Create the cache engine with optional L2 storage support.
+
+    If storage plugins are configured (via CLI or config file),
+    the engine will support tiered storage (CPU + L2).
+    """
+    config = create_config_from_args(args)
+
+    if config is not None:
+        logger.info(
+            "Using MPCacheEngine with L2 storage plugins: %s",
+            config.storage_plugins or "none",
+        )
+    else:
+        logger.info("Using MPCacheEngine (CPU-only storage)")
+
+    return MPCacheEngine(
+        chunk_size=args.chunk_size,
+        cpu_buffer_size=args.cpu_buffer_size,
+        config=config,
+    )
+
+
 def add_handler_helper(
     server: MessageQueueServer, request_type: RequestType, handler_function
 ):
@@ -511,14 +685,41 @@ def run_cache_server(
     chunk_size: int = 256,
     cpu_buffer_size: float = 5.0,
     max_workers: int = 1,
+    args=None,
 ):
-    # Initialize the engine
-    engine = MPCacheEngine(chunk_size, cpu_buffer_size)
+    """
+    Run the LMCache multi-process server.
+
+    Args:
+        host: Server host address
+        port: Server port
+        chunk_size: KV cache chunk size
+        cpu_buffer_size: CPU buffer size in GB
+        max_workers: Number of worker threads
+        args: Optional parsed command-line arguments (overrides other args)
+    """
+    # Support both keyword args and argparse namespace
+    if args is None:
+        # Standard
+        import argparse
+
+        args = argparse.Namespace(
+            host=host,
+            port=port,
+            chunk_size=chunk_size,
+            cpu_buffer_size=cpu_buffer_size,
+            max_workers=max_workers,
+        )
+
+    # Initialize the appropriate engine
+    engine = create_cache_engine(args)
 
     # Initialize the message queue server
     context = zmq.Context.instance()
     server = MessageQueueServer(
-        bind_url=f"tcp://{host}:{port}", context=context, max_workers=max_workers
+        bind_url=f"tcp://{args.host}:{args.port}",
+        context=context,
+        max_workers=args.max_workers,
     )
 
     # Add handlers
@@ -536,7 +737,7 @@ def run_cache_server(
     # Start the server
     torch.cuda.init()
     server.start()
-    logger.info("LMCache cache server is running...")
+    logger.info("LMCache cache server is running on %s:%d", args.host, args.port)
 
     # Dummy loop to keep the server running
     try:
@@ -545,34 +746,108 @@ def run_cache_server(
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
         server.close()
+        if hasattr(engine, "close"):
+            engine.close()
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="LMCache Cache Server")
+    parser = argparse.ArgumentParser(
+        description="LMCache Multi-process Cache Server",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Basic CPU-only server
+  python3 -m lmcache.v1.multiprocess.server --cpu-buffer-size 10
+
+  # Server with Raw Block backend (for TP > 1)
+  python3 -m lmcache.v1.multiprocess.server \\
+      --raw-block-device /dev/nvme0n1 \\
+      --cpu-buffer-size 10 \\
+      --enable-odirect
+
+  # Server with config file
+  python3 -m lmcache.v1.multiprocess.server --config-file my_config.yaml
+""",
+    )
+
+    # Basic server options
     parser.add_argument(
-        "--host", type=str, default="localhost", help="Host to bind the server"
+        "--host",
+        type=str,
+        default="localhost",
+        help="Host to bind the server (default: localhost)",
     )
     parser.add_argument(
-        "--port", type=int, default=5555, help="Port to bind the server"
+        "--port",
+        type=int,
+        default=5555,
+        help="Port to bind the server (default: 5555)",
     )
     parser.add_argument(
-        "--chunk-size", type=int, default=256, help="Chunk size for KV cache operations"
+        "--chunk-size",
+        type=int,
+        default=256,
+        help="Chunk size for KV cache in tokens (default: 256)",
     )
     parser.add_argument(
-        "--cpu-buffer-size", type=float, default=5.0, help="CPU buffer size in GB"
+        "--cpu-buffer-size",
+        type=float,
+        default=5.0,
+        help="CPU buffer size in GB (default: 5.0)",
     )
     parser.add_argument(
-        "--max-workers", type=int, default=1, help="Maximum number of worker threads"
+        "--max-workers",
+        type=int,
+        default=1,
+        help="Maximum number of worker threads (default: 1)",
     )
+
+    # Configuration file
+    parser.add_argument(
+        "--config-file",
+        type=str,
+        default=None,
+        help="Path to LMCache config YAML file for storage backends",
+    )
+
+    # Raw Block backend options
+    raw_block_group = parser.add_argument_group("Raw Block Backend")
+    raw_block_group.add_argument(
+        "--raw-block-device",
+        type=str,
+        default=None,
+        help="Path to raw block device (e.g., /dev/nvme0n1)",
+    )
+    raw_block_group.add_argument(
+        "--raw-block-capacity-gb",
+        type=float,
+        default=0,
+        help="Raw block capacity in GB (0 = use full device)",
+    )
+    raw_block_group.add_argument(
+        "--enable-odirect",
+        action="store_true",
+        help="Enable O_DIRECT for raw block I/O (bypasses page cache)",
+    )
+
+    # Local disk backend options
+    disk_group = parser.add_argument_group("Local Disk Backend")
+    disk_group.add_argument(
+        "--local-disk",
+        type=str,
+        default=None,
+        help="Path to local disk storage directory",
+    )
+    disk_group.add_argument(
+        "--max-local-disk-size",
+        type=float,
+        default=100.0,
+        help="Maximum local disk storage size in GB (default: 100)",
+    )
+
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    run_cache_server(
-        host=args.host,
-        port=args.port,
-        chunk_size=args.chunk_size,
-        cpu_buffer_size=args.cpu_buffer_size,
-        max_workers=args.max_workers,
-    )
+    run_cache_server(args)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -259,6 +259,14 @@ class MPCacheEngine:
     def _initialize_storage_manager(self, gpu_context: GPUCacheContext) -> None:
         """Initialize storage manager after first GPU context registers."""
         if self._storage_manager is not None:
+            # Check for race condition: if L2 is configured but storage manager
+            # was created without L2 support (via property access before registration)
+            if self._config is not None and not self._storage_manager.has_l2_storage():
+                raise RuntimeError(
+                    "MPCacheEngine was used before GPU context registration, "
+                    "preventing L2 storage initialization. "
+                    "Ensure register_kv_cache is called first."
+                )
             return
 
         metadata = None

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -53,11 +53,18 @@ def storage_plugin_launcher(
     Looks for backend configurations in config.extra_config and instantiates
     them using the specified module and class names.
     """
-    if not config.extra_config:
-        return
-
     # Get the list of allowed external backends if configured
     storage_plugins = set(config.storage_plugins) if config.storage_plugins else set()
+    if storage_plugins and not config.extra_config:
+        logger.warning(
+            "storage_plugins=%s is set but extra_config is empty; "
+            "plugin settings must be provided under extra_config, e.g. "
+            "extra_config.storage_plugin.<name>.module_path/class_name",
+            sorted(storage_plugins),
+        )
+        return
+    if not config.extra_config:
+        return
 
     for storage_plugin in storage_plugins:
         try:

--- a/lmcache/v1/storage_backend/plugins/__init__.py
+++ b/lmcache/v1/storage_backend/plugins/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Storage plugin implementations shipped in-tree.
+
+These are loaded via `LMCacheEngineConfig.storage_plugins` +
+`extra_config.storage_plugin.<name>.*`.
+
+See `docs/source/developer_guide/extending_lmcache/storage_plugins.rst`.
+"""

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -182,7 +182,6 @@ class RustRawBlockBackend(StoragePluginInterface):
         self.use_mp_issuer: bool = bool(
             extra.get("rust_raw_block.use_mp_issuer", False)
         )
-        self.mp_zero_copy: bool = bool(extra.get("rust_raw_block.mp_zero_copy", True))
 
         # Manifest persistence: save index to disk periodically and on shutdown.
         # Default interval: every 100 writes. Set to 0 to disable periodic saves.
@@ -609,31 +608,9 @@ class RustRawBlockBackend(StoragePluginInterface):
                             f"O_DIRECT payload {total_len} > slot {max_payload}"
                         )
 
-                if (
-                    self.mp_zero_copy
-                    and hasattr(memory_obj, "shm_view")
-                    and hasattr(memory_obj, "shm_off")
-                ):
-                    try:
-                        shm_view = memory_obj.shm_view()  # type: ignore[attr-defined]
-                        shm_off = int(memory_obj.shm_off)  # type: ignore[attr-defined]
-                        segs.append(
-                            (
-                                offset + self.header_bytes,
-                                shm_view,
-                                shm_off,
-                                payload_len,
-                                total_len,
-                            )
-                        )
-                    except Exception:
-                        segs.append(
-                            (offset + self.header_bytes, buf, 0, payload_len, total_len)
-                        )
-                else:
-                    segs.append(
-                        (offset + self.header_bytes, buf, 0, payload_len, total_len)
-                    )
+                segs.append(
+                    (offset + self.header_bytes, buf, 0, payload_len, total_len)
+                )
 
             f = mp.submit_pwritev(segs, priority=2)
             await asyncio.wrap_future(f)
@@ -692,33 +669,13 @@ class RustRawBlockBackend(StoragePluginInterface):
                 # Header write (copy is fine; small)
                 f0 = mp.submit_pwrite(offset, header, total_len=hdr_total, priority=2)
 
-                # Payload write: try SHM zero-copy if MemoryObj is SHM-backed.
-                f1 = None
-                if (
-                    self.mp_zero_copy
-                    and hasattr(memory_obj, "shm_view")
-                    and hasattr(memory_obj, "shm_off")
-                ):
-                    try:
-                        shm_view = memory_obj.shm_view()  # type: ignore[attr-defined]
-                        shm_off = int(memory_obj.shm_off)  # type: ignore[attr-defined]
-                        f1 = mp.submit_pwrite_shm(
-                            offset + self.header_bytes,
-                            shm_view,
-                            shm_off=shm_off,
-                            payload_len=payload_len,
-                            total_len=total_len,
-                            priority=2,
-                        )
-                    except Exception:
-                        f1 = None
-                if f1 is None:
-                    f1 = mp.submit_pwrite(
-                        offset + self.header_bytes,
-                        buf,
-                        total_len=total_len,
-                        priority=2,
-                    )
+                # Payload write
+                f1 = mp.submit_pwrite(
+                    offset + self.header_bytes,
+                    buf,
+                    total_len=total_len,
+                    priority=2,
+                )
 
                 await asyncio.wrap_future(f0)
                 await asyncio.wrap_future(f1)
@@ -819,30 +776,13 @@ class RustRawBlockBackend(StoragePluginInterface):
             pass
         if self.use_mp_issuer:
             mp = self._get_mp()
-            # If the destination is SHM-backed, do process-to-process zero-copy.
-            if (
-                self.mp_zero_copy
-                and hasattr(memory_obj, "shm_view")
-                and hasattr(memory_obj, "shm_off")
-            ):
-                shm_view = memory_obj.shm_view()  # type: ignore[attr-defined]
-                shm_off = int(memory_obj.shm_off)  # type: ignore[attr-defined]
-                f = mp.submit_pread_shm(
-                    entry.offset + self.header_bytes,
-                    shm_view,
-                    shm_off=shm_off,
-                    payload_len=payload_len,
-                    total_len=total_len,
-                    priority=0,
-                )
-            else:
-                f = mp.submit_pread_into(
-                    entry.offset + self.header_bytes,
-                    buf,
-                    payload_len=payload_len,
-                    total_len=total_len,
-                    priority=0,
-                )
+            f = mp.submit_pread_into(
+                entry.offset + self.header_bytes,
+                buf,
+                payload_len=payload_len,
+                total_len=total_len,
+                priority=0,
+            )
             f.result(timeout=60)
         else:
             raw = self._rawdev()
@@ -915,34 +855,20 @@ class RustRawBlockBackend(StoragePluginInterface):
                     total_len = payload_len
                     if self.use_odirect:
                         total_len = _round_up(payload_len, self.block_align)
-                    # Prefer SHM zero-copy when destination is SHM-backed.
-                    if hasattr(m, "shm_view") and hasattr(m, "shm_off"):
-                        shm_view = m.shm_view()  # type: ignore[attr-defined]
-                        shm_off = int(m.shm_off)  # type: ignore[attr-defined]
-                        reqs.append(
-                            (
-                                e.offset + self.header_bytes,
-                                shm_view,
-                                shm_off,
-                                payload_len,
-                                total_len,
-                            )
+                    buf = m.byte_array
+                    try:
+                        buf = buf.cast("B")
+                    except Exception:
+                        pass
+                    reqs.append(
+                        (
+                            e.offset + self.header_bytes,
+                            buf,
+                            0,
+                            payload_len,
+                            total_len,
                         )
-                    else:
-                        buf = m.byte_array
-                        try:
-                            buf = buf.cast("B")
-                        except Exception:
-                            pass
-                        reqs.append(
-                            (
-                                e.offset + self.header_bytes,
-                                buf,
-                                0,
-                                payload_len,
-                                total_len,
-                            )
-                        )
+                    )
                     m.metadata.cached_positions = e.meta.cached_positions
                 fb = mp.submit_preadv_into(reqs, priority=0)
                 await asyncio.wrap_future(fb)

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -1,0 +1,1171 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, List, Optional, Sequence
+import asyncio
+import json
+import os
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey, DiskCacheMetadata
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.storage_backend.abstract_backend import (
+    AllocatorBackendInterface,
+    StoragePluginInterface,
+)
+
+logger = init_logger(__name__)
+
+
+def _round_up(x: int, align: int) -> int:
+    return ((x + align - 1) // align) * align
+
+
+@dataclass
+class _Entry:
+    """In-memory index entry for a stored chunk."""
+
+    offset: int
+    size: int
+    meta: DiskCacheMetadata
+
+
+@dataclass
+class _Inflight:
+    offset: int
+    meta: DiskCacheMetadata
+
+
+class RustRawBlockBackend(StoragePluginInterface):
+    """
+    A storage plugin backend that stores KV chunks into a block device (raw)
+    using a Rust extension for pread/pwrite.
+
+    Features:
+    - High-throughput I/O via direct block device access
+    - O_DIRECT support to bypass page cache
+    - Manifest persistence for recovery across restarts
+    - Zero-copy operations via Rust extension
+
+    Supported Configurations:
+    - **TP=1 (Direct Mode)**: Single vLLM worker directly uses this backend
+    - **TP > 1 (MP Mode)**: LMCache MP server uses this backend to serve
+      multiple vLLM workers
+
+    .. warning::
+       **This backend does NOT support TP > 1 in direct connector mode.**
+
+       When using Tensor Parallelism (TP > 1), multiple vLLM workers would
+       independently access the same raw block device without coordination,
+       leading to metadata conflicts and data corruption.
+
+       For TP > 1 setups, use LMCache Multi-process mode where a single
+       MP server manages the raw block device:
+
+       .. code-block:: bash
+
+           # Start MP server with Raw Block
+           python3 -m lmcache.v1.multiprocess.server --raw-block-device /dev/nvme0n1
+
+           # Start vLLM with MP connector
+           vllm serve model --tensor-parallel-size 4 \\
+               --kv-transfer-config '{"kv_connector": ...}'
+
+       See the LMCache documentation on Multi-process Mode for details.
+    """
+
+    def __init__(
+        self,
+        config=None,
+        metadata=None,
+        local_cpu_backend=None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        dst_device: str = "cpu",
+    ):
+        super().__init__(
+            dst_device=dst_device,
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu_backend,
+            loop=loop,
+        )
+        if self.loop is None:
+            raise ValueError("RustRawBlockBackend requires an asyncio event loop")
+        if self.local_cpu_backend is None:
+            raise ValueError("RustRawBlockBackend requires local_cpu_backend")
+        if self.config is None:
+            raise ValueError("RustRawBlockBackend requires config")
+
+        # Check for Tensor Parallelism: Raw Block backend does NOT support TP > 1
+        # because multiple workers would independently access the raw block device
+        # without metadata synchronization, causing conflicts and data corruption.
+        #
+        # Allowed configurations:
+        # 1. world_size == 1 (single worker, e.g., TP=1)
+        # 2. role == "mp_server" (MP server manages storage for all workers)
+        if self.metadata is not None:
+            is_mp_server = getattr(self.metadata, "role", None) == "mp_server"
+            is_single_worker = self.metadata.world_size == 1
+
+            if not is_single_worker and not is_mp_server:
+                raise ValueError(
+                    "RustRawBlockBackend does not support "
+                    f"Tensor Parallelism (TP > 1). "
+                    f"Current world_size={self.metadata.world_size}. "
+                    "For TP > 1, use LMCache Multi-process mode instead:\n"
+                    "  1. Start LMCache server: "
+                    "python3 -m lmcache.v1.multiprocess.server "
+                    "--raw-block-device /dev/nvme0n1\n"
+                    "  2. Configure vLLM with: --kv-transfer-config "
+                    '\'{"kv_connector":"LMCacheMPConnector", '
+                    '"kv_role":"kv_both"}\'\n'
+                    "See: https://docs.lmcache.ai/kv_cache/multiprocess_mode.html"
+                )
+
+        extra = self.config.extra_config or {}
+        self.device_path: str = extra.get("rust_raw_block.device_path", "")
+        if not self.device_path:
+            raise ValueError("extra_config['rust_raw_block.device_path'] is required")
+
+        # Optional manifest for persistence across restart (best-effort).
+        self.manifest_path: Optional[str] = extra.get("rust_raw_block.manifest_path")
+
+        # Bytes available for this backend to use on the device.
+        # If unset, use the whole device size (blockdev --getsize64 equivalent).
+        self.capacity_bytes: int = int(extra.get("rust_raw_block.capacity_bytes", 0))
+
+        # Slot sizing: header + payload, aligned up to a block boundary.
+        # Default alignment 4096 (safe for NVMe/loop).
+        self.block_align: int = int(extra.get("rust_raw_block.block_align", 4096))
+        self.header_bytes: int = int(extra.get("rust_raw_block.header_bytes", 4096))
+        self.use_odirect: bool = bool(extra.get("rust_raw_block.use_odirect", False))
+
+        full_chunk_bytes = int(self.local_cpu_backend.get_full_chunk_size())
+        default_slot_bytes = _round_up(
+            self.header_bytes + full_chunk_bytes, self.block_align
+        )
+        self.slot_bytes: int = int(
+            extra.get("rust_raw_block.slot_bytes", default_slot_bytes)
+        )
+        if self.slot_bytes < self.header_bytes + 1:
+            raise ValueError("rust_raw_block.slot_bytes too small")
+        if self.slot_bytes % self.block_align != 0:
+            raise ValueError(
+                "rust_raw_block.slot_bytes must be multiple of block_align"
+            )
+        if self.header_bytes % self.block_align != 0:
+            raise ValueError(
+                "rust_raw_block.header_bytes must be multiple of block_align"
+            )
+
+        self._lock = threading.Lock()
+        self._index: dict[CacheEngineKey, _Entry] = {}
+        self._pinned: set[CacheEngineKey] = set()
+        self._inflight: dict[CacheEngineKey, _Inflight] = {}
+        self._lru: "OrderedDict[CacheEngineKey, None]" = OrderedDict()
+
+        self._next_slot: int = 0
+        self._free_slots: list[int] = []
+        self._max_slots: int = 0  # computed lazily once device size is known
+
+        # Optional: issue I/O in a separate process (reduces GIL contention).
+        self.use_mp_issuer: bool = bool(
+            extra.get("rust_raw_block.use_mp_issuer", False)
+        )
+        self.mp_zero_copy: bool = bool(extra.get("rust_raw_block.mp_zero_copy", True))
+
+        # Manifest persistence: save index to disk periodically and on shutdown.
+        # Default interval: every 100 writes. Set to 0 to disable periodic saves.
+        self._manifest_write_interval: int = int(
+            extra.get("rust_raw_block.manifest_write_interval", 100)
+        )
+        self._writes_since_manifest_save: int = 0
+
+        # Default manifest path: /tmp/lmcache_raw_block_<device_name>.manifest.json
+        if not self.manifest_path:
+            device_name = os.path.basename(self.device_path.rstrip("/"))
+            self.manifest_path = f"/tmp/lmcache_raw_block_{device_name}.manifest.json"
+            logger.info(
+                "RustRawBlockBackend: using default manifest_path=%s",
+                self.manifest_path,
+            )
+        # NOTE: we always use the Rust scheduler when not using the mp issuer.
+        # The legacy Python PQ executor path was removed to reduce config surface.
+
+        # Debug logging (rate-limited).
+        # Only emits when LMCache log level is DEBUG.
+        self._dbg_first_n: int = int(extra.get("rust_raw_block.debug_first_n", 4) or 0)
+        self._dbg_every_n: int = int(
+            extra.get("rust_raw_block.debug_every_n", 256) or 0
+        )
+        self._dbg_put_batches: int = 0
+        self._dbg_put_keys: int = 0
+        self._dbg_put_bytes: int = 0
+        self._dbg_get_calls: int = 0
+        self._dbg_get_bytes: int = 0
+        self._dbg_prefetch_batches: int = 0
+        self._dbg_prefetch_keys: int = 0
+        self._dbg_prefetch_bytes: int = 0
+
+        # Lazy import so normal LMCache usage doesn't require Rust extension installed
+        self._raw = None
+        self._scheduler = None
+        self._mp = None
+
+        # Track ongoing put tasks to match exists_in_put_tasks semantics.
+        self._put_lock = threading.Lock()
+        self._put_tasks: set[CacheEngineKey] = set()
+
+        logger.info(
+            "RustRawBlockBackend init: device=%s cap=%s slot=%d align=%d header=%d",
+            self.device_path,
+            self.capacity_bytes,
+            self.slot_bytes,
+            self.block_align,
+            self.header_bytes,
+        )
+
+        # Best-effort restore from manifest (if configured).
+        if self.manifest_path:
+            self._load_manifest(self.manifest_path)
+
+    def _dbg_should_log(self, n: int) -> bool:
+        if not logger.isEnabledFor(10):  # logging.DEBUG
+            return False
+        if self._dbg_first_n and n <= self._dbg_first_n:
+            return True
+        if self._dbg_every_n and n % self._dbg_every_n == 0:
+            return True
+        return False
+
+    def _dbg_key_short(self, key: CacheEngineKey) -> str:
+        try:
+            return f"chunk_hash={int(key.chunk_hash)}"
+        except Exception:
+            return "chunk_hash=?"
+
+    def __str__(self) -> str:
+        return "RustRawBlockBackend"
+
+    def _rawdev(self):
+        if self._raw is None:
+            try:
+                # Third Party
+                from lmcache_rust_raw_block_io import (  # type: ignore
+                    RawBlockDevice,
+                    RawBlockDevicePool,
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    "Rust raw-block extension is not installed. "
+                    "Install / build `rust_raw_block_io` and retry."
+                ) from e
+            # io_fds is optional; default to per-CPU fds (>=1).
+            extra = self.config.extra_config or {}
+            io_fds = int(extra.get("rust_raw_block.io_fds", 0) or 0) or (
+                os.cpu_count() or 1
+            )
+            if io_fds <= 1:
+                self._raw = RawBlockDevice(
+                    self.device_path,
+                    writable=True,
+                    use_odirect=self.use_odirect,
+                    alignment=self.block_align,
+                )
+            else:
+                # Per-CPU submission: choose FD based on sched_getcpu() in Rust.
+                self._raw = RawBlockDevicePool(
+                    self.device_path,
+                    writable=True,
+                    num_fds=io_fds,
+                    use_odirect=self.use_odirect,
+                    alignment=self.block_align,
+                )
+        return self._raw
+
+    def _get_scheduler(self):
+        if self._scheduler is None:
+            try:
+                # Third Party
+                from lmcache_rust_raw_block_io import RawBlockScheduler  # type: ignore
+            except Exception as e:
+                raise RuntimeError(
+                    "Rust raw-block scheduler extension is not installed."
+                ) from e
+            # io_fds/io_workers are optional; default to CPU count (>=1).
+            extra = self.config.extra_config or {}
+            io_fds = int(extra.get("rust_raw_block.io_fds", 0) or 0) or (
+                os.cpu_count() or 1
+            )
+            workers = int(extra.get("rust_raw_block.io_workers", 0) or 0) or (
+                os.cpu_count() or 1
+            )
+            self._scheduler = RawBlockScheduler(
+                self.device_path,
+                writable=True,
+                num_workers=workers,
+                num_fds=io_fds,
+                use_odirect=self.use_odirect,
+                alignment=self.block_align,
+            )
+        return self._scheduler
+
+    def _get_mp(self):
+        if self._mp is None:
+            # First Party
+            from lmcache.v1.storage_backend.mp_raw_block_io import (
+                RawBlockMPClient,  # type: ignore
+            )
+
+            # Keep mp configuration minimal: default to spawn and scratch SHM
+            # (no explicit SHM pool required).
+            extra = self.config.extra_config or {}
+            io_fds = int(extra.get("rust_raw_block.io_fds", 0) or 0) or (
+                os.cpu_count() or 1
+            )
+            workers = int(extra.get("rust_raw_block.io_workers", 0) or 0) or (
+                os.cpu_count() or 1
+            )
+            self._mp = RawBlockMPClient(
+                self.device_path,
+                num_workers=workers,
+                num_fds=io_fds,
+                use_odirect=self.use_odirect,
+                alignment=self.block_align,
+                # ctx/shm_pool_* are intentionally not configurable here anymore.
+            )
+        return self._mp
+
+    def _allocate_slot(self) -> int:
+        # Fixed-slot allocator with reuse via free list.
+        if self.capacity_bytes <= 0:
+            # Probe device size lazily via rust helper if capacity unset.
+            self.capacity_bytes = int(self._rawdev().size_bytes())
+        if self._max_slots <= 0:
+            self._max_slots = self.capacity_bytes // self.slot_bytes
+            if self._max_slots <= 0:
+                raise RuntimeError("raw block capacity too small for slot size")
+
+        if self._free_slots:
+            slot = self._free_slots.pop()
+            return slot * self.slot_bytes
+
+        if self._next_slot < self._max_slots:
+            slot = self._next_slot
+            self._next_slot += 1
+            return slot * self.slot_bytes
+
+        raise RuntimeError("No free slots available; eviction required")
+
+    def _touch(self, key: CacheEngineKey) -> None:
+        # Maintain simple LRU (least recent at beginning).
+        self._lru.pop(key, None)
+        self._lru[key] = None
+
+    def _evict_one(self) -> bool:
+        # Evict LRU victim that is not pinned and not inflight.
+        for victim in list(self._lru.keys()):
+            if victim in self._pinned:
+                continue
+            if victim in self._inflight:
+                continue
+            entry = self._index.pop(victim, None)
+            if entry is None:
+                self._lru.pop(victim, None)
+                continue
+            self._lru.pop(victim, None)
+            self._pinned.discard(victim)
+            slot = entry.offset // self.slot_bytes
+            self._free_slots.append(int(slot))
+            return True
+        return False
+
+    def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
+        with self._lock:
+            ok = key in self._index
+            if ok and pin:
+                self._pinned.add(key)
+            return ok
+
+    def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
+        with self._put_lock:
+            return key in self._put_tasks
+
+    def pin(self, key: CacheEngineKey) -> bool:
+        with self._lock:
+            if key in self._index:
+                self._pinned.add(key)
+                return True
+            return False
+
+    def unpin(self, key: CacheEngineKey) -> bool:
+        with self._lock:
+            if key in self._pinned:
+                self._pinned.remove(key)
+                return True
+            return key in self._index
+
+    def remove(self, key: CacheEngineKey, force: bool = True) -> bool:
+        # WIP: does not reclaim space yet; just drops index entry.
+        with self._lock:
+            existed = key in self._index or key in self._inflight
+            entry = self._index.pop(key, None)
+            inflight = self._inflight.pop(key, None)
+            self._pinned.discard(key)
+            self._lru.pop(key, None)
+            if entry is not None:
+                self._free_slots.append(int(entry.offset // self.slot_bytes))
+            if inflight is not None:
+                self._free_slots.append(int(inflight.offset // self.slot_bytes))
+            return existed
+
+    def batched_submit_put_task(
+        self,
+        keys: Sequence[CacheEngineKey],
+        objs: List[MemoryObj],
+        transfer_spec: Any = None,
+    ):
+        if logger.isEnabledFor(10):  # DEBUG
+            self._dbg_put_batches += 1
+            self._dbg_put_keys += int(len(keys))
+            try:
+                self._dbg_put_bytes += int(sum(len(o.byte_array) for o in objs))
+            except Exception:
+                pass
+            if self._dbg_should_log(self._dbg_put_batches):
+                logger.debug(
+                    "RustRawBlockBackend PUT: keys=%d inflight=%d indexed=%d",
+                    len(keys),
+                    len(self._inflight),
+                    len(self._index),
+                )
+
+        # Fast path: when using mp issuer, batch the entire put into a single
+        # pwritev request to avoid per-key IPC overhead.
+        if self.use_mp_issuer:
+            batch_keys: list[CacheEngineKey] = []
+            batch_offsets: list[int] = []
+            batch_headers: list[bytes] = []
+            batch_objs: list[MemoryObj] = []
+
+            for key, obj in zip(keys, objs, strict=False):
+                # Skip if already storing
+                with self._put_lock:
+                    if key in self._put_tasks:
+                        continue
+                    self._put_tasks.add(key)
+
+                with self._lock:
+                    if key in self._index or key in self._inflight:
+                        with self._put_lock:
+                            self._put_tasks.discard(key)
+                        continue
+                    # Ensure capacity (evict if needed) before allocating a slot
+                    while True:
+                        try:
+                            offset = self._allocate_slot()
+                            break
+                        except RuntimeError:
+                            if not self._evict_one():
+                                with self._put_lock:
+                                    self._put_tasks.discard(key)
+                                raise
+
+                    meta = DiskCacheMetadata(
+                        path=f"{self.device_path}@{offset}",
+                        size=len(obj.byte_array),
+                        shape=obj.metadata.shape,
+                        dtype=obj.metadata.dtype,
+                        cached_positions=obj.metadata.cached_positions,
+                        fmt=obj.metadata.fmt,
+                        pin_count=0,
+                    )
+                    self._inflight[key] = _Inflight(offset=offset, meta=meta)
+
+                header = self._encode_header(key, meta.size)
+                obj.ref_count_up()
+                batch_keys.append(key)
+                batch_offsets.append(offset)
+                batch_headers.append(header)
+                batch_objs.append(obj)
+
+            if not batch_keys:
+                return None
+
+            if logger.isEnabledFor(10) and self._dbg_should_log(self._dbg_put_batches):
+                # This is the actual raw-device write submission point.
+                # (2 segments per key: header + payload)
+                logger.debug(
+                    "RustRawBlockBackend PUT(mp): segs=%d keys=%d",
+                    2 * len(batch_keys),
+                    len(batch_keys),
+                )
+
+            assert self.loop is not None
+            fut = asyncio.run_coroutine_threadsafe(
+                self._submit_write_batch(
+                    keys=batch_keys,
+                    offsets=batch_offsets,
+                    headers=batch_headers,
+                    memory_objs=batch_objs,
+                ),
+                self.loop,
+            )
+            return [fut]
+
+        # Default path: per-key async writes.
+        futures = []
+        for key, obj in zip(keys, objs, strict=False):
+            # Skip if already storing
+            with self._put_lock:
+                if key in self._put_tasks:
+                    continue
+                self._put_tasks.add(key)
+
+            with self._lock:
+                if key in self._index or key in self._inflight:
+                    with self._put_lock:
+                        self._put_tasks.discard(key)
+                    continue
+                while True:
+                    try:
+                        offset = self._allocate_slot()
+                        break
+                    except RuntimeError:
+                        if not self._evict_one():
+                            with self._put_lock:
+                                self._put_tasks.discard(key)
+                            raise
+
+                meta = DiskCacheMetadata(
+                    path=f"{self.device_path}@{offset}",
+                    size=len(obj.byte_array),
+                    shape=obj.metadata.shape,
+                    dtype=obj.metadata.dtype,
+                    cached_positions=obj.metadata.cached_positions,
+                    fmt=obj.metadata.fmt,
+                    pin_count=0,
+                )
+                self._inflight[key] = _Inflight(offset=offset, meta=meta)
+
+            header = self._encode_header(key, meta.size)
+            obj.ref_count_up()
+            assert self.loop is not None
+            fut = asyncio.run_coroutine_threadsafe(
+                self._submit_write(
+                    key=key, offset=offset, header=header, memory_obj=obj
+                ),
+                self.loop,
+            )
+            futures.append(fut)
+        return futures or None
+
+    async def _submit_write_batch(
+        self,
+        *,
+        keys: Sequence[CacheEngineKey],
+        offsets: Sequence[int],
+        headers: Sequence[bytes],
+        memory_objs: Sequence[MemoryObj],
+    ) -> None:
+        """
+        Batch write for mp issuer: one IPC request + one Rust future.
+
+        IMPORTANT: ref_count_down happens on the event loop thread only.
+        """
+        mp = self._get_mp()
+        segs = []
+        try:
+            for key, offset, header, memory_obj in zip(
+                keys, offsets, headers, memory_objs, strict=False
+            ):
+                # Header segment
+                hdr_total = len(header)
+                if self.use_odirect:
+                    hdr_total = _round_up(hdr_total, self.block_align)
+                segs.append((offset, header, 0, len(header), hdr_total))
+
+                # Payload segment
+                buf = memory_obj.byte_array
+                if hasattr(buf, "cast"):
+                    buf = buf.cast("B")
+                payload_len = len(memory_obj.byte_array)
+                total_len = payload_len
+                if self.use_odirect:
+                    total_len = _round_up(payload_len, self.block_align)
+                    max_payload = self.slot_bytes - self.header_bytes
+                    if total_len > max_payload:
+                        raise RuntimeError(
+                            f"O_DIRECT payload {total_len} > slot {max_payload}"
+                        )
+
+                if (
+                    self.mp_zero_copy
+                    and hasattr(memory_obj, "shm_view")
+                    and hasattr(memory_obj, "shm_off")
+                ):
+                    try:
+                        shm_view = memory_obj.shm_view()  # type: ignore[attr-defined]
+                        shm_off = int(memory_obj.shm_off)  # type: ignore[attr-defined]
+                        segs.append(
+                            (
+                                offset + self.header_bytes,
+                                shm_view,
+                                shm_off,
+                                payload_len,
+                                total_len,
+                            )
+                        )
+                    except Exception:
+                        segs.append(
+                            (offset + self.header_bytes, buf, 0, payload_len, total_len)
+                        )
+                else:
+                    segs.append(
+                        (offset + self.header_bytes, buf, 0, payload_len, total_len)
+                    )
+
+            f = mp.submit_pwritev(segs, priority=2)
+            await asyncio.wrap_future(f)
+
+            # Commit inflight -> index
+            with self._lock:
+                for key in keys:
+                    inflight = self._inflight.pop(key, None)
+                    if inflight is not None:
+                        self._index[key] = _Entry(
+                            offset=inflight.offset,
+                            size=inflight.meta.size,
+                            meta=inflight.meta,
+                        )
+                        self._touch(key)
+
+            # Periodic manifest save
+            self._maybe_save_manifest()
+        except Exception:
+            # On error: roll back inflight slots so allocator can reuse them.
+            with self._lock:
+                for key in keys:
+                    inflight = self._inflight.pop(key, None)
+                    if inflight is not None:
+                        self._free_slots.append(int(inflight.offset // self.slot_bytes))
+            raise
+        finally:
+            for key, memory_obj in zip(keys, memory_objs, strict=False):
+                memory_obj.ref_count_down()
+                with self._put_lock:
+                    self._put_tasks.discard(key)
+
+    async def _submit_write(
+        self, key: CacheEngineKey, offset: int, header: bytes, memory_obj: MemoryObj
+    ) -> None:
+        try:
+            buf = memory_obj.byte_array
+            if hasattr(buf, "cast"):
+                buf = buf.cast("B")
+            payload_len = len(memory_obj.byte_array)
+            total_len = payload_len
+            if self.use_odirect:
+                total_len = _round_up(payload_len, self.block_align)
+                max_payload = self.slot_bytes - self.header_bytes
+                if total_len > max_payload:
+                    raise RuntimeError(
+                        f"O_DIRECT payload {total_len} > slot {max_payload}"
+                    )
+
+            if self.use_mp_issuer:
+                mp = self._get_mp()
+                hdr_total = len(header)
+                if self.use_odirect:
+                    hdr_total = _round_up(len(header), self.block_align)
+
+                # Header write (copy is fine; small)
+                f0 = mp.submit_pwrite(offset, header, total_len=hdr_total, priority=2)
+
+                # Payload write: try SHM zero-copy if MemoryObj is SHM-backed.
+                f1 = None
+                if (
+                    self.mp_zero_copy
+                    and hasattr(memory_obj, "shm_view")
+                    and hasattr(memory_obj, "shm_off")
+                ):
+                    try:
+                        shm_view = memory_obj.shm_view()  # type: ignore[attr-defined]
+                        shm_off = int(memory_obj.shm_off)  # type: ignore[attr-defined]
+                        f1 = mp.submit_pwrite_shm(
+                            offset + self.header_bytes,
+                            shm_view,
+                            shm_off=shm_off,
+                            payload_len=payload_len,
+                            total_len=total_len,
+                            priority=2,
+                        )
+                    except Exception:
+                        f1 = None
+                if f1 is None:
+                    f1 = mp.submit_pwrite(
+                        offset + self.header_bytes,
+                        buf,
+                        total_len=total_len,
+                        priority=2,
+                    )
+
+                await asyncio.wrap_future(f0)
+                await asyncio.wrap_future(f1)
+            else:
+                sched = self._get_scheduler()
+                # priority 2 = put (lowest)
+                hdr_total = len(header)
+                if self.use_odirect:
+                    hdr_total = _round_up(len(header), self.block_align)
+                fb = sched.submit_pwritev_from_buffers(
+                    [
+                        (offset, header, len(header), hdr_total),
+                        (offset + self.header_bytes, buf, payload_len, total_len),
+                    ],
+                    priority=2,
+                )
+                await asyncio.wrap_future(fb)
+
+            # Commit inflight -> index on success
+            with self._lock:
+                inflight = self._inflight.pop(key, None)
+                if inflight is not None:
+                    self._index[key] = _Entry(
+                        offset=inflight.offset,
+                        size=inflight.meta.size,
+                        meta=inflight.meta,
+                    )
+                    self._touch(key)
+
+            # Periodic manifest save
+            self._maybe_save_manifest()
+        finally:
+            # IMPORTANT: ref_count_down on the event loop thread only.
+            memory_obj.ref_count_down()
+            with self._put_lock:
+                self._put_tasks.discard(key)
+
+    def _encode_header(self, key: CacheEngineKey, payload_len: int) -> bytes:
+        # Header is block-aligned fixed-size region.
+        # Layout (little endian):
+        # 0..8   magic
+        # 8..16  chunk_hash (u64)
+        # 16..24 payload_len (u64)
+        # rest   zero
+        magic = b"LMCBLK01"
+        chunk_hash = int(key.chunk_hash) & ((1 << 64) - 1)
+        hdr = bytearray(self.header_bytes)
+        hdr[0:8] = magic
+        hdr[8:16] = chunk_hash.to_bytes(8, "little", signed=False)
+        hdr[16:24] = int(payload_len).to_bytes(8, "little", signed=False)
+        return bytes(hdr)
+
+    def _decode_header(self, header: bytes) -> tuple[int, int]:
+        # NOTE: header decoding is intentionally unused on the hot path.
+        # We rely on the in-memory index/manifest for payload size.
+        if len(header) < 24:
+            raise RuntimeError("short header")
+        if header[0:8] != b"LMCBLK01":
+            raise RuntimeError("bad magic")
+        chunk_hash = int.from_bytes(header[8:16], "little", signed=False)
+        payload_len = int.from_bytes(header[16:24], "little", signed=False)
+        return chunk_hash, payload_len
+
+    def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        if logger.isEnabledFor(10):
+            self._dbg_get_calls += 1
+        with self._lock:
+            entry = self._index.get(key)
+        if entry is None:
+            return None
+
+        meta = entry.meta
+        assert meta.shape is not None
+        assert meta.dtype is not None
+        payload_len = int(meta.size)
+        total_len = int(payload_len)
+        if self.use_odirect:
+            total_len = _round_up(payload_len, self.block_align)
+
+        if logger.isEnabledFor(10):
+            self._dbg_get_bytes += int(payload_len)
+            if self._dbg_should_log(self._dbg_get_calls):
+                logger.debug(
+                    "RustRawBlockBackend GET: %s offset=%d size=%d",
+                    self._dbg_key_short(key),
+                    int(entry.offset),
+                    int(payload_len),
+                )
+
+        # Default: allocate destination MemoryObj from LocalCPUBackend
+        assert self.local_cpu_backend is not None
+        memory_obj = self.local_cpu_backend.allocate(meta.shape, meta.dtype, meta.fmt)
+        assert memory_obj is not None
+        buf = memory_obj.byte_array
+        try:
+            buf = buf.cast("B")
+        except Exception:
+            pass
+        if self.use_mp_issuer:
+            mp = self._get_mp()
+            # If the destination is SHM-backed, do process-to-process zero-copy.
+            if (
+                self.mp_zero_copy
+                and hasattr(memory_obj, "shm_view")
+                and hasattr(memory_obj, "shm_off")
+            ):
+                shm_view = memory_obj.shm_view()  # type: ignore[attr-defined]
+                shm_off = int(memory_obj.shm_off)  # type: ignore[attr-defined]
+                f = mp.submit_pread_shm(
+                    entry.offset + self.header_bytes,
+                    shm_view,
+                    shm_off=shm_off,
+                    payload_len=payload_len,
+                    total_len=total_len,
+                    priority=0,
+                )
+            else:
+                f = mp.submit_pread_into(
+                    entry.offset + self.header_bytes,
+                    buf,
+                    payload_len=payload_len,
+                    total_len=total_len,
+                    priority=0,
+                )
+            f.result(timeout=60)
+        else:
+            raw = self._rawdev()
+            raw.pread_into(
+                entry.offset + self.header_bytes, buf, payload_len, total_len
+            )
+
+        memory_obj.metadata.cached_positions = meta.cached_positions
+        with self._lock:
+            self._touch(key)
+        return memory_obj
+
+    async def batched_async_contains(
+        self, lookup_id: str, keys: list[CacheEngineKey], pin: bool = False
+    ) -> int:
+        # Prefix semantics: stop at first miss.
+        hit = 0
+        with self._lock:
+            for k in keys:
+                if k not in self._index:
+                    break
+                if pin:
+                    self._pinned.add(k)
+                hit += 1
+        return hit
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        transfer_spec: Any = None,
+    ) -> list[MemoryObj]:
+        # Allocate upfront (like LocalDiskBackend) then read in background.
+        entries: list[_Entry] = []
+        mem_objs: list[MemoryObj] = []
+        with self._lock:
+            for k in keys:
+                e = self._index.get(k)
+                if e is None:
+                    break
+                entries.append(e)
+                meta = e.meta
+                assert meta.shape is not None
+                assert meta.dtype is not None
+                assert self.local_cpu_backend is not None
+                m = self.local_cpu_backend.allocate(meta.shape, meta.dtype, meta.fmt)
+                assert m is not None
+                mem_objs.append(m)
+
+        if logger.isEnabledFor(10):
+            self._dbg_prefetch_batches += 1
+            self._dbg_prefetch_keys += int(len(entries))
+            try:
+                self._dbg_prefetch_bytes += int(sum(int(e.meta.size) for e in entries))
+            except Exception:
+                pass
+            if self._dbg_should_log(self._dbg_prefetch_batches):
+                logger.debug(
+                    "RustRawBlockBackend PREFETCH: req=%d hit=%d",
+                    len(keys),
+                    len(entries),
+                )
+
+        async def _prefetch_async():
+            if self.use_mp_issuer:
+                mp = self._get_mp()
+                reqs = []
+                for k, e, m in zip(keys, entries, mem_objs, strict=False):
+                    payload_len = int(e.meta.size)
+                    total_len = payload_len
+                    if self.use_odirect:
+                        total_len = _round_up(payload_len, self.block_align)
+                    # Prefer SHM zero-copy when destination is SHM-backed.
+                    if hasattr(m, "shm_view") and hasattr(m, "shm_off"):
+                        shm_view = m.shm_view()  # type: ignore[attr-defined]
+                        shm_off = int(m.shm_off)  # type: ignore[attr-defined]
+                        reqs.append(
+                            (
+                                e.offset + self.header_bytes,
+                                shm_view,
+                                shm_off,
+                                payload_len,
+                                total_len,
+                            )
+                        )
+                    else:
+                        buf = m.byte_array
+                        try:
+                            buf = buf.cast("B")
+                        except Exception:
+                            pass
+                        reqs.append(
+                            (
+                                e.offset + self.header_bytes,
+                                buf,
+                                0,
+                                payload_len,
+                                total_len,
+                            )
+                        )
+                    m.metadata.cached_positions = e.meta.cached_positions
+                fb = mp.submit_preadv_into(reqs, priority=0)
+                await asyncio.wrap_future(fb)
+                return mem_objs
+
+            sched = self._get_scheduler()
+            reqs = []
+            for _k, e, m in zip(keys, entries, mem_objs, strict=False):
+                payload_len = int(e.meta.size)
+                buf = m.byte_array
+                try:
+                    buf = buf.cast("B")
+                except Exception:
+                    pass
+                total_len = payload_len
+                if self.use_odirect:
+                    total_len = _round_up(payload_len, self.block_align)
+                reqs.append((e.offset + self.header_bytes, buf, payload_len, total_len))
+                m.metadata.cached_positions = e.meta.cached_positions
+            fb = sched.submit_preadv_into(reqs, priority=0)
+            await asyncio.wrap_future(fb)
+            return mem_objs
+
+        # prefetch = highest priority (0)
+        return await _prefetch_async()
+
+    def get_allocator_backend(self) -> "AllocatorBackendInterface":
+        assert self.local_cpu_backend is not None
+        return self.local_cpu_backend
+
+    def close(self) -> None:
+        if logger.isEnabledFor(10):
+            logger.debug(
+                "RustRawBlockBackend stats: put=%d/%d/%d get=%d/%d prefetch=%d/%d/%d",
+                self._dbg_put_batches,
+                self._dbg_put_keys,
+                self._dbg_put_bytes,
+                self._dbg_get_calls,
+                self._dbg_get_bytes,
+                self._dbg_prefetch_batches,
+                self._dbg_prefetch_keys,
+                self._dbg_prefetch_bytes,
+            )
+
+        # Best-effort persist manifest before closing I/O.
+        if self.manifest_path:
+            try:
+                self._save_manifest(self.manifest_path)
+                logger.info(
+                    "RustRawBlockBackend: saved manifest to %s (entries=%d)",
+                    self.manifest_path,
+                    len(self._index),
+                )
+            except Exception as e:
+                logger.warning(f"Failed to save rust_raw_block manifest: {e}")
+
+        if self._scheduler is not None:
+            try:
+                self._scheduler.close()
+            except Exception:
+                pass
+            self._scheduler = None
+
+        if self._mp is not None:
+            try:
+                self._mp.close()
+            except Exception:
+                pass
+            self._mp = None
+
+        # Close rust device fd if opened
+        if self._raw is not None:
+            try:
+                self._raw.close()
+            except Exception:
+                pass
+            self._raw = None
+
+    def _maybe_save_manifest(self) -> None:
+        """Periodically save manifest based on write interval."""
+        if self._manifest_write_interval <= 0:
+            return
+        self._writes_since_manifest_save += 1
+        if self._writes_since_manifest_save >= self._manifest_write_interval:
+            self._writes_since_manifest_save = 0
+            if self.manifest_path:
+                try:
+                    self._save_manifest(self.manifest_path)
+                    logger.debug(
+                        "RustRawBlockBackend: manifest saved, entries=%d",
+                        len(self._index),
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to save periodic manifest: {e}")
+
+    def _save_manifest(self, path: str) -> None:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with self._lock:
+            data = {
+                "version": 1,
+                "device_path": self.device_path,
+                "capacity_bytes": self.capacity_bytes,
+                "block_align": self.block_align,
+                "header_bytes": self.header_bytes,
+                "slot_bytes": self.slot_bytes,
+                "next_slot": self._next_slot,
+                "free_slots": list(self._free_slots),
+                "lru_keys": [k.to_string() for k in self._lru.keys()],
+                "entries": {
+                    k.to_string(): {
+                        "offset": e.offset,
+                        "size": e.meta.size,
+                        "shape": list(e.meta.shape)
+                        if e.meta.shape is not None
+                        else None,
+                        "dtype": k._dtype_str,
+                        "fmt": (
+                            e.meta.fmt.name
+                            if e.meta.fmt and hasattr(e.meta.fmt, "name")
+                            else str(e.meta.fmt)
+                            if e.meta.fmt
+                            else None
+                        ),
+                        "cached_positions": (
+                            e.meta.cached_positions.tolist()
+                            if e.meta.cached_positions is not None
+                            and hasattr(e.meta.cached_positions, "tolist")
+                            else None
+                        ),
+                    }
+                    for k, e in self._index.items()
+                },
+            }
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+
+    def _load_manifest(self, path: str) -> None:
+        if not os.path.exists(path):
+            logger.info("RustRawBlockBackend: no manifest found at %s", path)
+            return
+        logger.info("RustRawBlockBackend: loading manifest from %s", path)
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or data.get("version") != 1:
+            logger.warning("Ignoring incompatible rust_raw_block manifest")
+            return
+        if data.get("device_path") and data.get("device_path") != self.device_path:
+            logger.warning("Manifest device_path mismatch; ignoring manifest")
+            return
+        if "slot_bytes" in data and int(data["slot_bytes"]) != int(self.slot_bytes):
+            logger.warning("Manifest slot_bytes mismatch; ignoring manifest")
+            return
+        # Restore core allocator state
+        with self._lock:
+            self.capacity_bytes = int(data.get("capacity_bytes", self.capacity_bytes))
+            self.block_align = int(data.get("block_align", self.block_align))
+            self.header_bytes = int(data.get("header_bytes", self.header_bytes))
+            self.slot_bytes = int(data.get("slot_bytes", self.slot_bytes))
+            self._next_slot = int(data.get("next_slot", 0))
+            self._free_slots = [int(x) for x in data.get("free_slots", [])]
+
+            # Restore entries
+            self._index.clear()
+            self._lru.clear()
+            entries = data.get("entries", {})
+            if isinstance(entries, dict):
+                for k_str, e in entries.items():
+                    try:
+                        key = CacheEngineKey.from_string(k_str)
+                    except Exception:
+                        continue
+                    if not isinstance(e, dict):
+                        continue
+                    offset = int(e.get("offset", 0))
+                    size = int(e.get("size", 0))
+                    shape_list = e.get("shape")
+                    fmt_name = e.get("fmt")
+                    shape = (
+                        torch.Size(list(shape_list)) if shape_list is not None else None
+                    )
+                    fmt = (
+                        MemoryFormat[fmt_name]
+                        if isinstance(fmt_name, str)
+                        and fmt_name in MemoryFormat.__members__
+                        else MemoryFormat.UNDEFINED
+                    )
+                    # Restore cached_positions if present
+                    cached_positions_list = e.get("cached_positions")
+                    cached_positions = (
+                        torch.tensor(cached_positions_list, dtype=torch.long)
+                        if cached_positions_list is not None
+                        else None
+                    )
+                    # Metadata recovery is best-effort.
+                    meta = DiskCacheMetadata(
+                        path=f"{self.device_path}@{offset}",
+                        size=size,
+                        shape=shape,
+                        dtype=key.dtype,
+                        cached_positions=cached_positions,
+                        fmt=fmt,
+                        pin_count=0,
+                    )
+                    self._index[key] = _Entry(offset=offset, size=size, meta=meta)
+
+            # Restore LRU order (fallback to insertion order if missing)
+            lru_keys = data.get("lru_keys", [])
+            if isinstance(lru_keys, list) and lru_keys:
+                for k_str in lru_keys:
+                    try:
+                        key = CacheEngineKey.from_string(k_str)
+                    except Exception:
+                        continue
+                    if key in self._index:
+                        self._lru[key] = None
+            else:
+                for k in self._index.keys():
+                    self._lru[k] = None
+
+            logger.info(
+                "RustRawBlockBackend: loaded manifest with %d entries, next_slot=%d",
+                len(self._index),
+                self._next_slot,
+            )

--- a/rust/raw_block/Cargo.toml
+++ b/rust/raw_block/Cargo.toml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "lmcache_rust_raw_block_io"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+name = "lmcache_rust_raw_block_io"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.24", features = ["extension-module"] }
+libc = "0.2"
+

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -1,0 +1,33 @@
+# LMCache Rust Raw Block I/O
+
+This crate provides raw block device I/O operations for LMCache using Rust and PyO3.
+
+## Building
+
+```bash
+cd rust/raw_block
+pip install maturin
+maturin develop --release
+```
+
+## Features
+
+- Direct block device access with O_DIRECT support
+- Batch read/write operations (preadv/pwritev)
+- Optional asynchronous I/O via multi-process mode
+
+## Usage
+
+```python
+from lmcache_rust_raw_block_io import RawBlockDevice
+
+# Open device
+dev = RawBlockDevice("/dev/nvme0n1", use_odirect=True)
+
+# Write data
+dev.pwrite(offset=0, data=b"hello", total_len=4096)
+
+# Read data
+buf = bytearray(4096)
+dev.pread_into(offset=0, buf=buf, length=5, total_len=4096)
+```

--- a/rust/raw_block/pyproject.toml
+++ b/rust/raw_block/pyproject.toml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["maturin>=1.8"]
+build-backend = "maturin"
+
+[project]
+name = "lmcache_rust_raw_block_io"
+version = "0.0.1"
+description = "Rust (PyO3) raw block I/O helpers for LMCache storage plugins."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.maturin]
+bindings = "pyo3"
+module-name = "lmcache_rust_raw_block_io"
+

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -691,10 +691,6 @@ impl RawBlockDevice {
                 return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
             }
         }
-        if total_len % align != 0 && self.use_odirect {
-            release_pybuffer(view);
-            return Err(PyValueError::new_err("invalid alignment"));
-        }
 
         // If padding is requested (total_len > payload_len), always use bounce.
         // For O_DIRECT we also always use bounce (Python buffer alignment is not guaranteed).

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -1,0 +1,1639 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use pyo3::exceptions::{PyOSError, PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use pyo3::types::PyAny;
+use std::ffi::CString;
+use std::os::unix::io::RawFd;
+use std::slice;
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+
+// Linux ioctl for block device size in bytes.
+// Defined in <linux/fs.h>: BLKGETSIZE64 _IOR(0x12,114,size_t)
+const BLKGETSIZE64: libc::c_ulong = 0x8008_1272;
+
+// Buffer protocol flags (from CPython C-API).
+const PYBUF_WRITABLE: i32 = 0x0001;
+const PYBUF_ND: i32 = 0x0008;
+const PYBUF_STRIDES: i32 = 0x0010 | PYBUF_ND;
+const PYBUF_ANY_CONTIGUOUS: i32 = 0x0080 | PYBUF_STRIDES;
+
+fn round_up(x: usize, align: usize) -> usize {
+    (x + align - 1) / align * align
+}
+
+fn cpu_count() -> usize {
+    // SAFETY: sysconf is a libc call; returns -1 on error.
+    let n = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+    if n <= 0 {
+        1
+    } else {
+        n as usize
+    }
+}
+
+fn errno() -> i32 {
+    // SAFETY: libc call.
+    unsafe { *libc::__errno_location() }
+}
+
+fn os_err(msg: &str) -> PyErr {
+    PyOSError::new_err((errno(), msg.to_string()))
+}
+
+#[derive(Clone, Debug)]
+enum ErrorInfo {
+    Os { errno: i32, msg: String },
+    Value { msg: String },
+    Runtime { msg: String },
+}
+
+fn errorinfo_to_pyerr(e: ErrorInfo) -> PyErr {
+    match e {
+        ErrorInfo::Os { errno, msg } => PyOSError::new_err((errno, msg)),
+        ErrorInfo::Value { msg } => PyValueError::new_err(msg),
+        ErrorInfo::Runtime { msg } => PyRuntimeError::new_err(msg),
+    }
+}
+
+fn pwrite_from_ptr_e(
+    fd: RawFd,
+    mut offset: u64,
+    mut ptr: *const u8,
+    mut len: usize,
+) -> Result<(), ErrorInfo> {
+    while len > 0 {
+        // SAFETY: caller guarantees ptr is valid for len bytes.
+        let chunk = unsafe { slice::from_raw_parts(ptr, len) };
+        let n = unsafe {
+            libc::pwrite(
+                fd,
+                chunk.as_ptr() as *const libc::c_void,
+                chunk.len(),
+                offset as libc::off_t,
+            )
+        };
+        if n < 0 {
+            return Err(ErrorInfo::Os {
+                errno: errno(),
+                msg: "pwrite failed".to_string(),
+            });
+        }
+        let n = n as usize;
+        offset += n as u64;
+        // SAFETY: advance ptr by n bytes.
+        unsafe {
+            ptr = ptr.add(n);
+        }
+        len -= n;
+    }
+    Ok(())
+}
+
+fn pread_into_e(fd: RawFd, offset: u64, mut dst: *mut u8, mut size: usize) -> Result<(), ErrorInfo> {
+    let mut off = offset;
+    while size > 0 {
+        let n = unsafe {
+            libc::pread(
+                fd,
+                dst as *mut libc::c_void,
+                size,
+                off as libc::off_t,
+            )
+        };
+        if n < 0 {
+            return Err(ErrorInfo::Os {
+                errno: errno(),
+                msg: "pread failed".to_string(),
+            });
+        }
+        if n == 0 {
+            return Err(ErrorInfo::Runtime {
+                msg: "unexpected EOF".to_string(),
+            });
+        }
+        let n = n as usize;
+        unsafe {
+            dst = dst.add(n);
+        }
+        off += n as u64;
+        size -= n;
+    }
+    Ok(())
+}
+
+fn aligned_buf_new_e(len: usize, align: usize) -> Result<AlignedBuf, ErrorInfo> {
+    let mut p: *mut libc::c_void = std::ptr::null_mut();
+    let rc = unsafe { libc::posix_memalign(&mut p as *mut *mut libc::c_void, align, len) };
+    if rc != 0 {
+        return Err(ErrorInfo::Runtime {
+            msg: format!("posix_memalign failed rc={rc}"),
+        });
+    }
+    if p.is_null() {
+        return Err(ErrorInfo::Runtime {
+            msg: "posix_memalign returned null".to_string(),
+        });
+    }
+    Ok(AlignedBuf { ptr: p as *mut u8, len, align })
+}
+
+fn fd_size_bytes(fd: RawFd) -> Result<u64, PyErr> {
+    // Try ioctl first (block device / loop device).
+    let mut size: u64 = 0;
+    // SAFETY: ioctl expects pointer to u64 for BLKGETSIZE64.
+    let rc = unsafe { libc::ioctl(fd, BLKGETSIZE64, &mut size as *mut u64) };
+    if rc == 0 {
+        return Ok(size);
+    }
+
+    // Fallback to fstat for regular files.
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    let rc2 = unsafe { libc::fstat(fd, &mut st as *mut libc::stat) };
+    if rc2 != 0 {
+        return Err(os_err("fstat failed"));
+    }
+    Ok(st.st_size as u64)
+}
+
+fn pwrite_all(fd: RawFd, mut offset: u64, mut buf: &[u8]) -> Result<(), PyErr> {
+    while !buf.is_empty() {
+        // SAFETY: pwrite reads from buf pointer for buf.len bytes.
+        let n = unsafe {
+            libc::pwrite(
+                fd,
+                buf.as_ptr() as *const libc::c_void,
+                buf.len(),
+                offset as libc::off_t,
+            )
+        };
+        if n < 0 {
+            return Err(os_err("pwrite failed"));
+        }
+        let n = n as usize;
+        offset += n as u64;
+        buf = &buf[n..];
+    }
+    Ok(())
+}
+
+fn pwrite_from_ptr(fd: RawFd, mut offset: u64, mut ptr: *const u8, mut len: usize) -> Result<(), PyErr> {
+    while len > 0 {
+        // SAFETY: caller guarantees ptr is valid for len bytes.
+        let chunk = unsafe { slice::from_raw_parts(ptr, len) };
+        let n = unsafe {
+            libc::pwrite(
+                fd,
+                chunk.as_ptr() as *const libc::c_void,
+                chunk.len(),
+                offset as libc::off_t,
+            )
+        };
+        if n < 0 {
+            return Err(os_err("pwrite failed"));
+        }
+        let n = n as usize;
+        offset += n as u64;
+        // SAFETY: advance ptr by n bytes.
+        unsafe {
+            ptr = ptr.add(n);
+        }
+        len -= n;
+    }
+    Ok(())
+}
+
+fn pread_exact(fd: RawFd, offset: u64, size: usize) -> Result<Vec<u8>, PyErr> {
+    let mut out = vec![0u8; size];
+    let mut read = 0usize;
+    while read < size {
+        // SAFETY: pread writes into out[read..] for remaining bytes.
+        let n = unsafe {
+            libc::pread(
+                fd,
+                out[read..].as_mut_ptr() as *mut libc::c_void,
+                size - read,
+                (offset as libc::off_t) + (read as libc::off_t),
+            )
+        };
+        if n < 0 {
+            return Err(os_err("pread failed"));
+        }
+        if n == 0 {
+            return Err(PyRuntimeError::new_err("unexpected EOF"));
+        }
+        read += n as usize;
+    }
+    Ok(out)
+}
+
+fn pread_into(fd: RawFd, offset: u64, mut dst: *mut u8, mut size: usize) -> Result<(), PyErr> {
+    let mut off = offset;
+    while size > 0 {
+        // SAFETY: pread writes into dst for size bytes.
+        let n = unsafe {
+            libc::pread(
+                fd,
+                dst as *mut libc::c_void,
+                size,
+                off as libc::off_t,
+            )
+        };
+        if n < 0 {
+            return Err(os_err("pread failed"));
+        }
+        if n == 0 {
+            return Err(PyRuntimeError::new_err("unexpected EOF"));
+        }
+        let n = n as usize;
+        // SAFETY: advance dst by n bytes.
+        unsafe {
+            dst = dst.add(n);
+        }
+        off += n as u64;
+        size -= n;
+    }
+    Ok(())
+}
+
+struct AlignedBuf {
+    ptr: *mut u8,
+    len: usize,
+    align: usize,
+}
+
+impl AlignedBuf {
+    fn new(len: usize, align: usize) -> Result<Self, PyErr> {
+        let mut p: *mut libc::c_void = std::ptr::null_mut();
+        // SAFETY: posix_memalign writes to p.
+        let rc = unsafe { libc::posix_memalign(&mut p as *mut *mut libc::c_void, align, len) };
+        if rc != 0 {
+            return Err(PyRuntimeError::new_err(format!("posix_memalign failed rc={rc}")));
+        }
+        if p.is_null() {
+            return Err(PyRuntimeError::new_err("posix_memalign returned null"));
+        }
+        Ok(Self { ptr: p as *mut u8, len, align })
+    }
+
+    fn as_mut_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.ptr as *const u8
+    }
+}
+
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                libc::free(self.ptr as *mut libc::c_void);
+            }
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}
+
+fn get_pybuffer<'py>(
+    py: Python<'py>,
+    obj: &Bound<'py, PyAny>,
+    writable: bool,
+) -> Result<pyo3::ffi::Py_buffer, PyErr> {
+    // SAFETY: PyObject_GetBuffer follows CPython buffer protocol.
+    unsafe {
+        let mut view: pyo3::ffi::Py_buffer = std::mem::zeroed();
+        let flags = if writable {
+            PYBUF_WRITABLE | PYBUF_ANY_CONTIGUOUS
+        } else {
+            PYBUF_ANY_CONTIGUOUS
+        };
+        let rc = pyo3::ffi::PyObject_GetBuffer(obj.as_ptr(), &mut view, flags);
+        if rc != 0 {
+            return Err(PyErr::fetch(py));
+        }
+        Ok(view)
+    }
+}
+
+fn release_pybuffer(mut view: pyo3::ffi::Py_buffer) {
+    // SAFETY: view was created by PyObject_GetBuffer.
+    unsafe {
+        pyo3::ffi::PyBuffer_Release(&mut view);
+    }
+}
+
+fn pick_fd(fds: &[RawFd]) -> RawFd {
+    if fds.len() == 1 {
+        return fds[0];
+    }
+    // SAFETY: sched_getcpu is a libc call; returns -1 on error.
+    let cpu = unsafe { libc::sched_getcpu() };
+    if cpu < 0 {
+        return fds[0];
+    }
+    let idx = (cpu as usize) % fds.len();
+    fds[idx]
+}
+
+fn pin_thread_to_cpu(cpu: usize) {
+    // Best-effort pinning (Linux).
+    #[cfg(target_os = "linux")]
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(cpu, &mut set);
+        let tid = libc::pthread_self();
+        let _rc = libc::pthread_setaffinity_np(tid, std::mem::size_of::<libc::cpu_set_t>(), &set);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Priority {
+    High,
+    Medium,
+    Low,
+}
+
+enum TaskKind {
+    Pwrite {
+        offset: u64,
+        payload_len: usize,
+        total_len: usize,
+    },
+    Pread {
+        offset: u64,
+        payload_len: usize,
+        total_len: usize,
+    },
+}
+
+struct HeldPyBuffer(pyo3::ffi::Py_buffer);
+
+// We treat Py_buffer as an owned handle whose underlying PyObject is kept alive
+// by the buffer protocol; we only touch/release it under the GIL.
+unsafe impl Send for HeldPyBuffer {}
+unsafe impl Sync for HeldPyBuffer {}
+
+impl HeldPyBuffer {
+    fn ptr_ro(&self) -> *const u8 {
+        self.0.buf as *const u8
+    }
+    fn ptr_rw(&self) -> *mut u8 {
+        self.0.buf as *mut u8
+    }
+    fn len(&self) -> usize {
+        self.0.len as usize
+    }
+    fn readonly(&self) -> i32 {
+        self.0.readonly
+    }
+    fn release(mut self) {
+        unsafe { pyo3::ffi::PyBuffer_Release(&mut self.0) };
+    }
+}
+
+struct Task {
+    prio: Priority,
+    kind: TaskKind,
+    buf: HeldPyBuffer,
+    future: Option<Py<PyAny>>, // concurrent.futures.Future
+    batch: Option<Arc<Mutex<BatchState>>>,
+}
+
+struct BatchState {
+    remaining: usize,
+    done: bool,
+    future: Py<PyAny>, // concurrent.futures.Future
+}
+
+struct WorkerQueue {
+    high: VecDeque<Task>,
+    mid: VecDeque<Task>,
+    low: VecDeque<Task>,
+    stop: bool,
+}
+
+struct WorkerState {
+    q: Mutex<WorkerQueue>,
+    cv: Condvar,
+}
+
+impl WorkerState {
+    fn new() -> Self {
+        Self {
+            q: Mutex::new(WorkerQueue {
+                high: VecDeque::new(),
+                mid: VecDeque::new(),
+                low: VecDeque::new(),
+                stop: false,
+            }),
+            cv: Condvar::new(),
+        }
+    }
+
+    fn push(&self, t: Task) {
+        let mut g = self.q.lock().unwrap();
+        match t.prio {
+            Priority::High => g.high.push_back(t),
+            Priority::Medium => g.mid.push_back(t),
+            Priority::Low => g.low.push_back(t),
+        }
+        self.cv.notify_one();
+    }
+
+    fn pop(&self) -> Option<Task> {
+        let mut g = self.q.lock().unwrap();
+        loop {
+            if g.stop {
+                return None;
+            }
+            if let Some(t) = g.high.pop_front() {
+                return Some(t);
+            }
+            if let Some(t) = g.mid.pop_front() {
+                return Some(t);
+            }
+            if let Some(t) = g.low.pop_front() {
+                return Some(t);
+            }
+            g = self.cv.wait(g).unwrap();
+        }
+    }
+
+    fn shutdown(&self) {
+        let mut g = self.q.lock().unwrap();
+        g.stop = true;
+        self.cv.notify_all();
+    }
+}
+
+fn make_concurrent_future(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    // Lazily import concurrent.futures.Future
+    let cf = py.import("concurrent.futures")?;
+    let cls = cf.getattr("Future")?;
+    let fut = cls.call0()?;
+    Ok(fut.into())
+}
+
+fn future_set_result(py: Python<'_>, fut: &Py<PyAny>) {
+    let _ = fut.bind(py).call_method1("set_result", (py.None(),));
+}
+
+fn future_set_exception(py: Python<'_>, fut: &Py<PyAny>, err: PyErr) {
+    let _ = fut.bind(py).call_method1("set_exception", (err,));
+}
+
+struct Completion {
+    buf: HeldPyBuffer,
+    future: Option<Py<PyAny>>,
+    batch: Option<Arc<Mutex<BatchState>>>,
+    err: Option<ErrorInfo>,
+}
+
+struct CompletionQueue {
+    items: VecDeque<Completion>,
+    stop: bool,
+}
+
+struct CompletionState {
+    q: Mutex<CompletionQueue>,
+    cv: Condvar,
+}
+
+impl CompletionState {
+    fn new() -> Self {
+        Self {
+            q: Mutex::new(CompletionQueue {
+                items: VecDeque::new(),
+                stop: false,
+            }),
+            cv: Condvar::new(),
+        }
+    }
+
+    fn push(&self, c: Completion) {
+        let mut g = self.q.lock().unwrap();
+        g.items.push_back(c);
+        self.cv.notify_one();
+    }
+
+    fn pop_batch(&self) -> Option<Vec<Completion>> {
+        let mut g = self.q.lock().unwrap();
+        loop {
+            if g.stop && g.items.is_empty() {
+                return None;
+            }
+            if !g.items.is_empty() {
+                let mut out = Vec::with_capacity(g.items.len());
+                while let Some(c) = g.items.pop_front() {
+                    out.push(c);
+                }
+                return Some(out);
+            }
+            g = self.cv.wait(g).unwrap();
+        }
+    }
+
+    fn shutdown(&self) {
+        let mut g = self.q.lock().unwrap();
+        g.stop = true;
+        self.cv.notify_all();
+    }
+}
+
+#[pyclass]
+struct RawBlockDevice {
+    fd: RawFd,
+    size: u64,
+    closed: bool,
+    use_odirect: bool,
+    alignment: usize,
+}
+
+#[pymethods]
+impl RawBlockDevice {
+    #[new]
+    #[pyo3(signature=(path, writable, use_odirect=false, alignment=4096))]
+    fn new(path: String, writable: bool, use_odirect: bool, alignment: usize) -> PyResult<Self> {
+        let cpath = CString::new(path.clone()).map_err(|_| PyValueError::new_err("path contains NUL"))?;
+        let mut flags = if writable { libc::O_RDWR } else { libc::O_RDONLY };
+        if use_odirect {
+            flags |= libc::O_DIRECT;
+        }
+        // SAFETY: open returns fd or -1.
+        let fd = unsafe { libc::open(cpath.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(os_err("open failed"));
+        }
+        let size = fd_size_bytes(fd)?;
+        Ok(Self { fd, size, closed: false, use_odirect, alignment })
+    }
+
+    fn size_bytes(&self) -> PyResult<u64> {
+        Ok(self.size)
+    }
+
+    fn pread<'py>(&self, py: Python<'py>, offset: u64, size: usize) -> PyResult<Bound<'py, PyBytes>> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = self.fd;
+        if !self.use_odirect {
+            let data = py.allow_threads(move || pread_exact(fd, offset, size))?;
+            return Ok(PyBytes::new(py, &data));
+        }
+
+        let align = self.alignment;
+        if align == 0 {
+            return Err(PyValueError::new_err("alignment must be > 0"));
+        }
+        if (offset as usize) % align != 0 {
+            return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+        }
+        let total = round_up(size, align);
+        let data = py.allow_threads(move || {
+            let bounce = AlignedBuf::new(total, align)?;
+            pread_into(fd, offset, bounce.as_mut_ptr(), total)?;
+            // SAFETY: bounce contains total bytes; copy only requested size.
+            let slice = unsafe { slice::from_raw_parts(bounce.as_ptr(), size) };
+            Ok::<Vec<u8>, PyErr>(slice.to_vec())
+        })?;
+        Ok(PyBytes::new(py, &data))
+    }
+
+    fn pwrite(&self, py: Python<'_>, offset: u64, data: &[u8]) -> PyResult<()> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = self.fd;
+        if !self.use_odirect {
+            let buf = data.to_vec();
+            py.allow_threads(move || pwrite_all(fd, offset, &buf))?;
+            return Ok(());
+        }
+
+        let align = self.alignment;
+        if (offset as usize) % align != 0 {
+            return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+        }
+        let payload_len = data.len();
+        let total_len = round_up(payload_len, align);
+        let buf = data.to_vec();
+        py.allow_threads(move || {
+            let bounce = AlignedBuf::new(total_len, align)?;
+            // SAFETY: bounce is total_len, buf is payload_len.
+            unsafe {
+                libc::memcpy(
+                    bounce.as_mut_ptr() as *mut libc::c_void,
+                    buf.as_ptr() as *const libc::c_void,
+                    payload_len,
+                );
+                if total_len > payload_len {
+                    libc::memset(
+                        bounce.as_mut_ptr().add(payload_len) as *mut libc::c_void,
+                        0,
+                        total_len - payload_len,
+                    );
+                }
+            }
+            pwrite_from_ptr(fd, offset, bounce.as_ptr(), total_len)
+        })?;
+        Ok(())
+    }
+
+    /// Zero-copy write: write the bytes from any Python buffer object.
+    #[pyo3(signature=(offset, data, payload_len=None, total_len=None))]
+    fn pwrite_from_buffer(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        data: &Bound<'_, PyAny>,
+        payload_len: Option<usize>,
+        total_len: Option<usize>,
+    ) -> PyResult<()> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = self.fd;
+
+        let view = get_pybuffer(py, data, false)?;
+        let ptr = view.buf as *const u8;
+        let buf_len = view.len as usize;
+        if ptr.is_null() {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("null buffer pointer"));
+        }
+
+        let payload_len = payload_len.unwrap_or(buf_len);
+        if payload_len > buf_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("payload_len exceeds buffer length"));
+        }
+        let mut total_len = total_len.unwrap_or(payload_len);
+        if total_len < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("total_len must be >= payload_len"));
+        }
+
+        let align = self.alignment;
+        if self.use_odirect {
+            if (offset as usize) % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+            }
+            if total_len % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+            }
+        }
+        if total_len % align != 0 && self.use_odirect {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("invalid alignment"));
+        }
+
+        // If padding is requested (total_len > payload_len), always use bounce.
+        // For O_DIRECT we also always use bounce (Python buffer alignment is not guaranteed).
+        let ptr_usize = ptr as usize;
+        let res = py.allow_threads(move || {
+            let src = ptr_usize as *const u8;
+            if total_len == payload_len && !self.use_odirect {
+                // direct write without padding
+                return pwrite_from_ptr(fd, offset, src, payload_len);
+            }
+            // bounce + optional pad zeros
+            let bounce = AlignedBuf::new(total_len, align)?;
+            unsafe {
+                libc::memcpy(
+                    bounce.as_mut_ptr() as *mut libc::c_void,
+                    src as *const libc::c_void,
+                    payload_len,
+                );
+                if total_len > payload_len {
+                    libc::memset(
+                        bounce.as_mut_ptr().add(payload_len) as *mut libc::c_void,
+                        0,
+                        total_len - payload_len,
+                    );
+                }
+            }
+            pwrite_from_ptr(fd, offset, bounce.as_ptr(), total_len)
+        });
+        release_pybuffer(view);
+        res?;
+        Ok(())
+    }
+
+    /// Zero-copy read: read exactly `size` bytes into a writable Python buffer.
+    #[pyo3(signature=(offset, out, payload_len, total_len=None))]
+    fn pread_into(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        out: &Bound<'_, PyAny>,
+        payload_len: usize,
+        total_len: Option<usize>,
+    ) -> PyResult<()> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = self.fd;
+        let view = get_pybuffer(py, out, true)?;
+        if view.readonly != 0 {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("output buffer is readonly"));
+        }
+        let cap = view.len as usize;
+        if cap < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err(format!(
+                "output buffer too small: cap={cap} need={payload_len}"
+            )));
+        }
+        let ptr = view.buf as *mut u8;
+        if ptr.is_null() {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("null buffer pointer"));
+        }
+
+        let mut total_len = total_len.unwrap_or(payload_len);
+        if total_len < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("total_len must be >= payload_len"));
+        }
+
+        let align = self.alignment;
+        if self.use_odirect {
+            if (offset as usize) % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+            }
+            if total_len % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+            }
+        }
+
+        let dst_usize = ptr as usize;
+        let res = py.allow_threads(move || {
+            let dst = dst_usize as *mut u8;
+            if total_len == payload_len && !self.use_odirect {
+                return pread_into(fd, offset, dst, payload_len);
+            }
+            // bounce read then copy payload_len into dst
+            let bounce = AlignedBuf::new(round_up(total_len, align), align)?;
+            pread_into(fd, offset, bounce.as_mut_ptr(), total_len)?;
+            unsafe {
+                libc::memcpy(
+                    dst as *mut libc::c_void,
+                    bounce.as_ptr() as *const libc::c_void,
+                    payload_len,
+                );
+            }
+            Ok(())
+        });
+        release_pybuffer(view);
+        res?;
+        Ok(())
+    }
+
+    fn close(&mut self) -> PyResult<()> {
+        if !self.closed {
+            // SAFETY: close fd once.
+            let rc = unsafe { libc::close(self.fd) };
+            if rc != 0 {
+                return Err(os_err("close failed"));
+            }
+            self.closed = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RawBlockDevice {
+    fn drop(&mut self) {
+        if !self.closed {
+            unsafe {
+                libc::close(self.fd);
+            }
+            self.closed = true;
+        }
+    }
+}
+
+#[pyclass]
+struct RawBlockDevicePool {
+    fds: Vec<RawFd>,
+    size: u64,
+    closed: bool,
+    use_odirect: bool,
+    alignment: usize,
+}
+
+#[pymethods]
+impl RawBlockDevicePool {
+    #[new]
+    #[pyo3(signature=(path, writable, num_fds=None, use_odirect=false, alignment=4096))]
+    fn new(
+        path: String,
+        writable: bool,
+        num_fds: Option<usize>,
+        use_odirect: bool,
+        alignment: usize,
+    ) -> PyResult<Self> {
+        let cpath =
+            CString::new(path).map_err(|_| PyValueError::new_err("path contains NUL"))?;
+        let mut flags = if writable { libc::O_RDWR } else { libc::O_RDONLY };
+        if use_odirect {
+            flags |= libc::O_DIRECT;
+        }
+        let n = num_fds.unwrap_or(0);
+        let n = if n == 0 { cpu_count() } else { n };
+        let n = std::cmp::max(1, n);
+
+        let mut fds: Vec<RawFd> = Vec::with_capacity(n);
+        for _ in 0..n {
+            // SAFETY: open returns fd or -1.
+            let fd = unsafe { libc::open(cpath.as_ptr(), flags) };
+            if fd < 0 {
+                // Cleanup already opened fds.
+                for ofd in fds.drain(..) {
+                    unsafe {
+                        libc::close(ofd);
+                    }
+                }
+                return Err(os_err("open failed"));
+            }
+            fds.push(fd);
+        }
+        let size = fd_size_bytes(fds[0])?;
+        Ok(Self {
+            fds,
+            size,
+            closed: false,
+            use_odirect,
+            alignment,
+        })
+    }
+
+    fn size_bytes(&self) -> PyResult<u64> {
+        Ok(self.size)
+    }
+
+    fn pread<'py>(
+        &self,
+        py: Python<'py>,
+        offset: u64,
+        size: usize,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = pick_fd(&self.fds);
+        if !self.use_odirect {
+            let data = py.allow_threads(move || pread_exact(fd, offset, size))?;
+            return Ok(PyBytes::new(py, &data));
+        }
+        let align = self.alignment;
+        if align == 0 {
+            return Err(PyValueError::new_err("alignment must be > 0"));
+        }
+        if (offset as usize) % align != 0 {
+            return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+        }
+        let total = round_up(size, align);
+        let data = py.allow_threads(move || {
+            let bounce = AlignedBuf::new(total, align)?;
+            pread_into(fd, offset, bounce.as_mut_ptr(), total)?;
+            let slice = unsafe { slice::from_raw_parts(bounce.as_ptr(), size) };
+            Ok::<Vec<u8>, PyErr>(slice.to_vec())
+        })?;
+        Ok(PyBytes::new(py, &data))
+    }
+
+    fn pwrite(&self, py: Python<'_>, offset: u64, data: &[u8]) -> PyResult<()> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = pick_fd(&self.fds);
+        if !self.use_odirect {
+            let buf = data.to_vec();
+            py.allow_threads(move || pwrite_all(fd, offset, &buf))?;
+            return Ok(());
+        }
+        let align = self.alignment;
+        if (offset as usize) % align != 0 {
+            return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+        }
+        let payload_len = data.len();
+        let total_len = round_up(payload_len, align);
+        let buf = data.to_vec();
+        py.allow_threads(move || {
+            let bounce = AlignedBuf::new(total_len, align)?;
+            unsafe {
+                libc::memcpy(
+                    bounce.as_mut_ptr() as *mut libc::c_void,
+                    buf.as_ptr() as *const libc::c_void,
+                    payload_len,
+                );
+                if total_len > payload_len {
+                    libc::memset(
+                        bounce.as_mut_ptr().add(payload_len) as *mut libc::c_void,
+                        0,
+                        total_len - payload_len,
+                    );
+                }
+            }
+            pwrite_from_ptr(fd, offset, bounce.as_ptr(), total_len)
+        })?;
+        Ok(())
+    }
+
+    #[pyo3(signature=(offset, data, payload_len=None, total_len=None))]
+    fn pwrite_from_buffer(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        data: &Bound<'_, PyAny>,
+        payload_len: Option<usize>,
+        total_len: Option<usize>,
+    ) -> PyResult<()> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = pick_fd(&self.fds);
+
+        let view = get_pybuffer(py, data, false)?;
+        let ptr = view.buf as *const u8;
+        let buf_len = view.len as usize;
+        if ptr.is_null() {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("null buffer pointer"));
+        }
+
+        let payload_len = payload_len.unwrap_or(buf_len);
+        if payload_len > buf_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("payload_len exceeds buffer length"));
+        }
+        let total_len = total_len.unwrap_or(payload_len);
+        if total_len < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("total_len must be >= payload_len"));
+        }
+
+        let align = self.alignment;
+        if self.use_odirect {
+            if (offset as usize) % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+            }
+            if total_len % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+            }
+        }
+
+        let ptr_usize = ptr as usize;
+        let res = py.allow_threads(move || {
+            let src = ptr_usize as *const u8;
+            if total_len == payload_len && !self.use_odirect {
+                return pwrite_from_ptr(fd, offset, src, payload_len);
+            }
+            let bounce = AlignedBuf::new(total_len, align)?;
+            unsafe {
+                libc::memcpy(
+                    bounce.as_mut_ptr() as *mut libc::c_void,
+                    src as *const libc::c_void,
+                    payload_len,
+                );
+                if total_len > payload_len {
+                    libc::memset(
+                        bounce.as_mut_ptr().add(payload_len) as *mut libc::c_void,
+                        0,
+                        total_len - payload_len,
+                    );
+                }
+            }
+            pwrite_from_ptr(fd, offset, bounce.as_ptr(), total_len)
+        });
+        release_pybuffer(view);
+        res?;
+        Ok(())
+    }
+
+    #[pyo3(signature=(offset, out, payload_len, total_len=None))]
+    fn pread_into(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        out: &Bound<'_, PyAny>,
+        payload_len: usize,
+        total_len: Option<usize>,
+    ) -> PyResult<()> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        let fd = pick_fd(&self.fds);
+
+        let view = get_pybuffer(py, out, true)?;
+        if view.readonly != 0 {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("output buffer is readonly"));
+        }
+        let cap = view.len as usize;
+        if cap < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err(format!(
+                "output buffer too small: cap={cap} need={payload_len}"
+            )));
+        }
+        let ptr = view.buf as *mut u8;
+        if ptr.is_null() {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("null buffer pointer"));
+        }
+
+        let total_len = total_len.unwrap_or(payload_len);
+        if total_len < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("total_len must be >= payload_len"));
+        }
+
+        let align = self.alignment;
+        if self.use_odirect {
+            if (offset as usize) % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+            }
+            if total_len % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+            }
+        }
+
+        let dst_usize = ptr as usize;
+        let res = py.allow_threads(move || {
+            let dst = dst_usize as *mut u8;
+            if total_len == payload_len && !self.use_odirect {
+                return pread_into(fd, offset, dst, payload_len);
+            }
+            let bounce = AlignedBuf::new(round_up(total_len, align), align)?;
+            pread_into(fd, offset, bounce.as_mut_ptr(), total_len)?;
+            unsafe {
+                libc::memcpy(
+                    dst as *mut libc::c_void,
+                    bounce.as_ptr() as *const libc::c_void,
+                    payload_len,
+                );
+            }
+            Ok(())
+        });
+        release_pybuffer(view);
+        res?;
+        Ok(())
+    }
+
+    fn close(&mut self) -> PyResult<()> {
+        if !self.closed {
+            for fd in self.fds.drain(..) {
+                unsafe {
+                    libc::close(fd);
+                }
+            }
+            self.closed = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RawBlockDevicePool {
+    fn drop(&mut self) {
+        if !self.closed {
+            for fd in self.fds.drain(..) {
+                unsafe {
+                    libc::close(fd);
+                }
+            }
+            self.closed = true;
+        }
+    }
+}
+
+#[pyclass]
+struct RawBlockScheduler {
+    fds: Vec<RawFd>,
+    size: u64,
+    closed: bool,
+    use_odirect: bool,
+    alignment: usize,
+    workers: Vec<Arc<WorkerState>>,
+    threads: Vec<thread::JoinHandle<()>>,
+    completion: Arc<CompletionState>,
+    completion_thread: Option<thread::JoinHandle<()>>,
+}
+
+#[pymethods]
+impl RawBlockScheduler {
+    #[new]
+    #[pyo3(signature=(path, writable, num_workers=None, num_fds=None, use_odirect=false, alignment=4096))]
+    fn new(
+        path: String,
+        writable: bool,
+        num_workers: Option<usize>,
+        num_fds: Option<usize>,
+        use_odirect: bool,
+        alignment: usize,
+    ) -> PyResult<Self> {
+        let cpath =
+            CString::new(path).map_err(|_| PyValueError::new_err("path contains NUL"))?;
+        let mut flags = if writable { libc::O_RDWR } else { libc::O_RDONLY };
+        if use_odirect {
+            flags |= libc::O_DIRECT;
+        }
+
+        let n_workers = num_workers.unwrap_or(0);
+        let n_workers = if n_workers == 0 { cpu_count() } else { n_workers };
+        let n_workers = std::cmp::max(1, n_workers);
+
+        let n_fds = num_fds.unwrap_or(0);
+        let n_fds = if n_fds == 0 { n_workers } else { n_fds };
+        let n_fds = std::cmp::max(1, n_fds);
+
+        let mut fds: Vec<RawFd> = Vec::with_capacity(n_fds);
+        for _ in 0..n_fds {
+            let fd = unsafe { libc::open(cpath.as_ptr(), flags) };
+            if fd < 0 {
+                for ofd in fds.drain(..) {
+                    unsafe { libc::close(ofd) };
+                }
+                return Err(os_err("open failed"));
+            }
+            fds.push(fd);
+        }
+        let size = fd_size_bytes(fds[0])?;
+
+        let mut workers: Vec<Arc<WorkerState>> = Vec::with_capacity(n_workers);
+        for _ in 0..n_workers {
+            workers.push(Arc::new(WorkerState::new()));
+        }
+
+        let completion = Arc::new(CompletionState::new());
+        let completion_clone = completion.clone();
+        let completion_thread = thread::spawn(move || {
+            // Drain completion queue in batches; process each batch under one GIL acquisition.
+            while let Some(batch) = completion_clone.pop_batch() {
+                Python::with_gil(|py| {
+                    for c in batch {
+                        c.buf.release();
+                        if let Some(errinfo) = c.err.clone() {
+                            let pyerr = errorinfo_to_pyerr(errinfo);
+                            if let Some(fut) = &c.future {
+                                future_set_exception(py, fut, pyerr.clone_ref(py));
+                            }
+                            if let Some(bs) = &c.batch {
+                                let mut st = bs.lock().unwrap();
+                                if !st.done {
+                                    st.done = true;
+                                    future_set_exception(py, &st.future, pyerr);
+                                }
+                            }
+                        } else {
+                            if let Some(fut) = &c.future {
+                                future_set_result(py, fut);
+                            }
+                            if let Some(bs) = &c.batch {
+                                let mut st = bs.lock().unwrap();
+                                if !st.done {
+                                    if st.remaining > 0 {
+                                        st.remaining -= 1;
+                                    }
+                                    if st.remaining == 0 {
+                                        st.done = true;
+                                        future_set_result(py, &st.future);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        let mut threads: Vec<thread::JoinHandle<()>> = Vec::with_capacity(n_workers);
+        for i in 0..n_workers {
+            let w = workers[i].clone();
+            let fds_clone = fds.clone();
+            let use_odirect = use_odirect;
+            let alignment = alignment;
+            let completion = completion.clone();
+            threads.push(thread::spawn(move || {
+                // best-effort cpu pin
+                pin_thread_to_cpu(i % cpu_count());
+                loop {
+                    let task = w.pop();
+                    if task.is_none() {
+                        break;
+                    }
+                    let task = task.unwrap();
+                    let fd = pick_fd(&fds_clone);
+                    let res: Result<(), ErrorInfo> = (|| match task.kind {
+                        TaskKind::Pwrite { offset, payload_len, total_len } => {
+                            // Use GIL only for buffer release & future completion; I/O without GIL.
+                            // pwrite_from_ptr needs pointer.
+                            let ptr = task.buf.ptr_ro();
+                            if ptr.is_null() {
+                                Err(ErrorInfo::Value { msg: "null buffer pointer".to_string() })
+                            } else if use_odirect {
+                                if (offset as usize) % alignment != 0 || total_len % alignment != 0 {
+                                    Err(ErrorInfo::Value { msg: "O_DIRECT alignment error".to_string() })
+                                } else {
+                                    // Always bounce for O_DIRECT to ensure alignment.
+                                    let bounce = aligned_buf_new_e(total_len, alignment)?;
+                                    unsafe {
+                                        libc::memcpy(
+                                            bounce.as_mut_ptr() as *mut libc::c_void,
+                                            ptr as *const libc::c_void,
+                                            payload_len,
+                                        );
+                                        if total_len > payload_len {
+                                            libc::memset(
+                                                bounce.as_mut_ptr().add(payload_len) as *mut libc::c_void,
+                                                0,
+                                                total_len - payload_len,
+                                            );
+                                        }
+                                    }
+                                    pwrite_from_ptr_e(fd, offset, bounce.as_ptr(), total_len)
+                                }
+                            } else {
+                                pwrite_from_ptr_e(fd, offset, ptr, payload_len)
+                            }
+                        }
+                        TaskKind::Pread { offset, payload_len, total_len } => {
+                            let ptr = task.buf.ptr_rw();
+                            if ptr.is_null() {
+                                Err(ErrorInfo::Value { msg: "null buffer pointer".to_string() })
+                            } else if use_odirect {
+                                if (offset as usize) % alignment != 0 || total_len % alignment != 0 {
+                                    Err(ErrorInfo::Value { msg: "O_DIRECT alignment error".to_string() })
+                                } else {
+                                    let bounce = aligned_buf_new_e(total_len, alignment)?;
+                                    pread_into_e(fd, offset, bounce.as_mut_ptr(), total_len)?;
+                                    unsafe {
+                                        libc::memcpy(
+                                            ptr as *mut libc::c_void,
+                                            bounce.as_ptr() as *const libc::c_void,
+                                            payload_len,
+                                        );
+                                    }
+                                    Ok(())
+                                }
+                            } else {
+                                pread_into_e(fd, offset, ptr, payload_len)
+                            }
+                        }
+                    })();
+
+                    completion.push(Completion {
+                        buf: task.buf,
+                        future: task.future,
+                        batch: task.batch,
+                        err: res.err(),
+                    });
+                }
+            }));
+        }
+
+        Ok(Self {
+            fds,
+            size,
+            closed: false,
+            use_odirect,
+            alignment,
+            workers,
+            threads,
+            completion,
+            completion_thread: Some(completion_thread),
+        })
+    }
+
+    fn size_bytes(&self) -> PyResult<u64> {
+        Ok(self.size)
+    }
+
+    #[pyo3(signature=(offset, data, payload_len, total_len, priority=2))]
+    fn submit_pwrite_from_buffer(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        data: &Bound<'_, PyAny>,
+        payload_len: usize,
+        total_len: usize,
+        priority: i32,
+    ) -> PyResult<Py<PyAny>> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("scheduler is closed"));
+        }
+        let view = get_pybuffer(py, data, false)?;
+        if payload_len > view.len as usize {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("payload_len exceeds buffer length"));
+        }
+        let fut = make_concurrent_future(py)?;
+        let prio = match priority {
+            0 => Priority::High,
+            1 => Priority::Medium,
+            _ => Priority::Low,
+        };
+        // Choose worker based on current CPU of submitter (per-cpu submission).
+        let cpu = unsafe { libc::sched_getcpu() };
+        let idx = if cpu < 0 {
+            0
+        } else {
+            (cpu as usize) % self.workers.len()
+        };
+        self.workers[idx].push(Task {
+            prio,
+            kind: TaskKind::Pwrite {
+                offset,
+                payload_len,
+                total_len,
+            },
+            buf: HeldPyBuffer(view),
+            future: Some(fut.clone_ref(py)),
+            batch: None,
+        });
+        Ok(fut)
+    }
+
+    #[pyo3(signature=(offset, out, payload_len, total_len, priority=0))]
+    fn submit_pread_into(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        out: &Bound<'_, PyAny>,
+        payload_len: usize,
+        total_len: usize,
+        priority: i32,
+    ) -> PyResult<Py<PyAny>> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("scheduler is closed"));
+        }
+        let view = get_pybuffer(py, out, true)?;
+        if view.readonly != 0 {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("output buffer is readonly"));
+        }
+        if payload_len > view.len as usize {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("output buffer too small"));
+        }
+        let fut = make_concurrent_future(py)?;
+        let prio = match priority {
+            0 => Priority::High,
+            1 => Priority::Medium,
+            _ => Priority::Low,
+        };
+        let cpu = unsafe { libc::sched_getcpu() };
+        let idx = if cpu < 0 {
+            0
+        } else {
+            (cpu as usize) % self.workers.len()
+        };
+        self.workers[idx].push(Task {
+            prio,
+            kind: TaskKind::Pread {
+                offset,
+                payload_len,
+                total_len,
+            },
+            buf: HeldPyBuffer(view),
+            future: Some(fut.clone_ref(py)),
+            batch: None,
+        });
+        Ok(fut)
+    }
+
+    #[pyo3(signature=(requests, priority=2))]
+    fn submit_pwritev_from_buffers(
+        &self,
+        py: Python<'_>,
+        requests: &Bound<'_, PyAny>,
+        priority: i32,
+    ) -> PyResult<Py<PyAny>> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("scheduler is closed"));
+        }
+
+        let fut = make_concurrent_future(py)?;
+        let prio = match priority {
+            0 => Priority::High,
+            1 => Priority::Medium,
+            _ => Priority::Low,
+        };
+
+        let mut parsed: Vec<(u64, HeldPyBuffer, usize, usize)> = Vec::new();
+        let iter = requests.iter()?;
+        for item in iter {
+            let obj = item?;
+            let tup = obj.downcast::<pyo3::types::PyTuple>()?;
+            if tup.len() != 4 {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                return Err(PyValueError::new_err(
+                    "each request must be a 4-tuple (offset, data, payload_len, total_len)",
+                ));
+            }
+            let offset: u64 = tup.get_item(0)?.extract()?;
+            let data = tup.get_item(1)?;
+            let payload_len: usize = tup.get_item(2)?.extract()?;
+            let total_len: usize = tup.get_item(3)?.extract()?;
+            let view = get_pybuffer(py, &data, false)?;
+            let held = HeldPyBuffer(view);
+            if payload_len > held.len() {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                held.release();
+                return Err(PyValueError::new_err("payload_len exceeds buffer length"));
+            }
+            if total_len < payload_len {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                held.release();
+                return Err(PyValueError::new_err("total_len must be >= payload_len"));
+            }
+            parsed.push((offset, held, payload_len, total_len));
+        }
+
+        if parsed.is_empty() {
+            future_set_result(py, &fut);
+            return Ok(fut);
+        }
+
+        let batch = Arc::new(Mutex::new(BatchState {
+            remaining: parsed.len(),
+            done: false,
+            future: fut.clone_ref(py),
+        }));
+
+        // Choose worker based on current CPU of submitter (per-cpu submission).
+        let cpu = unsafe { libc::sched_getcpu() };
+        let idx = if cpu < 0 {
+            0
+        } else {
+            (cpu as usize) % self.workers.len()
+        };
+        for (offset, held, payload_len, total_len) in parsed {
+            self.workers[idx].push(Task {
+                prio,
+                kind: TaskKind::Pwrite {
+                    offset,
+                    payload_len,
+                    total_len,
+                },
+                buf: held,
+                future: None,
+                batch: Some(batch.clone()),
+            });
+        }
+        Ok(fut)
+    }
+
+    #[pyo3(signature=(requests, priority=0))]
+    fn submit_preadv_into(
+        &self,
+        py: Python<'_>,
+        requests: &Bound<'_, PyAny>,
+        priority: i32,
+    ) -> PyResult<Py<PyAny>> {
+        if self.closed {
+            return Err(PyRuntimeError::new_err("scheduler is closed"));
+        }
+
+        let fut = make_concurrent_future(py)?;
+        let prio = match priority {
+            0 => Priority::High,
+            1 => Priority::Medium,
+            _ => Priority::Low,
+        };
+
+        let mut parsed: Vec<(u64, HeldPyBuffer, usize, usize)> = Vec::new();
+        let iter = requests.iter()?;
+        for item in iter {
+            let obj = item?;
+            let tup = obj.downcast::<pyo3::types::PyTuple>()?;
+            if tup.len() != 4 {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                return Err(PyValueError::new_err(
+                    "each request must be a 4-tuple (offset, out, payload_len, total_len)",
+                ));
+            }
+            let offset: u64 = tup.get_item(0)?.extract()?;
+            let out = tup.get_item(1)?;
+            let payload_len: usize = tup.get_item(2)?.extract()?;
+            let total_len: usize = tup.get_item(3)?.extract()?;
+            let view = get_pybuffer(py, &out, true)?;
+            let held = HeldPyBuffer(view);
+            if held.readonly() != 0 {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                held.release();
+                return Err(PyValueError::new_err("output buffer is readonly"));
+            }
+            if payload_len > held.len() {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                held.release();
+                return Err(PyValueError::new_err("output buffer too small"));
+            }
+            if total_len < payload_len {
+                for (_, b, _, _) in parsed.drain(..) {
+                    b.release();
+                }
+                held.release();
+                return Err(PyValueError::new_err("total_len must be >= payload_len"));
+            }
+            parsed.push((offset, held, payload_len, total_len));
+        }
+
+        if parsed.is_empty() {
+            future_set_result(py, &fut);
+            return Ok(fut);
+        }
+
+        let batch = Arc::new(Mutex::new(BatchState {
+            remaining: parsed.len(),
+            done: false,
+            future: fut.clone_ref(py),
+        }));
+
+        let cpu = unsafe { libc::sched_getcpu() };
+        let idx = if cpu < 0 {
+            0
+        } else {
+            (cpu as usize) % self.workers.len()
+        };
+        for (offset, held, payload_len, total_len) in parsed {
+            self.workers[idx].push(Task {
+                prio,
+                kind: TaskKind::Pread {
+                    offset,
+                    payload_len,
+                    total_len,
+                },
+                buf: held,
+                future: None,
+                batch: Some(batch.clone()),
+            });
+        }
+        Ok(fut)
+    }
+
+    fn close(&mut self) -> PyResult<()> {
+        if !self.closed {
+            for w in &self.workers {
+                w.shutdown();
+            }
+            for t in self.threads.drain(..) {
+                let _ = t.join();
+            }
+            // Drain completions and stop completion thread.
+            self.completion.shutdown();
+            if let Some(t) = self.completion_thread.take() {
+                let _ = t.join();
+            }
+            for fd in self.fds.drain(..) {
+                unsafe { libc::close(fd) };
+            }
+            self.closed = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RawBlockScheduler {
+    fn drop(&mut self) {
+        let _ = self.close();
+    }
+}
+
+#[pymodule]
+fn lmcache_rust_raw_block_io(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<RawBlockDevice>()?;
+    m.add_class::<RawBlockDevicePool>()?;
+    m.add_class::<RawBlockScheduler>()?;
+    Ok(())
+}
+

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Future
+from __future__ import annotations
+
+# Standard
+from concurrent.futures import Future
+import asyncio
+import os
+import tempfile
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.config import LMCacheEngineMetadata
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
+    RustRawBlockBackend,
+)
+
+
+def _has_ext() -> bool:
+    try:
+        # Third Party
+        import lmcache_rust_raw_block_io  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def loop_in_thread():
+    loop = asyncio.new_event_loop()
+    t = threading.Thread(target=loop.run_forever, name="test-loop", daemon=True)
+    t.start()
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=5)
+        loop.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_put_get_roundtrip(memory_allocator, loop_in_thread):
+    """Test basic put/get roundtrip with RustRawBlockBackend."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+        }
+        metadata = LMCacheEngineMetadata(
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            fmt="vllm",
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            key = CacheEngineKey("vllm", "test_model", 1, 0, 12345, torch.bfloat16)
+            allocator = AdHocMemoryAllocator(device="cpu")
+            obj = allocator.allocate(
+                (2, 16, 8, 128), torch.bfloat16, fmt=MemoryFormat.KV_T2D
+            )
+            assert obj is not None
+            assert obj.tensor is not None
+            obj.tensor.fill_(7)
+            expected = bytes(obj.byte_array)
+
+            futs = backend.batched_submit_put_task([key], [obj])
+            assert futs is not None
+            assert isinstance(futs[0], Future)
+            futs[0].result(timeout=10)
+
+            out = backend.get_blocking(key)
+            assert out is not None
+            assert bytes(out.byte_array) == expected
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_eviction_lru(memory_allocator, loop_in_thread):
+    """Test LRU eviction when capacity is exceeded."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_evict",
+        )
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.capacity_bytes": 2 * 4 * 1024 * 1024,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.slot_bytes": 4 * 1024 * 1024,
+        }
+        metadata = LMCacheEngineMetadata(
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            fmt="vllm",
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            alloc = AdHocMemoryAllocator(device="cpu")
+
+            k1 = CacheEngineKey("vllm", "test_model", 1, 0, 1, torch.bfloat16)
+            k2 = CacheEngineKey("vllm", "test_model", 1, 0, 2, torch.bfloat16)
+            k3 = CacheEngineKey("vllm", "test_model", 1, 0, 3, torch.bfloat16)
+
+            o1 = alloc.allocate(
+                (2, 16, 8, 128), torch.bfloat16, fmt=MemoryFormat.KV_T2D
+            )
+            o2 = alloc.allocate(
+                (2, 16, 8, 128), torch.bfloat16, fmt=MemoryFormat.KV_T2D
+            )
+            o3 = alloc.allocate(
+                (2, 16, 8, 128), torch.bfloat16, fmt=MemoryFormat.KV_T2D
+            )
+            assert o1 and o2 and o3
+            assert (
+                o1.tensor is not None
+                and o2.tensor is not None
+                and o3.tensor is not None
+            )
+            o1.tensor.fill_(1)
+            o2.tensor.fill_(2)
+            o3.tensor.fill_(3)
+
+            f1 = backend.batched_submit_put_task([k1], [o1])[0]
+            f2 = backend.batched_submit_put_task([k2], [o2])[0]
+            f1.result(timeout=10)
+            f2.result(timeout=10)
+
+            # Touch k1 so k2 becomes LRU
+            assert backend.get_blocking(k1) is not None
+
+            f3 = backend.batched_submit_put_task([k3], [o3])[0]
+            f3.result(timeout=10)
+
+            # k2 should be evicted
+            assert backend.contains(k2) is False
+            assert backend.get_blocking(k2) is None
+            assert backend.get_blocking(k1) is not None
+            assert backend.get_blocking(k3) is not None
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_manifest_roundtrip(memory_allocator, loop_in_thread):
+    """Test manifest persistence and restoration across backend restarts."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        manifest_path = os.path.join(td, "manifest.json")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        base_cfg = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_manifest",
+        )
+        base_cfg.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.manifest_path": manifest_path,
+        }
+        metadata = LMCacheEngineMetadata(
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            fmt="vllm",
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=base_cfg,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend1 = RustRawBlockBackend(
+            config=base_cfg,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        alloc = AdHocMemoryAllocator(device="cpu")
+        k1 = CacheEngineKey("vllm", "test_model", 1, 0, 111, torch.bfloat16)
+        o1 = alloc.allocate((2, 16, 8, 128), torch.bfloat16, fmt=MemoryFormat.KV_T2D)
+        assert o1 and o1.tensor is not None
+        o1.tensor.fill_(9)
+        expected = bytes(o1.byte_array)
+        try:
+            fut = backend1.batched_submit_put_task([k1], [o1])[0]
+            fut.result(timeout=10)
+        finally:
+            backend1.close()
+
+        # New backend instance should restore index and retrieve
+        backend2 = RustRawBlockBackend(
+            config=base_cfg,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        try:
+            assert backend2.contains(k1)
+            out = backend2.get_blocking(k1)
+            assert out is not None
+            assert bytes(out.byte_array) == expected
+        finally:
+            backend2.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a high-performance Rust-based raw block device storage backend for LMCache, 
enabling direct KV cache persistence to NVMe devices with O_DIRECT support.

### Key Features

**1. Rust Raw Block Storage Plugin (`rust/raw_block/`)**
- Direct block device I/O bypassing the filesystem layer
- Configurable O_DIRECT mode for page cache bypass
- Efficient batch read/write operations via async Scheduler
- Manifest-based key tracking with periodic persistence

**2. Python Plugin Wrapper (`lmcache/v1/storage_backend/plugins/`)**
- `RustRawBlockBackend` implementing `StorageBackendInterface`
- Multiple I/O modes: single-fd, multi-fd pool, scheduler

**3. Multi-Process (MP) Mode Support**
- New CLI arguments for MP server: `--raw-block-device`, `--enable-odirect`
- Enables TP > 1 deployments through centralized cache server
- Storage plugin configuration via `extra_config`

### Usage Examples

```bash
# Single-process mode (TP=1)
LMCACHE_CONFIG_FILE=config.yaml vllm serve model

# (TP > 1)
python3 -m lmcache.v1.multiprocess.server \
    --raw-block-device /dev/nvme0n1 \
    --enable-odirect \
    --cpu-buffer-size 2.0

vllm serve model --tensor-parallel-size 4 \
    --kv-transfer-config '{"kv_connector":"LMCacheMPConnector"}'
```

### Performance Characteristics
- Raw block I/O eliminates filesystem overhead
- O_DIRECT bypasses page cache for predictable latency
- Batch operations reduce syscall overhead

1. **Rust Extension Build**: The `rust/raw_block/` module requires `maturin` to build. Install with:
   ```bash
   cd rust/raw_block && pip install maturin && maturin develop
   ```

2. **Device Permissions**: Raw block device access requires appropriate permissions (typically root or device group membership)

3. **Testing**: Validated with 6-setup benchmark comparing Baseline, CPU-only, File System, FS+O_DIRECT, Raw Block, and Raw Block+O_DIRECT configurations and working well. I will send out the blog post for this later.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
