### PR TITLE
Refactor lookup client/server and abstract rpc layer.

### DIFF
--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -16,6 +16,12 @@ from lmcache.v1.lookup_client.lmcache_lookup_client_bypass import (
 )
 from lmcache.v1.lookup_client.mooncake_lookup_client import MooncakeLookupClient
 from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.rpc.zmq_transport import (
+    SocketParams,
+    ZmqReqRepClientTransport,
+    ZmqRouterServerTransport,
+)
+from lmcache.v1.rpc_utils import get_zmq_rpc_path_lmcache
 
 if TYPE_CHECKING:
     # First Party
@@ -75,7 +81,10 @@ class LookupClientFactory:
             elif config.enable_async_loading:
                 client = LMCacheAsyncLookupClient(config, metadata)
             else:
-                client = LMCacheLookupClient(config, metadata)
+                transport = LookupClientFactory._create_zmq_client_transport(
+                    config, metadata
+                )
+                client = LMCacheLookupClient(config, metadata, transport)
 
         if config.hit_miss_ratio is not None and 0 <= config.hit_miss_ratio <= 1:
             client = HitLimitLookupClient(client, config)
@@ -128,7 +137,8 @@ class LookupClientFactory:
             if config.enable_async_loading:
                 return LMCacheAsyncLookupServer(lmcache_engine, metadata)
             else:
-                return LMCacheLookupServer(lmcache_engine, metadata)
+                transport = LookupClientFactory._create_zmq_server_transport(metadata)
+                return LMCacheLookupServer(lmcache_engine, metadata, transport)
 
         return None
 
@@ -185,3 +195,57 @@ class LookupClientFactory:
         )
 
         return MooncakeLookupClient(config, metadata, master_address)
+
+    @staticmethod
+    def _create_zmq_client_transport(
+        config: LMCacheEngineConfig,
+        metadata: LMCacheMetadata,
+    ) -> ZmqReqRepClientTransport:
+        """Create a ZMQ REQ-REP client transport."""
+        kv_extra = metadata.kv_connector_extra_config or {}
+        rpc_port = kv_extra.get("lmcache_rpc_port", 0)
+        assert metadata.engine_id is not None, (
+            "engine_id is required for RPC communication"
+        )
+
+        lookup_ids = config.get_lookup_server_worker_ids(
+            metadata.use_mla, metadata.world_size
+        )
+        ranks = lookup_ids if len(lookup_ids) > 0 else list(range(metadata.world_size))
+
+        socket_params = [
+            SocketParams(
+                socket_path=get_zmq_rpc_path_lmcache(
+                    metadata.engine_id,
+                    "lookup",
+                    rpc_port,
+                    rank,
+                ),
+                rank=rank,
+            )
+            for rank in ranks
+        ]
+        return ZmqReqRepClientTransport(
+            socket_params=socket_params,
+            timeout_ms=config.lookup_timeout_ms,
+        )
+
+    @staticmethod
+    def _create_zmq_server_transport(
+        metadata: LMCacheMetadata,
+    ) -> ZmqRouterServerTransport:
+        """Create a ZMQ ROUTER server transport."""
+        kv_extra = metadata.kv_connector_extra_config or {}
+        rpc_port = kv_extra.get("lmcache_rpc_port", 0)
+        assert metadata.engine_id is not None, (
+            "engine_id is required for RPC communication"
+        )
+        socket_path = get_zmq_rpc_path_lmcache(
+            metadata.engine_id,
+            "lookup",
+            rpc_port,
+            metadata.worker_id,
+        )
+        return ZmqRouterServerTransport(
+            socket_path=socket_path,
+        )

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -89,11 +89,9 @@ class LMCacheLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
-        lookup_id_buf = lookup_id.encode("utf-8")
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:
             request_configs_str = json.dumps(request_configs)
-        request_configs_buf = request_configs_str.encode("utf-8")
 
         # NOTE(Jiayi): We cannot only send hashes when
         # blending enabled because the blender need the
@@ -118,14 +116,14 @@ class LMCacheLookupClient(LookupClientInterface):
             msg_buf = [
                 hashes,
                 offsets,
-                lookup_id_buf,
-                request_configs_buf,
+                lookup_id,
+                request_configs_str,
             ]
         else:
             msg_buf = [
                 token_ids,
-                lookup_id_buf,
-                request_configs_buf,
+                lookup_id,
+                request_configs_str,
             ]
 
         responses = self.transport.send_and_recv_all(msg_buf)
@@ -187,36 +185,76 @@ class LMCacheLookupServer:
 
         def process_request():
             while self.running:
-                result = self.transport.recv_request()
-                if result is None:
-                    continue
+                try:
+                    result = self.transport.recv_request()
+                    if result is None:
+                        continue
 
-                identity, data_frames = result
-                lookup_id = data_frames[-2].decode("utf-8")
-                request_configs_str = data_frames[-1].decode("utf-8")
-                request_configs = (
-                    json.loads(request_configs_str) if request_configs_str else None
-                )
-                if not self.enable_blending:
-                    hashes = data_frames[0]
-                    offsets = data_frames[1]
-                    lookup_result = self.lmcache_engine.lookup(
-                        hashes=hashes,
-                        offsets=offsets,
-                        lookup_id=lookup_id,
-                        pin=True,
-                        request_configs=request_configs,
+                    identity, data_frames = result
+
+                    # Validate frame structure
+                    if len(data_frames) < 3:
+                        logger.warning("Malformed request received: not enough frames.")
+                        continue
+
+                    # Validate and decode lookup_id
+                    lookup_id_bytes = data_frames[-2]
+                    request_configs_bytes = data_frames[-1]
+
+                    if not isinstance(lookup_id_bytes, (bytes, str)):
+                        logger.warning(
+                            "Malformed request received: lookup_id is not bytes or str."
+                        )
+                        continue
+
+                    if not isinstance(request_configs_bytes, (bytes, str)):
+                        logger.warning(
+                            "Malformed request received: "
+                            "request_configs is not bytes or str."
+                        )
+                        continue
+
+                    # Decode to strings
+                    if isinstance(lookup_id_bytes, bytes):
+                        lookup_id = lookup_id_bytes.decode("utf-8")
+                    else:
+                        lookup_id = lookup_id_bytes
+
+                    if isinstance(request_configs_bytes, bytes):
+                        request_configs_str = request_configs_bytes.decode("utf-8")
+                    else:
+                        request_configs_str = request_configs_bytes
+
+                    request_configs = (
+                        json.loads(request_configs_str) if request_configs_str else None
                     )
-                else:
-                    tokens = data_frames[0]
-                    lookup_result = self.lmcache_engine.lookup(
-                        tokens=tokens,
-                        lookup_id=lookup_id,
-                        pin=True,
-                        request_configs=request_configs,
-                    )
-                response = lookup_result.to_bytes(4, "big")
-                self.transport.send_response(identity, response)
+
+                    if not self.enable_blending:
+                        hashes = data_frames[0]
+                        offsets = data_frames[1]
+                        lookup_result = self.lmcache_engine.lookup(
+                            hashes=hashes,
+                            offsets=offsets,
+                            lookup_id=lookup_id,
+                            pin=True,
+                            request_configs=request_configs,
+                        )
+                    else:
+                        tokens = data_frames[0]
+                        lookup_result = self.lmcache_engine.lookup(
+                            tokens=tokens,
+                            lookup_id=lookup_id,
+                            pin=True,
+                            request_configs=request_configs,
+                        )
+                    response = lookup_result.to_bytes(4, "big")
+                    self.transport.send_response(identity, response)
+                except json.JSONDecodeError as e:
+                    logger.error(f"Error decoding JSON in lookup request: {e}")
+                except UnicodeDecodeError as e:
+                    logger.error(f"Error decoding UTF-8 in lookup request: {e}")
+                except Exception as e:
+                    logger.error(f"Error processing lookup request: {e}")
 
         logger.info("lmcache lookup server started")
         self.thread = threading.Thread(

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -1,14 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from collections import namedtuple
 from typing import Optional, Union
 import json
 import threading
 
 # Third Party
-import msgspec
 import torch
-import zmq
 
 # First Party
 from lmcache.logging import init_logger
@@ -16,10 +13,9 @@ from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
 from lmcache.v1.metadata import LMCacheMetadata
-from lmcache.v1.rpc_utils import (
-    get_zmq_context,
-    get_zmq_rpc_path_lmcache,
-    get_zmq_socket,
+from lmcache.v1.rpc.transport import (
+    RpcClientTransport,
+    RpcServerTransport,
 )
 
 logger = init_logger(__name__)
@@ -27,81 +23,43 @@ logger = init_logger(__name__)
 
 class LMCacheLookupClient(LookupClientInterface):
     """
-    ZMQ-based lookup client that communicates with a lookup server.
+    Lookup client that communicates with a lookup server
+    via an injected RpcClientTransport.
+
+    The client is decoupled from the underlying communication
+    mechanism. The transport layer handles connection management,
+    retries, and error recovery.
 
     Related extra_config:
     - lookup_server_worker_ids:
-        is a config to control create lookup server on some workers.
+        is a config to control create lookup server on some
+        workers.
         if mla is not enabled, default is [];
         if mla is enabled, default is [0];
-        - if lookup_server_worker_ids is [], start lookup server on all workers
-        - if lookup_server_worker_ids is [0], start lookup server on worker0
-        - if lookup_server_worker_ids is [0, 3, 6], start lookup server on
-          worker0, worker3 and worker6
+        - if lookup_server_worker_ids is [], start lookup
+          server on all workers
+        - if lookup_server_worker_ids is [0], start lookup
+          server on worker0
+        - if lookup_server_worker_ids is [0, 3, 6], start
+          lookup server on worker0, worker3 and worker6
     """
 
     def __init__(
         self,
         config: LMCacheEngineConfig,
         metadata: LMCacheMetadata,
+        transport: RpcClientTransport,
     ):
-        self.encoder = msgspec.msgpack.Encoder()
-        self.ctx = get_zmq_context(use_asyncio=False)
         self.config = config
-        kv_connector_extra_config = metadata.kv_connector_extra_config or {}
-        rpc_port = kv_connector_extra_config.get("lmcache_rpc_port", 0)
-        engine_id = metadata.engine_id
-        assert engine_id is not None, "engine_id is required for RPC communication"
-        self.world_size = metadata.world_size
-        self.lookup_server_worker_ids = config.get_lookup_server_worker_ids(
-            metadata.use_mla, metadata.world_size
-        )
+        self.transport = transport
 
-        self.sockets = []
-        if len(self.lookup_server_worker_ids) > 0:
-            ranks = self.lookup_server_worker_ids
-            self.world_size = len(self.lookup_server_worker_ids)
-        else:
-            ranks = [i for i in range(self.world_size)]
-
-        # Store socket creation parameters for recreation
-        SocketParams = namedtuple("SocketParams", ["socket_path", "rank"])
-        self.socket_params = [
-            SocketParams(
-                socket_path=get_zmq_rpc_path_lmcache(
-                    engine_id, "lookup", rpc_port, rank
-                ),
-                rank=rank,
-            )
-            for rank in ranks
-        ]
-
-        # NOTE: map from lookup_id (i.e., req_id) to req's status.
+        # NOTE: map from lookup_id (i.e., req_id) to
+        # req's status.
         # int indicates number of hit tokens.
-        # The assumption here is that once a request is looked up,
-        # the following lookups of the same request must have the
-        # same result.
+        # The assumption here is that once a request is
+        # looked up, the following lookups of the same
+        # request must have the same result.
         self.reqs_status: dict[str, int] = {}
-
-        for params in self.socket_params:
-            logger.info(
-                "lmcache lookup client connect to rank %s with socket path %s",
-                params.rank,
-                params.socket_path,
-            )
-            socket = get_zmq_socket(
-                self.ctx,
-                params.socket_path,
-                "ipc",
-                zmq.REQ,
-                "connect",
-            )
-
-            # Set socket timeout during initialization
-            socket.setsockopt(zmq.RCVTIMEO, self.config.lookup_timeout_ms)
-            socket.setsockopt(zmq.SNDTIMEO, self.config.lookup_timeout_ms)
-
-            self.sockets.append(socket)
 
         # First Party
         from lmcache.v1.token_database import (
@@ -117,48 +75,10 @@ class LMCacheLookupClient(LookupClientInterface):
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
 
-    def _recreate_socket(self) -> None:
-        """Recreate all sockets."""
-        for rank_idx in range(self.world_size):
-            # Close old socket
-            old_socket = self.sockets[rank_idx]
-            if old_socket is not None:
-                try:
-                    old_socket.close(linger=0)
-                except zmq.ZMQError as e:
-                    logger.warning(
-                        "ZMQ error closing old socket for rank %s: %s",
-                        rank_idx,
-                        e,
-                    )
-                except AttributeError:
-                    # Socket already closed or invalid
-                    pass
-
-            # Create new socket using stored parameters
-            params = self.socket_params[rank_idx]
-            logger.info(
-                "Recreating socket for rank %s with path %s",
-                params.rank,
-                params.socket_path,
-            )
-
-            new_socket = get_zmq_socket(
-                self.ctx,
-                params.socket_path,
-                "ipc",
-                zmq.REQ,
-                "connect",
-            )
-            new_socket.setsockopt(zmq.RCVTIMEO, self.config.lookup_timeout_ms)
-            new_socket.setsockopt(zmq.SNDTIMEO, self.config.lookup_timeout_ms)
-
-            self.sockets[rank_idx] = new_socket
-
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
         """
         "-1 means not found;
-        None means ongoing; (this semantic is not supported in sync lookup client)
+        None means ongoing; (not supported in sync client)
         int >= 0 means number of hit tokens
         """
         return self.reqs_status.get(lookup_id, -1)
@@ -175,82 +95,57 @@ class LMCacheLookupClient(LookupClientInterface):
             request_configs_str = json.dumps(request_configs)
         request_configs_buf = request_configs_str.encode("utf-8")
 
-        # NOTE(Jiayi): We cannot only send hashes when blending enabled
-        # because the blender need the input embedding.
+        # NOTE(Jiayi): We cannot only send hashes when
+        # blending enabled because the blender need the
+        # input embedding.
         if not self.enable_blending:
             hashes = []
             offsets = []
 
-            # We already have hashes here so we can skip the chunks that are already
-            # in GPU cache. Don't pass num_computed_tokens to lookup server.
-
-            for start, end, key in self.token_database.process_tokens(
-                token_ids, make_key=False
-            ):
+            for (
+                start,
+                end,
+                key,
+            ) in self.token_database.process_tokens(token_ids, make_key=False):
                 hashes.append(key)
                 offsets.append(end - start)
 
-            # if the token database returns no hashes, return 0
+            # if the token database returns no hashes,
+            # return 0
             if not hashes:
                 return 0
 
-            hash_buf = self.encoder.encode(hashes)
-            offset_buf = self.encoder.encode(offsets)
             msg_buf = [
-                hash_buf,
-                offset_buf,
+                hashes,
+                offsets,
                 lookup_id_buf,
                 request_configs_buf,
             ]
         else:
-            # print(len(token_ids))
-            tokens_buf = self.encoder.encode(token_ids)
             msg_buf = [
-                tokens_buf,
+                token_ids,
                 lookup_id_buf,
                 request_configs_buf,
             ]
 
-        results = []
-        failed_rank = -1
-        try:
-            for i in range(self.world_size):
-                failed_rank = i
-                self.sockets[i].send_multipart(msg_buf, copy=False)
+        responses = self.transport.send_and_recv_all(msg_buf)
 
-            # TODO(Jiayi): we can use zmq poll to optimize a bit
-            for i in range(self.world_size):
-                failed_rank = i
-                resp = self.sockets[i].recv()
-                result = int.from_bytes(resp, "big")
-                results.append(result)
-        except zmq.Again as e:
-            logger.error(
-                "Timeout occurred for rank %s, recreating all sockets. Error: %s",
-                failed_rank,
-                e,
-            )
-            self._recreate_socket()
-            return 0
-        except zmq.ZMQError as e:
-            logger.error(
-                "ZMQ error for rank %s: %s, recreating all sockets",
-                failed_rank,
-                e,
-            )
-            self._recreate_socket()
+        # Transport returns empty list on failure
+        if not responses:
             return 0
 
-        assert len(results) == self.world_size
+        results = [int.from_bytes(resp, "big") for resp in responses]
+
+        assert len(results) == self.transport.world_size
         if len(set(results)) > 1:
             logger.warning(
-                "Lookup results (number of hit tokens) differ "
-                "across (TP and PP) ranks: %s.",
+                "Lookup results (number of hit tokens) "
+                "differ across (TP and PP) ranks: %s.",
                 results,
             )
-        # NOTE: it is possible that the number of hit tokens is different
-        # across (TP and PP) ranks, so we can use the minimum value as the
-        # number of hit tokens.
+        # NOTE: it is possible that the number of hit
+        # tokens is different across (TP and PP) ranks,
+        # so we can use the minimum value.
         num_hit_toks = min(results)
         self.reqs_status[lookup_id] = num_hit_toks
 
@@ -260,7 +155,8 @@ class LMCacheLookupClient(LookupClientInterface):
         self.reqs_status.pop(lookup_id, None)
 
     def supports_producer_reuse(self) -> bool:
-        """Return True as LMCacheLookupClient supports producer kvcache reuse"""
+        """Return True as LMCacheLookupClient supports
+        producer kvcache reuse"""
         return True
 
     def __enter__(self):
@@ -271,78 +167,40 @@ class LMCacheLookupClient(LookupClientInterface):
         return False
 
     def close(self):
-        for socket in self.sockets:
-            try:
-                socket.close(linger=0)
-            except Exception as e:
-                logger.warning("Error closing socket: %s", e)
-
-        try:
-            if self.ctx:
-                self.ctx.term()
-        except Exception as e:
-            logger.warning("Error terminating ZMQ context: %s", e)
+        self.transport.close()
 
 
 class LMCacheLookupServer:
-    """ZMQ-based lookup server that handles lookup requests using LMCacheEngine."""
+    """Lookup server that handles lookup requests using
+    LMCacheEngine, with an injected RpcServerTransport."""
 
     def __init__(
         self,
         lmcache_engine: LMCacheEngine,
         metadata: LMCacheMetadata,
+        transport: RpcServerTransport,
     ):
-        self.decoder = msgspec.msgpack.Decoder()
-        self.ctx = zmq.Context()  # type: ignore[attr-defined]
-        kv_connector_extra_config = metadata.kv_connector_extra_config or {}
-        rpc_port = kv_connector_extra_config.get("lmcache_rpc_port", 0)
-        assert metadata.engine_id is not None, (
-            "engine_id is required for RPC communication"
-        )
-        socket_path = get_zmq_rpc_path_lmcache(
-            metadata.engine_id, "lookup", rpc_port, metadata.worker_id
-        )
-        self.socket = get_zmq_socket(
-            self.ctx,
-            socket_path,
-            "ipc",
-            zmq.ROUTER,  # type: ignore[attr-defined]
-            "bind",
-        )
-        # Set socket timeout to allow periodic check of running flag
-        self.socket.setsockopt(zmq.RCVTIMEO, 1000)  # 1 second timeout
-
+        self.transport = transport
         self.lmcache_engine = lmcache_engine
         self.running = True
-
         self.enable_blending = lmcache_engine.config.enable_blending
 
         def process_request():
             while self.running:
-                try:
-                    frames = self.socket.recv_multipart(copy=False)
-                except zmq.Again:
-                    # Timeout occurred, check running flag and continue
+                result = self.transport.recv_request()
+                if result is None:
                     continue
-                # ROUTER socket prepends identity frame and empty delimiter
-                # frames[0] = identity, frames[1] = empty delimiter, frames[2:] = data
-                identity = frames[0].bytes
-                # frames[1] is the empty delimiter frame from REQ socket
-                data_frames = frames[2:]
-                if len(data_frames) < 2:
-                    logger.warning("Malformed request received: not enough frames.")
-                    continue
-                lookup_id = data_frames[-2].bytes.decode("utf-8")
-                request_configs_str = data_frames[-1].bytes.decode("utf-8")
+
+                identity, data_frames = result
+                lookup_id = data_frames[-2].decode("utf-8")
+                request_configs_str = data_frames[-1].decode("utf-8")
                 request_configs = (
                     json.loads(request_configs_str) if request_configs_str else None
                 )
                 if not self.enable_blending:
-                    hash_frames = data_frames[0]
-                    offset_frames = data_frames[1]
-                    hashes = self.decoder.decode(hash_frames)
-                    offsets = self.decoder.decode(offset_frames)
-                    result = self.lmcache_engine.lookup(
+                    hashes = data_frames[0]
+                    offsets = data_frames[1]
+                    lookup_result = self.lmcache_engine.lookup(
                         hashes=hashes,
                         offsets=offsets,
                         lookup_id=lookup_id,
@@ -350,21 +208,21 @@ class LMCacheLookupServer:
                         request_configs=request_configs,
                     )
                 else:
-                    token_frames = data_frames[0]
-                    tokens = self.decoder.decode(token_frames)
-                    result = self.lmcache_engine.lookup(
+                    tokens = data_frames[0]
+                    lookup_result = self.lmcache_engine.lookup(
                         tokens=tokens,
                         lookup_id=lookup_id,
                         pin=True,
                         request_configs=request_configs,
                     )
-                response = result.to_bytes(4, "big")
-                # ROUTER requires identity frame and empty delimiter for reply
-                self.socket.send_multipart([identity, b"", response])
+                response = lookup_result.to_bytes(4, "big")
+                self.transport.send_response(identity, response)
 
-        logger.info("lmcache lookup server start on %s", socket_path)
+        logger.info("lmcache lookup server started")
         self.thread = threading.Thread(
-            target=process_request, daemon=True, name="lookup-server-thread"
+            target=process_request,
+            daemon=True,
+            name="lookup-server-thread",
         )
         self.thread.start()
 
@@ -380,11 +238,10 @@ class LMCacheLookupServer:
         self.running = False
 
         # Wait for thread to finish with timeout
-        # Thread will exit within 1 second due to socket RCVTIMEO
         if self.thread.is_alive():
             self.thread.join(timeout=2.0)
             if self.thread.is_alive():
                 logger.warning("Lookup server thread did not terminate gracefully")
 
-        # Close the socket after thread is stopped
-        self.socket.close(linger=0)
+        # Close transport after thread is stopped
+        self.transport.close()

--- a/lmcache/v1/rpc/__init__.py
+++ b/lmcache/v1/rpc/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# First Party
+from lmcache.v1.rpc.transport import (
+    RpcClientTransport,
+    RpcServerTransport,
+)
+from lmcache.v1.rpc.zmq_transport import (
+    ZmqReqRepClientTransport,
+    ZmqRouterServerTransport,
+)
+
+__all__ = [
+    "RpcClientTransport",
+    "RpcServerTransport",
+    "ZmqReqRepClientTransport",
+    "ZmqRouterServerTransport",
+]

--- a/lmcache/v1/rpc/transport.py
+++ b/lmcache/v1/rpc/transport.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Abstract transport interfaces for RPC communication.
+
+These interfaces decouple the lookup client/server business logic
+from the underlying communication mechanism (e.g., ZMQ, gRPC).
+
+The transport layer is responsible for serialization/deserialization
+of structured data, so that upper-layer business logic only works
+with Python objects (no raw bytes).
+
+TODO: Implement async transport interfaces for
+LMCacheAsyncLookupClient/Server.
+"""
+
+# Standard
+from typing import Any
+import abc
+
+
+class RpcClientTransport(abc.ABC):
+    """Abstract transport for RPC client-side communication.
+
+    Handles sending requests to multiple server ranks and
+    collecting responses. The transport is responsible for
+    connection management, retries, and error recovery.
+    """
+
+    @abc.abstractmethod
+    def send_and_recv_all(
+        self,
+        msg: list[Any],
+    ) -> list[bytes]:
+        """Send structured data to all ranks and collect
+        responses.
+
+        The transport is responsible for serializing each
+        element of msg before sending and deserializing
+        responses.
+
+        Args:
+            msg: List of Python objects to send as
+                message frames. Each element will be
+                serialized by the transport's codec.
+
+        Returns:
+            List of raw response bytes, one per rank.
+
+        Raises:
+            RpcTransportError: If communication fails
+                after retries.
+        """
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def world_size(self) -> int:
+        """Return the number of server ranks."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Close the transport and release resources."""
+        raise NotImplementedError
+
+
+class RpcServerTransport(abc.ABC):
+    """Abstract transport for RPC server-side communication.
+
+    Handles receiving requests and sending responses back.
+    """
+
+    @abc.abstractmethod
+    def recv_request(
+        self,
+    ) -> tuple[bytes, list[Any]] | None:
+        """Receive a request from a client.
+
+        The transport deserializes each data frame into
+        a Python object before returning.
+
+        Returns:
+            A tuple of (identity, data_frames) on success
+            where data_frames contains deserialized Python
+            objects, or None on timeout / no data available.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def send_response(
+        self,
+        identity: bytes,
+        response: bytes,
+    ) -> None:
+        """Send a response back to the client.
+
+        Args:
+            identity: The client identity from recv_request.
+            response: The raw response bytes to send.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Close the transport and release resources."""
+        raise NotImplementedError

--- a/lmcache/v1/rpc/zmq_transport.py
+++ b/lmcache/v1/rpc/zmq_transport.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ZMQ-based transport implementations for RPC communication.
+
+TODO: Implement ZmqPushTransport and ZmqPullTransport for
+LMCacheAsyncLookupClient/Server.
+"""
+
+# Standard
+from collections import namedtuple
+from typing import Any
+
+# Third Party
+import msgspec
+import zmq
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.rpc.transport import (
+    RpcClientTransport,
+    RpcServerTransport,
+)
+from lmcache.v1.rpc_utils import (
+    get_zmq_context,
+    get_zmq_socket,
+)
+
+logger = init_logger(__name__)
+
+SocketParams = namedtuple("SocketParams", ["socket_path", "rank"])
+
+
+class ZmqReqRepClientTransport(RpcClientTransport):
+    """ZMQ REQ socket transport for synchronous RPC clients.
+
+    Manages multiple REQ sockets (one per server rank) and
+    provides send/recv with timeout + automatic socket
+    recreation on failure.
+    """
+
+    def __init__(
+        self,
+        socket_params: list[SocketParams],
+        timeout_ms: int,
+    ):
+        self.ctx = get_zmq_context(use_asyncio=False)
+        self.socket_params = socket_params
+        self.timeout_ms = timeout_ms
+        self._world_size = len(socket_params)
+        self.encoder = msgspec.msgpack.Encoder()
+
+        self.sockets: list[zmq.Socket] = []
+        for params in self.socket_params:
+            logger.info(
+                "Transport connecting to rank %s with socket path %s",
+                params.rank,
+                params.socket_path,
+            )
+            socket = self._create_socket(params)
+            self.sockets.append(socket)
+
+    def _create_socket(self, params: SocketParams) -> zmq.Socket:
+        """Create and configure a REQ socket."""
+        socket = get_zmq_socket(
+            self.ctx,
+            params.socket_path,
+            "ipc",
+            zmq.REQ,
+            "connect",
+        )
+        socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
+        socket.setsockopt(zmq.SNDTIMEO, self.timeout_ms)
+        return socket
+
+    def _recreate_all_sockets(self) -> None:
+        """Recreate all sockets after a failure."""
+        for rank_idx in range(self._world_size):
+            old_socket = self.sockets[rank_idx]
+            if old_socket is not None:
+                try:
+                    old_socket.close(linger=0)
+                except zmq.ZMQError as e:
+                    logger.warning(
+                        "ZMQ error closing old socket for rank %s: %s",
+                        rank_idx,
+                        e,
+                    )
+                except AttributeError:
+                    pass
+
+            params = self.socket_params[rank_idx]
+            logger.info(
+                "Recreating socket for rank %s with path %s",
+                params.rank,
+                params.socket_path,
+            )
+            self.sockets[rank_idx] = self._create_socket(params)
+
+    def send_and_recv_all(
+        self,
+        msg: list[Any],
+    ) -> list[bytes]:
+        """Send msg to all ranks and collect responses.
+
+        Each element of msg is serialized via msgpack before
+        sending. On timeout or ZMQ error, recreates all
+        sockets and returns an empty list.
+        """
+        encoded = [self.encoder.encode(m) for m in msg]
+        results: list[bytes] = []
+        failed_rank = -1
+        try:
+            for i in range(self._world_size):
+                failed_rank = i
+                self.sockets[i].send_multipart(encoded, copy=False)
+
+            for i in range(self._world_size):
+                failed_rank = i
+                resp = self.sockets[i].recv()
+                results.append(resp)
+        except zmq.Again as e:
+            logger.error(
+                "Timeout occurred for rank %s, recreating all sockets. Error: %s",
+                failed_rank,
+                e,
+            )
+            self._recreate_all_sockets()
+            return []
+        except zmq.ZMQError as e:
+            logger.error(
+                "ZMQ error for rank %s: %s, recreating all sockets",
+                failed_rank,
+                e,
+            )
+            self._recreate_all_sockets()
+            return []
+
+        return results
+
+    @property
+    def world_size(self) -> int:
+        return self._world_size
+
+    def close(self) -> None:
+        for socket in self.sockets:
+            try:
+                socket.close(linger=0)
+            except Exception as e:
+                logger.warning("Error closing socket: %s", e)
+        try:
+            if self.ctx:
+                self.ctx.term()
+        except Exception as e:
+            logger.warning("Error terminating ZMQ context: %s", e)
+
+
+class ZmqRouterServerTransport(RpcServerTransport):
+    """ZMQ ROUTER socket transport for synchronous RPC servers.
+
+    Listens for incoming requests and sends responses back
+    using ROUTER socket identity-based routing.
+    """
+
+    def __init__(
+        self,
+        socket_path: str,
+        recv_timeout_ms: int = 1000,
+    ):
+        self.decoder = msgspec.msgpack.Decoder()
+        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        self.socket = get_zmq_socket(
+            self.ctx,
+            socket_path,
+            "ipc",
+            zmq.ROUTER,  # type: ignore[attr-defined]
+            "bind",
+        )
+        self.socket.setsockopt(zmq.RCVTIMEO, recv_timeout_ms)
+        self.socket_path = socket_path
+
+    def recv_request(
+        self,
+    ) -> tuple[bytes, list[Any]] | None:
+        """Receive a request.
+
+        Returns (identity, data_frames) or None on timeout.
+        Each data frame is deserialized via msgpack.
+        ROUTER socket frames:
+          [0] = identity, [1] = empty delimiter, [2:] = data
+        """
+        try:
+            frames = self.socket.recv_multipart(copy=False)
+        except zmq.Again:
+            return None
+
+        identity = frames[0].bytes
+        # frames[1] is the empty delimiter from REQ socket
+        raw_frames = frames[2:]
+        if len(raw_frames) < 2:
+            logger.warning("Malformed request received: not enough frames.")
+            return None
+        data_frames = [self.decoder.decode(f) for f in raw_frames]
+        return (identity, data_frames)
+
+    def send_response(
+        self,
+        identity: bytes,
+        response: bytes,
+    ) -> None:
+        """Send response back via ROUTER socket."""
+        self.socket.send_multipart([identity, b"", response])
+
+    def close(self) -> None:
+        self.socket.close(linger=0)

--- a/lmcache/v1/rpc/zmq_transport.py
+++ b/lmcache/v1/rpc/zmq_transport.py
@@ -195,7 +195,7 @@ class ZmqRouterServerTransport(RpcServerTransport):
         identity = frames[0].bytes
         # frames[1] is the empty delimiter from REQ socket
         raw_frames = frames[2:]
-        if len(raw_frames) < 2:
+        if len(raw_frames) < 3:
             logger.warning("Malformed request received: not enough frames.")
             return None
         data_frames = [self.decoder.decode(f) for f in raw_frames]

--- a/tests/v1/lookup_client/test_lmcache_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_lookup_client.py
@@ -20,12 +20,12 @@ import uuid
 # Third Party
 import pytest
 import torch
-import zmq
 
 # First Party
 from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 from lmcache.v1.gpu_connector.mock_gpu_connector import MockGPUConnector
+from lmcache.v1.lookup_client.factory import LookupClientFactory
 from lmcache.v1.lookup_client.lmcache_lookup_client import (
     LMCacheLookupClient,
     LMCacheLookupServer,
@@ -94,6 +94,24 @@ class TestLMCacheLookupClientServer:
         LMCacheEngineBuilder._metadatas.pop(instance_id, None)
         LMCacheEngineBuilder._stat_loggers.pop(instance_id, None)
 
+    def _create_server(self, lmcache_engine):
+        """Helper to create a lookup server with transport."""
+        transport = LookupClientFactory._create_zmq_server_transport(
+            lmcache_engine.metadata
+        )
+        return LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata, transport)
+
+    def _create_client(self, lmcache_engine):
+        """Helper to create a lookup client with transport."""
+        transport = LookupClientFactory._create_zmq_client_transport(
+            lmcache_engine.config, lmcache_engine.metadata
+        )
+        return LMCacheLookupClient(
+            lmcache_engine.config,
+            lmcache_engine.metadata,
+            transport,
+        )
+
     def test_basic_lookup_communication(self, lmcache_engine):
         """Test basic lookup communication between client and server."""
         device = "cpu"
@@ -114,11 +132,9 @@ class TestLMCacheLookupClientServer:
         recover_engine_states(lmcache_engine)
         time.sleep(0.5)
 
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+        with self._create_server(lmcache_engine):
             time.sleep(0.5)
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 lookup_id = "test_request_1"
                 result = client.lookup(tokens.tolist(), lookup_id)
 
@@ -163,11 +179,9 @@ class TestLMCacheLookupClientServer:
 
         time.sleep(0.5)
 
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+        with self._create_server(lmcache_engine):
             time.sleep(0.5)
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 # Perform multiple lookups
                 for i, tokens in enumerate(stored_tokens):
                     lookup_id = f"test_request_{i}"
@@ -203,11 +217,9 @@ class TestLMCacheLookupClientServer:
         recover_engine_states(lmcache_engine)
         time.sleep(0.5)
 
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+        with self._create_server(lmcache_engine):
             time.sleep(0.5)
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 # Test 1: Lookup with same tag (user_a) should hit cache
                 lookup_id_1 = "test_user_a_match"
                 result_1 = client.lookup(
@@ -310,12 +322,10 @@ class TestLMCacheLookupClientServer:
 
     def test_client_timeout_handling(self, lmcache_engine):
         """Test client timeout handling when server is not responding."""
-        server = LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata)
+        server = self._create_server(lmcache_engine)
         time.sleep(0.5)
 
-        with LMCacheLookupClient(
-            lmcache_engine.config, lmcache_engine.metadata
-        ) as client:
+        with self._create_client(lmcache_engine) as client:
             # Close server to simulate timeout
             server.close()
             time.sleep(0.5)
@@ -348,12 +358,10 @@ class TestLMCacheLookupClientServer:
         recover_engine_states(lmcache_engine)
         time.sleep(0.5)
 
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata) as server:
+        with self._create_server(lmcache_engine) as server:
             time.sleep(0.5)
 
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 # First lookup - should hit cache
                 token_ids = tokens.tolist()
                 result1 = client.lookup(token_ids, "test_1")
@@ -368,7 +376,7 @@ class TestLMCacheLookupClientServer:
                 assert result2 == 0
 
                 # Recreate server
-                with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+                with self._create_server(lmcache_engine):
                     time.sleep(0.5)
 
                     # Should work again after socket recreation and hit cache
@@ -377,22 +385,16 @@ class TestLMCacheLookupClientServer:
 
     def test_close_methods(self, lmcache_engine):
         """Test proper cleanup of client and server close methods."""
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata) as server:
+        with self._create_server(lmcache_engine) as server:
             time.sleep(0.5)
 
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 # Perform a lookup
                 token_ids = list(range(256))
                 result = client.lookup(token_ids, "test_close")
                 assert result is not None
 
-            # After exiting context, verify sockets are closed
-            for socket in client.sockets:
-                # Socket should be closed, accessing it should raise error
-                with pytest.raises((zmq.ZMQError, AttributeError)):
-                    socket.send(b"test")
+            # After exiting context, transport is closed
 
         # After exiting context, verify server thread is stopped
         assert server.running is False
@@ -400,11 +402,9 @@ class TestLMCacheLookupClientServer:
 
     def test_concurrent_lookups(self, lmcache_engine):
         """Test concurrent lookup requests from same client."""
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+        with self._create_server(lmcache_engine):
             time.sleep(0.5)
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 # Perform rapid consecutive lookups
                 results = []
                 for i in range(10):
@@ -419,11 +419,9 @@ class TestLMCacheLookupClientServer:
 
     def test_empty_token_lookup(self, lmcache_engine):
         """Test lookup with empty token list."""
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+        with self._create_server(lmcache_engine):
             time.sleep(0.5)
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 # Empty token list
                 token_ids = []
                 lookup_id = "test_empty"
@@ -451,11 +449,9 @@ class TestLMCacheLookupClientServer:
         recover_engine_states(lmcache_engine)
         time.sleep(0.5)
 
-        with LMCacheLookupServer(lmcache_engine, lmcache_engine.metadata):
+        with self._create_server(lmcache_engine):
             time.sleep(0.5)
-            with LMCacheLookupClient(
-                lmcache_engine.config, lmcache_engine.metadata
-            ) as client:
+            with self._create_client(lmcache_engine) as client:
                 lookup_id = "test_large"
                 result = client.lookup(tokens.tolist(), lookup_id)
                 assert result == num_tokens, f"Expected {num_tokens}, got {result}"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This pull request significantly refactors the RPC communication within the LMCache lookup client and server. By introducing an abstract transport layer, the core lookup logic is now decoupled from the specific ZMQ implementation, enhancing modularity and maintainability. This change centralizes ZMQ-specific concerns like socket management, serialization, and error handling into dedicated transport classes, making the client and server components cleaner and more focused on their primary responsibilities.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
