### PR TITLE
[CI]: Fix correctness test undefined symbol

### DIFF
--- a/.buildkite/scripts/vllm-correctness.sh
+++ b/.buildkite/scripts/vllm-correctness.sh
@@ -49,7 +49,7 @@ uv pip install -U vllm \
 
 # override previous lmcache from previous jobs
 # the source installation is from this PR
-uv pip install -e . --reinstall-package lmcache
+uv pip install -e . --reinstall-package lmcache --no-build-isolation
 
 # additional dependencies (please update manually if needed)
 # these packages are pretty stable so should not need to


### PR DESCRIPTION
The correctness tests uses `uv pip install -e .` on a fixed virtual environment to install LMCache from the latest PR. We need to add `--no-build-isolation` in order for the the torch version to become compatible with any updates from upstream vllm.