### PR TITLE
[Hotfix] Remove unnecessary MLA save_unfull_chunk enforcement

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -516,22 +516,6 @@ def _init_lmcache_engine(
     ):
         raise ValueError("MLA only works with naive serde mode..")
 
-    # MLA requires save_unfull_chunk=True for correct KV cache storage and retrieval.
-    # Without this, partial chunks would be discarded, causing incomplete cache
-    # and incorrect results in MLA mode.
-    if use_mla and not lmcache_config.save_unfull_chunk:
-        logger.warning(
-            "MLA (Multi-Level Attention) requires save_unfull_chunk=True "
-            "for correct KV cache storage. Automatically setting "
-            "save_unfull_chunk=True."
-        )
-        lmcache_config.save_unfull_chunk = True
-    elif use_mla:
-        logger.info(
-            "MLA mode enabled with save_unfull_chunk=True - all KV cache "
-            "including partial chunks will be stored"
-        )
-
     # construct kv shape (for mem pool)
     num_layer = model_config.get_num_layers(parallel_config)
     num_draft_layers = _calculate_draft_layers(vllm_config, model_config)


### PR DESCRIPTION
Remove the code block that enforced `save_unfull_chunk=True` for MLA (Multi-head Latent Attention) mode. 
This check was originally added thinking it was required due to a vLLM bug (vllm-project/vllm#26042), but @yoo-kumaneko  confirmed that save_unfull_chunk does not affect MLA cache storage.

**What this PR does / why we need it**:

This PR removes the unnecessary enforcement of `save_unfull_chunk=True` for MLA (Multi-head Latent Attention) mode in the vLLM v1 adapter.

**Special notes for your reviewers**:

- The `use_mla` variable is still used in other parts of the code (kv_shape calculation, metadata creation, layerwise+blending validation), so it was intentionally kept.
- This is a simple code removal with no functional changes to the core MLA logic.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests