### PR TITLE
[Feat] add concurrency control for allocate mem

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -798,7 +798,8 @@ class LMCacheEngine:
             if self.remove_after_retrieve and not self._is_passive():
                 assert self.storage_manager is not None
                 self.storage_manager.remove(key)
-            memory_obj.ref_count_down()
+            if memory_obj.get_ref_count() > 0:
+                memory_obj.ref_count_down()
 
         onload_time = retrieve_stats.time_to_retrieve()
 

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1633,6 +1633,11 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
 
         return True
 
+    def check_free_blocks(self, needed_blocks: int):
+        if len(self.free_blocks) < needed_blocks:
+            return False
+        return True
+
     def __str__(self):
         return "PagedTensorMemoryAllocator"
 
@@ -2303,6 +2308,9 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
             self.cpu_allocator.free(memory_obj)
         else:
             raise ValueError(f"Unsupported allocator type: {allocator_type}")
+
+    def check_gpu_blocks(self, needed_blocks: int):
+        return self.gpu_allocator.check_free_blocks(needed_blocks)
 
     def batched_free(
         self,

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -157,6 +157,8 @@ class PDBackend(AllocatorBackendInterface):
         # only receiver/decoder will.
         self.data: dict[CacheEngineKey, MemoryObj] = {}
         self.data_lock = threading.Lock()
+        self.condition = threading.Condition()
+        self.count_waiting_req = 0
 
         self.memory_allocator = self.initialize_allocator(config, metadata)
         assert isinstance(self.memory_allocator, PagedCpuGpuMemoryAllocator)
@@ -481,6 +483,15 @@ class PDBackend(AllocatorBackendInterface):
         alloc_indexes = []
         already_send_indexes = []
 
+        self.condition.acquire()
+        while not self.memory_allocator.check_gpu_blocks(total_allocs):
+            self.count_waiting_req += 1
+            self.condition.wait()
+            self.count_waiting_req -= 1
+
+            if self.memory_allocator.check_gpu_blocks(total_allocs):
+                break
+
         for idx, key_str in enumerate(alloc_request.keys):
             key = CacheEngineKey.from_string(key_str)
             if self.contains(key, pin=True):
@@ -573,8 +584,13 @@ class PDBackend(AllocatorBackendInterface):
             if mem_obj := self.data.get(key, None):
                 if mem_obj.get_ref_count() == 1:
                     del self.data[key]
-                return True
-            return False
+            else:
+                return False
+
+        mem_obj.ref_count_down()
+        if self.count_waiting_req > 0:
+            self.condition.notify_all()
+        return True
 
     ############################################################
     # Decoder functions end

--- a/lmcache/v1/storage_backend/pd_backend.py
+++ b/lmcache/v1/storage_backend/pd_backend.py
@@ -483,14 +483,11 @@ class PDBackend(AllocatorBackendInterface):
         alloc_indexes = []
         already_send_indexes = []
 
-        self.condition.acquire()
-        while not self.memory_allocator.check_gpu_blocks(total_allocs):
-            self.count_waiting_req += 1
-            self.condition.wait()
-            self.count_waiting_req -= 1
-
-            if self.memory_allocator.check_gpu_blocks(total_allocs):
-                break
+        with self.condition:
+            while not self.memory_allocator.check_gpu_blocks(total_allocs):
+                self.count_waiting_req += 1
+                self.condition.wait()
+                self.count_waiting_req -= 1
 
         for idx, key_str in enumerate(alloc_request.keys):
             key = CacheEngineKey.from_string(key_str)


### PR DESCRIPTION
why
avoid cpu idling and deadlock in high-concurrency scenarios.
what
add concurrency control and check free blocks for decode allocate mem
