### PR TITLE
[Core] enable lazy memory allocator by default in multi-process mode

### DIFF
--- a/lmcache/v1/multiprocess/mp_storage_manager.py
+++ b/lmcache/v1/multiprocess/mp_storage_manager.py
@@ -17,7 +17,13 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
-from lmcache.v1.memory_management import MemoryFormat, MemoryObj, MixedMemoryAllocator
+from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
+from lmcache.v1.memory_management import (
+    MemoryAllocatorInterface,
+    MemoryFormat,
+    MemoryObj,
+    MixedMemoryAllocator,
+)
 from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
 from lmcache.v1.storage_backend.cache_policy.lru import LRUCachePolicy
 
@@ -184,7 +190,7 @@ class LRUCachePolicyWithLock(LRUCachePolicy[IPCCacheEngineKey]):
 
 
 class MPStorageManager:
-    def __init__(self, cpu_buffer_size: float):
+    def __init__(self, cpu_buffer_size: float, disable_lazy_alloc: bool = False):
         """
         Args:
             cpu_buffer_size: the total size (in GB) of CPU memory buffer
@@ -197,8 +203,16 @@ class MPStorageManager:
 
         # Allocator for CPU memory (note: this will be moved to storage backend
         # implementation in the future)
+        self._memory_allocator: MemoryAllocatorInterface
         size_in_bytes = int(cpu_buffer_size * (1 << 30))  # Convert GB to bytes
-        self._memory_allocator = MixedMemoryAllocator(size_in_bytes)
+        if disable_lazy_alloc:
+            self._memory_allocator = MixedMemoryAllocator(size_in_bytes)
+        else:
+            init_size_in_bytes = min(20 << 30, size_in_bytes)  # 20 GB or total size
+            self._memory_allocator = LazyMemoryAllocator(
+                init_size_in_bytes, size_in_bytes
+            )
+
         self._allocator_lock = threading.Lock()
 
         # Reserved memory objects

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -24,6 +24,7 @@ import zmq
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.v1.gpu_connector import lmcache_memcpy_async_d2h, lmcache_memcpy_async_h2d
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey, KVCache
 from lmcache.v1.multiprocess.mp_storage_manager import MPStorageManager
@@ -206,7 +207,12 @@ class GPUCacheContext:
 
 
 class MPCacheEngine:
-    def __init__(self, chunk_size: int = 256, cpu_buffer_size: float = 5.0):
+    def __init__(
+        self,
+        chunk_size: int = 256,
+        cpu_buffer_size: float = 5.0,
+        disable_lazy_alloc: bool = False,
+    ):
         # GPU ID -> KV cache tensors
         self.gpu_contexts: dict[int, GPUCacheContext] = {}
 
@@ -217,7 +223,7 @@ class MPCacheEngine:
         self.lock = threading.Lock()
 
         # storage manager
-        self.storage_manager = MPStorageManager(cpu_buffer_size)
+        self.storage_manager = MPStorageManager(cpu_buffer_size, disable_lazy_alloc)
 
     def register_kv_cache(self, instance_id: int, kv_caches: KVCache) -> None:
         """
@@ -325,7 +331,7 @@ class MPCacheEngine:
                     )
 
                     assert memory_obj.tensor is not None
-                    memory_obj.tensor.copy_(tmp_buffer, non_blocking=True)
+                    lmcache_memcpy_async_d2h(tmp_buffer, memory_obj)
 
             event.record()
 
@@ -391,8 +397,7 @@ class MPCacheEngine:
                 # Copy from CPU to GPU
                 tmp_gpu_buffer_ = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
                 with self.lock:
-                    tmp_gpu_buffer_.copy_(memory_obj.tensor, non_blocking=True)
-
+                    lmcache_memcpy_async_h2d(memory_obj, tmp_gpu_buffer_)
                     lmc_ops.multi_layer_kv_transfer(
                         # memory_obj.tensor,
                         tmp_gpu_buffer_,
@@ -511,9 +516,10 @@ def run_cache_server(
     chunk_size: int = 256,
     cpu_buffer_size: float = 5.0,
     max_workers: int = 1,
+    disable_lazy_alloc: bool = False,
 ):
     # Initialize the engine
-    engine = MPCacheEngine(chunk_size, cpu_buffer_size)
+    engine = MPCacheEngine(chunk_size, cpu_buffer_size, disable_lazy_alloc)
 
     # Initialize the message queue server
     context = zmq.Context.instance()
@@ -564,6 +570,10 @@ def parse_args():
     parser.add_argument(
         "--max-workers", type=int, default=1, help="Maximum number of worker threads"
     )
+
+    parser.add_argument(
+        "--disable-lazy-alloc", action="store_true", help="Disable lazy allocation"
+    )
     return parser.parse_args()
 
 
@@ -575,4 +585,5 @@ if __name__ == "__main__":
         chunk_size=args.chunk_size,
         cpu_buffer_size=args.cpu_buffer_size,
         max_workers=args.max_workers,
+        disable_lazy_alloc=args.disable_lazy_alloc,
     )

