### PR TITLE
[refactor] remove Tuple type in allocate and batched_allocate

### DIFF
--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -2,7 +2,7 @@
 """Lazy memory allocator with async progressive expansion and zero-copy."""
 
 # Standard
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 import threading
 
 # Third Party
@@ -393,7 +393,7 @@ class LazyMixedMemoryAllocator(MixedMemoryAllocator):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -406,7 +406,7 @@ class LazyMixedMemoryAllocator(MixedMemoryAllocator):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -727,7 +727,7 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
@@ -749,7 +749,7 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
@@ -819,13 +819,11 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
     # TODO(chunxiaozheng): remove if after all params replaced by shapes/dtypes
     def _adapt_shapes_and_dtypes(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
     ) -> Tuple[list[torch.Size], list[torch.dtype]]:
         if isinstance(shapes, torch.Size):
             shapes = [shapes]
-        elif isinstance(shapes, tuple):
-            shapes = [torch.Size(shapes)]
 
         if isinstance(dtypes, torch.dtype):
             dtypes = [dtypes]
@@ -914,7 +912,7 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -984,7 +982,7 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -1268,7 +1266,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1312,7 +1310,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -1464,7 +1462,7 @@ class BufferAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.BINARY_BUFFER,
         allocator_type: Optional[str] = None,
@@ -1479,7 +1477,7 @@ class BufferAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.BINARY_BUFFER,
@@ -1543,7 +1541,7 @@ class HostMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1554,7 +1552,7 @@ class HostMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -1628,7 +1626,7 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1639,7 +1637,7 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -1728,7 +1726,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1749,7 +1747,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -1876,7 +1874,7 @@ class GPUMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1887,7 +1885,7 @@ class GPUMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -1937,7 +1935,7 @@ class AdHocMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         allocator_type: Optional[str] = None,
@@ -1970,7 +1968,7 @@ class AdHocMemoryAllocator(MemoryAllocatorInterface):
     @_lmcache_nvtx_annotate
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
@@ -2082,7 +2080,7 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
 
     def allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = "cpu",
@@ -2096,7 +2094,7 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
 
     def batched_allocate(
         self,
-        shapes: Union[torch.Size, Tuple[int, ...], list[torch.Size]],
+        shapes: Union[torch.Size, list[torch.Size]],
         dtypes: Union[torch.dtype, list[torch.dtype]],
         batch_size: int,
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,

--- a/lmcache/v1/multiprocess/mp_storage_manager.py
+++ b/lmcache/v1/multiprocess/mp_storage_manager.py
@@ -7,7 +7,7 @@ from collections.abc import Hashable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import compress
-from typing import Any, Generic, Iterator, TypeVar, Union
+from typing import Any, Generic, Iterator, TypeVar
 import threading
 import time
 
@@ -246,7 +246,7 @@ class MPStorageManager:
     def reserve(
         self,
         keys: list[IPCCacheEngineKey],
-        shape: Union[torch.Size, tuple[int, ...]],
+        shape: torch.Size,
         dtype: torch.dtype,
         fmt: MemoryFormat,
     ) -> ReserveResult:
@@ -327,7 +327,7 @@ class MPStorageManager:
         # Allocate memory objects
         with self._allocator_lock:
             objects = self._memory_allocator.batched_allocate(
-                shape, dtype, num_objects_to_allocate, fmt
+                [shape], [dtype], num_objects_to_allocate, fmt
             )
 
         if objects is not None:
@@ -362,7 +362,7 @@ class MPStorageManager:
 
                 # Try to allocate again
                 objects = self._memory_allocator.batched_allocate(
-                    shape, dtype, num_objects_to_allocate, fmt
+                    [shape], [dtype], num_objects_to_allocate, fmt
                 )
 
         if objects is not None:

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -20,13 +20,10 @@ from lmcache.utils import CacheEngineKey, start_loop_in_thread_with_exceptions
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.internal_api_server.api_server import app
-from lmcache.v1.memory_management import (
-    AdHocMemoryAllocator,
-    MemoryFormat,
-    MemoryObj,
-)
+from lmcache.v1.memory_management import AdHocMemoryAllocator
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+from tests.v1.utils import create_test_memory_obj
 
 
 class TestLoadFSChunksAPI:
@@ -131,14 +128,6 @@ class TestLoadFSChunksAPI:
             dtype=torch.bfloat16,
         )
 
