### PR TITLE
[MP][bugfix] still sending the payload when aligned_end==0

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -156,8 +156,7 @@ class LMCacheMPSchedulerAdapter:
             return
 
         aligned_end = (len(token_ids) // self.chunk_size) * self.chunk_size
-        if aligned_end == 0:
-            return
+
         keys = [
             self._create_key(
                 token_ids,


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The original LMCache crashes when sending a short request due to #2578 . This PR fixes this.


Before:

```bash
# LMCache multi-process server
python3 -m lmcache.v1.multiprocess.server --l1-size-gb 100 --eviction-policy LRU
# Prefill instance, enforce_eager for faster startup
vllm serve Qwen/Qwen3-14B --kv-transfer-config '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}' --gpu-memory-utilization 0.7 --no-enable-prefix-caching --enforce-eager --port 8000
```

Send request

```
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -N \
  -d '{
    "model": "Qwen/Qwen3-14B",
    "messages": [
      {
        "role": "user",
        "content": "Hello, how are you? I am fine, thank you. But I am not sure about you. Can you tell me more about yourself? I am a human."
      }
    ],
    "max_tokens": 100,
    "temperature": 0.7
  }'
```

will fail the engine.

<img width="1222" height="370" alt="image" src="https://github.com/user-attachments/assets/a78924e5-fec8-4624-8559-c2e9159ce188" />


After this PR:
<img width="725" height="65" alt="image" src="https://github.com/user-attachments/assets/ec103368-5fb1-4b82-95b5-c4ef2dbedc49" />

Request normally ends.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
