### PR TITLE
[CI]: remove `--enforce-eager` for integration tests

### DIFF
--- a/.buildkite/configs/dummy.yaml
+++ b/.buildkite/configs/dummy.yaml
@@ -14,7 +14,6 @@ vllm:
     - "1024"
     - "--gpu-memory-utilization"
     - "0.35"
-    - "--enforce-eager"
     - "--load-format"
     - "dummy"
     - "--kv-transfer-config"


### PR DESCRIPTION
The integration tests are failing now. We can compare the last working integration test logs with the newest failing logs.

The main difference is `enforce_eager`. Even though `--enforce-eager` flag was always passed into the integration tests (see `dummy.ayml`) (and hasn't been changed in the last 5 months), the enforce_eager has only turned to True in the last 2 days for some reason and this is the suspected cause of the integration test breaking.

<details>
  <summary>Working Integration Test Logs</summary>

```text
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:346] 
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:346]        â–ˆ     â–ˆ     â–ˆâ–„   â–„â–ˆ
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:346]  â–„â–„ â–„â–ˆ â–ˆ     â–ˆ     â–ˆ â–€â–„â–€ â–ˆ  version 0.16.0rc1.dev35+g64a40a7ab
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:346]   â–ˆâ–„â–ˆâ–€ â–ˆ     â–ˆ     â–ˆ     â–ˆ  model   meta-llama/Llama-3.2-1B-Instruct
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:346]    â–€â–€  â–€â–€â–€â–€â–€ â–€â–€â–€â–€â–€ â–€     â–€
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:346] 
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:32 [utils.py:282] non-default args: {'model_tag': 'meta-llama/Llama-3.2-1B-Instruct', 'api_server_count': 1, 'model': 'meta-llama/Llama-3.2-1B-Instruct', 'max_model_len': 1024, 'load_format': 'dummy', 'gpu_memory_utilization': 0.35, 'kv_transfer_config': KVTransferConfig(kv_connector='LMCacheConnectorV1', engine_id='b30c4c8a-4711-4c1e-bcf9-700716ec1be5', kv_buffer_device='cuda', kv_buffer_size=1000000000.0, kv_role='kv_both', kv_rank=None, kv_parallel_size=1, kv_ip='127.0.0.1', kv_port=14579, kv_connector_extra_config={}, kv_connector_module_path=None, enable_permute_local_kv=False, kv_load_failure_policy='recompute')}
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:37 [model.py:541] Resolved architecture: LlamaForCausalLM
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:37 [model.py:1559] Using max model len 1024
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:37 [scheduler.py:226] Chunked prefill is enabled with max_num_batched_tokens=8192.
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:08:37 [vllm.py:669] Asynchronous scheduling is enabled.
[0;36m(APIServer pid=1)[0;0m WARNING 01-31 02:08:37 [vllm.py:1037] Turning off hybrid kv cache manager because `--kv-transfer-config` is set. This will reduce the performance of vLLM on LLMs with sliding window attention or Mamba attention. If you are a developer of kv connector, please consider supporting hybrid kv cache manager for your connector by making sure your connector is a subclass of `SupportsHMA` defined in kv_connector/v1/base.py and use --no-disable-hybrid-kv-cache-manager to start vLLM.
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:08:42 [core.py:96] Initializing a V1 LLM engine (v0.16.0rc1.dev35+g64a40a7ab) with config: model='meta-llama/Llama-3.2-1B-Instruct', speculative_config=None, tokenizer='meta-llama/Llama-3.2-1B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=1024, download_dir=None, load_format=dummy, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=meta-llama/Llama-3.2-1B-Instruct, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'static_all_moe_layers': []}
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:08:44 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://74.81.65.237:55311 backend=nccl
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:08:44 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:08:45 [gpu_model_runner.py:4088] Starting to load model meta-llama/Llama-3.2-1B-Instruct...
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:08:58 [cuda.py:364] Using FLASH_ATTN attention backend out of potential backends: ('FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION')
[0;36m(EngineCore_DP0 pid=339)[0;0m <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
[0;36m(EngineCore_DP0 pid=339)[0;0m <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:00 [gpu_model_runner.py:4185] Model loading took 2.32 GiB memory and 13.754282 seconds
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:02 [backends.py:802] Using cache directory: /root/.cache/vllm/torch_compile_cache/cb679071ed/rank_0_0/backbone for vLLM's torch.compile
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:02 [backends.py:862] Dynamo bytecode transform time: 1.88 s
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:06 [backends.py:299] Cache the graph of compile range (1, 8192) for later use
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:18 [backends.py:316] Compiling a graph for compile range (1, 8192) takes 15.62 s
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:18 [monitor.py:34] torch.compile takes 17.51 s in total
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:20 [gpu_worker.py:359] Available KV cache memory: 26.14 GiB
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:20 [kv_cache_utils.py:1307] GPU KV cache size: 856,624 tokens
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:20 [kv_cache_utils.py:1312] Maximum concurrency for 1,024 tokens per request: 836.55x
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:20 [factory.py:64] Creating v1 connector with name: LMCacheConnectorV1 and engine_id: b30c4c8a-4711-4c1e-bcf9-700716ec1be5
[0;36m(EngineCore_DP0 pid=339)[0;0m WARNING 01-31 02:09:20 [base.py:166] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:20 [lmcache_connector.py:95] Initializing latest dev LMCache connector
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:09:20,551] LMCache WARNING:[0m No LMCache configuration file is set. Trying to read configurations from the environment variables. [3m(utils.py:55:lmcache.integration.vllm.utils)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:09:20,551] LMCache WARNING:[0m You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE [3m(utils.py:59:lmcache.integration.vllm.utils)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,551] LMCache INFO:[0m num_layer: 16, chunk_size: 256, num_kv_head (per gpu): 8, head_size: 64, hidden_dim (D) for KV (per gpu): 512, use mla: False, kv shape: (16, 2, 256, 8, 64), num_draft_layers: 0 [3m(manager.py:319:lmcache.v1.manager)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,551] LMCache INFO:[0m CUDA device is available. Using CUDA for LMCache engine. [3m(manager.py:447:lmcache.v1.manager)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,570] LMCache INFO:[0m Creating LMCacheEngine instance vllm-instance [3m(cache_engine.py:1862:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,570] LMCache INFO:[0m NUMA mapping for instance vllm-instance: None [3m(cache_engine.py:1865:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:09:20,570] LMCache WARNING:[0m Could not load 'builtin' from vLLM. Using builtin hash. This may cause inconsistencies in distributed caching. [3m(token_database.py:136:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:09:20,570] LMCache WARNING:[0m Using builtin hash without PYTHONHASHSEED set. For production environments (non-testing scenarios), you MUST set PYTHONHASHSEED to ensure consistent hashing across processes. Example: export PYTHONHASHSEED=0 [3m(token_database.py:143:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,570] LMCache INFO:[0m Initialized NONE_HASH=b"\x02.\x1f\x0bX?q\x92\xff'ye~\x89\x99&\xc6\x84\xa3\x87\xf8\x02\tK\xc8\x03\x94S\x81?d\x07" from vLLM (>= PR#20511) [3m(token_database.py:74:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,570] LMCache INFO:[0m Using hash algorithm: builtin [3m(token_database.py:84:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,573] LMCache INFO:[0m Creating LMCacheEngine with config: {'chunk_size': 256, 'local_cpu': True, 'max_local_cpu_size': 5.0, 'reserve_local_cpu_size': 0.0, 'local_disk': None, 'max_local_disk_size': 0.0, 'remote_url': None, 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'pre_caching_hash_algorithm': 'builtin', 'enable_blending': False, 'blend_recompute_ratios': None, 'blend_thresholds': None, 'blend_check_layers': None, 'blend_min_tokens': 256, 'blend_special_str': ' # # ', 'enable_p2p': False, 'p2p_host': None, 'p2p_init_ports': None, 'p2p_lookup_ports': None, 'enable_controller': False, 'lmcache_instance_id': None, 'controller_pull_url': None, 'controller_reply_url': None, 'lmcache_worker_ports': None, 'lmcache_worker_ids': None, 'lmcache_worker_heartbeat_delay_time': 10, 'lmcache_worker_heartbeat_time': None, 'enable_pd': False, 'pd_role': None, 'pd_buffer_size': None, 'pd_buffer_device': None, 'pd_peer_host': None, 'pd_peer_init_port': None, 'pd_peer_alloc_port': None, 'pd_proxy_host': None, 'pd_proxy_port': None, 'transfer_channel': None, 'nixl_backends': None, 'nixl_buffer_size': None, 'nixl_buffer_device': None, 'gds_path': None, 'cufile_buffer_size': None, 'audit_actual_remote_url': None, 'internal_api_server_host': '0.0.0.0', 'extra_config': None, 'save_unfull_chunk': False, 'blocking_timeout_secs': 10, 'external_lookup_client': None, 'py_enable_gc': True, 'cache_policy': 'LRU', 'numa_mode': None, 'enable_async_loading': False, 'internal_api_server_enabled': False, 'internal_api_server_port_start': 6999, 'priority_limit': None, 'internal_api_server_include_index_list': None, 'internal_api_server_socket_path_prefix': None, 'runtime_plugin_locations': None, 'storage_plugins': None, 'lookup_timeout_ms': 3000, 'hit_miss_ratio': None, 'lookup_server_worker_ids': None, 'enable_scheduler_bypass_lookup': False, 'script_allowed_imports': None, 'enable_lazy_memory_allocator': False, 'lazy_memory_initial_ratio': 0.2, 'lazy_memory_expand_trigger_ratio': 0.5, 'lazy_memory_step_ratio': 0.1, 'lazy_memory_safe_size': 0.0, 'enable_chunk_statistics': False, 'chunk_statistics_auto_start_statistics': False, 'chunk_statistics_auto_exit_timeout_hours': 0.0, 'chunk_statistics_auto_exit_target_unique_chunks': 0, 'chunk_statistics_strategy': 'memory_bloom_filter', 'enable_kv_events': False, 'use_gpu_connector_v3': False, 'pin_timeout_sec': 300, 'pin_check_interval_sec': 30, 'remote_config_url': None, 'app_id': None} [3m(cache_engine.py:108:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,573] LMCache INFO:[0m LMCacheWorker is not initialized (related configs: enable_controller: False, role: worker, worker_id: 0, worker_ids: [0]). [3m(cache_engine.py:150:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,573] LMCache INFO:[0m KV events are disabled. [3m(cache_engine.py:179:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:20,573] LMCache INFO:[0m Initializing usage context. [3m(usage_context.py:411:lmcache.usage_context)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,203] LMCache INFO:[0m PeriodicThread PinMonitor-thread entering main loop (interval=30.0s) [3m(periodic_thread.py:279:lmcache.v1.periodic_thread)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,204] LMCache INFO:[0m Started PeriodicThread: PinMonitor-thread (level=critical, interval=30.0s, init_wait=0.0s) [3m(periodic_thread.py:239:lmcache.v1.periodic_thread)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,204] LMCache INFO:[0m PinMonitor started [3m(pin_monitor.py:212:lmcache.v1.pin_monitor)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,544] LMCache INFO:[0m lmcache lookup server start on /tmp/engine_b30c4c8a-4711-4c1e-bcf9-700716ec1be5_service_lookup_lmcache_rpc_port_0 [3m(lmcache_lookup_client.py:366:lmcache.v1.lookup_client.lmcache_lookup_client)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,545] LMCache INFO:[0m Internal API server disabled. internal_api_server_enabled=False, port_offset=1, port=7000, socket_path=None, include_index_list=None [3m(api_server.py:58:lmcache.v1.internal_api_server.api_server)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,545] LMCache INFO:[0m LMCache initialized for role KVConnectorRole.WORKER with version 0.3.14.dev8-g7c8097122, vllm version 0.16.0rc1.dev35+g64a40a7ab, lmcache cache_engine metadata: LMCacheMetadata(model_name='meta-llama/Llama-3.2-1B-Instruct', world_size=1, local_world_size=1, worker_id=0, local_worker_id=0, kv_dtype=torch.bfloat16, kv_shape=(16, 2, 256, 8, 64), use_mla=False, role='worker', served_model_name='meta-llama/Llama-3.2-1B-Instruct', chunk_size=256, kv_layer_groups_manager=KVLayerGroupsManager(kv_layer_groups=[]), engine_id='b30c4c8a-4711-4c1e-bcf9-700716ec1be5', kv_connector_extra_config={}) [3m(vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:09:24 [utils.py:38] Connectors do not specify a kv cache layout, defaulting to NHD.
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,802] LMCache INFO:[0m Registering KV caches [3m(vllm_v1_adapter.py:728:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,802] LMCache INFO:[0m KV layer groups: [KVLayerGroupInfo(layers=16, indices=0-15, shape=torch.Size([2, 53539, 16, 8, 64]), dtype=torch.bfloat16)] [3m(kv_layer_groups.py:211:lmcache.v1.kv_layer_groups)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,802] LMCache INFO:[0m Post initializing LMCacheEngine [3m(cache_engine.py:257:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,802] LMCache INFO:[0m Initialize storage manager on rank 0, use layerwise: False,save only first rank: False [3m(cache_engine.py:269:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,803] LMCache INFO:[0m Initializing LRUCachePolicy [3m(lru.py:22:lmcache.v1.storage_backend.cache_policy.lru)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:24,803] LMCache INFO:[0m NUMA mapping None [3m(local_cpu_backend.py:369:lmcache.v1.storage_backend.local_cpu_backend)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:09:26,097] LMCache WARNING:[0m Controller message sender is not initialized [3m(local_cpu_backend.py:101:lmcache.v1.storage_backend.local_cpu_backend)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:26,105] LMCache INFO:[0m No active health checks to monitor, skipping monitor thread [3m(base.py:520:lmcache.v1.health_monitor.base)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:09:26,105] LMCache INFO:[0m Health monitor initialized and started at manager level (role=worker) [3m(manager.py:221:lmcache.v1.manager)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m 2026-01-31 02:09:26,106 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
[0;36m(EngineCore_DP0 pid=339)[0;0m 2026-01-31 02:09:26,279 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
[0;36m(EngineCore_DP0 pid=339)[0;0m 
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|          | 0/51 [00:00<?, ?it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   2%|â–         | 1/51 [00:00<00:14,  3.53it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   6%|â–Œ         | 3/51 [00:00<00:07,  6.64it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  10%|â–‰         | 5/51 [00:00<00:05,  7.99it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  12%|â–ˆâ–        | 6/51 [00:00<00:05,  8.34it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  14%|â–ˆâ–Ž        | 7/51 [00:00<00:05,  8.11it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  16%|â–ˆâ–Œ        | 8/51 [00:01<00:05,  8.03it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  18%|â–ˆâ–Š        | 9/51 [00:01<00:05,  8.09it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  20%|â–ˆâ–‰        | 10/51 [00:01<00:05,  7.77it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  22%|â–ˆâ–ˆâ–       | 11/51 [00:01<00:05,  7.99it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  24%|â–ˆâ–ˆâ–Ž       | 12/51 [00:01<00:05,  7.79it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  25%|â–ˆâ–ˆâ–Œ       | 13/51 [00:01<00:04,  8.18it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  29%|â–ˆâ–ˆâ–‰       | 15/51 [00:01<00:03, 10.62it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  33%|â–ˆâ–ˆâ–ˆâ–Ž      | 17/51 [00:02<00:04,  8.26it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  35%|â–ˆâ–ˆâ–ˆâ–Œ      | 18/51 [00:02<00:04,  7.59it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  37%|â–ˆâ–ˆâ–ˆâ–‹      | 19/51 [00:02<00:04,  6.80it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  39%|â–ˆâ–ˆâ–ˆâ–‰      | 20/51 [00:02<00:04,  6.60it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  43%|â–ˆâ–ˆâ–ˆâ–ˆâ–Ž     | 22/51 [00:02<00:03,  8.17it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  47%|â–ˆâ–ˆâ–ˆâ–ˆâ–‹     | 24/51 [00:03<00:03,  8.94it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  49%|â–ˆâ–ˆâ–ˆâ–ˆâ–‰     | 25/51 [00:03<00:03,  8.08it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  53%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž    | 27/51 [00:03<00:02,  8.32it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  57%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹    | 29/51 [00:03<00:02,  9.01it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  59%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰    | 30/51 [00:03<00:02,  8.61it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  61%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ    | 31/51 [00:03<00:02,  8.41it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  65%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–   | 33/51 [00:04<00:02,  8.83it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  69%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š   | 35/51 [00:04<00:01,  9.62it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  73%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž  | 37/51 [00:04<00:01, 10.23it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  76%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹  | 39/51 [00:04<00:01, 10.72it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  80%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ  | 41/51 [00:04<00:00, 11.03it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  84%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ– | 43/51 [00:04<00:00, 11.05it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  90%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ | 46/51 [00:05<00:00, 13.84it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  98%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š| 50/51 [00:05<00:00, 18.87it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 51/51 [00:05<00:00,  9.78it/s]
[0;36m(EngineCore_DP0 pid=339)[0;0m 
Capturing CUDA graphs (decode, FULL):   0%|          | 0/51 [00:00<?, ?it/s]
Capturing CUDA graphs (decode, FULL):   2%|â–         | 1/51 [01:40<1:24:08, 100.96s/it]
Capturing CUDA graphs (decode, FULL):   4%|â–         | 2/51 [01:41<34:00, 41.64s/it]   
Capturing CUDA graphs (decode, FULL):   8%|â–Š         | 4/51 [01:41<12:12, 15.59s/it]
Capturing CUDA graphs (decode, FULL):  12%|â–ˆâ–        | 6/51 [01:41<06:11,  8.26s/it]
Capturing CUDA graphs (decode, FULL):  16%|â–ˆâ–Œ        | 8/51 [01:41<03:33,  4.96s/it]
Capturing CUDA graphs (decode, FULL):  20%|â–ˆâ–‰        | 10/51 [01:41<02:10,  3.19s/it]
Capturing CUDA graphs (decode, FULL):  24%|â–ˆâ–ˆâ–Ž       | 12/51 [01:41<01:23,  2.13s/it]
Capturing CUDA graphs (decode, FULL):  27%|â–ˆâ–ˆâ–‹       | 14/51 [01:42<00:54,  1.46s/it]
Capturing CUDA graphs (decode, FULL):  31%|â–ˆâ–ˆâ–ˆâ–      | 16/51 [01:42<00:35,  1.02s/it]
Capturing CUDA graphs (decode, FULL):  35%|â–ˆâ–ˆâ–ˆâ–Œ      | 18/51 [01:42<00:25,  1.32it/s]
Capturing CUDA graphs (decode, FULL):  37%|â–ˆâ–ˆâ–ˆâ–‹      | 19/51 [01:42<00:20,  1.56it/s]
Capturing CUDA graphs (decode, FULL):  39%|â–ˆâ–ˆâ–ˆâ–‰      | 20/51 [01:42<00:16,  1.85it/s]
Capturing CUDA graphs (decode, FULL):  43%|â–ˆâ–ˆâ–ˆâ–ˆâ–Ž     | 22/51 [01:43<00:10,  2.67it/s]
Capturing CUDA graphs (decode, FULL):  47%|â–ˆâ–ˆâ–ˆâ–ˆâ–‹     | 24/51 [01:43<00:07,  3.63it/s]
Capturing CUDA graphs (decode, FULL):  51%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆ     | 26/51 [01:43<00:05,  4.78it/s]
Capturing CUDA graphs (decode, FULL):  55%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–    | 28/51 [01:43<00:04,  5.66it/s]
Capturing CUDA graphs (decode, FULL):  59%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰    | 30/51 [01:43<00:03,  6.60it/s]
Capturing CUDA graphs (decode, FULL):  63%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž   | 32/51 [01:44<00:02,  7.40it/s]
Capturing CUDA graphs (decode, FULL):  67%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹   | 34/51 [01:44<00:01,  8.67it/s]
Capturing CUDA graphs (decode, FULL):  71%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ   | 36/51 [01:44<00:01, 10.35it/s]
Capturing CUDA graphs (decode, FULL):  75%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–  | 38/51 [01:44<00:01, 11.26it/s]
Capturing CUDA graphs (decode, FULL):  78%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š  | 40/51 [01:44<00:01, 10.40it/s]
Capturing CUDA graphs (decode, FULL):  82%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ– | 42/51 [01:44<00:00, 11.45it/s]
Capturing CUDA graphs (decode, FULL):  86%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹ | 44/51 [01:44<00:00, 12.96it/s]
Capturing CUDA graphs (decode, FULL):  94%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–| 48/51 [01:45<00:00, 18.52it/s]
Capturing CUDA graphs (decode, FULL): 100%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 51/51 [01:45<00:00,  2.06s/it]
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:11:17 [gpu_model_runner.py:5192] Graph capturing finished in 111 secs, took -0.41 GiB
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:11:17 [core.py:272] init engine (profile, create kv cache, warmup model) took 137.41 seconds
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:11:18 [factory.py:64] Creating v1 connector with name: LMCacheConnectorV1 and engine_id: b30c4c8a-4711-4c1e-bcf9-700716ec1be5
[0;36m(EngineCore_DP0 pid=339)[0;0m WARNING 01-31 02:11:18 [base.py:166] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:11:18 [lmcache_connector.py:95] Initializing latest dev LMCache connector
[0;36m(EngineCore_DP0 pid=339)[0;0m [31;20m[2026-01-31 02:11:18,058] LMCache ERROR:[0m PrometheusLogger instance already created withdifferent metadata. This should not happen except in test [3m(observability.py:1755:lmcache.observability)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:11:18,058] LMCache INFO:[0m lmcache lookup client connect to rank 0 with socket path /tmp/engine_b30c4c8a-4711-4c1e-bcf9-700716ec1be5_service_lookup_lmcache_rpc_port_0 [3m(lmcache_lookup_client.py:88:lmcache.v1.lookup_client.lmcache_lookup_client)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:11:18,058] LMCache WARNING:[0m Could not load 'builtin' from vLLM. Using builtin hash. This may cause inconsistencies in distributed caching. [3m(token_database.py:136:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [33;20m[2026-01-31 02:11:18,058] LMCache WARNING:[0m Using builtin hash without PYTHONHASHSEED set. For production environments (non-testing scenarios), you MUST set PYTHONHASHSEED to ensure consistent hashing across processes. Example: export PYTHONHASHSEED=0 [3m(token_database.py:143:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:11:18,058] LMCache INFO:[0m Initialized NONE_HASH=b'\xe3\xf9j\rV\x98`\xf5\x9ch>\x93\x971d\xd0\xd2\xd4k,\x8c.\x9e\xad\xeb\xe0\x1e&\x1e\x0b\xb6m' from vLLM (>= PR#20511) [3m(token_database.py:74:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:11:18,058] LMCache INFO:[0m Using hash algorithm: builtin [3m(token_database.py:84:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:11:18,058] LMCache INFO:[0m Internal API server disabled. internal_api_server_enabled=False, port_offset=0, port=6999, socket_path=None, include_index_list=None [3m(api_server.py:58:lmcache.v1.internal_api_server.api_server)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:11:18,059] LMCache INFO:[0m LMCache initialized for role KVConnectorRole.SCHEDULER with version 0.3.14.dev8-g7c8097122, vllm version 0.16.0rc1.dev35+g64a40a7ab, lmcache cache_engine metadata: None [3m(vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(EngineCore_DP0 pid=339)[0;0m INFO 01-31 02:11:18 [vllm.py:669] Asynchronous scheduling is enabled.
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:18 [api_server.py:455] Supported tasks: ['generate']
[0;36m(APIServer pid=1)[0;0m WARNING 01-31 02:11:18 [model.py:1369] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.6, 'top_p': 0.9}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:18 [serving.py:184] Warming up chat template processing...
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [hf.py:316] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [serving.py:219] Chat template warmup completed in 617.6ms
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [api_server.py:460] Starting vLLM API server 0 on http://0.0.0.0:8000
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:38] Available routes are:
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /openapi.json, Methods: HEAD, GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /docs, Methods: HEAD, GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /docs/oauth2-redirect, Methods: HEAD, GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /redoc, Methods: HEAD, GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /load, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /version, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /scale_elastic_ep, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /is_scaling_elastic_ep, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /tokenize, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /detokenize, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /inference/v1/generate, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /pause, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /resume, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /is_paused, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /metrics, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /health, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/models, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /ping, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /ping, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /invocations, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/chat/completions, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/chat/completions/render, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/responses, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/responses/{response_id}, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/responses/{response_id}/cancel, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/completions, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/completions/render, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 01-31 02:11:19 [launcher.py:47] Route: /v1/messages, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO:     Started server process [1]
[0;36m(APIServer pid=1)[0;0m INFO:     Waiting for application startup.
[0;36m(APIServer pid=1)[0;0m INFO:     Application startup complete.
[0;36m(APIServer pid=1)[0;0m INFO:     127.0.0.1:49378 - "GET /v1/models HTTP/1.1" 200 OK
[0;36m(EngineCore_DP0 pid=339)[0;0m [32;20m[2026-01-31 02:11:22,662] LMCache INFO:[0m Reqid: cmpl-b38967919c127670-0-9e564c5a, Total tokens 31, LMCache hit tokens: 0, need to load: 0 [3m(vllm_v1_adapter.py:1283:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(APIServer pid=1)[0;0m INFO:     127.0.0.1:49380 - "POST /v1/completions HTTP/1.1" 200 OK
```
</details>


<details>
  <summary>Failing Integration Test Logs</summary>

```
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:314] 
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:314]        â–ˆ     â–ˆ     â–ˆâ–„   â–„â–ˆ
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:314]  â–„â–„ â–„â–ˆ â–ˆ     â–ˆ     â–ˆ â–€â–„â–€ â–ˆ  version 0.16.0rc1.dev88+ge535d90de
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:314]   â–ˆâ–„â–ˆâ–€ â–ˆ     â–ˆ     â–ˆ     â–ˆ  model   meta-llama/Llama-3.2-1B-Instruct
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:314]    â–€â–€  â–€â–€â–€â–€â–€ â–€â–€â–€â–€â–€ â–€     â–€
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:314] 
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:25 [utils.py:250] non-default args: {'model_tag': 'meta-llama/Llama-3.2-1B-Instruct', 'api_server_count': 1, 'model': 'meta-llama/Llama-3.2-1B-Instruct', 'max_model_len': 1024, 'enforce_eager': True, 'load_format': 'dummy', 'gpu_memory_utilization': 0.35, 'kv_transfer_config': KVTransferConfig(kv_connector='LMCacheConnectorV1', engine_id='32cbd003-fd9f-4674-bed5-4833539dd0b6', kv_buffer_device='cuda', kv_buffer_size=1000000000.0, kv_role='kv_both', kv_rank=None, kv_parallel_size=1, kv_ip='127.0.0.1', kv_port=14579, kv_connector_extra_config={}, kv_connector_module_path=None, enable_permute_local_kv=False, kv_load_failure_policy='recompute')}
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:30 [model.py:532] Resolved architecture: LlamaForCausalLM
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:30 [model.py:1543] Using max model len 1024
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:30 [scheduler.py:226] Chunked prefill is enabled with max_num_batched_tokens=8192.
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:30 [vllm.py:669] Asynchronous scheduling is enabled.
[0;36m(APIServer pid=1)[0;0m WARNING 02-01 23:01:30 [vllm.py:707] Enforce eager set, overriding optimization level to -O0
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:01:30 [vllm.py:807] Cudagraph is disabled under eager mode
[0;36m(APIServer pid=1)[0;0m WARNING 02-01 23:01:30 [vllm.py:1037] Turning off hybrid kv cache manager because `--kv-transfer-config` is set. This will reduce the performance of vLLM on LLMs with sliding window attention or Mamba attention. If you are a developer of kv connector, please consider supporting hybrid kv cache manager for your connector by making sure your connector is a subclass of `SupportsHMA` defined in kv_connector/v1/base.py and use --no-disable-hybrid-kv-cache-manager to start vLLM.
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:35 [core.py:96] Initializing a V1 LLM engine (v0.16.0rc1.dev88+ge535d90de) with config: model='meta-llama/Llama-3.2-1B-Instruct', speculative_config=None, tokenizer='meta-llama/Llama-3.2-1B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=1024, download_dir=None, load_format=dummy, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=meta-llama/Llama-3.2-1B-Instruct, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'static_all_moe_layers': []}
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:38 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://74.81.65.237:45841 backend=nccl
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:38 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:39 [gpu_model_runner.py:4112] Starting to load model meta-llama/Llama-3.2-1B-Instruct...
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:52 [cuda.py:364] Using FLASH_ATTN attention backend out of potential backends: ('FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION')
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:53 [gpu_model_runner.py:4209] Model loading took 2.32 GiB memory and 14.011977 seconds
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:55 [gpu_worker.py:359] Available KV cache memory: 26.14 GiB
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:55 [kv_cache_utils.py:1307] GPU KV cache size: 856,624 tokens
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:55 [kv_cache_utils.py:1312] Maximum concurrency for 1,024 tokens per request: 836.55x
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:55 [factory.py:64] Creating v1 connector with name: LMCacheConnectorV1 and engine_id: 32cbd003-fd9f-4674-bed5-4833539dd0b6
[0;36m(EngineCore_DP0 pid=340)[0;0m WARNING 02-01 23:01:55 [base.py:166] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:01:55 [lmcache_connector.py:95] Initializing latest dev LMCache connector
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:01:55,853] LMCache WARNING:[0m No LMCache configuration file is set. Trying to read configurations from the environment variables. [3m(utils.py:55:lmcache.integration.vllm.utils)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:01:55,853] LMCache WARNING:[0m You can set the configuration file through the environment variable: LMCACHE_CONFIG_FILE [3m(utils.py:59:lmcache.integration.vllm.utils)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,853] LMCache INFO:[0m num_layer: 16, chunk_size: 256, num_kv_head (per gpu): 8, head_size: 64, hidden_dim (D) for KV (per gpu): 512, use mla: False, kv shape: (16, 2, 256, 8, 64), num_draft_layers: 0 [3m(manager.py:319:lmcache.v1.manager)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,853] LMCache INFO:[0m CUDA device is available. Using CUDA for LMCache engine. [3m(manager.py:447:lmcache.v1.manager)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,881] LMCache INFO:[0m Creating LMCacheEngine instance vllm-instance [3m(cache_engine.py:1862:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,881] LMCache INFO:[0m NUMA mapping for instance vllm-instance: None [3m(cache_engine.py:1865:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:01:55,881] LMCache WARNING:[0m Could not load 'builtin' from vLLM. Using builtin hash. This may cause inconsistencies in distributed caching. [3m(token_database.py:136:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:01:55,881] LMCache WARNING:[0m Using builtin hash without PYTHONHASHSEED set. For production environments (non-testing scenarios), you MUST set PYTHONHASHSEED to ensure consistent hashing across processes. Example: export PYTHONHASHSEED=0 [3m(token_database.py:143:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,881] LMCache INFO:[0m Initialized NONE_HASH=b'Qs\xe3I\xccP\x1e\xf6\xf9}\xce$\x0fZ\xcf\xec\xf0\x17\x1ab\xba\xa5\xe5\xd2\xf3\x1c\xa7Qz\xb3\xd6\x02' from vLLM (>= PR#20511) [3m(token_database.py:74:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,881] LMCache INFO:[0m Using hash algorithm: builtin [3m(token_database.py:84:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,884] LMCache INFO:[0m Creating LMCacheEngine with config: {'chunk_size': 256, 'local_cpu': True, 'max_local_cpu_size': 5.0, 'reserve_local_cpu_size': 0.0, 'local_disk': None, 'max_local_disk_size': 0.0, 'remote_url': None, 'remote_serde': 'naive', 'use_layerwise': False, 'save_decode_cache': False, 'pre_caching_hash_algorithm': 'builtin', 'enable_blending': False, 'blend_recompute_ratios': None, 'blend_thresholds': None, 'blend_check_layers': None, 'blend_min_tokens': 256, 'blend_special_str': ' # # ', 'enable_p2p': False, 'p2p_host': None, 'p2p_init_ports': None, 'p2p_lookup_ports': None, 'enable_controller': False, 'lmcache_instance_id': None, 'controller_pull_url': None, 'controller_reply_url': None, 'lmcache_worker_ports': None, 'lmcache_worker_ids': None, 'lmcache_worker_heartbeat_delay_time': 10, 'lmcache_worker_heartbeat_time': None, 'enable_pd': False, 'pd_role': None, 'pd_buffer_size': None, 'pd_buffer_device': None, 'pd_peer_host': None, 'pd_peer_init_port': None, 'pd_peer_alloc_port': None, 'pd_proxy_host': None, 'pd_proxy_port': None, 'transfer_channel': None, 'nixl_backends': None, 'nixl_buffer_size': None, 'nixl_buffer_device': None, 'gds_path': None, 'cufile_buffer_size': None, 'audit_actual_remote_url': None, 'internal_api_server_host': '0.0.0.0', 'extra_config': None, 'save_unfull_chunk': False, 'blocking_timeout_secs': 10, 'external_lookup_client': None, 'py_enable_gc': True, 'cache_policy': 'LRU', 'numa_mode': None, 'enable_async_loading': False, 'internal_api_server_enabled': False, 'internal_api_server_port_start': 6999, 'priority_limit': None, 'internal_api_server_include_index_list': None, 'internal_api_server_socket_path_prefix': None, 'runtime_plugin_locations': None, 'storage_plugins': None, 'lookup_timeout_ms': 3000, 'hit_miss_ratio': None, 'lookup_server_worker_ids': None, 'enable_scheduler_bypass_lookup': False, 'script_allowed_imports': None, 'enable_lazy_memory_allocator': False, 'lazy_memory_initial_ratio': 0.2, 'lazy_memory_expand_trigger_ratio': 0.5, 'lazy_memory_step_ratio': 0.1, 'lazy_memory_safe_size': 0.0, 'enable_chunk_statistics': False, 'chunk_statistics_auto_start_statistics': False, 'chunk_statistics_auto_exit_timeout_hours': 0.0, 'chunk_statistics_auto_exit_target_unique_chunks': 0, 'chunk_statistics_strategy': 'memory_bloom_filter', 'enable_kv_events': False, 'use_gpu_connector_v3': False, 'pin_timeout_sec': 300, 'pin_check_interval_sec': 30, 'remote_config_url': None, 'app_id': None} [3m(cache_engine.py:108:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,884] LMCache INFO:[0m LMCacheWorker is not initialized (related configs: enable_controller: False, role: worker, worker_id: 0, worker_ids: [0]). [3m(cache_engine.py:150:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,884] LMCache INFO:[0m KV events are disabled. [3m(cache_engine.py:179:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:55,884] LMCache INFO:[0m Initializing usage context. [3m(usage_context.py:411:lmcache.usage_context)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:59,600] LMCache INFO:[0m PeriodicThread PinMonitor-thread entering main loop (interval=30.0s) [3m(periodic_thread.py:279:lmcache.v1.periodic_thread)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:59,600] LMCache INFO:[0m Started PeriodicThread: PinMonitor-thread (level=critical, interval=30.0s, init_wait=0.0s) [3m(periodic_thread.py:239:lmcache.v1.periodic_thread)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:59,601] LMCache INFO:[0m PinMonitor started [3m(pin_monitor.py:212:lmcache.v1.pin_monitor)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:59,840] LMCache INFO:[0m lmcache lookup server start on /tmp/engine_32cbd003-fd9f-4674-bed5-4833539dd0b6_service_lookup_lmcache_rpc_port_0 [3m(lmcache_lookup_client.py:366:lmcache.v1.lookup_client.lmcache_lookup_client)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:59,841] LMCache INFO:[0m Internal API server disabled. internal_api_server_enabled=False, port_offset=1, port=7000, socket_path=None, include_index_list=None [3m(api_server.py:58:lmcache.v1.internal_api_server.api_server)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:01:59,841] LMCache INFO:[0m LMCache initialized for role KVConnectorRole.WORKER with version 0.3.14.dev9-gf398a4a37, vllm version 0.16.0rc1.dev88+ge535d90de, lmcache cache_engine metadata: LMCacheMetadata(model_name='meta-llama/Llama-3.2-1B-Instruct', world_size=1, local_world_size=1, worker_id=0, local_worker_id=0, kv_dtype=torch.bfloat16, kv_shape=(16, 2, 256, 8, 64), use_mla=False, role='worker', served_model_name='meta-llama/Llama-3.2-1B-Instruct', chunk_size=256, kv_layer_groups_manager=KVLayerGroupsManager(kv_layer_groups=[]), engine_id='32cbd003-fd9f-4674-bed5-4833539dd0b6', kv_connector_extra_config={}) [3m(vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:02:00 [utils.py:38] Connectors do not specify a kv cache layout, defaulting to NHD.
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:00,084] LMCache INFO:[0m Registering KV caches [3m(vllm_v1_adapter.py:728:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:00,084] LMCache INFO:[0m KV layer groups: [KVLayerGroupInfo(layers=16, indices=0-15, shape=torch.Size([2, 53539, 16, 8, 64]), dtype=torch.bfloat16)] [3m(kv_layer_groups.py:211:lmcache.v1.kv_layer_groups)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:00,084] LMCache INFO:[0m Post initializing LMCacheEngine [3m(cache_engine.py:257:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:00,084] LMCache INFO:[0m Initialize storage manager on rank 0, use layerwise: False,save only first rank: False [3m(cache_engine.py:269:lmcache.v1.cache_engine)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:00,085] LMCache INFO:[0m Initializing LRUCachePolicy [3m(lru.py:22:lmcache.v1.storage_backend.cache_policy.lru)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:00,085] LMCache INFO:[0m NUMA mapping None [3m(local_cpu_backend.py:369:lmcache.v1.storage_backend.local_cpu_backend)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:02:01,261] LMCache WARNING:[0m Controller message sender is not initialized [3m(local_cpu_backend.py:101:lmcache.v1.storage_backend.local_cpu_backend)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:01,269] LMCache INFO:[0m No active health checks to monitor, skipping monitor thread [3m(base.py:520:lmcache.v1.health_monitor.base)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:01,269] LMCache INFO:[0m Health monitor initialized and started at manager level (role=worker) [3m(manager.py:221:lmcache.v1.manager)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m 2026-02-01 23:02:01,269 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
[0;36m(EngineCore_DP0 pid=340)[0;0m 2026-02-01 23:02:01,393 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:02:01 [core.py:272] init engine (profile, create kv cache, warmup model) took 7.71 seconds
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:02:02 [factory.py:64] Creating v1 connector with name: LMCacheConnectorV1 and engine_id: 32cbd003-fd9f-4674-bed5-4833539dd0b6
[0;36m(EngineCore_DP0 pid=340)[0;0m WARNING 02-01 23:02:02 [base.py:166] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:02:02 [lmcache_connector.py:95] Initializing latest dev LMCache connector
[0;36m(EngineCore_DP0 pid=340)[0;0m [31;20m[2026-02-01 23:02:02,085] LMCache ERROR:[0m PrometheusLogger instance already created withdifferent metadata. This should not happen except in test [3m(observability.py:1755:lmcache.observability)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:02,086] LMCache INFO:[0m lmcache lookup client connect to rank 0 with socket path /tmp/engine_32cbd003-fd9f-4674-bed5-4833539dd0b6_service_lookup_lmcache_rpc_port_0 [3m(lmcache_lookup_client.py:88:lmcache.v1.lookup_client.lmcache_lookup_client)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:02:02,086] LMCache WARNING:[0m Could not load 'builtin' from vLLM. Using builtin hash. This may cause inconsistencies in distributed caching. [3m(token_database.py:136:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [33;20m[2026-02-01 23:02:02,086] LMCache WARNING:[0m Using builtin hash without PYTHONHASHSEED set. For production environments (non-testing scenarios), you MUST set PYTHONHASHSEED to ensure consistent hashing across processes. Example: export PYTHONHASHSEED=0 [3m(token_database.py:143:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:02,086] LMCache INFO:[0m Initialized NONE_HASH=b'\r\x0f\xda\t]\xcfm\xd3\x7f\x9f\x82\xc7R\xf6O\xef\xea\x05\xf2\xb9\x9e \xa4]rK\xfb\xe6!\x84\x83\xbc' from vLLM (>= PR#20511) [3m(token_database.py:74:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:02,086] LMCache INFO:[0m Using hash algorithm: builtin [3m(token_database.py:84:lmcache.v1.token_database)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:02,086] LMCache INFO:[0m Internal API server disabled. internal_api_server_enabled=False, port_offset=0, port=6999, socket_path=None, include_index_list=None [3m(api_server.py:58:lmcache.v1.internal_api_server.api_server)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:02,086] LMCache INFO:[0m LMCache initialized for role KVConnectorRole.SCHEDULER with version 0.3.14.dev9-gf398a4a37, vllm version 0.16.0rc1.dev88+ge535d90de, lmcache cache_engine metadata: None [3m(vllm_v1_adapter.py:472:lmcache.integration.vllm.vllm_v1_adapter)[0m
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:02:02 [vllm.py:669] Asynchronous scheduling is enabled.
[0;36m(EngineCore_DP0 pid=340)[0;0m WARNING 02-01 23:02:02 [vllm.py:714] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
[0;36m(EngineCore_DP0 pid=340)[0;0m INFO 02-01 23:02:02 [vllm.py:807] Cudagraph is disabled under eager mode
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:02 [api_server.py:455] Supported tasks: ['generate']
[0;36m(APIServer pid=1)[0;0m WARNING 02-01 23:02:02 [model.py:1353] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.6, 'top_p': 0.9}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:02 [serving.py:184] Warming up chat template processing...
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [hf.py:317] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [serving.py:209] Chat template warmup completed in 478.0ms
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [api_server.py:460] Starting vLLM API server 0 on http://0.0.0.0:8000
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:38] Available routes are:
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /openapi.json, Methods: GET, HEAD
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /docs, Methods: GET, HEAD
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /docs/oauth2-redirect, Methods: GET, HEAD
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /redoc, Methods: GET, HEAD
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /load, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /version, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /scale_elastic_ep, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /is_scaling_elastic_ep, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /tokenize, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /detokenize, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /inference/v1/generate, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /pause, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /resume, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /is_paused, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /metrics, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /health, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/models, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /ping, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /ping, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /invocations, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/chat/completions, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/chat/completions/render, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/responses, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/responses/{response_id}, Methods: GET
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/responses/{response_id}/cancel, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/completions, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/completions/render, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO 02-01 23:02:03 [launcher.py:47] Route: /v1/messages, Methods: POST
[0;36m(APIServer pid=1)[0;0m INFO:     Started server process [1]
[0;36m(APIServer pid=1)[0;0m INFO:     Waiting for application startup.
[0;36m(APIServer pid=1)[0;0m INFO:     Application startup complete.
[0;36m(APIServer pid=1)[0;0m INFO:     127.0.0.1:49458 - "GET /v1/models HTTP/1.1" 200 OK
[0;36m(EngineCore_DP0 pid=340)[0;0m [32;20m[2026-02-01 23:02:15,615] LMCache INFO:[0m Reqid: cmpl-b14c848a7be0096b-0-a8da95df, Total tokens 31, LMCache hit tokens: 0, need to load: 0 [3m(vllm_v1_adapter.py:1283:lmcache.integration.vllm.vllm_v1_adapter)[0m
```
</details>
