### PR TITLE
[1/N][Core] Add backend IO adapter for async put/get signature compatibility

### DIFF
--- a/lmcache/v1/storage_backend/backend_io_adapter.py
+++ b/lmcache/v1/storage_backend/backend_io_adapter.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+import inspect
+import warnings
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import MemoryObj
+
+_LEGACY_WARNED: set[tuple[type[Any], str]] = set()
+
+_SIGNATURE_MISMATCH_PATTERNS = (
+    "unexpected keyword argument",
+    "missing required keyword-only argument",
+    "missing 1 required positional argument",
+    "missing 2 required positional arguments",
+    "missing 3 required positional arguments",
+    "required positional argument",
+    "takes ",
+    "positional argument",
+    "positional arguments",
+    "multiple values for argument",
+    "too many positional arguments",
+)
+
+
+def _warn_legacy_once(backend: Any, method_name: str, details: str) -> None:
+    backend_cls = backend.__class__
+    warn_key = (backend_cls, method_name)
+    if warn_key in _LEGACY_WARNED:
+        return
+    _LEGACY_WARNED.add(warn_key)
+    warnings.warn(
+        (
+            f"Legacy backend signature detected for {backend_cls.__name__}."
+            f"{method_name}: {details}"
+        ),
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def reset_legacy_warning_state_for_tests() -> None:
+    _LEGACY_WARNED.clear()
+
+
+def _is_signature_mismatch(exc: TypeError) -> bool:
+    message = str(exc).lower()
+    return any(token in message for token in _SIGNATURE_MISMATCH_PATTERNS)
+
+
+def _get_signature(method: Any) -> inspect.Signature | None:
+    try:
+        return inspect.signature(method)
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_var_keyword(sig: inspect.Signature) -> bool:
+    return any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+
+
+def _supports_param(sig: inspect.Signature, name: str) -> bool:
+    return name in sig.parameters or _has_var_keyword(sig)
+
+
+def _positional_params(sig: inspect.Signature) -> list[inspect.Parameter]:
+    return [
+        p
+        for p in sig.parameters.values()
+        if p.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+
+
+def _legacy_non_blocking_order(sig: inspect.Signature) -> bool:
+    positional = _positional_params(sig)
+    if not positional:
+        return False
+    return positional[0].name == "lookup_id"
+
+
+def _legacy_transfer_positional(sig: inspect.Signature) -> bool:
+    positional = _positional_params(sig)
+    if len(positional) >= 3:
+        return True
+    return any(
+        p.kind == inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values()
+    )
+
+
+def _try_candidates(
+    method_name: str,
+    attempts: list[tuple[str, Any]],
+) -> tuple[str, Any]:
+    last_exc: TypeError | None = None
+    for candidate_name, attempt in attempts:
+        try:
+            return candidate_name, attempt()
+        except TypeError as exc:
+            if not _is_signature_mismatch(exc):
+                raise
+            last_exc = exc
+            continue
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError(f"No call attempts available for {method_name}")
+
+
+def call_batched_get_non_blocking(
+    backend: Any,
+    *,
+    keys: list[CacheEngineKey],
+    lookup_id: str,
+    transfer_spec: Any = None,
+) -> Any:
+    method = backend.batched_get_non_blocking
+    sig = _get_signature(method)
+
+    if sig is not None:
+        if _legacy_non_blocking_order(sig):
+            args: list[Any] = [lookup_id, keys]
+            if _legacy_transfer_positional(sig):
+                args.append(transfer_spec)
+            _warn_legacy_once(
+                backend,
+                "batched_get_non_blocking",
+                (
+                    "please update to batched_get_non_blocking("
+                    "keys, *, lookup_id, transfer_spec=None)."
+                ),
+            )
+            return method(*args)
+
+        kwargs: dict[str, Any] = {}
+        if _supports_param(sig, "lookup_id"):
+            kwargs["lookup_id"] = lookup_id
+        if _supports_param(sig, "transfer_spec"):
+            kwargs["transfer_spec"] = transfer_spec
+        if "lookup_id" not in kwargs:
+            _warn_legacy_once(
+                backend,
+                "batched_get_non_blocking",
+                (
+                    "backend does not accept lookup_id keyword; "
+                    "please update to batched_get_non_blocking("
+                    "keys, *, lookup_id, transfer_spec=None)."
+                ),
+            )
+        return method(keys, **kwargs)
+
+    attempts = [
+        (
+            "canonical",
+            lambda: method(keys, lookup_id=lookup_id, transfer_spec=transfer_spec),
+        ),
+        (
+            "legacy-positional",
+            lambda: method(lookup_id, keys, transfer_spec),
+        ),
+        (
+            "legacy-no-transfer-spec",
+            lambda: method(lookup_id, keys),
+        ),
+    ]
+    selected, result = _try_candidates("batched_get_non_blocking", attempts)
+    if selected != "canonical":
+        _warn_legacy_once(
+            backend,
+            "batched_get_non_blocking",
+            (
+                "fallback dispatch used; please update to "
+                "batched_get_non_blocking(keys, *, lookup_id, transfer_spec=None)."
+            ),
+        )
+    return result
+
+
+def call_batched_get_blocking(
+    backend: Any,
+    *,
+    keys: list[CacheEngineKey],
+    lookup_id: str | None = None,
+    transfer_spec: Any = None,
+) -> Any:
+    method = backend.batched_get_blocking
+    sig = _get_signature(method)
+
+    if sig is not None:
+        kwargs: dict[str, Any] = {}
+        if _supports_param(sig, "lookup_id"):
+            kwargs["lookup_id"] = lookup_id
+        if _supports_param(sig, "transfer_spec"):
+            kwargs["transfer_spec"] = transfer_spec
+        if "lookup_id" not in kwargs or "transfer_spec" not in kwargs:
+            _warn_legacy_once(
+                backend,
+                "batched_get_blocking",
+                (
+                    "please update to batched_get_blocking("
+                    "keys, *, lookup_id=None, transfer_spec=None)."
+                ),
+            )
+        return method(keys, **kwargs)
+
+    attempts = [
+        (
+            "canonical",
+            lambda: method(keys, lookup_id=lookup_id, transfer_spec=transfer_spec),
+        ),
+        ("no-lookup-id", lambda: method(keys, transfer_spec=transfer_spec)),
+        ("legacy-minimal", lambda: method(keys)),
+    ]
+    selected, result = _try_candidates("batched_get_blocking", attempts)
+    if selected != "canonical":
+        _warn_legacy_once(
+            backend,
+            "batched_get_blocking",
+            (
+                "fallback dispatch used; please update to "
+                "batched_get_blocking(keys, *, lookup_id=None, transfer_spec=None)."
+            ),
+        )
+    return result
+
+
+def call_batched_submit_put_task(
+    backend: Any,
+    *,
+    keys: Sequence[CacheEngineKey],
+    objs: list[MemoryObj],
+    lookup_id: str | None = None,
+    transfer_spec: Any = None,
+) -> Any:
+    method = backend.batched_submit_put_task
+    sig = _get_signature(method)
+
+    if sig is not None:
+        kwargs: dict[str, Any] = {}
+        if _supports_param(sig, "lookup_id"):
+            kwargs["lookup_id"] = lookup_id
+        if _supports_param(sig, "transfer_spec"):
+            kwargs["transfer_spec"] = transfer_spec
+        if "lookup_id" not in kwargs or "transfer_spec" not in kwargs:
+            _warn_legacy_once(
+                backend,
+                "batched_submit_put_task",
+                (
+                    "please update to batched_submit_put_task("
+                    "keys, objs, *, lookup_id=None, transfer_spec=None)."
+                ),
+            )
+        return method(keys, objs, **kwargs)
+
+    attempts = [
+        (
+            "canonical",
+            lambda: method(keys, objs, lookup_id=lookup_id, transfer_spec=transfer_spec),
+        ),
+        ("no-lookup-id", lambda: method(keys, objs, transfer_spec=transfer_spec)),
+        ("legacy-minimal", lambda: method(keys, objs)),
+    ]
+    selected, result = _try_candidates("batched_submit_put_task", attempts)
+    if selected != "canonical":
+        _warn_legacy_once(
+            backend,
+            "batched_submit_put_task",
+            (
+                "fallback dispatch used; please update to "
+                "batched_submit_put_task(keys, objs, *, "
+                "lookup_id=None, transfer_spec=None)."
+            ),
+        )
+    return result

--- a/lmcache/v1/storage_backend/backend_io_adapter.py
+++ b/lmcache/v1/storage_backend/backend_io_adapter.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# Standard
+# Future
 from __future__ import annotations
 
+# Standard
 from collections.abc import Sequence
 from typing import Any
 import inspect
@@ -61,9 +62,7 @@ def _get_signature(method: Any) -> inspect.Signature | None:
 
 
 def _has_var_keyword(sig: inspect.Signature) -> bool:
-    return any(
-        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
-    )
+    return any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
 
 
 def _supports_param(sig: inspect.Signature, name: str) -> bool:
@@ -261,7 +260,9 @@ def call_batched_submit_put_task(
     attempts = [
         (
             "canonical",
-            lambda: method(keys, objs, lookup_id=lookup_id, transfer_spec=transfer_spec),
+            lambda: method(
+                keys, objs, lookup_id=lookup_id, transfer_spec=transfer_spec
+            ),
         ),
         ("no-lookup-id", lambda: method(keys, objs, transfer_spec=transfer_spec)),
         ("legacy-minimal", lambda: method(keys, objs)),

--- a/tests/v1/storage_backend/test_backend_io_adapter.py
+++ b/tests/v1/storage_backend/test_backend_io_adapter.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import asyncio
+import warnings
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.backend_io_adapter import (
+    call_batched_get_blocking,
+    call_batched_get_non_blocking,
+    call_batched_submit_put_task,
+    reset_legacy_warning_state_for_tests,
+)
+
+
+class NewStyleBackend:
+    def __init__(self):
+        self.calls = []
+
+    async def batched_get_non_blocking(self, keys, *, lookup_id, transfer_spec=None):
+        self.calls.append(("nb_get", keys, lookup_id, transfer_spec))
+        return ("nb_get", keys, lookup_id, transfer_spec)
+
+    def batched_get_blocking(self, keys, lookup_id=None, transfer_spec=None):
+        self.calls.append(("blk_get", keys, lookup_id, transfer_spec))
+        return ("blk_get", keys, lookup_id, transfer_spec)
+
+    def batched_submit_put_task(
+        self, keys, objs, *, lookup_id=None, transfer_spec=None
+    ):
+        self.calls.append(("put", keys, objs, lookup_id, transfer_spec))
+        return ("put", keys, objs, lookup_id, transfer_spec)
+
+
+class LegacyNonBlockingBackend:
+    def __init__(self):
+        self.calls = []
+
+    async def batched_get_non_blocking(self, lookup_id, keys, transfer_spec=None):
+        self.calls.append(("nb_get_legacy", lookup_id, keys, transfer_spec))
+        return ("nb_get_legacy", lookup_id, keys, transfer_spec)
+
+
+class BuggyNewStyleBackend:
+    async def batched_get_non_blocking(self, keys, *, lookup_id, transfer_spec=None):
+        raise TypeError("internal bug")
+
+
+@pytest.fixture(autouse=True)
+def reset_warning_cache():
+    reset_legacy_warning_state_for_tests()
+    yield
+    reset_legacy_warning_state_for_tests()
+
+
+def test_new_style_backend_dispatch_has_no_deprecation_warning():
+    backend = NewStyleBackend()
+    keys = ["k1", "k2"]
+    objs = ["o1", "o2"]
+    transfer_spec = {"spec": "new-style"}
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always", DeprecationWarning)
+        nb_result = asyncio.run(
+            call_batched_get_non_blocking(
+                backend,
+                keys=keys,
+                lookup_id="req-1",
+                transfer_spec=transfer_spec,
+            )
+        )
+        blk_result = call_batched_get_blocking(
+            backend,
+            keys=keys,
+            lookup_id="req-2",
+            transfer_spec=transfer_spec,
+        )
+        put_result = call_batched_submit_put_task(
+            backend,
+            keys=keys,
+            objs=objs,
+            lookup_id="req-3",
+            transfer_spec=transfer_spec,
+        )
+
+    assert records == []
+    assert nb_result == ("nb_get", keys, "req-1", transfer_spec)
+    assert blk_result == ("blk_get", keys, "req-2", transfer_spec)
+    assert put_result == ("put", keys, objs, "req-3", transfer_spec)
+
+
+def test_legacy_non_blocking_warns_once_and_uses_legacy_order():
+    backend = LegacyNonBlockingBackend()
+    keys = ["k1", "k2"]
+    transfer_spec = {"spec": "legacy"}
+
+    with warnings.catch_warnings(record=True) as first_records:
+        warnings.simplefilter("always", DeprecationWarning)
+        first_result = asyncio.run(
+            call_batched_get_non_blocking(
+                backend,
+                keys=keys,
+                lookup_id="legacy-req",
+                transfer_spec=transfer_spec,
+            )
+        )
+
+    with warnings.catch_warnings(record=True) as second_records:
+        warnings.simplefilter("always", DeprecationWarning)
+        second_result = asyncio.run(
+            call_batched_get_non_blocking(
+                backend,
+                keys=keys,
+                lookup_id="legacy-req-2",
+                transfer_spec=transfer_spec,
+            )
+        )
+
+    assert first_result == ("nb_get_legacy", "legacy-req", keys, transfer_spec)
+    assert second_result == ("nb_get_legacy", "legacy-req-2", keys, transfer_spec)
+    assert len(first_records) == 1
+    assert issubclass(first_records[0].category, DeprecationWarning)
+    assert "Legacy backend signature detected" in str(first_records[0].message)
+    assert second_records == []
+
+
+def test_internal_type_error_is_not_swallowed():
+    backend = BuggyNewStyleBackend()
+
+    with pytest.raises(TypeError, match="internal bug"):
+        asyncio.run(
+            call_batched_get_non_blocking(
+                backend,
+                keys=["k1"],
+                lookup_id="req-bug",
+                transfer_spec={"x": 1},
+            )
+        )
+
+
+def test_transfer_spec_identity_is_preserved_for_all_wrappers():
+    backend = NewStyleBackend()
+    sentinel_transfer_spec = object()
+    keys = ["k1"]
+    objs = ["o1"]
+
+    nb_result = asyncio.run(
+        call_batched_get_non_blocking(
+            backend,
+            keys=keys,
+            lookup_id="req-nb",
+            transfer_spec=sentinel_transfer_spec,
+        )
+    )
+    blk_result = call_batched_get_blocking(
+        backend,
+        keys=keys,
+        lookup_id="req-blk",
+        transfer_spec=sentinel_transfer_spec,
+    )
+    put_result = call_batched_submit_put_task(
+        backend,
+        keys=keys,
+        objs=objs,
+        lookup_id="req-put",
+        transfer_spec=sentinel_transfer_spec,
+    )
+
+    assert nb_result[3] is sentinel_transfer_spec
+    assert blk_result[3] is sentinel_transfer_spec
+    assert put_result[4] is sentinel_transfer_spec


### PR DESCRIPTION
I made first step of the series that for the discussion in https://github.com/LMCache/LMCache/issues/2585.
This PR adds the compatibility foundation for async put/get signature standardization without changing production call sites yet.

  - Adds a new internal adapter module: `lmcache/v1/storage_backend/backend_io_adapter.py`
  - Introduces three wrapper functions:
    - `call_batched_get_non_blocking(backend, *, keys, lookup_id, transfer_spec=None)`
    - `call_batched_get_blocking(backend, *, keys, lookup_id=None, transfer_spec=None)`
    - `call_batched_submit_put_task(backend, *, keys, objs, lookup_id=None, transfer_spec=None)`
  - Adapter prefers canonical calls, but supports legacy backend signatures/order when needed.
  - Adds focused unit tests in `tests/v1/storage_backend/test_backend_io_adapter.py` for:
    - new-style dispatch (no warning)
    - legacy non-blocking order fallback (warn once)
    - no swallowing of internal `TypeError`
    - `transfer_spec` plumbing/identity preservation

  Why needed:
  #2083, #2350

  **Special notes for your reviewers**:

  - Scope is intentionally small: adapter + unit tests only.
  - No `StorageManager` call-site changes in this PR.
  - No backend implementation signature changes in this PR.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
