### PR TITLE
[Misc][Chore] Print out locked memory objects when running L1Manager.memcheck()

### DIFF
--- a/lmcache/v1/multiprocess/distributed/l1_manager.py
+++ b/lmcache/v1/multiprocess/distributed/l1_manager.py
@@ -521,3 +521,20 @@ class L1Manager:
     def memcheck(self) -> None:
         """Perform memory check for L1 cache."""
         self._memory_manager.memcheck()
+
+        # Log the locked objects for debugging
+        num_write_locked = 0
+        num_read_locked = 0
+        for key, entry in self._objects.items():
+            if entry.write_lock.is_locked():
+                num_write_locked += 1
+            if entry.read_lock.is_locked():
+                num_read_locked += 1
+
+        logger.info(
+            "L1Manager memcheck: total objects = %d, write-locked = %d, "
+            "read-locked = %d",
+            len(self._objects),
+            num_write_locked,
+            num_read_locked,
+        )


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

For better debugging

Note: the script to trigger the memcheck and clear:
```python
from typing import Any
import zmq
from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
from lmcache.v1.multiprocess.protocol import RequestType, get_response_class

def send_lmcache_request(
    mq_client: MessageQueueClient,
    request_type: RequestType,
    payloads: list[Any],
) -> MessagingFuture[Any]:
    future = mq_client.submit_request(
        request_type, payloads, get_response_class(request_type)
    )
    print(future.result())
    return future

if __name__ == "__main__":
    client = MessageQueueClient("tcp://localhost:6555", zmq.Context())

    send_lmcache_request(client, RequestType.CLEAR, [])

```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
