### PR TITLE
[CI]: Stabilize Github Disk Action 

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,27 +1,29 @@
 name: 'Free Disk Space'
-description: 'Frees disk space on the runner'
+description: 'Frees disk space on the runner safely'
 runs:
   using: "composite"
   steps:
     - name: Print disk space before cleanup
-      run: |
-        df -h
+      run: df -h
       shell: bash
+
     - name: Free Disk Space Linux
       if: runner.os == 'Linux'
       run: |
-        sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
-        sudo rm -rf \
-          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-          /usr/lib/jvm || true
-        sudo apt install aptitude -y >/dev/null 2>&1
-        sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
-        sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
-        sudo apt-get autoremove -y >/dev/null 2>&1
-        sudo apt-get autoclean -y >/dev/null 2>&1
+        # 1. Remove massive toolsets first (fastest gain)
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup /usr/lib/jvm /usr/local/lib/node_modules || true
+        
+        # 2. Clean Docker images
+        sudo docker image prune -af >/dev/null 2>&1 || true
+
+        # 3. Clean APT (Skip aptitude, use standard apt-get)
+        # We wrap this in a block to ensure the script continues even if apt is locked
+        sudo apt-get update >/dev/null 2>&1 || true
+        sudo apt-get purge -y mysql-client mysql-server google-cloud-sdk azure-cli >/dev/null 2>&1 || true
+        sudo apt-get autoremove -y >/dev/null 2>&1 || true
+        sudo apt-get clean >/dev/null 2>&1 || true
       shell: bash
+
     - name: Print disk space after cleanup
-      run: |
-        df -h
+      run: df -h
       shell: bash


### PR DESCRIPTION
- Replaced `aptitude` with standard `apt-get` for package removal.

- Added `|| true` to all cleanup commands.

- Added a quick `apt-get update` to ensure package lists are valid before purging.

- Included `/usr/local/lib/node_modules` in the manual deletion list.

This was likely caused by a recent update to the GitHub Runner's Ubuntu image, which created dependency conflicts that `aptitude` couldn't resolve automatically.