### PR TITLE
[1/N][Northbound] Introduce KVCacheFormat

### DIFF
--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -88,6 +88,19 @@ def init_lmcache_engine(
     torch.cuda.device(local_rank)
     device = torch.device(f"cuda:{local_rank}")
     # Use global rank for metadata (tensor parallel rank)
+    hidden_dim_size = num_kv_head * head_dim
+
+    # Describe the KV format so LMCache core stays engine-agnostic.
+    # First Party
+    from lmcache.v1.kvcache_format import build_dense_format_single_group
+
+    kv_format = build_dense_format_single_group(
+        block_size=chunk_size,
+        hidden_dim=hidden_dim_size,
+        num_layers=num_layer,
+        dtype=kv_dtype,
+    )
+
     metadata = LMCacheMetadata(
         model_name=model_config.model_path,
         world_size=tp_size,
@@ -96,11 +109,11 @@ def init_lmcache_engine(
         local_worker_id=local_rank,
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,
+        chunk_size=chunk_size,
+        kv_format=kv_format,
     )
 
     use_gpu = need_gpu_interm_buffer(config)
-
-    hidden_dim_size = num_kv_head * head_dim
 
     gpu_connector: GPUConnectorInterface
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -18,6 +18,7 @@ import torch
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import apply_remote_configs, fetch_remote_config
+from lmcache.v1.kvcache_format import build_dense_format_single_group
 
 logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
@@ -203,6 +204,17 @@ def create_lmcache_metadata(
     num_kv_head = model_cfg.get_num_kv_heads(parallel_cfg)
     head_size = model_cfg.get_head_size()
     kv_shape = (num_layer, 1 if use_mla else 2, chunk_size, num_kv_head, head_size)
+    hidden_dim = head_size if use_mla else num_kv_head * head_size
+
+    kv_format = build_dense_format_single_group(
+        num_layers=num_layer,
+        dtype=kv_dtype,
+        hidden_dim=hidden_dim,
+        block_size=chunk_size,
+        use_mla=use_mla,
+        separation="packed",
+        format_version="v1",
+    )
 
     # Extract engine_id and kv_connector_extra_config from vllm_config if available
     engine_id = None
@@ -229,6 +241,7 @@ def create_lmcache_metadata(
         served_model_name=model_cfg.served_model_name,
         engine_id=engine_id,
         kv_connector_extra_config=kv_connector_extra_config,
+        kv_format=kv_format,
     )
 
     return metadata, config

--- a/lmcache/v1/__init__.py
+++ b/lmcache/v1/__init__.py
@@ -1,2 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Local
+from .kvcache_format import (  # noqa: F401
+    KV_FORMAT_SCHEMA_VERSION,
+    KVCacheFormat,
+    KVCacheLayout,
+    KVLayerGroupSpec,
+    L0LayoutSpec,
+    build_dense_format_single_group,
+    deserialize_kvcache_format,
+    serialize_kvcache_format,
+    validate_kvcache_format,
+)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -75,6 +75,24 @@ ProcessedChunk = Tuple[CacheEngineKey, MemoryObj, int, int]
 ProcessTokensInternalResult = Tuple[List[ProcessedChunk], int]
 
 
+def _validate_metadata_kv_format(metadata: LMCacheMetadata) -> None:
+    """Validate kv_format (if provided) against legacy metadata fields."""
+    layout, fmt = metadata.get_kv_layout("in integration mode")
+    if fmt is None:
+        return
+
+    logger.info(
+        "Using kv_format in integration mode: %s/%s "
+        "separation=%s block=%s layers=%s hidden_dim=%s",
+        fmt.family,
+        fmt.canonical,
+        fmt.separation,
+        layout["block_size"],
+        layout["num_layers"],
+        layout["hidden_dim"],
+    )
+
+
 class CacheEngineEndSignal:
     pass
 
@@ -106,6 +124,7 @@ class LMCacheEngine:
         broadcast_object_fn: Callable[[Any, int], Any],
     ):
         logger.info(f"Creating LMCacheEngine with config: {config}")
+        _validate_metadata_kv_format(metadata)
         self.config = config
         self.metadata = metadata
         self.token_database = token_database

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -23,14 +23,31 @@ from lmcache.v1.storage_backend.storage_manager import StorageManager
 
 def _get_default_metadata(model: str) -> LMCacheMetadata:
     """Get default metadata for testing"""
+    # First Party
+    from lmcache.v1.kvcache_format import build_dense_format_single_group
+
+    kv_dtype = torch.bfloat16
+    kv_shape = (8, 2, 16, 8, 16)
+    hidden_dim = kv_shape[3] * kv_shape[4]
+    kv_format = build_dense_format_single_group(
+        num_layers=kv_shape[0],
+        dtype=kv_dtype,
+        hidden_dim=hidden_dim,
+        block_size=kv_shape[2],
+        use_mla=False,
+        separation="packed",
+    )
+
     return LMCacheMetadata(
         model_name=model,
         world_size=8,
         local_world_size=8,
         worker_id=0,
         local_worker_id=0,
-        kv_dtype=torch.bfloat16,
-        kv_shape=(8, 2, 16, 8, 16),
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
+        kv_format=kv_format,
+        chunk_size=kv_shape[2],
     )
 
 

--- a/lmcache/v1/gpu_connector.py
+++ b/lmcache/v1/gpu_connector.py
@@ -78,6 +78,16 @@ def lmcache_memcpy_async_d2h(
         memory_obj.tensor.copy_(gpu_buffer, non_blocking=True)
 
 
+def _kv_layout_from_metadata(metadata: LMCacheMetadata) -> dict:
+    """Extract a uniform layout description, honoring kv_format when present.
+
+    Returns dict with keys: block_size, hidden_dim, num_layers, use_mla, dtype.
+    Raises ValueError on inconsistencies between kv_format and legacy fields.
+    """
+    layout, _ = metadata.get_kv_layout("for connector use")
+    return layout
+
+
 class GPUConnectorInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
@@ -236,22 +246,16 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         Returns:
             A new instance of VLLMPagedMemGPUConnectorV2.
         """
-        # Extract parameters from metadata
-        # kv_shape: (num_layer, 2 or 1, chunk_size, num_kv_head, head_size)
-        num_layers = metadata.kv_shape[0]
-        chunk_size = metadata.kv_shape[2]
-        num_kv_head = metadata.kv_shape[3]
-        head_size = metadata.kv_shape[4]
-        hidden_dim_size = num_kv_head * head_size
+        layout = _kv_layout_from_metadata(metadata)
 
         return cls(
-            hidden_dim_size=hidden_dim_size,
-            num_layers=num_layers,
+            hidden_dim_size=layout["hidden_dim"],
+            num_layers=layout["num_layers"],
             use_gpu=use_gpu,
-            chunk_size=chunk_size,
-            dtype=metadata.kv_dtype,
+            chunk_size=layout["block_size"],
+            dtype=layout["dtype"],
             device=device,
-            use_mla=metadata.use_mla,
+            use_mla=layout["use_mla"],
         )
 
     def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
@@ -448,7 +452,11 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         device: Optional[torch.device] = None,
     ) -> "VLLMPagedMemGPUConnectorV3":
         assert device is not None
-        return cls(metadata, device, use_gpu)
+        layout = _kv_layout_from_metadata(metadata)
+        connector = cls(metadata, device, use_gpu)
+        connector.chunk_size = layout["block_size"]
+        connector.use_mla = layout["use_mla"]
+        return connector
 
     def _initialize_kv_cache_pointers(self):
         if self.init:
@@ -649,18 +657,13 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         Returns:
             A new instance of VLLMBufferLayerwiseGPUConnector.
         """
-        # Extract parameters from metadata
-        # kv_shape: (num_layer, 2 or 1, chunk_size, num_kv_head, head_size)
-        num_layers = metadata.kv_shape[0]
-        num_kv_head = metadata.kv_shape[3]
-        head_size = metadata.kv_shape[4]
-        hidden_dim_size = num_kv_head * head_size
+        layout = _kv_layout_from_metadata(metadata)
 
         return cls(
-            hidden_dim_size=hidden_dim_size,
-            num_layers=num_layers,
+            hidden_dim_size=layout["hidden_dim"],
+            num_layers=layout["num_layers"],
             use_gpu=use_gpu,
-            dtype=metadata.kv_dtype,
+            dtype=layout["dtype"],
             device=device,
         )
 
@@ -1053,22 +1056,16 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
         Returns:
             A new instance of VLLMPagedMemLayerwiseGPUConnector.
         """
-        # Extract parameters from metadata
-        # kv_shape: (num_layer, 2 or 1, chunk_size, num_kv_head, head_size)
-        num_layers = metadata.kv_shape[0]
-        chunk_size = metadata.kv_shape[2]
-        num_kv_head = metadata.kv_shape[3]
-        head_size = metadata.kv_shape[4]
-        hidden_dim_size = num_kv_head * head_size
+        layout = _kv_layout_from_metadata(metadata)
 
         return cls(
-            hidden_dim_size=hidden_dim_size,
-            num_layers=num_layers,
+            hidden_dim_size=layout["hidden_dim"],
+            num_layers=layout["num_layers"],
             use_gpu=use_gpu,
-            chunk_size=chunk_size,
-            dtype=metadata.kv_dtype,
+            chunk_size=layout["block_size"],
+            dtype=layout["dtype"],
             device=device,
-            use_mla=metadata.use_mla,
+            use_mla=layout["use_mla"],
         )
 
     def _lazy_initialize_buffer(self, kv_caches):

--- a/lmcache/v1/kvcache_format.py
+++ b/lmcache/v1/kvcache_format.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVCache format descriptor for engine-agnostic KV layout definitions.
+
+Layout is expressed as a single routing key (KVCacheLayout) to avoid a Cartesian
+product of partially-valid combinations. Family/canonical/separation are derived
+from that routing key and documented below.
+
+Separation meaning:
+- packed: K and V live in a single tensor/buffer (e.g., a 2LTD-style [2, L, ...]
+  layout) and are copied together.
+- separated: K and V live in separate tensors/buffers and are copied separately.
+
+Canonical meaning:
+- KV_2LTD: dense MHA layout with K/V packed along a leading dimension.
+- KV_MLA_FMT: MLA latent layout.
+
+Examples:
+- vLLM dense MHA (paged attention): kv_shape=(L, 2, block, H, D) maps to
+  layout=MHA_DENSE_PACKED, block_size=block, hidden_dim=H*D.
+- SGLang dense MHA: same mapping as vLLM for integration mode.
+- MLA models (use_mla=True): layout=MLA_LATENT_PACKED with the same block_size.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Literal, Optional, Protocol, Sequence, TypedDict
+import re
+
+# Third Party
+import msgspec
+
+# Public schema/version identifier for the format descriptor.
+KV_FORMAT_SCHEMA_VERSION = 1
+
+Family = Literal["MHA_DENSE", "MLA_LATENT"]
+Canonical = Literal["KV_2LTD", "KV_MLA_FMT"]
+Separation = Literal["packed", "separated"]
+KVCacheLayout = Literal[
+    "MHA_DENSE_PACKED",
+    "MHA_DENSE_SEPARATED",
+    "MLA_LATENT_PACKED",
+    "MLA_LATENT_SEPARATED",
+]
+Addressing = Literal["gpu_block_ids"]
+
+
+class L0LayoutSpec(msgspec.Struct, frozen=True):
+    addressing: Addressing
+    block_size: int
+    pointer_order: Optional[str] = None
+
+
+class KVLayerGroupSpec(msgspec.Struct, frozen=True):
+    start_layer: int
+    num_layers: int
+    dtype: str
+    hidden_dim: int
+
+
+class KVCacheFormat(msgspec.Struct, frozen=True):
+    layout: KVCacheLayout
+    l0: L0LayoutSpec
+    layer_groups: list[KVLayerGroupSpec]
+    format_id: str
+    schema_version: int = KV_FORMAT_SCHEMA_VERSION
+
+    @property
+    def family(self) -> Family:
+        return _LAYOUT_DEFS[self.layout]["family"]
+
+    @property
+    def canonical(self) -> Canonical:
+        return _LAYOUT_DEFS[self.layout]["canonical"]
+
+    @property
+    def separation(self) -> Optional[Separation]:
+        return _LAYOUT_DEFS[self.layout]["separation"]
+
+    @property
+    def use_mla(self) -> bool:
+        return _LAYOUT_DEFS[self.layout]["use_mla"]
+
+
+_FORMAT_ID_RE = re.compile(
+    r"^[A-Za-z0-9._:-]+(/[A-Za-z0-9._:-]+)*$"
+)  # simple, versioned-friendly
+
+
+class _LayoutDef(TypedDict):
+    family: Family
+    canonical: Canonical
+    separation: Optional[Separation]
+    use_mla: bool
+
+
+_LAYOUT_DEFS: dict[KVCacheLayout, _LayoutDef] = {
+    "MHA_DENSE_PACKED": {
+        "family": "MHA_DENSE",
+        "canonical": "KV_2LTD",
+        "separation": "packed",
+        "use_mla": False,
+    },
+    "MHA_DENSE_SEPARATED": {
+        "family": "MHA_DENSE",
+        "canonical": "KV_2LTD",
+        "separation": "separated",
+        "use_mla": False,
+    },
+    "MLA_LATENT_PACKED": {
+        "family": "MLA_LATENT",
+        "canonical": "KV_MLA_FMT",
+        "separation": "packed",
+        "use_mla": True,
+    },
+    "MLA_LATENT_SEPARATED": {
+        "family": "MLA_LATENT",
+        "canonical": "KV_MLA_FMT",
+        "separation": "separated",
+        "use_mla": True,
+    },
+}
+
+
+class _KVMetadata(Protocol):
+    kv_format: Optional[KVCacheFormat]
+    kv_shape: tuple
+    use_mla: bool
+    kv_dtype: object
+    chunk_size: int
+
+
+def _validate_layer_groups(layer_groups: Sequence[KVLayerGroupSpec]) -> None:
+    if not layer_groups:
+        raise ValueError("layer_groups must be non-empty")
+
+    # Ensure groups are sorted and non-overlapping.
+    sorted_groups = sorted(layer_groups, key=lambda g: g.start_layer)
+    prev_end = 0
+    for group in sorted_groups:
+        if group.start_layer < 0:
+            raise ValueError("start_layer must be non-negative")
+        if group.num_layers <= 0:
+            raise ValueError("num_layers must be positive")
+        if group.hidden_dim <= 0:
+            raise ValueError("hidden_dim must be positive")
+        if not group.dtype:
+            raise ValueError("dtype must be non-empty")
+        if group.start_layer < prev_end:
+            raise ValueError("layer_groups overlap or are unsorted")
+        prev_end = group.start_layer + group.num_layers
+
+
+def validate_kvcache_format(fmt: KVCacheFormat) -> KVCacheFormat:
+    """Validate a KVCacheFormat, raising ValueError on issues."""
+    if fmt.layout not in _LAYOUT_DEFS:
+        raise ValueError(f"unsupported layout: {fmt.layout}")
+
+    if fmt.l0.block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if fmt.l0.addressing != "gpu_block_ids":
+        raise ValueError("addressing must be 'gpu_block_ids' for v1")
+
+    if not fmt.format_id or not _FORMAT_ID_RE.match(fmt.format_id):
+        raise ValueError(
+            "format_id must be non-empty, versioned string-like "
+            "(e.g., 'mha_dense/packed/v1')"
+        )
+
+    if fmt.schema_version != KV_FORMAT_SCHEMA_VERSION:
+        raise ValueError(
+            "schema_version mismatch: "
+            f"{fmt.schema_version} != {KV_FORMAT_SCHEMA_VERSION}"
+        )
+
+    _validate_layer_groups(fmt.layer_groups)
+    return fmt
+
+
+def serialize_kvcache_format(fmt: KVCacheFormat) -> bytes:
+    """Serialize format to msgpack bytes."""
+    return msgspec.msgpack.encode(validate_kvcache_format(fmt))
+
+
+def deserialize_kvcache_format(data: bytes) -> KVCacheFormat:
+    """Deserialize and validate format from msgpack bytes."""
+    fmt = msgspec.msgpack.decode(data, type=KVCacheFormat)
+    return validate_kvcache_format(fmt)
+
+
+def _dtype_to_str(dtype: object) -> str:
+    # Accept torch.dtype or string; avoid importing torch to keep core engine-agnostic.
+    if dtype is None:
+        raise ValueError("dtype cannot be None")
+    if isinstance(dtype, str):
+        if not dtype:
+            raise ValueError("dtype string cannot be empty")
+        return dtype
+    return str(dtype)
+
+
+def _layout_from_kv_shape(
+    kv_shape: Optional[tuple], use_mla: bool, kv_dtype: object
+) -> dict:
+    if kv_shape is None:
+        raise ValueError("kv_shape must be provided when kv_format is absent")
+    num_layers = kv_shape[0]
+    block_size = kv_shape[2]
+    hidden_dim = kv_shape[3] * kv_shape[4]
+    return {
+        "block_size": block_size,
+        "hidden_dim": hidden_dim,
+        "num_layers": num_layers,
+        "use_mla": use_mla,
+        "dtype": kv_dtype,
+    }
+
+
+def get_kv_layout_from_metadata(
+    metadata: _KVMetadata, *, hidden_dim_context: str
+) -> tuple[dict, Optional[KVCacheFormat]]:
+    """Return a layout dict and optional validated format from metadata.
+
+    This centralizes the validation of kv_format against legacy metadata fields
+    to avoid duplicating the same logic in multiple call sites.
+    """
+    kv_format = getattr(metadata, "kv_format", None)
+    kv_shape = getattr(metadata, "kv_shape", None)
+    use_mla = metadata.use_mla
+    kv_dtype = metadata.kv_dtype
+    chunk_size = getattr(metadata, "chunk_size", None)
+
+    if kv_format is None:
+        return _layout_from_kv_shape(kv_shape, use_mla, kv_dtype), None
+
+    fmt = validate_kvcache_format(kv_format)
+    block_size = fmt.l0.block_size
+    total_layers = max(g.start_layer + g.num_layers for g in fmt.layer_groups)
+    hidden_dims = {g.hidden_dim for g in fmt.layer_groups}
+    if len(hidden_dims) != 1:
+        raise ValueError(
+            "kv_format must use a uniform hidden_dim across layer_groups "
+            f"{hidden_dim_context}"
+        )
+    hidden_dim = hidden_dims.pop()
+
+    if kv_shape is not None:
+        num_layers_shape = kv_shape[0]
+        chunk_size_shape = kv_shape[2]
+        hidden_dim_shape = kv_shape[3] * kv_shape[4]
+        if num_layers_shape != total_layers:
+            raise ValueError(
+                "kv_format layers "
+                f"({total_layers}) mismatch kv_shape[0] ({num_layers_shape})"
+            )
+        if chunk_size_shape != block_size:
+            raise ValueError(
+                "kv_format block_size "
+                f"({block_size}) mismatch kv_shape chunk_size ({chunk_size_shape})"
+            )
+        if hidden_dim_shape != hidden_dim:
+            raise ValueError(
+                "kv_format hidden_dim "
+                f"({hidden_dim}) mismatch kv_shape inferred hidden_dim "
+                f"({hidden_dim_shape})"
+            )
+
+    if chunk_size is not None and chunk_size != block_size:
+        raise ValueError(
+            "kv_format block_size "
+            f"({block_size}) mismatch metadata.chunk_size ({chunk_size})"
+        )
+
+    dtype_str = _dtype_to_str(kv_dtype)
+    for group in fmt.layer_groups:
+        if group.dtype != dtype_str:
+            raise ValueError(
+                f"kv_format dtype {group.dtype} mismatch metadata.kv_dtype {dtype_str}"
+            )
+
+    expected_use_mla = fmt.use_mla
+    if use_mla != expected_use_mla:
+        raise ValueError(
+            "kv_format family "
+            f"({fmt.family}) inconsistent with metadata.use_mla ({use_mla})"
+        )
+
+    layout = {
+        "block_size": block_size,
+        "hidden_dim": hidden_dim,
+        "num_layers": total_layers,
+        "use_mla": expected_use_mla,
+        "dtype": kv_dtype,
+    }
+    return layout, fmt
+
+
+def build_dense_format_single_group(
+    num_layers: int,
+    dtype: object,
+    hidden_dim: int,
+    block_size: int,
+    *,
+    use_mla: bool = False,
+    separation: Separation = "packed",
+    format_version: str = "v1",
+) -> KVCacheFormat:
+    """Convenience builder for a single-group dense or MLA layout."""
+    if num_layers <= 0:
+        raise ValueError("num_layers must be positive")
+    if hidden_dim <= 0:
+        raise ValueError("hidden_dim must be positive")
+
+    if separation not in ("packed", "separated"):
+        raise ValueError("separation must be 'packed' or 'separated'")
+
+    if use_mla:
+        layout: KVCacheLayout = (
+            "MLA_LATENT_PACKED" if separation == "packed" else "MLA_LATENT_SEPARATED"
+        )
+    else:
+        layout = "MHA_DENSE_PACKED" if separation == "packed" else "MHA_DENSE_SEPARATED"
+
+    format_id = (
+        f"mla_latent/{separation}/{format_version}"
+        if use_mla
+        else f"mha_dense/{separation}/{format_version}"
+    )
+
+    layer_group = KVLayerGroupSpec(
+        start_layer=0,
+        num_layers=num_layers,
+        dtype=_dtype_to_str(dtype),
+        hidden_dim=hidden_dim,
+    )
+    l0 = L0LayoutSpec(addressing="gpu_block_ids", block_size=block_size)
+    fmt = KVCacheFormat(
+        layout=layout,
+        l0=l0,
+        layer_groups=[layer_group],
+        format_id=format_id,
+    )
+    return validate_kvcache_format(fmt)

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -345,6 +345,17 @@ class LMCacheManager:
                 )
 
         # Create metadata
+        # First Party
+        from lmcache.v1.kvcache_format import build_dense_format_single_group
+
+        kv_format = build_dense_format_single_group(
+            num_layers=num_layer,
+            dtype=kv_dtype,
+            hidden_dim=num_kv_head * head_size,
+            block_size=chunk_size,
+            use_mla=use_mla,
+            separation="packed",
+        )
         metadata = LMCacheMetadata(
             model_name=model_config.model,
             world_size=parallel_config.world_size,
@@ -359,6 +370,7 @@ class LMCacheManager:
             chunk_size=self._config.chunk_size,
             engine_id=engine_id,
             kv_connector_extra_config=kv_connector_extra_config,
+            kv_format=kv_format,
         )
 
         # Create GPU connector

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Tuple
 
 # Third Party
 import torch
@@ -9,6 +9,7 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.kvcache_format import KVCacheFormat, get_kv_layout_from_metadata
 
 logger = init_logger(__name__)
 
@@ -64,6 +65,8 @@ class LMCacheMetadata:
     engine_id: Optional[str] = None
     """ extra config from kv_connector (e.g., lmcache_rpc_port) """
     kv_connector_extra_config: Optional[dict] = None
+    """ declared KV cache format descriptor (integration mode; optional) """
+    kv_format: Optional[KVCacheFormat] = None
 
     def is_first_rank(self) -> bool:
         """Check if the current worker is the first rank"""
@@ -112,3 +115,9 @@ class LMCacheMetadata:
         if self.kv_layer_groups_manager.kv_layer_groups:
             return self.kv_layer_groups_manager.num_groups
         return 1
+
+    def get_kv_layout(
+        self, hidden_dim_context: str
+    ) -> Tuple[dict, Optional[KVCacheFormat]]:
+        """Return derived KV layout and optional validated KVCacheFormat."""
+        return get_kv_layout_from_metadata(self, hidden_dim_context=hidden_dim_context)

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -608,17 +608,30 @@ def main():
             kv_shape[4],
         )
 
+        # First Party
+        from lmcache.v1.kvcache_format import build_dense_format_single_group
+
+        hidden_dim = kv_shape[3] * kv_shape[4]
+        kv_format = build_dense_format_single_group(
+            num_layers=kv_shape[0],
+            dtype=kv_dtype,
+            hidden_dim=hidden_dim,
+            block_size=kv_shape[2],
+            use_mla=args.use_mla,
+            separation="packed",
+        )
+
         metadata = LMCacheMetadata(
             model_name=args.model_name,
             world_size=args.world_size,
             local_world_size=args.world_size,
             worker_id=args.worker_id,
             local_worker_id=args.worker_id,
-            fmt=args.fmt,
             kv_dtype=kv_dtype,
             kv_shape=kv_shape,
             use_mla=args.use_mla,
             role="worker",
+            kv_format=kv_format,
         )
 
         starter = LMCacheStandaloneStarter(config, metadata, layer_groups, args.device)

--- a/tests/v1/test_kvcache_format.py
+++ b/tests/v1/test_kvcache_format.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.check.utils import _get_default_metadata
+from lmcache.v1.gpu_connector import VLLMPagedMemGPUConnectorV2
+from lmcache.v1.kvcache_format import (
+    KV_FORMAT_SCHEMA_VERSION,
+    KVCacheFormat,
+    KVLayerGroupSpec,
+    L0LayoutSpec,
+    build_dense_format_single_group,
+    deserialize_kvcache_format,
+    serialize_kvcache_format,
+    validate_kvcache_format,
+)
+from lmcache.v1.metadata import LMCacheMetadata
+
+
+def test_round_trip_serialization():
+    fmt = build_dense_format_single_group(
+        num_layers=2,
+        dtype=torch.float16,
+        hidden_dim=128,
+        block_size=256,
+        use_mla=False,
+        separation="packed",
+    )
+    encoded = serialize_kvcache_format(fmt)
+    decoded = deserialize_kvcache_format(encoded)
+    assert decoded == fmt
+
+
+def test_validation_rejects_invalid_block_size():
+    fmt = KVCacheFormat(
+        layout="MHA_DENSE_PACKED",
+        l0=L0LayoutSpec(
+            addressing="gpu_block_ids",
+            block_size=0,  # invalid
+        ),
+        layer_groups=[
+            KVLayerGroupSpec(
+                start_layer=0,
+                num_layers=1,
+                dtype="torch.float16",
+                hidden_dim=128,
+            )
+        ],
+        format_id="mha_dense/packed/v1",
+    )
+    with pytest.raises(ValueError):
+        validate_kvcache_format(fmt)
+
+
+def test_validation_rejects_overlapping_groups():
+    fmt = KVCacheFormat(
+        layout="MHA_DENSE_PACKED",
+        l0=L0LayoutSpec(
+            addressing="gpu_block_ids",
+            block_size=256,
+        ),
+        layer_groups=[
+            KVLayerGroupSpec(
+                start_layer=0,
+                num_layers=2,
+                dtype="torch.float16",
+                hidden_dim=128,
+            ),
+            KVLayerGroupSpec(
+                start_layer=1,  # overlaps previous group
+                num_layers=1,
+                dtype="torch.float16",
+                hidden_dim=128,
+            ),
+        ],
+        format_id="mha_dense/packed/v1",
+    )
+    with pytest.raises(ValueError):
+        validate_kvcache_format(fmt)
+
+
+def test_schema_version_mismatch_rejected():
+    fmt = KVCacheFormat(
+        layout="MHA_DENSE_PACKED",
+        l0=L0LayoutSpec(
+            addressing="gpu_block_ids",
+            block_size=256,
+        ),
+        layer_groups=[
+            KVLayerGroupSpec(
+                start_layer=0,
+                num_layers=1,
+                dtype="torch.float16",
+                hidden_dim=128,
+            )
+        ],
+        format_id="mha_dense/packed/v1",
+        schema_version=KV_FORMAT_SCHEMA_VERSION + 1,
+    )
+    with pytest.raises(ValueError):
+        validate_kvcache_format(fmt)
+
+
+def test_mla_builder_uses_mla_canonical_and_hidden_dim():
+    fmt = build_dense_format_single_group(
+        num_layers=4,
+        dtype=torch.bfloat16,
+        hidden_dim=64,
+        block_size=128,
+        use_mla=True,
+        separation="packed",
+    )
+    assert fmt.layout == "MLA_LATENT_PACKED"
+    assert fmt.family == "MLA_LATENT"
+    assert fmt.canonical == "KV_MLA_FMT"
+    assert fmt.layer_groups[0].hidden_dim == 64
+
+
+def test_builder_uses_dtype_canonicalization():
+    fmt = build_dense_format_single_group(
+        num_layers=2,
+        dtype=torch.bfloat16,
+        hidden_dim=32,
+        block_size=64,
+        use_mla=False,
+        separation="packed",
+    )
+    assert fmt.layer_groups[0].dtype == str(torch.bfloat16)
+
+
+def test_vllm_connector_from_metadata_uses_kv_format():
+    kv_dtype = torch.float16
+    kv_shape = (4, 2, 256, 8, 16)  # hidden_dim = 128
+    kv_format = build_dense_format_single_group(
+        num_layers=4,
+        dtype=kv_dtype,
+        hidden_dim=128,
+        block_size=256,
+        use_mla=False,
+        separation="packed",
+    )
+    metadata = LMCacheMetadata(
+        model_name="test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
+        kv_format=kv_format,
+        chunk_size=256,
+    )
+
+    connector = VLLMPagedMemGPUConnectorV2.from_metadata(
+        metadata, use_gpu=False, device=None
+    )
+    assert connector.hidden_dim_size == 128
+    assert connector.num_layers == 4
+
+
+def test_vllm_connector_rejects_inconsistent_block_size():
+    kv_dtype = torch.float16
+    kv_shape = (4, 2, 128, 8, 16)  # chunk_size mismatch vs kv_format
+    kv_format = build_dense_format_single_group(
+        num_layers=4,
+        dtype=kv_dtype,
+        hidden_dim=128,
+        block_size=256,
+        use_mla=False,
+        separation="packed",
+    )
+    metadata = LMCacheMetadata(
+        model_name="test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
+        kv_format=kv_format,
+        chunk_size=128,
+    )
+
+    with pytest.raises(ValueError):
+        VLLMPagedMemGPUConnectorV2.from_metadata(metadata, use_gpu=False, device=None)
+
+
+def test_get_kv_layout_from_metadata_without_format():
+    kv_dtype = torch.float16
+    kv_shape = (2, 2, 128, 4, 16)  # hidden_dim = 64
+    metadata = LMCacheMetadata(
+        model_name="test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
+        chunk_size=128,
+    )
+
+    layout, fmt = metadata.get_kv_layout("for test")
+    assert fmt is None
+    assert layout["block_size"] == 128
+    assert layout["hidden_dim"] == 64
+    assert layout["num_layers"] == 2
+    assert layout["use_mla"] is False
+
+
+def test_default_metadata_includes_kv_format():
+    metadata = _get_default_metadata("test-model")
+    assert metadata.kv_format is not None
+    layout, fmt = metadata.get_kv_layout("for test")
+    assert fmt is not None
+    assert layout["block_size"] == metadata.kv_shape[2]


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a KVCacheFormat descriptor contract in LMCache core for integration mode.
- Validates `kv_format` against legacy metadata early to fail on mismatches.
- Makes GPU connectors honor declared layout when present, without engine-name branching.
- Wires vLLM and SGLang integrations to declare the format, while keeping cache keys unchanged in this PR.

**Special notes for your reviewers**:
- Scope is intentionally limited to integration mode (no MP protocol changes here).
- `kv_format` is not added to cache keys in this PR.
- manual A/B correctness runs were done for vLLM and SGLang with `chunk_size=8`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests