### PR TITLE
 [Test] Require PYTHONHASHSEED for lookup client tests

### DIFF
--- a/tests/v1/lookup_client/test_lmcache_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_lookup_client.py
@@ -1,5 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
+"""
+Tests for LMCacheLookupClient and LMCacheLookupServer communication.
+
+IMPORTANT: These tests require PYTHONHASHSEED to be set for consistent hashing.
+In production, LMCacheLookupClient and LMCacheLookupServer run in separate
+processes (scheduler vs worker), and PYTHONHASHSEED must be set consistently
+across all processes to ensure hash consistency for cache lookups.
+
+Run with: PYTHONHASHSEED=0 pytest tests/v1/lookup_client/test_lmcache_lookup_client.py
+"""
 # Standard
+import os
 import random
 import tempfile
 import time
@@ -25,6 +36,18 @@ from tests.v1.utils import (
     generate_kv_cache_paged_list_tensors,
     generate_tokens,
     recover_engine_states,
+)
+
+# Skip all tests in this module if PYTHONHASHSEED is not set.
+# This reflects production requirements where consistent hashing across
+# processes (scheduler/worker) requires PYTHONHASHSEED to be set.
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PYTHONHASHSEED") is None,
+    reason=(
+        "PYTHONHASHSEED must be set for consistent hashing between "
+        "LMCacheLookupClient and LMCacheLookupServer. "
+        "Run with: PYTHONHASHSEED=0 pytest ..."
+    ),
 )
 
 

--- a/tests/v1/lookup_client/test_lmcache_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_lookup_client.py
@@ -9,6 +9,7 @@ across all processes to ensure hash consistency for cache lookups.
 
 Run with: PYTHONHASHSEED=0 pytest tests/v1/lookup_client/test_lmcache_lookup_client.py
 """
+
 # Standard
 import os
 import random


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a `PYTHONHASHSEED` requirement to `test_lmcache_lookup_client.py` to reflect the production environment.

In production, `LMCacheLookupClient` (scheduler process) and `LMCacheLookupServer` (worker process) run in separate processes. For consistent hash computation between these processes, `PYTHONHASHSEED` must be set to ensure the same hash values are generated for cache lookups.

Previously, tests would fail because multiple `TokenDatabase` instances were created within the same test, and without `PYTHONHASHSEED`, the hash initialization could produce different values, causing store/lookup hash mismatches.

**Changes:**
- Add module-level docstring explaining the `PYTHONHASHSEED` requirement
- Add `pytestmark` to skip all tests if `PYTHONHASHSEED` is not set

**Special notes for your reviewers**:

- Run tests with: `PYTHONHASHSEED=0 pytest tests/v1/lookup_client/test_lmcache_lookup_client.py`
- Without `PYTHONHASHSEED`: 9 tests skipped
- With `PYTHONHASHSEED=0`: 9 tests passed

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests