### PR TITLE
fix: 'the multi_layer_kv_transfer function has an incorrect addressing calculation' issuefix: kv layout issue.

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -169,6 +169,19 @@ __global__ void single_layer_kv_transfer_kernel(
   }
 }
 
+// For vLLM
+__device__ __forceinline__ int64_t page_buffer_offset_non_mla(
+    const int k_or_v, const int head_id, const int page_block_id,
+    const int page_token_id, const int page_buffer_size, const int num_heads,
+    const int page_scalars_per_head, const int page_scalars_per_token,
+    const int scalar_offset) {
+  return (int64_t)k_or_v * page_buffer_size * page_scalars_per_head +
+         (int64_t)page_block_id * num_heads * page_scalars_per_head +
+         (int64_t)head_id * page_scalars_per_head +
+         (int64_t)page_token_id * page_scalars_per_token +
+         scalar_offset % page_scalars_per_token;
+}
+
 __device__ __forceinline__ int64_t page_buffer_offset(
     const int k_or_v, const int token_idx, const int scalar_offset,
     const int scalars_per_token, const int page_buffer_size) {
@@ -179,6 +192,16 @@ __device__ __forceinline__ int64_t page_buffer_offset(
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
     const int token_idx, const int scalar_offset, const int scalars_per_token) {
   return token_idx * scalars_per_token + scalar_offset;
+}
+
+// For LMCache
+__device__ __forceinline__ int64_t key_value_offset_non_mla(
+    const int k_or_v, const int layer_idx, const int head_id,
+    const int scalar_offset, const int num_layers, const int num_heads,
+    const int scalars_per_head) {
+  return (int64_t)k_or_v * num_layers * num_heads * scalars_per_head +
+         (int64_t)layer_idx * num_heads * scalars_per_head +
+         (int64_t)head_id * scalars_per_head + scalar_offset;
 }
 
 __device__ __forceinline__ int64_t
@@ -237,6 +260,56 @@ __global__ void single_layer_kv_transfer_sgl_kernel(
       sgl_key_cache[sgl_key_value_idx] = lmc_key_value_cache[lmc_key_idx];
       sgl_value_cache[sgl_key_value_idx] = lmc_key_value_cache[lmc_value_idx];
     }
+  }
+}
+
+/**
+ * Quickly load KV cache between vLLM paged memory and offloading buffer
+ * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][block.z,
+ * head_id, thread.x]
+ */
+template <typename scalar_t, bool DIRECTION>
+__global__ void load_and_reshape_multi_layer_non_mla_kernel(
+    scalar_t* __restrict__ key_value,           // [2, num_layer, num_heads,
+                                                // scalars_per_head]
+    scalar_t** __restrict__ paged_buffer_ptrs,  // [num_layers] * [2,
+                                                // num_blocks, block_size,
+                                                // num_heads, head_size]
+    const int64_t* __restrict__ slot_mapping,   // [num_tokens]
+    const int scalars_per_head, const int page_scalars_per_head,
+    const int page_scalars_per_token, const int elements_per_xword,
+    const int page_buffer_size, const int num_layers, const int num_heads,
+    const int block_size, const int head_size) {
+  const int head_id = blockIdx.x;
+  const int layer_id = blockIdx.y;
+  const int k_or_v = blockIdx.z;
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+
+  scalar_t* paged_buffer_ptr = paged_buffer_ptrs[layer_id];
+
+  /** Copy the data from page buffer to key_value **/
+  for (int i = tid; i < scalars_per_head; i += num_threads) {
+    const int token_id = i * elements_per_xword / head_size;
+    const int64_t slot_idx = slot_mapping[token_id];
+    if (slot_idx < 0) {
+      return;
+    }
+
+    const int page_block_id = static_cast<int>(slot_idx / block_size);
+    const int page_token_id = static_cast<int>(slot_idx % block_size);
+
+    const int64_t lmcache_offset = key_value_offset_non_mla(
+        k_or_v, layer_id, head_id, i, num_layers, num_heads, scalars_per_head);
+
+    const int64_t vllm_offset = page_buffer_offset_non_mla(
+        k_or_v, head_id, page_block_id, page_token_id, page_buffer_size,
+        num_heads, page_scalars_per_head, page_scalars_per_token, i);
+
+    if (DIRECTION)  // 1 is paged buffer to LMCache
+      key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
+    else  // 0 is LMCache to paged buffer
+      paged_buffer_ptr[vllm_offset] = key_value[lmcache_offset];
   }
 }
 
