### PR TITLE
[Northbound 1/N]: Clean up LMCacheMetadata

### DIFF
--- a/docs/source/kv_cache/storage_backends/redis.rst
+++ b/docs/source/kv_cache/storage_backends/redis.rst
@@ -297,9 +297,9 @@ LMCache stores data in Redis using a structured key format. Each key contains th
 
 .. code-block:: text
 
-    format@model_name@world_size@worker_id@chunk_hash
+    use_case@model_name@world_size@worker_id@chunk_hash
 
-- `format`: The model format (e.g., "vllm" or "huggingface")
+- `use_case`: The use case of the model (e.g., "vllm" or "huggingface" or "sglang" or "standalone")
 - `model_name`: Name of the language model
 - `world_size`: Total number of workers in distributed deployment
 - `worker_id`: ID of the worker that created this cache entry

--- a/docs/source/kv_cache/storage_backends/redis.rst
+++ b/docs/source/kv_cache/storage_backends/redis.rst
@@ -297,12 +297,11 @@ LMCache stores data in Redis using a structured key format. Each key contains th
 
 .. code-block:: text
 
-    use_case@model_name@world_size@worker_id@chunk_hash
+    model_name@world_size@worker_id@chunk_hash
 
-- `use_case`: The use case of the model (e.g., "vllm" or "huggingface" or "sglang" or "standalone")
 - `model_name`: Name of the language model
 - `world_size`: Total number of workers in distributed deployment
-- `worker_id`: ID of the worker that created this cache entry
+- `worker_id`: ID of the worker that created this cache entry, in the range of [0, world_size - 1]
 - `chunk_hash`: Hash of the token chunk (SHA-256 based)
 
 For example, a typical key might look like:

--- a/examples/kubernetes/health_probe.py
+++ b/examples/kubernetes/health_probe.py
@@ -40,7 +40,6 @@ def main():
             msg = ClientMetaMessage(
                 ClientCommand.HEALTH,
                 key=CacheEngineKey(
-                    use_case="",
                     model_name="",
                     world_size=0,
                     worker_id=0,

--- a/examples/kubernetes/health_probe.py
+++ b/examples/kubernetes/health_probe.py
@@ -40,7 +40,7 @@ def main():
             msg = ClientMetaMessage(
                 ClientCommand.HEALTH,
                 key=CacheEngineKey(
-                    fmt="",
+                    use_case="",
                     model_name="",
                     world_size=0,
                     worker_id=0,

--- a/examples/redis_lookup/README.md
+++ b/examples/redis_lookup/README.md
@@ -78,11 +78,10 @@ docker run --runtime nvidia --gpus all \
 LMCache stores data in Redis using a structured key format. Each key contains the following information in a delimited format:
 
 ```
-use_case@model_name@world_size@worker_id@chunk_hash
+model_name@world_size@worker_id@chunk_hash
 ```
 
 Where:
-- `use_case`: The use case (e.g., "vllm" or "huggingface" or "sglang" or "standalone")
 - `model_name`: Name of the language model
 - `world_size`: Total number of workers in distributed deployment
 - `worker_id`: ID of the worker that created this cache entry

--- a/examples/redis_lookup/README.md
+++ b/examples/redis_lookup/README.md
@@ -78,11 +78,11 @@ docker run --runtime nvidia --gpus all \
 LMCache stores data in Redis using a structured key format. Each key contains the following information in a delimited format:
 
 ```
-format@model_name@world_size@worker_id@chunk_hash
+use_case@model_name@world_size@worker_id@chunk_hash
 ```
 
 Where:
-- `format`: The model format (e.g., "vllm" or "huggingface")
+- `use_case`: The use case (e.g., "vllm" or "huggingface" or "sglang" or "standalone")
 - `model_name`: Name of the language model
 - `world_size`: Total number of workers in distributed deployment
 - `worker_id`: ID of the worker that created this cache entry

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -1,106 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from dataclasses import dataclass, field
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import Tuple
 
 # Third Party
 import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 
 logger = init_logger(__name__)
-
-
-@dataclass
-class LMCacheMetadata:
-    """
-    LMCacheMetadata should be extracted from the northbound
-    serving engine configuration
-    """
-
-    """name of the LLM model"""
-    model_name: str
-    """ world size when running under a distributed setting """
-    world_size: int
-    """ worker id when running under a distributed setting """
-    worker_id: int
-    """ the data type of kv tensors """
-    # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
-    kv_dtype: torch.dtype
-    """ the shape of kv tensors """
-    # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
-    """ (num_layer, 2, chunk_size, num_kv_head, head_size) """
-    kv_shape: tuple[int, int, int, int, int]
-    """ use case of LMCache (vllm, sglang, standalone, etc.) """
-    use_case: str = "vllm"
-    """ whether use MLA"""
-    use_mla: bool = False
-    """ the role of the current instance (e.g., 'scheduler', 'worker') """
-    role: Optional[str] = None
-    """ the first rank of the distributed setting """
-    # TODO(baoloongmao): first_rank should be configurable
-    first_rank = 0
-    served_model_name: Optional[str] = None
-    """chunk size"""
-    chunk_size: int = 256
-    """ Manager for groups of layers with identical KV cache structure """
-    kv_layer_groups_manager: KVLayerGroupsManager = field(
-        default_factory=KVLayerGroupsManager
-    )
-    """ engine_id for RPC path (used by lookup client/server) """
-    engine_id: Optional[str] = None
-    """ extra config from kv_connector (e.g., lmcache_rpc_port) """
-    kv_connector_extra_config: Optional[dict] = None
-
-    def is_first_rank(self) -> bool:
-        """Check if the current worker is the first rank"""
-        return self.worker_id == self.first_rank
-
-    # TODO(chunxiaozheng): some uts do not `build_kv_layer_groups`
-    def get_dtypes(self) -> list[torch.dtype]:
-        if self.kv_layer_groups_manager.kv_layer_groups:
-            return [
-                group.dtype for group in self.kv_layer_groups_manager.kv_layer_groups
-            ]
-        return [self.kv_dtype]
-
-    def get_shapes(self, num_tokens: Optional[int] = None) -> list[torch.Size]:
-        """Get the shapes of the KV cache in LMCache"""
-        if num_tokens is None:
-            num_tokens = self.chunk_size
-        if self.kv_layer_groups_manager.kv_layer_groups:
-            shapes = []
-            kv_size = 1 if self.use_mla else 2
-            for group in self.kv_layer_groups_manager.kv_layer_groups:
-                shapes.append(
-                    torch.Size(
-                        [
-                            kv_size,
-                            group.num_layers,
-                            num_tokens,
-                            group.hidden_dim_size,
-                        ]
-                    )
-                )
-            return shapes
-        else:
-            return [
-                torch.Size(
-                    [
-                        self.kv_shape[1],
-                        self.kv_shape[0],
-                        num_tokens,
-                        self.kv_shape[3] * self.kv_shape[4],
-                    ]
-                )
-            ]
-
-    def get_num_groups(self) -> int:
-        if self.kv_layer_groups_manager.kv_layer_groups:
-            return self.kv_layer_groups_manager.num_groups
-        return 1
 
 
 @dataclass

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -14,9 +14,9 @@ logger = init_logger(__name__)
 
 
 @dataclass
-class LMCacheEngineMetadata:
+class LMCacheMetadata:
     """
-    LMCacheEngineMetadata should be extracted from the northbound
+    LMCacheMetadata should be extracted from the northbound
     serving engine configuration
     """
 
@@ -105,7 +105,7 @@ class LMCacheEngineMetadata:
 
 @dataclass
 class LMCacheMemPoolMetadata:
-    """Subset of `LMCacheEngineMetadata` to initialize MemPool"""
+    """Subset of `LMCacheMetadata` to initialize MemPool"""
 
     kv_shape: Tuple[int, int, int, int, int]
     kv_dtype: torch.dtype

--- a/lmcache/config.py
+++ b/lmcache/config.py
@@ -15,15 +15,17 @@ logger = init_logger(__name__)
 
 @dataclass
 class LMCacheEngineMetadata:
-    """name of the LLM model"""
+    """
+    LMCacheEngineMetadata should be extracted from the northbound
+    serving engine configuration
+    """
 
+    """name of the LLM model"""
     model_name: str
     """ world size when running under a distributed setting """
     world_size: int
     """ worker id when running under a distributed setting """
     worker_id: int
-    """ the format of kv tensors """
-    fmt: str
     """ the data type of kv tensors """
     # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
     kv_dtype: torch.dtype
@@ -31,6 +33,8 @@ class LMCacheEngineMetadata:
     # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
     """ (num_layer, 2, chunk_size, num_kv_head, head_size) """
     kv_shape: tuple[int, int, int, int, int]
+    """ use case of LMCache (vllm, sglang, standalone, etc.) """
+    use_case: str = "vllm"
     """ whether use MLA"""
     use_mla: bool = False
     """ the role of the current instance (e.g., 'scheduler', 'worker') """
@@ -47,8 +51,6 @@ class LMCacheEngineMetadata:
     )
     """ engine_id for RPC path (used by lookup client/server) """
     engine_id: Optional[str] = None
-    """ total number of ranks (tensor_parallel_size * pipeline_parallel_size) """
-    num_ranks: int = 1
     """ extra config from kv_connector (e.g., lmcache_rpc_port) """
     kv_connector_extra_config: Optional[dict] = None
 

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -87,7 +87,9 @@ def init_lmcache_engine(
     metadata = LMCacheMetadata(
         model_name=model_config.model_path,
         world_size=tp_size,
+        local_world_size=tp_size,
         worker_id=global_rank,
+        local_worker_id=local_rank,
         use_case="sglang",
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -90,7 +90,6 @@ def init_lmcache_engine(
         local_world_size=tp_size,
         worker_id=global_rank,
         local_worker_id=local_rank,
-        use_case="sglang",
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,
     )

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -10,7 +10,7 @@ import torch
 import torch.distributed as dist
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.integration.sglang.utils import ENGINE_NAME, lmcache_get_config
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
@@ -84,13 +84,13 @@ def init_lmcache_engine(
     torch.cuda.device(local_rank)
     device = torch.device(f"cuda:{local_rank}")
     # Use global rank for metadata (tensor parallel rank)
-    metadata = LMCacheEngineMetadata(
-        model_config.model_path,
-        tp_size,
-        global_rank,
-        "sgl",
-        kv_dtype,
-        kv_shape,
+    metadata = LMCacheMetadata(
+        model_name=model_config.model_path,
+        world_size=tp_size,
+        worker_id=global_rank,
+        use_case="sglang",
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
     )
 
     use_gpu = need_gpu_interm_buffer(config)

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -10,7 +10,6 @@ import torch
 import torch.distributed as dist
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.integration.sglang.utils import ENGINE_NAME, lmcache_get_config
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
@@ -21,6 +20,7 @@ from lmcache.v1.gpu_connector import (
     SGLangGPUConnector,
     SGLangLayerwiseGPUConnector,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -216,7 +216,6 @@ def create_lmcache_metadata(
             )
 
     # Create metadata
-    num_ranks = parallel_cfg.tensor_parallel_size * parallel_cfg.pipeline_parallel_size
     metadata = LMCacheEngineMetadata(
         model_cfg.model,
         parallel_cfg.world_size,
@@ -228,7 +227,6 @@ def create_lmcache_metadata(
         role,
         served_model_name=model_cfg.served_model_name,
         engine_id=engine_id,
-        num_ranks=num_ranks,
         kv_connector_extra_config=kv_connector_extra_config,
     )
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -217,14 +217,14 @@ def create_lmcache_metadata(
 
     # Create metadata
     metadata = LMCacheMetadata(
-        model_cfg.model,
-        parallel_cfg.world_size,
-        parallel_cfg.rank,
-        "vllm",
-        kv_dtype,
-        kv_shape,
-        use_mla,
-        role,
+        model_name=model_cfg.model,
+        world_size=parallel_cfg.world_size,
+        worker_id=parallel_cfg.rank,
+        use_case="vllm",
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
+        use_mla=use_mla,
+        role=role,
         served_model_name=model_cfg.served_model_name,
         engine_id=engine_id,
         kv_connector_extra_config=kv_connector_extra_config,

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -222,7 +222,6 @@ def create_lmcache_metadata(
         local_world_size=parallel_cfg.world_size,
         worker_id=parallel_cfg.rank,
         local_worker_id=parallel_cfg.rank,
-        use_case="vllm",
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,
         use_mla=use_mla,

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -154,7 +154,7 @@ def create_lmcache_metadata(
     role=None,
 ):
     """
-    Create LMCacheEngineMetadata from vLLM configuration.
+    Create LMCacheMetadata from vLLM configuration.
 
     This function extracts common metadata creation logic that was duplicated
     across multiple files.
@@ -167,7 +167,7 @@ def create_lmcache_metadata(
         cache_config: Cache configuration (alternative to vllm_config)
 
     Returns:
-        tuple: (LMCacheEngineMetadata, LMCacheEngineConfig)
+        tuple: (LMCacheMetadata, LMCacheEngineConfig)
     """
     # Third Party
     # Try to import from old location before merged https://github.com/vllm-project/vllm/pull/26908
@@ -178,7 +178,7 @@ def create_lmcache_metadata(
         # Third Party
         from vllm.utils import get_kv_cache_torch_dtype
     # First Party
-    from lmcache.config import LMCacheEngineMetadata
+    from lmcache.config import LMCacheMetadata
 
     config = lmcache_get_or_create_config()
     # Support both vllm_config object and individual config parameters
@@ -216,7 +216,7 @@ def create_lmcache_metadata(
             )
 
     # Create metadata
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_cfg.model,
         parallel_cfg.world_size,
         parallel_cfg.rank,

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -178,7 +178,7 @@ def create_lmcache_metadata(
         # Third Party
         from vllm.utils import get_kv_cache_torch_dtype
     # First Party
-    from lmcache.config import LMCacheMetadata
+    from lmcache.v1.metadata import LMCacheMetadata
 
     config = lmcache_get_or_create_config()
     # Support both vllm_config object and individual config parameters

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -219,7 +219,9 @@ def create_lmcache_metadata(
     metadata = LMCacheMetadata(
         model_name=model_cfg.model,
         world_size=parallel_cfg.world_size,
+        local_world_size=parallel_cfg.world_size,
         worker_id=parallel_cfg.rank,
+        local_worker_id=parallel_cfg.rank,
         use_case="vllm",
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -11,7 +11,7 @@ from prometheus_client import REGISTRY
 import prometheus_client
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.usage_context import ContinuousUsageContext
 from lmcache.utils import thread_safe
@@ -605,7 +605,7 @@ class PrometheusLogger:
     _counter_cls = prometheus_client.Counter
     _histogram_cls = prometheus_client.Histogram
 
-    def __init__(self, metadata: LMCacheEngineMetadata):
+    def __init__(self, metadata: LMCacheMetadata):
         # Ensure PROMETHEUS_MULTIPROC_DIR is set before any metric registration
         if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
             default_dir = "/tmp/lmcache_prometheus"
@@ -1345,7 +1345,7 @@ class PrometheusLogger:
         )
 
     @staticmethod
-    def _metadata_to_labels(metadata: LMCacheEngineMetadata):
+    def _metadata_to_labels(metadata: LMCacheMetadata):
         labels = {
             "model_name": metadata.model_name,
             "worker_id": metadata.worker_id,
@@ -1358,7 +1358,7 @@ class PrometheusLogger:
     _instance = None
 
     @staticmethod
-    def GetOrCreate(metadata: LMCacheEngineMetadata) -> "PrometheusLogger":
+    def GetOrCreate(metadata: LMCacheMetadata) -> "PrometheusLogger":
         if PrometheusLogger._instance is None:
             PrometheusLogger._instance = PrometheusLogger(metadata)
         # assert PrometheusLogger._instance.metadata == metadata, \
@@ -1388,7 +1388,7 @@ class PrometheusLogger:
 
 
 class LMCacheStatsLogger:
-    def __init__(self, metadata: LMCacheEngineMetadata, log_interval: int):
+    def __init__(self, metadata: LMCacheMetadata, log_interval: int):
         self.metadata = metadata
         self.log_interval = log_interval
         self.monitor = LMCStatsMonitor.GetOrCreate()

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -11,10 +11,10 @@ from prometheus_client import REGISTRY
 import prometheus_client
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.usage_context import ContinuousUsageContext
 from lmcache.utils import thread_safe
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/storage_backend/serde/cachegen_decoder.py
+++ b/lmcache/storage_backend/serde/cachegen_decoder.py
@@ -128,7 +128,6 @@ class CacheGenDeserializer(Deserializer):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
         self.output_buffer: Optional[torch.Tensor] = None
-        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 
@@ -202,14 +201,11 @@ class CacheGenDeserializer(Deserializer):
                 encoder_output.head_size,
             )
         )
-        match self.use_case:
-            case "vllm":
-                return blob.permute((1, 0, 2, 3, 4)).to(
-                    self.dtype
-                )  # [nlayers, 2, ntokens, num_heads, head_size]
-            case "huggingface":
-                return blob.permute((1, 0, 3, 2, 4)).to(
-                    self.dtype
-                )  # [nlayers, 2, num_heads, ntokens, head_size]
-            case _:
-                raise RuntimeError("Unknown use case %s" % self.use_case)
+
+        return blob.permute((1, 0, 2, 3, 4)).to(
+            self.dtype
+        )  # [nlayers, 2, ntokens, num_heads, head_size]
+        # huggingface
+        # return blob.permute((1, 0, 3, 2, 4)).to(
+        #     self.dtype
+        # )  # [nlayers, 2, num_heads, ntokens, head_size]

--- a/lmcache/storage_backend/serde/cachegen_decoder.py
+++ b/lmcache/storage_backend/serde/cachegen_decoder.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_basics import (
     CacheGenConfig,
@@ -121,7 +121,7 @@ class CacheGenDeserializer(Deserializer):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         dtype,
     ):
         self.dtype = dtype

--- a/lmcache/storage_backend/serde/cachegen_decoder.py
+++ b/lmcache/storage_backend/serde/cachegen_decoder.py
@@ -6,7 +6,6 @@ from typing import List, Optional
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_basics import (
     CacheGenConfig,
@@ -16,6 +15,7 @@ from lmcache.storage_backend.serde.cachegen_basics import (
 from lmcache.storage_backend.serde.serde import Deserializer
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 if torch.cuda.is_available():
     import lmcache.c_ops as lmc_ops

--- a/lmcache/storage_backend/serde/cachegen_decoder.py
+++ b/lmcache/storage_backend/serde/cachegen_decoder.py
@@ -128,7 +128,7 @@ class CacheGenDeserializer(Deserializer):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
         self.output_buffer: Optional[torch.Tensor] = None
-        self.fmt = metadata.fmt
+        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 
@@ -202,7 +202,7 @@ class CacheGenDeserializer(Deserializer):
                 encoder_output.head_size,
             )
         )
-        match self.fmt:
+        match self.use_case:
             case "vllm":
                 return blob.permute((1, 0, 2, 3, 4)).to(
                     self.dtype
@@ -212,4 +212,4 @@ class CacheGenDeserializer(Deserializer):
                     self.dtype
                 )  # [nlayers, 2, num_heads, ntokens, head_size]
             case _:
-                raise RuntimeError("Unknown format %s" % self.fmt)
+                raise RuntimeError("Unknown use case %s" % self.use_case)

--- a/lmcache/storage_backend/serde/cachegen_encoder.py
+++ b/lmcache/storage_backend/serde/cachegen_encoder.py
@@ -6,7 +6,6 @@ from typing import Dict, Tuple
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_basics import (
     CacheGenConfig,
@@ -16,6 +15,7 @@ from lmcache.storage_backend.serde.cachegen_basics import (
 from lmcache.storage_backend.serde.serde import Serializer
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 if torch.cuda.is_available():
     import lmcache.c_ops as lmc_ops

--- a/lmcache/storage_backend/serde/cachegen_encoder.py
+++ b/lmcache/storage_backend/serde/cachegen_encoder.py
@@ -6,7 +6,7 @@ from typing import Dict, Tuple
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_basics import (
     CacheGenConfig,
@@ -340,7 +340,7 @@ def encode_function(
 
 
 class CacheGenSerializer(Serializer):
-    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
+    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
         self.use_case = metadata.use_case

--- a/lmcache/storage_backend/serde/cachegen_encoder.py
+++ b/lmcache/storage_backend/serde/cachegen_encoder.py
@@ -343,7 +343,6 @@ class CacheGenSerializer(Serializer):
     def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
-        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 
@@ -384,8 +383,8 @@ class CacheGenSerializer(Serializer):
 
         # TODO: permute is expensive here, need a better way to do it at lower
         # level
-        if self.use_case == "huggingface":
-            tensor = tensor.permute(0, 1, 3, 2, 4)
+        # huggingface:
+        # tensor = tensor.permute(0, 1, 3, 2, 4)
         """ expecting a tensor of shape 
         [num_layers, 2, num_tokens, num_heads, head_size] """
         ntokens = tensor.shape[2]

--- a/lmcache/storage_backend/serde/cachegen_encoder.py
+++ b/lmcache/storage_backend/serde/cachegen_encoder.py
@@ -343,7 +343,7 @@ class CacheGenSerializer(Serializer):
     def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
-        self.fmt = metadata.fmt
+        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 
@@ -384,7 +384,7 @@ class CacheGenSerializer(Serializer):
 
         # TODO: permute is expensive here, need a better way to do it at lower
         # level
-        if self.fmt == "huggingface":
+        if self.use_case == "huggingface":
             tensor = tensor.permute(0, 1, 3, 2, 4)
         """ expecting a tensor of shape 
         [num_layers, 2, num_tokens, num_heads, head_size] """

--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -81,7 +81,7 @@ class EngineMessage:
         self.model_name = metadata.model_name
         self.world_size = metadata.world_size
         self.worker_id = metadata.worker_id
-        self.fmt = metadata.fmt
+        self.use_case = metadata.use_case
         self.kv_dtype = metadata.kv_dtype
         self.kv_shape = metadata.kv_shape
 

--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -18,10 +18,10 @@ import requests
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.connections import global_http_connection
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 if TYPE_CHECKING:
     # First Party

--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -81,7 +81,6 @@ class EngineMessage:
         self.model_name = metadata.model_name
         self.world_size = metadata.world_size
         self.worker_id = metadata.worker_id
-        self.use_case = metadata.use_case
         self.kv_dtype = metadata.kv_dtype
         self.kv_shape = metadata.kv_shape
 

--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -18,7 +18,7 @@ import requests
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.connections import global_http_connection
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
@@ -67,7 +67,7 @@ class EnvMessage:
 
 
 class EngineMessage:
-    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
+    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         self.chunksize = config.chunk_size
         self.local_device = "cpu" if config.local_cpu else "cuda"
         self.max_local_cache_size = int(config.max_local_cpu_size)
@@ -106,7 +106,7 @@ class UsageContext:
         self,
         server_url: str,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         local_log: Optional[str] = None,
     ):
         self.server_url = server_url
@@ -286,7 +286,7 @@ class UsageContext:
 class ContinuousUsageContext:
     _instance = None
 
-    def __init__(self, metadata: LMCacheEngineMetadata):
+    def __init__(self, metadata: LMCacheMetadata):
         self.cache_lifespan_buckets = [
             0,
             1,
@@ -304,7 +304,7 @@ class ContinuousUsageContext:
             2500,
             5000,
         ]
-        self.metadata: LMCacheEngineMetadata = metadata
+        self.metadata: LMCacheMetadata = metadata
         self.cache_usage_url: str = urljoin(
             os.getenv("LMCACHE_USAGE_TRACK_URL", "http://stats.lmcache.ai:8080"),
             "cache-usage",
@@ -329,7 +329,7 @@ class ContinuousUsageContext:
         self.cache_lifespan_data: List[float] = []
 
     @staticmethod
-    def GetOrCreate(metadata: LMCacheEngineMetadata) -> "ContinuousUsageContext":
+    def GetOrCreate(metadata: LMCacheMetadata) -> "ContinuousUsageContext":
         if ContinuousUsageContext._instance is None:
             ContinuousUsageContext._instance = ContinuousUsageContext(metadata)
         if ContinuousUsageContext._instance.metadata != metadata:
@@ -400,7 +400,7 @@ class ContinuousUsageContext:
 
 def InitializeUsageContext(
     config: LMCacheEngineConfig,
-    metadata: LMCacheEngineMetadata,
+    metadata: LMCacheMetadata,
     local_log: Optional[str] = None,
 ):
     server_url = urljoin(

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -318,7 +318,7 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
 
     Args:
         key_str: String in format:
-            fmt@model@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
+            use_case@model@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
 
     Returns:
         CacheEngineKey if no layer_id, LayerCacheEngineKey if valid layer_id
@@ -331,7 +331,7 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
 
 @dataclass(slots=True)
 class CacheEngineKey:
-    fmt: str
+    use_case: str
     model_name: str
     world_size: int
     worker_id: int
@@ -358,7 +358,7 @@ class CacheEngineKey:
     def __hash__(self):
         return hash(
             (
-                self.fmt,
+                self.use_case,
                 self.model_name,
                 self.world_size,
                 self.worker_id,
@@ -371,7 +371,7 @@ class CacheEngineKey:
     def __eq__(self, other):
         if type(self) is type(other):
             return (
-                self.fmt == other.fmt
+                self.use_case == other.use_case
                 and self.model_name == other.model_name
                 and self.world_size == other.world_size
                 and self.worker_id == other.worker_id
@@ -384,7 +384,7 @@ class CacheEngineKey:
 
     def to_string(self):
         s = (
-            f"{self.fmt}@{self.model_name}@{self.world_size}"
+            f"{self.use_case}@{self.model_name}@{self.world_size}"
             f"@{self.worker_id}@{self.chunk_hash_hex}@{self._dtype_str}"
         )
         if self.tags is not None and len(self.tags) != 0:
@@ -398,7 +398,7 @@ class CacheEngineKey:
         for layer_id in range(num_layers):
             keys.append(
                 LayerCacheEngineKey(
-                    self.fmt,
+                    self.use_case,
                     self.model_name,
                     self.world_size,
                     self.worker_id,
@@ -413,7 +413,7 @@ class CacheEngineKey:
     def get_first_layer(self) -> "LayerCacheEngineKey":
         """Return the key for the first layer"""
         key = LayerCacheEngineKey(
-            self.fmt,
+            self.use_case,
             self.model_name,
             self.world_size,
             self.worker_id,
@@ -451,7 +451,7 @@ class CacheEngineKey:
         # Note(Kuntai): this is used for serializing CacheEngineKey via msgpack.
         msg = {
             "__type__": "CacheEngineKey",
-            "fmt": self.fmt,
+            "use_case": self.use_case,
             "model_name": self.model_name,
             "world_size": self.world_size,
             "worker_id": self.worker_id,
@@ -475,7 +475,7 @@ class CacheEngineKey:
                     raise ValueError(f"Invalid key dict: {d}")
                 request_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
-            fmt=d["fmt"],
+            use_case=d["use_case"],
             model_name=d["model_name"],
             world_size=d["world_size"],
             worker_id=d["worker_id"],
@@ -487,7 +487,7 @@ class CacheEngineKey:
     def with_new_worker_id(self, new_worker_id: int) -> "CacheEngineKey":
         # Reconstruct the cache engine key with new worker id
         return CacheEngineKey(
-            self.fmt,
+            self.use_case,
             self.model_name,
             self.world_size,
             new_worker_id,
@@ -512,7 +512,7 @@ class LayerCacheEngineKey(CacheEngineKey):
     def __hash__(self):
         return hash(
             (
-                self.fmt,
+                self.use_case,
                 self.model_name,
                 self.world_size,
                 self.worker_id,
@@ -531,7 +531,7 @@ class LayerCacheEngineKey(CacheEngineKey):
 
     def to_string(self):
         s = (
-            f"{self.fmt}@{self.model_name}@{self.world_size}"
+            f"{self.use_case}@{self.model_name}@{self.world_size}"
             f"@{self.worker_id}@{self.chunk_hash_hex}@{self._dtype_str}@{self.layer_id}"
         )
         if self.tags is not None and len(self.tags) != 0:
@@ -545,7 +545,7 @@ class LayerCacheEngineKey(CacheEngineKey):
         for layer_id in range(num_layers):
             keys.append(
                 LayerCacheEngineKey(
-                    self.fmt,
+                    self.use_case,
                     self.model_name,
                     self.world_size,
                     self.worker_id,

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -318,20 +318,19 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
 
     Args:
         key_str: String in format:
-            use_case@model@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
+            model_name@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
 
     Returns:
         CacheEngineKey if no layer_id, LayerCacheEngineKey if valid layer_id
     """
     parts = key_str.strip().split("@")
-    if len(parts) >= 6 and parts[5].isdigit():
+    if len(parts) >= 5 and parts[4].isdigit():
         return LayerCacheEngineKey.from_string(key_str)
     return CacheEngineKey.from_string(key_str)
 
 
 @dataclass(slots=True)
 class CacheEngineKey:
-    use_case: str
     model_name: str
     world_size: int
     worker_id: int
@@ -358,7 +357,6 @@ class CacheEngineKey:
     def __hash__(self):
         return hash(
             (
-                self.use_case,
                 self.model_name,
                 self.world_size,
                 self.worker_id,
@@ -371,8 +369,7 @@ class CacheEngineKey:
     def __eq__(self, other):
         if type(self) is type(other):
             return (
-                self.use_case == other.use_case
-                and self.model_name == other.model_name
+                self.model_name == other.model_name
                 and self.world_size == other.world_size
                 and self.worker_id == other.worker_id
                 and self.chunk_hash == other.chunk_hash
@@ -384,7 +381,7 @@ class CacheEngineKey:
 
     def to_string(self):
         s = (
-            f"{self.use_case}@{self.model_name}@{self.world_size}"
+            f"{self.model_name}@{self.world_size}"
             f"@{self.worker_id}@{self.chunk_hash_hex}@{self._dtype_str}"
         )
         if self.tags is not None and len(self.tags) != 0:
@@ -398,7 +395,6 @@ class CacheEngineKey:
         for layer_id in range(num_layers):
             keys.append(
                 LayerCacheEngineKey(
-                    self.use_case,
                     self.model_name,
                     self.world_size,
                     self.worker_id,
@@ -413,7 +409,6 @@ class CacheEngineKey:
     def get_first_layer(self) -> "LayerCacheEngineKey":
         """Return the key for the first layer"""
         key = LayerCacheEngineKey(
-            self.use_case,
             self.model_name,
             self.world_size,
             self.worker_id,
@@ -427,23 +422,22 @@ class CacheEngineKey:
     @staticmethod
     def from_string(s):
         parts = s.split("@")
-        if len(parts) < 6:
+        if len(parts) < 5:
             raise ValueError(f"Invalid key string: {s}")
         request_configs = None
-        if len(parts) >= 7:
+        if len(parts) >= 6:
             request_configs = {}
-            for kv in parts[6:]:
+            for kv in parts[5:]:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
         return CacheEngineKey(
             parts[0],
-            parts[1],
+            int(parts[1]),
             int(parts[2]),
-            int(parts[3]),
-            int(parts[4], 16),
-            STR_DTYPE_TO_TORCH_DTYPE[parts[5]],
+            int(parts[3], 16),
+            STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
             request_configs,
         )
 
@@ -451,7 +445,6 @@ class CacheEngineKey:
         # Note(Kuntai): this is used for serializing CacheEngineKey via msgpack.
         msg = {
             "__type__": "CacheEngineKey",
-            "use_case": self.use_case,
             "model_name": self.model_name,
             "world_size": self.world_size,
             "worker_id": self.worker_id,
@@ -475,7 +468,6 @@ class CacheEngineKey:
                     raise ValueError(f"Invalid key dict: {d}")
                 request_configs[kvs[0]] = kvs[1]
         return CacheEngineKey(
-            use_case=d["use_case"],
             model_name=d["model_name"],
             world_size=d["world_size"],
             worker_id=d["worker_id"],
@@ -487,7 +479,6 @@ class CacheEngineKey:
     def with_new_worker_id(self, new_worker_id: int) -> "CacheEngineKey":
         # Reconstruct the cache engine key with new worker id
         return CacheEngineKey(
-            self.use_case,
             self.model_name,
             self.world_size,
             new_worker_id,
@@ -512,7 +503,6 @@ class LayerCacheEngineKey(CacheEngineKey):
     def __hash__(self):
         return hash(
             (
-                self.use_case,
                 self.model_name,
                 self.world_size,
                 self.worker_id,
@@ -531,7 +521,7 @@ class LayerCacheEngineKey(CacheEngineKey):
 
     def to_string(self):
         s = (
-            f"{self.use_case}@{self.model_name}@{self.world_size}"
+            f"{self.model_name}@{self.world_size}"
             f"@{self.worker_id}@{self.chunk_hash_hex}@{self._dtype_str}@{self.layer_id}"
         )
         if self.tags is not None and len(self.tags) != 0:
@@ -545,7 +535,6 @@ class LayerCacheEngineKey(CacheEngineKey):
         for layer_id in range(num_layers):
             keys.append(
                 LayerCacheEngineKey(
-                    self.use_case,
                     self.model_name,
                     self.world_size,
                     self.worker_id,
@@ -560,25 +549,24 @@ class LayerCacheEngineKey(CacheEngineKey):
     @staticmethod
     def from_string(s):
         parts = s.split("@")
-        if len(parts) < 7:
+        if len(parts) < 6:
             raise ValueError(f"Invalid key string: {s}")
         request_configs = None
-        if len(parts) >= 8:
+        if len(parts) >= 7:
             request_configs = {}
-            for kv in parts[7:]:
+            for kv in parts[6:]:
                 kvs = kv.split("%", 1)
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
         return LayerCacheEngineKey(
             parts[0],
-            parts[1],
+            int(parts[1]),
             int(parts[2]),
-            int(parts[3]),
-            int(parts[4], 16),
-            STR_DTYPE_TO_TORCH_DTYPE[parts[5]],
+            int(parts[3], 16),
+            STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
             request_configs,
-            int(parts[6]),
+            int(parts[5]),
         )
 
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -395,13 +395,13 @@ class CacheEngineKey:
         for layer_id in range(num_layers):
             keys.append(
                 LayerCacheEngineKey(
-                    self.model_name,
-                    self.world_size,
-                    self.worker_id,
-                    self.chunk_hash,
-                    self.dtype,
-                    self.request_configs,
-                    layer_id,
+                    model_name=self.model_name,
+                    world_size=self.world_size,
+                    worker_id=self.worker_id,
+                    chunk_hash=self.chunk_hash,
+                    dtype=self.dtype,
+                    request_configs=self.request_configs,
+                    layer_id=layer_id,
                 )
             )
         return keys
@@ -409,13 +409,13 @@ class CacheEngineKey:
     def get_first_layer(self) -> "LayerCacheEngineKey":
         """Return the key for the first layer"""
         key = LayerCacheEngineKey(
-            self.model_name,
-            self.world_size,
-            self.worker_id,
-            self.chunk_hash,
-            self.dtype,
-            self.request_configs,
-            0,
+            model_name=self.model_name,
+            world_size=self.world_size,
+            worker_id=self.worker_id,
+            chunk_hash=self.chunk_hash,
+            dtype=self.dtype,
+            request_configs=self.request_configs,
+            layer_id=0,
         )
         return key
 
@@ -433,12 +433,12 @@ class CacheEngineKey:
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
         return CacheEngineKey(
-            parts[0],
-            int(parts[1]),
-            int(parts[2]),
-            int(parts[3], 16),
-            STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
-            request_configs,
+            model_name=parts[0],
+            world_size=int(parts[1]),
+            worker_id=int(parts[2]),
+            chunk_hash=int(parts[3], 16),
+            dtype=STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
+            request_configs=request_configs,
         )
 
     def to_dict(self):
@@ -480,11 +480,11 @@ class CacheEngineKey:
         # Reconstruct the cache engine key with new worker id
         return CacheEngineKey(
             self.model_name,
-            self.world_size,
-            new_worker_id,
-            self.chunk_hash,
-            self.dtype,
-            self.request_configs,
+            world_size=self.world_size,
+            worker_id=new_worker_id,
+            chunk_hash=self.chunk_hash,
+            dtype=self.dtype,
+            request_configs=self.request_configs,
         )
 
     @property
@@ -535,13 +535,13 @@ class LayerCacheEngineKey(CacheEngineKey):
         for layer_id in range(num_layers):
             keys.append(
                 LayerCacheEngineKey(
-                    self.model_name,
-                    self.world_size,
-                    self.worker_id,
-                    self.chunk_hash,
-                    self.dtype,
-                    self.request_configs,
-                    layer_id,
+                    model_name=self.model_name,
+                    world_size=self.world_size,
+                    worker_id=self.worker_id,
+                    chunk_hash=self.chunk_hash,
+                    dtype=self.dtype,
+                    request_configs=self.request_configs,
+                    layer_id=layer_id,
                 )
             )
         return keys
@@ -560,13 +560,13 @@ class LayerCacheEngineKey(CacheEngineKey):
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
         return LayerCacheEngineKey(
-            parts[0],
-            int(parts[1]),
-            int(parts[2]),
-            int(parts[3], 16),
-            STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
-            request_configs,
-            int(parts[5]),
+            model_name=parts[0],
+            world_size=int(parts[1]),
+            worker_id=int(parts[2]),
+            chunk_hash=int(parts[3], 16),
+            dtype=STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
+            request_configs=request_configs,
+            layer_id=int(parts[5]),
         )
 
 

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -10,7 +10,6 @@ import zmq
 import zmq.asyncio
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_controller.full_sync_sender import FullSyncSender
 from lmcache.v1.cache_controller.message import (
@@ -44,6 +43,7 @@ from lmcache.v1.cache_controller.message import (
     WorkerReqRetMsg,
 )
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc_utils import (
     DEFAULT_SOCKET_RECV_TIMEOUT_MS,
     DEFAULT_SOCKET_SEND_TIMEOUT_MS,

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -10,7 +10,7 @@ import zmq
 import zmq.asyncio
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_controller.full_sync_sender import FullSyncSender
 from lmcache.v1.cache_controller.message import (
@@ -72,7 +72,7 @@ class LMCacheWorker:
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         lmcache_engine: "LMCacheEngine",
     ):
         # TODO (Jiayi): "instance_id" might not be needed anymore.

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -28,7 +28,6 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
@@ -57,6 +56,7 @@ from lmcache.v1.memory_management import (  # noqa: E501
     PagedTensorMemoryAllocator,
     TensorMemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.pin_monitor import PinMonitor
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 from lmcache.v1.system_detection import NUMADetector, NUMAMapping

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -28,7 +28,7 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
 from lmcache.usage_context import InitializeUsageContext
@@ -99,7 +99,7 @@ class LMCacheEngine:
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         token_database: TokenDatabase,
         gpu_connector: Optional[GPUConnectorInterface],
         broadcast_fn: Callable[[torch.Tensor, int], None],
@@ -1742,7 +1742,7 @@ class LMCacheEngine:
 class LMCacheEngineBuilder:
     _instances: Dict[str, LMCacheEngine] = {}
     _cfgs: Dict[str, LMCacheEngineConfig] = {}
-    _metadatas: Dict[str, LMCacheEngineMetadata] = {}
+    _metadatas: Dict[str, LMCacheMetadata] = {}
     _stat_loggers: Dict[str, LMCacheStatsLogger] = {}
 
     # TODO(Jiayi): Please remove this helper function in the future.
@@ -1750,7 +1750,7 @@ class LMCacheEngineBuilder:
     @staticmethod
     def _Create_memory_allocator(
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         numa_mapping: Optional[NUMAMapping] = None,
     ) -> MemoryAllocatorInterface:
         # NOTE: should remove this function after fixing the unit tests:
@@ -1825,7 +1825,7 @@ class LMCacheEngineBuilder:
     @staticmethod
     def _Create_token_database(
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ) -> TokenDatabase:
         if config.enable_blending:
             return SegmentTokenDatabase(config, metadata)
@@ -1836,7 +1836,7 @@ class LMCacheEngineBuilder:
         cls,
         instance_id: str,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         gpu_connector: Optional[GPUConnectorInterface],
         broadcast_fn: Callable[[torch.Tensor, int], None],
         broadcast_object_fn: Callable[[Any, int], Any],

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -29,7 +29,6 @@ def _get_default_metadata(model: str) -> LMCacheMetadata:
         local_world_size=8,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(8, 2, 16, 8, 16),
     )
@@ -38,12 +37,11 @@ def _get_default_metadata(model: str) -> LMCacheMetadata:
 def create_test_key(model: str, key_id: str = "test_key") -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey(
-        "vllm",
-        model,
-        8,
-        0,
-        int(hashlib.sha256(key_id.encode()).hexdigest(), 16),
-        torch.bfloat16,
+        model_name=model,
+        world_size=8,
+        worker_id=0,
+        chunk_hash=int(hashlib.sha256(key_id.encode()).hexdigest(), 16),
+        dtype=torch.bfloat16,
     )
 
 

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -26,7 +26,9 @@ def _get_default_metadata(model: str) -> LMCacheMetadata:
     return LMCacheMetadata(
         model_name=model,
         world_size=8,
+        local_world_size=8,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(8, 2, 16, 8, 16),

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -12,7 +12,7 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 
 # Import from lmcache with absolute paths
@@ -21,13 +21,13 @@ from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 
-def _get_default_metadata(model: str) -> LMCacheEngineMetadata:
+def _get_default_metadata(model: str) -> LMCacheMetadata:
     """Get default metadata for testing"""
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name=model,
         world_size=8,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(8, 2, 16, 8, 16),
     )
@@ -46,7 +46,7 @@ def create_test_key(model: str, key_id: str = "test_key") -> CacheEngineKey:
 
 
 def create_test_memory_obj_for_storage_manager(
-    storage_manager: StorageManager, metadata: LMCacheEngineMetadata
+    storage_manager: StorageManager, metadata: LMCacheMetadata
 ) -> Optional[MemoryObj]:
     """Create a test MemoryObj for testing with StorageManager."""
     # The metadata.kv_shape is in vllm format:
@@ -131,7 +131,7 @@ def wait_put_tasks_complete(
 
 
 def create_memory_objects_batch(
-    storage_manager: StorageManager, metadata: LMCacheEngineMetadata, batch_size: int
+    storage_manager: StorageManager, metadata: LMCacheMetadata, batch_size: int
 ) -> list[MemoryObj]:
     """Create a batch of memory objects for reuse"""
     memory_objs = []

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -12,11 +12,11 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 
 # Import from lmcache with absolute paths
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -7,7 +7,6 @@ import abc
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import ENGINE_NAME
 from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
@@ -15,6 +14,7 @@ from lmcache.v1.compute.blend.utils import LMCBlenderBuilder
 from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.memory_management import GPUMemoryAllocator  # noqa: E501
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 
 if torch.cuda.is_available():
     # First Party

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -7,7 +7,7 @@ import abc
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import ENGINE_NAME
 from lmcache.logging import init_logger
 from lmcache.utils import _lmcache_nvtx_annotate
@@ -222,11 +222,11 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
     @classmethod
     def from_metadata(
         cls,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
     ) -> "VLLMPagedMemGPUConnectorV2":
-        """Create a connector from LMCacheEngineMetadata.
+        """Create a connector from LMCacheMetadata.
 
         Args:
             metadata: The LMCache engine metadata containing model configuration.
@@ -420,7 +420,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
     def __init__(
         self,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         device: torch.device,
         use_gpu: bool = False,
     ):
@@ -443,7 +443,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
     @classmethod
     def from_metadata(
         cls,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
     ) -> "VLLMPagedMemGPUConnectorV3":
@@ -635,11 +635,11 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
     @classmethod
     def from_metadata(
         cls,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
     ) -> "VLLMBufferLayerwiseGPUConnector":
-        """Create a connector from LMCacheEngineMetadata.
+        """Create a connector from LMCacheMetadata.
 
         Args:
             metadata: The LMCache engine metadata containing model configuration.
@@ -1039,11 +1039,11 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
     @classmethod
     def from_metadata(
         cls,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
     ) -> "VLLMPagedMemLayerwiseGPUConnector":
-        """Create a connector from LMCacheEngineMetadata.
+        """Create a connector from LMCacheMetadata.
 
         Args:
             metadata: The LMCache engine metadata containing model configuration.

--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -264,7 +264,7 @@ class RemoteBackendHealthCheck(HealthCheck):
     @contextmanager
     def _resource_manager(self):
         key = CacheEngineKey(
-            fmt="vllm",
+            use_case="vllm",
             model_name="test",
             world_size=1,
             worker_id=0,

--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -264,7 +264,6 @@ class RemoteBackendHealthCheck(HealthCheck):
     @contextmanager
     def _resource_manager(self):
         key = CacheEngineKey(
-            use_case="vllm",
             model_name="test",
             world_size=1,
             worker_id=0,

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -42,7 +42,7 @@ class LookupClientFactory:
         Args:
             config: The LMCache engine configuration
             metadata: The LMCache engine metadata (includes engine_id,
-                num_ranks, kv_connector_extra_config)
+                world_size, kv_connector_extra_config)
             lmcache_engine: Optional LMCacheEngine instance for
                 bypass lookup client
 
@@ -99,7 +99,7 @@ class LookupClientFactory:
         Args:
             lmcache_engine: The LMCache engine instance
             metadata: The LMCache engine metadata (includes engine_id,
-                num_ranks, kv_connector_extra_config, worker_id)
+                world_size, kv_connector_extra_config, worker_id)
 
         Returns:
             A lookup server instance, or None if no server should be created

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING, Optional, Union
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -16,6 +15,7 @@ from lmcache.v1.lookup_client.lmcache_lookup_client_bypass import (
     LMCacheBypassLookupClient,
 )
 from lmcache.v1.lookup_client.mooncake_lookup_client import MooncakeLookupClient
+from lmcache.v1.metadata import LMCacheMetadata
 
 if TYPE_CHECKING:
     # First Party

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Optional, Union
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -33,7 +33,7 @@ class LookupClientFactory:
     @staticmethod
     def create_lookup_client(
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         lmcache_engine: Optional[LMCacheEngine] = None,
     ) -> LookupClientInterface:
         """
@@ -91,7 +91,7 @@ class LookupClientFactory:
     @staticmethod
     def create_lookup_server(
         lmcache_engine: LMCacheEngine,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ) -> Optional[Union["LMCacheLookupServer", "LMCacheAsyncLookupServer"]]:
         """
         Create a lookup server based on the configuration.
@@ -136,7 +136,7 @@ class LookupClientFactory:
     def _create_external_lookup_client(
         external_lookup_uri: str,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ) -> LookupClientInterface:
         """
         Create an external lookup client based on the URI format.
@@ -176,7 +176,7 @@ class LookupClientFactory:
     def _create_mooncake_lookup_client(
         master_address: str,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ) -> "MooncakeLookupClient":
         """Create a MooncakeLookupClient instance."""
         # First Party

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -10,7 +10,7 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -49,7 +49,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ):
         # lookup_id -> first lookup time
         # this helps us support timeout semantics
@@ -304,7 +304,7 @@ class LMCacheAsyncLookupServer:
     def __init__(
         self,
         lmcache_engine: LMCacheEngine,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ):
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
         kv_connector_extra_config = metadata.kv_connector_extra_config or {}

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -10,7 +10,6 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -20,6 +19,7 @@ from lmcache.v1.lookup_client.async_lookup_message import (
     LookupRequestMsg,
     LookupResponseMsg,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc_utils import (
     get_zmq_context,
     get_zmq_rpc_path_lmcache,

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -61,7 +61,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         rpc_port = kv_connector_extra_config.get("lmcache_rpc_port", 0)
         engine_id = metadata.engine_id
         assert engine_id is not None, "engine_id is required for RPC communication"
-        self.num_ranks = metadata.num_ranks
+        self.world_size = metadata.world_size
         self.lookup_server_worker_ids = config.get_lookup_server_worker_ids(
             metadata.use_mla, metadata.world_size
         )
@@ -69,9 +69,9 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         self.push_sockets = []
         if len(self.lookup_server_worker_ids) > 0:
             ranks = self.lookup_server_worker_ids
-            self.num_ranks = len(self.lookup_server_worker_ids)
+            self.world_size = len(self.lookup_server_worker_ids)
         else:
-            ranks = [i for i in range(self.num_ranks)]
+            ranks = [i for i in range(self.world_size)]
 
         for rank in ranks:
             worker_socket_path = get_zmq_rpc_path_lmcache(
@@ -212,7 +212,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         # Serialize message using msgspec
         msg_buf = msgspec.msgpack.encode(msg)
 
-        for i in range(self.num_ranks):
+        for i in range(self.world_size):
             self.push_sockets[i].send(msg_buf, copy=False)
         time.sleep(self.lookup_backoff_time)
         return None
@@ -233,7 +233,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                         self.res_for_each_worker[lookup_id].append(res)
                     all_res = self.res_for_each_worker[lookup_id]
 
-                    if len(all_res) == self.num_ranks:
+                    if len(all_res) == self.world_size:
                         self.res_for_each_worker.pop(lookup_id)
 
                         # NOTE: it is possible that the number of hit
@@ -276,7 +276,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         msg = LookupCleanupMsg(lookup_id=lookup_id)
         msg_buf = msgspec.msgpack.encode(msg)
 
-        for i in range(self.num_ranks):
+        for i in range(self.world_size):
             self.push_sockets[i].send(msg_buf, copy=False)
         logger.debug("Sent cleanup message for lookup_id=%s", lookup_id)
 

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -52,7 +52,7 @@ class LMCacheLookupClient(LookupClientInterface):
         rpc_port = kv_connector_extra_config.get("lmcache_rpc_port", 0)
         engine_id = metadata.engine_id
         assert engine_id is not None, "engine_id is required for RPC communication"
-        self.num_ranks = metadata.num_ranks
+        self.world_size = metadata.world_size
         self.lookup_server_worker_ids = config.get_lookup_server_worker_ids(
             metadata.use_mla, metadata.world_size
         )
@@ -60,9 +60,9 @@ class LMCacheLookupClient(LookupClientInterface):
         self.sockets = []
         if len(self.lookup_server_worker_ids) > 0:
             ranks = self.lookup_server_worker_ids
-            self.num_ranks = len(self.lookup_server_worker_ids)
+            self.world_size = len(self.lookup_server_worker_ids)
         else:
-            ranks = [i for i in range(self.num_ranks)]
+            ranks = [i for i in range(self.world_size)]
 
         # Store socket creation parameters for recreation
         SocketParams = namedtuple("SocketParams", ["socket_path", "rank"])
@@ -120,7 +120,7 @@ class LMCacheLookupClient(LookupClientInterface):
 
     def _recreate_socket(self) -> None:
         """Recreate all sockets."""
-        for rank_idx in range(self.num_ranks):
+        for rank_idx in range(self.world_size):
             # Close old socket
             old_socket = self.sockets[rank_idx]
             if old_socket is not None:
@@ -215,12 +215,12 @@ class LMCacheLookupClient(LookupClientInterface):
         results = []
         failed_rank = -1
         try:
-            for i in range(self.num_ranks):
+            for i in range(self.world_size):
                 failed_rank = i
                 self.sockets[i].send_multipart(msg_buf, copy=False)
 
             # TODO(Jiayi): we can use zmq poll to optimize a bit
-            for i in range(self.num_ranks):
+            for i in range(self.world_size):
                 failed_rank = i
                 resp = self.sockets[i].recv()
                 result = int.from_bytes(resp, "big")
@@ -242,7 +242,7 @@ class LMCacheLookupClient(LookupClientInterface):
             self._recreate_socket()
             return 0
 
-        assert len(results) == self.num_ranks
+        assert len(results) == self.world_size
         if len(set(results)) > 1:
             logger.warning(
                 "Lookup results (number of hit tokens) differ "

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -11,7 +11,7 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -43,7 +43,7 @@ class LMCacheLookupClient(LookupClientInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ):
         self.encoder = msgspec.msgpack.Encoder()
         self.ctx = get_zmq_context(use_asyncio=False)
@@ -291,7 +291,7 @@ class LMCacheLookupServer:
     def __init__(
         self,
         lmcache_engine: LMCacheEngine,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ):
         self.decoder = msgspec.msgpack.Decoder()
         self.ctx = zmq.Context()  # type: ignore[attr-defined]

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -11,11 +11,11 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc_utils import (
     get_zmq_context,
     get_zmq_rpc_path_lmcache,

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -25,7 +25,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         lmcache_engine: LMCacheEngine,
     ):
         """

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -6,11 +6,11 @@ from typing import Optional, Union
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
@@ -19,7 +19,7 @@ class MooncakeLookupClient(LookupClientInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         master_addr: str,
     ):
         # Third Party

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -6,11 +6,11 @@ from typing import Optional, Union
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -16,7 +16,7 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
     # First Party
-    from lmcache.config import LMCacheEngineMetadata
+    from lmcache.config import LMCacheMetadata
     from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
         LMCacheAsyncLookupServer,
     )
@@ -87,7 +87,7 @@ class LMCacheManager:
 
         # Components (initialized later)
         self._lmcache_engine: Optional[LMCacheEngine] = None
-        self._lmcache_engine_metadata: Optional[LMCacheEngineMetadata] = None
+        self._lmcache_engine_metadata: Optional[LMCacheMetadata] = None
         self._lookup_client: Optional[LookupClientInterface] = None
         self._lookup_server: Optional[
             Union["LMCacheLookupServer", "LMCacheAsyncLookupServer"]
@@ -308,7 +308,7 @@ class LMCacheManager:
                 )
 
         # Create metadata
-        metadata = LMCacheEngineMetadata(
+        metadata = LMCacheMetadata(
             model_name=model_config.model,
             world_size=parallel_config.world_size,
             worker_id=parallel_config.rank,
@@ -603,7 +603,7 @@ class LMCacheManager:
         return self._lmcache_engine
 
     @property
-    def lmcache_engine_metadata(self) -> Optional[LMCacheEngineMetadata]:
+    def lmcache_engine_metadata(self) -> Optional[LMCacheMetadata]:
         """Get the LMCache engine metadata."""
         return self._lmcache_engine_metadata
 

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -308,23 +308,18 @@ class LMCacheManager:
                 )
 
         # Create metadata
-        num_ranks = (
-            parallel_config.tensor_parallel_size
-            * parallel_config.pipeline_parallel_size
-        )
         metadata = LMCacheEngineMetadata(
-            model_config.model,
-            parallel_config.world_size,
-            parallel_config.rank,
-            "vllm",
-            kv_dtype,
-            kv_shape,
-            use_mla,
-            role,
+            model_name=model_config.model,
+            world_size=parallel_config.world_size,
+            worker_id=parallel_config.rank,
+            use_case="vllm",
+            kv_dtype=kv_dtype,
+            kv_shape=kv_shape,
+            use_mla=use_mla,
+            role=role,
             served_model_name=model_config.served_model_name,
             chunk_size=self._config.chunk_size,
             engine_id=engine_id,
-            num_ranks=num_ranks,
             kv_connector_extra_config=kv_connector_extra_config,
         )
 

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -311,7 +311,9 @@ class LMCacheManager:
         metadata = LMCacheMetadata(
             model_name=model_config.model,
             world_size=parallel_config.world_size,
+            local_world_size=parallel_config.world_size,
             worker_id=parallel_config.rank,
+            local_worker_id=parallel_config.rank,
             use_case="vllm",
             kv_dtype=kv_dtype,
             kv_shape=kv_shape,

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -314,7 +314,6 @@ class LMCacheManager:
             local_world_size=parallel_config.world_size,
             worker_id=parallel_config.rank,
             local_worker_id=parallel_config.rank,
-            use_case="vllm",
             kv_dtype=kv_dtype,
             kv_shape=kv_shape,
             use_mla=use_mla,

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -16,7 +16,6 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
@@ -27,6 +26,7 @@ from lmcache.v1.health_monitor.constants import (
 )
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.offload_server.zmq_server import ZMQOffloadServer
 from lmcache.v1.plugin.runtime_plugin_launcher import RuntimePluginLauncher
 
@@ -35,11 +35,11 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
     # First Party
-    from lmcache.config import LMCacheMetadata
     from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
         LMCacheAsyncLookupServer,
     )
     from lmcache.v1.lookup_client.lmcache_lookup_client import LMCacheLookupServer
+    from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -23,10 +23,22 @@ class LMCacheMetadata:
 
     """name of the LLM model"""
     model_name: str
-    """ world size when running under a distributed setting """
+    """ global world size when running under a distributed setting 
+    (total number of workers)"""
     world_size: int
+    """ host world size (workers on active localhost)
+    This information can be useful for multi-node
+    deployment. Will be the same as world_size 
+    in single-node deployments.
+    """
+    local_world_size: int
     """ worker id when running under a distributed setting """
     worker_id: int
+    """ host worker id (a gpu bound worker id on active localhost)
+    This information can be useful for multi-node deployment. 
+    Will be the same as worker_id in single-node deployments.
+    """
+    local_worker_id: int
     """ the data type of kv tensors """
     # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
     kv_dtype: torch.dtype

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -46,8 +46,6 @@ class LMCacheMetadata:
     # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
     """ (num_layer, 2, chunk_size, num_kv_head, head_size) """
     kv_shape: tuple[int, int, int, int, int]
-    """ use case of LMCache (vllm, sglang, standalone, etc.) """
-    use_case: str = "vllm"
     """ whether use MLA"""
     use_mla: bool = False
     """ the role of the current instance (e.g., 'scheduler', 'worker') """

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from dataclasses import dataclass, field
+from typing import Optional
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class LMCacheMetadata:
+    """
+    LMCacheMetadata should be extracted from the northbound
+    serving engine configuration and wrap the extraction of
+    attributes (e.g. model name, tp rank, etc.)
+    """
+
+    """name of the LLM model"""
+    model_name: str
+    """ world size when running under a distributed setting """
+    world_size: int
+    """ worker id when running under a distributed setting """
+    worker_id: int
+    """ the data type of kv tensors """
+    # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
+    kv_dtype: torch.dtype
+    """ the shape of kv tensors """
+    # (Deprecated) Will be replaced by kv_layer_groups_manager in the future
+    """ (num_layer, 2, chunk_size, num_kv_head, head_size) """
+    kv_shape: tuple[int, int, int, int, int]
+    """ use case of LMCache (vllm, sglang, standalone, etc.) """
+    use_case: str = "vllm"
+    """ whether use MLA"""
+    use_mla: bool = False
+    """ the role of the current instance (e.g., 'scheduler', 'worker') """
+    role: Optional[str] = None
+    """ the first rank of the distributed setting """
+    # TODO(baoloongmao): first_rank should be configurable
+    first_rank = 0
+    served_model_name: Optional[str] = None
+    """chunk size"""
+    chunk_size: int = 256
+    """ Manager for groups of layers with identical KV cache structure """
+    kv_layer_groups_manager: KVLayerGroupsManager = field(
+        default_factory=KVLayerGroupsManager
+    )
+    """ engine_id for RPC path (used by lookup client/server) """
+    engine_id: Optional[str] = None
+    """ extra config from kv_connector (e.g., lmcache_rpc_port) """
+    kv_connector_extra_config: Optional[dict] = None
+
+    def is_first_rank(self) -> bool:
+        """Check if the current worker is the first rank"""
+        return self.worker_id == self.first_rank
+
+    # TODO(chunxiaozheng): some uts do not `build_kv_layer_groups`
+    def get_dtypes(self) -> list[torch.dtype]:
+        if self.kv_layer_groups_manager.kv_layer_groups:
+            return [
+                group.dtype for group in self.kv_layer_groups_manager.kv_layer_groups
+            ]
+        return [self.kv_dtype]
+
+    def get_shapes(self, num_tokens: Optional[int] = None) -> list[torch.Size]:
+        """Get the shapes of the KV cache in LMCache"""
+        if num_tokens is None:
+            num_tokens = self.chunk_size
+        if self.kv_layer_groups_manager.kv_layer_groups:
+            shapes = []
+            kv_size = 1 if self.use_mla else 2
+            for group in self.kv_layer_groups_manager.kv_layer_groups:
+                shapes.append(
+                    torch.Size(
+                        [
+                            kv_size,
+                            group.num_layers,
+                            num_tokens,
+                            group.hidden_dim_size,
+                        ]
+                    )
+                )
+            return shapes
+        else:
+            return [
+                torch.Size(
+                    [
+                        self.kv_shape[1],
+                        self.kv_shape[0],
+                        num_tokens,
+                        self.kv_shape[3] * self.kv_shape[4],
+                    ]
+                )
+            ]
+
+    def get_num_groups(self) -> int:
+        if self.kv_layer_groups_manager.kv_layer_groups:
+            return self.kv_layer_groups_manager.num_groups
+        return 1

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -101,6 +101,8 @@ class CudaIPCWrapper:
         return pickle.loads(data)
 
 
+# TODO: consider adding local_world_size and local_worker_id
+# for multi-node use cases
 @dataclass(order=True, frozen=True)
 class IPCCacheEngineKey:
     model_name: str

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -617,7 +617,9 @@ def main():
         metadata = LMCacheMetadata(
             model_name=args.model_name,
             world_size=args.world_size,
+            local_world_size=args.world_size,
             worker_id=args.worker_id,
+            local_worker_id=args.worker_id,
             fmt=args.fmt,
             kv_dtype=kv_dtype,
             kv_shape=kv_shape,

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -24,7 +24,6 @@ import sys
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import get_size_bytes, lmcache_get_or_create_config
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
@@ -32,6 +31,7 @@ from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import parse_command_line_extra_params
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.mock_gpu_connector import MockGPUConnector
 from lmcache.v1.standalone.manager import StandaloneLMCacheManager
 from lmcache.v1.xpu_connector import VLLMPagedMemXPUConnectorV2

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -623,7 +623,6 @@ def main():
             kv_shape=kv_shape,
             use_mla=args.use_mla,
             role="worker",
-            num_ranks=args.world_size,
         )
 
         starter = LMCacheStandaloneStarter(config, metadata, layer_groups, args.device)

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -24,7 +24,7 @@ import sys
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import get_size_bytes, lmcache_get_or_create_config
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
@@ -198,7 +198,7 @@ class LMCacheStandaloneStarter:
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         layer_groups: List[LayerGroupSpec],
         device: str = "cpu",
     ):
@@ -614,7 +614,7 @@ def main():
             kv_shape[4],
         )
 
-        metadata = LMCacheEngineMetadata(
+        metadata = LMCacheMetadata(
             model_name=args.model_name,
             world_size=args.world_size,
             worker_id=args.worker_id,

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -543,12 +543,6 @@ def parse_args() -> argparse.Namespace:
         help="Enable MLA (Multi-Level Attention)",
     )
     parser.add_argument(
-        "--fmt",
-        type=str,
-        default="vllm",
-        help="Cache format (default: vllm)",
-    )
-    parser.add_argument(
         "--device",
         type=str,
         default="cpu",

--- a/lmcache/v1/standalone/manager.py
+++ b/lmcache/v1/standalone/manager.py
@@ -10,11 +10,11 @@ removing vLLM dependencies and simplifying the initialization logic.
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
 from lmcache.v1.manager import LMCacheManager
+from lmcache.v1.metadata import LMCacheMetadata
 
 if TYPE_CHECKING:
     # Fir

--- a/lmcache/v1/standalone/manager.py
+++ b/lmcache/v1/standalone/manager.py
@@ -10,7 +10,7 @@ removing vLLM dependencies and simplifying the initialization logic.
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
@@ -34,7 +34,7 @@ class StandaloneLMCacheManager(LMCacheManager):
     def __init__(
         self,
         config: Any,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         gpu_connector: Any,
         broadcast_fn: Callable,
         broadcast_object_fn: Callable,
@@ -45,7 +45,7 @@ class StandaloneLMCacheManager(LMCacheManager):
 
         Args:
             config: LMCache engine configuration
-            metadata: Pre-constructed LMCacheEngineMetadata
+            metadata: Pre-constructed LMCacheMetadata
             gpu_connector: GPU connector instance
             broadcast_fn: Broadcast function for tensor parallel
             broadcast_object_fn: Broadcast function for objects

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -9,7 +9,7 @@ import importlib  # Added for dynamic import
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def is_cuda_worker(metadata: LMCacheEngineMetadata) -> bool:
+def is_cuda_worker(metadata: LMCacheMetadata) -> bool:
     """
     Check if the current role is worker and CUDA is available.
 
@@ -41,7 +41,7 @@ def is_cuda_worker(metadata: LMCacheEngineMetadata) -> bool:
 
 def storage_plugin_launcher(
     config: LMCacheEngineConfig,
-    metadata: LMCacheEngineMetadata,
+    metadata: LMCacheMetadata,
     loop: asyncio.AbstractEventLoop,
     local_cpu_backend: Optional[LocalCPUBackend],
     dst_device: str,
@@ -105,7 +105,7 @@ def storage_plugin_launcher(
 
 def CreateStorageBackends(
     config: LMCacheEngineConfig,
-    metadata: LMCacheEngineMetadata,
+    metadata: LMCacheMetadata,
     loop: asyncio.AbstractEventLoop,
     dst_device: str = "cuda",
     lmcache_worker: Optional["LMCacheWorker"] = None,

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -9,9 +9,9 @@ import importlib  # Added for dynamic import
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.gds_backend import GdsBackend
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -9,7 +9,7 @@ import asyncio
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
@@ -288,7 +288,7 @@ class AllocatorBackendInterface(StorageBackendInterface):
 
     @abc.abstractmethod
     def initialize_allocator(
-        self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata
+        self, config: LMCacheEngineConfig, metadata: LMCacheMetadata
     ) -> MemoryAllocatorInterface:
         """
         Create the correct memory allocator for the current storage backend
@@ -388,7 +388,7 @@ class StoragePluginInterface(StorageBackendInterface):
         self,
         dst_device: str = "cuda",
         config: Optional[LMCacheEngineConfig] = None,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
         local_cpu_backend: Optional["LocalCPUBackend"] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
@@ -400,7 +400,7 @@ class StoragePluginInterface(StorageBackendInterface):
             (e.g., "cuda" or "cpu").
         :param LMCacheEngineConfig config: Optional configuration object for the
             cache engine.
-        :param LMCacheEngineMetadata metadata: Optional metadata describing the cache
+        :param LMCacheMetadata metadata: Optional metadata describing the cache
             engine state or version.
         :param LocalCPUBackend local_cpu_backend: Optional backend for local CPU-based
             inference or caching.

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -9,7 +9,6 @@ import asyncio
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
@@ -17,6 +16,7 @@ from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 
 if TYPE_CHECKING:
     # First Party

--- a/lmcache/v1/storage_backend/batched_message_sender.py
+++ b/lmcache/v1/storage_backend/batched_message_sender.py
@@ -5,7 +5,6 @@ import queue
 import threading
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import PrometheusLogger
 from lmcache.v1.cache_controller.message import (
@@ -14,6 +13,7 @@ from lmcache.v1.cache_controller.message import (
     OpType,
 )
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 if TYPE_CHECKING:
     # First Party

--- a/lmcache/v1/storage_backend/batched_message_sender.py
+++ b/lmcache/v1/storage_backend/batched_message_sender.py
@@ -5,7 +5,7 @@ import queue
 import threading
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import PrometheusLogger
 from lmcache.v1.cache_controller.message import (
@@ -51,7 +51,7 @@ class BatchedMessageSender:
 
     def __init__(
         self,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         config: LMCacheEngineConfig,
         location: str,
         lmcache_worker: "LMCacheWorker",

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -10,7 +10,7 @@ import inspect
 import pkgutil
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
@@ -113,7 +113,7 @@ class ConnectorContext:
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: Optional[LocalCPUBackend],
         config: Optional[LMCacheEngineConfig],
-        metadata: Optional[LMCacheEngineMetadata],
+        metadata: Optional[LMCacheMetadata],
     ):
         self.url = url
         self.loop = loop
@@ -167,7 +167,7 @@ class ConnectorManager:
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: Optional[LocalCPUBackend],
         config: Optional[LMCacheEngineConfig] = None,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
     ) -> None:
         logger.info("Initializing ConnectorManager")
         self.context = ConnectorContext(
@@ -231,7 +231,7 @@ def CreateConnector(
     loop: asyncio.AbstractEventLoop,
     local_cpu_backend: Optional[LocalCPUBackend],
     config: Optional[LMCacheEngineConfig] = None,
-    metadata: Optional[LMCacheEngineMetadata] = None,
+    metadata: Optional[LMCacheMetadata] = None,
 ) -> InstrumentedRemoteConnector:
     """
     Create a remote connector from the given URL.

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -10,9 +10,9 @@ import inspect
 import pkgutil
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.connector.instrumented_connector import (
     InstrumentedRemoteConnector,

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -8,7 +8,7 @@ import asyncio
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import get_size_bytes
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
@@ -34,7 +34,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
     """
 
     def __init__(
-        self, config: LMCacheEngineConfig, metadata: Optional[LMCacheEngineMetadata]
+        self, config: LMCacheEngineConfig, metadata: Optional[LMCacheMetadata]
     ):
         """
         Initialize some common attributes, which will be used in the subclasses.

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -8,12 +8,12 @@ import asyncio
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import get_size_bytes
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.protocol import get_remote_metadata_bytes, init_remote_metadata_info
 
 logger = init_logger(__name__)

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -20,7 +20,6 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
@@ -29,6 +28,7 @@ from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 
 logger = init_logger(__name__)

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
@@ -182,7 +182,7 @@ class GdsBackend(AllocatorBackendInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
         dst_device: str = "cuda",
     ):
@@ -838,7 +838,7 @@ class GdsBackend(AllocatorBackendInterface):
         raise NotImplementedError("Remote backend does not support remove now.")
 
     def initialize_allocator(
-        self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata
+        self, config: LMCacheEngineConfig, metadata: LMCacheMetadata
     ) -> CuFileMemoryAllocator:
         assert config.cufile_buffer_size is not None
         return CuFileMemoryAllocator(config.cufile_buffer_size * 1024**2)

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -9,7 +9,7 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import get_size_bytes
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
@@ -45,7 +45,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
         dst_device: str = "cuda",
         lmcache_worker: Optional["LMCacheWorker"] = None,
         memory_allocator: Optional[MemoryAllocatorInterface] = None,
@@ -271,7 +271,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         self,
         configured_cpu_size: float,
         config: LMCacheEngineConfig,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
     ) -> float:
         """
         Calculate the effective CPU memory size based on system available memory
@@ -326,7 +326,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
     def initialize_allocator(
         self,
         config: LMCacheEngineConfig,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
     ) -> MemoryAllocatorInterface:
         cpu_size = config.max_local_cpu_size
 

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -9,7 +9,6 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.integration.vllm.utils import get_size_bytes
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
@@ -23,6 +22,7 @@ from lmcache.v1.memory_management import (
     MixedMemoryAllocator,
     PagedCpuGpuMemoryAllocator,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.batched_message_sender import BatchedMessageSender
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -11,13 +11,13 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
 from lmcache.v1.cache_controller.message import OpType
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.batched_message_sender import BatchedMessageSender
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -11,7 +11,7 @@ import time
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
@@ -102,7 +102,7 @@ class LocalDiskBackend(StorageBackendInterface):
         local_cpu_backend: LocalCPUBackend,
         dst_device: str = "cuda",
         lmcache_worker: Optional["LMCacheWorker"] = None,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
     ):
         if torch.cuda.is_available():
             super().__init__(dst_device)

--- a/lmcache/v1/storage_backend/naive_serde/__init__.py
+++ b/lmcache/v1/storage_backend/naive_serde/__init__.py
@@ -3,8 +3,8 @@
 from typing import Optional, Tuple
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.naive_serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.v1.storage_backend.naive_serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.storage_backend.naive_serde.kivi_serde import (

--- a/lmcache/v1/storage_backend/naive_serde/__init__.py
+++ b/lmcache/v1/storage_backend/naive_serde/__init__.py
@@ -3,7 +3,7 @@
 from typing import Optional, Tuple
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.naive_serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.v1.storage_backend.naive_serde.cachegen_encoder import CacheGenSerializer
@@ -20,7 +20,7 @@ from lmcache.v1.storage_backend.naive_serde.serde import Deserializer, Serialize
 
 def CreateSerde(
     serde_type: str,
-    metadata: LMCacheEngineMetadata,
+    metadata: LMCacheMetadata,
     config: LMCacheEngineConfig,
 ) -> Tuple[Serializer, Deserializer]:
     s: Optional[Serializer] = None

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
@@ -6,7 +6,6 @@ from typing import Optional
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_basics import (
     CacheGenGPUEncoderOutput,
@@ -24,6 +23,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.naive_serde.cachegen_basics import CacheGenConfig
 from lmcache.v1.storage_backend.naive_serde.serde import Deserializer
 

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
@@ -36,7 +36,7 @@ class CacheGenDeserializer(Deserializer):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
         self.output_buffer: Optional[torch.Tensor] = None
-        self.fmt = metadata.fmt
+        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 
@@ -114,14 +114,14 @@ class CacheGenDeserializer(Deserializer):
                 encoder_output.head_size,
             )
         )
-        match self.fmt:
+        match self.use_case:
             case "vllm":
                 hidden_dim = blob.shape[-1] * blob.shape[-2]
                 kv_chunk = blob.reshape(*blob.shape[:-2], hidden_dim).to(
                     self.dtype
                 )  # [nlayers, 2, ntokens, num_heads, head_size]
             case _:
-                raise RuntimeError("Unknown format %s" % self.fmt)
+                raise RuntimeError("Unknown use case %s" % self.use_case)
 
         memory_obj = TensorMemoryObj(
             raw_data=kv_chunk,

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
@@ -36,7 +36,6 @@ class CacheGenDeserializer(Deserializer):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
         self.output_buffer: Optional[torch.Tensor] = None
-        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 
@@ -114,14 +113,11 @@ class CacheGenDeserializer(Deserializer):
                 encoder_output.head_size,
             )
         )
-        match self.use_case:
-            case "vllm":
-                hidden_dim = blob.shape[-1] * blob.shape[-2]
-                kv_chunk = blob.reshape(*blob.shape[:-2], hidden_dim).to(
-                    self.dtype
-                )  # [nlayers, 2, ntokens, num_heads, head_size]
-            case _:
-                raise RuntimeError("Unknown use case %s" % self.use_case)
+
+        hidden_dim = blob.shape[-1] * blob.shape[-2]
+        kv_chunk = blob.reshape(*blob.shape[:-2], hidden_dim).to(
+            self.dtype
+        )  # [nlayers, 2, ntokens, num_heads, head_size]
 
         memory_obj = TensorMemoryObj(
             raw_data=kv_chunk,

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_decoder.py
@@ -6,7 +6,7 @@ from typing import Optional
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_basics import (
     CacheGenGPUEncoderOutput,
@@ -31,7 +31,7 @@ logger = init_logger(__name__)
 
 
 class CacheGenDeserializer(Deserializer):
-    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
+    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         self.dtype = metadata.kv_dtype
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -3,7 +3,7 @@
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_encoder import encode_function
 from lmcache.utils import _lmcache_nvtx_annotate
@@ -16,7 +16,7 @@ logger = init_logger(__name__)
 
 
 class CacheGenSerializer(Serializer):
-    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
+    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
         self.use_case = metadata.use_case

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -3,12 +3,12 @@
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_encoder import encode_function
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import BytesBufferMemoryObj, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.naive_serde.cachegen_basics import CacheGenConfig
 from lmcache.v1.storage_backend.naive_serde.serde import Serializer
 

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -19,7 +19,7 @@ class CacheGenSerializer(Serializer):
     def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
-        self.fmt = metadata.fmt
+        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -19,7 +19,6 @@ class CacheGenSerializer(Serializer):
     def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         self.cachegen_config = CacheGenConfig.from_model_name(metadata.model_name)
         self.chunk_size = config.chunk_size
-        self.use_case = metadata.use_case
         self.key_bins = self.make_key_bins(self.cachegen_config)
         self.value_bins = self.make_value_bins(self.cachegen_config)
 

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -35,7 +35,7 @@ from nixl._api import (
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
@@ -85,7 +85,7 @@ class NixlStorageConfig:
 
     @staticmethod
     def from_cache_engine_config(
-        config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata
+        config: LMCacheEngineConfig, metadata: LMCacheMetadata
     ):
         assert config.nixl_buffer_size is not None
         assert config.nixl_buffer_device is not None
@@ -491,7 +491,7 @@ class NixlStorageBackend(AllocatorBackendInterface, ABC):
         self,
         nixl_config: NixlStorageConfig,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
     ):
         """
@@ -513,7 +513,7 @@ class NixlStorageBackend(AllocatorBackendInterface, ABC):
     def initialize_allocator(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ) -> PagedTensorMemoryAllocator:
         extra_config = config.extra_config
         enable_nixl_storage = extra_config is not None and extra_config.get(
@@ -626,7 +626,7 @@ class NixlStorageBackend(AllocatorBackendInterface, ABC):
     def CreateNixlStorageBackend(
         config: LMCacheEngineConfig,
         loop: asyncio.AbstractEventLoop,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ):
         """
         Create a Nixl backend with the given configuration.
@@ -650,7 +650,7 @@ class NixlStaticStorageBackend(NixlStorageBackend):
         self,
         nixl_config: NixlStorageConfig,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
     ):
         super().__init__(nixl_config, config, metadata, loop)
@@ -933,7 +933,7 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         self,
         nixl_config: NixlStorageConfig,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
         cache_policy: Optional[PresenceCache] = None,
     ):
@@ -991,7 +991,7 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
 
     def init_chunk_meta(
         self,
-        metadata: Optional[LMCacheEngineMetadata],
+        metadata: Optional[LMCacheMetadata],
     ) -> None:
         """Initialize chunk metadata similar to base_connector.init_chunk_meta()"""
         if metadata is None:

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -35,7 +35,6 @@ from nixl._api import (
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
@@ -48,6 +47,7 @@ from lmcache.v1.memory_management import (
     _allocate_gpu_memory,
     _free_cpu_memory,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy
 from lmcache.v1.transfer_channel.transfer_utils import get_correct_device

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -12,7 +12,6 @@ import zmq
 import zmq.asyncio
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
@@ -27,6 +26,7 @@ from lmcache.v1.memory_management import (
     MemoryObj,
     PagedCpuGpuMemoryAllocator,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc_utils import (
     DEFAULT_SOCKET_RECV_TIMEOUT_MS,
     DEFAULT_SOCKET_SEND_TIMEOUT_MS,

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -12,7 +12,7 @@ import zmq
 import zmq.asyncio
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import CacheEngineKey
@@ -159,7 +159,7 @@ class P2PBackend(StorageBackendInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
         lmcache_worker: "LMCacheWorker",

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -12,7 +12,6 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import (
     STR_DTYPE_TO_TORCH_DTYPE,
@@ -25,6 +24,7 @@ from lmcache.v1.memory_management import (
     MemoryObj,
     PagedCpuGpuMemoryAllocator,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc_utils import get_zmq_context, get_zmq_socket
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
 from lmcache.v1.transfer_channel import CreateTransferChannel

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -12,7 +12,7 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import (
     STR_DTYPE_TO_TORCH_DTYPE,
@@ -83,7 +83,7 @@ class PDConfig:
     @staticmethod
     def from_cache_engine_config(
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         tp_rank: int,
     ) -> "PDConfig":
         """Convert the LMCacheEngineConfig to PDConfig"""
@@ -143,7 +143,7 @@ class PDBackend(AllocatorBackendInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
     ):
         self.running = True
 
@@ -206,7 +206,7 @@ class PDBackend(AllocatorBackendInterface):
         return self.__class__.__name__
 
     def initialize_allocator(
-        self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata
+        self, config: LMCacheEngineConfig, metadata: LMCacheMetadata
     ) -> PagedCpuGpuMemoryAllocator:
         # First Party
         from lmcache.v1.transfer_channel.transfer_utils import (

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -7,13 +7,13 @@ import threading
 import time
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.exceptions import IrrecoverableException
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.connector import CreateConnector
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -7,7 +7,7 @@ import threading
 import time
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
@@ -27,7 +27,7 @@ class RemoteBackend(StorageBackendInterface):
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: Optional[LocalCPUBackend],
         dst_device: str = "cuda",

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -23,7 +23,6 @@ import threading
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import PrometheusLogger
 from lmcache.utils import (
@@ -37,6 +36,7 @@ from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import CreateStorageBackends, is_cuda_worker
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -23,7 +23,7 @@ import threading
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.observability import PrometheusLogger
 from lmcache.utils import (
@@ -220,7 +220,7 @@ class StorageManager:
     def __init__(
         self,
         config: LMCacheEngineConfig,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         event_manager: EventManager,
         lmcache_worker: Optional["LMCacheWorker"] = None,
         async_lookup_server: Optional["LMCacheAsyncLookupServer"] = None,

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -212,7 +212,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         # collapse the CacheEngineKey.world_size to 1 so that cache keys
         # become world-size agnostic across compatible deployments.
         return CacheEngineKey(
-            self.metadata.fmt,
+            self.metadata.use_case,
             self.metadata.model_name,
             self.metadata.world_size if not self.save_only_first_rank else 1,
             self.metadata.worker_id,

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -21,7 +21,7 @@ from transformers import AutoTokenizer
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
@@ -50,7 +50,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
     def __init__(
         self,
         config: Optional[LMCacheEngineConfig] = None,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
     ):
         global NONE_HASH
 
@@ -244,7 +244,7 @@ class ChunkedTokenDatabase(TokenDatabase):
     def __init__(
         self,
         config: Optional[LMCacheEngineConfig] = None,
-        metadata: Optional[LMCacheEngineMetadata] = None,
+        metadata: Optional[LMCacheMetadata] = None,
     ):
         super(ChunkedTokenDatabase, self).__init__(config, metadata)
 
@@ -397,7 +397,7 @@ class SegmentTokenDatabase(TokenDatabase):
     In the future, we might need to implement a fast substring match.
     """
 
-    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheEngineMetadata):
+    def __init__(self, config: LMCacheEngineConfig, metadata: LMCacheMetadata):
         super(SegmentTokenDatabase, self).__init__(config, metadata)
 
         self.tokenizer = AutoTokenizer.from_pretrained(metadata.model_name)

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -212,7 +212,6 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         # collapse the CacheEngineKey.world_size to 1 so that cache keys
         # become world-size agnostic across compatible deployments.
         return CacheEngineKey(
-            self.metadata.use_case,
             self.metadata.model_name,
             self.metadata.world_size if not self.save_only_first_rank else 1,
             self.metadata.worker_id,

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -21,10 +21,10 @@ from transformers import AutoTokenizer
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey, _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/xpu_connector.py
+++ b/lmcache/v1/xpu_connector.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
@@ -80,11 +80,11 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
     @classmethod
     def from_metadata(
         cls,
-        metadata: LMCacheEngineMetadata,
+        metadata: LMCacheMetadata,
         use_gpu: bool = False,
         device: Optional[torch.device] = None,
     ) -> "VLLMPagedMemXPUConnectorV2":
-        """Create a connector from LMCacheEngineMetadata.
+        """Create a connector from LMCacheMetadata.
 
         Args:
             metadata: The LMCache engine metadata containing model configuration.

--- a/lmcache/v1/xpu_connector.py
+++ b/lmcache/v1/xpu_connector.py
@@ -19,10 +19,10 @@ from typing import List, Optional
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -144,7 +144,6 @@ def test_store_1GB(
 
     # lmcache and vllm configs
     device = "cuda"
-    fmt = "vllm"
     num_tokens = 2000
 
     num_blocks = 1000
@@ -172,7 +171,7 @@ def test_store_1GB(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -259,7 +258,6 @@ def test_retrieve_1GB_allhit(
 
     # lmcache and vllm configs
     device = "cuda"
-    fmt = "vllm"
     num_tokens = 2000
 
     num_blocks = 1000
@@ -294,7 +292,7 @@ def test_retrieve_1GB_allhit(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -379,7 +377,6 @@ def test_lookup_20K_tokens(
 
     # lmcache and vllm configs
     device = "cuda"
-    fmt = "vllm"
     num_tokens = 2000
 
     num_blocks = 1000
@@ -413,7 +410,7 @@ def test_lookup_20K_tokens(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,

--- a/tests/benchmarks/test_cachegen.py
+++ b/tests/benchmarks/test_cachegen.py
@@ -4,10 +4,10 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 
 def generate_kv_cache(num_tokens, use_case, device):

--- a/tests/benchmarks/test_cachegen.py
+++ b/tests/benchmarks/test_cachegen.py
@@ -4,23 +4,23 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.config import LMCacheEngineConfig
 
 
-def generate_kv_cache(num_tokens, fmt, device):
+def generate_kv_cache(num_tokens, use_case, device):
     ret = []
     num_layers = 32
     num_heads = 8
     head_size = 128
     shape = (
         [num_tokens, num_heads, head_size]
-        if fmt == "vllm"
+        if use_case == "vllm"
         else [num_heads, num_tokens, head_size]
     )
-    dtype = torch.bfloat16 if fmt == "vllm" else torch.float16
+    dtype = torch.bfloat16 if use_case == "vllm" else torch.float16
 
     for i in range(num_layers):
         k = torch.rand(shape, dtype=dtype, device=device)
@@ -37,41 +37,41 @@ def to_blob(kv_tuples):
 
 
 # @pytest.mark.parametrize("chunk_size", [64, 256, 768])
-# @pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
-# def test_cachegen_encoder_bench(benchmark, chunk_size, fmt):
-#    fmt = "vllm"
+# @pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
+# def test_cachegen_encoder_bench(benchmark, chunk_size, use_case):
+#    use_case = "vllm"
 #    config = LMCacheEngineConfig.from_defaults(chunk_size = chunk_size)
-#    metadata = LMCacheEngineMetadata(
+#    metadata = LMCacheMetadata(
 # model_name = "mistralai/Mistral-7B-Instruct-v0.2",
-# world_size = 1, worker_id = 0, fmt = fmt)
+# world_size = 1, worker_id = 0, use_case = use_case)
 #    serializer = CacheGenSerializer(config, metadata)
 #
-#    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
+#    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
 #
 #    benchmark(serializer.to_bytes, kv)
 
 
 @pytest.mark.benchmark(group="cachegen")
-@pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
+@pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
 @pytest.mark.parametrize("chunk_size", [64, 256, 768])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer/Deserializer",
 )
-def test_cachegen_decoder_bench(benchmark, fmt, chunk_size):
+def test_cachegen_decoder_bench(benchmark, use_case, chunk_size):
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
         worker_id=0,
-        fmt=fmt,
+        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
     output = serializer.to_bytes(kv)
 
     benchmark(deserializer.from_bytes, output)

--- a/tests/benchmarks/test_cachegen.py
+++ b/tests/benchmarks/test_cachegen.py
@@ -10,17 +10,13 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.metadata import LMCacheMetadata
 
 
-def generate_kv_cache(num_tokens, use_case, device):
+def generate_kv_cache(num_tokens, device):
     ret = []
     num_layers = 32
     num_heads = 8
     head_size = 128
-    shape = (
-        [num_tokens, num_heads, head_size]
-        if use_case == "vllm"
-        else [num_heads, num_tokens, head_size]
-    )
-    dtype = torch.bfloat16 if use_case == "vllm" else torch.float16
+    shape = [num_tokens, num_heads, head_size]
+    dtype = torch.bfloat16
 
     for i in range(num_layers):
         k = torch.rand(shape, dtype=dtype, device=device)
@@ -37,29 +33,26 @@ def to_blob(kv_tuples):
 
 
 # @pytest.mark.parametrize("chunk_size", [64, 256, 768])
-# @pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
-# def test_cachegen_encoder_bench(benchmark, chunk_size, use_case):
-#    use_case = "vllm"
+# def test_cachegen_encoder_bench(benchmark, chunk_size):
 #    config = LMCacheEngineConfig.from_defaults(chunk_size = chunk_size)
 #    metadata = LMCacheMetadata(
 # model_name = "mistralai/Mistral-7B-Instruct-v0.2",
 # world_size = 1, local_world_size = 1, worker_id = 0,
-#    local_worker_id = 0, use_case = use_case)
+#    local_worker_id = 0)
 #    serializer = CacheGenSerializer(config, metadata)
 #
-#    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
+#    kv = to_blob(generate_kv_cache(chunk_size, "cuda"))
 #
 #    benchmark(serializer.to_bytes, kv)
 
 
 @pytest.mark.benchmark(group="cachegen")
-@pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
 @pytest.mark.parametrize("chunk_size", [64, 256, 768])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer/Deserializer",
 )
-def test_cachegen_decoder_bench(benchmark, use_case, chunk_size):
+def test_cachegen_decoder_bench(benchmark, chunk_size):
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
@@ -67,14 +60,13 @@ def test_cachegen_decoder_bench(benchmark, use_case, chunk_size):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size, "cuda"))
     output = serializer.to_bytes(kv)
 
     benchmark(deserializer.from_bytes, output)

--- a/tests/benchmarks/test_cachegen.py
+++ b/tests/benchmarks/test_cachegen.py
@@ -43,7 +43,8 @@ def to_blob(kv_tuples):
 #    config = LMCacheEngineConfig.from_defaults(chunk_size = chunk_size)
 #    metadata = LMCacheMetadata(
 # model_name = "mistralai/Mistral-7B-Instruct-v0.2",
-# world_size = 1, worker_id = 0, use_case = use_case)
+# world_size = 1, local_world_size = 1, worker_id = 0,
+#    local_worker_id = 0, use_case = use_case)
 #    serializer = CacheGenSerializer(config, metadata)
 #
 #    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
@@ -63,7 +64,9 @@ def test_cachegen_decoder_bench(benchmark, use_case, chunk_size):
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.memory_management import MixedMemoryAllocator
 
@@ -494,8 +494,8 @@ def use_shared_allocator(request, monkeypatch, memory_allocator):
 
 @pytest.fixture(scope="function")
 def lmcache_engine_metadata(role="worker"):
-    """Create a fresh LMCacheEngineMetadata for each test."""
-    return LMCacheEngineMetadata(
+    """Create a fresh LMCacheMetadata for each test."""
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -512,7 +512,6 @@ def lmcache_engine_metadata(role="worker"):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(32, 2, 256, 32, 128),
         use_mla=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -498,7 +498,9 @@ def lmcache_engine_metadata(role="worker"):
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(32, 2, 256, 32, 128),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.memory_management import MixedMemoryAllocator
+from lmcache.v1.metadata import LMCacheMetadata
 
 # This is to mock the constructor and destructor of
 # MixedMemoryAllocator and PinMemoryAllocator to
@@ -499,7 +499,7 @@ def lmcache_engine_metadata(role="worker"):
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(32, 2, 256, 32, 128),
         use_mla=False,

--- a/tests/disagg/test_nixl_cache_engine.py
+++ b/tests/disagg/test_nixl_cache_engine.py
@@ -130,7 +130,9 @@ def create_metadata() -> LMCacheMetadata:
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,

--- a/tests/disagg/test_nixl_cache_engine.py
+++ b/tests/disagg/test_nixl_cache_engine.py
@@ -133,7 +133,6 @@ def create_metadata() -> LMCacheMetadata:
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
     )

--- a/tests/disagg/test_nixl_cache_engine.py
+++ b/tests/disagg/test_nixl_cache_engine.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
@@ -118,7 +118,7 @@ def create_config(role: str, host: str, port: int) -> LMCacheEngineConfig:
     return config
 
 
-def create_metadata() -> LMCacheEngineMetadata:
+def create_metadata() -> LMCacheMetadata:
     """Create metadata for the LMCacheEngine."""
     # Define KV shape: (num_layers, 2, chunk_size, num_heads, head_dim)
     chunk_size = 256
@@ -127,11 +127,11 @@ def create_metadata() -> LMCacheEngineMetadata:
     head_dim = 128
     kv_shape = (num_layers, 2, chunk_size, num_heads, head_dim)
 
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
     )

--- a/tests/disagg/test_nixl_cache_engine.py
+++ b/tests/disagg/test_nixl_cache_engine.py
@@ -10,12 +10,12 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/tests/disagg/test_nixl_channel.py
+++ b/tests/disagg/test_nixl_channel.py
@@ -31,7 +31,7 @@ def generate_test_data(
     for i in range(num_objs):
         keys.append(
             CacheEngineKey(
-                fmt="test",
+                use_case="vllm",
                 model_name="test_model",
                 world_size=1,
                 worker_id=0,

--- a/tests/disagg/test_nixl_channel.py
+++ b/tests/disagg/test_nixl_channel.py
@@ -31,7 +31,6 @@ def generate_test_data(
     for i in range(num_objs):
         keys.append(
             CacheEngineKey(
-                use_case="vllm",
                 model_name="test_model",
                 world_size=1,
                 worker_id=0,

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -15,11 +15,11 @@ import torch
 pytest.importorskip("nixl", reason="nixl package is required for nixl tests")
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.nixl_storage_backend import (
     NixlStorageBackend,
     NixlStorageConfig,

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -83,6 +83,8 @@ def create_test_metadata() -> LMCacheMetadata:
     return LMCacheMetadata(
         model_name="test_model",
         worker_id=0,
+        local_world_size=1,
+        local_worker_id=0,
         world_size=1,
         use_case="test",
         kv_dtype=torch.bfloat16,

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -15,7 +15,7 @@ import torch
 pytest.importorskip("nixl", reason="nixl package is required for nixl tests")
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
@@ -78,9 +78,9 @@ def create_test_config(
     return config
 
 
-def create_test_metadata() -> LMCacheEngineMetadata:
+def create_test_metadata() -> LMCacheMetadata:
     """Create test metadata for NixlStorageBackend"""
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name="test_model",
         worker_id=0,
         world_size=1,

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -39,7 +39,7 @@ def generate_test_data(
     for i in range(num_objs):
         keys.append(
             CacheEngineKey(
-                fmt="test",
+                use_case="vllm",
                 model_name="test_model",
                 world_size=1,
                 worker_id=0,
@@ -84,7 +84,7 @@ def create_test_metadata() -> LMCacheEngineMetadata:
         model_name="test_model",
         worker_id=0,
         world_size=1,
-        fmt="test",
+        use_case="test",
         kv_dtype=torch.bfloat16,
         kv_shape=(
             32,

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -39,7 +39,6 @@ def generate_test_data(
     for i in range(num_objs):
         keys.append(
             CacheEngineKey(
-                use_case="vllm",
                 model_name="test_model",
                 world_size=1,
                 worker_id=0,
@@ -86,7 +85,6 @@ def create_test_metadata() -> LMCacheMetadata:
         local_world_size=1,
         local_worker_id=0,
         world_size=1,
-        use_case="test",
         kv_dtype=torch.bfloat16,
         kv_shape=(
             32,

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -49,7 +49,9 @@ def test_cachegen_encoder(chunk_size):
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
@@ -57,7 +59,9 @@ def test_cachegen_encoder(chunk_size):
     metadata2 = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case=use_case2,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
@@ -115,7 +119,9 @@ def test_cachegen_unmatched_size(use_case):
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -91,7 +91,9 @@ def test_cachegen_decoder(use_case, chunk_size):
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -11,17 +11,13 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.metadata import LMCacheMetadata
 
 
-def generate_kv_cache(num_tokens, use_case, device):
+def generate_kv_cache(num_tokens, device):
     ret = []
     num_layers = 32
     num_heads = 8
     head_size = 128
-    shape = (
-        [num_tokens, num_heads, head_size]
-        if use_case == "vllm"
-        else [num_heads, num_tokens, head_size]
-    )
-    dtype = torch.bfloat16 if use_case == "vllm" else torch.float16
+    shape = [num_tokens, num_heads, head_size]
+    dtype = torch.bfloat16
 
     for i in range(num_layers):
         k = torch.rand(shape, dtype=dtype, device=device)
@@ -43,8 +39,6 @@ def to_blob(kv_tuples):
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer",
 )
 def test_cachegen_encoder(chunk_size):
-    use_case = "vllm"
-    use_case2 = "huggingface"
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
@@ -52,41 +46,39 @@ def test_cachegen_encoder(chunk_size):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
-    metadata2 = LMCacheMetadata(
-        model_name="mistralai/Mistral-7B-Instruct-v0.2",
-        world_size=1,
-        local_world_size=1,
-        worker_id=0,
-        local_worker_id=0,
-        use_case=use_case2,
-        kv_dtype=torch.bfloat16,
-        kv_shape=None,
-    )
+    # metadata2 = LMCacheMetadata(
+    #     model_name="mistralai/Mistral-7B-Instruct-v0.2",
+    #     world_size=1,
+    #     local_world_size=1,
+    #     worker_id=0,
+    #     local_worker_id=0,
+    #     kv_dtype=torch.bfloat16,
+    #     kv_shape=None,
+    # )
     serializer = CacheGenSerializer(config, metadata)
-    serializer2 = CacheGenSerializer(config, metadata2)
+    # serializer2 = CacheGenSerializer(config, metadata2)
 
-    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size, "cuda"))
     output = serializer.to_bytes(kv)
-    kv2 = kv.permute([0, 1, 3, 2, 4])
-    output2 = serializer2.to_bytes(kv2)
+    # huggingface:
+    # kv2 = kv.permute([0, 1, 3, 2, 4])
+    # output2 = serializer2.to_bytes(kv2)
 
-    assert abs(len(output) - len(output2)) < 10
+    # assert abs(len(output) - len(output2)) < 10
     output_dict = CacheGenEncoderOutput.from_bytes(output)
     assert output_dict.num_heads == 8
     assert output_dict.head_size == 128
 
 
-@pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
 @pytest.mark.parametrize("chunk_size", [16, 128, 256])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer",
 )
-def test_cachegen_decoder(use_case, chunk_size):
+def test_cachegen_decoder(chunk_size):
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
@@ -94,14 +86,13 @@ def test_cachegen_decoder(use_case, chunk_size):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size, "cuda"))
     output = serializer.to_bytes(kv)
 
     decoded_kv = deserializer.from_bytes(output)
@@ -109,14 +100,12 @@ def test_cachegen_decoder(use_case, chunk_size):
     assert decoded_kv.mean() != 0
 
 
-@pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer",
 )
-def test_cachegen_unmatched_size(use_case):
+def test_cachegen_unmatched_size():
     chunk_size = 256
-    use_case = "vllm"
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
     metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
@@ -124,14 +113,13 @@ def test_cachegen_unmatched_size(use_case):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size - 20, use_case, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size - 20, "cuda"))
     output = serializer.to_bytes(kv)
 
     decoded_kv = deserializer.from_bytes(output)

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -4,11 +4,11 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.storage_backend.serde.cachegen_basics import CacheGenEncoderOutput
 from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 
 
 def generate_kv_cache(num_tokens, use_case, device):

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -4,24 +4,24 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.storage_backend.serde.cachegen_basics import CacheGenEncoderOutput
 from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.config import LMCacheEngineConfig
 
 
-def generate_kv_cache(num_tokens, fmt, device):
+def generate_kv_cache(num_tokens, use_case, device):
     ret = []
     num_layers = 32
     num_heads = 8
     head_size = 128
     shape = (
         [num_tokens, num_heads, head_size]
-        if fmt == "vllm"
+        if use_case == "vllm"
         else [num_heads, num_tokens, head_size]
     )
-    dtype = torch.bfloat16 if fmt == "vllm" else torch.float16
+    dtype = torch.bfloat16 if use_case == "vllm" else torch.float16
 
     for i in range(num_layers):
         k = torch.rand(shape, dtype=dtype, device=device)
@@ -43,29 +43,29 @@ def to_blob(kv_tuples):
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer",
 )
 def test_cachegen_encoder(chunk_size):
-    fmt = "vllm"
-    fmt2 = "huggingface"
+    use_case = "vllm"
+    use_case2 = "huggingface"
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
         worker_id=0,
-        fmt=fmt,
+        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
-    metadata2 = LMCacheEngineMetadata(
+    metadata2 = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
         worker_id=0,
-        fmt=fmt2,
+        use_case=use_case2,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     serializer2 = CacheGenSerializer(config, metadata2)
 
-    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
     output = serializer.to_bytes(kv)
     kv2 = kv.permute([0, 1, 3, 2, 4])
     output2 = serializer2.to_bytes(kv2)
@@ -76,26 +76,26 @@ def test_cachegen_encoder(chunk_size):
     assert output_dict.head_size == 128
 
 
-@pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
+@pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
 @pytest.mark.parametrize("chunk_size", [16, 128, 256])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer",
 )
-def test_cachegen_decoder(fmt, chunk_size):
+def test_cachegen_decoder(use_case, chunk_size):
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
         worker_id=0,
-        fmt=fmt,
+        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size, fmt, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size, use_case, "cuda"))
     output = serializer.to_bytes(kv)
 
     decoded_kv = deserializer.from_bytes(output)
@@ -103,27 +103,27 @@ def test_cachegen_decoder(fmt, chunk_size):
     assert decoded_kv.mean() != 0
 
 
-@pytest.mark.parametrize("fmt", ["vllm", "huggingface"])
+@pytest.mark.parametrize("use_case", ["vllm", "huggingface"])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to CacheGenSerializer",
 )
-def test_cachegen_unmatched_size(fmt):
+def test_cachegen_unmatched_size(use_case):
     chunk_size = 256
-    fmt = "vllm"
+    use_case = "vllm"
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="mistralai/Mistral-7B-Instruct-v0.2",
         world_size=1,
         worker_id=0,
-        fmt=fmt,
+        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=None,
     )
     serializer = CacheGenSerializer(config, metadata)
     deserializer = CacheGenDeserializer(config, metadata, torch.bfloat16)
 
-    kv = to_blob(generate_kv_cache(chunk_size - 20, fmt, "cuda"))
+    kv = to_blob(generate_kv_cache(chunk_size - 20, use_case, "cuda"))
     output = serializer.to_bytes(kv)
 
     decoded_kv = deserializer.from_bytes(output)

--- a/tests/v1/cache_controller/conftest.py
+++ b/tests/v1/cache_controller/conftest.py
@@ -61,7 +61,13 @@ def create_test_config(
 
 def create_test_key(key_id: int) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
-    return CacheEngineKey("vllm", "test_model", 3, 123, key_id, torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=0,
+        chunk_hash=key_id,
+        dtype=torch.bfloat16,
+    )
 
 
 # ============= Mock Classes =============

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -15,7 +15,7 @@ import torch
 import yaml
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey, start_loop_in_thread_with_exceptions
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
@@ -66,7 +66,7 @@ class TestLoadFSChunksAPI:
     @pytest.fixture
     def test_metadata(self):
         """Create test metadata."""
-        return LMCacheEngineMetadata(
+        return LMCacheMetadata(
             model_name="test_model",
             world_size=1,
             worker_id=0,
@@ -133,7 +133,7 @@ class TestLoadFSChunksAPI:
         temp_fs_path: str,
         async_loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
-        test_metadata: LMCacheEngineMetadata,
+        test_metadata: LMCacheMetadata,
         num_chunks: int = 3,
     ):
         """Prepare test data by putting chunks into FSConnector."""

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -15,12 +15,12 @@ import torch
 import yaml
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey, start_loop_in_thread_with_exceptions
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.internal_api_server.api_server import app
 from lmcache.v1.memory_management import AdHocMemoryAllocator
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 from tests.v1.utils import create_test_memory_obj
@@ -70,7 +70,7 @@ class TestLoadFSChunksAPI:
             model_name="test_model",
             world_size=1,
             worker_id=0,
-            fmt="vllm",
+            use_case="vllm",
             kv_dtype=torch.bfloat16,
             kv_shape=(28, 2, 256, 8, 128),
         )

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -120,7 +120,7 @@ class TestLoadFSChunksAPI:
     def _create_test_key(self, key_id: int) -> CacheEngineKey:
         """Create a test CacheEngineKey."""
         return CacheEngineKey(
-            fmt="vllm",
+            use_case="vllm",
             model_name="test_model",
             world_size=1,
             worker_id=0,

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -69,7 +69,9 @@ class TestLoadFSChunksAPI:
         return LMCacheMetadata(
             model_name="test_model",
             world_size=1,
+            local_world_size=1,
             worker_id=0,
+            local_worker_id=0,
             use_case="vllm",
             kv_dtype=torch.bfloat16,
             kv_shape=(28, 2, 256, 8, 128),

--- a/tests/v1/internal_api_server/test_load_fs_chunks.py
+++ b/tests/v1/internal_api_server/test_load_fs_chunks.py
@@ -72,7 +72,6 @@ class TestLoadFSChunksAPI:
             local_world_size=1,
             worker_id=0,
             local_worker_id=0,
-            use_case="vllm",
             kv_dtype=torch.bfloat16,
             kv_shape=(28, 2, 256, 8, 128),
         )
@@ -122,7 +121,6 @@ class TestLoadFSChunksAPI:
     def _create_test_key(self, key_id: int) -> CacheEngineKey:
         """Create a test CacheEngineKey."""
         return CacheEngineKey(
-            use_case="vllm",
             model_name="test_model",
             world_size=1,
             worker_id=0,

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -82,7 +82,9 @@ def local_cpu_backend():
     metadata = LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(64, 2, 1, 8, 128),

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -25,7 +25,13 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 def create_test_key(key_id: str) -> CacheEngineKey:
     """Helper to create a test CacheEngineKey"""
-    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), dtype=torch.uint8)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=torch.uint8,
+    )
 
 
 def create_mock_memory_obj(backend: LocalCPUBackend, data: bytes) -> MemoryObj:
@@ -85,7 +91,6 @@ def local_cpu_backend():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(64, 2, 1, 8, 128),
     )

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -9,7 +9,6 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
@@ -18,6 +17,7 @@ from lmcache.v1.memory_management import (
     MemoryObj,
     TensorMemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.connector.audit_connector import AuditConnector
 from lmcache.v1.storage_backend.connector.mock_connector import MockConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
@@ -83,7 +83,7 @@ def local_cpu_backend():
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(64, 2, 1, 8, 128),
     )

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
@@ -79,7 +79,7 @@ def local_cpu_backend():
         remote_url="mock://test",
         extra_config={},
     )
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/v1/storage_backend/test_batched_message_sender.py
+++ b/tests/v1/storage_backend/test_batched_message_sender.py
@@ -55,7 +55,13 @@ def create_test_config(
 
 def create_test_key(key_id: str = "test_key") -> CacheEngineKey:
     """Create a test CacheEngineKey."""
-    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+    )
 
 
 class TestBatchedMessageSender:

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -35,7 +35,9 @@ def create_test_metadata():
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
@@ -31,8 +31,8 @@ def create_test_config(fs_path: str):
 
 
 def create_test_metadata():
-    """Create a test metadata for LMCacheEngineMetadata."""
-    return LMCacheEngineMetadata(
+    """Create a test metadata for LMCacheMetadata."""
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -38,7 +38,6 @@ def create_test_metadata():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )
@@ -46,7 +45,13 @@ def create_test_metadata():
 
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
-    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+    )
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -36,7 +36,7 @@ def create_test_metadata():
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -10,10 +10,10 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 from tests.v1.utils import create_test_memory_obj

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
@@ -37,8 +37,8 @@ def create_test_key(key_id: int = 0) -> CacheEngineKey:
 
 
 def create_test_metadata():
-    """Create a test metadata for LMCacheEngineMetadata."""
-    return LMCacheEngineMetadata(
+    """Create a test metadata for LMCacheMetadata."""
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -13,10 +13,10 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.gds_backend import GdsBackend
 from tests.v1.utils import create_test_memory_obj
 

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -33,7 +33,13 @@ def create_test_config(gds_path: str):
 
 
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
-    return CacheEngineKey("vllm", "testmodel", 3, 123, key_id, torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=key_id,
+        dtype=torch.bfloat16,
+    )
 
 
 def create_test_metadata():
@@ -44,7 +50,6 @@ def create_test_metadata():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -41,7 +41,9 @@ def create_test_metadata():
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -33,8 +33,9 @@ def create_test_config(gds_path: str):
 
 
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
+    # NO UNDERSCORE HERE for model_name
     return CacheEngineKey(
-        model_name="test_model",
+        model_name="testmodel",
         world_size=3,
         worker_id=1,
         chunk_hash=key_id,

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -42,7 +42,7 @@ def create_test_metadata():
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -55,7 +55,13 @@ def create_test_config(
 
 def create_test_key(key_id: str = "test_key") -> CacheEngineKey:
     """Create a test CacheEngineKey."""
-    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=0,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+    )
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -53,7 +53,9 @@ def create_test_metadata():
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -54,7 +54,7 @@ def create_test_metadata():
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -56,7 +56,6 @@ def create_test_metadata():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )
@@ -64,7 +63,13 @@ def create_test_metadata():
 
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
-    return CacheEngineKey("vllm", "test_model", 3, 123, hash(key_id), torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+    )
 
 
 @pytest.fixture

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -10,9 +10,9 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
@@ -49,8 +49,8 @@ def create_test_config(disk_path: str, max_disk_size: float = 1.0):
 
 
 def create_test_metadata():
-    """Create a test metadata for LMCacheEngineMetadata."""
-    return LMCacheEngineMetadata(
+    """Create a test metadata for LMCacheMetadata."""
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/v1/storage_backend/test_p2p_backend_with_controller.py
+++ b/tests/v1/storage_backend/test_p2p_backend_with_controller.py
@@ -199,7 +199,7 @@ def create_test_metadata(worker_id: int = 0):
         model_name="test_model",
         world_size=2,
         worker_id=worker_id,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )

--- a/tests/v1/storage_backend/test_p2p_backend_with_controller.py
+++ b/tests/v1/storage_backend/test_p2p_backend_with_controller.py
@@ -198,7 +198,9 @@ def create_test_metadata(worker_id: int = 0):
     return LMCacheMetadata(
         model_name="test_model",
         world_size=2,
+        local_world_size=2,
         worker_id=worker_id,
+        local_worker_id=worker_id,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),

--- a/tests/v1/storage_backend/test_p2p_backend_with_controller.py
+++ b/tests/v1/storage_backend/test_p2p_backend_with_controller.py
@@ -15,7 +15,6 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.cache_controller.message import (
@@ -27,6 +26,7 @@ from lmcache.v1.memory_management import (
     MemoryFormat,
     PagedCpuGpuMemoryAllocator,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.p2p_backend import P2PBackend
 from lmcache.v1.transfer_channel.transfer_utils import P2PInitSideRetMsg

--- a/tests/v1/storage_backend/test_p2p_backend_with_controller.py
+++ b/tests/v1/storage_backend/test_p2p_backend_with_controller.py
@@ -15,7 +15,7 @@ import torch
 import zmq
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.cache_controller.message import (
@@ -195,7 +195,7 @@ def create_test_config(
 
 def create_test_metadata(worker_id: int = 0):
     """Create test metadata"""
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=2,
         worker_id=worker_id,

--- a/tests/v1/storage_backend/test_p2p_backend_with_controller.py
+++ b/tests/v1/storage_backend/test_p2p_backend_with_controller.py
@@ -201,7 +201,6 @@ def create_test_metadata(worker_id: int = 0):
         local_world_size=2,
         worker_id=worker_id,
         local_worker_id=worker_id,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
     )
@@ -210,7 +209,12 @@ def create_test_metadata(worker_id: int = 0):
 def create_test_key(key_id: str = "test_key") -> CacheEngineKey:
     """Create a test CacheEngineKey"""
     return CacheEngineKey(
-        "vllm", "test_model", 2, 0, hash(key_id), torch.bfloat16, None
+        model_name="test_model",
+        world_size=2,
+        worker_id=0,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+        request_configs=None,
     )
 
 

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -27,7 +27,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventType
 from lmcache.v1.storage_backend.storage_manager import StorageManager
@@ -79,11 +79,11 @@ def storage_manager_config():
 @pytest.fixture
 def storage_manager_metadata():
     """Create test metadata for StorageManager."""
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
         role="scheduler",

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -85,7 +85,6 @@ def storage_manager_metadata():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),
         role="scheduler",

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -82,7 +82,9 @@ def storage_manager_metadata():
     metadata = LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(28, 2, 256, 8, 128),

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -27,9 +27,9 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventType
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 

--- a/tests/v1/storage_backend/test_storage_plugin.py
+++ b/tests/v1/storage_backend/test_storage_plugin.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager
@@ -166,7 +166,7 @@ def create_test_config(
 
 def create_test_metadata():
     """Create test metadata for testing."""
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/v1/storage_backend/test_storage_plugin.py
+++ b/tests/v1/storage_backend/test_storage_plugin.py
@@ -170,7 +170,7 @@ def create_test_metadata():
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(
             4,

--- a/tests/v1/storage_backend/test_storage_plugin.py
+++ b/tests/v1/storage_backend/test_storage_plugin.py
@@ -18,7 +18,6 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager
@@ -26,6 +25,7 @@ from lmcache.v1.memory_management import (
     AdHocMemoryAllocator,
     MemoryObj,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,

--- a/tests/v1/storage_backend/test_storage_plugin.py
+++ b/tests/v1/storage_backend/test_storage_plugin.py
@@ -169,7 +169,9 @@ def create_test_metadata():
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(

--- a/tests/v1/storage_backend/test_storage_plugin.py
+++ b/tests/v1/storage_backend/test_storage_plugin.py
@@ -137,12 +137,11 @@ MOCK_BACKEND_STORAGE_PLUGINS = ["mock_backend"]
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey(
-        "vllm",
-        "test_model",
-        1,  # world_size
-        0,  # worker_id
-        key_id,  # chunk_hash
-        torch.bfloat16,
+        model_name="test_model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=key_id,
+        dtype=torch.bfloat16,
     )
 
 
@@ -172,7 +171,6 @@ def create_test_metadata():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(
             4,

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -57,7 +57,6 @@ def get_expected_count(token_len, save_unfull_chunk, chunk_size):
 )
 def test_paged_same_retrieve_store(save_unfull_chunk, autorelease_v1):
     device = "cuda"
-    fmt = "vllm"
     num_tokens = 2000
     num_blocks = 1000
     block_size = 16
@@ -95,7 +94,7 @@ def test_paged_same_retrieve_store(save_unfull_chunk, autorelease_v1):
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -133,7 +132,6 @@ def test_paged_same_retrieve_store(save_unfull_chunk, autorelease_v1):
     check_paged_kv_cache_equal(retrieved_cache, kv_cache, slot_mapping[:expected_count])
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("chunk_size", [128, 256])
 @pytest.mark.parametrize("backend", ["cpu", "local_disk", "remote", "remote_cachegen"])
 @pytest.mark.parametrize("save_unfull_chunk", [False, True])
@@ -143,7 +141,7 @@ def test_paged_same_retrieve_store(save_unfull_chunk, autorelease_v1):
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
 def test_paged_retrieve_prefix(
-    fmt, chunk_size, backend, save_unfull_chunk, lmserver_v1_process, autorelease_v1
+    chunk_size, backend, save_unfull_chunk, lmserver_v1_process, autorelease_v1
 ):
     url = None
     remote_serde = None
@@ -192,7 +190,7 @@ def test_paged_retrieve_prefix(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -252,7 +250,6 @@ def test_paged_retrieve_prefix(
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("chunk_size", [256])
 @pytest.mark.parametrize(
     "backend",
@@ -265,7 +262,7 @@ def test_paged_retrieve_prefix(
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
 def test_paged_store_offset(
-    fmt, chunk_size, backend, save_unfull_chunk, lmserver_v1_process, autorelease_v1
+    chunk_size, backend, save_unfull_chunk, lmserver_v1_process, autorelease_v1
 ):
     url = None
     if backend == "remote":
@@ -302,7 +299,7 @@ def test_paged_store_offset(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -362,7 +359,6 @@ def test_paged_store_offset(
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("chunk_size", [128])  # , 256])
 @pytest.mark.parametrize(
     "backend",
@@ -376,9 +372,7 @@ def test_paged_store_offset(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
-def test_paged_mixed_retrieve(
-    fmt, chunk_size, backend, save_unfull_chunk, autorelease_v1
-):
+def test_paged_mixed_retrieve(chunk_size, backend, save_unfull_chunk, autorelease_v1):
     device = "cuda"
     num_tokens = 2000
     new_num_tokens = 1000
@@ -414,7 +408,7 @@ def test_paged_mixed_retrieve(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -522,13 +516,12 @@ def test_paged_mixed_retrieve(
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("save_unfull_chunk", [False, True])
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
-def test_paged_store_kv_tensors_mask(fmt, save_unfull_chunk, autorelease_v1):
+def test_paged_store_kv_tensors_mask(save_unfull_chunk, autorelease_v1):
     device = "cuda"
     num_tokens = 1000
     new_num_tokens = 2000
@@ -563,7 +556,7 @@ def test_paged_store_kv_tensors_mask(fmt, save_unfull_chunk, autorelease_v1):
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -684,7 +677,6 @@ def test_paged_store_kv_tensors_mask(fmt, save_unfull_chunk, autorelease_v1):
         recover_engine_states(engine)
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("chunk_size", [128])
 @pytest.mark.parametrize(
     "backend",
@@ -707,7 +699,6 @@ def test_paged_store_kv_tensors_mask(fmt, save_unfull_chunk, autorelease_v1):
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
 def test_paged_hierarchy_retrieve(
-    fmt,
     chunk_size,
     backend,
     retrieve_from,
@@ -757,7 +748,7 @@ def test_paged_hierarchy_retrieve(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -866,7 +857,6 @@ def test_paged_prefetch_retrieve(
     test_lookup_id = "test_lookup_id"
 
     chunk_size = 256
-    fmt = "vllm"
     kv_shape = (32, 2, chunk_size, 8, 128)
     connector = create_gpu_connector(1024, 32)
 
@@ -899,7 +889,7 @@ def test_paged_prefetch_retrieve(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -978,7 +968,6 @@ def test_paged_prefetch_retrieve(
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("chunk_size", [256])
 @pytest.mark.parametrize(
     "backend",
@@ -998,7 +987,7 @@ def test_paged_prefetch_retrieve(
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
 def test_paged_mem_leak(
-    fmt, chunk_size, backend, save_unfull_chunk, lmserver_v1_process, autorelease_v1
+    chunk_size, backend, save_unfull_chunk, lmserver_v1_process, autorelease_v1
 ):
     url = None
     if "remote" in backend:
@@ -1030,7 +1019,7 @@ def test_paged_mem_leak(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -1078,7 +1067,6 @@ def test_paged_mem_leak(
         subprocess.run(shlex.split("rm -rf local/disk_test/local_disk/"))
 
 
-@pytest.mark.parametrize("fmt", ["vllm"])
 @pytest.mark.parametrize("chunk_size", [256])
 @pytest.mark.parametrize(
     "backend",
@@ -1094,7 +1082,7 @@ def test_paged_mem_leak(
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
 def test_paged_retrieve_after_eviction(
-    fmt, chunk_size, backend, save_unfull_chunk, autorelease_v1
+    chunk_size, backend, save_unfull_chunk, autorelease_v1
 ):
     device = "cuda"
     # NOTE: The default backend cache size is 2 GB.
@@ -1129,7 +1117,7 @@ def test_paged_retrieve_after_eviction(
         LMCacheEngineBuilder.get_or_create(
             "test",
             cfg,
-            dumb_metadata(fmt, kv_shape),
+            dumb_metadata(kv_shape),
             connector,
             mock_up_broadcast_fn,
             mock_up_broadcast_object_fn,
@@ -1240,7 +1228,6 @@ def test_builder(autorelease_v1):
 )
 def test_force_store_wait(autorelease_v1):
     device = "cuda"
-    fmt = "vllm"
     num_tokens = 10000
     num_blocks = 5000
     block_size = 16
@@ -1283,7 +1270,7 @@ def test_force_store_wait(autorelease_v1):
             LMCacheEngineBuilder.get_or_create(
                 "test",
                 cfg,
-                dumb_metadata(fmt, kv_shape),
+                dumb_metadata(kv_shape),
                 connector,
                 mock_up_broadcast_fn,
                 mock_up_broadcast_object_fn,

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -404,7 +404,6 @@ def _get_metadata(use_mla: bool):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=dtype,
         kv_shape=kv_shape,
         use_mla=use_mla,

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -9,9 +9,9 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PinMemoryAllocator
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.protocol import RemoteMetadata
 from lmcache.v1.storage_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.connector import CreateConnector

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PinMemoryAllocator
 from lmcache.v1.protocol import RemoteMetadata
@@ -398,14 +398,14 @@ def test_cluster_metadata_without_kv_bytes(url, autorelease_v1):
 def _get_metadata(use_mla: bool):
     kv_shape = (32, 1 if use_mla else 2, 256, 1 if use_mla else 8, 128)
     dtype = torch.bfloat16
-    metadata = LMCacheEngineMetadata(
-        "deepseek/DeepSeek-R1",
-        1,
-        0,
-        "vllm",
-        dtype,
-        kv_shape,
-        use_mla,
+    metadata = LMCacheMetadata(
+        model_name="deepseek/DeepSeek-R1",
+        world_size=1,
+        worker_id=0,
+        use_case="vllm",
+        kv_dtype=dtype,
+        kv_shape=kv_shape,
+        use_mla=use_mla,
     )
     return metadata
 

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -401,7 +401,9 @@ def _get_metadata(use_mla: bool):
     metadata = LMCacheMetadata(
         model_name="deepseek/DeepSeek-R1",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=dtype,
         kv_shape=kv_shape,

--- a/tests/v1/test_freeze_mode_integration.py
+++ b/tests/v1/test_freeze_mode_integration.py
@@ -265,7 +265,7 @@ def test_freeze_direct_api(autorelease_v1):
     )
 
     connector = MockGPUConnector(kv_shape=kv_shape)
-    metadata = dumb_metadata("vllm", kv_shape)
+    metadata = dumb_metadata(kv_shape)
 
     engine = autorelease_v1(
         LMCacheEngineBuilder.get_or_create(

--- a/tests/v1/test_freeze_mode_integration.py
+++ b/tests/v1/test_freeze_mode_integration.py
@@ -66,7 +66,9 @@ def test_freeze_with_real_cache_engine(autorelease_v1):
     metadata = LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,

--- a/tests/v1/test_freeze_mode_integration.py
+++ b/tests/v1/test_freeze_mode_integration.py
@@ -8,11 +8,11 @@ import requests
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.internal_api_server.api_server import InternalAPIServer
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.mock_gpu_connector import MockGPUConnector
 from tests.v1.utils import (
     MockAdapter,

--- a/tests/v1/test_freeze_mode_integration.py
+++ b/tests/v1/test_freeze_mode_integration.py
@@ -69,7 +69,6 @@ def test_freeze_with_real_cache_engine(autorelease_v1):
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
     )

--- a/tests/v1/test_freeze_mode_integration.py
+++ b/tests/v1/test_freeze_mode_integration.py
@@ -63,7 +63,14 @@ def test_freeze_with_real_cache_engine(autorelease_v1):
     # Create mock GPU connector that works on CPU
     connector = MockGPUConnector(kv_shape=kv_shape)
     # Use explicit metadata with worker_id=0 to control port offset
-    metadata = LMCacheMetadata("test_model", 1, 0, "vllm", torch.bfloat16, kv_shape)
+    metadata = LMCacheMetadata(
+        model_name="test_model",
+        world_size=1,
+        worker_id=0,
+        use_case="vllm",
+        kv_dtype=torch.bfloat16,
+        kv_shape=kv_shape,
+    )
 
     # Create engine
     engine = autorelease_v1(

--- a/tests/v1/test_freeze_mode_integration.py
+++ b/tests/v1/test_freeze_mode_integration.py
@@ -8,7 +8,7 @@ import requests
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
@@ -63,9 +63,7 @@ def test_freeze_with_real_cache_engine(autorelease_v1):
     # Create mock GPU connector that works on CPU
     connector = MockGPUConnector(kv_shape=kv_shape)
     # Use explicit metadata with worker_id=0 to control port offset
-    metadata = LMCacheEngineMetadata(
-        "test_model", 1, 0, "vllm", torch.bfloat16, kv_shape
-    )
+    metadata = LMCacheMetadata("test_model", 1, 0, "vllm", torch.bfloat16, kv_shape)
 
     # Create engine
     engine = autorelease_v1(

--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -52,7 +52,7 @@ def test_gds_backend_sanity():
     BASE_DIR = Path(__file__).parent
     GDS_DIR = "/tmp/gds/test-cache"
     TEST_KEY = CacheEngineKey(
-        fmt="vllm",
+        use_case="vllm",
         model_name="meta-llama/Llama-3.1-70B-Instruct",
         world_size=8,
         worker_id=0,

--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -52,7 +52,6 @@ def test_gds_backend_sanity():
     BASE_DIR = Path(__file__).parent
     GDS_DIR = "/tmp/gds/test-cache"
     TEST_KEY = CacheEngineKey(
-        use_case="vllm",
         model_name="meta-llama/Llama-3.1-70B-Instruct",
         world_size=8,
         worker_id=0,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -871,7 +871,6 @@ def _create_metadata(use_mla, kv_caches):
         local_world_size=8,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(32, 2, 256, num_heads, 128),
         use_mla=use_mla,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -10,7 +10,6 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.v1.gpu_connector import (
     SGLangGPUConnector,
     VLLMBufferLayerwiseGPUConnector,
@@ -25,6 +24,7 @@ from lmcache.v1.memory_management import (
     PinMemoryAllocator,
     TensorMemoryAllocator,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 
 # Local
 from .utils import (

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -866,13 +866,13 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
 def _create_metadata(use_mla, kv_caches):
     num_heads = 1 if use_mla else 8
     metadata = LMCacheMetadata(
-        "test",
-        8,
-        0,
-        "vllm",
-        torch.bfloat16,
-        (32, 2, 256, num_heads, 128),
-        use_mla,
+        model_name="test",
+        world_size=8,
+        worker_id=0,
+        use_case="vllm",
+        kv_dtype=torch.bfloat16,
+        kv_shape=(32, 2, 256, num_heads, 128),
+        use_mla=use_mla,
     )
     metadata.kv_layer_groups_manager.build_kv_layer_groups(kv_caches)
     return metadata

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.v1.gpu_connector import (
     SGLangGPUConnector,
     VLLMBufferLayerwiseGPUConnector,
@@ -865,7 +865,7 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
 
 def _create_metadata(use_mla, kv_caches):
     num_heads = 1 if use_mla else 8
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         "test",
         8,
         0,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -868,7 +868,9 @@ def _create_metadata(use_mla, kv_caches):
     metadata = LMCacheMetadata(
         model_name="test",
         world_size=8,
+        local_world_size=8,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(32, 2, 256, num_heads, 128),

--- a/tests/v1/test_health_monitor_fallback_recovery.py
+++ b/tests/v1/test_health_monitor_fallback_recovery.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.health_monitor.base import HealthMonitor
@@ -123,7 +123,7 @@ def test_config():
 
 @pytest.fixture
 def test_metadata():
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
         worker_id=0,

--- a/tests/v1/test_health_monitor_fallback_recovery.py
+++ b/tests/v1/test_health_monitor_fallback_recovery.py
@@ -129,7 +129,6 @@ def test_metadata():
         local_world_size=1,
         worker_id=0,
         local_worker_id=0,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(4, 2, 256, 8, 128),
         role="worker",

--- a/tests/v1/test_health_monitor_fallback_recovery.py
+++ b/tests/v1/test_health_monitor_fallback_recovery.py
@@ -17,7 +17,6 @@ import pytest
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.health_monitor.base import HealthMonitor
@@ -26,6 +25,7 @@ from lmcache.v1.health_monitor.checks.remote_backend_check import (
 )
 from lmcache.v1.health_monitor.constants import FallbackPolicy
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
@@ -127,7 +127,7 @@ def test_metadata():
         model_name="test_model",
         world_size=1,
         worker_id=0,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(4, 2, 256, 8, 128),
         role="worker",

--- a/tests/v1/test_health_monitor_fallback_recovery.py
+++ b/tests/v1/test_health_monitor_fallback_recovery.py
@@ -126,7 +126,9 @@ def test_metadata():
     return LMCacheMetadata(
         model_name="test_model",
         world_size=1,
+        local_world_size=1,
         worker_id=0,
+        local_worker_id=0,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=(4, 2, 256, 8, 128),

--- a/tests/v1/test_health_monitor_fallback_recovery.py
+++ b/tests/v1/test_health_monitor_fallback_recovery.py
@@ -626,7 +626,11 @@ class TestFallbackIntegrationWithRealStorageManager:
         """Test contains operation respects bypass mode."""
         sm = real_storage_manager
         test_key = CacheEngineKey(
-            "vllm", "test_model", 1, 0, hash("test"), torch.bfloat16
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            chunk_hash=hash("test"),
+            dtype=torch.bfloat16,
         )
 
         # Test with LocalCPUBackend bypass

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -55,7 +55,9 @@ def run(config: LMCacheEngineConfig, shape, dtype):
         metadata = LMCacheMetadata(
             model_name="Llama-3.1-70B-Instruct",
             world_size=1,
+            local_world_size=1,
             worker_id=0,
+            local_worker_id=0,
             use_case="vllm",
             kv_dtype=dtype,
             kv_shape=shape,

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -11,10 +11,10 @@ import torch
 pytest.importorskip("nixl", reason="nixl package is required for nixl tests")
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PagedTensorMemoryAllocator
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageBackend
 

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -11,7 +11,7 @@ import torch
 pytest.importorskip("nixl", reason="nixl package is required for nixl tests")
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PagedTensorMemoryAllocator
@@ -52,7 +52,7 @@ def run(config: LMCacheEngineConfig, shape, dtype):
         thread = threading.Thread(target=thread_loop.run_forever)
         thread.start()
 
-        metadata = LMCacheEngineMetadata(
+        metadata = LMCacheMetadata(
             "Llama-3.1-70B-Instruct",
             0,
             0,

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -53,13 +53,12 @@ def run(config: LMCacheEngineConfig, shape, dtype):
         thread.start()
 
         metadata = LMCacheMetadata(
-            "Llama-3.1-70B-Instruct",
-            0,
-            0,
-            "MemoryFormat.KV_2LTD",
-            dtype,
-            shape,
-            False,
+            model_name="Llama-3.1-70B-Instruct",
+            world_size=1,
+            worker_id=0,
+            use_case="vllm",
+            kv_dtype=dtype,
+            kv_shape=shape,
         )
 
         backends = CreateStorageBackends(

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -21,7 +21,6 @@ from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageBackend
 
 def create_key(chunk_hash: str):
     return CacheEngineKey(
-        use_case="vllm",
         model_name="meta-llama/Llama-3.1-70B-Instruct",
         world_size=8,
         worker_id=0,
@@ -58,7 +57,6 @@ def run(config: LMCacheEngineConfig, shape, dtype):
             local_world_size=1,
             worker_id=0,
             local_worker_id=0,
-            use_case="vllm",
             kv_dtype=dtype,
             kv_shape=shape,
         )

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -21,7 +21,7 @@ from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageBackend
 
 def create_key(chunk_hash: str):
     return CacheEngineKey(
-        fmt="MemoryFormat.KV_2LTD",
+        use_case="vllm",
         model_name="meta-llama/Llama-3.1-70B-Instruct",
         world_size=8,
         worker_id=0,

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -67,7 +67,9 @@ def test_remote_mla_worker_id_as0(mock_stream):
         kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
         world_size=4,
+        local_world_size=4,
         worker_id=2,
+        local_worker_id=2,
     )
     metadata0 = LMCacheMetadata(
         model_name="test-model",
@@ -76,7 +78,9 @@ def test_remote_mla_worker_id_as0(mock_stream):
         kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
         world_size=4,
+        local_world_size=4,
         worker_id=0,
+        local_worker_id=0,
     )
 
     # Create memory allocator and local backend

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -62,7 +62,6 @@ def test_remote_mla_worker_id_as0(mock_stream):
 
     metadata = LMCacheMetadata(
         model_name="test-model",
-        use_case="vllm",
         kv_dtype=torch.float16,
         kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
@@ -73,7 +72,6 @@ def test_remote_mla_worker_id_as0(mock_stream):
     )
     metadata0 = LMCacheMetadata(
         model_name="test-model",
-        use_case="vllm",
         kv_dtype=torch.float16,
         kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
@@ -107,7 +105,6 @@ def test_remote_mla_worker_id_as0(mock_stream):
 
     # Create key
     key = CacheEngineKey(
-        use_case="vllm",
         model_name="test-model",
         world_size=4,
         worker_id=2,
@@ -127,7 +124,6 @@ def test_remote_mla_worker_id_as0(mock_stream):
     backend0.connection = backend.connection
     # Create key
     key0 = CacheEngineKey(
-        use_case="vllm",
         model_name="test-model",
         world_size=4,
         worker_id=0,

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -11,9 +11,9 @@ import threading
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -11,7 +11,7 @@ import threading
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.storage_backend.connector import RemoteConnector
@@ -60,18 +60,18 @@ def test_remote_mla_worker_id_as0(mock_stream):
         extra_config={"remote_enable_mla_worker_id_as0": True},
     )
 
-    metadata = LMCacheEngineMetadata(
+    metadata = LMCacheMetadata(
         model_name="test-model",
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.float16,
         kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,
         world_size=4,
         worker_id=2,
     )
-    metadata0 = LMCacheEngineMetadata(
+    metadata0 = LMCacheMetadata(
         model_name="test-model",
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.float16,
         kv_shape=(32, 1, 256, 64, 128),
         use_mla=True,

--- a/tests/v1/test_remote_mla_worker_id_as0.py
+++ b/tests/v1/test_remote_mla_worker_id_as0.py
@@ -103,7 +103,7 @@ def test_remote_mla_worker_id_as0(mock_stream):
 
     # Create key
     key = CacheEngineKey(
-        fmt="vllm",
+        use_case="vllm",
         model_name="test-model",
         world_size=4,
         worker_id=2,
@@ -123,7 +123,7 @@ def test_remote_mla_worker_id_as0(mock_stream):
     backend0.connection = backend.connection
     # Create key
     key0 = CacheEngineKey(
-        fmt="vllm",
+        use_case="vllm",
         model_name="test-model",
         world_size=4,
         worker_id=0,

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -14,7 +14,7 @@ import uuid
 import torch
 
 # First Party
-from lmcache.config import LMCacheEngineMetadata
+from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
@@ -29,14 +29,14 @@ def recover_gpu_connector_states(gpu_connector):
     gpu_connector.kv_cache_pointers_on_gpu = {}
 
 
-def dumb_metadata(fmt="vllm", kv_shape=(32, 2, 256, 8, 128)):
-    return LMCacheEngineMetadata("test_model", 3, 123, fmt, torch.bfloat16, kv_shape)
+def dumb_metadata(use_case="vllm", kv_shape=(32, 2, 256, 8, 128)):
+    return LMCacheMetadata("test_model", 3, 123, use_case, torch.bfloat16, kv_shape)
 
 
 def dumb_metadata_with_model_name(
-    model_name: str, fmt="vllm", kv_shape=(32, 2, 256, 8, 128)
+    model_name: str, use_case="vllm", kv_shape=(32, 2, 256, 8, 128)
 ):
-    return LMCacheEngineMetadata(model_name, 3, 123, fmt, torch.bfloat16, kv_shape)
+    return LMCacheMetadata(model_name, 3, 123, use_case, torch.bfloat16, kv_shape)
 
 
 def dumb_cache_engine_key(id: int = 0) -> CacheEngineKey:
@@ -95,17 +95,17 @@ def get_available_ports(count: int, host: str = "127.0.0.1") -> list[int]:
     return ports
 
 
-def generate_kv_cache(num_tokens, fmt, device):
+def generate_kv_cache(num_tokens, use_case, device):
     ret = []
     num_layers = 32
     num_heads = 8
     head_size = 128
     shape = (
         [num_tokens, num_heads, head_size]
-        if fmt == "vllm"
+        if use_case == "vllm"
         else [num_heads, num_tokens, head_size]
     )
-    dtype = torch.bfloat16 if fmt == "vllm" else torch.float16
+    dtype = torch.bfloat16 if use_case == "vllm" else torch.float16
 
     for i in range(num_layers):
         k = torch.rand(shape, dtype=dtype, device=device)
@@ -225,8 +225,8 @@ def generate_tokens(num_tokens, device, fixed=False):
         return torch.randint(0, 10000, size=[num_tokens]).to(device)
 
 
-def concatenate_kv_caches(kv_chunks, fmt):
-    dim = 1 if fmt == "huggingface" else 0
+def concatenate_kv_caches(kv_chunks, use_case):
+    dim = 1 if use_case == "huggingface" else 0
     ret = []
     for kv_layer in zip(*kv_chunks, strict=False):
         klist, vlist = zip(*kv_layer, strict=False)
@@ -488,9 +488,9 @@ def create_test_metadata(
     kv_shape: tuple = (4, 2, 256, 8, 128),
     engine_id: Optional[str] = "test_engine",
     kv_connector_extra_config: Optional[dict] = None,
-) -> LMCacheEngineMetadata:
+) -> LMCacheMetadata:
     """Create test metadata for LMCacheEngine."""
-    return LMCacheEngineMetadata(
+    return LMCacheMetadata(
         model_name="test_model",
         world_size=world_size,
         worker_id=worker_id,

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -33,7 +33,9 @@ def dumb_metadata(use_case="vllm", kv_shape=(32, 2, 256, 8, 128)):
     return LMCacheMetadata(
         model_name="test_model",
         world_size=3,
-        worker_id=123,
+        local_world_size=3,
+        worker_id=1,
+        local_worker_id=1,
         use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
@@ -46,7 +48,9 @@ def dumb_metadata_with_model_name(
     return LMCacheMetadata(
         model_name=model_name,
         world_size=3,
-        worker_id=123,
+        local_world_size=3,
+        worker_id=1,
+        local_worker_id=1,
         use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
@@ -507,7 +511,9 @@ def create_test_metadata(
     return LMCacheMetadata(
         model_name="test_model",
         world_size=world_size,
+        local_world_size=world_size,
         worker_id=worker_id,
+        local_worker_id=worker_id,
         use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -487,7 +487,6 @@ def create_test_metadata(
     world_size: int = 1,
     kv_shape: tuple = (4, 2, 256, 8, 128),
     engine_id: Optional[str] = "test_engine",
-    num_ranks: int = 1,
     kv_connector_extra_config: Optional[dict] = None,
 ) -> LMCacheEngineMetadata:
     """Create test metadata for LMCacheEngine."""
@@ -495,11 +494,10 @@ def create_test_metadata(
         model_name="test_model",
         world_size=world_size,
         worker_id=worker_id,
-        fmt="vllm",
+        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
         engine_id=engine_id,
-        num_ranks=num_ranks,
         kv_connector_extra_config=kv_connector_extra_config,
     )
 

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -14,11 +14,11 @@ import uuid
 import torch
 
 # First Party
-from lmcache.config import LMCacheMetadata
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
 from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
 
 
 def recover_engine_states(engine):

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -30,13 +30,27 @@ def recover_gpu_connector_states(gpu_connector):
 
 
 def dumb_metadata(use_case="vllm", kv_shape=(32, 2, 256, 8, 128)):
-    return LMCacheMetadata("test_model", 3, 123, use_case, torch.bfloat16, kv_shape)
+    return LMCacheMetadata(
+        model_name="test_model",
+        world_size=3,
+        worker_id=123,
+        use_case=use_case,
+        kv_dtype=torch.bfloat16,
+        kv_shape=kv_shape,
+    )
 
 
 def dumb_metadata_with_model_name(
     model_name: str, use_case="vllm", kv_shape=(32, 2, 256, 8, 128)
 ):
-    return LMCacheMetadata(model_name, 3, 123, use_case, torch.bfloat16, kv_shape)
+    return LMCacheMetadata(
+        model_name=model_name,
+        world_size=3,
+        worker_id=123,
+        use_case=use_case,
+        kv_dtype=torch.bfloat16,
+        kv_shape=kv_shape,
+    )
 
 
 def dumb_cache_engine_key(id: int = 0) -> CacheEngineKey:

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -29,36 +29,38 @@ def recover_gpu_connector_states(gpu_connector):
     gpu_connector.kv_cache_pointers_on_gpu = {}
 
 
-def dumb_metadata(use_case="vllm", kv_shape=(32, 2, 256, 8, 128)):
+def dumb_metadata(kv_shape=(32, 2, 256, 8, 128)):
     return LMCacheMetadata(
         model_name="test_model",
         world_size=3,
         local_world_size=3,
         worker_id=1,
         local_worker_id=1,
-        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
     )
 
 
-def dumb_metadata_with_model_name(
-    model_name: str, use_case="vllm", kv_shape=(32, 2, 256, 8, 128)
-):
+def dumb_metadata_with_model_name(model_name: str, kv_shape=(32, 2, 256, 8, 128)):
     return LMCacheMetadata(
         model_name=model_name,
         world_size=3,
         local_world_size=3,
         worker_id=1,
         local_worker_id=1,
-        use_case=use_case,
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
     )
 
 
 def dumb_cache_engine_key(id: int = 0) -> CacheEngineKey:
-    return CacheEngineKey("vllm", "test_model", 3, 123, id, torch.bfloat16)
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=id,
+        dtype=torch.bfloat16,
+    )
 
 
 def random_string(N):
@@ -132,17 +134,13 @@ def get_available_ports(count: int, host: str = "127.0.0.1") -> list[int]:
     return ports
 
 
-def generate_kv_cache(num_tokens, use_case, device):
+def generate_kv_cache(num_tokens, device):
     ret = []
     num_layers = 32
     num_heads = 8
     head_size = 128
-    shape = (
-        [num_tokens, num_heads, head_size]
-        if use_case == "vllm"
-        else [num_heads, num_tokens, head_size]
-    )
-    dtype = torch.bfloat16 if use_case == "vllm" else torch.float16
+    shape = [num_tokens, num_heads, head_size]
+    dtype = torch.bfloat16
 
     for i in range(num_layers):
         k = torch.rand(shape, dtype=dtype, device=device)
@@ -262,8 +260,8 @@ def generate_tokens(num_tokens, device, fixed=False):
         return torch.randint(0, 10000, size=[num_tokens]).to(device)
 
 
-def concatenate_kv_caches(kv_chunks, use_case):
-    dim = 1 if use_case == "huggingface" else 0
+def concatenate_kv_caches(kv_chunks):
+    dim = 0
     ret = []
     for kv_layer in zip(*kv_chunks, strict=False):
         klist, vlist = zip(*kv_layer, strict=False)
@@ -533,7 +531,6 @@ def create_test_metadata(
         local_world_size=world_size,
         worker_id=worker_id,
         local_worker_id=worker_id,
-        use_case="vllm",
         kv_dtype=torch.bfloat16,
         kv_shape=kv_shape,
         engine_id=engine_id,


### PR DESCRIPTION
From discussion in https://github.com/LMCache/LMCache/pull/2457, we have decided to split the serving engine agnostic manager into 4 PRs (could be more). 

This first PR is the dirty PR to deprecate the `num_ranks` field (`world_size` already has TP x PP information) and to change the previous `fmt` attribute to `use_case`, which will allow us to make the Metadata data structure more useful in the future when increasing the northbound integrations (e.g. changing field exposure based on `use_case`).

This PR touches many files but most of them are unit tests.

Finally, this PR: 
1. renames `LMCacheEngineMetadata` to `LMCacheMetadata` in preparation of the metadata primarily being consumed by the new `LMCacheManager` class
2. moves the `LMCacheMetadata` from `lmcache/config.py` to `lmcache/v1/metadata.py` in preparation to deprecate v0 code in the future.

**EDIT**
From @ApostaC's suggestion, also added `local_world_size` and `local_worker_id` fields to the metadata. In single-node cases, these will be identical to `world_size` and `worker_id`