### PR TITLE
[Docs] Add long_doc_qa Benchmarks for Evaluating P2P KV-Cache Sharing Efficiency

### DIFF
--- a/docs/source/kv_cache/p2p_sharing.rst
+++ b/docs/source/kv_cache/p2p_sharing.rst
@@ -29,7 +29,7 @@ The only difference between the two configurations is the ``lmcache_instance_id`
 
     chunk_size: 256
     local_cpu: True
-    max_local_cpu_size: 5
+    max_local_cpu_size: 10
     enable_async_loading: True
 
     # P2P configurations
@@ -55,7 +55,7 @@ The only difference between the two configurations is the ``lmcache_instance_id`
 
     chunk_size: 256
     local_cpu: True
-    max_local_cpu_size: 5
+    max_local_cpu_size: 10
     enable_async_loading: True
 
     # P2P configurations
@@ -87,6 +87,11 @@ Setup and Usage
 Make sure that the 8300 and 8400 ports are set up in **controller_pull_url** and **controller_reply_url** in the configuration files.
 Port 9000 is the controller main port, which is arbitrary and can be changed.
 
+After starting the controller, access the WebUI at:
+
+http://localhost:9000/
+
+ 
 **Step 2: Start vLLM Engines with LMCache Workers**
 
 If the NIC supports RDMA:
@@ -158,3 +163,62 @@ When the second request successfully retrieves cache from the first instance, yo
     (EngineCore_DP0 pid=2577584)[2025-09-21 00:00:11,792] LMCache INFO: Retrieved 1002 out of total 1002 out of total 1002 tokens. size: 0.1223 gb, cost 60.3595 ms, throughput: 2.0264 GB/s; (cache_engine.py:496:lmcache.v1.cache_engine)
 
 These logs indicate successful P2P connection establishment and high-throughput cache retrieval.
+
+
+
+**Step 4: Benchmarking P2P Cache Sharing**
+
+Send a request workload to instance 1 to populate the cache:
+
+.. code-block:: bash
+
+    python benchmarks/long_doc_qa/long_doc_qa.py \
+    --model meta-llama/Meta-Llama-3.1-8B-Instruct \
+    --num-documents 50 \
+    --document-length 10000 \
+    --output-len 100 \
+    --repeat-count 1 \
+    --repeat-mode tile \
+    --port 8010 \
+    --max-inflight-requests 4
+
+Send the same request workload to instance 2 to demonstrate cache retrieval from **instance 1**:
+
+.. code-block:: bash
+
+    python benchmarks/long_doc_qa/long_doc_qa.py \
+    --model meta-llama/Meta-Llama-3.1-8B-Instruct \
+    --num-documents 50 \
+    --document-length 10000 \
+    --output-len 100 \
+    --repeat-count 1 \
+    --repeat-mode tile \
+    --port 8011 \
+    --max-inflight-requests 4
+
+
+Benchmark Results
+-----------------
+
+First instance metrics:
+
+.. code-block:: text
+
+    === BENCHMARK RESULTS ===
+    Query round mean TTFT: 0.466s
+    Query round time: 19.838s
+    Query round prompt count: 50
+    Query round successful prompt count: 50
+
+Second instance metrics:
+
+.. code-block:: text
+
+    === BENCHMARK RESULTS ===
+    Query round mean TTFT: 0.360s
+    Query round time: 17.896s
+    Query round prompt count: 50
+    Query round successful prompt count: 50
+
+From this example, we can see a 22% reduction in TTFT (0.466s → 0.360s), with LMCache P2P sharing.
+

--- a/docs/source/kv_cache/p2p_sharing.rst
+++ b/docs/source/kv_cache/p2p_sharing.rst
@@ -203,22 +203,20 @@ Benchmark Results
 First instance metrics:
 
 .. code-block:: text
-
-    === BENCHMARK RESULTS ===
-    Query round mean TTFT: 0.466s
-    Query round time: 19.838s
-    Query round prompt count: 50
-    Query round successful prompt count: 50
+ 
+    Warmup round mean TTFT: 0.466s
+    Warmup round time: 19.838s
+    Warmup round prompt count: 50
+    Warmup round successful prompt count: 50
 
 Second instance metrics:
 
 .. code-block:: text
+ 
+    Warmup round mean TTFT: 0.360s
+    Warmup round time: 17.896s
+    Warmup round prompt count: 50
+    Warmup round successful prompt count: 50
 
-    === BENCHMARK RESULTS ===
-    Query round mean TTFT: 0.360s
-    Query round time: 17.896s
-    Query round prompt count: 50
-    Query round successful prompt count: 50
-
-From this example, we can see a 22% reduction in TTFT (0.466s → 0.360s), with LMCache P2P sharing.
+In this example, the warm-up round metric in long_doc_qa is used because no existing KV cache is reused within an instance. With LMCache P2P sharing enabled, the time to first token (TTFT) is reduced by 22%, from 0.466 s to 0.360 s.
 


### PR DESCRIPTION
PR Description

This PR documents how to use the existing long_doc_qa benchmark to evaluate peer-to-peer (P2P) KV-cache sharing efficiency between two vLLM instances.

⸻

What this PR does / why we need it
	•	Adds clear documentation for running the long_doc_qa benchmark in a two-instance vLLM setup
	•	Describes how the benchmark can be used to assess P2P KV-cache reuse and transfer behavior

⸻

Special notes for your reviewers
	•	This is a documentation-only PR and does not introduce any runtime or code changes
	•	The benchmark is intended solely for performance evaluation and debugging of P2P KV-cache sharing