### PR TITLE
[Bugfix] fix  the negative results of the multi-round-qa periodic summary logging

### DIFF
--- a/benchmarks/multi_round_qa/multi-round-qa.py
+++ b/benchmarks/multi_round_qa/multi-round-qa.py
@@ -552,7 +552,6 @@ class UserSessionManager:
         pending_queries = len([s for s in self.sessions if s.has_unfinished_request])
         assert self.start_time is not None
         start_time = max(self.start_time, start_time)
-        end_time = min(end_time, df["finish_time"].max())
         qps = self.workload_config.qps
 
         df = UserSessionManager.ProcessSummary(


### PR DESCRIPTION
If there is not any finished requests in a summary logging period, the end_time will be the finish_time of a request in the previous period, which is less than the start_time of current period and results in a negative total_time

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
