### PR TITLE
[bugfix] Fix fp8 cache

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -185,9 +185,25 @@ __global__ void single_layer_kv_transfer_kernel(
 
 __device__ __forceinline__ int64_t page_buffer_offset(
     const int k_or_v, const int token_idx, const int scalar_offset,
-    const int scalars_per_token, const int page_buffer_size) {
-  return k_or_v * page_buffer_size * scalars_per_token +
-         token_idx * scalars_per_token + scalar_offset;
+    const int scalars_per_token, const int page_buffer_size,
+    const int block_size, const bool two_major) {
+  if (two_major) {
+    // K/V-first layout: [2, num_blocks, block_size, num_heads, head_dim]
+    // page_buffer_size = num_blocks * block_size (total tokens across all blocks)
+    return k_or_v * page_buffer_size * scalars_per_token +
+           token_idx * scalars_per_token + scalar_offset;
+  } else {
+    // Block-first layout: [num_blocks, 2, block_size, num_heads, head_dim]
+    // page_buffer_size = num_blocks (number of blocks)
+    // Each block contains 2 (K/V) * block_size * num_heads * head_dim elements
+    int block_idx = token_idx / block_size;
+    int offset_in_block = token_idx % block_size;
+    int block_kv_size = 2 * block_size * scalars_per_token;
+    // K offset: block_start * page_buffer_size + offset_in_block * scalars_per_token
+    // V offset: block_start * page_buffer_size + block_size * scalars_per_token + offset_in_block * scalars_per_token
+    return block_idx * block_kv_size + k_or_v * block_size * scalars_per_token +
+           offset_in_block * scalars_per_token + scalar_offset;
+  }
 }
 
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
@@ -269,7 +285,7 @@ __global__ void load_and_reshape_multi_layer_kernel(
                                                 // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
     const int scalars_per_token, const int num_tokens, const int num_layers,
-    const int page_buffer_size) {
+    const int page_buffer_size, const int block_size, const bool two_major) {
   const int token_id = blockIdx.x;
   const int layer_id = blockIdx.y;
   const int k_or_v = blockIdx.z;
@@ -290,7 +306,8 @@ __global__ void load_and_reshape_multi_layer_kernel(
                          num_tokens, num_layers);
 
     const int64_t vllm_offset = page_buffer_offset(
-        k_or_v, slot_idx, i, scalars_per_token, page_buffer_size);
+        k_or_v, slot_idx, i, scalars_per_token, page_buffer_size, block_size,
+        two_major);
 
     if (DIRECTION)  // 1 is paged buffer to LMCache
       key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
@@ -407,7 +424,8 @@ void multi_layer_kv_transfer_templated(
     const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
-    const bool direction, const bool use_mla) {
+    const bool direction, const bool use_mla, const int block_size,
+    const bool two_major) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
       get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
@@ -435,13 +453,15 @@ void multi_layer_kv_transfer_templated(
     lmc::load_and_reshape_multi_layer_kernel<T, false>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
                                      slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
+                                     num_layers, page_buffer_size, block_size,
+                                     two_major);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     lmc::load_and_reshape_multi_layer_kernel<T, true>
         <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,
                                      slot_mapping_ptr, num_xwords, num_tokens,
-                                     num_layers, page_buffer_size);
+                                     num_layers, page_buffer_size, block_size,
+                                     two_major);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 }
@@ -454,7 +474,8 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& slot_mapping,
                              const torch::Device& paged_memory_device,
                              const int page_buffer_size, const bool direction,
