### PR TITLE
[Bugfix] Fallback when lazy allocator is unavailable

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -384,20 +384,24 @@ class LocalCPUBackend(AllocatorBackendInterface):
             )
 
             if use_lazy:
-                raise RuntimeError("LazyMixedMemoryAllocator being refactored.")
-            else:
-                if config.enable_lazy_memory_allocator:
-                    logger.info(
-                        f"LazyMixedMemoryAllocator is disabled because "
-                        f"cpu_size ({cpu_size:.2f} GB) does not exceed "
-                        f"lazy_memory_safe_size "
-                        f"({config.lazy_memory_safe_size:.2f} GB). "
-                        f"Using MixedMemoryAllocator instead."
-                    )
-                return MixedMemoryAllocator(
-                    int(cpu_size * 1024**3),
-                    numa_mapping=numa_mapping,
+                logger.warning(
+                    "LazyMixedMemoryAllocator is temporarily unavailable; "
+                    "falling back to MixedMemoryAllocator with full allocation. "
+                    "Disable enable_lazy_memory_allocator or reduce "
+                    "max_local_cpu_size to avoid large pinned allocations."
                 )
+            elif config.enable_lazy_memory_allocator:
+                logger.info(
+                    f"LazyMixedMemoryAllocator is disabled because "
+                    f"cpu_size ({cpu_size:.2f} GB) does not exceed "
+                    f"lazy_memory_safe_size "
+                    f"({config.lazy_memory_safe_size:.2f} GB). "
+                    f"Using MixedMemoryAllocator instead."
+                )
+            return MixedMemoryAllocator(
+                int(cpu_size * 1024**3),
+                numa_mapping=numa_mapping,
+            )
 
     @_lmcache_nvtx_annotate
     def allocate(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Fixes #2448

**What this PR does / why we need it**:
- Avoid a hard crash when `enable_lazy_memory_allocator` is enabled but the lazy allocator is unavailable.
- Log a warning and fall back to `MixedMemoryAllocator` so vLLM can start.

**Special notes for your reviewers**:
- Behavior change: full pinned allocation is used in this fallback path; users can disable lazy allocation or reduce `max_local_cpu_size` to avoid large allocations.
- Single-file change in `lmcache/v1/storage_backend/local_cpu_backend.py`.
- Testing: not run (config-specific behavior).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
