### PR TITLE
[Feat] staging buffer mode when local_cpu is false for diskbackend

### DIFF
--- a/docs/source/kv_cache/storage_backends/local_storage.rst
+++ b/docs/source/kv_cache/storage_backends/local_storage.rst
@@ -64,6 +64,61 @@ backends have asynchronous put() operations so that the IO latency will not slow
 The local disk backend also has a prefetch() operation that will preemptively move KV caches from the disk to CPU RAM offloading storage
 (i.e. ``LMCACHE_LOCAL_CPU=True`` should be set, see :doc:`CPU RAM <./cpu_ram>`) for specified tokens (these KV caches are also still kept in the disk).
 
+.. _staging-buffer-mode:
+
+Staging Buffer Mode (Disk-Only Caching)
+---------------------------------------
+
+When you want to use **only disk** for KV cache storage (without CPU caching), you need to enable
+the ``use_only_staging_buffer`` flag along with ``local_cpu: false``.
+
+**Why is this needed?**
+
+Even with ``local_cpu: false``, CPU memory is still required as a **staging buffer** for data transfers
+between GPU and disk. By default, this staging buffer also participates in cache lookups, which means
+data might be served from CPU memory instead of disk.
+
+With ``use_only_staging_buffer: true``, the CPU memory is used **only** as a temporary staging buffer:
+
+- Cache lookups skip the CPU backend entirely
+- Data is always retrieved from disk
+- No write-back to CPU after disk retrieval
+- CPU memory usage is minimized
+
+**Configuration comparison:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
+
+   * - Configuration
+     - CPU in Lookups
+     - Behavior
+   * - ``local_cpu: true``
+     - Yes
+     - Normal CPU+Disk tiered caching
+   * - ``local_cpu: false``
+     - Yes
+     - CPU still participates in lookups (default behavior)
+   * - | ``local_cpu: false``
+       | ``use_only_staging_buffer: true``
+     - No
+     - **Disk-only caching** (CPU is staging buffer only)
+
+**Environment Variables:**
+
+.. code-block:: bash
+
+    export LMCACHE_LOCAL_CPU=false
+    export LMCACHE_USE_ONLY_STAGING_BUFFER=true
+
+**Configuration File:**
+
+.. code-block:: yaml
+
+    local_cpu: false
+    use_only_staging_buffer: true
+
 .. _local-storage-online-inference-example:
 
 Online Inference Example
@@ -114,7 +169,7 @@ GPU memory and LMCache is necessary to keep KV caches in non-GPU memory:
 
 **Step 2. Start a vLLM server with Disk offloading enabled:**
 
-*Generally, it is not recommended but we will disable CPU offloading to feel just the disk offloading latency.*
+*Generally, it is not recommended but we will disable CPU caching to feel just the disk offloading latency.*
 
 Create a an lmcache configuration file called: ``disk-offload.yaml``
 
@@ -124,17 +179,27 @@ Example ``config.yaml``:
 
     chunk_size: 256
     local_cpu: false
+    use_only_staging_buffer: true  # Required for disk-only caching
     max_local_cpu_size: 5.0
     local_disk: "file:///local/disk_test/local_disk/"
     max_local_disk_size: 5.0
 
-If you don't want to use a config file, uncomment the first five environment variables
+.. note::
+
+    The ``use_only_staging_buffer: true`` flag is required to ensure that cache lookups
+    go directly to disk and skip the CPU backend. Without this flag, CPU memory would
+    still participate in cache lookups even with ``local_cpu: false``.
+
+    See :ref:`staging-buffer-mode` for more details.
+
+If you don't want to use a config file, uncomment the first six environment variables
 and then comment out the ``LMCACHE_CONFIG_FILE`` below:
 
 .. code-block:: bash
 
     # LMCACHE_CHUNK_SIZE=256 \
     # LMCACHE_LOCAL_CPU=False \