-                             const bool use_mla) {
+                             const bool use_mla, const int block_size,
+                             const bool two_major) {
   int num_origin_elements = key_value.size(3);
   int copy_size = num_origin_elements * key_value.element_size();
 #ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
@@ -462,7 +483,7 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
     do {                                                                \
       multi_layer_kv_transfer_templated<type>(                          \
           key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
-          page_buffer_size, direction, use_mla);                        \
+          page_buffer_size, direction, use_mla, block_size, two_major); \
     } while (0)
 #endif
   if (copy_size % 8 == 0) {

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -18,7 +18,8 @@ void multi_layer_kv_transfer(torch::Tensor& key_value,
                              const torch::Tensor& slot_mapping,
                              const torch::Device& paged_memory_device,
                              const int page_buffer_size, const bool direction,
-                             const bool use_mla);
+                             const bool use_mla, const int block_size = 8,
+                             const bool two_major = true);
 
 void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -16,7 +16,17 @@ PYBIND11_MODULE(c_ops, m) {
       .value("H2D", TransferDirection::H2D)
       .value("D2H", TransferDirection::D2H)
       .export_values();
-  m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer);
+  m.def(
+      "multi_layer_kv_transfer", &multi_layer_kv_transfer,
+      py::arg("key_value"),
+      py::arg("key_value_ptrs"),
+      py::arg("slot_mapping"),
+      py::arg("paged_memory_device"),
+      py::arg("page_buffer_size"),
+      py::arg("direction"),
+      py::arg("use_mla"),
+      py::arg("block_size") = 8,
+      py::arg("two_major") = true);
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);
   m.def("single_layer_kv_transfer", &single_layer_kv_transfer);

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -198,6 +198,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         # works with a single device?
         self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
         self.page_buffer_size = 0
+        self.block_size = 8  # Default block size for vLLM
+        self.two_major = True  # Default: K/V-first (shape[0] == 2)
 
         self.kvcaches: Optional[List[torch.Tensor]] = None
 
@@ -265,14 +267,29 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.num_layers, dtype=torch.int64, device=self.device
         )
         self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
+        shape = kv_caches[0].shape
+
         if self.use_mla:
             # kv_caches[0].shape: [num_pages, page_size, head_size]
             assert kv_caches[0].dim() == 3
             self.page_buffer_size = kv_caches[0].shape[0] * kv_caches[0].shape[1]
         else:
-            # kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size]
+            # kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size] (K/V-first)
+            # or [num_blocks, 2, num_pages, num_heads, block_size, head_size] (Block-first, FP8)
+            # Note: vLLM uses block_size param, not num_pages
             assert kv_caches[0].dim() == 5
-            self.page_buffer_size = kv_caches[0].shape[1] * kv_caches[0].shape[2]
+            # Detect layout by checking first dimension
+            if shape[0] == 2:
+                # K/V-first layout (BF16): [2, num_blocks, block_size, num_heads, head_dim]
+                self.two_major = True
+                self.page_buffer_size = shape[1] * shape[2]  # num_blocks * block_size
+                self.block_size = shape[2]
+            else:
+                # Block-first layout (FP8): [num_blocks, 2, block_size, num_heads, head_dim]
+                self.two_major = False
+                self.page_buffer_size = shape[0]  # num_blocks
+                self.block_size = shape[2]
+                logger.info(f"Detected Block-first KV cache layout (FP8): shape={shape}")
 
         return self.kv_cache_pointers_on_gpu[idx]
 
@@ -330,6 +347,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.page_buffer_size,
             False,
             self.use_mla,
+            self.block_size,
+            self.two_major,
         )
 
     @_lmcache_nvtx_annotate
@@ -375,6 +394,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     self.page_buffer_size,
                     True,
                     self.use_mla,
+                    self.block_size,
+                    self.two_major,
                 )
             else:
                 # kvcaches -> gpu_buffer -> memobj
@@ -388,6 +409,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     self.page_buffer_size,
                     True,
                     self.use_mla,
+                    self.block_size,
+                    self.two_major,
                 )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -274,9 +274,9 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             assert kv_caches[0].dim() == 3
             self.page_buffer_size = kv_caches[0].shape[0] * kv_caches[0].shape[1]
         else:
-            # kv_caches[0].shape: [2, num_pages, page_size, num_heads, head_size] (K/V-first)
-            # or [num_blocks, 2, num_pages, num_heads, block_size, head_size] (Block-first, FP8)
-            # Note: vLLM uses block_size param, not num_pages
+            # kv_caches[0].shape: [2, num_blocks, block_size, num_heads, head_size] (K/V-first)
+            # or [num_blocks, 2, block_size, num_heads, head_dim] (Block-first, FP8)
+            # Note: dimension 3 is block_size, not num_pages
             assert kv_caches[0].dim() == 5
             # Detect layout by checking first dimension
             if shape[0] == 2:

--- a/tests/test_fp8_cache.py
+++ b/tests/test_fp8_cache.py
@@ -1,0 +1,111 @@
+import os
+import logging
+import sys
+orig_out = sys.stdout
+orig_err = sys.stderr
+# 重定向 stdout 到 /dev/null (扔掉日志)
+sys.stdout = open(os.devnull, 'w')
+# --- 日志抑制配置开始 ---
+# 设置环境变量，强制 vllm 只输出错误级别以上的日志
+os.environ["VLLM_LOGGING_LEVEL"] = "ERROR"
+os.environ["LMCACHE_LOG_LEVEL"] = "ERROR"
+# 配置 Python 标准库 logging
+# 这里使用 force=True 确保覆盖默认配置，format='' 避免输出任何前缀
+logging.basicConfig(level=logging.ERROR, format='', force=True)
+# 针对性地屏蔽 vllm 和 lmcache 的日志
+logging.getLogger("vllm").setLevel(logging.ERROR)
+logging.getLogger("lmcache").setLevel(logging.ERROR)
+# --- 日志抑制配置结束 ---
+
+# Set token chunk size to 256
+os.environ["LMCACHE_CHUNK_SIZE"] = "256"
+# Enable CPU memory backend
+os.environ["LMCACHE_LOCAL_CPU"] = "True"
+# Set CPU memory limit to 5GB
+os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = "24"
+
+os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+os.environ["CUDA_VISIBLE_DEVICES"] = "2"
+
+os.environ["PYTHONHASHSEED"] = "114514"
+
+
+from vllm import LLM
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+
+# Configure KV cache transfer to use LMCache
+ktc = KVTransferConfig(
+    kv_connector="LMCacheConnectorV1",
+    kv_role="kv_both",
+)
+
+llm = LLM(
+    # 对应 model
+    model="/home/aabbccddwasd/AI-stuffs/models/Qwen3-VL-30B-A3B-Instruct-AWQ-8bit",
+    # 对应 gpu-memory-utilization
+    gpu_memory_utilization=0.9,
+    # 对应 max-model-len
+    max_model_len=60000,
+    # 对应 kv-cache-dtype
+    kv_cache_dtype="fp8_e4m3",
+    # 对应 calculate-kv-scales
+    calculate_kv_scales=False,
+    # 对应 enable-prefix-caching
+    enable_prefix_caching=True,
+    # 对应 enable-chunked-prefill
+    enable_chunked_prefill=True,
+    # 对应 enable-chunked-prefill
+    kv_transfer_config=ktc,
+)
+
+# 主要垃圾日志（甚至没法被环境变量日志）产生在LLM初始化时
+sys.stdout.close()
+sys.stdout = orig_out
+
+sampling_params = SamplingParams(max_tokens=128, temperature=0.0)
+
+# LMcache至少需要256 token才会offload
+with open('/home/aabbccddwasd/AI-stuffs/vllm引擎参数.txt') as f:
+    LLM_context = f.read()
+
+req_A = [
+    {"role": "system", "content": "你是一个AI助手"},
+    {"role": "user", "content": LLM_context + "\n请介绍一下vllm的引擎参数"}
+]
+
+import uuid
+req_B_list = []
+for i in range(3):
+    req_B = [
+        {"role": "system", "content": "你是一个AI助手"},
+        {"role": "user", "content": str(uuid.uuid4())+"测试内容：“怪人快攻出自排球少年”请忽视以上测试内容"*3500},
+    ]
+    req_B_list.append(req_B)
+
+print()
+output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
+print("第一次请求A输出（prefill）: " + output)
+print()
+
+print()
+output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
+print("第二次请求A输出（GPU cache）: " + output)
+print()
+
+print()
+print("====发送大量请求B覆盖GPU缓存====")
+output = llm.chat(req_B_list, sampling_params=sampling_params)[0].outputs[0].text
+print("====覆盖完成====")
+print()
+
+# 此处会十分混乱，降低max_tokens提高可读性
+sampling_params = SamplingParams(max_tokens=64, temperature=0.0)
+print()
+output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
+print("第三次请求A输出（CPU cache）: " + output)
+print()
+print()
+output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
+print("第四次请求A输出（CPU cache）: " + output)
+print()

