### PR TITLE
[Bugfix] Fix layerwise wait_for_save concurrency crash with request-scoped storers

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1603,7 +1603,9 @@ class LMCacheConnectorV1Impl:
         # Layerwise save uses request-scoped generators. If request finishes
         # without entering wait_for_save (abort/error/evict path), make sure
         # we release the generator entry to avoid leaking state.
-        if self.use_layerwise:
+        if getattr(self, "use_layerwise", False) and hasattr(
+            self, "_layerwise_save_storers"
+        ):
             self._layerwise_save_storers.pop(request.request_id, None)
 
         # Cleanup if request was aborted

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -957,6 +957,9 @@ class LMCacheConnectorV1Impl:
                 num_retrieved_tokens = ret_token_mask.sum().item()
                 logger.info(f"Retrieved {num_retrieved_tokens} tokens")
 
+        if self.layerwise_retrievers:
+            self.current_layer += 1
+
         return
 
     @_lmcache_nvtx_annotate

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1025,6 +1025,7 @@ class LMCacheConnectorV1Impl:
                 if self.kv_role == "kv_producer":
                     skip_leading_tokens = 0
                 else:
+                    assert save_spec is not None
                     skip_leading_tokens = save_spec.skip_leading_tokens
 
                     if skip_leading_tokens == len(token_ids):

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -506,7 +506,9 @@ class LMCacheConnectorV1Impl:
         self.layerwise_retrievers: list[
             Generator[Optional[torch.Tensor], None, None]
         ] = []
-        self.layerwise_storers: list[Generator[Optional[torch.Tensor], None, None]] = []
+        self._layerwise_save_storers: dict[
+            str, Generator[Optional[torch.Tensor], None, None]
+        ] = {}
         self._stats_monitor = LMCStatsMonitor.GetOrCreate()
 
         # Role-specific initialization
@@ -999,16 +1001,17 @@ class LMCacheConnectorV1Impl:
         assert len(self.kv_caches) > 0
 
         kvcaches = list(self.kv_caches.values())
-        if self.current_layer == 0:
-            self.layerwise_storers = []
+        is_first = True
 
-            is_first = True
+        for request in connector_metadata.requests:
+            save_spec = request.save_spec
+            if (
+                save_spec is None or not save_spec.can_save
+            ) and self.kv_role != "kv_producer":
+                continue
 
-            for idx, request in enumerate(connector_metadata.requests):
-                save_spec = request.save_spec
-                if save_spec is None or not save_spec.can_save:
-                    continue
-
+            layerwise_storer = self._layerwise_save_storers.get(request.req_id)
+            if layerwise_storer is None:
                 token_ids = request.token_ids
                 assert isinstance(token_ids, list)
 
@@ -1056,14 +1059,11 @@ class LMCacheConnectorV1Impl:
                     sync=is_first,
                     req_id=request.req_id,
                 )
-                self.layerwise_storers.append(layerwise_storer)
+                self._layerwise_save_storers[request.req_id] = layerwise_storer
                 if is_first:
                     is_first = False
 
-        for layerwise_storer in self.layerwise_storers:
             next(layerwise_storer)
-
-        self.current_layer += 1
 
     @_lmcache_nvtx_annotate
     def wait_for_save(self):
@@ -1077,11 +1077,13 @@ class LMCacheConnectorV1Impl:
             return
 
         if self.use_layerwise:
-            for layerwise_storer in self.layerwise_storers:
-                next(layerwise_storer)
-
-            # unpin the kv caches according to req_id
             for request in connector_metadata.requests:
+                layerwise_storer = self._layerwise_save_storers.pop(
+                    request.req_id, None
+                )
+                if layerwise_storer is not None:
+                    next(layerwise_storer)
+                # unpin the kv caches according to req_id
                 self.lmcache_engine.lookup_unpin(request.req_id)
             return
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1600,6 +1600,12 @@ class LMCacheConnectorV1Impl:
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, Optional[dict[str, Any]]]:
+        # Layerwise save uses request-scoped generators. If request finishes
+        # without entering wait_for_save (abort/error/evict path), make sure
+        # we release the generator entry to avoid leaking state.
+        if self.use_layerwise:
+            self._layerwise_save_storers.pop(request.request_id, None)
+
         # Cleanup if request was aborted
         if request.status == RequestStatus.FINISHED_ABORTED and self.async_loading:
             # Cancel any ongoing async lookup and prefetch tasks on workers

--- a/tests/v1/test_vllm_layerwise_wait_for_save.py
+++ b/tests/v1/test_vllm_layerwise_wait_for_save.py
@@ -113,9 +113,38 @@ def test_wait_for_save_repeated_call_does_not_readvance_finalized_storer() -> No
     assert engine.store_steps["req-1"] == 2
 
 
+def test_multi_layer_save_and_finalize() -> None:
+    connector, _, engine = _make_connector([_make_req("req-1"), _make_req("req-2")])
+    num_layers = 4
+
+    for _ in range(num_layers):
+        connector.save_kv_layer("layer_x", torch.zeros(1), None)
+
+    assert engine.store_steps["req-1"] == num_layers
+    assert engine.store_steps["req-2"] == num_layers
+
+    connector.wait_for_save()
+    assert engine.store_steps["req-1"] == num_layers + 1
+    assert engine.store_steps["req-2"] == num_layers + 1
+    assert connector._layerwise_save_storers == {}
+
+
 def test_layerwise_save_skips_requests_that_cannot_save() -> None:
     connector, _, engine = _make_connector([_make_req("req-1", can_save=False)])
     connector.kv_role = "kv_both"
     connector.save_kv_layer("layer0", torch.zeros(1), None)
     assert engine.store_calls == []
+    assert connector._layerwise_save_storers == {}
+
+
+def test_layerwise_save_kv_producer_ignores_can_save_flag() -> None:
+    connector, _, engine = _make_connector([_make_req("req-1", can_save=False)])
+
+    connector.save_kv_layer("layer0", torch.zeros(1), None)
+    assert engine.store_calls == ["req-1"]
+    assert engine.store_steps["req-1"] == 1
+    assert set(connector._layerwise_save_storers.keys()) == {"req-1"}
+
+    connector.wait_for_save()
+    assert engine.store_steps["req-1"] == 2
     assert connector._layerwise_save_storers == {}

