### PR TITLE
[CI/CD][MP] add vllm prefill overhead test for multiprocess mode

### DIFF
--- a/.buildkite/scripts/multiprocessing-test/README.md
+++ b/.buildkite/scripts/multiprocessing-test/README.md
@@ -1,0 +1,339 @@
+# LMCache Multiprocessing Tests
+
+This directory contains end-to-end integration tests for LMCache's multiprocessing functionality. These tests validate that LMCache correctly caches KV tensors and provides performance benefits when integrated with vLLM.
+
+## Overview
+
+The test suite runs two vLLM servers in parallel:
+1. **vLLM with LMCache** - Connected to an LMCache multiprocessing server for KV caching
+2. **vLLM baseline** - Standard vLLM without LMCache (for performance comparison)
+
+Tests send workloads to both servers and verify:
+- Correctness: LMCache produces identical outputs to baseline
+- Performance: LMCache meets latency/throughput thresholds
+- Caching behavior: Repeated requests benefit from cached KV tensors
+
+## Quick Start
+
+Run all tests:
+
+```bash
+./run-mp-test.sh
+```
+
+This will:
+1. Build the Docker image
+2. Launch LMCache and vLLM containers
+3. Run all benchmark tests
+4. Clean up containers (even on failure)
+
+## Script Structure
+
+```
+multiprocessing-test/
+├── run-mp-test.sh           # Main orchestrator - runs everything
+├── common.sh                # Shared utilities (setup_venv, RESULTS_DIR)
+│
+├── build-mp-docker-image.sh # Builds lmcache/vllm-openai:test image
+├── launch-containers.sh     # Starts LMCache + vLLM containers
+├── wait-for-vllm.sh         # Waits for vLLM health endpoints
+├── cleanup.sh               # Stops and removes containers
+│
+├── run-lm-eval.sh           # Test: lm_eval workload (correctness)
+├── run-vllm-bench.sh        # Test: vllm bench serve (throughput)
+├── run-long-doc-qa.sh       # Test: Long document QA (latency)
+│
+└── README.md                # This file
+```
+
+### Script Descriptions
+
+| Script | Purpose |
+|--------|---------|
+| `run-mp-test.sh` | Main entry point. Orchestrates the entire test pipeline and ensures cleanup runs on exit. |
+| `common.sh` | Shared utilities sourced by test scripts. Provides `setup_venv()` function and common variables (`RESULTS_DIR`, `BUILD_ID`, `VENV_DIR`). |
+| `build-mp-docker-image.sh` | Builds the `lmcache/vllm-openai:test` Docker image from the repository's Dockerfile. |
+| `launch-containers.sh` | Launches three containers: LMCache server, vLLM with LMCache, and baseline vLLM. |
+| `wait-for-vllm.sh` | Polls health endpoints until both vLLM servers are ready. |
+| `cleanup.sh` | Stops and removes all test containers. Captures logs before cleanup for debugging. |
+| `run-lm-eval.sh` | Runs GSM8K evaluation twice to verify caching produces identical outputs. |
+| `run-vllm-bench.sh` | Benchmarks throughput using `vllm bench serve` and compares LMCache vs baseline. |
+| `run-long-doc-qa.sh` | Tests long-context caching with document QA workload and verifies latency thresholds. |
+
+## Test Descriptions
+
+### 1. LM-Eval Workload (`run-lm-eval.sh`)
+
+**Purpose:** Verify that LMCache produces deterministic, correct outputs.
+
+**How it works:**
+1. Runs `lm_eval` with GSM8K task against vLLM+LMCache (first run populates cache)
+2. Runs the same evaluation again (second run uses cached KV tensors)
+3. Compares output samples from both runs
+
+**Pass criteria:** Sample outputs from both runs must be identical.
+
+### 2. vLLM Bench Serve (`run-vllm-bench.sh`)
+
+**Purpose:** Verify LMCache doesn't significantly degrade throughput.
+
+**How it works:**
+1. Runs `vllm bench serve` with random prompts against baseline vLLM
+2. Runs the same benchmark against vLLM+LMCache
+3. Compares throughput metrics
+
+**Pass criteria:**
+- All prompts complete successfully
+- LMCache throughput is within 5% of baseline
+
+### 3. Long Document QA (`run-long-doc-qa.sh`)
+
+**Purpose:** Verify LMCache provides latency benefits for long-context workloads.
+
+**How it works:**
+1. Runs long document QA benchmark against baseline vLLM
+2. Runs the same benchmark against vLLM+LMCache
+3. Compares TTFT (Time To First Token) and round-trip latency
+
+**Pass criteria:**
+- `query_ttft_per_prompt` ≤ 0.22s (loading 10K tokens)
+- `query_round_time_per_prompt` ≤ 0.58s
+
+## Expected Outputs
+
+All test results are saved to a shared directory:
+
+```
+/tmp/lmcache_ci_results_${BUILD_ID}/
+├── lm_eval/
+│   ├── first_run/
+│   │   └── samples_gsm8k_*.jsonl
+│   └── second_run/
+│       └── samples_gsm8k_*.jsonl
+├── long_doc_qa/
+│   ├── lmcache_result.json
+│   ├── baseline_result.json
+│   ├── lmcache_output.txt
+│   └── baseline_output.txt
+└── vllm_bench/
+    ├── lmcache.json
+    └── baseline.json
+```
+
+### Sample Output Files
+
+**vllm_bench/lmcache.json:** (some fields are excluded)
+```json
+{
+  "total_input_tokens": 500000,
+  "completed": 50,
+  "total_token_throughput": 12345.67
+}
+```
+
+**long_doc_qa/lmcache_result.json:** (some fields are excluded)
+```json
+{
+  "query_ttft_per_prompt": 0.15,
+  "query_round_time_per_prompt": 0.45,
+  "warmup_round_time_per_prompt": 2.1
+}
+```
+
+## Configuration
+
+All scripts support configuration via environment variables:
+
+### Common Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BUILD_ID` | `local_<timestamp>` | Unique identifier for this test run |
+| `RESULTS_DIR` | `/tmp/lmcache_ci_results_${BUILD_ID}` | Directory for all test outputs |
+| `VENV_DIR` | `<workspace>/.venv` | Python virtual environment path |
+| `MODEL` | `Qwen/Qwen3-14B` | Model to use for testing |
+| `VLLM_PORT` | `8000` | Port for vLLM with LMCache |
+| `VLLM_BASELINE_PORT` | `9000` | Port for baseline vLLM |
+| `LMCACHE_PORT` | `6555` | Port for LMCache server |
+| `MAX_WAIT_SECONDS` | `300` | Timeout for vLLM startup |
+
+### Test-Specific Variables
+
+**run-lm-eval.sh:**
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NUM_CONCURRENT` | `50` | Concurrent requests |
+| `LIMIT` | `300` | Number of samples |
+
+**run-vllm-bench.sh:**
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NUM_PROMPTS` | `50` | Number of prompts |
+| `RANDOM_INPUT_LEN` | `10000` | Input token length |
+| `RANDOM_OUTPUT_LEN` | `1` | Output token length |
+| `RANDOM_SEED` | `<timestamp>` | Seed for reproducibility |
+
+**run-long-doc-qa.sh:**
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOCUMENT_LENGTH` | `10000` | Document length in tokens |
+| `NUM_DOCUMENTS` | `30` | Number of documents |
+| `OUTPUT_LEN` | `200` | Output length |
+| `MAX_LMCACHE_TTFT` | `0.22` | Max allowed TTFT (seconds) |
+| `MAX_LMCACHE_QUERY_ROUND_TIME` | `0.58` | Max allowed round time (seconds) |
+
+## Adding a New Test
+
+To add a new test to the suite:
+
+### 1. Create Your Test Script
+
+Create a new script (e.g., `run-my-test.sh`) following this template:
+
+```bash
+#!/bin/bash
+# Brief description of your test
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common utilities
+source "$SCRIPT_DIR/common.sh"
+
+# Configuration (use environment variables with defaults)
+MY_PARAM="${MY_PARAM:-default_value}"
+
+# Output directory (subdirectory of shared RESULTS_DIR)
+MY_TEST_DIR="$RESULTS_DIR/my_test"
+
+echo "=== My Test ==="
+echo "Results dir: $MY_TEST_DIR"
+
+# Create results directory
+mkdir -p "$MY_TEST_DIR"
+
+# Your test functions here
+run_my_test() {
+    # Implementation
+    echo "Running test..."
+}
+
+verify_results() {
+    # Verification logic
+    # Return 0 on success, 1 on failure
+    return 0
+}
+
+# Main execution
+main() {
+    # Setup venv with required packages
+    setup_venv package1 package2
+    
+    # Run test
+    run_my_test
+    
+    # Verify results
+    if ! verify_results; then
+        echo "❌ Test failed"
+        exit 1
+    fi
+    
+    echo "✅ Test passed"
+}
+
+main "$@"
+```
+
+### 2. Add to Orchestrator
+
+Edit `run-mp-test.sh` to include your test:
+
+```bash
+# Step N: Run your test
+echo "============================================"
+echo "=== Step N: Running my test ==="
+echo "============================================"
+if ! "$SCRIPT_DIR/run-my-test.sh"; then
+    echo "❌ my test failed"
+    TEST_RESULT=1
+    exit 1
+fi
+echo ""
+```
+
+### 3. Guidelines
+
+- **Use `common.sh`**: Source it to get `setup_venv()`, `RESULTS_DIR`, `BUILD_ID`, etc.
+- **Use subdirectories**: Store outputs in `$RESULTS_DIR/your_test_name/`
+- **Exit codes**: Return 0 on success, non-zero on failure
+- **Logging**: Use clear status indicators (✅, ❌) and descriptive messages
+- **Cleanup**: Don't leave temporary files outside `RESULTS_DIR`
+- **Configuration**: Use environment variables with sensible defaults
+- **Comparison tests**: When comparing LMCache vs baseline, run baseline first to avoid any warm-up effects benefiting LMCache unfairly
+
+### 4. Test Your Script
+
+Run your script in isolation first:
+
+```bash
+# Start containers manually
+./launch-containers.sh
+./wait-for-vllm.sh
+
+# Run your test
+./run-my-test.sh
+
+# Cleanup
+./cleanup.sh
+```
+
+Then run the full suite:
+
+```bash
+./run-mp-test.sh
+```
+
+## Troubleshooting
+
+### Container logs
+
+If tests fail, check container logs:
+
+```bash
+docker logs lmcache-mp-test-<pid>
+docker logs vllm-mp-test-<pid>
+docker logs vllm-baseline-test-<pid>
+```
+
+The cleanup script automatically captures the last 50 lines of logs before removing containers.
+
+### Common issues
+
+1. **vLLM timeout**: Increase `MAX_WAIT_SECONDS` or check GPU availability
+2. **Out of memory**: Reduce model size or adjust `--gpu-memory-utilization`
+3. **Port conflicts**: Change `VLLM_PORT`, `VLLM_BASELINE_PORT`, or `LMCACHE_PORT`
+4. **Model not found**: Ensure HuggingFace cache is mounted correctly
+
+### Running individual tests
+
+You can run tests individually after containers are up:
+
+```bash
+# Start infrastructure
+./build-mp-docker-image.sh
+./launch-containers.sh
+./wait-for-vllm.sh
+
+# Run specific test
+./run-lm-eval.sh
+# or
+./run-vllm-bench.sh
+# or
+./run-long-doc-qa.sh
+
+# Cleanup when done
+./cleanup.sh
+```
+

--- a/.buildkite/scripts/multiprocessing-test/cleanup.sh
+++ b/.buildkite/scripts/multiprocessing-test/cleanup.sh
@@ -4,6 +4,7 @@
 
 LMCACHE_CONTAINER_NAME="${LMCACHE_CONTAINER_NAME:-lmcache-mp-test}"
 VLLM_CONTAINER_NAME="${VLLM_CONTAINER_NAME:-vllm-mp-test}"
+VLLM_BASELINE_CONTAINER_NAME="${VLLM_BASELINE_CONTAINER_NAME:-vllm-baseline-test}"
 
 echo "=== Cleaning up containers ==="
 
@@ -31,14 +32,15 @@ cleanup_container() {
     fi
 }
 
-# Cleanup both containers
+# Cleanup all containers
+cleanup_container "$VLLM_BASELINE_CONTAINER_NAME"
 cleanup_container "$VLLM_CONTAINER_NAME"
 cleanup_container "$LMCACHE_CONTAINER_NAME"
 
 echo "=== Cleanup complete ==="
 
 # List any remaining test containers (for debugging)
-remaining=$(docker ps -a --format '{{.Names}}' | grep -E "(lmcache|vllm).*-mp-test" || true)
+remaining=$(docker ps -a --format '{{.Names}}' | grep -E "(lmcache|vllm).*-(mp|baseline)-test" || true)
 if [ -n "$remaining" ]; then
     echo "Warning: Some test containers may still exist:"
     echo "$remaining"

--- a/.buildkite/scripts/multiprocessing-test/common.sh
+++ b/.buildkite/scripts/multiprocessing-test/common.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Common utilities for multiprocessing tests
+# Source this file to use shared functions and variables
+
+# Get the directory where this script is located
+COMMON_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "$COMMON_SCRIPT_DIR/../../../.." && pwd)"
+LMCACHE_DIR="$(cd "$COMMON_SCRIPT_DIR/../../.." && pwd)"
+
+# Common configuration
+BUILD_ID="${BUILD_ID:-local_$(date +%Y%m%d_%H%M%S)}"
+VENV_DIR="${VENV_DIR:-$WORKSPACE_DIR/.venv}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/lmcache_ci_results_${BUILD_ID}}"
+
+# Setup virtual environment
+# Usage: setup_venv [packages...]
+# Example: setup_venv openai pandas matplotlib
+setup_venv() {
+    local packages=("$@")
+    
+    echo "=== Setting up virtual environment ==="
+    
+    if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
+        echo "Virtual environment already exists at $VENV_DIR"
+    else
+        echo "Creating virtual environment with uv..."
+        
+        # Check if uv is available
+        if ! command -v uv &> /dev/null; then
+            echo "uv not found, installing..."
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+        fi
+        
+        # Create venv with uv
+        uv venv "$VENV_DIR"
+        echo "Virtual environment created"
+    fi
+    
+    # Activate virtual environment
+    source "$VENV_DIR/bin/activate"
+    echo "Virtual environment activated"
+    
+    # Install dependencies if provided
+    if [ ${#packages[@]} -gt 0 ]; then
+        echo "Installing dependencies: ${packages[*]}"
+        uv pip install "${packages[@]}" --quiet
+        echo "Dependencies installed"
+    fi
+    
+    echo ""
+}
+
+# Ensure results directory exists
+ensure_results_dir() {
+    mkdir -p "$RESULTS_DIR"
+    echo "Results directory: $RESULTS_DIR"
+}
+

--- a/.buildkite/scripts/multiprocessing-test/launch-containers.sh
+++ b/.buildkite/scripts/multiprocessing-test/launch-containers.sh
@@ -13,9 +13,21 @@ export VLLM_BASELINE_CONTAINER_NAME="${VLLM_BASELINE_CONTAINER_NAME:-vllm-baseli
 LMCACHE_PORT="${LMCACHE_PORT:-6555}"
 VLLM_PORT="${VLLM_PORT:-8000}"
 VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
-CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-50}"
+
+CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-80}"
 MAX_WORKERS="${MAX_WORKERS:-4}"
 MODEL="${MODEL:-Qwen/Qwen3-14B}"
+
+# Check GPU memory and set gpu-memory-utilization if > 100GB
+GPU_MEMORY_UTIL_ARG=""
+GPU_MEMORY_MB=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits | head -n 1 | tr -d ' ')
+GPU_MEMORY_GB=$((GPU_MEMORY_MB / 1024))
+echo "Detected GPU memory: ${GPU_MEMORY_GB}GB (${GPU_MEMORY_MB}MB)"
+
+if [ "$GPU_MEMORY_GB" -gt 100 ]; then
+    echo "GPU memory > 100GB, adding --gpu-memory-utilization 0.5"
+    GPU_MEMORY_UTIL_ARG="--gpu-memory-utilization 0.5"
+fi
 
 echo "=== Launching LMCache container ==="
 echo "Container name: $LMCACHE_CONTAINER_NAME"
@@ -60,7 +72,8 @@ docker run -d \
     "$MODEL" \
     --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT}}" \
     --port "$VLLM_PORT" \
-    --no-async-scheduling
+    --no-async-scheduling \
+    $GPU_MEMORY_UTIL_ARG
 
 echo "vLLM container started"
 
@@ -83,7 +96,8 @@ docker run -d \
     lmcache/vllm-openai:test \
     "$MODEL" \
     --port "$VLLM_BASELINE_PORT" \
-    --no-async-scheduling
+    --no-async-scheduling \
+    $GPU_MEMORY_UTIL_ARG
 
 echo "vLLM baseline container started"
 

--- a/.buildkite/scripts/multiprocessing-test/launch-containers.sh
+++ b/.buildkite/scripts/multiprocessing-test/launch-containers.sh
@@ -7,10 +7,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Container names (exported so cleanup script can use them)
 export LMCACHE_CONTAINER_NAME="${LMCACHE_CONTAINER_NAME:-lmcache-mp-test}"
 export VLLM_CONTAINER_NAME="${VLLM_CONTAINER_NAME:-vllm-mp-test}"
+export VLLM_BASELINE_CONTAINER_NAME="${VLLM_BASELINE_CONTAINER_NAME:-vllm-baseline-test}"
 
 # Configuration
 LMCACHE_PORT="${LMCACHE_PORT:-6555}"
 VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
 CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-50}"
 MAX_WORKERS="${MAX_WORKERS:-4}"
 MODEL="${MODEL:-Qwen/Qwen3-14B}"
@@ -49,6 +51,7 @@ docker run -d \
     --volume ~/.cache/huggingface:/root/.cache/huggingface \
     --network host \
     --ipc host \
+    --env CUDA_VISIBLE_DEVICES=0 \
     --env VLLM_ENABLE_V1_MULTIPROCESSING=0 \
     --env VLLM_ATTENTION_BACKEND=FLASH_ATTN \
     --env VLLM_BATCH_INVARIANT=1 \
@@ -56,10 +59,34 @@ docker run -d \
     lmcache/vllm-openai:test \
     "$MODEL" \
     --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT}}" \
+    --port "$VLLM_PORT" \
     --no-async-scheduling
 
 echo "vLLM container started"
 
+echo "=== Launching vLLM baseline container (without LMCache) ==="
+echo "Container name: $VLLM_BASELINE_CONTAINER_NAME"
+echo "Port: $VLLM_BASELINE_PORT"
+
+docker run -d \
+    --name "$VLLM_BASELINE_CONTAINER_NAME" \
+    --runtime nvidia \
+    --gpus all \
+    --volume ~/.cache/huggingface:/root/.cache/huggingface \
+    --network host \
+    --ipc host \
+    --env CUDA_VISIBLE_DEVICES=1 \
+    --env VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+    --env VLLM_ATTENTION_BACKEND=FLASH_ATTN \
+    --env VLLM_BATCH_INVARIANT=1 \
+    --env PYTHONHASHSEED=0 \
+    lmcache/vllm-openai:test \
+    "$MODEL" \
+    --port "$VLLM_BASELINE_PORT" \
+    --no-async-scheduling
+
+echo "vLLM baseline container started"
+
 echo "=== Containers launched ==="
-docker ps --filter "name=$LMCACHE_CONTAINER_NAME" --filter "name=$VLLM_CONTAINER_NAME"
+docker ps --filter "name=$LMCACHE_CONTAINER_NAME" --filter "name=$VLLM_CONTAINER_NAME" --filter "name=$VLLM_BASELINE_CONTAINER_NAME"
 

--- a/.buildkite/scripts/multiprocessing-test/run-lm-eval.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-lm-eval.sh
@@ -6,20 +6,20 @@ set -e
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Source common utilities
+source "$SCRIPT_DIR/common.sh"
 
 # Configuration
 VLLM_PORT="${VLLM_PORT:-8000}"
 MODEL="${MODEL:-Qwen/Qwen3-14B}"
 NUM_CONCURRENT="${NUM_CONCURRENT:-50}"
 LIMIT="${LIMIT:-300}"
-VENV_DIR="${VENV_DIR:-$WORKSPACE_DIR/.venv}"
-BUILD_ID="${BUILD_ID:-local_$(date +%Y%m%d_%H%M%S)}"
-RESULTS_DIR="${RESULTS_DIR:-/tmp/lm_eval_results_${BUILD_ID}}"
 
-# Output directories for first and second runs
-FIRST_RUN_DIR="$RESULTS_DIR/first_run"
-SECOND_RUN_DIR="$RESULTS_DIR/second_run"
+# Output directories for first and second runs (subdirectories of shared RESULTS_DIR)
+LM_EVAL_DIR="$RESULTS_DIR/lm_eval"
+FIRST_RUN_DIR="$LM_EVAL_DIR/first_run"
+SECOND_RUN_DIR="$LM_EVAL_DIR/second_run"
 
 echo "=== LM-Eval Workload Test ==="
 echo "Model: $MODEL"
@@ -28,44 +28,12 @@ echo "Concurrent requests: $NUM_CONCURRENT"
 echo "Limit: $LIMIT"
 echo "Virtual env: $VENV_DIR"
 echo "Build ID: $BUILD_ID"
-echo "Results dir: $RESULTS_DIR"
+echo "Results dir: $LM_EVAL_DIR"
 echo ""
 
 # Create results directories
 mkdir -p "$FIRST_RUN_DIR"
 mkdir -p "$SECOND_RUN_DIR"
-
-# Setup virtual environment
-setup_venv() {
-    echo "=== Setting up virtual environment ==="
-    
-    if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
-        echo "Virtual environment already exists at $VENV_DIR"
-    else
-        echo "Creating virtual environment with uv..."
-        
-        # Check if uv is available
-        if ! command -v uv &> /dev/null; then
-            echo "uv not found, installing..."
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-            export PATH="$HOME/.local/bin:$PATH"
-        fi
-        
-        # Create venv with uv
-        uv venv "$VENV_DIR"
-        echo "Virtual environment created"
-    fi
-    
-    # Activate virtual environment
-    source "$VENV_DIR/bin/activate"
-    echo "Virtual environment activated"
-    
-    # Install dependencies
-    echo "Installing dependencies..."
-    uv pip install 'lm-eval[api]' openai pandas --quiet
-    echo "Dependencies installed"
-    echo ""
-}
 
 # Run lm_eval
 run_lm_eval() {
@@ -138,7 +106,7 @@ verify_samples_match() {
 
 # Main execution
 main() {
-    setup_venv
+    setup_venv 'lm-eval[api]' openai pandas
     
     # First run - populates cache
     echo "============================================"
@@ -164,10 +132,9 @@ main() {
     echo "============================================"
     echo "=== ✅ LM-Eval workload test completed ==="
     echo "============================================"
-    echo "Results saved to: $RESULTS_DIR"
+    echo "Results saved to: $LM_EVAL_DIR"
     echo "  - First run: $FIRST_RUN_DIR"
     echo "  - Second run: $SECOND_RUN_DIR"
 }
 
 main "$@"
-

--- a/.buildkite/scripts/multiprocessing-test/run-long-doc-qa.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-long-doc-qa.sh
@@ -6,8 +6,9 @@ set -e
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-LMCACHE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Source common utilities
+source "$SCRIPT_DIR/common.sh"
 
 # Configuration
 VLLM_PORT="${VLLM_PORT:-8000}"
@@ -23,15 +24,14 @@ REPEAT_MODE="${REPEAT_MODE:-tile}"
 SHUFFLE_SEED="${SHUFFLE_SEED:-0}"
 MAX_INFLIGHT_REQUESTS="${MAX_INFLIGHT_REQUESTS:-5}"
 
-VENV_DIR="${VENV_DIR:-$WORKSPACE_DIR/.venv}"
-BUILD_ID="${BUILD_ID:-local_$(date +%Y%m%d_%H%M%S)}"
-RESULTS_DIR="${RESULTS_DIR:-/tmp/long_doc_qa_results_${BUILD_ID}}"
-
 # Performance thresholds for LMCache (test fails if exceeded)
 # 0.22s for loading 10K tokens of Qwen3-14B
 # 0.58s for query round time of Qwen3-14B
 MAX_LMCACHE_TTFT="${MAX_LMCACHE_TTFT:-0.22}"
 MAX_LMCACHE_QUERY_ROUND_TIME="${MAX_LMCACHE_QUERY_ROUND_TIME:-0.58}"
+
+# Output directory (subdirectory of shared RESULTS_DIR)
+LONG_DOC_QA_DIR="$RESULTS_DIR/long_doc_qa"
 
 echo "=== Long Doc QA Test ==="
 echo "Model: $MODEL"
@@ -46,7 +46,7 @@ echo "Shuffle seed: $SHUFFLE_SEED"
 echo "Max inflight requests: $MAX_INFLIGHT_REQUESTS"
 echo "Virtual env: $VENV_DIR"
 echo "Build ID: $BUILD_ID"
-echo "Results dir: $RESULTS_DIR"
+echo "Results dir: $LONG_DOC_QA_DIR"
 echo ""
 echo "Performance thresholds (LMCache):"
 echo "  Max TTFT: ${MAX_LMCACHE_TTFT}s"
@@ -54,39 +54,7 @@ echo "  Max query round time: ${MAX_LMCACHE_QUERY_ROUND_TIME}s"
 echo ""
 
 # Create results directory
-mkdir -p "$RESULTS_DIR"
-
-# Setup virtual environment
-setup_venv() {
-    echo "=== Setting up virtual environment ==="
-    
-    if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
-        echo "Virtual environment already exists at $VENV_DIR"
-    else
-        echo "Creating virtual environment with uv..."
-        
-        # Check if uv is available
-        if ! command -v uv &> /dev/null; then
-            echo "uv not found, installing..."
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-            export PATH="$HOME/.local/bin:$PATH"
-        fi
-        
-        # Create venv with uv
-        uv venv "$VENV_DIR"
-        echo "Virtual environment created"
-    fi
-    
-    # Activate virtual environment
-    source "$VENV_DIR/bin/activate"
-    echo "Virtual environment activated"
-    
-    # Install dependencies
-    echo "Installing dependencies..."
-    uv pip install openai pandas matplotlib --quiet
-    echo "Dependencies installed"
-    echo ""
-}
+mkdir -p "$LONG_DOC_QA_DIR"
 
 # Run long_doc_qa benchmark
 run_long_doc_qa() {
@@ -98,7 +66,7 @@ run_long_doc_qa() {
     echo "Port: $port"
     echo "Result file: $result_file"
     
-    local output_file="$RESULTS_DIR/${description}_output.txt"
+    local output_file="$LONG_DOC_QA_DIR/${description}_output.txt"
     
     # Run long_doc_qa.py and capture JSON output
     python3 "$LMCACHE_DIR/benchmarks/long_doc_qa/long_doc_qa.py" \
@@ -142,8 +110,8 @@ except json.JSONDecodeError:
 
 # Compare and summarize results
 compare_results() {
-    local lmcache_result="$RESULTS_DIR/lmcache_result.json"
-    local baseline_result="$RESULTS_DIR/baseline_result.json"
+    local lmcache_result="$LONG_DOC_QA_DIR/lmcache_result.json"
+    local baseline_result="$LONG_DOC_QA_DIR/baseline_result.json"
     
     echo "=== Comparing benchmark results ==="
     
@@ -261,7 +229,7 @@ EOF
 
 # Verify LMCache performance meets thresholds
 verify_thresholds() {
-    local lmcache_result="$RESULTS_DIR/lmcache_result.json"
+    local lmcache_result="$LONG_DOC_QA_DIR/lmcache_result.json"
     
     echo "=== Verifying LMCache performance thresholds ==="
     echo "Max allowed TTFT: ${MAX_LMCACHE_TTFT}s"
@@ -326,19 +294,19 @@ EOF
 
 # Main execution
 main() {
-    setup_venv
+    setup_venv openai pandas matplotlib
     
     # Run benchmark against baseline vLLM (without LMCache)
     echo "============================================"
     echo "=== Benchmark: Baseline vLLM (without LMCache) ==="
     echo "============================================"
-    run_long_doc_qa "$VLLM_BASELINE_PORT" "$RESULTS_DIR/baseline_result.json" "baseline"
+    run_long_doc_qa "$VLLM_BASELINE_PORT" "$LONG_DOC_QA_DIR/baseline_result.json" "baseline"
     
     # Run benchmark against vLLM with LMCache
     echo "============================================"
     echo "=== Benchmark: vLLM with LMCache ==="
     echo "============================================"
-    run_long_doc_qa "$VLLM_PORT" "$RESULTS_DIR/lmcache_result.json" "lmcache"
+    run_long_doc_qa "$VLLM_PORT" "$LONG_DOC_QA_DIR/lmcache_result.json" "lmcache"
     
     # Compare and summarize results
     echo "============================================"
@@ -361,10 +329,9 @@ main() {
     echo "============================================"
     echo "=== ✅ Long Doc QA test completed ==="
     echo "============================================"
-    echo "Results saved to: $RESULTS_DIR"
-    echo "  - LMCache: $RESULTS_DIR/lmcache_result.json"
-    echo "  - Baseline: $RESULTS_DIR/baseline_result.json"
+    echo "Results saved to: $LONG_DOC_QA_DIR"
+    echo "  - LMCache: $LONG_DOC_QA_DIR/lmcache_result.json"
+    echo "  - Baseline: $LONG_DOC_QA_DIR/baseline_result.json"
 }
 
 main "$@"
-

--- a/.buildkite/scripts/multiprocessing-test/run-long-doc-qa.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-long-doc-qa.sh
@@ -26,9 +26,9 @@ MAX_INFLIGHT_REQUESTS="${MAX_INFLIGHT_REQUESTS:-5}"
 
 # Performance thresholds for LMCache (test fails if exceeded)
 # 0.22s for loading 10K tokens of Qwen3-14B
-# 0.58s for query round time of Qwen3-14B
+# 0.50s for query round time of Qwen3-14B
 MAX_LMCACHE_TTFT="${MAX_LMCACHE_TTFT:-0.22}"
-MAX_LMCACHE_QUERY_ROUND_TIME="${MAX_LMCACHE_QUERY_ROUND_TIME:-0.58}"
+MAX_LMCACHE_QUERY_ROUND_TIME="${MAX_LMCACHE_QUERY_ROUND_TIME:-0.50}"
 
 # Output directory (subdirectory of shared RESULTS_DIR)
 LONG_DOC_QA_DIR="$RESULTS_DIR/long_doc_qa"

--- a/.buildkite/scripts/multiprocessing-test/run-long-doc-qa.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-long-doc-qa.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+# Run long_doc_qa workload test against both vLLM servers
+# Compares performance between LMCache-enabled and baseline vLLM
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+LMCACHE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Configuration
+VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
+MODEL="${MODEL:-Qwen/Qwen3-14B}"
+
+DOCUMENT_LENGTH="${DOCUMENT_LENGTH:-10000}"
+NUM_DOCUMENTS="${NUM_DOCUMENTS:-30}"
+OUTPUT_LEN="${OUTPUT_LEN:-200}"
+
+REPEAT_COUNT="${REPEAT_COUNT:-2}"
+REPEAT_MODE="${REPEAT_MODE:-tile}"
+SHUFFLE_SEED="${SHUFFLE_SEED:-0}"
+MAX_INFLIGHT_REQUESTS="${MAX_INFLIGHT_REQUESTS:-5}"
+
+VENV_DIR="${VENV_DIR:-$WORKSPACE_DIR/.venv}"
+BUILD_ID="${BUILD_ID:-local_$(date +%Y%m%d_%H%M%S)}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/long_doc_qa_results_${BUILD_ID}}"
+
+# Performance thresholds for LMCache (test fails if exceeded)
+# 0.22s for loading 10K tokens of Qwen3-14B
+# 0.58s for query round time of Qwen3-14B
+MAX_LMCACHE_TTFT="${MAX_LMCACHE_TTFT:-0.22}"
+MAX_LMCACHE_QUERY_ROUND_TIME="${MAX_LMCACHE_QUERY_ROUND_TIME:-0.58}"
+
+echo "=== Long Doc QA Test ==="
+echo "Model: $MODEL"
+echo "vLLM Port (with LMCache): $VLLM_PORT"
+echo "vLLM Baseline Port (without LMCache): $VLLM_BASELINE_PORT"
+echo "Document length: $DOCUMENT_LENGTH"
+echo "Number of documents: $NUM_DOCUMENTS"
+echo "Output length: $OUTPUT_LEN"
+echo "Repeat count: $REPEAT_COUNT"
+echo "Repeat mode: $REPEAT_MODE"
+echo "Shuffle seed: $SHUFFLE_SEED"
+echo "Max inflight requests: $MAX_INFLIGHT_REQUESTS"
+echo "Virtual env: $VENV_DIR"
+echo "Build ID: $BUILD_ID"
+echo "Results dir: $RESULTS_DIR"
+echo ""
+echo "Performance thresholds (LMCache):"
+echo "  Max TTFT: ${MAX_LMCACHE_TTFT}s"
+echo "  Max query round time: ${MAX_LMCACHE_QUERY_ROUND_TIME}s"
+echo ""
+
+# Create results directory
+mkdir -p "$RESULTS_DIR"
+
+# Setup virtual environment
+setup_venv() {
+    echo "=== Setting up virtual environment ==="
+    
+    if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
+        echo "Virtual environment already exists at $VENV_DIR"
+    else
+        echo "Creating virtual environment with uv..."
+        
+        # Check if uv is available
+        if ! command -v uv &> /dev/null; then
+            echo "uv not found, installing..."
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+        fi
+        
+        # Create venv with uv
+        uv venv "$VENV_DIR"
+        echo "Virtual environment created"
+    fi
+    
+    # Activate virtual environment
+    source "$VENV_DIR/bin/activate"
+    echo "Virtual environment activated"
+    
+    # Install dependencies
+    echo "Installing dependencies..."
+    uv pip install openai pandas matplotlib --quiet
+    echo "Dependencies installed"
+    echo ""
+}
+
+# Run long_doc_qa benchmark
+run_long_doc_qa() {
+    local port="$1"
+    local result_file="$2"
+    local description="$3"
+    
+    echo "=== Running long_doc_qa ($description) ==="
+    echo "Port: $port"
+    echo "Result file: $result_file"
+    
+    local output_file="$RESULTS_DIR/${description}_output.txt"
+    
+    # Run long_doc_qa.py and capture JSON output
+    python3 "$LMCACHE_DIR/benchmarks/long_doc_qa/long_doc_qa.py" \
+        --port "$port" \
+        --model "$MODEL" \
+        --document-length "$DOCUMENT_LENGTH" \
+        --num-documents "$NUM_DOCUMENTS" \
+        --output-len "$OUTPUT_LEN" \
+        --repeat-count "$REPEAT_COUNT" \
+        --repeat-mode "$REPEAT_MODE" \
+        --shuffle-seed "$SHUFFLE_SEED" \
+        --max-inflight-requests "$MAX_INFLIGHT_REQUESTS" \
+        --output "$output_file" \
+        --json-output \
+        2>>"$output_file" | tee "$result_file"
+    
+    echo "✅ $description benchmark completed"
+    echo ""
+}
+
+# Extract a field from JSON file (last line)
+extract_json_field() {
+    local json_file="$1"
+    local field="$2"
+    
+    # Get the last line which should be the JSON output
+    local json_line
+    json_line=$(tail -n 1 "$json_file")
+    
+    python3 -c "
+import json
+import sys
+try:
+    data = json.loads('$json_line')
+    value = data.get('$field', 'null')
+    print(value if value is not None else 'null')
+except json.JSONDecodeError:
+    print('null')
+"
+}
+
+# Compare and summarize results
+compare_results() {
+    local lmcache_result="$RESULTS_DIR/lmcache_result.json"
+    local baseline_result="$RESULTS_DIR/baseline_result.json"
+    
+    echo "=== Comparing benchmark results ==="
+    
+    # Check if result files exist
+    if [ ! -f "$lmcache_result" ]; then
+        echo "❌ LMCache result file not found: $lmcache_result"
+        return 1
+    fi
+    
+    if [ ! -f "$baseline_result" ]; then
+        echo "❌ Baseline result file not found: $baseline_result"
+        return 1
+    fi
+    
+    # Extract values from LMCache result
+    lmcache_query_ttft=$(extract_json_field "$lmcache_result" "query_ttft_per_prompt")
+    lmcache_query_round_time=$(extract_json_field "$lmcache_result" "query_round_time_per_prompt")
+    lmcache_warmup_round_time=$(extract_json_field "$lmcache_result" "warmup_round_time_per_prompt")
+    
+    # Extract values from baseline result
+    baseline_query_ttft=$(extract_json_field "$baseline_result" "query_ttft_per_prompt")
+    baseline_query_round_time=$(extract_json_field "$baseline_result" "query_round_time_per_prompt")
+    baseline_warmup_round_time=$(extract_json_field "$baseline_result" "warmup_round_time_per_prompt")
+    
+    echo ""
+    echo "============================================"
+    echo "=== Performance Summary ==="
+    echo "============================================"
+    echo ""
+    
+    # Calculate and display comparison
+    python3 << EOF
+import sys
+
+def safe_float(val):
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+def format_comparison(name, lmcache_val, baseline_val):
+    lmcache = safe_float(lmcache_val)
+    baseline = safe_float(baseline_val)
+    
+    if lmcache is None or baseline is None:
+        return f"{name}: Unable to compare (invalid values)"
+    
+    if baseline > 0:
+        diff_pct = ((lmcache - baseline) / baseline) * 100
+        if diff_pct < 0:
+            status = "✅ FASTER"
+            diff_str = f"{abs(diff_pct):.2f}% faster"
+        elif diff_pct > 10:
+            status = "❌ SLOWER"
+            diff_str = f"{diff_pct:.2f}% slower"
+        else:
+            status = "✅ OK"
+            diff_str = f"{diff_pct:.2f}% slower"
+    else:
+        status = "⚠️"
+        diff_str = "N/A"
+    
+    return f"{name}:\n  Baseline:  {baseline:.4f}s\n  LMCache:   {lmcache:.4f}s\n  Diff:      {diff_str} {status}"
+
+print("=" * 50)
+print("Query TTFT per Prompt (Time to First Token)")
+print("=" * 50)
+print(format_comparison("query_ttft_per_prompt", "$lmcache_query_ttft", "$baseline_query_ttft"))
+print()
+
+print("=" * 50)
+print("Query Round Time per Prompt (End-to-End Latency)")
+print("=" * 50)
+print(format_comparison("query_round_time_per_prompt", "$lmcache_query_round_time", "$baseline_query_round_time"))
+print()
+
+print("=" * 50)
+print("Warmup Round Time per Prompt")
+print("=" * 50)
+print(format_comparison("warmup_round_time_per_prompt", "$lmcache_warmup_round_time", "$baseline_warmup_round_time"))
+print()
+
+# Summary table
+print("=" * 50)
+print("Summary Table")
+print("=" * 50)
+print(f"{'Metric':<35} {'Baseline':>12} {'LMCache':>12} {'Diff':>10}")
+print("-" * 70)
+
+metrics = [
+    ("query_ttft_per_prompt", "$baseline_query_ttft", "$lmcache_query_ttft"),
+    ("query_round_time_per_prompt", "$baseline_query_round_time", "$lmcache_query_round_time"),
+    ("warmup_round_time_per_prompt", "$baseline_warmup_round_time", "$lmcache_warmup_round_time"),
+]
+
+for name, baseline_val, lmcache_val in metrics:
+    baseline = safe_float(baseline_val)
+    lmcache = safe_float(lmcache_val)
+    
+    if baseline is not None and lmcache is not None:
+        if baseline > 0:
+            diff_pct = ((lmcache - baseline) / baseline) * 100
+            diff_str = f"{diff_pct:+.1f}%"
+        else:
+            diff_str = "N/A"
+        print(f"{name:<35} {baseline:>12.4f} {lmcache:>12.4f} {diff_str:>10}")
+    else:
+        print(f"{name:<35} {'N/A':>12} {'N/A':>12} {'N/A':>10}")
+
+print()
+EOF
+    
+    return 0
+}
+
+# Verify LMCache performance meets thresholds
+verify_thresholds() {
+    local lmcache_result="$RESULTS_DIR/lmcache_result.json"
+    
+    echo "=== Verifying LMCache performance thresholds ==="
+    echo "Max allowed TTFT: ${MAX_LMCACHE_TTFT}s"
+    echo "Max allowed query round time: ${MAX_LMCACHE_QUERY_ROUND_TIME}s"
+    echo ""
+    
+    # Extract LMCache values
+    lmcache_query_ttft=$(extract_json_field "$lmcache_result" "query_ttft_per_prompt")
+    lmcache_query_round_time=$(extract_json_field "$lmcache_result" "query_round_time_per_prompt")
+    
+    # Verify thresholds using Python
+    python3 << EOF
+import sys
+
+def safe_float(val):
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+ttft = safe_float("$lmcache_query_ttft")
+query_round_time = safe_float("$lmcache_query_round_time")
+max_ttft = float("$MAX_LMCACHE_TTFT")
+max_query_round_time = float("$MAX_LMCACHE_QUERY_ROUND_TIME")
+
+failed = False
+
+print("=" * 50)
+print("Threshold Verification")
+print("=" * 50)
+
+# Check TTFT
+if ttft is None:
+    print("❌ query_ttft_per_prompt: Unable to parse value")
+    failed = True
+elif ttft <= max_ttft:
+    print(f"✅ query_ttft_per_prompt: {ttft:.4f}s <= {max_ttft}s (PASS)")
+else:
+    print(f"❌ query_ttft_per_prompt: {ttft:.4f}s > {max_ttft}s (FAIL)")
+    failed = True
+
+# Check query round time
+if query_round_time is None:
+    print("❌ query_round_time_per_prompt: Unable to parse value")
+    failed = True
+elif query_round_time <= max_query_round_time:
+    print(f"✅ query_round_time_per_prompt: {query_round_time:.4f}s <= {max_query_round_time}s (PASS)")
+else:
+    print(f"❌ query_round_time_per_prompt: {query_round_time:.4f}s > {max_query_round_time}s (FAIL)")
+    failed = True
+
+print()
+
+if failed:
+    print("❌ Threshold verification FAILED")
+    sys.exit(1)
+else:
+    print("✅ All thresholds passed")
+    sys.exit(0)
+EOF
+}
+
+# Main execution
+main() {
+    setup_venv
+    
+    # Run benchmark against baseline vLLM (without LMCache)
+    echo "============================================"
+    echo "=== Benchmark: Baseline vLLM (without LMCache) ==="
+    echo "============================================"
+    run_long_doc_qa "$VLLM_BASELINE_PORT" "$RESULTS_DIR/baseline_result.json" "baseline"
+    
+    # Run benchmark against vLLM with LMCache
+    echo "============================================"
+    echo "=== Benchmark: vLLM with LMCache ==="
+    echo "============================================"
+    run_long_doc_qa "$VLLM_PORT" "$RESULTS_DIR/lmcache_result.json" "lmcache"
+    
+    # Compare and summarize results
+    echo "============================================"
+    echo "=== Comparing Results ==="
+    echo "============================================"
+    if ! compare_results; then
+        echo "❌ Comparison failed"
+        exit 1
+    fi
+    
+    # Verify LMCache performance meets thresholds
+    echo "============================================"
+    echo "=== Verifying Performance Thresholds ==="
+    echo "============================================"
+    if ! verify_thresholds; then
+        echo "❌ Threshold verification failed"
+        exit 1
+    fi
+    
+    echo "============================================"
+    echo "=== ✅ Long Doc QA test completed ==="
+    echo "============================================"
+    echo "Results saved to: $RESULTS_DIR"
+    echo "  - LMCache: $RESULTS_DIR/lmcache_result.json"
+    echo "  - Baseline: $RESULTS_DIR/baseline_result.json"
+}
+
+main "$@"
+

--- a/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
@@ -9,8 +9,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Export container names and configuration for all scripts
 export LMCACHE_CONTAINER_NAME="lmcache-mp-test-$$"
 export VLLM_CONTAINER_NAME="vllm-mp-test-$$"
+export VLLM_BASELINE_CONTAINER_NAME="vllm-baseline-test-$$"
 export LMCACHE_PORT="${LMCACHE_PORT:-6555}"
 export VLLM_PORT="${VLLM_PORT:-8000}"
+export VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
 export MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
 export BUILD_ID="${BUILD_ID:-local_$$}"
 
@@ -35,8 +37,10 @@ echo "============================================"
 echo "Build ID: $BUILD_ID"
 echo "LMCache container: $LMCACHE_CONTAINER_NAME"
 echo "vLLM container: $VLLM_CONTAINER_NAME"
+echo "vLLM baseline container: $VLLM_BASELINE_CONTAINER_NAME"
 echo "LMCache port: $LMCACHE_PORT"
 echo "vLLM port: $VLLM_PORT"
+echo "vLLM baseline port: $VLLM_BASELINE_PORT"
 echo ""
 
 # Step 1: Build docker images
@@ -83,9 +87,20 @@ if ! "$SCRIPT_DIR/run-lm-eval.sh"; then
 fi
 echo ""
 
+# Step 5: Run vllm bench serve test
+echo "============================================"
+echo "=== Step 5: Running vllm bench serve ==="
+echo "============================================"
+if ! "$SCRIPT_DIR/run-vllm-bench.sh"; then
+    echo "❌ vllm bench serve test failed"
+    TEST_RESULT=1
+    exit 1
+fi
+echo ""
+
 echo "============================================"
 echo "=== ✅ All tests passed! ==="
 echo "============================================"
 
-# Step 5: Cleanup runs automatically via trap
+# Step 6: Cleanup runs automatically via trap
 

--- a/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
@@ -98,9 +98,20 @@ if ! "$SCRIPT_DIR/run-vllm-bench.sh"; then
 fi
 echo ""
 
+# Step 6: Run long doc QA test
+echo "============================================"
+echo "=== Step 6: Running long doc QA ==="
+echo "============================================"
+if ! "$SCRIPT_DIR/run-long-doc-qa.sh"; then
+    echo "❌ long doc QA test failed"
+    TEST_RESULT=1
+    exit 1
+fi
+echo ""
+
 echo "============================================"
 echo "=== ✅ All tests passed! ==="
 echo "============================================"
 
-# Step 6: Cleanup runs automatically via trap
+# Step 7: Cleanup runs automatically via trap
 

--- a/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+# Run vllm bench serve test against both vLLM servers
+# Compares performance between LMCache-enabled and baseline vLLM
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Configuration
+VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
+MODEL="${MODEL:-Qwen/Qwen3-14B}"
+NUM_PROMPTS="${NUM_PROMPTS:-50}"
+RANDOM_INPUT_LEN="${RANDOM_INPUT_LEN:-10000}"
+RANDOM_OUTPUT_LEN="${RANDOM_OUTPUT_LEN:-1}"
+VENV_DIR="${VENV_DIR:-$WORKSPACE_DIR/.venv}"
+BUILD_ID="${BUILD_ID:-local_$(date +%Y%m%d_%H%M%S)}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/vllm_bench_results_${BUILD_ID}}"
+
+# Expected values
+EXPECTED_TOTAL_INPUT_TOKENS=$((NUM_PROMPTS * RANDOM_INPUT_LEN))
+EXPECTED_COMPLETED=NUM_PROMPTS
+MAX_SLOWDOWN_PERCENT=5
+
+# Generate a random seed once for reproducibility across both benchmarks
+RANDOM_SEED="${RANDOM_SEED:-$(date +%s)}"
+
+echo "=== vLLM Bench Serve Test ==="
+echo "Model: $MODEL"
+echo "vLLM Port (with LMCache): $VLLM_PORT"
+echo "vLLM Baseline Port (without LMCache): $VLLM_BASELINE_PORT"
+echo "Number of prompts: $NUM_PROMPTS"
+echo "Random input length: $RANDOM_INPUT_LEN"
+echo "Random output length: $RANDOM_OUTPUT_LEN"
+echo "Virtual env: $VENV_DIR"
+echo "Build ID: $BUILD_ID"
+echo "Results dir: $RESULTS_DIR"
+echo ""
+
+# Create results directory
+mkdir -p "$RESULTS_DIR"
+
+# Setup virtual environment
+setup_venv() {
+    echo "=== Setting up virtual environment ==="
+    
+    if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
+        echo "Virtual environment already exists at $VENV_DIR"
+    else
+        echo "Creating virtual environment with uv..."
+        
+        # Check if uv is available
+        if ! command -v uv &> /dev/null; then
+            echo "uv not found, installing..."
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+        fi
+        
+        # Create venv with uv
+        uv venv "$VENV_DIR"
+        echo "Virtual environment created"
+    fi
+    
+    # Activate virtual environment
+    source "$VENV_DIR/bin/activate"
+    echo "Virtual environment activated"
+    
+    # Install dependencies
+    echo "Installing dependencies..."
+    uv pip install vllm openai --quiet
+    echo "Dependencies installed"
+    echo ""
+}
+
+# Run vllm bench serve
+run_vllm_bench() {
+    local port="$1"
+    local result_filename="$2"
+    local description="$3"
+    local seed="$4"
+    
+    echo "=== Running vllm bench serve ($description) ==="
+    echo "Port: $port"
+    echo "Seed: $seed"
+    echo "Result file: $RESULTS_DIR/$result_filename"
+    
+    vllm bench serve \
+        --seed "$seed" \
+        --port "$port" \
+        --model "$MODEL" \
+        --dataset-name random \
+        --random-input-len "$RANDOM_INPUT_LEN" \
+        --random-output-len "$RANDOM_OUTPUT_LEN" \
+        --num-prompts "$NUM_PROMPTS" \
+        --ignore-eos \
+        --backend openai-chat \
+        --endpoint /v1/chat/completions \
+        --result-dir "$RESULTS_DIR" \
+        --result-filename "$result_filename" \
+        --save-result
+    
+    echo "✅ $description benchmark completed"
+    echo ""
+}
+
+# Extract a numeric field from JSON file
+extract_json_field() {
+    local json_file="$1"
+    local field="$2"
+    
+    python3 -c "
+import json
+with open('$json_file', 'r') as f:
+    data = json.load(f)
+print(data.get('$field', 'null'))
+"
+}
+
+# Verify benchmark results
+verify_results() {
+    local lmcache_result="$RESULTS_DIR/lmcache.json"
+    local baseline_result="$RESULTS_DIR/baseline.json"
+    
+    echo "=== Verifying benchmark results ==="
+    
+    # Check if result files exist
+    if [ ! -f "$lmcache_result" ]; then
+        echo "❌ LMCache result file not found: $lmcache_result"
+        return 1
+    fi
+    
+    if [ ! -f "$baseline_result" ]; then
+        echo "❌ Baseline result file not found: $baseline_result"
+        return 1
+    fi
+    
+    echo "LMCache result: $lmcache_result"
+    echo "Baseline result: $baseline_result"
+    echo ""
+    
+    # Extract values from LMCache result
+    lmcache_total_input_tokens=$(extract_json_field "$lmcache_result" "total_input_tokens")
+    lmcache_completed=$(extract_json_field "$lmcache_result" "completed")
+    lmcache_throughput=$(extract_json_field "$lmcache_result" "total_token_throughput")
+    
+    # Extract values from baseline result
+    baseline_total_input_tokens=$(extract_json_field "$baseline_result" "total_input_tokens")
+    baseline_completed=$(extract_json_field "$baseline_result" "completed")
+    baseline_throughput=$(extract_json_field "$baseline_result" "total_token_throughput")
+    
+    echo "=== LMCache Results ==="
+    echo "  total_input_tokens: $lmcache_total_input_tokens"
+    echo "  completed: $lmcache_completed"
+    echo "  total_token_throughput: $lmcache_throughput"
+    echo ""
+    
+    echo "=== Baseline Results ==="
+    echo "  total_input_tokens: $baseline_total_input_tokens"
+    echo "  completed: $baseline_completed"
+    echo "  total_token_throughput: $baseline_throughput"
+    echo ""
+    
+    # Verification
+    local failed=0
+    
+    echo "=== Verification ==="
+    
+    # Check total_input_tokens for LMCache
+    if [ "$lmcache_total_input_tokens" -eq "$EXPECTED_TOTAL_INPUT_TOKENS" ] 2>/dev/null; then
+        echo "✅ LMCache total_input_tokens: $lmcache_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
+    else
+        echo "❌ LMCache total_input_tokens: $lmcache_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
+        failed=1
+    fi
+    
+    # Check total_input_tokens for baseline
+    if [ "$baseline_total_input_tokens" -eq "$EXPECTED_TOTAL_INPUT_TOKENS" ] 2>/dev/null; then
+        echo "✅ Baseline total_input_tokens: $baseline_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
+    else
+        echo "❌ Baseline total_input_tokens: $baseline_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
+        failed=1
+    fi
+    
+    # Check completed for LMCache
+    if [ "$lmcache_completed" -eq "$EXPECTED_COMPLETED" ] 2>/dev/null; then
+        echo "✅ LMCache completed: $lmcache_completed (expected: $EXPECTED_COMPLETED)"
+    else
+        echo "❌ LMCache completed: $lmcache_completed (expected: $EXPECTED_COMPLETED)"
+        failed=1
+    fi
+    
+    # Check completed for baseline
+    if [ "$baseline_completed" -eq "$EXPECTED_COMPLETED" ] 2>/dev/null; then
+        echo "✅ Baseline completed: $baseline_completed (expected: $EXPECTED_COMPLETED)"
+    else
+        echo "❌ Baseline completed: $baseline_completed (expected: $EXPECTED_COMPLETED)"
+        failed=1
+    fi
+    
+    # Check throughput comparison (LMCache should not be more than 10% slower)
+    throughput_check=$(python3 -c "
+lmcache_tp = $lmcache_throughput
+baseline_tp = $baseline_throughput
+max_slowdown = $MAX_SLOWDOWN_PERCENT
+
+# Calculate the minimum acceptable throughput (90% of baseline)
+min_acceptable = baseline_tp * (1 - max_slowdown / 100.0)
+
+# Calculate actual slowdown percentage
+if baseline_tp > 0:
+    slowdown_pct = ((baseline_tp - lmcache_tp) / baseline_tp) * 100
+else:
+    slowdown_pct = 0
+
+if lmcache_tp >= min_acceptable:
+    print(f'PASS|{slowdown_pct:.2f}')
+else:
+    print(f'FAIL|{slowdown_pct:.2f}')
+")
+    
+    throughput_status=$(echo "$throughput_check" | cut -d'|' -f1)
+    slowdown_pct=$(echo "$throughput_check" | cut -d'|' -f2)
+    
+    if [ "$throughput_status" = "PASS" ]; then
+        echo "✅ Throughput comparison: LMCache is ${slowdown_pct}% slower (max allowed: ${MAX_SLOWDOWN_PERCENT}%)"
+    else
+        echo "❌ Throughput comparison: LMCache is ${slowdown_pct}% slower (max allowed: ${MAX_SLOWDOWN_PERCENT}%)"
+        failed=1
+    fi
+    
+    echo ""
+    
+    if [ "$failed" -eq 1 ]; then
+        return 1
+    fi
+    
+    return 0
+}
+
+# Main execution
+main() {
+    setup_venv
+    
+    echo "Using random seed: $RANDOM_SEED"
+    echo ""
+    
+    # Run benchmark against baseline vLLM (without LMCache)
+    echo "============================================"
+    echo "=== Benchmark: Baseline vLLM (without LMCache) ==="
+    echo "============================================"
+    run_vllm_bench "$VLLM_BASELINE_PORT" "baseline.json" "Baseline vLLM" "$RANDOM_SEED"
+    
+    # Run benchmark against vLLM with LMCache
+    echo "============================================"
+    echo "=== Benchmark: vLLM with LMCache ==="
+    echo "============================================"
+    run_vllm_bench "$VLLM_PORT" "lmcache.json" "vLLM with LMCache" "$RANDOM_SEED"
+    
+    # Verify results
+    echo "============================================"
+    echo "=== Verifying benchmark results ==="
+    echo "============================================"
+    if ! verify_results; then
+        echo "❌ Verification failed"
+        exit 1
+    fi
+    
+    echo "============================================"
+    echo "=== ✅ vLLM Bench test completed ==="
+    echo "============================================"
+    echo "Results saved to: $RESULTS_DIR"
+    echo "  - LMCache: $RESULTS_DIR/lmcache.json"
+    echo "  - Baseline: $RESULTS_DIR/baseline.json"
+}
+
+main "$@"
+

--- a/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
@@ -6,7 +6,9 @@ set -e
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Source common utilities
+source "$SCRIPT_DIR/common.sh"
 
 # Configuration
 VLLM_PORT="${VLLM_PORT:-8000}"
@@ -15,9 +17,6 @@ MODEL="${MODEL:-Qwen/Qwen3-14B}"
 NUM_PROMPTS="${NUM_PROMPTS:-50}"
 RANDOM_INPUT_LEN="${RANDOM_INPUT_LEN:-10000}"
 RANDOM_OUTPUT_LEN="${RANDOM_OUTPUT_LEN:-1}"
-VENV_DIR="${VENV_DIR:-$WORKSPACE_DIR/.venv}"
-BUILD_ID="${BUILD_ID:-local_$(date +%Y%m%d_%H%M%S)}"
-RESULTS_DIR="${RESULTS_DIR:-/tmp/vllm_bench_results_${BUILD_ID}}"
 
 # Expected values
 EXPECTED_TOTAL_INPUT_TOKENS=$((NUM_PROMPTS * RANDOM_INPUT_LEN))
@@ -26,6 +25,9 @@ MAX_SLOWDOWN_PERCENT=5
 
 # Generate a random seed once for reproducibility across both benchmarks
 RANDOM_SEED="${RANDOM_SEED:-$(date +%s)}"
+
+# Output directory (subdirectory of shared RESULTS_DIR)
+VLLM_BENCH_DIR="$RESULTS_DIR/vllm_bench"
 
 echo "=== vLLM Bench Serve Test ==="
 echo "Model: $MODEL"
@@ -36,43 +38,11 @@ echo "Random input length: $RANDOM_INPUT_LEN"
 echo "Random output length: $RANDOM_OUTPUT_LEN"
 echo "Virtual env: $VENV_DIR"
 echo "Build ID: $BUILD_ID"
-echo "Results dir: $RESULTS_DIR"
+echo "Results dir: $VLLM_BENCH_DIR"
 echo ""
 
 # Create results directory
-mkdir -p "$RESULTS_DIR"
-
-# Setup virtual environment
-setup_venv() {
-    echo "=== Setting up virtual environment ==="
-    
-    if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
-        echo "Virtual environment already exists at $VENV_DIR"
-    else
-        echo "Creating virtual environment with uv..."
-        
-        # Check if uv is available
-        if ! command -v uv &> /dev/null; then
-            echo "uv not found, installing..."
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-            export PATH="$HOME/.local/bin:$PATH"
-        fi
-        
-        # Create venv with uv
-        uv venv "$VENV_DIR"
-        echo "Virtual environment created"
-    fi
-    
-    # Activate virtual environment
-    source "$VENV_DIR/bin/activate"
-    echo "Virtual environment activated"
-    
-    # Install dependencies
-    echo "Installing dependencies..."
-    uv pip install vllm openai --quiet
-    echo "Dependencies installed"
-    echo ""
-}
+mkdir -p "$VLLM_BENCH_DIR"
 
 # Run vllm bench serve
 run_vllm_bench() {
@@ -84,7 +54,7 @@ run_vllm_bench() {
     echo "=== Running vllm bench serve ($description) ==="
     echo "Port: $port"
     echo "Seed: $seed"
-    echo "Result file: $RESULTS_DIR/$result_filename"
+    echo "Result file: $VLLM_BENCH_DIR/$result_filename"
     
     vllm bench serve \
         --seed "$seed" \
@@ -97,7 +67,7 @@ run_vllm_bench() {
         --ignore-eos \
         --backend openai-chat \
         --endpoint /v1/chat/completions \
-        --result-dir "$RESULTS_DIR" \
+        --result-dir "$VLLM_BENCH_DIR" \
         --result-filename "$result_filename" \
         --save-result
     
@@ -120,8 +90,8 @@ print(data.get('$field', 'null'))
 
 # Verify benchmark results
 verify_results() {
-    local lmcache_result="$RESULTS_DIR/lmcache.json"
-    local baseline_result="$RESULTS_DIR/baseline.json"
+    local lmcache_result="$VLLM_BENCH_DIR/lmcache.json"
+    local baseline_result="$VLLM_BENCH_DIR/baseline.json"
     
     echo "=== Verifying benchmark results ==="
     
@@ -241,7 +211,7 @@ else:
 
 # Main execution
 main() {
-    setup_venv
+    setup_venv vllm openai
     
     echo "Using random seed: $RANDOM_SEED"
     echo ""
@@ -270,10 +240,9 @@ main() {
     echo "============================================"
     echo "=== ✅ vLLM Bench test completed ==="
     echo "============================================"
-    echo "Results saved to: $RESULTS_DIR"
-    echo "  - LMCache: $RESULTS_DIR/lmcache.json"
-    echo "  - Baseline: $RESULTS_DIR/baseline.json"
+    echo "Results saved to: $VLLM_BENCH_DIR"
+    echo "  - LMCache: $VLLM_BENCH_DIR/lmcache.json"
+    echo "  - Baseline: $VLLM_BENCH_DIR/baseline.json"
 }
 
 main "$@"
-

--- a/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
@@ -21,7 +21,7 @@ RESULTS_DIR="${RESULTS_DIR:-/tmp/vllm_bench_results_${BUILD_ID}}"
 
 # Expected values
 EXPECTED_TOTAL_INPUT_TOKENS=$((NUM_PROMPTS * RANDOM_INPUT_LEN))
-EXPECTED_COMPLETED=NUM_PROMPTS
+EXPECTED_COMPLETED=$NUM_PROMPTS
 MAX_SLOWDOWN_PERCENT=5
 
 # Generate a random seed once for reproducibility across both benchmarks

--- a/.buildkite/scripts/multiprocessing-test/wait-for-vllm.sh
+++ b/.buildkite/scripts/multiprocessing-test/wait-for-vllm.sh
@@ -1,52 +1,77 @@
 #!/bin/bash
-# Wait for vLLM server to be ready
+# Wait for vLLM servers to be ready
 set -e
 
 VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
 MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-600}"
 VLLM_CONTAINER_NAME="${VLLM_CONTAINER_NAME:-vllm-mp-test}"
+VLLM_BASELINE_CONTAINER_NAME="${VLLM_BASELINE_CONTAINER_NAME:-vllm-baseline-test}"
 
-echo "=== Waiting for vLLM to be ready ==="
-echo "Port: $VLLM_PORT"
-echo "Max wait time: ${MAX_WAIT_SECONDS}s"
+# Function to wait for a single vLLM server
+wait_for_vllm_server() {
+    local port="$1"
+    local container_name="$2"
+    local description="$3"
+    
+    echo "=== Waiting for $description to be ready ==="
+    echo "Port: $port"
+    echo "Container: $container_name"
+    echo "Max wait time: ${MAX_WAIT_SECONDS}s"
+    
+    start_time=$(date +%s)
+    end_time=$((start_time + MAX_WAIT_SECONDS))
+    
+    while true; do
+        current_time=$(date +%s)
+        elapsed=$((current_time - start_time))
+        
+        if [ "$current_time" -ge "$end_time" ]; then
+            echo "❌ Timeout: $description did not become ready within ${MAX_WAIT_SECONDS} seconds"
+            echo ""
+            echo "=== $description container logs ==="
+            docker logs --tail 100 "$container_name" 2>&1 || true
+            return 1
+        fi
+        
+        # Check if container is still running
+        if ! docker ps --format '{{.Names}}' | grep -q "^${container_name}$"; then
+            echo "❌ $description container is not running"
+            echo ""
+            echo "=== $description container logs ==="
+            docker logs "$container_name" 2>&1 || true
+            return 1
+        fi
+        
+        # Check if vLLM health endpoint is responding
+        if curl -sf "http://localhost:${port}/health" > /dev/null 2>&1; then
+            echo "✅ $description is ready! (took ${elapsed}s)"
+            return 0
+        fi
+        
+        # Also try the models endpoint as a fallback
+        if curl -sf "http://localhost:${port}/v1/models" > /dev/null 2>&1; then
+            echo "✅ $description is ready! (took ${elapsed}s)"
+            return 0
+        fi
+        
+        echo "Waiting for $description... (${elapsed}s elapsed)"
+        sleep 5
+    done
+}
 
-start_time=$(date +%s)
-end_time=$((start_time + MAX_WAIT_SECONDS))
+# Wait for vLLM with LMCache
+if ! wait_for_vllm_server "$VLLM_PORT" "$VLLM_CONTAINER_NAME" "vLLM (with LMCache)"; then
+    exit 1
+fi
 
-while true; do
-    current_time=$(date +%s)
-    elapsed=$((current_time - start_time))
-    
-    if [ "$current_time" -ge "$end_time" ]; then
-        echo "❌ Timeout: vLLM did not become ready within ${MAX_WAIT_SECONDS} seconds"
-        echo ""
-        echo "=== vLLM container logs ==="
-        docker logs --tail 100 "$VLLM_CONTAINER_NAME" 2>&1 || true
-        exit 1
-    fi
-    
-    # Check if container is still running
-    if ! docker ps --format '{{.Names}}' | grep -q "^${VLLM_CONTAINER_NAME}$"; then
-        echo "❌ vLLM container is not running"
-        echo ""
-        echo "=== vLLM container logs ==="
-        docker logs "$VLLM_CONTAINER_NAME" 2>&1 || true
-        exit 1
-    fi
-    
-    # Check if vLLM health endpoint is responding
-    if curl -sf "http://localhost:${VLLM_PORT}/health" > /dev/null 2>&1; then
-        echo "✅ vLLM is ready! (took ${elapsed}s)"
-        exit 0
-    fi
-    
-    # Also try the models endpoint as a fallback
-    if curl -sf "http://localhost:${VLLM_PORT}/v1/models" > /dev/null 2>&1; then
-        echo "✅ vLLM is ready! (took ${elapsed}s)"
-        exit 0
-    fi
-    
-    echo "Waiting for vLLM... (${elapsed}s elapsed)"
-    sleep 5
-done
+echo ""
+
+# Wait for vLLM baseline (without LMCache)
+if ! wait_for_vllm_server "$VLLM_BASELINE_PORT" "$VLLM_BASELINE_CONTAINER_NAME" "vLLM baseline (without LMCache)"; then
+    exit 1
+fi
+
+echo ""
+echo "=== All vLLM servers are ready ==="
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR is part of #2357

- It adds vLLM prefill speed test to make sure that the multi-process mode only introduces minimal (<5%) overhead to vLLM itself.
- Also added long-doc-qa test for retrieve speed test
- Also added a README to explain the CI scripts and how to contribute

<img width="1066" height="216" alt="image" src="https://github.com/user-attachments/assets/fe27a614-d2b5-4094-a9ab-60a3b3fc2265" />

<img width="1110" height="930" alt="image" src="https://github.com/user-attachments/assets/7b3e5fe6-a043-4653-92fa-579108a62fd4" />


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
