### PR TITLE
[bugfix] fix LMCacheManager get kv_caches error

### DIFF
--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -644,6 +644,12 @@ class LMCacheManager:
         """Get the role of this manager (scheduler or worker)."""
         return self._role
 
+    @property
+    def kv_caches(self) -> dict[str, torch.Tensor]:
+        if self._connector is not None and hasattr(self._connector, "kv_caches"):
+            return self._connector.kv_caches
+        return {}
+
     def is_healthy(self) -> bool:
         """
         Check if the LMCacheManager is healthy.


### PR DESCRIPTION
The `lmcache_adapter` is instance of `LMCacheManager`, and the `/cache/kvcache/check` in `InternalApiServer` will cause some errors in following position: 
<img width="987" height="375" alt="Clipboard_Screenshot_1768822317" src="https://github.com/user-attachments/assets/ab5dfb6c-95fb-453c-9dd3-45a1371898a1" />
