### PR TITLE
[Bugfix] Fix parsing error always returning a CacheEngineKey + unit tests

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -317,9 +317,11 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
     """Parse a key string into either a CacheEngineKey or LayerCacheEngineKey.
 
     Args:
-        key_str: String in format:
-            CacheEngineKey:      model_name@world_size@worker_id@chunk_hash@dtype[@tag%value...]
-            LayerCacheEngineKey: model_name@world_size@worker_id@chunk_hash@dtype@layer_id[@tag%value...]
+    key_str: String in format:
+        CacheEngineKey:
+            model_name@world_size@worker_id@chunk_hash@dtype[@tag%value...]
+        LayerCacheEngineKey:
+            model_name@world_size@worker_id@chunk_hash@dtype@layer_id[@tag%value...]
 
     Returns:
         CacheEngineKey if no layer_id, LayerCacheEngineKey if valid layer_id

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -318,13 +318,17 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
 
     Args:
         key_str: String in format:
-            model_name@world_size@worker_id@chunk_hash[@layer_id][@tag%value...]
+            CacheEngineKey:      model_name@world_size@worker_id@chunk_hash@dtype[@tag%value...]
+            LayerCacheEngineKey: model_name@world_size@worker_id@chunk_hash@dtype@layer_id[@tag%value...]
 
     Returns:
         CacheEngineKey if no layer_id, LayerCacheEngineKey if valid layer_id
     """
     parts = key_str.strip().split("@")
-    if len(parts) >= 5 and parts[4].isdigit():
+    # parts[0]=model, [1]=world_size, [2]=worker_id, [3]=chunk_hash, [4]=dtype
+    # parts[5]=layer_id OR tag%value
+    # If parts[5] exists and is a digit (not containing '%'), it's a LayerCacheEngineKey
+    if len(parts) >= 6 and parts[5].isdigit():
         return LayerCacheEngineKey.from_string(key_str)
     return CacheEngineKey.from_string(key_str)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for lmcache.utils module."""
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import (
+    CacheEngineKey,
+    LayerCacheEngineKey,
+    parse_cache_key,
+)
+
+
+class TestCacheKeyParsing:
+    """Tests for CacheEngineKey and LayerCacheEngineKey parsing."""
+
+    def test_parse_cache_key_without_tags(self):
+        """Test parsing CacheEngineKey without tags."""
+        key_str = "model@2@0@abc123@bfloat16"
+        result = parse_cache_key(key_str)
+        
+        assert isinstance(result, CacheEngineKey)
+        assert not isinstance(result, LayerCacheEngineKey)
+        assert result.model_name == "model"
+        assert result.world_size == 2
+        assert result.worker_id == 0
+        assert result.chunk_hash == 0xabc123
+        assert result.dtype == torch.bfloat16
+
+    def test_parse_cache_key_with_tags(self):
+        """Test parsing CacheEngineKey with tags - demonstrates the bug."""
+        key_str = "model@2@0@abc123@bfloat16@mytag%myvalue@othertag%othervalue"
+        result = parse_cache_key(key_str)
+        
+        # This should be CacheEngineKey, not LayerCacheEngineKey
+        assert isinstance(result, CacheEngineKey)
+        assert not isinstance(result, LayerCacheEngineKey)
+        assert result.model_name == "model"
+        assert result.world_size == 2
+        assert result.worker_id == 0
+        assert result.chunk_hash == 0xabc123
+        assert result.dtype == torch.bfloat16
+        assert result.tags is not None
+        assert ("mytag", "myvalue") in result.tags
+        assert ("othertag", "othervalue") in result.tags
+
+    def test_parse_layer_cache_key_without_tags(self):
+        """Test parsing LayerCacheEngineKey without tags."""
+        key_str = "model@2@0@abc123@bfloat16@5"
+        result = parse_cache_key(key_str)
+        
+        assert isinstance(result, LayerCacheEngineKey)
+        assert result.model_name == "model"
+        assert result.world_size == 2
+        assert result.worker_id == 0
+        assert result.chunk_hash == 0xabc123
+        assert result.dtype == torch.bfloat16
+        assert result.layer_id == 5
+
+    def test_parse_layer_cache_key_with_tags(self):
+        """Test parsing LayerCacheEngineKey with tags - demonstrates the bug."""
+        key_str = "model@2@0@abc123@bfloat16@5@mytag%myvalue"
+        result = parse_cache_key(key_str)
+        
+        # This should be LayerCacheEngineKey with layer_id=5 and tags
+        assert isinstance(result, LayerCacheEngineKey)
+        assert result.model_name == "model"
+        assert result.world_size == 2
+        assert result.worker_id == 0
+        assert result.chunk_hash == 0xabc123
+        assert result.dtype == torch.bfloat16
+        assert result.layer_id == 5
+        assert result.tags is not None
+        assert ("mytag", "myvalue") in result.tags
+
+    def test_roundtrip_cache_engine_key_without_tags(self):
+        """Test that CacheEngineKey serialization round-trips correctly."""
+        original = CacheEngineKey(
+            model_name="test-model",
+            world_size=4,
+            worker_id=1,
+            chunk_hash=0xdeadbeef,
+            dtype=torch.float16,
+            request_configs=None,
+        )
+        
+        key_str = original.to_string()
+        parsed = parse_cache_key(key_str)
+        
+        assert isinstance(parsed, CacheEngineKey)
+        assert not isinstance(parsed, LayerCacheEngineKey)
+        assert parsed == original
+
+    def test_roundtrip_cache_engine_key_with_tags(self):
+        """Test that CacheEngineKey with tags serialization round-trips correctly."""
+        original = CacheEngineKey(
+            model_name="test-model",
+            world_size=4,
+            worker_id=1,
+            chunk_hash=0xdeadbeef,
+            dtype=torch.float32,
+            request_configs={
+                "lmcache.tag.user": "alice",
+                "lmcache.tag.session": "xyz789",
+            },
+        )
+        
+        key_str = original.to_string()
+        parsed = parse_cache_key(key_str)
+        
+        assert isinstance(parsed, CacheEngineKey)
+        assert not isinstance(parsed, LayerCacheEngineKey)
+        assert parsed == original
+
+    def test_roundtrip_layer_cache_engine_key_without_tags(self):
+        """Test that LayerCacheEngineKey serialization round-trips correctly."""
+        original = LayerCacheEngineKey(
+            model_name="test-model",
+            world_size=4,
+            worker_id=1,
+            chunk_hash=0xdeadbeef,
+            dtype=torch.bfloat16,
+            request_configs=None,
+            layer_id=7,
+        )
+        
+        key_str = original.to_string()
+        parsed = parse_cache_key(key_str)
+        
+        assert isinstance(parsed, LayerCacheEngineKey)
+        assert parsed == original
+        assert parsed.layer_id == 7
+
+    def test_roundtrip_layer_cache_engine_key_with_tags(self):
+        """Test that LayerCacheEngineKey with tags serialization round-trips correctly."""
+        original = LayerCacheEngineKey(
+            model_name="test-model",
+            world_size=4,
+            worker_id=1,
+            chunk_hash=0xdeadbeef,
+            dtype=torch.bfloat16,
+            request_configs={
+                "lmcache.tag.user": "bob",
+                "lmcache.tag.priority": "high",
+            },
+            layer_id=3,
+        )
+        
+        key_str = original.to_string()
+        parsed = parse_cache_key(key_str)
+        
+        assert isinstance(parsed, LayerCacheEngineKey)
+        assert parsed == original
+        assert parsed.layer_id == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for lmcache.utils module."""
+
 # Third Party
