### PR TITLE
[refactor]: handle optional mooncake NUMA binding import

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -176,6 +176,7 @@ class MooncakestoreConnector(RemoteConnector):
                     try:
                         # Third Party
                         from mooncake.store import bind_to_numa_node
+
                         if numa_id is not None:
                             bind_to_numa_node(numa_id)
                             logger.info(

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -179,13 +179,14 @@ class MooncakestoreConnector(RemoteConnector):
                         if numa_id is not None:
                             bind_to_numa_node(numa_id)
                             logger.info(
-                                f"GPU {current_device_id}, NUMA node {numa_id} binding done"
+                                f"GPU {current_device_id}, "
+                                f"NUMA node {numa_id} binding done"
                             )
                         else:
                             logger.info(
                                 f"NUMA mapping not found for GPU {current_device_id}"
                             )
-                    except ImportError as e:
+                    except ImportError:
                         logger.warning(
                             "unable to import bind_to_numa_node from mooncake.store"
                         )

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -113,7 +113,6 @@ class MooncakestoreConnector(RemoteConnector):
             from mooncake.store import (
                 MooncakeDistributedStore,
                 ReplicateConfig,
-                bind_to_numa_node,
             )
         except ImportError as e:
             raise ImportError(
@@ -174,14 +173,21 @@ class MooncakestoreConnector(RemoteConnector):
                     logger.info(
                         f"NUMA mapping detected (pre-Mooncake setup): {gpu_to_numa}"
                     )
-                    if numa_id is not None:
-                        bind_to_numa_node(numa_id)
-                        logger.info(
-                            f"GPU {current_device_id}, NUMA node {numa_id} binding done"
-                        )
-                    else:
-                        logger.info(
-                            f"NUMA mapping not found for GPU {current_device_id}"
+                    try:
+                        # Third Party
+                        from mooncake.store import bind_to_numa_node
+                        if numa_id is not None:
+                            bind_to_numa_node(numa_id)
+                            logger.info(
+                                f"GPU {current_device_id}, NUMA node {numa_id} binding done"
+                            )
+                        else:
+                            logger.info(
+                                f"NUMA mapping not found for GPU {current_device_id}"
+                            )
+                    except ImportError as e:
+                        logger.warning(
+                            "unable to import bind_to_numa_node from mooncake.store"
                         )
                 else:
                     logger.info("NUMA mapping unavailable or disabled")


### PR DESCRIPTION
The `bind_to_numa_node` function in `mooncake.store` may fail to import in certain environments (e.g., non-cuda system or environments without proper NUMA libraries), which currently prevents the MooncakeConnector from initializing entirely.

This commit:
- Moves `bind_to_numa_node` import into a local try-except block.
- Degrades gracefully by logging a warning if the import fails, allowing the connector to continue running without NUMA binding.
- Keeps core components (`MooncakeDistributedStore`, `ReplicateConfig`) as required dependencies.

