### PR TITLE
[Refactor]Move health_monitor to lmcacheManager level 

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -12,6 +13,12 @@ from typing import (
     Tuple,
     Union,
 )
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.health_monitor.base import HealthMonitor
+
+# Standard
 import asyncio
 import gc
 import multiprocessing
@@ -23,7 +30,7 @@ import torch
 # First Party
 from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
-from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor, PrometheusLogger
+from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
 from lmcache.utils import (
     CacheEngineKey,
@@ -39,11 +46,6 @@ from lmcache.v1.gpu_connector import (
     SGLangLayerwiseGPUConnector,
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemLayerwiseGPUConnector,
-)
-from lmcache.v1.health_monitor.base import HealthMonitor
-from lmcache.v1.health_monitor.constants import (
-    DEFAULT_PING_INTERVAL,
-    PING_INTERVAL_CONFIG_KEY,
 )
 from lmcache.v1.memory_management import CuFileMemoryAllocator  # noqa: E501
 from lmcache.v1.memory_management import (  # noqa: E501
@@ -217,13 +219,38 @@ class LMCacheEngine:
         # Flag to control KVCache Check logging (can be toggled via API)
         self.kvcache_check_log_enabled = False
 
-        # Health monitor for the entire LMCache engine
-        # Will be initialized in post_init when storage_manager is created
-        self.health_monitor: Optional[HealthMonitor] = None
-
         gc.collect()
         if not config.py_enable_gc:
             gc.disable()
+
+        # Health monitor reference (injected by LMCacheManager)
+        self._health_monitor: Optional["HealthMonitor"] = None
+
+    def set_health_monitor(self, health_monitor: "HealthMonitor") -> None:
+        """
+        Set the health monitor reference.
+
+        This is called by LMCacheManager after creating the HealthMonitor
+        to inject the reference into the engine.
+
+        Args:
+            health_monitor: The HealthMonitor instance from LMCacheManager
+        """
+        self._health_monitor = health_monitor
+
+    def is_healthy(self) -> bool:
+        """
+        Check if the LMCache system is healthy.
+
+        This method delegates to the HealthMonitor if one is set.
+        If no health monitor is set, it returns True (assume healthy).
+
+        Returns:
+            bool: True if healthy, False otherwise
+        """
+        if self._health_monitor is not None:
+            return self._health_monitor.is_healthy()
+        return True
 
     def post_init(self, **kwargs) -> None:
         if not self.post_inited:
@@ -252,8 +279,6 @@ class LMCacheEngine:
                     lmcache_worker=self.lmcache_worker,
                     async_lookup_server=async_lookup_server,
                 )
-                # Initialize health monitor at engine level
-                self._init_health_monitor()
             self.post_inited = True
 
     def freeze(self, enabled: bool) -> None:
@@ -282,56 +307,6 @@ class LMCacheEngine:
         if self.storage_manager is not None:
             return self.storage_manager.is_frozen()
         return False
-
-    def _init_health_monitor(self) -> None:
-        """
-        Initialize the health monitor for the entire LMCache engine.
-
-        This is called during post_init after storage_manager is created.
-        The HealthMonitor automatically discovers and instantiates all
-        HealthCheck subclasses.
-        """
-        # Get ping interval from config
-        ping_interval = self.config.get_extra_config_value(
-            PING_INTERVAL_CONFIG_KEY, DEFAULT_PING_INTERVAL
-        )
-
-        # Create health monitor with cache engine - it will auto-discover health checks
-        self.health_monitor = HealthMonitor(
-            cache_engine=self,
-            ping_interval=ping_interval,
-        )
-
-        # Start the health monitor
-        self.health_monitor.start()
-        logger.info("Health monitor initialized and started at engine level")
-
-        # Setup metrics callback for health status
-        prometheus_logger = PrometheusLogger.GetInstanceOrNone()
-        if prometheus_logger is not None:
-            prometheus_logger.lmcache_is_healthy.set_function(
-                lambda: 1 if self.is_healthy() else 0
-            )
-
-    def is_healthy(self) -> bool:
-        """
-        Check if the LMCache engine is healthy.
-
-        Returns:
-            bool: True if healthy, False otherwise
-        """
-        if self.health_monitor is None:
-            return True
-        return self.health_monitor.is_healthy()
-
-    def get_health_monitor(self) -> Optional[HealthMonitor]:
-        """
-        Get the health monitor instance.
-
-        Returns:
-            Optional[HealthMonitor]: The health monitor, or None if not initialized
-        """
-        return self.health_monitor
 
     @_lmcache_nvtx_annotate
     @torch.inference_mode()
@@ -1428,15 +1403,6 @@ class LMCacheEngine:
     def close(self) -> None:
         """Close the cache engine and free all the resources"""
         logger.info("Closing LMCacheEngine...")
-
-        # Stop health monitor first
-        if self.health_monitor is not None:
-            try:
-                logger.info("Stopping health monitor...")
-                self.health_monitor.stop()
-                logger.info("Health monitor stopped successfully")
-            except Exception as e:
-                logger.error(f"Error stopping health monitor: {e}")
 
         if self.lmcache_worker is not None:
             try:

--- a/lmcache/v1/health_monitor/base.py
+++ b/lmcache/v1/health_monitor/base.py
@@ -15,7 +15,7 @@ from lmcache.v1.health_monitor.constants import DEFAULT_PING_INTERVAL
 
 if TYPE_CHECKING:
     # First Party
-    from lmcache.v1.cache_engine import LMCacheEngine
+    from lmcache.v1.manager import LMCacheManager
 
 logger = init_logger(__name__)
 
@@ -27,8 +27,8 @@ class HealthCheck(ABC):
     Subclasses should implement the check() method to perform specific
     health checks. Each health check represents one aspect of system health.
 
-    Subclasses must also implement the create_from_engine() classmethod
-    to create instances from a CacheEngine.
+    Subclasses must also implement the create() classmethod
+    to create instances from a LMCacheManager.
 
     Example:
         class DatabaseHealthCheck(HealthCheck):
@@ -42,9 +42,11 @@ class HealthCheck(ABC):
                 return self.db.ping()
 
             @classmethod
-            def create_from_engine(cls, engine: "LMCacheEngine") -> List["HealthCheck"]:
-                # Create instances from engine's components
-                return [cls(engine.db_connection)]
+            def create(
+                cls, manager: "LMCacheManager"
+            ) -> List["HealthCheck"]:
+                # Create instances from manager's components
+                return [cls(manager.lmcache_engine.db_connection)]
     """
 
     @abstractmethod
@@ -76,15 +78,15 @@ class HealthCheck(ABC):
 
     @classmethod
     @abstractmethod
-    def create_from_engine(cls, engine: "LMCacheEngine") -> List["HealthCheck"]:
+    def create(cls, manager: "LMCacheManager") -> List["HealthCheck"]:
         """
-        Create health check instance(s) from a CacheEngine.
+        Create health check instance(s) from a LMCacheManager.
 
-        This method should extract the necessary components from the engine
+        This method should extract the necessary components from the manager
         and create one or more health check instances.
 
         Args:
-            engine: The LMCacheEngine instance
+            manager: The LMCacheManager instance
 
         Returns:
             List[HealthCheck]: List of health check instances.
@@ -95,23 +97,23 @@ class HealthCheck(ABC):
 
 class HealthMonitor:
     """
-    Health monitor for the entire LMCache Engine.
+    Health monitor for the entire LMCache system.
 
     This is the unified health monitor for the entire LMCache system.
     It supports extensible health checks and provides a centralized way
-    to check the health status of the cache engine.
+    to check the health status of the LMCacheManager.
 
     The monitor automatically discovers and instantiates all HealthCheck
-    subclasses using their create_from_engine() method.
+    subclasses using their create() method.
 
     The monitor runs in a background thread and periodically executes
     all registered health checks. If any check fails, the system is
     marked as unhealthy.
 
     Usage:
-        # Create a health monitor with cache engine
+        # Create a health monitor with manager
         health_monitor = HealthMonitor(
-            cache_engine=engine,
+            manager=manager,
             ping_interval=30.0
         )
 
@@ -129,10 +131,10 @@ class HealthMonitor:
 
     def __init__(
         self,
-        cache_engine: "LMCacheEngine",
+        manager: "LMCacheManager",
         ping_interval: float = DEFAULT_PING_INTERVAL,
     ):
-        self._cache_engine = cache_engine
+        self._manager = manager
         self._health_checks: List[HealthCheck] = []
 
         # Health status
@@ -154,8 +156,8 @@ class HealthMonitor:
         Discover all HealthCheck subclasses and instantiate them.
 
         This method dynamically scans all modules in the checks package,
-        finds all HealthCheck subclasses, calls their create_from_engine()
-        method to create instances, and adds them to the health checks list.
+        finds all HealthCheck subclasses and calls their `create()`
+        method to create instances.
         """
         # Standard
         import importlib
@@ -183,7 +185,7 @@ class HealthMonitor:
                         and obj != HealthCheck
                     ):
                         try:
-                            instances = obj.create_from_engine(self._cache_engine)
+                            instances = obj.create(self._manager)
                             for instance in instances:
                                 self._health_checks.append(instance)
                                 logger.info(

--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -21,7 +21,7 @@ from lmcache.v1.health_monitor.constants import (
 
 if TYPE_CHECKING:
     # First Party
-    from lmcache.v1.cache_engine import LMCacheEngine
+    from lmcache.v1.manager import LMCacheManager
     from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 
 logger = init_logger(__name__)
@@ -47,15 +47,15 @@ class RemoteBackendHealthCheck(HealthCheck):
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
 
     @classmethod
-    def create_from_engine(cls, engine: "LMCacheEngine") -> List[HealthCheck]:
+    def create(cls, manager: "LMCacheManager") -> List[HealthCheck]:
         """
-        Create RemoteBackendHealthCheck instances from a CacheEngine.
+        Create RemoteBackendHealthCheck instances from a LMCacheManager.
 
         This method finds all RemoteBackend instances in the storage manager
         and creates a health check for each one.
 
         Args:
-            engine: The LMCacheEngine instance
+            manager: The LMCacheManager instance
 
         Returns:
             List of RemoteBackendHealthCheck instances
@@ -66,7 +66,9 @@ class RemoteBackendHealthCheck(HealthCheck):
 
         instances: List[HealthCheck] = []
 
-        if engine.storage_manager is None:
+        # Get engine from manager
+        engine = manager.lmcache_engine
+        if engine is None or engine.storage_manager is None:
             return instances
 
         for backend_name, backend in engine.storage_manager.storage_backends.items():

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -20,6 +20,11 @@ from lmcache.config import LMCacheEngineMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.health_monitor.base import HealthMonitor
+from lmcache.v1.health_monitor.constants import (
+    DEFAULT_PING_INTERVAL,
+    PING_INTERVAL_CONFIG_KEY,
+)
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
 from lmcache.v1.offload_server.zmq_server import ZMQOffloadServer
@@ -52,6 +57,7 @@ class LMCacheManager:
     - OffloadServer
     - InternalAPIServer
     - RuntimePluginLauncher
+    - HealthMonitor
 
     This manager supports two main modes:
     - vLLM integration mode (requires vllm_config)
@@ -89,6 +95,7 @@ class LMCacheManager:
         self._offload_server: Optional[ZMQOffloadServer] = None
         self._api_server: Optional[InternalAPIServer] = None
         self._runtime_plugin_launcher: Optional[RuntimePluginLauncher] = None
+        self._health_monitor: Optional[HealthMonitor] = None
 
         # Initialize components based on role
         self._init_components()
@@ -178,6 +185,46 @@ class LMCacheManager:
             self._vllm_config.parallel_config.tensor_parallel_size,
             worker_id,
         )
+
+    def _init_health_monitor(self) -> None:
+        """
+        Initialize the health monitor for the LMCacheManager.
+
+        This is called during post_init after all components are initialized.
+        The HealthMonitor automatically discovers and instantiates all
+        HealthCheck subclasses based on the manager's role and components.
+        """
+        # First Party
+        from lmcache.observability import PrometheusLogger
+
+        # Get ping interval from config
+        ping_interval = self._config.get_extra_config_value(
+            PING_INTERVAL_CONFIG_KEY, DEFAULT_PING_INTERVAL
+        )
+
+        # Create health monitor with manager - it will auto-discover health checks
+        self._health_monitor = HealthMonitor(
+            manager=self,
+            ping_interval=ping_interval,
+        )
+
+        # Inject health monitor into engine (if exists)
+        if self._lmcache_engine is not None:
+            self._lmcache_engine.set_health_monitor(self._health_monitor)
+
+        # Start the health monitor
+        self._health_monitor.start()
+        logger.info(
+            "Health monitor initialized and started at manager level (role=%s)",
+            self._role,
+        )
+
+        # Setup metrics callback for health status
+        prometheus_logger = PrometheusLogger.GetInstanceOrNone()
+        if prometheus_logger is not None:
+            prometheus_logger.lmcache_is_healthy.set_function(
+                lambda: 1 if self.is_healthy() else 0
+            )
 
     def _create_lmcache_engine(self, role: str) -> LMCacheEngine:
         """
@@ -446,6 +493,8 @@ class LMCacheManager:
         Post-initialization after KV caches are registered.
         """
         if self._lmcache_engine is None:
+            # Initialize health monitor for scheduler (even without engine)
+            self._init_health_monitor()
             return
 
         # vLLM mode post-init
@@ -460,6 +509,9 @@ class LMCacheManager:
             async_lookup_server = self._lookup_server
 
         self._lmcache_engine.post_init(async_lookup_server=async_lookup_server)
+
+        # Initialize health monitor after engine post_init completes
+        self._init_health_monitor()
 
     def stop_services(self) -> None:
         """Stop all managed components gracefully."""
@@ -487,6 +539,10 @@ class LMCacheManager:
             except Exception as e:
                 logger.error("Error closing %s: %s", name, e)
                 errors.append((name, e))
+
+        # Stop health monitor first
+        if self._health_monitor is not None:
+            _safe_close("health_monitor", self._health_monitor.stop, timeout=5.0)
 
         # Close offload server
         if self._offload_server is not None:
@@ -577,6 +633,27 @@ class LMCacheManager:
     def api_server(self) -> Optional[InternalAPIServer]:
         """Get the API server instance."""
         return self._api_server
+
+    @property
+    def health_monitor(self) -> Optional[HealthMonitor]:
+        """Get the health monitor instance."""
+        return self._health_monitor
+
+    @property
+    def role(self) -> str:
+        """Get the role of this manager (scheduler or worker)."""
+        return self._role
+
+    def is_healthy(self) -> bool:
+        """
+        Check if the LMCacheManager is healthy.
+
+        Returns:
+            bool: True if healthy, False otherwise
+        """
+        if self._health_monitor is None:
+            return True
+        return self._health_monitor.is_healthy()
 
     @property
     def config(self) -> LMCacheEngineConfig:

--- a/tests/v1/test_health_monitor.py
+++ b/tests/v1/test_health_monitor.py
@@ -46,7 +46,7 @@ class SimpleHealthCheck(HealthCheck):
         self._healthy = healthy
 
     @classmethod
-    def create_from_engine(cls, engine) -> List[HealthCheck]:
+    def create(cls, manager) -> List[HealthCheck]:
         return [cls()]
 
 
@@ -58,7 +58,7 @@ class ExceptionHealthCheck(HealthCheck):
         raise RuntimeError("Simulated failure")
 
     @classmethod
-    def create_from_engine(cls, engine) -> List[HealthCheck]:
+    def create(cls, manager) -> List[HealthCheck]:
         return [cls()]
 
 
@@ -72,7 +72,7 @@ class IrrecoverableHealthCheck(HealthCheck):
         raise IrrecoverableException("Simulated irrecoverable failure")
 
     @classmethod
-    def create_from_engine(cls, engine) -> List[HealthCheck]:
+    def create(cls, manager) -> List[HealthCheck]:
         return [cls()]
 
 
@@ -82,16 +82,17 @@ class IrrecoverableHealthCheck(HealthCheck):
 
 
 @pytest.fixture
-def mock_engine():
-    engine = MagicMock()
-    engine.config.extra_config = None
-    engine.storage_manager = None
-    return engine
+def mock_manager():
+    manager = MagicMock()
+    manager.lmcache_engine = MagicMock()
+    manager.lmcache_engine.config.extra_config = None
+    manager.lmcache_engine.storage_manager = None
+    return manager
 
 
 @pytest.fixture
-def monitor(mock_engine):
-    return HealthMonitor(cache_engine=mock_engine, ping_interval=0.1)
+def monitor(mock_manager):
+    return HealthMonitor(manager=mock_manager, ping_interval=0.1)
 
 
 @pytest.fixture
@@ -138,8 +139,8 @@ class TestHealthCheckBase:
 
 
 class TestHealthMonitor:
-    def test_initialization(self, mock_engine):
-        monitor = HealthMonitor(cache_engine=mock_engine, ping_interval=10.0)
+    def test_initialization(self, mock_manager):
+        monitor = HealthMonitor(manager=mock_manager, ping_interval=10.0)
         assert monitor.is_healthy() is True
         assert monitor._ping_interval == 10.0
 
@@ -247,7 +248,7 @@ class TestRemoteBackendHealthCheck:
     def test_name_includes_url(self, mock_backend):
         assert "localhost:1234" in RemoteBackendHealthCheck(mock_backend).name()
 
-    def test_create_from_engine_with_remote_backend(self):
+    def test_create_with_remote_backend(self):
         # First Party
         from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 
@@ -257,18 +258,22 @@ class TestRemoteBackendHealthCheck:
         mock_backend.config = MagicMock()
         mock_backend.config.extra_config = None
 
-        mock_engine = MagicMock()
-        mock_engine.storage_manager = MagicMock()
-        mock_engine.storage_manager.storage_backends = {"RemoteBackend": mock_backend}
+        mock_manager = MagicMock()
+        mock_manager.lmcache_engine = MagicMock()
+        mock_manager.lmcache_engine.storage_manager = MagicMock()
+        mock_manager.lmcache_engine.storage_manager.storage_backends = {
+            "RemoteBackend": mock_backend
+        }
 
-        checks = RemoteBackendHealthCheck.create_from_engine(mock_engine)
+        checks = RemoteBackendHealthCheck.create(mock_manager)
         assert len(checks) == 1 and "localhost:1234" in checks[0].name()
 
-    def test_create_from_engine_no_remote_backend(self):
-        mock_engine = MagicMock()
-        mock_engine.storage_manager = MagicMock()
-        mock_engine.storage_manager.storage_backends = {}
-        assert len(RemoteBackendHealthCheck.create_from_engine(mock_engine)) == 0
+    def test_create_no_remote_backend(self):
+        mock_manager = MagicMock()
+        mock_manager.lmcache_engine = MagicMock()
+        mock_manager.lmcache_engine.storage_manager = MagicMock()
+        mock_manager.lmcache_engine.storage_manager.storage_backends = {}
+        assert len(RemoteBackendHealthCheck.create(mock_manager)) == 0
 
 
 # ============================================================================
@@ -325,7 +330,7 @@ class TestIrrecoverableException:
                 raise IrrecoverableException("Stop now")
 
             @classmethod
-            def create_from_engine(cls, engine) -> List[HealthCheck]:
+            def create(cls, manager) -> List[HealthCheck]:
                 return [cls()]
 
         monitor._health_checks = [CountingIrrecoverableCheck()]


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR is a refactor changes almost, but there are following changes meanwhile.

- LMCacheEngine Operation Gating: The LMCacheEngine now actively uses the health status to conditionally block operations (e.g., store, retrieve, lookup) if the system is unhealthy. This is a new operational behavior aimed at enhancing stability.
- Irrecoverable Error Handling: A new IrrecoverableException is introduced, which triggers specific behavior in the HealthMonitor to mark the system as permanently unhealthy. This is a new error handling mechanism.
- Prometheus Metric for Health Status: A new Prometheus gauge (lmcache:lmcache_is_healthy) has been added for clearer observability of the system's health status.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
