### PR TITLE
[CI]: fix attention backend for mp tests

### DIFF
--- a/.buildkite/scripts/multiprocessing-test/launch-containers.sh
+++ b/.buildkite/scripts/multiprocessing-test/launch-containers.sh
@@ -65,12 +65,12 @@ docker run -d \
     --ipc host \
     --env CUDA_VISIBLE_DEVICES=0 \
     --env VLLM_ENABLE_V1_MULTIPROCESSING=0 \
-    --env VLLM_ATTENTION_BACKEND=FLASH_ATTN \
     --env VLLM_BATCH_INVARIANT=1 \
     --env PYTHONHASHSEED=0 \
     lmcache/vllm-openai:test \
     "$MODEL" \
     --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT}}" \
+    --attention-backend FLASH_ATTN \
     --port "$VLLM_PORT" \
     --no-async-scheduling \
     $GPU_MEMORY_UTIL_ARG
@@ -90,12 +90,12 @@ docker run -d \
     --ipc host \
     --env CUDA_VISIBLE_DEVICES=1 \
     --env VLLM_ENABLE_V1_MULTIPROCESSING=0 \
-    --env VLLM_ATTENTION_BACKEND=FLASH_ATTN \
     --env VLLM_BATCH_INVARIANT=1 \
     --env PYTHONHASHSEED=0 \
     lmcache/vllm-openai:test \
     "$MODEL" \
     --port "$VLLM_BASELINE_PORT" \
+    --attention-backend FLASH_ATTN \
     --no-async-scheduling \
     $GPU_MEMORY_UTIL_ARG
 


### PR DESCRIPTION
The env var has been deprecated and now the MP tests cannot pass: 
```text
(EngineCore_DP0 pid=345) ERROR 01-28 00:18:04 [core.py:946] RuntimeError: VLLM batch_invariant mode requires an attention backend in ['FLASH_ATTN', 'FLASHINFER', 'FLASH_ATTN_MLA', 'TRITON_MLA'], but got 'None'. Please use --attention-backend or attention_config to set one of the supported backends before enabling batch_invariant.
```