### PR TITLE
Skip retrieve kvcache if hit token < min_retrieve_tokens threshold

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -76,6 +76,9 @@ Basic cache settings that control the core functionality of LMCache.
    * - priority_limit
      - LMCACHE_PRIORITY_LIMIT
      - Caches requests only if priority value ≤ limit. (**Not applicable for PD Disaggregation**) Type: int. Default: None
+   * - min_retrieve_tokens
+     - LMCACHE_MIN_RETRIEVE_TOKENS
+     - Minimum number of hit tokens required to perform retrieve. If hit tokens < this value, skip retrieve but still record the hits to avoid re-storing existing chunks. See :ref:`performance_tuning` for a working example. Default: 0 (disabled)
    * - extra_config
      - LMCACHE_EXTRA_CONFIG={"key": value, ...}
      - Additional configuration as JSON dict. For NUMA manual mode, include "gpu_to_numa_mapping": {gpu_id: numa_node, ...}. Default: {}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -129,6 +129,7 @@ Documentation
    production/kubernetes_deployment
    production/kv_cache_events
    production/observability/index
+   production/performance_tuning
 
 :raw-html:`<br />`
 

--- a/docs/source/production/performance_tuning.rst
+++ b/docs/source/production/performance_tuning.rst
@@ -1,0 +1,116 @@
+.. _performance_tuning:
+
+Performance Tuning
+==================
+
+This guide covers key LMCache configuration options that can help
+you optimize performance in production deployments.
+
+Minimum Retrieve Tokens
+------------------------
+
+When LMCache finds a partial KV cache hit, it loads the cached tokens
+into GPU memory to avoid recomputation. However, if only a small
+number of tokens are hit, the overhead of loading them from the
+cache may outweigh the benefit of skipping recomputation.
+
+The ``min_retrieve_tokens`` setting lets you set a threshold: if the
+number of tokens that need to be loaded is below this value, LMCache
+will skip the retrieve and let the inference engine recompute them
+instead.
+
+.. note::
+
+    Even when retrieve is skipped, LMCache still records the hit
+    tokens internally so that it does **not** re-store chunks that
+    already exist in the cache.
+
+When to Use
+~~~~~~~~~~~
+
+Consider setting ``min_retrieve_tokens`` when:
+
+- For the backend you are using, the transfer latency is noticeable
+  for small payloads.
+- Your workload has many requests with **low cache hit ratios**,
+  where recomputation is faster than cache loading.
+- You want to reduce unnecessary I/O for marginal cache hits.
+
+You can increase or decrease based on your latency observations.
+
+Configuration
+~~~~~~~~~~~~~
+
+**YAML configuration file:**
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    local_cpu: true
+    min_retrieve_tokens: 1024
+
+**Environment variable:**
+
+.. code-block:: bash
+
+    export LMCACHE_MIN_RETRIEVE_TOKENS=1024
+
+Working Example
+~~~~~~~~~~~~~~~
+
+1. Create an LMCache configuration file ``lmcache_config.yaml``:
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    local_cpu: true
+    max_local_cpu_size: 5.0
+    min_retrieve_tokens: 1024
+
+2. Start vLLM with LMCache:
+
+.. code-block:: bash
+
+    LMCACHE_CONFIG_FILE=lmcache_config.yaml \
+        vllm serve Qwen/Qwen3-0.6B \
+        --kv-transfer-config \
+        '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' \
+        --disable-log-requests \
+        --no-enable-prefix-caching
+
+3. Send a request to populate the cache:
+
+.. code-block:: bash
+
+    curl http://localhost:8000/v1/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "Qwen/Qwen3-0.6B",
+        "prompt": "Explain the theory of relativity.",
+        "max_tokens": 50,
+        "temperature": 0.7
+      }'
+
+4. Send a similar request that partially reuses the cached prefix:
+
+.. code-block:: bash
+
+    curl http://localhost:8000/v1/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "Qwen/Qwen3-0.6B",
+        "prompt": "Explain the theory of relativity in simple terms....",
+        "max_tokens": 50,
+        "temperature": 0.7
+      }'
+
+5. Check the server logs. If the number of loadable hit tokens is
+   below 1024, you will see a log message like:
+
+.. code-block:: text
+
+    LMCache hit tokens: 762, but need to load: 762 < min_retrieve 1024,
+    skip retrieve but record for save skip
+
+This confirms that the small cache hit was skipped in favor of
+recomputation, avoiding unnecessary transfer overhead.

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1282,15 +1282,34 @@ class LMCacheConnectorV1Impl:
         if num_external_hit_tokens == request.num_tokens:
             need_to_allocate -= 1
 