-    def _create_test_memory_obj(
-        self, shape=(2, 16, 8, 128), dtype=torch.bfloat16
-    ) -> MemoryObj:
-        """Create a test MemoryObj."""
-        allocator = AdHocMemoryAllocator(device="cpu")
-        memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-        return memory_obj
-
     def _prepare_test_data(
         self,
         temp_fs_path: str,
@@ -164,7 +153,7 @@ class TestLoadFSChunksAPI:
         try:
             for i in range(num_chunks):
                 key = self._create_test_key(i)
-                memory_obj = self._create_test_memory_obj()
+                memory_obj = create_test_memory_obj()
                 future = remote_backend.submit_put_task(key, memory_obj)
                 if future:
                     future.result(timeout=5.0)

--- a/tests/v1/multiprocess/test_mp_storage_manager.py
+++ b/tests/v1/multiprocess/test_mp_storage_manager.py
@@ -44,7 +44,7 @@ def test_keys():
 @pytest.fixture
 def test_shape():
     """Standard test shape for tensors."""
-    return (2, 16, 16, 128)
+    return torch.Size([2, 16, 16, 128])
 
 
 @pytest.fixture
@@ -189,7 +189,7 @@ class TestReserve:
     ):
         """Test that MemoryExhaustedError is raised when memory is exhausted."""
         # Try to allocate very large tensors that exceed buffer
-        large_shape = (2, 100, 1000, 1000)  # Very large shape
+        large_shape = torch.Size([2, 100, 1000, 1000])  # Very large shape
 
         with pytest.raises(MemoryExhaustedError):
             small_storage_manager.reserve(
@@ -200,8 +200,8 @@ class TestReserve:
         self, small_storage_manager, test_keys, test_shape, test_dtype, test_format
     ):
         # Try to reserve and commit a lot of small tensors (total size is large)
-        large_shape = (2, 50, 50, 256)  # Moderate size
-        small_shape = (2, 5, 50, 256)  # Small size (1/10 of large)
+        large_shape = torch.Size([2, 50, 50, 256])  # Moderate size
+        small_shape = torch.Size([2, 5, 50, 256])  # Small size (1/10 of large)
 
         # First, reserve a single key with large shape should fail
         with pytest.raises(MemoryExhaustedError):
@@ -340,7 +340,7 @@ class TestLookup:
         self, small_storage_manager, test_keys, test_shape, test_dtype, test_format
     ):
         """Test that lookup locks the objects so they cannot be evicted."""
