### PR TITLE
add checksum validator in storage manager

### DIFF
--- a/lmcache/v1/storage_backend/checksum_validation.py
+++ b/lmcache/v1/storage_backend/checksum_validation.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+# Standard
+import hashlib
+import importlib.util
+import threading
+import time
+from collections import OrderedDict
+from typing import Optional, Sequence
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryObj
+
+logger = init_logger(__name__)
+
+_CHECKSUM_ALGORITHM = "xxh3"
+_CHECKSUM_CACHE_MAX_SIZE = 1_000_000
+
+
+def _resolve_xxhash_module():
+    if importlib.util.find_spec("xxhash") is None:
+        return None
+    import xxhash
+
+    return xxhash
+
+
+class ChecksumValidator:
+    def __init__(self, config: LMCacheEngineConfig) -> None:
+        self.enabled = bool(config.get_extra_config_value("enable_validation", False))
+        # Checksum cache: (key, algorithm) -> checksum
+        # The cache is used as LRU cache with size limit _CHECKSUM_CACHE_MAX_SIZE
+        self._checksums: OrderedDict[tuple[CacheEngineKey, str], str] = OrderedDict()
+        self._lock = threading.Lock()
+        self._algorithm = "md5"
+        self._xxhash_module = None
+        self._profile_lock = threading.Lock()
+        if self.enabled:
+            if _CHECKSUM_ALGORITHM == "xxh3":
+                self._xxhash_module = _resolve_xxhash_module()
+                if self._xxhash_module is None:
+                    logger.info(
+                        "xxhash not available; falling back to md5 for checksums"
+                    )
+                else:
+                    self._algorithm = "xxh3"
+
+    def record_checksums(
+        self, keys: Sequence[CacheEngineKey], memory_objs: Sequence[MemoryObj]
+    ) -> None:
+        if not self.enabled:
+            return
+        for key, memory_obj in zip(keys, memory_objs, strict=False):
+            checksum = self._calculate_checksum(memory_obj)
+            cache_key = (key, self._algorithm)
+            # Use _checksums as LRU cache
+            with self._lock:
+                self._checksums[cache_key] = checksum
+                self._checksums.move_to_end(cache_key)
+                if len(self._checksums) > _CHECKSUM_CACHE_MAX_SIZE:
+                    self._checksums.popitem(last=False)
+
+    def validate_checksums(
+        self,
+        keys: Sequence[CacheEngineKey],
+        memory_objs: Sequence[Optional[MemoryObj]],
+    ) -> None:
+        if not self.enabled:
+            return
+        for key, memory_obj in zip(keys, memory_objs, strict=False):
+            if memory_obj is None:
+                continue
+            checksum = self._calculate_checksum(memory_obj)
+            cache_key = (key, self._algorithm)
+            with self._lock:
+                expected = self._checksums.get(cache_key)
+                if expected is not None:
+                    self._checksums.move_to_end(cache_key)
+            # No checksum found could be due to many reasons like restart,
+            # kv cache reuse across nodes or cache expiration.
+            # Simply log a debug message and continue
+            if expected is None:
+                logger.debug(
+                    "No checksum recorded for key %s (hash=%s)",
+                    key.to_string(),
+                    hash(key),
+                )
+                continue
+            # Checksum mismatch is a serious error
+            if expected != checksum:
+                logger.error(
+                    "Checksum mismatch for key %s (hash=%s): expected=%s actual=%s",
+                    key.to_string(),
+                    hash(key),
+                    expected,
+                    checksum,
+                )
+
+    def _calculate_checksum(self, memory_obj: MemoryObj) -> str:
+        payload = memory_obj.byte_array
+        if self._algorithm == "xxh3" and self._xxhash_module is not None:
+            checksum = self._xxhash_module.xxh3_128_hexdigest(payload)
+        else:
+            checksum = hashlib.md5(payload).hexdigest()
+        return checksum

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -42,6 +42,7 @@ from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,
     StorageBackendInterface,
 )
+from lmcache.v1.storage_backend.checksum_validation import ChecksumValidator
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 if TYPE_CHECKING:
@@ -257,6 +258,7 @@ class StorageManager:
         self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
         self.worker_id = metadata.worker_id
+        self.checksum_validator = ChecksumValidator(config)
 
         self.event_manager = event_manager
 
@@ -414,6 +416,8 @@ class StorageManager:
             ks, objs = obj_dict[cname]
             backend.batched_submit_put_task(ks, objs, transfer_spec=transfer_spec)
 
+        self.checksum_validator.record_checksums(keys, memory_objs)
+
         for cname, (ks, objs) in obj_dict.items():
             for memory_obj in objs:
                 memory_obj.ref_count_down()
@@ -495,6 +499,7 @@ class StorageManager:
                     #  policy module
                     memory_objs_no_none = cast(List[MemoryObj], memory_objs)
                     local_cpu_backend.batched_submit_put_task(keys, memory_objs_no_none)
+                self.checksum_validator.validate_checksums(keys, memory_objs)
                 return memory_objs
         return None
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -35,6 +35,7 @@ sortedcontainers
 torch
 transformers >= 4.51.1
 uvicorn
+xxhash
 httptools
 # Right now we are using cuda 12.x to align with serving engines
 cupy-cuda12x


### PR DESCRIPTION
**Why**
We want to test lmcache with external storage. In testing, backend or connector code bugs can cause wrong read/write data, and external storage itself can also return wrong data. So we need a data validation feature that can be enabled in test environment.
I have read through a checksum tool introduced by #2245, however it has a different design goal. #2245 is to verify vllm's prefix cache blocks are idential after computation and retrival. Such check could be turned on and off via API and assumes that vllm's still holding those block. This PR focuses more on data integrity before put and after get from storage backends.

**What**
- Checksum validation is disabled by default, and could be enabled via extra_config `enable_validation`
- Add checksum validation in storage manager flow, so if checksum mismatch happens it only prints log and does not affect main logic.
- Use an LRU cache with default max size 1,000,000 to store checksum values.
- The cache key is based on cacheengine key + algorithm, so different algorithms do not conflict.
- Use xxhash as option (very fast on x86). Performance impact is within 20%, ok for test usage.

**Impact**
xxhash is widely used hash algorithm and is tens time faster than python's builtin md5, see my test with 16MB data on AMD EPYC 9754
```
                 | lat (ms)  | thr (MB/s) 
--------------------------------------------------------------------------------
MD5 (Standard)   |    25.930 |     617.1
XXH3 (128-bit)   |     0.648 |   24700.8
```
xxhash is 40 times faster

I also tested it with LMBenchmark long input short output at qps=1
results with base version
```
  Processing speed: 1.0163 reqs/s
  Input tokens per second: 21702.7791 tokens/s
  Output tokens per second: 101.1128 tokens/s
  Average generation throughput (per request): 26.3281 tokens/req/s
  Average TTFT: 0.5868s
```
results with changed version + enable validation
```
  Processing speed: 1.0163 reqs/s
  Input tokens per second: 21625.9981 tokens/s
  Output tokens per second: 100.5133 tokens/s
  Average generation throughput (per request): 23.4480 tokens/req/s
  Average TTFT: 0.6842s
```
