### PR TITLE
[Chore][Logging]: update logs to include vLLM computed tokens

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1264,9 +1264,11 @@ class LMCacheConnectorV1Impl:
 
         if num_external_hit_tokens is None:
             logger.debug(
-                "Reqid: %s, Total tokens %d, LMCache hit tokens: None.",
+                "Reqid: %s, Total tokens %d, Inference Engine computed tokens: %d, "
+                "LMCache hit tokens: None.",
                 req_id,
                 request.num_tokens,
+                num_computed_tokens,
             )
             return None
 
@@ -1281,11 +1283,13 @@ class LMCacheConnectorV1Impl:
             need_to_allocate -= 1
 
         logger.info(
-            "Reqid: %s, Total tokens %d, LMCache hit tokens: %d, need to load: %d",
+            "Reqid: %s, Total tokens %d, Inference Engine computed tokens: %d, "
+            "LMCache hit tokens: %d, need to load: %d",
             req_id,
             request.num_tokens,
+            num_computed_tokens,
             num_external_hit_tokens,
-            need_to_allocate,
+            max(need_to_allocate, 0),
         )
 
         self.load_specs[req_id] = LoadSpec(


### PR DESCRIPTION
When I enabled both vLLM prefix caching and lmcache, I found that the logger sometimes printed a negative value for need_to_allocate, so I applied a simple fix.

- Include vLLM computed tokens in debug and info logs
- Fix need_to_allocate edge case with max()

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
