### PR TITLE
Fix MooncakeLookupClient to use config hostname instead of hardcoded …

### DIFF
--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -178,10 +178,15 @@ class LookupClientFactory:
         config: LMCacheEngineConfig,
         metadata: LMCacheEngineMetadata,
     ) -> "MooncakeLookupClient":
-        """Create a MooncakeLookupClient instance."""
+        """Create a MooncakeLookupClient instance.
+
+        Note: master_address parameter is kept for backward compatibility with URI parsing,
+        but is no longer used. The master server address is now read from the config's
+        extra_config.master_server_address field for consistency with MooncakestoreConnector.
+        """
         # First Party
         from lmcache.v1.lookup_client.mooncake_lookup_client import (
             MooncakeLookupClient,
         )
 
-        return MooncakeLookupClient(config, metadata, master_address)
+        return MooncakeLookupClient(config, metadata)

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -25,14 +25,28 @@ class MooncakeLookupClient(LookupClientInterface):
         # Third Party
         from mooncake.store import MooncakeDistributedStore
 
+        # First Party
+        from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+            MooncakeStoreConfig,
+        )
+
+        # Load Mooncake configuration from LMCache config to avoid hardcoded values
+        mooncake_config = MooncakeStoreConfig.load_from_lmcache_config(config)
+
+        logger.info(
+            "MooncakeLookupClient using configuration: hostname=%s, protocol=%s",
+            mooncake_config.local_hostname or "(auto-detect)",
+            mooncake_config.protocol,
+        )
+
         self.store = MooncakeDistributedStore()
         self.store.setup(
-            "localhost",
-            "P2PHANDSHAKE",
-            0,
-            16 * 1024 * 1024,
-            "tcp",
-            "",
+            mooncake_config.local_hostname or "",
+            mooncake_config.metadata_server,
+            mooncake_config.global_segment_size,
+            mooncake_config.local_buffer_size,
+            mooncake_config.protocol,
+            mooncake_config.device_name,
             master_addr,
         )
 

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -20,7 +20,6 @@ class MooncakeLookupClient(LookupClientInterface):
         self,
         config: LMCacheEngineConfig,
         metadata: LMCacheEngineMetadata,
-        master_addr: str,
     ):
         # Third Party
         from mooncake.store import MooncakeDistributedStore
@@ -34,9 +33,10 @@ class MooncakeLookupClient(LookupClientInterface):
         mooncake_config = MooncakeStoreConfig.load_from_lmcache_config(config)
 
         logger.info(
-            "MooncakeLookupClient using configuration: hostname=%s, protocol=%s",
+            "MooncakeLookupClient using configuration: hostname=%s, protocol=%s, master_server=%s",
             mooncake_config.local_hostname or "(auto-detect)",
             mooncake_config.protocol,
+            mooncake_config.master_server_address,
         )
 
         self.store = MooncakeDistributedStore()
@@ -47,7 +47,7 @@ class MooncakeLookupClient(LookupClientInterface):
             mooncake_config.local_buffer_size,
             mooncake_config.protocol,
             mooncake_config.device_name,
-            master_addr,
+            mooncake_config.master_server_address,
         )
 
         # Initialize token database for processing tokens


### PR DESCRIPTION
…localhost

Fixes #2232

## Problem
MooncakeLookupClient was using hardcoded 'localhost' and other hardcoded values when setting up the Mooncake store, which prevented cross-process KV cache sharing. When multiple vLLM processes tried to share KV caches through Mooncake, the lookup client couldn't find caches stored by other processes because all processes registered with the same 'localhost' identity.

## Solution
- Load MooncakeStoreConfig from LMCache config (same as MooncakestoreConnector)
- Use config values for hostname, metadata_server, global_segment_size, etc.
- Each process now registers with its actual hostname/IP
- Enables proper cross-process KV cache lookup and sharing

## Changes
- Import MooncakeStoreConfig from mooncakestore_connector
- Call MooncakeStoreConfig.load_from_lmcache_config(config)
- Replace all hardcoded setup() parameters with config values
- Add logging to show which hostname is being used

## Testing
This fix allows decode processes to successfully retrieve KV caches stored by prefill processes in disaggregated serving setups using Mooncake as the persistent storage backend.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