+    # LMCACHE_USE_ONLY_STAGING_BUFFER=True \
     # LMCACHE_MAX_LOCAL_CPU_SIZE=5.0 \
     # LMCACHE_LOCAL_DISK="file:///local/disk_test/local_disk/" \
     # LMCACHE_MAX_LOCAL_DISK_SIZE=5.0 \
@@ -229,11 +294,23 @@ Then run:
 Since we're in streaming mode, you'll be able to feel the TTFT differential in
 real time!
 
-Note that if we were to enable ``LMCACHE_LOCAL_CPU=True``, we would just be using
-the same example from :doc:`CPU RAM <./cpu_ram>` since the CPU RAM is checked before
-the disk by LMCache. In practice, the disk will be capable of storing a larger
-quantity of KV caches so the CPU RAM offloading will only be able to store a
-subset of the disk's KV caches.
+.. note::
+
+    **Understanding CPU and Disk interaction:**
+
+    - With ``local_cpu: true`` (default), CPU RAM is checked **before** disk.
+      This provides faster access for cached data but uses more CPU memory.
+
+    - With ``local_cpu: false`` and ``use_only_staging_buffer: false`` (default),
+      CPU still participates in cache lookups. This is the legacy behavior.
+
+    - With ``local_cpu: false`` and ``use_only_staging_buffer: true``,
+      lookups go **directly to disk**, skipping CPU entirely.
+      CPU is only used as a temporary staging buffer for GPU-to-disk transfers.
+
+    In practice, the disk will be capable of storing a larger quantity of KV caches,
+    so when both CPU and disk caching are enabled, the CPU RAM will only store a
+    subset (the most recently used) of the disk's KV caches.
 
 **Example Output:**
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -67,6 +67,17 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": True,
         "env_converter": _to_bool,
     },
+    "use_only_staging_buffer": {
+        "type": bool,
+        "default": False,
+        "env_converter": _to_bool,
+        "description": (
+            "When enabled with local_cpu=False, CPU memory is only used as a "
+            "staging buffer for disk/remote backends. Lookups and gets will skip "
+            "CPU backend and go directly to disk/remote. This prevents CPU cache "
+            "hits when the intent is to use disk as the persistent storage tier."
+        ),
+    },
     "max_local_cpu_size": {"type": float, "default": 5.0, "env_converter": float},
     "reserve_local_cpu_size": {"type": float, "default": 0.0, "env_converter": float},
     "local_disk": {

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -292,6 +292,7 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
         memory_obj: MemoryObj,
+        on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
     ):
         assert memory_obj.tensor is not None
 
@@ -339,6 +340,7 @@ class LocalDiskBackend(StorageBackendInterface):
                 self.async_save_bytes_to_disk,
                 key=key,
                 memory_obj=memory_obj,
+                on_complete_callback=on_complete_callback,
             ),
             self.loop,
         )
@@ -349,9 +351,10 @@ class LocalDiskBackend(StorageBackendInterface):
         keys: Sequence[CacheEngineKey],
         memory_objs: List[MemoryObj],
         transfer_spec: Any = None,
+        on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
     ) -> None:
         for key, memory_obj in zip(keys, memory_objs, strict=False):
-            self.submit_put_task(key, memory_obj)
+            self.submit_put_task(key, memory_obj, on_complete_callback)
 
     def get_blocking(
         self,
@@ -458,9 +461,17 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
         memory_obj: MemoryObj,
+        on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
     ) -> None:
         """
         Convert KV to bytes and async store bytes to disk.
+
+        Args:
+            key: The cache key for this KV chunk.
+            memory_obj: The memory object containing the KV data.
+            on_complete_callback: Optional callback to invoke after the disk
+                write completes. Used by StorageManager to release staging
+                buffer entries when use_only_staging_buffer is enabled.
         """
         kv_chunk = memory_obj.tensor
         assert kv_chunk is not None
@@ -490,6 +501,13 @@ class LocalDiskBackend(StorageBackendInterface):
         self.insert_key(key, size, shape, dtype, fmt, cached_positions=cached_positions)
 
         self.disk_worker.remove_put_task(key)
