### PR TITLE
[CI]: Add stress test pipeline with real-multi-round-qa benchmark

### DIFF
--- a/.buildkite/pipelines/stress-tests.yml
+++ b/.buildkite/pipelines/stress-tests.yml
@@ -1,0 +1,32 @@
+steps:
+  - label: ":books: Real Multi-Round QA"
+    key: "real-multi-round-qa"
+    command: |
+      uv venv --python 3.12 .venv-$BUILDKITE_BUILD_ID
+      source .venv-$BUILDKITE_BUILD_ID/bin/activate
+
+      uv pip install --upgrade pip setuptools wheel
+      uv pip install -r requirements/common.txt
+      uv pip install -e . --no-build-isolation
+      uv pip install -U vllm --pre --extra-index-url https://wheels.vllm.ai/nightly
+
+      source .buildkite/scripts/pick-free-gpu.sh 18000
+
+      bash .buildkite/scripts/real-multi-round-qa.sh
+    artifact_paths:
+      - "real-multi-round-qa-64k-results.json"
+      - "lmcache_vllm.log"
+
+  - label: ":wastebasket: Kill all"
+    key: "clean"
+    depends_on: "real-multi-round-qa"
+    allow_dependency_failure: true
+    command: bash .buildkite/scripts/bare-machine-cleanup.sh
+
+  - label: "Clean up"
+    depends_on: "clean"
+    command: |
+      export TARGET="$PWD"
+      echo "Deleting current workspace $TARGET"
+      cd /
+      sudo rm -rf "$TARGET"

--- a/.buildkite/scripts/real-multi-round-qa.sh
+++ b/.buildkite/scripts/real-multi-round-qa.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -ex
+
+MODEL="meta-llama/Llama-3.2-1B-Instruct"
+
+# Clone LMBenchmark repository
+git clone --depth 1 -b multiround https://github.com/ningziwen/LMBenchmark.git /tmp/LMBenchmark
+
+# Install requirements
+pip install -r /tmp/LMBenchmark/real-multi-round-qa/requirements.txt
+
+# Download novel data (64k)
+python3 /tmp/LMBenchmark/real-multi-round-qa/prepare.py \
+    --output /tmp/novels \
+    --model $MODEL \
+    --start 0 \
+    --end 100
+
+# Start the vLLM server with LMCache
+LMCACHE_TRACK_USAGE="false" lmcache_vllm serve $MODEL \
+    --disable-log-requests > lmcache_vllm.log 2>&1 &
+
+echo "Waiting for service to start..."
+timeout=120
+elapsed=0
+until grep -q "Uvicorn running on" lmcache_vllm.log; do
+    if [ $elapsed -ge $timeout ]; then
+        echo "Timeout: Service did not start within $timeout seconds."
+        cat lmcache_vllm.log
+        exit 1
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+    echo "Waiting... ($elapsed seconds elapsed)"
+done
+echo "Service started successfully."
+
+# Run the real-multi-round-qa benchmark (64k)
+python3 /tmp/LMBenchmark/real-multi-round-qa/multi-round-qa.py \
+    --num-users 5 \
+    --num-rounds 5 \
+    --src-dir /tmp/novels/64k \
+    --answer-len 512 \
+    --model $MODEL \
+    --base-url http://localhost:8000 \
+    --timeout 300 \
+    --time 600 \
+    --output real-multi-round-qa-64k-results.json


### PR DESCRIPTION
⚠️ **DRAFT PR - Early feedback requested**

This PR depends on [LMBenchmark PR](https://github.com/LMCache/LMBenchmark/pull/36) being merged first.

---

**What this PR does / why we need it**:

Adds a stress test pipeline using the real-multi-round-qa benchmark from LMBenchmark. This enables continuous stress testing of LMCache with realistic multi-turn conversation workloads using 64k context novels. This tests should capture the issues related to memory leaking that require long running.

The stress test:
- Maintains 5 concurrent users with constant load (--num-users mode)
- Runs 5 rounds of Q&A per session
- Uses 64k context from Gutenberg novels
- Runs for 10 minutes (600 seconds)
- Collects TTFT, ITL, and throughput metrics

**Files added:**
- `.buildkite/pipelines/stress-tests.yml` - Buildkite pipeline definition
- `.buildkite/scripts/real-multi-round-qa.sh` - Script to run the benchmark

**Special notes for your reviewers**:

Requires LMBenchmark multiround branch to be merged to main first. The script clones from `https://github.com/ningziwen/LMBenchmark.git` branch `multiround`.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
