### PR TITLE
[UT] Skip gpu connector benchmark tests when plugin missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # Standard
 from dataclasses import dataclass
 from unittest.mock import patch
+import importlib.util
 import random
 import shlex
 import socket
@@ -16,6 +17,12 @@ import torch
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.memory_management import MixedMemoryAllocator
 from lmcache.v1.metadata import LMCacheMetadata
+
+if importlib.util.find_spec("pytest_benchmark") is None:
+
+    @pytest.fixture
+    def benchmark():
+        pytest.skip("pytest-benchmark is not installed")
 
 # This is to mock the constructor and destructor of
 # MixedMemoryAllocator and PinMemoryAllocator to


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Adds a fallback benchmark fixture that skips benchmark tests when pytest-benchmark is not installed.
This prevents hard failures in environments without the plugin while keeping benchmark tests intact when it is available.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