+
+        # Call the completion callback if provided (e.g., to release staging buffer)
+        if on_complete_callback is not None:
+            try:
+                on_complete_callback(key)
+            except Exception as e:
+                logger.warning(f"on_complete_callback failed for key {key}: {e}")
 
     def batched_async_load_bytes_from_disk(
         self,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
         LMCacheAsyncLookupServer,
     )
+    from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 
 logger = init_logger(__name__)
 
@@ -397,6 +398,22 @@ class StorageManager:
             memory_objs,
         )
 
+        # When staging buffer mode is enabled, create a callback to release
+        # CPU cache entries after disk write completes
+        staging_buffer_callback = None
+        if (
+            not self.config.local_cpu
+            and self.config.use_only_staging_buffer
+            and "LocalCPUBackend" in self.storage_backends
+        ):
+            local_cpu_backend = self.storage_backends["LocalCPUBackend"]
+            assert isinstance(local_cpu_backend, LocalCPUBackend)
+
+            def staging_buffer_callback(key: CacheEngineKey) -> None:
+                """Release CPU staging buffer entry after disk write completes."""
+                local_cpu_backend.remove(key, force=True)
+                logger.debug(f"Released staging buffer for key {key}")
+
         for backend_name, backend in self.storage_backends.items():
             if location and backend_name != location:
                 continue
@@ -412,7 +429,21 @@ class StorageManager:
             # NOTE: the handling of exists_in_put_tasks
             # is done in the backend
             ks, objs = obj_dict[cname]
-            backend.batched_submit_put_task(ks, objs, transfer_spec=transfer_spec)
+
+            # Pass callback to disk backend for staging buffer release
+            if (
+                backend_name == "LocalDiskBackend"
+                and staging_buffer_callback is not None
+            ):
+                disk_backend = cast("LocalDiskBackend", backend)
+                disk_backend.batched_submit_put_task(
+                    ks,
+                    objs,
+                    transfer_spec=transfer_spec,
+                    on_complete_callback=staging_buffer_callback,
+                )
+            else:
+                backend.batched_submit_put_task(ks, objs, transfer_spec=transfer_spec)
 
         for cname, (ks, objs) in obj_dict.items():
             for memory_obj in objs:
@@ -433,9 +464,14 @@ class StorageManager:
             # are allocated by the allocator backend.
             memory_obj = backend.get_blocking(key)
             if memory_obj:
+                # Write-back to CPU cache (skip if use_only_staging_buffer is enabled)
                 if (
                     backend_name not in ["LocalCPUBackend", "PDBackend"]
                     and "LocalCPUBackend" in self.storage_backends
+                    and not (
+                        not self.config.local_cpu
+                        and self.config.use_only_staging_buffer
+                    )
                 ):
                     local_cpu_backend = self.storage_backends["LocalCPUBackend"]
                     assert isinstance(local_cpu_backend, LocalCPUBackend)
@@ -477,10 +513,15 @@ class StorageManager:
             if memory_objs:
                 # Align with single-key `get()` logic:
                 # auto-write remote data to local CPU cache
