### PR TITLE
[Bugfix][Async] Avoid vLLM-side double-free error by implementing request lifecycle tracking

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -130,13 +130,13 @@ class LMCacheMPSchedulerAdapter:
         # Request futures
         self.lookup_futures: dict[str, MessagingFuture[LookupResult]] = {}
 
-        # NOTE(Kuntai): Maintain a set of executing request ids.
-        # This is needed: vLLM currently has double-free issue when calling
-        # worker-side `get_finished`. We need to memorize the set of 
-        # executing requests to avoid such double free.
-        self.executing_request_ids: set[str] = set()
-        self.executing_request_ids_at_this_step: set[str] = set()
-
+        # Track request IDs to prevent double-free in async scheduling.
+        # tracked_reqs: all currently executing requests (added on start,
+        # removed on finish)
+        # new_reqs_this_step: requests newly added this scheduler step
+        # (cleared each step)
+        self.tracked_reqs: set[str] = set()
+        self.new_reqs_this_step: set[str] = set()
 
         self.model_name = model_name
         self.world_size = world_size
@@ -150,35 +150,24 @@ class LMCacheMPSchedulerAdapter:
         self.blocks_in_chunk = self.chunk_size // vllm_block_size
 
     @_lmcache_nvtx_annotate
-    def maybe_add_to_executing_request_ids(self, request_id: str):
-        """
-        Add a request id to the set of executing request ids.
-        """
-        if request_id in self.executing_request_ids:
+    def track_request(self, request_id: str):
+        """Start tracking a request. Idempotent - ignores already-tracked requests."""
+        if request_id in self.tracked_reqs:
             return
-        self.executing_request_ids_at_this_step.add(request_id)
-        self.executing_request_ids.add(request_id)
-
+        self.new_reqs_this_step.add(request_id)
+        self.tracked_reqs.add(request_id)
 
     @_lmcache_nvtx_annotate
-    def remove_from_executing_request_ids(self, request_id: str):
-        """
-        Remove a request id from the set of executing request ids.
-        """
-        if request_id not in self.executing_request_ids:
-            logger.warning("Request id %s is double-freed by `request_finished`")
-            return
-        self.executing_request_ids.remove(request_id)
-
+    def untrack_request(self, request_id: str):
+        """Stop tracking a request (called when request finishes)."""
+        self.tracked_reqs.discard(request_id)
 
     @_lmcache_nvtx_annotate
-    def get_executing_request_ids_at_this_step(self) -> set[str]:
-        """
-        Clear the set of executing request ids for this step.
-        """
-        return_value = self.executing_request_ids_at_this_step.copy()
-        self.executing_request_ids_at_this_step.clear()
-        return return_value
+    def pop_new_reqs_this_step(self) -> set[str]:
+        """Return and clear the set of newly tracked requests this step."""
+        result = self.new_reqs_this_step.copy()
+        self.new_reqs_this_step.clear()
+        return result
 
     @_lmcache_nvtx_annotate
     def maybe_submit_lookup_request(self, request_id: str, block_hashes: list[bytes]):
@@ -309,8 +298,11 @@ class LMCacheMPWorkerAdapter:
         )
         self.blocks_in_chunk = chunk_size // vllm_block_size
 
-
-        self.executing_request_ids_worker: set[str] = set()
+        # Double-free prevention: track active requests on worker side.
+        # None = feature not enabled (vLLM hasn't called track_new_reqs yet)
+        # set() = feature enabled, tracks requests that haven't been
+        # returned as finished
+        self._active_reqs: set[str] | None = None
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """
@@ -510,20 +502,17 @@ class LMCacheMPWorkerAdapter:
         # Calculate the final finished stores
         ret_stores.update(self._update_and_get_finished_store())
 
-        # intersect with the executing request ids
-        # to prevent double-free
-
-        # Find those that will be discarded (not present in executing_request_ids_worker)
-        discarded = ret_stores.difference(self.executing_request_ids_worker)
-        if discarded:
-            for req_id in discarded:
-                logger.info(
-                    "Request id %s is called by `get_finished` twice. Avoid returning "
-                    "to prevent double-free",
-                    req_id,
+        # Double-free prevention: only return each request as finished once.
+        # If _active_reqs is None, the feature is not enabled (old vLLM version).
+        if self._active_reqs is not None:
+            # Filter to only return requests we're actively tracking
+            duplicate_reqs = ret_stores - self._active_reqs
+            if duplicate_reqs:
+                logger.debug(
+                    "Filtering duplicate finished requests: %s", duplicate_reqs
                 )
-        ret_stores.intersection_update(self.executing_request_ids_worker)
-        self.executing_request_ids_worker.difference_update(ret_stores)
+            ret_stores &= self._active_reqs
+            self._active_reqs -= ret_stores
 
         return ret_stores, finished_retrieves
 
@@ -545,17 +534,16 @@ class LMCacheMPWorkerAdapter:
 
         self.mq_client.close()
 
-
-    def add_new_executing_request_ids_at_this_step_worker(self, request_ids: set[str]):
+    def track_new_reqs(self, request_ids: set[str]):
         """
