### PR TITLE
[CI]: Correctness test specify attn backend with CLI flag

### DIFF
--- a/.buildkite/scripts/vllm-correctness.sh
+++ b/.buildkite/scripts/vllm-correctness.sh
@@ -147,12 +147,12 @@ PORT=$(find_free_port)
 echo "[INFO] Starting BASE vLLM server on port ${PORT}..."
 
 VLLM_SERVER_DEV_MODE=1 \
-VLLM_ATTENTION_BACKEND=FLASH_ATTN \
 VLLM_BATCH_INVARIANT=1 \
 vllm serve "${MODEL}" \
     --port "${PORT}" \
     --trust-remote-code \
     --enforce-eager \
+    --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
     -cc.level=0 \
     >"${VLLM_LOG}" 2>&1 &
@@ -199,11 +199,11 @@ echo "[INFO] Starting LMCACHE vLLM server on port ${PORT}..."
 LMCACHE_CONFIG_FILE=cpu.yaml \
 VLLM_SERVER_DEV_MODE=1 \
 VLLM_BATCH_INVARIANT=1 \
-VLLM_ATTENTION_BACKEND=FLASH_ATTN \
 vllm serve "${MODEL}" \
     --port "${PORT}" \
     --trust-remote-code \
     --enforce-eager \
+    --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
     -cc.level=0 \
     --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \


### PR DESCRIPTION
It looks like the `VLLM_ATTENTION_BACKEND` environment has been deprecated in the nightly builds (which the correctness suite uses).