@@ -361,6 +434,86 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  * Processes all the layers at the same time
  *
  * Each layer in vLLM's KV buffer has a shape of
+ * [2, PAGE_BUFFER_SIZE, num_tokens*head_size]
+ *
+ * Each thread block processes the copy for a head
+ * The grid size should be (num_heads, num_layers, 2)
+ *
+ * Therefore:
+ *  - k/v -- block.z
+ *  - layer id -- block.y
+ *  - head id -- block.x
+ *  - offset within a head -- thread.x
+ *
+ * The function does:
+ * key_value[block.z, block.y, block.x, thread.x] = ptrs[block.y][block.z,
+ * head_id, thread.x]
+ *
+ * Param:
+ *  - direction: false  means LMCache to PagedBuffer, true  means PagedBuffer to
+ * LMCache
+ */
+template <typename T>
+void multi_layer_kv_transfer_non_mla_templated(
+    torch::Tensor&
+        key_value,  // key/value must be on gpu/pinned cpu.
+                    // [2, num_layer, num_heads, num_tokens*head_size] for
+                    // flash_attn.
+                    // [1, num_layer, num_tokens, aligned_head_size]
+                    // for MLA.
+
+    const torch::Tensor& key_value_ptrs,  // [num_layers]
+    const torch::Tensor& slot_mapping,    // [num_tokens],
+    const torch::Device& paged_memory_device, const int page_buffer_size,
+    const int block_size, const int head_size, const bool direction,
+    const bool use_mla) {
+  T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
+  T** page_buffer_ptrs =
+      get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
+  const int64_t* slot_mapping_ptr =
+      get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
+
+  const int num_layers = key_value.size(1);
+  const int num_heads = key_value.size(2);
+  const int num_tokens = slot_mapping.size(0);
+  const int num_origin_elements = key_value.size(3);
+  const int elements_per_xword = sizeof(T) / key_value.element_size();
+  const int num_xwords = num_origin_elements / elements_per_xword;
+  const int page_num_xwords = block_size * head_size / elements_per_xword;
+  const int page_scalars_per_token = head_size / elements_per_xword;
+
+  int k_or_v_size = 2;
+  if (use_mla) {
+    k_or_v_size = 1;
+  }
+
+  dim3 grid(num_heads, num_layers, k_or_v_size);
+  dim3 block(std::min(num_xwords, 128));
+
+  const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  if (not direction) {
+    lmc::load_and_reshape_multi_layer_non_mla_kernel<T, false>
+        <<<grid, block, 0, stream>>>(
+            key_value_ptr, page_buffer_ptrs, slot_mapping_ptr, num_xwords,
+            page_num_xwords, page_scalars_per_token, elements_per_xword,
+            page_buffer_size, num_layers, num_heads, block_size, head_size);
+  } else {
+    lmc::load_and_reshape_multi_layer_non_mla_kernel<T, true>
+        <<<grid, block, 0, stream>>>(
+            key_value_ptr, page_buffer_ptrs, slot_mapping_ptr, num_xwords,
+            page_num_xwords, page_scalars_per_token, elements_per_xword,
+            page_buffer_size, num_layers, num_heads, block_size, head_size);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+/**
+ * Quickly offload KV cache from vLLM paged memory to the offloading buffer
+ * Processes all the layers at the same time
+ *
+ * Each layer in vLLM's KV buffer has a shape of
  * [2, PAGE_BUFFER_SIZE, num_heads*head_size]
  *
  * Each thread block processes the copy for a token
@@ -430,6 +583,35 @@ void multi_layer_kv_transfer_templated(
                                      num_layers, page_buffer_size);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
+}
+
+void multi_layer_kv_transfer_non_mla(torch::Tensor& key_value,
+                                     const torch::Tensor& key_value_ptrs,
+                                     const torch::Tensor& slot_mapping,
+                                     const torch::Device& paged_memory_device,
+                                     const int page_buffer_size,
+                                     const int block_size, const int head_size,
+                                     const bool direction, const bool use_mla) {
+  const int num_origin_elements = key_value.size(3);
+  const int copy_size = num_origin_elements * key_value.element_size();
+#ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
+  #define LAUNCH_MULTI_LAYER_KV_TRANSFER(type)                          \
+    do {                                                                \
+      multi_layer_kv_transfer_non_mla_templated<type>(                  \
+          key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
+          page_buffer_size, block_size, head_size, direction, use_mla); \
+    } while (0)
+#endif
+  if (copy_size % 8 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int64_t);
+  } else if (copy_size % 4 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int32_t);
+  } else if (copy_size % 2 == 0) {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int16_t);
+  } else {
+    LAUNCH_MULTI_LAYER_KV_TRANSFER(int8_t);
+  }
+#undef LAUNCH_MULTI_LAYER_KV_TRANSFER
 }
 
 /**

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -8,6 +8,14 @@
 // #ifndef MEM_KERNELS_CUH
 // #define MEM_KERNELS_CUH
 
+void multi_layer_kv_transfer_non_mla(torch::Tensor& key_value,
+                                     const torch::Tensor& key_value_ptrs,
+                                     const torch::Tensor& slot_mapping,
+                                     const torch::Device& paged_memory_device,
+                                     const int page_buffer_size,
+                                     const int block_size, const int head_size,
+                                     const bool direction, const bool use_mla);
+
 void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& key_value_ptrs,
                              const torch::Tensor& slot_mapping,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -12,6 +12,7 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(c_ops, m) {
+  m.def("multi_layer_kv_transfer_non_mla", &multi_layer_kv_transfer_non_mla);
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -122,6 +122,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 
     def __init__(
         self,
+        num_kv_head: int,
+        head_size: int,
         hidden_dim_size: int,
         num_layers: int,
         use_gpu: bool = False,
@@ -133,8 +135,14 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         - chunk_size: The MAX size of the chunk to be copied to GPU.
         - dtype: The data type of the intermediate buffer.
         """
+        self.num_kv_head = num_kv_head
+        self.head_size = head_size
         self.hidden_dim_size = hidden_dim_size
         self.num_layers = num_layers
+        assert "block_size" in kwargs, (
+            "block_size should be provided to create a GPU buffer."
+        )
+        self.block_size = kwargs["block_size"]
         self.kv_cache_pointers = torch.empty(
             num_layers, dtype=torch.int64, device="cpu"
         )
@@ -167,6 +175,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
     def from_metadata(
         cls,
         metadata: LMCacheEngineMetadata,
+        block_size: int,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
     ) -> "VLLMPagedMemGPUConnectorV2":
@@ -189,6 +198,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         hidden_dim_size = num_kv_head * head_size
 
         return cls(
+            num_kv_head=num_kv_head,
+            head_size=head_size,
             hidden_dim_size=hidden_dim_size,
             num_layers=num_layers,
             use_gpu=use_gpu,
@@ -196,6 +207,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             dtype=metadata.kv_dtype,
             device=device,
             use_mla=metadata.use_mla,
+            block_size=block_size,
         )
 
     def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
@@ -216,7 +228,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         else:
             # kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size]
             assert kv_caches[0].dim() == 5
-            self.page_buffer_size = kv_caches[0].shape[1] * kv_caches[0].shape[2]
+            self.page_buffer_size = kv_caches[0].shape[1] * kv_caches[0].shape[3]
 
         return self.kv_cache_pointers_on_gpu[idx]
 
@@ -266,15 +278,28 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 
         kv_cache_pointers = self._initialize_pointers(self.kvcaches)
 
-        lmc_ops.multi_layer_kv_transfer(
-            memory_obj.tensor,
-            kv_cache_pointers,
-            slot_mapping[start:end],
-            self.device,
-            self.page_buffer_size,
-            False,
-            self.use_mla,
-        )
+        if self.use_mla:
+            lmc_ops.multi_layer_kv_transfer(
+                memory_obj.tensor,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                self.device,
+                self.page_buffer_size,
+                False,
+                self.use_mla,
+            )
+        else:
+            lmc_ops.multi_layer_kv_transfer_non_mla(
+                memory_obj.tensor,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                self.device,
+                self.page_buffer_size,
+                self.block_size,
+                self.head_size,
+                False,
+                self.use_mla,
+            )
 
     @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
@@ -310,29 +335,58 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         kv_cache_pointers = self._initialize_pointers(self.kvcaches)
 
         with torch.cuda.stream(self.store_stream):
-            if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
-                lmc_ops.multi_layer_kv_transfer(
-                    memory_obj.tensor,
-                    kv_cache_pointers,
-                    slot_mapping[start:end],
-                    self.kvcaches[0].device,
-                    self.page_buffer_size,
-                    True,
-                    self.use_mla,
-                )
+            if (self.gpu_buffer is None or
+                (end - start) * self.head_size != self.gpu_buffer.shape[3]):
+                if self.use_mla:
+                    lmc_ops.multi_layer_kv_transfer(
+                        memory_obj.tensor,
+                        kv_cache_pointers,
+                        slot_mapping[start:end],
+                        self.kvcaches[0].device,
+                        self.page_buffer_size,
+                        True,
+                        self.use_mla,
+                    )
+                else:
+                    lmc_ops.multi_layer_kv_transfer_non_mla(
+                        memory_obj.tensor,
+                        kv_cache_pointers,
+                        slot_mapping[start:end],
+                        self.kvcaches[0].device,
+                        self.page_buffer_size,
+                        self.block_size,
+                        self.head_size,
+                        True,
+                        self.use_mla,
+                    )
             else:
                 # kvcaches -> gpu_buffer -> memobj
                 assert self.gpu_buffer.device == self.kvcaches[0].device
-                tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
-                lmc_ops.multi_layer_kv_transfer(
-                    tmp_gpu_buffer,
-                    kv_cache_pointers,
-                    slot_mapping[start:end],
-                    self.kvcaches[0].device,
-                    self.page_buffer_size,
-                    True,
-                    self.use_mla,
-                )
+                if self.use_mla:
+                    tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
+                    lmc_ops.multi_layer_kv_transfer(
+                        tmp_gpu_buffer,
+                        kv_cache_pointers,
+                        slot_mapping[start:end],
+                        self.kvcaches[0].device,
+                        self.page_buffer_size,
+                        True,
+                        self.use_mla,
+                    )
+                else:
+                    tmp_gpu_buffer = \
+                        self.gpu_buffer[:, :, :, : (end - start) * self.head_size]
+                    lmc_ops.multi_layer_kv_transfer_non_mla(
+                        tmp_gpu_buffer,
+                        kv_cache_pointers,
+                        slot_mapping[start:end],
+                        self.kvcaches[0].device,
+                        self.page_buffer_size,
+                        self.block_size,
+                        self.head_size,
+                        True,
+                        self.use_mla,
+                    )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
         if not memory_obj.tensor.is_cuda:
@@ -358,7 +412,12 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 
     def get_shape(self, num_tokens: int) -> torch.Size:
         kv_size = 1 if self.use_mla else 2
-        return torch.Size([kv_size, self.num_layers, num_tokens, self.hidden_dim_size])
+        if self.use_mla:
+            return torch.Size([kv_size, self.num_layers,
+                               num_tokens, self.hidden_dim_size])
+        else:
+            return torch.Size([kv_size, self.num_layers,
+                               self.num_kv_head, num_tokens * self.head_size])
 
 
 class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -283,7 +283,7 @@ class LMCacheManager:
 
         # Create GPU connector
         vllm_gpu_connector = self._create_gpu_connector(
-            role, use_mla, metadata, device, current_platform
+            role, use_mla, metadata, device, current_platform, cache_config.block_size
         )
 
         # Get tensor parallel group
@@ -381,7 +381,8 @@ class LMCacheManager:
 
         return device, torch_dev, dev_name
 
-    def _create_gpu_connector(self, role, use_mla, metadata, device, current_platform):
+    def _create_gpu_connector(self, role, use_mla, metadata, device,
+                              current_platform, block_size):
         """Create the GPU connector based on configuration."""
         # First Party
         from lmcache.v1.gpu_connector import (
@@ -414,7 +415,7 @@ class LMCacheManager:
                 )
             else:
                 return VLLMPagedMemGPUConnectorV2.from_metadata(
-                    metadata, use_gpu, device
+                    metadata, block_size, use_gpu, device
                 )
         elif current_platform.is_xpu():
             return VLLMPagedMemXPUConnectorV2.from_metadata(metadata, use_gpu, device)

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -160,7 +160,8 @@ def test_store_1GB(
     num_repeats = 10
 
     # Initialize related modules
-    connector = create_gpu_connector(num_heads * head_dim, num_layers)
+    connector = create_gpu_connector(num_heads, head_dim, num_heads * head_dim,
+                                     num_layers, block_size)
     kv_cache = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
@@ -275,7 +276,8 @@ def test_retrieve_1GB_allhit(
     num_repeats = 10
 
     # Initialize related modules
-    connector = create_gpu_connector(num_heads * head_dim, num_layers)
+    connector = create_gpu_connector(num_heads, head_dim, num_heads * head_dim,
+                                     num_layers, block_size)
     kv_cache = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )
@@ -393,7 +395,8 @@ def test_lookup_20K_tokens(
     num_repeats = 10
 
     # Initialize related modules
-    connector = create_gpu_connector(num_heads * head_dim, num_layers)
+    connector = create_gpu_connector(num_heads, head_dim, num_heads * head_dim,
+                                     num_layers, block_size)
     kv_cache = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
     )

--- a/tests/disagg/test_nixl_cache_engine.py
+++ b/tests/disagg/test_nixl_cache_engine.py
@@ -187,7 +187,8 @@ if __name__ == "__main__":
     # Create the VLLMPagedMemGPUConnectorV2
     hidden_dim = 1024
     num_layers = 32
-    gpu_connector = VLLMPagedMemGPUConnectorV2(hidden_dim, num_layers)
+    gpu_connector = VLLMPagedMemGPUConnectorV2(8, 128, hidden_dim,
+                                               num_layers, block_size=block_size)
 
     # Calculate the expected total size of data
     kv_shape = gpu_connector.get_shape(config.chunk_size)

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -66,7 +66,7 @@ def test_paged_same_retrieve_store(save_unfull_chunk, autorelease_v1):
     chunk_size = 256
     kv_shape = (32, 2, chunk_size, 8, 128)
 
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
 
@@ -163,7 +163,7 @@ def test_paged_retrieve_prefix(
     num_blocks = 1000
     block_size = 16
     dtype = torch.bfloat16
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -278,7 +278,7 @@ def test_paged_store_offset(
     num_blocks = 1000
     block_size = 16
     dtype = torch.bfloat16
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_total_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -387,7 +387,7 @@ def test_paged_mixed_retrieve(
     dtype = torch.bfloat16
 
     kv_shape = (32, 2, chunk_size, 8, 128)
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -538,7 +538,7 @@ def test_paged_store_kv_tensors_mask(fmt, save_unfull_chunk, autorelease_v1):
 
     chunk_size = 256
     kv_shape = (32, 2, chunk_size, 8, 128)
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -726,7 +726,7 @@ def test_paged_hierarchy_retrieve(
     block_size = 16
     dtype = torch.bfloat16
 
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -868,7 +868,7 @@ def test_paged_prefetch_retrieve(
     chunk_size = 256
     fmt = "vllm"
     kv_shape = (32, 2, chunk_size, 8, 128)
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -1010,7 +1010,7 @@ def test_paged_mem_leak(
     num_blocks = 1000
     block_size = 16
     dtype = torch.bfloat16
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens = generate_tokens(num_tokens, device)
     kv_cache = generate_kv_cache_paged_list_tensors(
@@ -1104,7 +1104,7 @@ def test_paged_retrieve_after_eviction(
     num_blocks = 1000
     block_size = 16
     dtype = torch.bfloat16
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     tokens_1 = generate_tokens(num_tokens, device)
     tokens_2 = generate_tokens(num_tokens, device)
@@ -1249,7 +1249,7 @@ def test_force_store_wait(autorelease_v1):
     chunk_size = 256
     kv_shape = (32, 2, chunk_size, 8, 128)
 
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
     kv_cache = generate_kv_cache_paged_list_tensors(
         num_blocks, device, block_size, dtype
@@ -1313,7 +1313,7 @@ def test_builder_destroy(autorelease_v1):
     """Test the destroy method of LMCacheEngineBuilder"""
     instance_id = "test_destroy"
     cfg = LMCacheEngineConfig.from_legacy(chunk_size=256)
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, 16)
 
     # Verify instance doesn't exist initially
     should_be_none = LMCacheEngineBuilder.get(instance_id)
@@ -1366,7 +1366,7 @@ def test_builder_destroy_multiple_instances(autorelease_v1):
     instance_id1 = "test_destroy_1"
     instance_id2 = "test_destroy_2"
     cfg = LMCacheEngineConfig.from_legacy(chunk_size=256)
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, 16)
 
     # Create two engine instances
     engine1 = LMCacheEngineBuilder.get_or_create(
@@ -1430,7 +1430,7 @@ def test_multi_device_backends(save_unfull_chunk, autorelease_v1):
     block_size = 16
     dtype = torch.bfloat16
 
-    connector = create_gpu_connector(1024, 32)
+    connector = create_gpu_connector(8, 128, 1024, 32, block_size)
     metadata = dumb_metadata()
     metadata.model_name = "test-model"  # NOTE: Gds does not accept name with '_'
 
@@ -1470,7 +1470,7 @@ def test_multi_device_backends(save_unfull_chunk, autorelease_v1):
             }
         )
 
-        connector = create_gpu_connector(1024, 32)
+        connector = create_gpu_connector(8, 128, 1024, 32, block_size)
 
         engine = autorelease_v1(
             LMCacheEngineBuilder.get_or_create(

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -108,10 +108,20 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
     allocator = PinMemoryAllocator(1024 * 1024 * 1024)
 
     gpu_kv_src = generate_kv_cache_paged_list_tensors(
-        num_blocks=num_blocks, device=device, block_size=block_size, use_mla=use_mla
+        num_blocks=num_blocks,
+        device=device,
+        block_size=block_size,
+        use_mla=use_mla,
+        num_layers=num_layers,
+        head_size=head_size,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
-        num_blocks=num_blocks, device=device, block_size=block_size, use_mla=use_mla
+        num_blocks=num_blocks,
+        device=device,
+        block_size=block_size,
+        use_mla=use_mla,
+        num_layers=num_layers,
+        head_size=head_size,
     )
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
@@ -129,6 +139,8 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
             )
 
     connector = VLLMPagedMemGPUConnectorV2(
+        num_heads,
+        head_size,
         hidden_dim,
         num_layers,
         use_gpu=use_gpu,
@@ -136,8 +148,11 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
         dtype=gpu_kv_src[0].dtype,
         device=device,
         use_mla=use_mla,
+        block_size=block_size,
     )
     connector2 = VLLMPagedMemGPUConnectorV2(
+        num_heads,
+        head_size,
         hidden_dim,
         num_layers,
         use_gpu=use_gpu,
@@ -145,6 +160,7 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
         dtype=gpu_kv_src[0].dtype,
         device=device,
         use_mla=use_mla,
+        block_size=block_size,
     )
     assert connector.use_mla == use_mla
     assert connector2.use_mla == use_mla
@@ -182,7 +198,7 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, use_mla):
         )
     else:
         check_paged_kv_cache_equal(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size
+            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, block_size
         )
     allocator.close()
 
@@ -717,7 +733,8 @@ def test_vllm_paged_connector_v2_to_gpu_bench(benchmark):
     slot_mapping = random.sample(range(0, num_blocks * block_size), chunk_size)
     slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
 
-    connector = VLLMPagedMemGPUConnectorV2(hidden_dim, num_layers)
+    connector = VLLMPagedMemGPUConnectorV2(num_heads, head_size, hidden_dim,
+                                           num_layers, block_size=block_size)
     shape = connector.get_shape(chunk_size)
     memory_obj = allocator.allocate(shape, gpu_kv_src[0][0].dtype)
     connector.from_gpu(

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -133,7 +133,7 @@ def generate_kv_cache_paged_list_tensors(
     shape = (
         [num_blocks, block_size, head_size]
         if use_mla
-        else [2, num_blocks, block_size, num_heads, head_size]
+        else [2, num_blocks, num_heads, block_size, head_size]
     )
 
     for i in range(num_layers):
@@ -142,6 +142,8 @@ def generate_kv_cache_paged_list_tensors(
             kv = torch.randint(0, 256, shape, dtype=dtype, device=device)
         else:
             kv = torch.rand(shape, dtype=dtype, device=device)
+        if not use_mla:
+            kv = kv.transpose(2, 3)
         ret.append(kv)
 
     return ret
@@ -273,30 +275,33 @@ def check_mem_obj_equal(left, right, use_mla: bool = False):
             assert (left_v[:, :, :] == right_v[:, :, :]).all()
 
 
-def check_paged_kv_cache_equal(left, right, slot_mapping, num_heads=8, head_size=128):
+def check_paged_kv_cache_equal(
+    left, right, slot_mapping, num_heads=8, head_size=128, block_size=16
+):
     """
     check whether two paged kv caches are the same at slot_mapping
     """
-    token_dim = 0
+    block_dim = 0
+    token_dim = 1
     num_tokens = slot_mapping.shape[0]
     for left_kv, right_kv in zip(left, right, strict=False):
-        left_k = left_kv[0].reshape(-1, num_heads, head_size)
-        left_v = left_kv[1].reshape(-1, num_heads, head_size)
-        right_k = right_kv[0].reshape(-1, num_heads, head_size)
-        right_v = right_kv[1].reshape(-1, num_heads, head_size)
+        assert len(left_kv[0].shape) == 4
+        assert len(left_kv[1].shape) == 4
+        assert len(right_kv[0].shape) == 4
+        assert len(right_kv[1].shape) == 4
 
-        assert len(left_k.shape) == 3
-        assert len(left_v.shape) == 3
-        assert len(right_k.shape) == 3
-        assert len(right_v.shape) == 3
+        assert left_kv[0].shape[block_dim] * left_kv[0].shape[token_dim] >= num_tokens
+        assert left_kv[1].shape[block_dim] * left_kv[1].shape[token_dim] >= num_tokens
+        assert right_kv[0].shape[block_dim] * right_kv[0].shape[token_dim] >= num_tokens
+        assert right_kv[1].shape[block_dim] * right_kv[1].shape[token_dim] >= num_tokens
 
-        assert left_k.shape[token_dim] >= num_tokens
-        assert left_v.shape[token_dim] >= num_tokens
-        assert right_k.shape[token_dim] >= num_tokens
-        assert right_v.shape[token_dim] >= num_tokens
+        block_ids = (slot_mapping // block_size).to(torch.long)
+        token_ids = (slot_mapping % block_size).to(torch.long)
 
-        assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
-        assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
+        assert (left_kv[0][block_ids, token_ids, :, :] ==
+                right_kv[0][block_ids, token_ids, :, :]).all()
+        assert (left_kv[1][block_ids, token_ids, :, :] ==
+                right_kv[1][block_ids, token_ids, :, :]).all()
 
 
 def check_sglang_paged_kv_cache_equal(
@@ -346,8 +351,9 @@ def check_kv_cache_device(kvs, device):
         assert v.device == torch.device(device)
 
 
-def create_gpu_connector(hidden_dim, num_layers):
-    return VLLMPagedMemGPUConnectorV2(hidden_dim, num_layers)
+def create_gpu_connector(num_heads, head_dim, hidden_dim, num_layers, block_size):
+    return VLLMPagedMemGPUConnectorV2(num_heads, head_dim, hidden_dim,
+                                      num_layers, block_size=block_size)
 
 
 def get_all_methods_from_base(base_class):


### PR DESCRIPTION
Fix issue: https://github.com/LMCache/LMCache/issues/2374

I tested the mistralai/Mistral-7B-Instruct-v0.2 model and printed the following logs:
layer_name: model.layers.0.self_attn.attn
self.kv_caches[layer_name].shape: torch.Size([2, 7286, 64, 8, 128]), stride: (477495296, 65536, 128, 8192, 1)

For linear addressing in the data copy function (multi_layer_kv_transfer), a contiguous memory layout is required. From the above shape and strides, we can infer that the dimension order of the contiguous data should be shape[0] -> shape[1] -> shape[3] -> shape[2] -> shape[4].
Therefore, the current implementation of the multi_layer_kv_transfer function is incorrect, and I have fixed this bug accordingly.
In addition, I have also conducted tests on the following models:
Qwen/Qwen3-32B
deepseek-ai/DeepSeek-V2-Lite-Chat