### PR TITLE
Mark unhealthy while init or post_init failed

### DIFF
--- a/docs/source/production/observability/health_monitor.rst
+++ b/docs/source/production/observability/health_monitor.rst
@@ -84,6 +84,19 @@ The health monitor runs in a background thread:
 3. When unhealthy, store/retrieve operations are blocked with a warning log
 4. Once all checks pass again, the system is marked as healthy and operations resume
 
+Initialization Failure Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When initialization or post-initialization fails irrecoverably:
+
+1. The system is marked with ``_init_failed = True``
+2. ``is_healthy()`` method returns ``False`` permanently
+3. Health monitoring thread will not start (if initialization fails before it starts)
+4. The system operates in degraded mode (recompute-only)
+
+This ensures that irrecoverable initialization errors don't cause cascading failures
+and the system can gracefully fall back to recomputation.
+
 Graceful Degradation
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -226,6 +226,9 @@ class LMCacheEngine:
         # Health monitor reference (injected by LMCacheManager)
         self._health_monitor: Optional["HealthMonitor"] = None
 
+        # Flag to indicate if initialization failed (irrecoverable error)
+        self._init_failed = False
+
     def set_health_monitor(self, health_monitor: "HealthMonitor") -> None:
         """
         Set the health monitor reference.
@@ -242,15 +245,38 @@ class LMCacheEngine:
         """
         Check if the LMCache system is healthy.
 
-        This method delegates to the HealthMonitor if one is set.
-        If no health monitor is set, it returns True (assume healthy).
+        This method returns False if:
+        - Initialization failed (irrecoverable error)
+        - HealthMonitor reports unhealthy
+
+        If no health monitor is set and initialization succeeded,
+        it returns True (assume healthy).
 
         Returns:
             bool: True if healthy, False otherwise
         """
+        if self._init_failed:
+            return False
         if self._health_monitor is not None:
             return self._health_monitor.is_healthy()
         return True
+
+    def mark_init_failed(self, reason: str = "") -> None:
+        """
+        Mark the engine as having failed initialization.
+
+        This is called by LMCacheManager when an irrecoverable error occurs
+        during initialization or post_init. Once marked, is_healthy() will
+        always return False, causing the system to fall back to recomputation.
+
+        Args:
+            reason: Optional reason string for logging
+        """
+        self._init_failed = True
+        if reason:
+            logger.error("LMCacheEngine marked as init failed: %s", reason)
+        else:
+            logger.error("LMCacheEngine marked as init failed")
 
     def post_init(self, **kwargs) -> None:
         if not self.post_inited:

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -97,8 +97,21 @@ class LMCacheManager:
         self._runtime_plugin_launcher: Optional[RuntimePluginLauncher] = None
         self._health_monitor: Optional[HealthMonitor] = None
 
+        # Flag to track if initialization failed
+        self._init_failed = False
+        self._init_failed_reason: str = ""
+
         # Initialize components based on role
-        self._init_components()
+        try:
+            self._init_components()
+        except Exception as e:
+            self._init_failed = True
+            self._init_failed_reason = str(e)
+            logger.error(
+                "Failed to initialize LMCacheManager components: %s. "
+                "System will operate in degraded mode (recompute).",
+                e,
+            )
 
     def _init_components(self) -> None:
         """Initialize components based on the role for vLLM mode."""
@@ -521,30 +534,60 @@ class LMCacheManager:
         if self._runtime_plugin_launcher is not None:
             self._runtime_plugin_launcher.launch_plugins()
 
+    def _handle_post_init_failure(self, e: Exception) -> None:
+        """
+        Handle initialization failure during post_init.
+
+        This method is shared between LMCacheManager and subclasses to avoid
+        code duplication.
+
+        Args:
+            e: The exception that caused the failure
+        """
+        self._init_failed = True
+        self._init_failed_reason = str(e)
+        if self._lmcache_engine is not None:
+            self._lmcache_engine.mark_init_failed(str(e))
+        logger.error(
+            "Failed during post_init: %s. "
+            "System will operate in degraded mode (recompute).",
+            e,
+        )
+
     def post_init(self) -> None:
         """
         Post-initialization after KV caches are registered.
         """
+        # If initialization already failed, mark engine and return early
+        if self._init_failed:
+            if self._lmcache_engine is not None:
+                self._lmcache_engine.mark_init_failed(self._init_failed_reason)
+            logger.warning("Skipping post_init due to previous initialization failure")
+            return
+
         if self._lmcache_engine is None:
             # Initialize health monitor for scheduler (even without engine)
             self._init_health_monitor()
             return
 
-        # vLLM mode post-init
-        # First Party
-        from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
-            LMCacheAsyncLookupServer,
-        )
+        try:
+            # vLLM mode post-init
+            # First Party
+            from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
+                LMCacheAsyncLookupServer,
+            )
 
-        async_lookup_server = None
-        if self._config.enable_async_loading and self._lookup_server is not None:
-            assert isinstance(self._lookup_server, LMCacheAsyncLookupServer)
-            async_lookup_server = self._lookup_server
+            async_lookup_server = None
+            if self._config.enable_async_loading and self._lookup_server is not None:
+                assert isinstance(self._lookup_server, LMCacheAsyncLookupServer)
+                async_lookup_server = self._lookup_server
 
-        self._lmcache_engine.post_init(async_lookup_server=async_lookup_server)
+            self._lmcache_engine.post_init(async_lookup_server=async_lookup_server)
 
-        # Initialize health monitor after engine post_init completes
-        self._init_health_monitor()
+            # Initialize health monitor after engine post_init completes
+            self._init_health_monitor()
+        except Exception as e:
+            self._handle_post_init_failure(e)
 
     def stop_services(self) -> None:
         """Stop all managed components gracefully."""
@@ -687,12 +730,21 @@ class LMCacheManager:
         """
         Check if the LMCacheManager is healthy.
 