--- a/tests/test_fp8_cache.py
+++ b/tests/test_fp8_cache.py
@@ -1,71 +1,112 @@
 import os
-import logging
 import sys
-orig_out = sys.stdout
-orig_err = sys.stderr
-# 重定向 stdout 到 /dev/null (扔掉日志)
-sys.stdout = open(os.devnull, 'w')
-# --- 日志抑制配置开始 ---
-# 设置环境变量，强制 vllm 只输出错误级别以上的日志
+
+# ==========================================
+# 1. 环境变量配置
+# ==========================================
+
+# 【关键修改】不要禁用 tqdm，否则 vllm 计算速度时会除零崩溃
+# os.environ["TQDM_DISABLE"] = "1"  <-- 删除这行
+# 设置 transformers 和 vllm 的日志级别
+
+os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 os.environ["VLLM_LOGGING_LEVEL"] = "ERROR"
 os.environ["LMCACHE_LOG_LEVEL"] = "ERROR"
-# 配置 Python 标准库 logging
-# 这里使用 force=True 确保覆盖默认配置，format='' 避免输出任何前缀
-logging.basicConfig(level=logging.ERROR, format='', force=True)
-# 针对性地屏蔽 vllm 和 lmcache 的日志
-logging.getLogger("vllm").setLevel(logging.ERROR)
-logging.getLogger("lmcache").setLevel(logging.ERROR)
-# --- 日志抑制配置结束 ---
 
-# Set token chunk size to 256
+# 其他环境变量
 os.environ["LMCACHE_CHUNK_SIZE"] = "256"
-# Enable CPU memory backend
 os.environ["LMCACHE_LOCAL_CPU"] = "True"
-# Set CPU memory limit to 5GB
 os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = "24"
-
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 os.environ["CUDA_VISIBLE_DEVICES"] = "2"
-
 os.environ["PYTHONHASHSEED"] = "114514"
 
+# 导入必要的库
+import logging
 
-from vllm import LLM
+logging.basicConfig(level=logging.ERROR, format='')
+
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
 
-# Configure KV cache transfer to use LMCache
-ktc = KVTransferConfig(
-    kv_connector="LMCacheConnectorV1",
-    kv_role="kv_both",
-)
 
-llm = LLM(
-    # 对应 model
-    model="/home/aabbccddwasd/AI-stuffs/models/Qwen3-VL-30B-A3B-Instruct-AWQ-8bit",
-    # 对应 gpu-memory-utilization
-    gpu_memory_utilization=0.9,
-    # 对应 max-model-len
-    max_model_len=60000,
-    # 对应 kv-cache-dtype
-    kv_cache_dtype="fp8_e4m3",
-    # 对应 calculate-kv-scales
-    calculate_kv_scales=False,
-    # 对应 enable-prefix-caching
-    enable_prefix_caching=True,
-    # 对应 enable-chunked-prefill
-    enable_chunked_prefill=True,
-    # 对应 enable-chunked-prefill
-    kv_transfer_config=ktc,
-)
+# ==========================================
+# 2. 修复后的重定向逻辑 (核心修改)
+# ==========================================
+class OutputSilencer:
+    def __init__(self):
+        self.saved_stdout_fd = None
+        self.saved_stderr_fd = None
+        self.devnull_fd = None
 
-# 主要垃圾日志（甚至没法被环境变量日志）产生在LLM初始化时
-sys.stdout.close()
-sys.stdout = orig_out
+    def silence(self):
+        # 1. 备份原始的 FD 1 (stdout) 和 FD 2 (stderr)
+        # os.dup() 会返回一个新的未使用的 FD 编号 (如 3, 4)
+        self.saved_stdout_fd = os.dup(1)
+        self.saved_stderr_fd = os.dup(2)
+        # 2. 打开 /dev/null
+        self.devnull_fd = os.open(os.devnull, os.O_RDWR)
+        # 3. 重定向 FD 1 和 FD 2 指向 /dev/null
+        os.dup2(self.devnull_fd, 1)
+        os.dup2(self.devnull_fd, 2)
+        # 4. 同步 Python 层的对象，防止 print 报错
+        sys.stdout = open(1, 'w')
+        sys.stderr = open(2, 'w')
+
+    def restore(self):
+        if self.saved_stdout_fd is None:
+            return
+        # 1. 关闭当前的 /dev/null FD 引用 (可选，dup2会自动关闭目标)
+
+        # 2. 将备份的 FD (3, 4) 复制回 FD 1 和 FD 2
+        os.dup2(self.saved_stdout_fd, 1)
+        os.dup2(self.saved_stderr_fd, 2)
+        # 3. 关闭备份的临时 FD (释放资源)
+        os.close(self.saved_stdout_fd)
+        os.close(self.saved_stderr_fd)
+        # 4. 恢复 Python 的 sys 对象引用
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+        # 重置状态
+        self.saved_stdout_fd = None
+
+
+# ==========================================
+# 3. 执行逻辑
+# ==========================================
+silencer = OutputSilencer()
+print(">>> [INFO] 开始静默初始化 LLM...")
+# 开始静默
+silencer.silence()
+
+try:
+    ktc = KVTransferConfig(
+        kv_connector="LMCacheConnectorV1",
+        kv_role="kv_both",
+    )
+
+    llm = LLM(
+        model="/home/aabbccddwasd/AI-stuffs/models/Qwen3-VL-30B-A3B-Instruct-AWQ-8bit",
+        gpu_memory_utilization=0.9,
+        max_model_len=60000,
+        kv_cache_dtype="fp8_e4m3",
+        calculate_kv_scales=False,
+        enable_prefix_caching=True,
+        enable_chunked_prefill=True,
+        kv_transfer_config=ktc,
+    )
+finally:
+    # 无论初始化成功与否，都恢复输出，否则你看不到报错信息
+    silencer.restore()
+
+print(">>> [SUCCESS] LLM 初始化完成，输出已恢复！")
+print()
+
+# --- 后续推理代码 ---
 
 sampling_params = SamplingParams(max_tokens=128, temperature=0.0)
 
-# LMcache至少需要256 token才会offload
 with open('/home/aabbccddwasd/AI-stuffs/vllm引擎参数.txt') as f:
     LLM_context = f.read()
 
@@ -75,37 +116,38 @@ req_A = [
 ]
 
 import uuid
+
 req_B_list = []
 for i in range(3):
     req_B = [
         {"role": "system", "content": "你是一个AI助手"},
-        {"role": "user", "content": str(uuid.uuid4())+"测试内容：“怪人快攻出自排球少年”请忽视以上测试内容"*3500},
+        {"role": "user", "content": str(uuid.uuid4()) + "测试内容：“怪人快攻出自排球少年”请忽视以上测试内容" * 3500},
     ]
     req_B_list.append(req_B)
 
