### PR TITLE
[CI/Build] P2P verbose log and add trim to long_doc_qa

### DIFF
--- a/.buildkite/scripts/vllm-integration-tests.sh
+++ b/.buildkite/scripts/vllm-integration-tests.sh
@@ -518,9 +518,11 @@ run_long_doc_qa() {
 
     # Check if baseline exists, skip comparisons if not
     if [[ -z "$baseline_json" ]] || ! echo "$baseline_json" | jq -e . >/dev/null 2>&1; then
-        echo "⚠️  No baseline found for $feature_type.json - skipping performance comparisons"
-        echo "   This is expected for newly added configs. Baseline will be generated on next nightly run."
-        echo "   Current metrics: TTFT=$query_ttft_per_prompt, Latency=$query_round_time_per_prompt, Warmup=$warmup_round_time_per_prompt"
+        if [[ "$feature_type" != "dummy" ]]; then
+            echo "⚠️  No baseline found for $feature_type.json - skipping performance comparisons"
+            echo "   This is expected for newly added configs. Baseline will be generated on next nightly run."
+            echo "   Current metrics: TTFT=$query_ttft_per_prompt, Latency=$query_round_time_per_prompt, Warmup=$warmup_round_time_per_prompt"
+        fi
         return 0
     fi
 

--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -56,6 +56,10 @@ Commandline arguments:
 
     --hit-miss-ratio: In query round, control how many of the prompts
     will miss the cache. For example, 3:1 means every fourth repeated prompt
+    will miss the cache. 2:2 means 2 hits and 2 misses.
+
+    --trim-fraction: Exclude the smallest X fraction and largest X fraction
+    and calculate mean of the rest. For example, 0.1 drops bottom 10% and top 10%.
 """
 
 # Standard
@@ -452,6 +456,28 @@ def visualize_results(warmup_df, benchmark_df):
     plot_bars(benchmark_df, "Query Round", "query_round.png")
 
 
+def trimmed_mean(series: pd.Series, trim_fraction: float) -> float:
+    """
+    Exclude the smallest trim_fraction and largest trim_fraction and take mean
+    of the rest. If trim_fraction <= 0, returns normal mean.
+    """
+    s = series.dropna()
+    if len(s) == 0:
+        return float("nan")
+    if trim_fraction <= 0:
+        return float(s.mean())
+
+    if not (0.0 <= trim_fraction < 0.5):
+        raise ValueError("--trim-fraction must be in [0, 0.5).")
+
+    s = s.sort_values()
+    n = len(s)
+    k = int(n * trim_fraction)
+    if n - 2 * k <= 0:
+        return float(s.mean())
+    return float(s.iloc[k : n - k].mean())
+
+
 async def main(args):
     random.seed(args.shuffle_seed)
 
@@ -533,18 +559,57 @@ async def main(args):
     benchmark_df.to_csv("query_round.csv", index=False)
 
     # Print results
-    warmup_mean_ttft = warmup_df.query("successful == True")["ttft"].mean()
-    query_mean_ttft = benchmark_df.query("successful == True")["ttft"].mean()
+    warmup_mean_ttft = trimmed_mean(
+        warmup_df.query("successful == True")["ttft"], args.trim_fraction
+    )
+    query_mean_ttft = trimmed_mean(
+        benchmark_df.query("successful == True")["ttft"], args.trim_fraction
+    )
+
     warmup_success_count = warmup_df.query("successful == True").shape[0]
     query_success_count = benchmark_df.query("successful == True").shape[0]
+
+    warmup_round_time_per_prompt = trimmed_mean(
+        (
+            warmup_df.query("successful == True")["request_end"]
+            - warmup_df.query("successful == True")["request_start"]
+        ),
+        args.trim_fraction,
+    )
+    query_round_time_per_prompt = trimmed_mean(
+        (
+            benchmark_df.query("successful == True")["request_end"]
+            - benchmark_df.query("successful == True")["request_start"]
+        ),
+        args.trim_fraction,
+    )
+
     CSI = "\x1b["
     RESET = CSI + "0m"
-    print(f"Warmup round mean TTFT: {warmup_mean_ttft:.3f}s")
+
+    if args.trim_fraction > 0:
+        print(
+            f"Warmup round trimmed mean TTFT (trim={args.trim_fraction:.2f}): "
+            f"{warmup_mean_ttft:.3f}s"
+        )
+    else:
+        print(f"Warmup round mean TTFT: {warmup_mean_ttft:.3f}s")
+
+    # Keep original wall-clock round time line (unchanged)
     print(f"Warmup round time: {warmup_end_time - warmup_start_time:.3f}s")
     print(f"Warmup round prompt count: {len(warmup_df)}")
     print(f"Warmup round successful prompt count: {warmup_success_count}")
     print(f"{CSI}36;1m\n=== BENCHMARK RESULTS ==={RESET}")
-    print(f"{CSI}32mQuery round mean TTFT: {query_mean_ttft:.3f}s{RESET}")
+
+    if args.trim_fraction > 0:
+        print(
+            f"{CSI}32mQuery round trimmed mean TTFT (trim={args.trim_fraction:.2f}): "
+            f"{query_mean_ttft:.3f}s{RESET}"
+        )
+    else:
+        print(f"{CSI}32mQuery round mean TTFT: {query_mean_ttft:.3f}s{RESET}")
+
+    # Keep original wall-clock round time line (unchanged)
     print(
         f"{CSI}33mQuery round time: "
         f"{benchmark_end_time - benchmark_start_time:.3f}s{RESET}"
@@ -556,10 +621,6 @@ async def main(args):
         visualize_results(warmup_df, benchmark_df)
 
     if args.json_output:
-        query_duration = benchmark_end_time - benchmark_start_time
-        query_round_time_per_prompt = query_duration / len(benchmark_df)
-        warmup_duration = warmup_end_time - warmup_start_time
-        warmup_round_time_per_prompt = warmup_duration / len(warmup_df)
         # Standard
         import json
 
@@ -710,6 +771,16 @@ def create_argument_parser():
         "--json-output",
         action="store_true",
         help="Print benchmark summary as a single JSON line to stdout.",
+    )
+
+    parser.add_argument(
+        "--trim-fraction",
+        type=float,
+        default=0.0,
+        help=(
+            "Exclude the smallest and largest fraction of successful samples "
+            "before averaging. Example: 0.1 drops bottom 10% and top 10%."
+        ),
     )
 
     return parser

--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -565,51 +565,16 @@ async def main(args):
     query_mean_ttft = trimmed_mean(
         benchmark_df.query("successful == True")["ttft"], args.trim_fraction
     )
-
     warmup_success_count = warmup_df.query("successful == True").shape[0]
     query_success_count = benchmark_df.query("successful == True").shape[0]
-
-    warmup_round_time_per_prompt = trimmed_mean(
-        (
-            warmup_df.query("successful == True")["request_end"]
-            - warmup_df.query("successful == True")["request_start"]
-        ),
-        args.trim_fraction,
-    )
-    query_round_time_per_prompt = trimmed_mean(
-        (
-            benchmark_df.query("successful == True")["request_end"]
-            - benchmark_df.query("successful == True")["request_start"]
-        ),
-        args.trim_fraction,
-    )
-
     CSI = "\x1b["
     RESET = CSI + "0m"
-
-    if args.trim_fraction > 0:
-        print(
-            f"Warmup round trimmed mean TTFT (trim={args.trim_fraction:.2f}): "
-            f"{warmup_mean_ttft:.3f}s"
-        )
-    else:
-        print(f"Warmup round mean TTFT: {warmup_mean_ttft:.3f}s")
-
-    # Keep original wall-clock round time line (unchanged)
+    print(f"Warmup round mean TTFT: {warmup_mean_ttft:.3f}s")
     print(f"Warmup round time: {warmup_end_time - warmup_start_time:.3f}s")
     print(f"Warmup round prompt count: {len(warmup_df)}")
     print(f"Warmup round successful prompt count: {warmup_success_count}")
     print(f"{CSI}36;1m\n=== BENCHMARK RESULTS ==={RESET}")
-
-    if args.trim_fraction > 0:
-        print(
-            f"{CSI}32mQuery round trimmed mean TTFT (trim={args.trim_fraction:.2f}): "
-            f"{query_mean_ttft:.3f}s{RESET}"
-        )
-    else:
-        print(f"{CSI}32mQuery round mean TTFT: {query_mean_ttft:.3f}s{RESET}")
-
-    # Keep original wall-clock round time line (unchanged)
+    print(f"{CSI}32mQuery round mean TTFT: {query_mean_ttft:.3f}s{RESET}")
     print(
         f"{CSI}33mQuery round time: "
         f"{benchmark_end_time - benchmark_start_time:.3f}s{RESET}"
@@ -621,6 +586,18 @@ async def main(args):
         visualize_results(warmup_df, benchmark_df)
 
     if args.json_output:
+        query_duration = (
+            benchmark_df.query("successful == True")["request_end"]
+            - benchmark_df.query("successful == True")["request_start"]
+        )
+        query_round_time_per_prompt = trimmed_mean(query_duration, args.trim_fraction)
+
+        warmup_duration = (
+            warmup_df.query("successful == True")["request_end"]
+            - warmup_df.query("successful == True")["request_start"]
+        )
+        warmup_round_time_per_prompt = trimmed_mean(warmup_duration, args.trim_fraction)
+
         # Standard
         import json
 

--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -586,17 +586,10 @@ async def main(args):
         visualize_results(warmup_df, benchmark_df)
 
     if args.json_output:
-        query_duration = (
-            benchmark_df.query("successful == True")["request_end"]
-            - benchmark_df.query("successful == True")["request_start"]
-        )
-        query_round_time_per_prompt = trimmed_mean(query_duration, args.trim_fraction)
-
-        warmup_duration = (
-            warmup_df.query("successful == True")["request_end"]
-            - warmup_df.query("successful == True")["request_start"]
-        )
-        warmup_round_time_per_prompt = trimmed_mean(warmup_duration, args.trim_fraction)
+        query_duration = benchmark_end_time - benchmark_start_time
+        query_round_time_per_prompt = query_duration / len(benchmark_df)
+        warmup_duration = warmup_end_time - warmup_start_time
+        warmup_round_time_per_prompt = warmup_duration / len(warmup_df)
 
         # Standard
         import json

--- a/benchmarks/long_doc_qa/long_doc_qa.py
+++ b/benchmarks/long_doc_qa/long_doc_qa.py
@@ -590,7 +590,6 @@ async def main(args):
         query_round_time_per_prompt = query_duration / len(benchmark_df)
         warmup_duration = warmup_end_time - warmup_start_time
         warmup_round_time_per_prompt = warmup_duration / len(warmup_df)
-
         # Standard
         import json
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Only minor changes.

**What this PR does / why we need it**:
1. Make the P2P first engine logs more verbose.

Previously, the logs looked like this:

<img alt="image" src="https://github.com/user-attachments/assets/e2966b07-4d93-4e76-9564-ddb1686a8d7c" width="700"/>

This is not correct. In the P2P test case, only the second engine is used for performance measurement. Therefore, the first engine is not expected to have any baselines to compare against, and its logs should not raise a warning.

2. Add a trim option for calculating the mean TTFT.

Currently, we compute the round time as the total elapsed time divided by the number of requests. This is not equivalent to taking the mean of per-round times. As a result, trimming does not work for the round-time-per-prompt metric.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