+        Returns False if:
+        - Initialization failed
+        - HealthMonitor reports unhealthy
+        - Engine reports unhealthy
+
         Returns:
             bool: True if healthy, False otherwise
         """
-        if self._health_monitor is None:
-            return True
-        return self._health_monitor.is_healthy()
+        if self._init_failed:
+            return False
+        if self._lmcache_engine is not None and not self._lmcache_engine.is_healthy():
+            return False
+        if self._health_monitor is not None:
+            return self._health_monitor.is_healthy()
+        return True
 
     @property
     def config(self) -> LMCacheEngineConfig:

--- a/lmcache/v1/standalone/manager.py
+++ b/lmcache/v1/standalone/manager.py
@@ -97,13 +97,16 @@ class StandaloneLMCacheManager(LMCacheManager):
                 self._lmcache_engine.mark_init_failed(self._init_failed_reason)
             logger.warning("Skipping post_init due to previous initialization failure")
             return
-        if self._lmcache_engine is not None:
-            # Standalone mode post-init is simpler (no async_lookup_server)
-            self._lmcache_engine.post_init()
+        try:
+            if self._lmcache_engine is not None:
+                # Standalone mode post-init is simpler (no async_lookup_server)
+                self._lmcache_engine.post_init()
 
-        # Initialize health monitor after engine post_init completes (if engine exists)
-        # This also sets up PeriodicThreadRegistry metrics
-        self._init_health_monitor()
+            # Initialize health monitor after engine post_init completes
+            # This also sets up PeriodicThreadRegistry metrics
+            self._init_health_monitor()
+        except Exception as e:
+            self._handle_post_init_failure(e)
 
     def stop_services(self) -> None:
         """Shutdown for standalone mode with simplified logic."""

--- a/lmcache/v1/standalone/manager.py
+++ b/lmcache/v1/standalone/manager.py
@@ -91,6 +91,12 @@ class StandaloneLMCacheManager(LMCacheManager):
 
     def post_init(self) -> None:
         """Post-initialization for standalone mode."""
+        # If initialization already failed, mark engine and return early
+        if self._init_failed:
+            if self._lmcache_engine is not None:
+                self._lmcache_engine.mark_init_failed(self._init_failed_reason)
+            logger.warning("Skipping post_init due to previous initialization failure")
+            return
         if self._lmcache_engine is not None:
             # Standalone mode post-init is simpler (no async_lookup_server)
             self._lmcache_engine.post_init()

--- a/tests/v1/test_manager.py
+++ b/tests/v1/test_manager.py
@@ -477,3 +477,192 @@ class TestLMCacheManagerCalculateDraftLayers:
             )
 
         assert manager._calculate_draft_layers() == 3
+
+
+class TestLMCacheManagerInitFailure:
+    """Tests for LMCacheManager initialization failure handling."""
+
+    def test_init_components_exception_makes_unhealthy(self):
+        """Test that exception during _init_components makes manager unhealthy."""
+        config = LMCacheEngineConfig.from_defaults()
+        vllm_config = MagicMock()
+        connector = MagicMock()
+
+        with patch.object(
+            LMCacheManager,
+            "_init_components",
+            side_effect=RuntimeError("Test init failure"),
+        ):
+            manager = LMCacheManager(
+                config=config,
+                vllm_config=vllm_config,
+                role="worker",
+                connector=connector,
+            )
+
+        # Verify through is_healthy API
+        assert manager.is_healthy() is False
+
+    def test_post_init_skipped_when_init_failed(self):
+        """Test that post_init marks engine unhealthy when init failed."""
+        config = LMCacheEngineConfig.from_defaults()
+        vllm_config = MagicMock()
+        connector = MagicMock()
+
+        with patch.object(
+            LMCacheManager,
+            "_init_components",
+            side_effect=RuntimeError("Test init failure"),
+        ):
+            manager = LMCacheManager(
+                config=config,
+                vllm_config=vllm_config,
+                role="worker",
+                connector=connector,
+            )
+
+        mock_engine = MagicMock()
+        manager._lmcache_engine = mock_engine
+
+        manager.post_init()
+
+        # Engine should be marked as init failed
+        mock_engine.mark_init_failed.assert_called_once()
+        # Manager should report unhealthy
+        assert manager.is_healthy() is False
+
+    def test_post_init_exception_makes_unhealthy(self):
+        """Test that exception during post_init makes system unhealthy."""
+        config = LMCacheEngineConfig.from_defaults()
+        vllm_config = MagicMock()
+        connector = MagicMock()
+
+        with patch.object(LMCacheManager, "_init_components"):
+            manager = LMCacheManager(
+                config=config,
+                vllm_config=vllm_config,
+                role="worker",
+                connector=connector,
+            )
+
+        mock_engine = MagicMock()
+        mock_engine.post_init.side_effect = RuntimeError("Test post_init failure")
+        manager._lmcache_engine = mock_engine
+
+        manager.post_init()
+
+        # Verify engine was marked as failed
+        mock_engine.mark_init_failed.assert_called_once()
+        # Manager should report unhealthy
+        assert manager.is_healthy() is False
+
+    def test_unhealthy_engine_makes_manager_unhealthy(self):
+        """Test that manager is unhealthy when engine is unhealthy."""
+        config = LMCacheEngineConfig.from_defaults()
+        vllm_config = MagicMock()
+        connector = MagicMock()
+
+        with patch.object(LMCacheManager, "_init_components"):
+            manager = LMCacheManager(
+                config=config,
+                vllm_config=vllm_config,
+                role="worker",
+                connector=connector,
+            )
+
+        mock_engine = MagicMock()
+        mock_engine.is_healthy.return_value = False
+        manager._lmcache_engine = mock_engine
+
+        assert manager.is_healthy() is False
+
+    def test_healthy_when_all_components_healthy(self):
+        """Test that manager is healthy when all components are healthy."""
+        config = LMCacheEngineConfig.from_defaults()
+        vllm_config = MagicMock()
+        connector = MagicMock()
+
+        with patch.object(LMCacheManager, "_init_components"):
+            manager = LMCacheManager(
+                config=config,
+                vllm_config=vllm_config,
+                role="worker",
+                connector=connector,
+            )
+
+        mock_engine = MagicMock()
+        mock_engine.is_healthy.return_value = True
+        manager._lmcache_engine = mock_engine
+
+        mock_health_monitor = MagicMock()
+        mock_health_monitor.is_healthy.return_value = True
+        manager._health_monitor = mock_health_monitor
+
+        assert manager.is_healthy() is True
+
+
+class TestLMCacheEngineInitFailure:
+    """Tests for LMCacheEngine init failure behavior on lookup/retrieve."""
+
+    def test_lookup_returns_zero_when_init_failed(self):
+        """Test that lookup returns 0 when engine is marked as init failed."""
+        # First Party
+        from lmcache.v1.cache_engine import LMCacheEngine
+
+        engine = MagicMock(spec=LMCacheEngine)
+        engine._init_failed = False
+        engine._health_monitor = None
+
+        # Attach real methods to the mock
+        engine.mark_init_failed = LMCacheEngine.mark_init_failed.__get__(
+            engine, LMCacheEngine
+        )
+        engine.is_healthy = LMCacheEngine.is_healthy.__get__(engine, LMCacheEngine)
+
+        # Call mark_init_failed and verify is_healthy returns False
+        engine.mark_init_failed("Test reason")
+        assert engine.is_healthy() is False
+
+    def test_retrieve_returns_empty_mask_when_init_failed(self):
+        """Test retrieve returns all-False mask when engine init failed."""
+        # First Party
+        from lmcache.v1.cache_engine import LMCacheEngine
+
+        engine = MagicMock(spec=LMCacheEngine)
+        engine._init_failed = False
+        engine._health_monitor = None
+
+        # Attach real methods to the mock
+        engine.mark_init_failed = LMCacheEngine.mark_init_failed.__get__(
+            engine, LMCacheEngine
+        )
+        engine.is_healthy = LMCacheEngine.is_healthy.__get__(engine, LMCacheEngine)
+
+        # Mark as init failed and verify is_healthy returns False
+        # (which would cause retrieve to return all-False mask)
+        engine.mark_init_failed("Test reason")
+        assert engine.is_healthy() is False
+
+    def test_mark_init_failed_makes_engine_unhealthy(self):
+        """Test that mark_init_failed makes engine report unhealthy."""
+        # First Party
+        from lmcache.v1.cache_engine import LMCacheEngine
+
+        engine = MagicMock(spec=LMCacheEngine)
+        engine._init_failed = False
+        engine._health_monitor = None
+
+        # Attach real methods to the mock
+        engine.mark_init_failed = LMCacheEngine.mark_init_failed.__get__(
+            engine, LMCacheEngine
+        )
+        engine.is_healthy = LMCacheEngine.is_healthy.__get__(engine, LMCacheEngine)
+
+        # Verify initially healthy
+        assert engine.is_healthy() is True
+
+        # Call the method under test
+        engine.mark_init_failed("Test reason")
+
+        # Assert on the outcome
+        assert engine.is_healthy() is False


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR improves the robustness of the LMCache system by introducing explicit error handling during its initialization and post-initialization phases. It ensures that if any critical component fails to initialize, the system is correctly marked as unhealthy, preventing further operations and allowing it to gracefully fall back to a degraded mode (recomputation). This change enhances system reliability and provides clearer health status reporting.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