-        logger.info(
-            "Reqid: %s, Total tokens %d, Inference Engine computed tokens: %d, "
-            "LMCache hit tokens: %d, need to load: %d",
-            req_id,
-            request.num_tokens,
-            num_computed_tokens,
-            num_external_hit_tokens,
-            max(need_to_allocate, 0),
-        )
+        # Check if hit tokens meet the minimum for retrieve
+        # If below minimum, skip retrieve but still record hit tokens
+        # for skip_leading_tokens to avoid re-storing existing chunks
+        min_retrieve = self.config.min_retrieve_tokens
+        below_min_retrieve = min_retrieve > 0 and need_to_allocate < min_retrieve
+
+        if below_min_retrieve:
+            logger.info(
+                "Reqid: %s, Total tokens %d, Inference Engine computed tokens: %d, "
+                "LMCache hit tokens: %d, but need to load: %d < min_retrieve %d, "
+                "skip retrieve but record for save skip",
+                req_id,
+                request.num_tokens,
+                num_computed_tokens,
+                num_external_hit_tokens,
+                max(need_to_allocate, 0),
+                min_retrieve,
+            )
+        else:
+            logger.info(
+                "Reqid: %s, Total tokens %d, Inference Engine computed tokens: %d, "
+                "LMCache hit tokens: %d, need to load: %d",
+                req_id,
+                request.num_tokens,
+                num_computed_tokens,
+                num_external_hit_tokens,
+                max(need_to_allocate, 0),
+            )
 
         self.load_specs[req_id] = LoadSpec(
             vllm_cached_tokens=num_computed_tokens,
@@ -1298,7 +1317,7 @@ class LMCacheConnectorV1Impl:
             can_load=False,
         )
 
-        if need_to_allocate <= 0:
+        if below_min_retrieve or need_to_allocate <= 0:
             return 0
 
         # TODO: Align to vLLM block size. Should test whether it can be removed

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -328,6 +328,17 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": 3000,
         "env_converter": int,
     },
+    "min_retrieve_tokens": {
+        "type": int,
+        "default": 0,
+        "env_converter": int,
+        "description": (
+            "Minimum number of hit tokens required to perform retrieve. "
+            "If hit tokens < min_retrieve_tokens, skip retrieve but the "
+            "actual hit count is still used for skip_leading_tokens to avoid "
+            "re-storing existing chunks. Default is 0 (disabled)."
+        ),
+    },
     "hit_miss_ratio": {
         "type": Optional[float],
         "default": None,
@@ -497,6 +508,11 @@ def _validate_config(self):
     #         "CPU memory fragmentation"
     #     )
     #     self.save_unfull_chunk = False
+
+    if self.min_retrieve_tokens < 0:
+        raise ValueError(
+            "min_retrieve_tokens must be >= 0, got %d" % self.min_retrieve_tokens
+        )
 
     if self.enable_blending:
         if not self.save_unfull_chunk:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

By setting a minimum threshold for hit tokens, the system can intelligently bypass the retrieval process for minor cache hits, thereby optimizing performance. Even when retrieval is skipped, the system ensures that the actual hit count is still utilized to prevent redundant storage of existing data chunks.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