+                # (skip if use_only_staging_buffer is enabled)
                 if (
                     backend_name not in ["LocalCPUBackend", "PDBackend"]
                     and "LocalCPUBackend" in self.storage_backends
                     and None not in memory_objs
+                    and not (
+                        not self.config.local_cpu
+                        and self.config.use_only_staging_buffer
+                    )
                 ):
                     logger.debug(
                         "Storing %s objects from %s to LocalCPUBackend",
@@ -1025,6 +1066,15 @@ class StorageManager:
             with self._freeze_lock:
                 if self._freeze and backend_name != "LocalCPUBackend":
                     continue
+            # When use_only_staging_buffer is enabled with local_cpu disabled,
+            # skip LocalCPUBackend for lookups/gets.
+            # CPU is only used as allocator/staging buffer, not for caching.
+            if (
+                backend_name == "LocalCPUBackend"
+                and not self.config.local_cpu
+                and self.config.use_only_staging_buffer
+            ):
+                continue
             if location and backend_name != location:
                 continue
             if search_range and backend_name not in search_range:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new `use_only_staging_buffer` configuration flag that enables disk-only caching mode in LMCache. 
When enabled with `local_cpu=false`, CPU memory is used **only** as a temporary staging buffer for GPU-to-disk transfers, and all cache lookups go directly to disk.

### Problem

Currently, even with `local_cpu=false`, CPU memory still participates in cache lookups. This means:
- Data retrieved from disk is written back to CPU cache
- Subsequent lookups hit CPU cache instead of disk
- CPU memory usage grows over time with cached data

This behavior is problematic when users want pure disk-only caching for scenarios like:
- Limited CPU memory environments
- Testing disk backend performance in isolation
- Ensuring data persistence on disk without CPU cache interference

### Solution

Add `use_only_staging_buffer` flag that, when combined with `local_cpu=false`:
1. Skips CPU backend in lookups - Cache lookups go directly to disk
2. Disables write-back - Data retrieved from disk is not cached in CPU
3. Releases staging buffer after disk write - CPU memory is freed after GPU→Disk transfer completes

### Data Flow Comparison

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    BEFORE (local_cpu=false only)                            │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│  PUT (Store KV Cache):                                                      │
│  ┌─────┐    ┌─────────────┐    ┌──────┐                                     │
│  │ GPU │───►│ CPU (stage) │───►│ Disk │                                     │
│  └─────┘    └─────────────┘    └──────┘                                     │
│                   │                                                         │
│                   └── CPU keeps data (memory grows)                         │
│                                                                             │
│  GET (Lookup & Retrieve):                                                   │
│  ┌──────┐    ┌─────────────┐    ┌─────┐                                     │
│  │ Disk │───►│ CPU (cache) │───►│ GPU │                                     │
│  └──────┘    └─────────────┘    └─────┘                                     │
│                   │                                                         │
│                   └── Write-back to CPU (unexpected CPU hits later)         │
│                                                                             │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────────┐
│           AFTER (local_cpu=false + use_only_staging_buffer=true)            │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│  PUT (Store KV Cache):                                                      │
│  ┌─────┐    ┌─────────────┐    ┌──────┐                                     │
│  │ GPU │───►│ CPU (stage) │───►│ Disk │                                     │
│  └─────┘    └─────────────┘    └──────┘                                     │
│                   │                                                         │
│                   └──────────────────── CPU buffer released after write     │
│                                                                             │
│  GET (Lookup & Retrieve):                                                   │
│  ┌──────┐    ┌─────────────┐    ┌─────┐                                     │
│  │ Disk │───►│ CPU (stage) │───►│ GPU │                                     │
│  └──────┘    └─────────────┘    └─────┘                                     │
│                   │                                                         │
│                   └── No write-back, staging only                           │
│                                                                             │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Configuration Comparison

| Configuration | CPU in Lookups | Behavior |
|---------------|----------------|----------|
| `local_cpu: true` | Yes | Normal CPU+Disk tiered caching |
| `local_cpu: false` | Yes | CPU still participates in lookups (legacy) |
| `local_cpu: false` + `use_only_staging_buffer: true` | **No** | **Disk-only caching** (CPU is staging buffer only) |

### Usage

**Environment Variables:**
```bash
export LMCACHE_LOCAL_CPU=false
export LMCACHE_USE_ONLY_STAGING_BUFFER=true
```

**Configuration File:**
```yaml
local_cpu: false
use_only_staging_buffer: true
local_disk: "file:///path/to/disk/cache/"
max_local_disk_size: 100.0
```

**Special notes for your reviewers**:

1. Default value is `false`, so existing behavior is unchanged
2. Used completion callback pattern to release staging buffer after async disk write completes, avoiding race conditions

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