-print()
+print("正在发送请求 A (Prefill)...")
 output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
 print("第一次请求A输出（prefill）: " + output)
 print()
 
-print()
+print("正在发送请求 A (GPU Cache)...")
 output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
 print("第二次请求A输出（GPU cache）: " + output)
 print()
 
-print()
 print("====发送大量请求B覆盖GPU缓存====")
 output = llm.chat(req_B_list, sampling_params=sampling_params)[0].outputs[0].text
 print("====覆盖完成====")
 print()
 
-# 此处会十分混乱，降低max_tokens提高可读性
 sampling_params = SamplingParams(max_tokens=64, temperature=0.0)
-print()
+
+print("正在发送请求 A (CPU Cache - 第1次)...")
 output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
 print("第三次请求A输出（CPU cache）: " + output)
 print()
-print()
+
+print("正在发送请求 A (CPU Cache - 第2次)...")
 output = llm.chat(req_A, sampling_params=sampling_params)[0].outputs[0].text
 print("第四次请求A输出（CPU cache）: " + output)
 print()

--- a/tests/v1/test_block_first_kernel.py
+++ b/tests/v1/test_block_first_kernel.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA kernel Block-first vs K/V-first layout support test.
+
+This test validates that the CUDA kernel correctly handles both:
+1. K/V-first layout: [2, num_blocks, block_size, num_heads, head_dim] (BF16)
+2. Block-first layout: [num_blocks, 2, block_size, num_heads, head_dim] (FP8)
+"""
+
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.config import LMCacheEngineMetadata
+
+
+
+# Check CUDA availability
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+@pytest.mark.skipif(
+    not CUDA_AVAILABLE,
+    reason="CUDA not available on this system",
+)
+def test_kv_first_layout_detection():
+    """Test K/V-first layout detection (BF16 style)."""
+    # Create metadata for K/V-first layout
+    # Shape: [2, num_blocks, block_size, num_heads, head_dim]
+    num_layers = 32
+    num_blocks = 2561
+    block_size = 8
+    num_kv_head = 16
+    head_size = 128
+    chunk_size = 256
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-kvfirst",
+        world_size=1,
+        worker_id=0,
+        fmt="normal",
+        kv_shape=(num_layers, 2, chunk_size, num_kv_head, head_size),
+        kv_dtype=torch.bfloat16,
+        chunk_size=chunk_size,
+        use_mla=False,
+    )
+
+    # Create connector
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+
+    # Create mock KV caches with K/V-first layout
+    # shape[0] == 2 indicates K/V-first
+    kv_caches = [
+        torch.empty((2, num_blocks, block_size, num_kv_head, head_size), dtype=torch.bfloat16, device='cuda')
+        for _ in range(num_layers)
+    ]
+    
+
+    # Verify default values
+    assert connector.block_size == 8, "Default block_size should be 8"
+    assert connector.two_major == True, "Default two_major should be True (K/V-first)"
+
+    # Initialize pointers should detect K/V-first layout
+    _ = connector._initialize_pointers(kv_caches)
+
+    # Check detection results
+    assert connector.two_major == True, "Should detect K/V-first layout when shape[0] == 2"
+    assert connector.block_size == block_size, f"Block size should be {block_size}"
+    assert connector.page_buffer_size == num_blocks * block_size, (
+        "page_buffer_size should be num_blocks * block_size for K/V-first"
+    )
+
+
+def test_block_first_layout_detection():
+    """Test Block-first layout detection (FP8 style)."""
+    # Create metadata for Block-first layout
+    # Shape: [num_blocks, 2, block_size, num_heads, head_dim]
+    num_layers = 32
+    num_blocks = 2701
+    block_size = 8
+    num_kv_head = 16
+    head_size = 128
+    chunk_size = 256
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-blockfirst",
+        world_size=1,
+        worker_id=0,
+        fmt="normal",
+        kv_shape=(num_layers, 2, chunk_size, num_kv_head, head_size),
+        kv_dtype=torch.uint8,  # FP8 stored as uint8
+        chunk_size=chunk_size,
+        use_mla=False,
+    )
+
+    # Create connector
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+
+    # Create mock KV caches with Block-first layout
+    # shape[0] != 2 indicates Block-first
+    kv_caches = [
+        torch.empty((num_blocks, 2, block_size, num_kv_head, head_size), dtype=torch.uint8, device='cuda')
+        for _ in range(num_layers)
+    ]
+
+    # Initialize pointers should detect Block-first layout
+    _ = connector._initialize_pointers(kv_caches)
+
+    # Check detection results
+    assert connector.two_major == False, "Should detect Block-first layout when shape[0] != 2"
+    assert connector.block_size == block_size, f"Block size should be {block_size}"
+    assert connector.page_buffer_size == num_blocks, (
+        "page_buffer_size should be num_blocks for Block-first"
+    )
+
+
+def test_page_buffer_size_kvf16():
+    """Test page_buffer_size calculation for K/V-first (BF16) layout."""
+    num_blocks = 2561
+    block_size = 8
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        fmt="normal",
+        kv_shape=(32, 2, 256, 16, 128),
+        kv_dtype=torch.bfloat16,
+        chunk_size=256,
+        use_mla=False,
+    )
+
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+
+    kv_caches = [torch.empty((2, num_blocks, block_size, 16, 128), dtype=torch.bfloat16, device='cuda')]
+
+    _ = connector._initialize_pointers(kv_caches)
+
+    # K/V-first: page_buffer_size = num_blocks * block_size
+    expected = num_blocks * block_size
+    assert connector.page_buffer_size == expected, (
+        f"page_buffer_size should be {expected} for K/V-first, got {connector.page_buffer_size}"
+    )
+
+
+def test_page_buffer_size_block_first_fp8():
+    """Test page_buffer_size calculation for Block-first (FP8) layout."""
+    num_blocks = 2701
+    block_size = 8
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        fmt="normal",
+        kv_shape=(32, 2, 256, 16, 128),
+        kv_dtype=torch.uint8,
+        chunk_size=256,
+        use_mla=False,
+    )
+
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+
+    kv_caches = [torch.empty((num_blocks, 2, block_size, 16, 128), dtype=torch.uint8, device='cuda')]
+
+    _ = connector._initialize_pointers(kv_caches)
+
+    # Block-first: page_buffer_size = num_blocks
+    expected = num_blocks
+    assert connector.page_buffer_size == expected, (
+        f"page_buffer_size should be {expected} for Block-first, got {connector.page_buffer_size}"
+    )
+
+
+def test_block_size_extraction():
+    """Test block_size extraction from KV cache shape."""
+    block_size_8 = 8
+    block_size_16 = 16
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        fmt="normal",
+        kv_shape=(32, 2, 256, 16, 128),
+        kv_dtype=torch.bfloat16,
+        chunk_size=256,
+        use_mla=False,
+    )
+
+    # Test with block_size = 8
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+    kv_caches = [
+        torch.empty((2561, 2, block_size_8, 16, 128), dtype=torch.bfloat16, device='cuda')
+    ]
+    _ = connector._initialize_pointers(kv_caches)
+    assert connector.block_size == block_size_8, f"Block size should be {block_size_8}"
+
+    # Test with block_size = 16
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+    kv_caches = [torch.empty((2701, 2, block_size_16, 16, 128), dtype=torch.uint8, device='cuda')]
+    _ = connector._initialize_pointers(kv_caches)
+    assert connector.block_size == block_size_16, f"Block size should be {block_size_16}"
+
+
+def test_detection_idempotency():
+    """Test that layout detection is idempotent (same result on repeated calls)."""
+    num_blocks = 2701
+    block_size = 8
+
+    metadata = LMCacheEngineMetadata(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        fmt="normal",
+        kv_shape=(32, 2, 256, 16, 128),
+        kv_dtype=torch.uint8,
+        chunk_size=256,
+        use_mla=False,
+    )
+
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(metadata)
+
+    kv_caches = [torch.empty((num_blocks, 2, block_size, 16, 128), dtype=torch.uint8, device='cuda')]
+
+    # First detection
+    _ = connector._initialize_pointers(kv_caches)
+    first_block_size = connector.block_size
+    first_two_major = connector.two_major
+    first_page_buffer_size = connector.page_buffer_size
+
+    # Second detection (should return cached result)
+    _ = connector._initialize_pointers(kv_caches)
+    second_block_size = connector.block_size
+    second_two_major = connector.two_major
+    second_page_buffer_size = connector.page_buffer_size
+
+    # Results should be identical
+    assert first_block_size == second_block_size, "block_size should be consistent"
+    assert first_two_major == second_two_major, "two_major should be consistent"
+    assert first_page_buffer_size == second_page_buffer_size, (
+        "page_buffer_size should be consistent"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix FP8 KV cache data corruption when retrieving from CPU storage.

### Problem

vLLM uses **Block-first layout** `[num_blocks, 2, ...]` for FP8 KV cache,
while LMCache assumed **K/V-first layout** `[2, num_blocks, ...]`.
This mismatch caused incorrect memory offset calculation, resulting in:
  - V data being written to wrong GPU memory locations
  - Severe data corruption when reading cached FP8 KV cache
  - BF16 dtype worked correctly (uses K/V-first Layout)

### Root Cause

CUDA kernel `page_buffer_offset` function used K/V-first formula:
```cpp
offset = k_or_v * page_buffer_size * scalars_per_token + token_idx...
```

Block-first layout (FP8) requires:
  offset = block_idx * block_kv_size + k_or_v * block_size * scalars_per_token...

The incorrect page_buffer_size calculation (32 vs 2701 for FP8) led to V data
  being written beyond the intended memory range.

Solution

  1. Layout Detection - Auto-detect layout by checking KV cache shape
    - shape[0] == 2: K/V-first (BF16)
    - shape[0] != 2: Block-first (FP8)
  2. CUDA Kernel Update - Support both layouts
    - Add block_size and two_major parameters to kernel
    - Use appropriate offset formula based on layout type
    - Default values maintain backward compatibility
  3. Parameter Propagation - Pass detected parameters through all layers
    - gpu_connector.py: Detect and store layout info
    - to_gpu()/from_gpu(): Pass kernel parameters
  4. Pybind Fix - Explicit parameter declarations for Python bindings
    - Ensures backward compatibility with existing code
    - Default values: block_size=8, two_major=true

Changes

  - csrc/mem_kernels.cu: Add dual-layout support (+31 -10)
  - csrc/mem_kernels.cuh: Update function signature (+2 -1)
  - csrc/pybind.cpp: Explicit parameter declarations (+11 -1)
  - lmcache/v1/gpu_connector.py: Layout detection and parameter passing (+25 -2)
  - tests/v1/test_block_first_kernel.py: Add 6 unit tests (+247)

Verification

  ✅ All existing tests pass (test_mem_kernels.py: 25 passed)
  ✅ New layout tests pass (6 passed)
  ✅ FP8 cache retrieval works correctly (tested end-to-end)
  ✅ BF16 no regression (tested end-to-end)

Special notes for your reviewers:

The core fix is in the CUDA kernel's page_buffer_offset function which now
chooses the correct offset formula based on the two_major parameter. This
parameter defaults to true (K/V-first) for backward compatibility with all
existing BF16 usage.

The layout detection happens automatically in _initialize_pointers() when
KV cache pointers are first initialized, making it transparent to users.

If applicable:

- this PR contains user facing changes - docs added
- this PR contains unit tests