### PR TITLE
Convert zmq type of lookup client->server from req to router

### DIFF
--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -330,11 +330,14 @@ class LMCacheLookupServer:
                 identity = frames[0].bytes
                 # frames[1] is the empty delimiter frame from REQ socket
                 data_frames = frames[2:]
+                if len(data_frames) < 2:
+                    logger.warning("Malformed request received: not enough frames.")
+                    continue
                 lookup_id = data_frames[-2].bytes.decode("utf-8")
                 request_configs_str = data_frames[-1].bytes.decode("utf-8")
-                request_configs = None
-                if request_configs_str != "":
-                    request_configs = json.loads(request_configs_str)
+                request_configs = (
+                    json.loads(request_configs_str) if request_configs_str else None
+                )
                 if not self.enable_blending:
                     hash_frames = data_frames[0]
                     offset_frames = data_frames[1]

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -307,7 +307,7 @@ class LMCacheLookupServer:
             self.ctx,
             socket_path,
             "ipc",
-            zmq.REP,  # type: ignore[attr-defined]
+            zmq.ROUTER,  # type: ignore[attr-defined]
             "bind",
         )
         # Set socket timeout to allow periodic check of running flag
@@ -325,14 +325,19 @@ class LMCacheLookupServer:
                 except zmq.Again:
                     # Timeout occurred, check running flag and continue
                     continue
-                lookup_id = frames[-2].bytes.decode("utf-8")
-                request_configs_str = frames[-1].bytes.decode("utf-8")
+                # ROUTER socket prepends identity frame and empty delimiter
+                # frames[0] = identity, frames[1] = empty delimiter, frames[2:] = data
+                identity = frames[0].bytes
+                # frames[1] is the empty delimiter frame from REQ socket
+                data_frames = frames[2:]
+                lookup_id = data_frames[-2].bytes.decode("utf-8")
+                request_configs_str = data_frames[-1].bytes.decode("utf-8")
                 request_configs = None
                 if request_configs_str != "":
                     request_configs = json.loads(request_configs_str)
                 if not self.enable_blending:
-                    hash_frames = frames[0]
-                    offset_frames = frames[1]
+                    hash_frames = data_frames[0]
+                    offset_frames = data_frames[1]
                     hashes = self.decoder.decode(hash_frames)
                     offsets = self.decoder.decode(offset_frames)
                     result = self.lmcache_engine.lookup(
@@ -343,7 +348,7 @@ class LMCacheLookupServer:
                         request_configs=request_configs,
                     )
                 else:
-                    token_frames = frames[0]
+                    token_frames = data_frames[0]
                     tokens = self.decoder.decode(token_frames)
                     result = self.lmcache_engine.lookup(
                         tokens=tokens,
@@ -352,7 +357,8 @@ class LMCacheLookupServer:
                         request_configs=request_configs,
                     )
                 response = result.to_bytes(4, "big")
-                self.socket.send(response)
+                # ROUTER requires identity frame and empty delimiter for reply
+                self.socket.send_multipart([identity, b"", response])
 
         logger.info("lmcache lookup server start on %s", socket_path)
         self.thread = threading.Thread(target=process_request, daemon=True)


### PR DESCRIPTION
## Summary

Replace `zmq.REP` socket with `zmq.ROUTER` socket in `LMCacheLookupServer` to improve robustness without impacting performance.

## Motivation

The `REP` (reply) socket type in ZeroMQ operates with a strict state machine that enforces a `recv -> send -> recv -> send` pattern. This rigid constraint can cause issues in edge cases:

1. **Client disconnection handling**: If a client disconnects after sending a request but before receiving a response, the `REP` socket can get stuck in an inconsistent state, potentially blocking subsequent requests.
2. **Error recovery**: When exceptions occur during message processing, the `REP` socket's state machine may become corrupted, requiring socket recreation.

## Changes

- Changed `LMCacheLookupServer` socket type from `zmq.REP` to `zmq.ROUTER`
- Updated message handling to properly extract identity frames and data frames
- Modified response sending to include identity frame and empty delimiter as required by ROUTER protocol

## Trade-offs

### Pros
- **Better fault tolerance**: `ROUTER` socket is stateless and handles client disconnections gracefully
- **No strict state machine**: Eliminates the risk of socket state corruption
- **Async-ready**: Enables potential future optimizations for async message handling
- **Client compatibility**: No changes required on the client side (`REQ` sockets work seamlessly with `ROUTER`)

### Cons
- **Slightly more complex code**: Need to handle identity frames explicitly
- **Minimal memory overhead**: Additional frame parsing for each message (negligible in practice)

## Performance Impact

The performance impact is minimal:
- Both socket types use the same underlying transport (IPC)
- The additional identity frame handling is O(1) per message
- All existing tests pass without modification