-        Add new executing request ids to the internal state.
+        Register new requests for double-free prevention tracking.
+        This enables the dedup feature on first call.
         """
-        for req_id in request_ids:
-            logger.info(
-                "Request id %s is added to the executing request ids at this step",
-                req_id,
-            )
-        self.executing_request_ids_worker.update(request_ids)
+        if self._active_reqs is None:
+            self._active_reqs = set()
+        self._active_reqs.update(request_ids)
+        if request_ids:
+            logger.debug("Tracking new requests: %s", request_ids)
 
     # Helper functions
     def _update_and_get_finished_store(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -130,6 +130,14 @@ class LMCacheMPSchedulerAdapter:
         # Request futures
         self.lookup_futures: dict[str, MessagingFuture[LookupResult]] = {}
 
+        # NOTE(Kuntai): Maintain a set of executing request ids.
+        # This is needed: vLLM currently has double-free issue when calling
+        # worker-side `get_finished`. We need to memorize the set of 
+        # executing requests to avoid such double free.
+        self.executing_request_ids: set[str] = set()
+        self.executing_request_ids_at_this_step: set[str] = set()
+
+
         self.model_name = model_name
         self.world_size = world_size
         self.worker_id = kv_rank
@@ -140,6 +148,37 @@ class LMCacheMPSchedulerAdapter:
             "LMCache chunk size should be a multiple of vLLM block size"
         )
         self.blocks_in_chunk = self.chunk_size // vllm_block_size
+
+    @_lmcache_nvtx_annotate
+    def maybe_add_to_executing_request_ids(self, request_id: str):
+        """
+        Add a request id to the set of executing request ids.
+        """
+        if request_id in self.executing_request_ids:
+            return
+        self.executing_request_ids_at_this_step.add(request_id)
+        self.executing_request_ids.add(request_id)
+
+
+    @_lmcache_nvtx_annotate
+    def remove_from_executing_request_ids(self, request_id: str):
+        """
+        Remove a request id from the set of executing request ids.
+        """
+        if request_id not in self.executing_request_ids:
+            logger.warning("Request id %s is double-freed by `request_finished`")
+            return
+        self.executing_request_ids.remove(request_id)
+
+
+    @_lmcache_nvtx_annotate
+    def get_executing_request_ids_at_this_step(self) -> set[str]:
+        """
+        Clear the set of executing request ids for this step.
+        """
+        return_value = self.executing_request_ids_at_this_step.copy()
+        self.executing_request_ids_at_this_step.clear()
+        return return_value
 
     @_lmcache_nvtx_annotate
     def maybe_submit_lookup_request(self, request_id: str, block_hashes: list[bytes]):
@@ -269,6 +308,9 @@ class LMCacheMPWorkerAdapter:
             "LMCache chunk size should be a multiple of vLLM block size"
         )
         self.blocks_in_chunk = chunk_size // vllm_block_size
+
+
+        self.executing_request_ids_worker: set[str] = set()
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """
@@ -468,6 +510,21 @@ class LMCacheMPWorkerAdapter:
         # Calculate the final finished stores
         ret_stores.update(self._update_and_get_finished_store())
 
+        # intersect with the executing request ids
+        # to prevent double-free
+
+        # Find those that will be discarded (not present in executing_request_ids_worker)
+        discarded = ret_stores.difference(self.executing_request_ids_worker)
+        if discarded:
+            for req_id in discarded:
+                logger.info(
+                    "Request id %s is called by `get_finished` twice. Avoid returning "
+                    "to prevent double-free",
+                    req_id,
+                )
+        ret_stores.intersection_update(self.executing_request_ids_worker)
+        self.executing_request_ids_worker.difference_update(ret_stores)
+
         return ret_stores, finished_retrieves
 
     def num_blocks_per_chunk(self) -> int:
@@ -487,6 +544,18 @@ class LMCacheMPWorkerAdapter:
         ).result()
 
         self.mq_client.close()
+
+
+    def add_new_executing_request_ids_at_this_step_worker(self, request_ids: set[str]):
+        """
+        Add new executing request ids to the internal state.
+        """
+        for req_id in request_ids:
+            logger.info(
+                "Request id %s is added to the executing request ids at this step",
+                req_id,
+            )
+        self.executing_request_ids_worker.update(request_ids)
 
     # Helper functions
     def _update_and_get_finished_store(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -130,14 +130,6 @@ class LMCacheMPSchedulerAdapter:
         # Request futures
         self.lookup_futures: dict[str, MessagingFuture[LookupResult]] = {}
 
-        # Track request IDs to prevent double-free in async scheduling.
-        # tracked_reqs: all currently executing requests (added on start,
-        # removed on finish)
-        # new_reqs_this_step: requests newly added this scheduler step
-        # (cleared each step)
-        self.tracked_reqs: set[str] = set()
-        self.new_reqs_this_step: set[str] = set()
-
         self.model_name = model_name
         self.world_size = world_size
         self.worker_id = kv_rank
@@ -148,26 +140,6 @@ class LMCacheMPSchedulerAdapter:
             "LMCache chunk size should be a multiple of vLLM block size"
         )
         self.blocks_in_chunk = self.chunk_size // vllm_block_size
-
-    @_lmcache_nvtx_annotate
-    def track_request(self, request_id: str):
-        """Start tracking a request. Idempotent - ignores already-tracked requests."""
-        if request_id in self.tracked_reqs:
-            return
-        self.new_reqs_this_step.add(request_id)
-        self.tracked_reqs.add(request_id)
-
-    @_lmcache_nvtx_annotate
-    def untrack_request(self, request_id: str):
-        """Stop tracking a request (called when request finishes)."""
-        self.tracked_reqs.discard(request_id)
-
-    @_lmcache_nvtx_annotate
-    def pop_new_reqs_this_step(self) -> set[str]:
-        """Return and clear the set of newly tracked requests this step."""
-        result = self.new_reqs_this_step.copy()
-        self.new_reqs_this_step.clear()
-        return result
 
     @_lmcache_nvtx_annotate
     def maybe_submit_lookup_request(self, request_id: str, block_hashes: list[bytes]):


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes a double-free issue when vLLM's async scheduler calls get_finished() multiple times for the same request ID.

This also require vLLM change. But this PR is implemented in a way that the merge order between vLLM / LMCache does not matter.

Design graph:
```
┌─────────────────────────────────────────────────────────────────────────────┐
│                            SCHEDULER SIDE (vLLM)                            │
│  ┌─────────────────────────────────────────────────────────────────────┐    │
│  │ LMCacheMPSchedulerAdapter                                           │    │
│  │   tracked_reqs: set[str]      ← all active requests                 │    │
│  │   new_reqs_this_step: set[str] ← requests added THIS step           │    │
│  │                                                                     │    │
│  │   track_request(id)       → add to both sets (idempotent)           │    │
│  │   untrack_request(id)     → remove from tracked_reqs                │    │
│  │   pop_new_reqs_this_step() → return & clear new_reqs_this_step      │    │
│  └─────────────────────────────────────────────────────────────────────┘    │
│                                    │                                        │
│                        ┌───────────▼───────────┐                            │
│                        │ LMCacheMPConnector    │                            │
│                        │  metadata.new_req_ids │ ← carried to worker        │
│                        └───────────────────────┘                            │
└─────────────────────────────────────────────────────────────────────────────┘
                                     │
                         (metadata passed to worker)
                                     ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                            WORKER SIDE (LMCache)                            │
│  ┌─────────────────────────────────────────────────────────────────────┐    │
│  │ LMCacheMPWorkerAdapter                                              │    │
│  │   _active_reqs: set[str] | None                                     │    │
│  │     - None = feature disabled (old vLLM)                            │    │
│  │     - set() = feature enabled, tracks unreturned requests           │    │
│  │                                                                     │    │
│  │   track_new_reqs(ids) → enables feature, adds IDs to _active_reqs   │    │
│  │   get_finished(...)   → filters via _active_reqs if enabled         │    │
│  └─────────────────────────────────────────────────────────────────────┘    │
└─────────────────────────────────────────────────────────────────────────────┘
```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