-import pytest
 import torch
 
 # First Party
@@ -13,132 +13,150 @@ from lmcache.utils import (
 
 
 class TestCacheKeyParsing:
-    """Tests for CacheEngineKey and LayerCacheEngineKey parsing."""
+    """
+    Tests for CacheEngineKey and LayerCacheEngineKey parsing.
+    """
 
     def test_parse_cache_key_without_tags(self):
-        """Test parsing CacheEngineKey without tags."""
+        """
+        Test parsing CacheEngineKey without tags.
+        """
         key_str = "model@2@0@abc123@bfloat16"
         result = parse_cache_key(key_str)
-        
+
         assert isinstance(result, CacheEngineKey)
         assert not isinstance(result, LayerCacheEngineKey)
         assert result.model_name == "model"
         assert result.world_size == 2
         assert result.worker_id == 0
-        assert result.chunk_hash == 0xabc123
+        assert result.chunk_hash == 0xABC123
         assert result.dtype == torch.bfloat16
 
     def test_parse_cache_key_with_tags(self):
-        """Test parsing CacheEngineKey with tags - demonstrates the bug."""
+        """
+        Test parsing CacheEngineKey with tags.
+        """
         key_str = "model@2@0@abc123@bfloat16@mytag%myvalue@othertag%othervalue"
         result = parse_cache_key(key_str)
-        
+
         # This should be CacheEngineKey, not LayerCacheEngineKey
         assert isinstance(result, CacheEngineKey)
         assert not isinstance(result, LayerCacheEngineKey)
         assert result.model_name == "model"
         assert result.world_size == 2
         assert result.worker_id == 0
-        assert result.chunk_hash == 0xabc123
+        assert result.chunk_hash == 0xABC123
         assert result.dtype == torch.bfloat16
         assert result.tags is not None
         assert ("mytag", "myvalue") in result.tags
         assert ("othertag", "othervalue") in result.tags
 
     def test_parse_layer_cache_key_without_tags(self):
-        """Test parsing LayerCacheEngineKey without tags."""
+        """
+        Test parsing LayerCacheEngineKey without tags.
+        """
         key_str = "model@2@0@abc123@bfloat16@5"
         result = parse_cache_key(key_str)
-        
+
         assert isinstance(result, LayerCacheEngineKey)
         assert result.model_name == "model"
         assert result.world_size == 2
         assert result.worker_id == 0
-        assert result.chunk_hash == 0xabc123
+        assert result.chunk_hash == 0xABC123
         assert result.dtype == torch.bfloat16
         assert result.layer_id == 5
 
     def test_parse_layer_cache_key_with_tags(self):
-        """Test parsing LayerCacheEngineKey with tags - demonstrates the bug."""
+        """
+        Test parsing LayerCacheEngineKey with tags - demonstrates the bug.
+        """
         key_str = "model@2@0@abc123@bfloat16@5@mytag%myvalue"
         result = parse_cache_key(key_str)
-        
+
         # This should be LayerCacheEngineKey with layer_id=5 and tags
         assert isinstance(result, LayerCacheEngineKey)
         assert result.model_name == "model"
         assert result.world_size == 2
         assert result.worker_id == 0
-        assert result.chunk_hash == 0xabc123
+        assert result.chunk_hash == 0xABC123
         assert result.dtype == torch.bfloat16
         assert result.layer_id == 5
         assert result.tags is not None
         assert ("mytag", "myvalue") in result.tags
 
     def test_roundtrip_cache_engine_key_without_tags(self):
-        """Test that CacheEngineKey serialization round-trips correctly."""
+        """
+        Test that CacheEngineKey serialization round-trips correctly.
+        """
         original = CacheEngineKey(
             model_name="test-model",
             world_size=4,
             worker_id=1,
-            chunk_hash=0xdeadbeef,
+            chunk_hash=0xDEADBEEF,
             dtype=torch.float16,
             request_configs=None,
         )
-        
+
         key_str = original.to_string()
         parsed = parse_cache_key(key_str)
-        
+
         assert isinstance(parsed, CacheEngineKey)
         assert not isinstance(parsed, LayerCacheEngineKey)
         assert parsed == original
 
     def test_roundtrip_cache_engine_key_with_tags(self):
-        """Test that CacheEngineKey with tags serialization round-trips correctly."""
+        """
+        Test that CacheEngineKey with tags serialization round-trips correctly.
+        """
         original = CacheEngineKey(
             model_name="test-model",
             world_size=4,
             worker_id=1,
-            chunk_hash=0xdeadbeef,
+            chunk_hash=0xDEADBEEF,
             dtype=torch.float32,
             request_configs={
                 "lmcache.tag.user": "alice",
                 "lmcache.tag.session": "xyz789",
             },
         )
-        
+
         key_str = original.to_string()
         parsed = parse_cache_key(key_str)
-        
+
         assert isinstance(parsed, CacheEngineKey)
         assert not isinstance(parsed, LayerCacheEngineKey)
         assert parsed == original
 
     def test_roundtrip_layer_cache_engine_key_without_tags(self):
-        """Test that LayerCacheEngineKey serialization round-trips correctly."""
+        """
+        Test that LayerCacheEngineKey serialization round-trips correctly.
+        """
         original = LayerCacheEngineKey(
             model_name="test-model",
             world_size=4,
             worker_id=1,
-            chunk_hash=0xdeadbeef,
+            chunk_hash=0xDEADBEEF,
             dtype=torch.bfloat16,
             request_configs=None,
             layer_id=7,
         )
-        
+
         key_str = original.to_string()
         parsed = parse_cache_key(key_str)
-        
+
         assert isinstance(parsed, LayerCacheEngineKey)
         assert parsed == original
         assert parsed.layer_id == 7
 
     def test_roundtrip_layer_cache_engine_key_with_tags(self):
-        """Test that LayerCacheEngineKey with tags serialization round-trips correctly."""
+        """
+        Test that LayerCacheEngineKey with tags serialization round-trips correctly.
+        """
         original = LayerCacheEngineKey(
             model_name="test-model",
             world_size=4,
             worker_id=1,
-            chunk_hash=0xdeadbeef,
+            chunk_hash=0xDEADBEEF,
             dtype=torch.bfloat16,
             request_configs={
                 "lmcache.tag.user": "bob",
@@ -146,10 +164,10 @@ class TestCacheKeyParsing:
             },
             layer_id=3,
         )
-        
+
         key_str = original.to_string()
         parsed = parse_cache_key(key_str)
-        
+
         assert isinstance(parsed, LayerCacheEngineKey)
         assert parsed == original
         assert parsed.layer_id == 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to parsing error in `parse_cache_key` function. The number of parts and index assumed to be layer ID were not up to date with the latest to_string representation of CacheEngineKey and LayerCacheEngineKey.
Added unit tests for future prevention.

**Special notes for your reviewers**:
This solution is probably quickest. Distinguishing between CacheEngineKey and LayerCacheEngineKey strings through indices is prone to errors if the string representation changes. Perhaps consider in the future a different hint for the key type (prefix "key:model_name@..." vs. "layerkey:model_name@..." or a different separator)

**If applicable**:

- [x] this PR contains unit tests
