### PR TITLE
[doc]: sphinx version mismatch

### DIFF
--- a/docs/source/kv_cache/p2p_sharing.rst
+++ b/docs/source/kv_cache/p2p_sharing.rst
@@ -218,7 +218,5 @@ Second instance metrics:
     Warmup round prompt count: 50
     Warmup round successful prompt count: 50
 
-In this example, the warm-up round metric in long_doc_qa is used because no existing KV cache is reused within an instance. 
-
-With LMCache P2P sharing enabled, the time to first token (TTFT) is reduced by 22%, from 0.466 s to 0.360 s.
+In this example, the warm-up round metric in long_doc_qa is used because no existing KV cache is reused within an instance. With LMCache P2P sharing enabled, the time to first token (TTFT) is reduced by 22%, from 0.466 s to 0.360 s.
 

--- a/docs/source/kv_cache/p2p_sharing.rst
+++ b/docs/source/kv_cache/p2p_sharing.rst
@@ -218,5 +218,7 @@ Second instance metrics:
     Warmup round prompt count: 50
     Warmup round successful prompt count: 50
 
-In this example, the warm-up round metric in long_doc_qa is used because no existing KV cache is reused within an instance. With LMCache P2P sharing enabled, the time to first token (TTFT) is reduced by 22%, from 0.466 s to 0.360 s.
+In this example, the warm-up round metric in long_doc_qa is used because no existing KV cache is reused within an instance. 
+
+With LMCache P2P sharing enabled, the time to first token (TTFT) is reduced by 22%, from 0.466 s to 0.360 s.
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-Sphinx==9.1.0
+sphinx>=6,<9
 sphinx-rtd-theme==3.0.2
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0


### PR DESCRIPTION
The docs build failed because we pinned an incompatible dependency set:

sphinx-rtd-theme==3.0.2 declares:
sphinx >=6, <9

We pinned:
sphinx==9.1.0