### PR TITLE
Release memory object when allocated memory_obj with none tensor

### DIFF
--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -94,7 +94,17 @@ def allocate_and_copy_objects(
             busy_loop=False,
         )
 
-        if memory_obj is None or memory_obj.tensor is None:
+        if memory_obj is None:
+            break
+
+        if memory_obj.tensor is None:
+            # This should not happen with current implementation,
+            # but handle it defensively to avoid memory leak
+            logger.warning(
+                "Allocated MemoryObj has None tensor, this is unexpected. "
+                "Releasing the memory object."
+            )
+            memory_obj.ref_count_down()
             break
 
         with torch.cuda.stream(stream):


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Implemented a fix to prevent potential memory leaks by ensuring that memory_obj instances are properly released if their tensor attribute is None after allocation.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
