### PR TITLE
[Fix] standardize chunk_hash handling and fix CacheEngineKey to_string bug

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -385,7 +385,7 @@ class CacheEngineKey:
     def to_string(self):
         s = (
             f"{self.fmt}@{self.model_name}@{self.world_size}"
-            f"@{self.worker_id}@{self.chunk_hash:x}@{self._dtype_str}"
+            f"@{self.worker_id}@{self.chunk_hash_hex}@{self._dtype_str}"
         )
         if self.tags is not None and len(self.tags) != 0:
             tags = [f"{k}%{v}" for k, v in self.tags]
@@ -496,6 +496,12 @@ class CacheEngineKey:
             self.request_configs,
         )
 
+    @property
+    def chunk_hash_hex(self) -> str:
+        if isinstance(self.chunk_hash, bytes):
+            return self.chunk_hash.hex()
+        return f"{self.chunk_hash:x}"
+
 
 @dataclass(slots=True)
 class LayerCacheEngineKey(CacheEngineKey):
@@ -526,7 +532,7 @@ class LayerCacheEngineKey(CacheEngineKey):
     def to_string(self):
         s = (
             f"{self.fmt}@{self.model_name}@{self.world_size}"
-            f"@{self.worker_id}@{self.chunk_hash:x}@{self._dtype_str}@{self.layer_id}"
+            f"@{self.worker_id}@{self.chunk_hash_hex}@{self._dtype_str}@{self.layer_id}"
         )
         if self.tags is not None and len(self.tags) != 0:
             tags = [f"{k}%{v}" for k, v in self.tags]


### PR DESCRIPTION
1. Update chunk_hash type hint to Union[int, bytes] for better type safety
2. Extract hex conversion logic into CacheEngineKey.chunk_hash_hex property


this is to fix below error msg:

(Worker_TP0_EP0 pid=133480) [2026-01-19 01:30:39,212] LMCache WARNING: Returning False (remote_backend.py:156:lmcache.v1.storage_backend.remote_backend)
(Worker_TP0_EP0 pid=133480) [2026-01-19 01:30:39,212] LMCache ERROR: Remote connection failed in contains (remote_backend.py:157:lmcache.v1.storage_backend.remote_backend)
(Worker_TP0_EP0 pid=133480) Traceback (most recent call last):
(Worker_TP0_EP0 pid=133480)   File "/mnt/disk3/hlin76/v1/LMCache/lmcache/v1/storage_backend/remote_backend.py", line 147, in contains
(Worker_TP0_EP0 pid=133480)     return self.connection.exists_sync(key)
(Worker_TP0_EP0 pid=133480)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=133480)   File "/mnt/disk3/hlin76/v1/LMCache/lmcache/v1/storage_backend/connector/instrumented_connector.py", line 63, in exists_sync
(Worker_TP0_EP0 pid=133480)     return self._connector.exists_sync(key)
(Worker_TP0_EP0 pid=133480)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=133480)   File "/mnt/disk3/hlin76/v1/LMCache/lmcache/v1/storage_backend/connector/mooncakestore_connector.py", line 274, in exists_sync
(Worker_TP0_EP0 pid=133480)     return self.store.is_exist(key.to_string())
(Worker_TP0_EP0 pid=133480)                                ^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=133480)   File "/mnt/disk3/hlin76/v1/LMCache/lmcache/utils.py", line 397, in to_string
(Worker_TP0_EP0 pid=133480)     f"@{self.worker_id}@{self.chunk_hash:x}@{self._dtype_str}"
(Worker_TP0_EP0 pid=133480)                         ^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=133480) TypeError: unsupported format string passed to bytes.format