-        small_shape = (2, 4, 50, 256)  # Small size
+        small_shape = torch.Size([2, 4, 50, 256])  # Small size
         # Reserve and commit multiple small tensors to fill up memory
         target_keys = test_keys[:1]
         handle, _ = small_storage_manager.reserve(
@@ -499,7 +499,7 @@ class TestClose:
     def test_close_after_operations(self, test_keys, test_dtype, test_format):
         """Test that close works after performing operations."""
         manager = MPStorageManager(cpu_buffer_size=1.0)
-        shape = (2, 16, 16, 128)
+        shape = torch.Size([2, 16, 16, 128])
 
         # Perform some operations
         handle, _ = manager.reserve(test_keys[:3], shape, test_dtype, test_format)
@@ -572,7 +572,7 @@ class TestThreadSafety:
         """Test concurrent reserve operations from multiple threads."""
         num_threads = 10
         keys_per_thread = 5
-        shape = (2, 10, 16, 64)
+        shape = torch.Size([2, 10, 16, 64])
 
         def reserve_keys(thread_id):
             keys = [
@@ -604,7 +604,7 @@ class TestThreadSafety:
     ):
         """Test concurrent reserve and commit operations."""
         num_threads = 10
-        shape = (2, 10, 16, 64)
+        shape = torch.Size([2, 10, 16, 64])
 
         def reserve_and_commit(thread_id):
             keys = [
@@ -637,7 +637,7 @@ class TestThreadSafety:
         (should skip duplicates).
         """
         num_threads = 10
-        shape = (2, 10, 16, 64)
+        shape = torch.Size([2, 10, 16, 64])
         keys = test_keys[:5]  # Same keys for all threads
 
         def reserve_keys():
@@ -665,7 +665,7 @@ class TestThreadSafety:
         """Test concurrent lookup and retrieve operations."""
         # First, commit some keys
         keys = test_keys[:10]
-        shape = (2, 10, 16, 64)
+        shape = torch.Size([2, 10, 16, 64])
         handle, _ = storage_manager.reserve(keys, shape, test_dtype, test_format)
         storage_manager.commit(handle)
 
@@ -692,7 +692,7 @@ class TestThreadSafety:
     ):
         """Test interleaved reserve, commit, and lookup operations."""
         num_threads = 10
-        shape = (2, 10, 16, 64)
+        shape = torch.Size([2, 10, 16, 64])
         barrier = threading.Barrier(num_threads)
 
         def thread_operation(thread_id):
@@ -735,7 +735,7 @@ class TestThreadSafety:
         """Stress test with many concurrent operations."""
         num_threads = 50
         operations_per_thread = 10
-        shape = (2, 10, 16, 32)
+        shape = torch.Size([2, 10, 16, 32])
 
         def perform_operations(thread_id):
             for i in range(operations_per_thread):
@@ -774,7 +774,7 @@ class TestThreadSafety:
     ):
         """Test that reserve handles are allocated correctly under concurrency."""
         num_threads = 100
-        shape = (2, 10, 16, 32)
+        shape = torch.Size([2, 10, 16, 32])
 
         def get_handle(thread_id):
             keys = [IPCCacheEngineKey.from_int_hash("model1", 1, 0, thread_id)]

--- a/tests/v1/storage_backend/test_batched_message_sender.py
+++ b/tests/v1/storage_backend/test_batched_message_sender.py
@@ -12,11 +12,6 @@ from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.cache_controller.message import OpType
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import (
-    AdHocMemoryAllocator,
-    MemoryFormat,
-    MemoryObj,
-)
 from lmcache.v1.storage_backend.batched_message_sender import (
     BatchedMessageSender,
 )
@@ -61,13 +56,6 @@ def create_test_config(
 def create_test_key(key_id: str = "test_key") -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
-
-
-def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> MemoryObj:
-    """Create a test MemoryObj using AdHocMemoryAllocator for testing."""
-    allocator = AdHocMemoryAllocator(device="cpu")
-    memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-    return memory_obj
 
 
 class TestBatchedMessageSender:

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -13,13 +13,10 @@ import torch
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import (
-    AdHocMemoryAllocator,
-    MemoryFormat,
-    MemoryObj,
-)
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+from tests.v1.utils import create_test_memory_obj
 
 
 def create_test_config(fs_path: str):
@@ -48,13 +45,6 @@ def create_test_metadata():
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
-
-
-def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> MemoryObj:
-    """Create a test MemoryObj using AdHocMemoryAllocator for testing."""
-    allocator = AdHocMemoryAllocator(device="cpu")
-    memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-    return memory_obj
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -16,8 +16,9 @@ import torch
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat, MemoryObj
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.gds_backend import GdsBackend
+from tests.v1.utils import create_test_memory_obj
 
 
 def create_test_config(gds_path: str):
@@ -33,14 +34,6 @@ def create_test_config(gds_path: str):
 
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     return CacheEngineKey("vllm", "testmodel", 3, 123, key_id, torch.bfloat16)
-
-
-def create_test_memory_obj(
-    shape=(2, 16, 8, 128), dtype=torch.bfloat16, device="cuda"
-) -> MemoryObj:
-    allocator = AdHocMemoryAllocator(device=device)
-    memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-    return memory_obj
 
 
 def create_test_metadata():
@@ -110,7 +103,7 @@ class TestGdsBackend:
 
     def test_key_to_path_and_insert_key(self, gds_backend):
         key = create_test_key(0)
-        memory_obj = create_test_memory_obj()
+        memory_obj = create_test_memory_obj(device="cuda")
         gds_backend.insert_key(key, memory_obj)
         # Check that the key is in hot_cache
         assert key in gds_backend.hot_cache
@@ -125,7 +118,7 @@ class TestGdsBackend:
 
     def test_contains_key_exists(self, gds_backend):
         key = create_test_key(0)
-        memory_obj = create_test_memory_obj()
+        memory_obj = create_test_memory_obj(device="cuda")
         gds_backend.insert_key(key, memory_obj)
         assert gds_backend.contains(key)
         assert gds_backend.contains(key, pin=True)

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -11,13 +11,10 @@ from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.cache_controller.message import BatchedKVOperationMsg, OpType
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import (
-    AdHocMemoryAllocator,
-    MemoryFormat,
-    MemoryObj,
-)
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.pin_monitor import PinMonitor
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from tests.v1.utils import create_test_memory_obj
 
 
 class MockLookupServer:
@@ -59,13 +56,6 @@ def create_test_config(
 def create_test_key(key_id: str = "test_key") -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
-
-
-def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> MemoryObj:
-    """Create a test MemoryObj using AdHocMemoryAllocator for testing."""
-    allocator = AdHocMemoryAllocator(device="cpu")
-    memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-    return memory_obj
 
 
 @pytest.fixture
@@ -200,8 +190,8 @@ class TestLocalCPUBackend:
     def test_submit_put_task_reinsert(self, local_cpu_backend):
         """Test submit_put_task() with reinsertion."""
         key = create_test_key("test_key")
-        memory_obj1 = create_test_memory_obj(shape=(2, 16, 8, 128))
-        memory_obj2 = create_test_memory_obj(shape=(2, 32, 8, 128))
+        memory_obj1 = create_test_memory_obj(shape=torch.Size([2, 16, 8, 128]))
+        memory_obj2 = create_test_memory_obj(shape=torch.Size([2, 32, 8, 128]))
 
         # First insertion
         local_cpu_backend.submit_put_task(key, memory_obj1)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -13,10 +13,6 @@ import torch
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import (
-    MemoryFormat,
-    MemoryObj,
-)
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 
@@ -67,16 +63,6 @@ def create_test_metadata():
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
-
-
-def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> MemoryObj:
-    """Create a test MemoryObj using AdHocMemoryAllocator for testing."""
-    # First Party
-    from lmcache.v1.memory_management import AdHocMemoryAllocator
-
-    allocator = AdHocMemoryAllocator(device="cpu")
-    memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-    return memory_obj
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_storage_plugin.py
+++ b/tests/v1/storage_backend/test_storage_plugin.py
@@ -24,7 +24,6 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager
 from lmcache.v1.memory_management import (
     AdHocMemoryAllocator,
-    MemoryFormat,
     MemoryObj,
 )
 from lmcache.v1.storage_backend import CreateStorageBackends
@@ -33,6 +32,7 @@ from lmcache.v1.storage_backend.abstract_backend import (
     StoragePluginInterface,
 )
 from lmcache.v1.storage_backend.storage_manager import StorageManager
+from tests.v1.utils import create_test_memory_obj
 
 
 class MockStoragePlugin(StoragePluginInterface):
@@ -180,13 +180,6 @@ def create_test_metadata():
             128,
         ),  # (num_layers, 2, chunk_size, num_heads, head_dim)
     )
-
-
-def create_test_memory_obj(shape=(2, 16, 8, 128), dtype=torch.bfloat16) -> MemoryObj:
-    """Create a test MemoryObj using AdHocMemoryAllocator."""
-    allocator = AdHocMemoryAllocator(device="cpu")
-    memory_obj = allocator.allocate(shape, dtype, fmt=MemoryFormat.KV_T2D)
-    return memory_obj
 
 
 def get_mock_backend(storage_manager_or_backends):

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -18,6 +18,7 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat, MemoryObj
 
 
 def recover_engine_states(engine):
@@ -556,3 +557,12 @@ def create_mock_vllm_config(
     )
 
     return vllm_config
+
+
+def create_test_memory_obj(shape=None, dtype=torch.bfloat16, device="cpu") -> MemoryObj:
+    """Create a test MemoryObj using AdHocMemoryAllocator for testing."""
+    if shape is None:
+        shape = torch.Size([2, 16, 8, 128])
+    allocator = AdHocMemoryAllocator(device=device)
+    memory_obj = allocator.allocate([shape], [dtype], fmt=MemoryFormat.KV_T2D)
+    return memory_obj


### PR DESCRIPTION
clear `shape` and `dtype` code, in current pr, I first clear the `Tuple`, and will clear the `shape` and `dtype` in next pr.