--- a/tests/v1/test_vllm_layerwise_wait_for_save.py
+++ b/tests/v1/test_vllm_layerwise_wait_for_save.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+import torch
+from vllm.v1.request import RequestStatus
+
+pytest.importorskip("vllm")
+
+# First Party
+from lmcache.integration.vllm.vllm_v1_adapter import (
+    LMCacheConnectorMetadata,
+    LMCacheConnectorV1Impl,
+    SaveSpec,
+)
+
+
+class _FakeParent:
+    def __init__(self, metadata):
+        self._connector_metadata = metadata
+
+    def _get_connector_metadata(self):
+        return self._connector_metadata
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.unpinned: list[str] = []
+        self.store_steps: dict[str, int] = {}
+        self.store_calls: list[str] = []
+
+    def lookup_unpin(self, req_id: str) -> None:
+        self.unpinned.append(req_id)
+
+    def store_layer(self, token_ids, **kwargs):
+        req_id = kwargs["req_id"]
+        self.store_calls.append(req_id)
+        self.store_steps.setdefault(req_id, 0)
+
+        def _storer():
+            while True:
+                self.store_steps[req_id] += 1
+                yield None
+
+        return _storer()
+
+
+class _FakeManager:
+    def __init__(self, engine: _FakeEngine):
+        self.lmcache_engine = engine
+        self.lookup_client = None
+
+
+class _FakeLookupClient:
+    def __init__(self):
+        self.cancelled: list[str] = []
+
+    def cancel_lookup(self, lookup_id: str):
+        self.cancelled.append(lookup_id)
+
+
+def _make_req(req_id: str, can_save: bool = True):
+    return SimpleNamespace(
+        req_id=req_id,
+        token_ids=[1, 2, 3, 4],
+        slot_mapping=torch.arange(4, dtype=torch.long),
+        save_spec=SaveSpec(skip_leading_tokens=0, can_save=can_save),
+    )
+
+
+def _make_connector(requests):
+    metadata = LMCacheConnectorMetadata(requests=requests)
+    engine = _FakeEngine()
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector._parent = _FakeParent(metadata)
+    connector._manager = _FakeManager(engine)
+    connector.kv_role = "kv_producer"
+    connector.use_layerwise = True
+    connector.device = "cpu"
+    connector._lmcache_chunk_size = 8
+    connector.kv_caches = {"layer0": torch.zeros(1)}
+    connector._layerwise_save_storers = {}
+    connector.async_loading = False
+    return connector, metadata, engine
+
+
+def test_layerwise_storer_is_request_scoped_across_interleaved_finalize() -> None:
+    connector, metadata, engine = _make_connector(
+        [_make_req("req-1"), _make_req("req-2")]
+    )
+
+    connector.save_kv_layer("layer0", torch.zeros(1), None)
+    assert engine.store_calls == ["req-1", "req-2"]
+    assert engine.store_steps["req-1"] == 1
+    assert engine.store_steps["req-2"] == 1
+
+    metadata.requests = [_make_req("req-1")]
+    connector.wait_for_save()
+    assert engine.store_steps["req-1"] == 2
+    assert engine.store_steps["req-2"] == 1
+    assert engine.unpinned == ["req-1"]
+    assert set(connector._layerwise_save_storers.keys()) == {"req-2"}
+
+    metadata.requests = [_make_req("req-2")]
+    connector.wait_for_save()
+    assert engine.store_steps["req-2"] == 2
+    assert engine.unpinned == ["req-1", "req-2"]
+    assert connector._layerwise_save_storers == {}
+
+
+def test_wait_for_save_repeated_call_does_not_readvance_finalized_storer() -> None:
+    connector, metadata, engine = _make_connector([_make_req("req-1")])
+    connector.save_kv_layer("layer0", torch.zeros(1), None)
+    assert engine.store_steps["req-1"] == 1
+
+    connector.wait_for_save()
+    assert engine.store_steps["req-1"] == 2
+    assert connector._layerwise_save_storers == {}
+
+    connector.wait_for_save()
+    assert engine.store_steps["req-1"] == 2
+
+
+def test_layerwise_save_skips_requests_that_cannot_save() -> None:
+    connector, _, engine = _make_connector([_make_req("req-1", can_save=False)])
+    connector.kv_role = "kv_both"
+    connector.save_kv_layer("layer0", torch.zeros(1), None)
+    assert engine.store_calls == []
+    assert connector._layerwise_save_storers == {}
+
+
+def test_request_finished_aborted_cleans_layerwise_storer() -> None:
+    connector, _, _ = _make_connector([_make_req("req-1")])
+    connector.async_loading = True
+    connector._manager.lookup_client = _FakeLookupClient()
+    connector._layerwise_save_storers = {"req-1": iter([None])}
+
+    req = SimpleNamespace(status=RequestStatus.FINISHED_ABORTED, request_id="req-1")
+    connector.request_finished(req, [])
+
+    assert connector._layerwise_save_storers == {}
+    assert connector.lookup_client is not None
+    assert connector.lookup_client.cancelled == ["req-1"]
+
+
+def test_request_finished_normal_cleans_layerwise_storer() -> None:
+    connector, _, _ = _make_connector([_make_req("req-2")])
+    connector._layerwise_save_storers = {"req-2": iter([None])}
+
+    req = SimpleNamespace(status=RequestStatus.FINISHED_STOPPED, request_id="req-2")
+    connector.request_finished(req, [])
+
+    assert connector._layerwise_save_storers == {}

--- a/tests/v1/test_vllm_layerwise_wait_for_save.py
+++ b/tests/v1/test_vllm_layerwise_wait_for_save.py
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Standard
 from types import SimpleNamespace
 
-# Third Party
-import pytest
 import torch
-from vllm.v1.request import RequestStatus
 