--- a/tests/v1/multiprocess/test_mp_storage_manager.py
+++ b/tests/v1/multiprocess/test_mp_storage_manager.py
@@ -20,7 +20,10 @@ from lmcache.v1.multiprocess.mp_storage_manager import (
 @pytest.fixture
 def storage_manager():
     """Create a storage manager with 1GB buffer for testing."""
-    manager = MPStorageManager(cpu_buffer_size=1.0)
+    disable_lazy_alloc = True if not torch.cuda.is_available() else False
+    manager = MPStorageManager(
+        cpu_buffer_size=1.0, disable_lazy_alloc=disable_lazy_alloc
+    )
     yield manager
     # Cleanup after test
     manager.close()
@@ -29,7 +32,11 @@ def storage_manager():
 @pytest.fixture
 def small_storage_manager():
     """Create a storage manager with very small buffer to test memory exhaustion."""
-    manager = MPStorageManager(cpu_buffer_size=0.0625)  # 64MB
+    disable_lazy_alloc = True if not torch.cuda.is_available() else False
+    manager = MPStorageManager(
+        cpu_buffer_size=0.0625,  # 64MB
+        disable_lazy_alloc=disable_lazy_alloc,
+    )
     yield manager
     # Cleanup after test
     manager.close()

--- a/tests/v1/multiprocess/test_mp_storage_manager.py
+++ b/tests/v1/multiprocess/test_mp_storage_manager.py
@@ -16,11 +16,16 @@ from lmcache.v1.multiprocess.mp_storage_manager import (
 )
 
 
+def should_disable_lazy_alloc():
+    """Determine if lazy allocation should be disabled based on CUDA availability."""
+    return True if not torch.cuda.is_available() else False
+
+
 # Fixtures
 @pytest.fixture
 def storage_manager():
     """Create a storage manager with 1GB buffer for testing."""
-    disable_lazy_alloc = True if not torch.cuda.is_available() else False
+    disable_lazy_alloc = should_disable_lazy_alloc()
     manager = MPStorageManager(
         cpu_buffer_size=1.0, disable_lazy_alloc=disable_lazy_alloc
     )
@@ -32,7 +37,7 @@ def storage_manager():
 @pytest.fixture
 def small_storage_manager():
     """Create a storage manager with very small buffer to test memory exhaustion."""
-    disable_lazy_alloc = True if not torch.cuda.is_available() else False
+    disable_lazy_alloc = should_disable_lazy_alloc()
     manager = MPStorageManager(
         cpu_buffer_size=0.0625,  # 64MB
         disable_lazy_alloc=disable_lazy_alloc,
@@ -70,7 +75,9 @@ def test_format():
 class TestInit:
     def test_initialization(self):
         """Test that storage manager initializes correctly."""
-        manager = MPStorageManager(cpu_buffer_size=1.0)
+        manager = MPStorageManager(
+            cpu_buffer_size=1.0, disable_lazy_alloc=should_disable_lazy_alloc()
+        )
         assert manager is not None
         manager.close()
 
@@ -78,7 +85,9 @@ class TestInit:
         """Test initialization with various buffer sizes."""
         sizes = [0.1, 0.5, 1.0, 2.0]
         for size in sizes:
-            manager = MPStorageManager(cpu_buffer_size=size)
+            manager = MPStorageManager(
+                cpu_buffer_size=size, disable_lazy_alloc=should_disable_lazy_alloc()
+            )
             assert manager is not None
             manager.close()
 
@@ -500,12 +509,16 @@ class TestPrefetch:
 class TestClose:
     def test_close_basic(self):
         """Test that close can be called successfully."""
-        manager = MPStorageManager(cpu_buffer_size=0.5)
+        manager = MPStorageManager(
+            cpu_buffer_size=0.5, disable_lazy_alloc=should_disable_lazy_alloc()
+        )
         manager.close()
 
     def test_close_after_operations(self, test_keys, test_dtype, test_format):
         """Test that close works after performing operations."""
-        manager = MPStorageManager(cpu_buffer_size=1.0)
+        manager = MPStorageManager(
+            cpu_buffer_size=1.0, disable_lazy_alloc=should_disable_lazy_alloc()
+        )
         shape = torch.Size([2, 16, 16, 128])
 
         # Perform some operations

--- a/tests/v1/multiprocess/test_mp_storage_manager.py
+++ b/tests/v1/multiprocess/test_mp_storage_manager.py
@@ -29,7 +29,7 @@ def storage_manager():
 @pytest.fixture
 def small_storage_manager():
     """Create a storage manager with very small buffer to test memory exhaustion."""
-    manager = MPStorageManager(cpu_buffer_size=0.001)  # 1MB
+    manager = MPStorageManager(cpu_buffer_size=0.0625)  # 64MB
     yield manager
     # Cleanup after test
     manager.close()
@@ -200,8 +200,8 @@ class TestReserve:
         self, small_storage_manager, test_keys, test_shape, test_dtype, test_format
     ):
         # Try to reserve and commit a lot of small tensors (total size is large)
-        large_shape = torch.Size([2, 50, 50, 256])  # Moderate size
-        small_shape = torch.Size([2, 5, 50, 256])  # Small size (1/10 of large)
+        large_shape = torch.Size([2, 50, 1500, 256])  # Moderate size
+        small_shape = torch.Size([2, 5, 1500, 256])  # Small size (1/10 of large)
 
         # First, reserve a single key with large shape should fail
         with pytest.raises(MemoryExhaustedError):
@@ -340,7 +340,7 @@ class TestLookup:
         self, small_storage_manager, test_keys, test_shape, test_dtype, test_format
     ):
         """Test that lookup locks the objects so they cannot be evicted."""
-        small_shape = torch.Size([2, 4, 50, 256])  # Small size
+        small_shape = torch.Size([2, 5, 1500, 256])  # Small size
         # Reserve and commit multiple small tensors to fill up memory
         target_keys = test_keys[:1]
         handle, _ = small_storage_manager.reserve(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Part of #2379 
This PR enables lazy memory allocator by default in multi-process mode, and also introduces a new flag to use the "non-lazy" allocator.

**This PR will be directly tested by multi-process mode testing**

