### PR TITLE
[Fix]: remove duplicated ref count decrement calls of Mooncake Connector

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -533,9 +533,6 @@ class MooncakestoreConnector(RemoteConnector):
             logger.warning(
                 "Timeout during batch_put_from; some decoders may redo prefill."
             )
-        finally:
-            for obj in memory_objs:
-                obj.ref_count_down()
 
     async def _batched_put_with_metadata(
         self,
@@ -543,10 +540,7 @@ class MooncakestoreConnector(RemoteConnector):
         memory_objs: List[MemoryObj],
     ) -> None:
         for key, obj in zip(keys, memory_objs, strict=False):
-            try:
-                await self._put_with_metadata(key.to_string(), obj)
-            finally:
-                obj.ref_count_down()
+            await self._put_with_metadata(key.to_string(), obj)
 
     async def _put_without_metadata(self, key_str: str, memory_obj: MemoryObj):
         """


### PR DESCRIPTION
**What this PR does / why we need it**:

Both `InstrumentedRemoteConnector.batched_put()`  and `MooncakestoreConnector._batched_put_zero_copy()`/`_batched_put_with_metadata()` call `ref_count_down()` in their `finally` blocks, resulting in double free.

Other connectors like `RedisConnector`do NOT call `ref_count_down()` in their `batched_put()` methods because `InstrumentedRemoteConnector` is designed to handle this uniformly.

**Fix**:

Remove the redundant `ref_count_down()` calls in `mooncakestore_connector.py`:
- `_batched_put_zero_copy()` method (line 536-538)
- `_batched_put_with_metadata()` method (line 548-549)

This aligns with the behavior of other connectors and the design intent of `InstrumentedRemoteConnector`.

**Special notes for your reviewers**:

- This issue only occurs when using mooncakestore backend; `local_cpu` backend is not affected since it doesn't go through `RemoteBackend` and `InstrumentedRemoteConnector`.
- The fix follows the existing pattern used by `RedisConnector` .