-pytest.importorskip("vllm")
-
-# First Party
 from lmcache.integration.vllm.vllm_v1_adapter import (
     LMCacheConnectorMetadata,
     LMCacheConnectorV1Impl,
@@ -51,15 +44,6 @@ class _FakeEngine:
 class _FakeManager:
     def __init__(self, engine: _FakeEngine):
         self.lmcache_engine = engine
-        self.lookup_client = None
-
-
-class _FakeLookupClient:
-    def __init__(self):
-        self.cancelled: list[str] = []
-
-    def cancel_lookup(self, lookup_id: str):
-        self.cancelled.append(lookup_id)
 
 
 def _make_req(req_id: str, can_save: bool = True):
@@ -83,8 +67,6 @@ def _make_connector(requests):
     connector._lmcache_chunk_size = 8
     connector.kv_caches = {"layer0": torch.zeros(1)}
     connector._layerwise_save_storers = {}
-    connector.current_layer = 0
-    connector.async_loading = False
     return connector, metadata, engine
 
 
@@ -101,15 +83,15 @@ def test_layerwise_storer_is_request_scoped_across_interleaved_finalize() -> Non
     metadata.requests = [_make_req("req-1")]
     connector.wait_for_save()
     assert engine.store_steps["req-1"] == 2
-    assert engine.store_steps["req-2"] == 2
+    assert engine.store_steps["req-2"] == 1
     assert engine.unpinned == ["req-1"]
-    assert len(connector.layerwise_storers) == 2
+    assert set(connector._layerwise_save_storers.keys()) == {"req-2"}
 
     metadata.requests = [_make_req("req-2")]
     connector.wait_for_save()
-    assert engine.store_steps["req-2"] == 3
+    assert engine.store_steps["req-2"] == 2
     assert engine.unpinned == ["req-1", "req-2"]
-    assert len(connector.layerwise_storers) == 2
+    assert connector._layerwise_save_storers == {}
 
 
 def test_wait_for_save_repeated_call_does_not_readvance_finalized_storer() -> None:
@@ -119,10 +101,10 @@ def test_wait_for_save_repeated_call_does_not_readvance_finalized_storer() -> No
 
     connector.wait_for_save()
     assert engine.store_steps["req-1"] == 2
-    assert len(connector.layerwise_storers) == 1
+    assert connector._layerwise_save_storers == {}
 
     connector.wait_for_save()
-    assert engine.store_steps["req-1"] == 3
+    assert engine.store_steps["req-1"] == 2
 
 
 def test_layerwise_save_skips_requests_that_cannot_save() -> None:
@@ -130,36 +112,4 @@ def test_layerwise_save_skips_requests_that_cannot_save() -> None:
     connector.kv_role = "kv_both"
     connector.save_kv_layer("layer0", torch.zeros(1), None)
     assert engine.store_calls == []
-    assert connector.layerwise_storers == []
-
-
-def test_request_finished_aborted_cleans_layerwise_storer() -> None:
-    connector, _, _ = _make_connector([_make_req("req-1")])
-    connector.async_loading = True
-    connector._manager.lookup_client = _FakeLookupClient()
-    connector._layerwise_save_storers = {"req-1": iter([None])}
-
-    req = SimpleNamespace(status=RequestStatus.FINISHED_ABORTED, request_id="req-1")
-    connector.request_finished(req, [])
-
     assert connector._layerwise_save_storers == {}
-    assert connector.lookup_client is not None
-    assert connector.lookup_client.cancelled == ["req-1"]
-
-
-def test_request_finished_normal_cleans_layerwise_storer() -> None:
-    connector, _, _ = _make_connector([_make_req("req-2")])
-    connector._layerwise_save_storers = {"req-2": iter([None])}
-
-    req = SimpleNamespace(status=RequestStatus.FINISHED_STOPPED, request_id="req-2")
-    connector.request_finished(req, [])
-
-    assert connector._layerwise_save_storers == {}
-
-
-def test_request_finished_without_use_layerwise_attribute() -> None:
-    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
-    req = SimpleNamespace(status=RequestStatus.FINISHED_STOPPED, request_id="req-x")
-
-    # Ensure this path is safe even if use_layerwise is not initialized yet.
-    connector.request_finished(req, [])

--- a/tests/v1/test_vllm_layerwise_wait_for_save.py
+++ b/tests/v1/test_vllm_layerwise_wait_for_save.py
@@ -83,6 +83,7 @@ def _make_connector(requests):
     connector._lmcache_chunk_size = 8
     connector.kv_caches = {"layer0": torch.zeros(1)}
     connector._layerwise_save_storers = {}
+    connector.current_layer = 0
     connector.async_loading = False
     return connector, metadata, engine
 
@@ -100,15 +101,15 @@ def test_layerwise_storer_is_request_scoped_across_interleaved_finalize() -> Non
     metadata.requests = [_make_req("req-1")]
     connector.wait_for_save()
     assert engine.store_steps["req-1"] == 2
-    assert engine.store_steps["req-2"] == 1
+    assert engine.store_steps["req-2"] == 2
     assert engine.unpinned == ["req-1"]
-    assert set(connector._layerwise_save_storers.keys()) == {"req-2"}
+    assert len(connector.layerwise_storers) == 2
 
     metadata.requests = [_make_req("req-2")]
     connector.wait_for_save()
-    assert engine.store_steps["req-2"] == 2
+    assert engine.store_steps["req-2"] == 3
     assert engine.unpinned == ["req-1", "req-2"]
-    assert connector._layerwise_save_storers == {}
+    assert len(connector.layerwise_storers) == 2
 
 
 def test_wait_for_save_repeated_call_does_not_readvance_finalized_storer() -> None:
@@ -118,10 +119,10 @@ def test_wait_for_save_repeated_call_does_not_readvance_finalized_storer() -> No
 
     connector.wait_for_save()
     assert engine.store_steps["req-1"] == 2
-    assert connector._layerwise_save_storers == {}
+    assert len(connector.layerwise_storers) == 1
 
     connector.wait_for_save()
-    assert engine.store_steps["req-1"] == 2
+    assert engine.store_steps["req-1"] == 3
 
 
 def test_layerwise_save_skips_requests_that_cannot_save() -> None:
@@ -129,7 +130,7 @@ def test_layerwise_save_skips_requests_that_cannot_save() -> None:
     connector.kv_role = "kv_both"
     connector.save_kv_layer("layer0", torch.zeros(1), None)
     assert engine.store_calls == []
-    assert connector._layerwise_save_storers == {}
+    assert connector.layerwise_storers == []
 
 
 def test_request_finished_aborted_cleans_layerwise_storer() -> None:
@@ -154,3 +155,11 @@ def test_request_finished_normal_cleans_layerwise_storer() -> None:
     connector.request_finished(req, [])
 
     assert connector._layerwise_save_storers == {}
+
+
+def test_request_finished_without_use_layerwise_attribute() -> None:
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    req = SimpleNamespace(status=RequestStatus.FINISHED_STOPPED, request_id="req-x")
+
+    # Ensure this path is safe even if use_layerwise is not initialized yet.
+    connector.request_finished(req, [])

--- a/tests/v1/test_vllm_layerwise_wait_for_save.py
+++ b/tests/v1/test_vllm_layerwise_wait_for_save.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
 from types import SimpleNamespace
 
+# Third Party
+import pytest
 import torch
 
+pytest.importorskip("vllm")
+
+# First Party
 from lmcache.integration.vllm.vllm_v1_adapter import (
     LMCacheConnectorMetadata,
     LMCacheConnectorV1Impl,


### PR DESCRIPTION
fix #2453 
This PR fixes a layerwise save concurrency bug in the vLLM v1 integration that 
could crash EngineCore under high-concurrency traffic.

In the previous flow, layerwise save generators were tracked in a shared list and finalized without request-level ownership. Under interleaved request scheduling, wait_for_save() could advance an already-exhausted generator, causing StopIteration / RuntimeError: generator raised StopIteration, which then surfaced as EngineDeadError.

This patch makes layerwise storers request-scoped (req_id -> generator) and finalizes them by request ID, 
preventing cross-request generator reuse.

  It also aligns a layerwise save skip condition with non-layerwise behavior:

  - (save_spec is None or not save_spec.can_save) is skipped only for non-kv_producer roles.

  If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
