### PR TITLE
Fix KV cache calculator for GLM GQA models

### DIFF
--- a/docs/source/_static/kv_cache_calculator.html
+++ b/docs/source/_static/kv_cache_calculator.html
@@ -287,7 +287,8 @@
             
             // Calculate based on model architecture
             const isDeepSeek = model.includes('DeepSeek');
-            const isQwen3 = model.toLowerCase().includes('qwen/qwen3-');
+            const hasHeadDim = Number.isFinite(config.head_dim)
+                && Number.isFinite(config.num_key_value_heads);
             
             let totalElements;
             let totalBytes;
@@ -309,8 +310,8 @@
                     <strong>Total Bytes:</strong> ${totalElements} × ${dtypeSize} = ${totalBytes} bytes<br>
                     <strong>KV Cache Size:</strong> ${totalBytes} / (1024³) ≈ ${sizeGB.toFixed(4)} GB
                 `;
-            } else if (isQwen3 && config.head_dim) {
-                // Qwen3 with explicit head_dim
+            } else if (hasHeadDim) {
+                // Models with explicit head_dim (e.g., GQA architectures)
                 totalElements = 2 * config.num_hidden_layers * tokens * config.num_key_value_heads * config.head_dim;
                 totalBytes = totalElements * dtypeSize;
                 sizeGB = totalBytes / (1024 ** 3);
@@ -389,7 +390,8 @@
             
             // Calculate based on model architecture
             const isDeepSeek = model.includes('DeepSeek');
-            const isQwen3 = model.toLowerCase().includes('qwen/qwen3-');
+            const hasHeadDim = Number.isFinite(config.head_dim)
+                && Number.isFinite(config.num_key_value_heads);
             
             let maxTokens;
             let details = '';
@@ -411,8 +413,8 @@
                     <strong>Bytes per Token:</strong> ${elementsPerToken} × ${dtypeSize} = ${bytesPerToken} bytes<br>
                     <strong>Maximum Tokens:</strong> ${totalBytes} / ${bytesPerToken} = ${maxTokens} tokens
                 `;
-            } else if (isQwen3 && config.head_dim) {
-                // Qwen3: tokens = total_bytes / (2 × layers × kv_heads × head_dim × dtype_size)
+            } else if (hasHeadDim) {
+                // Explicit head_dim: tokens = total_bytes / (2 × layers × kv_heads × head_dim × dtype_size)
                 const elementsPerToken = 2 * config.num_hidden_layers * config.num_key_value_heads * config.head_dim;
                 const bytesPerToken = elementsPerToken * dtypeSize;
                 maxTokens = Math.floor(totalBytes / bytesPerToken);
@@ -486,4 +488,3 @@
     </script>
 </body>
 </html>
-

--- a/docs/source/_static/modelconfig.json
+++ b/docs/source/_static/modelconfig.json
@@ -127,5 +127,19 @@
         "num_attention_heads": 32,
         "num_hidden_layers": 32,
         "num_key_value_heads": 32
+    },
+    "zai-org/GLM-4.5": {
+        "hidden_size": 5120,
+        "num_attention_heads": 96,
+        "num_hidden_layers": 92,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
+    "zai-org/GLM-4.6": {
+        "hidden_size": 5120,
+        "num_attention_heads": 96,
+        "num_hidden_layers": 92,
+        "num_key_value_heads": 8,
+        "head_dim": 128
     }
 }


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

  - Fixes KV cache calculator for GLM‑4.5/4.6 by treating any model with head_dim as GQA and by adding GLM configs to the docs static `modelconfig.json`.
  - Fixes #2248.

**Special notes for your reviewers**:

  - This change updates the docs/static calculator assets; the public site may need redeploy to pick up `docs/source/_static/
    kv_cache_calculator.html` and `docs/source/_static/modelconfig.json`.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
