### PR TITLE
Add a backend api to support dynamic  close&create backends

### DIFF
--- a/docs/source/internal_api_server/dynamic_backend_management.rst
+++ b/docs/source/internal_api_server/dynamic_backend_management.rst
@@ -1,0 +1,176 @@
+.. _dynamic_backend_management:
+
+Dynamic Backend Management
+==========================
+
+LMCache provides a set of internal API endpoints that allow you to **list**,
+**close**, and **create** storage backends at runtime without restarting the
+serving engine.  This is useful when you need to switch between different
+storage configurations on the fly — for example, migrating from a
+``LocalDiskBackend`` to a ``GdsBackend``, or changing the remote connector
+from a filesystem connector to Redis.
+
+Overview
+--------
+
+The workflow for dynamically switching a storage backend is:
+
+1. **Close** the backend you want to replace.
+2. **Update** the relevant configuration via the ``POST /conf`` API.
+3. **Create** new backends — only backends that are not already present
+   will be created.
+
+Any backend that was **not** closed will be skipped during creation,
+so the operation is safe and idempotent.
+
+API Endpoints
+-------------
+
+``GET /backends``
+^^^^^^^^^^^^^^^^^
+
+List all active storage backends.
+
+.. code-block:: bash
+
+    curl http://localhost:7000/backends
+
+Response:
+
+.. code-block:: json
+
+    {
+      "LocalCPUBackend": "LocalCPUBackend",
+      "RemoteBackend": "RemoteBackend"
+    }
+
+``DELETE /backends/{backend_name}``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Close and remove a specific storage backend.  After this call the backend
+is fully shut down and removed from the internal dictionary, ensuring no
+stale references remain.
+
+.. code-block:: bash
+
+    curl -X DELETE http://localhost:7000/backends/RemoteBackend
+
+Response:
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "message": "Backend RemoteBackend closed",
+      "backends": {
+        "LocalCPUBackend": "LocalCPUBackend"
+      }
+    }
+
+``POST /backends``
+^^^^^^^^^^^^^^^^^^
+
+Create new storage backends based on the current ``LMCacheEngineConfig``.
+Existing backends are skipped.
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:7000/backends
+
+Response:
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "created": {
+        "RemoteBackend": "RemoteBackend"
+      },
+      "backends": {
+        "LocalCPUBackend": "LocalCPUBackend",
+        "RemoteBackend": "RemoteBackend"
+      }
+    }
+
+Use-Case Examples
+-----------------
+
+Switching from ``LocalDiskBackend`` to ``GdsBackend``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you originally configured a local-disk backend and want to migrate to
+NVIDIA GPUDirect Storage (GDS) at runtime:
+
+.. code-block:: bash
+
+    # 1. Close the old disk backend
+    curl -X DELETE http://localhost:7000/backends/LocalDiskBackend
+
+    # 2. Disable local_disk and set the GDS path
+    curl -X POST http://localhost:7000/conf \
+      -H "Content-Type: application/json" \
+      -d '{
+        "local_disk": false,
+        "gds_path": "/mnt/nvme/lmcache_gds"
+      }'
+
+    # 3. Create the new GDS backend
+    curl -X POST http://localhost:7000/backends
+
+    # 4. Verify the new backend list
+    curl http://localhost:7000/backends
+
+Switching ``RemoteBackend`` connector (FS → Redis)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the remote connector type without restarting:
+
+.. code-block:: bash
+
+    # 1. Close the old remote backend
+    curl -X DELETE http://localhost:7000/backends/RemoteBackend
+
+    # 2. Update the remote URL to point to Redis
+    curl -X POST http://localhost:7000/conf \
+      -H "Content-Type: application/json" \
+      -d '{
+        "remote_url": "redis://redis-host:6379"
+      }'
+
+    # 3. Create the new remote backend with Redis connector
+    curl -X POST http://localhost:7000/backends
+
+    # 4. Verify
+    curl http://localhost:7000/backends
+
+Replacing only one backend while keeping others
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If only the ``RemoteBackend`` needs to be updated but the
+``LocalCPUBackend`` should stay untouched:
+
+.. code-block:: bash
+
+    # Close only the remote backend
+    curl -X DELETE http://localhost:7000/backends/RemoteBackend
+
+    # Update config
+    curl -X POST http://localhost:7000/conf \
+      -H "Content-Type: application/json" \
+      -d '{"remote_url": "redis://new-redis:6379"}'
+
+    # Create — LocalCPUBackend is skipped (already present)
+    curl -X POST http://localhost:7000/backends
+
+Notes
+-----
+
+- Closing the ``LocalCPUBackend`` is possible but should be done with
+  caution since many other backends rely on it as an intermediate buffer.
+- The ``POST /backends`` endpoint calls the same ``CreateStorageBackends``
+  factory that is used during engine initialization, so all backend types
+  (local CPU, local disk, GDS, remote, P2P, plugins, etc.) are
+  supported.
+- After creating backends, the ``StorageManager`` automatically refreshes
+  its internal references (``non_allocator_backends``,
+  ``local_cpu_backend``, etc.).

--- a/lmcache/v1/internal_api_server/vllm/backend_api.py
+++ b/lmcache/v1/internal_api_server/vllm/backend_api.py
@@ -165,3 +165,57 @@ async def create_backends(request: Request):
             },
             status_code=500,
         )
+
+
+@router.post("/backends/{backend_name}/recreate")
+async def recreate_backend(request: Request, backend_name: str):
+    """Recreate a specific storage backend atomically.
+
+    The backend will be closed and recreated from the current
+    config in a single step.
+
+    Args:
+        backend_name: Name of the backend to recreate
+            (e.g. ``RemoteBackend``).
+
+    Returns:
+        JSONResponse: Dict of recreated backends and the
+        full list of active backends.
+
+    Example:
+        .. code-block:: bash
+
+            curl -X POST \\
+                http://localhost:7000/backends/RemoteBackend/recreate
+    """
+    sm = _get_storage_manager(request)
+    if sm is None:
+        return _unavailable_response("/backends")
+
+    try:
+        created = sm.recreate_backend(backend_name)
+        return JSONResponse(
+            content={
+                "status": "success",
+                "recreated": created,
+                "backends": sm.list_backends(),
+            },
+        )
+    except KeyError:
+        return JSONResponse(
+            content={
+                "status": "not_found",
+                "message": ("Backend %s not found" % backend_name),
+                "backends": sm.list_backends(),
+            },
+            status_code=404,
+        )
+    except Exception as e:
+        logger.exception("Failed to recreate backend: %s", backend_name)
+        return JSONResponse(
+            content={
+                "error": "Failed to recreate backend",
+                "message": str(e),
+            },
+            status_code=500,
+        )

--- a/lmcache/v1/internal_api_server/vllm/backend_api.py
+++ b/lmcache/v1/internal_api_server/vllm/backend_api.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import json
+
+# Third Party
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+def _get_storage_manager(request: Request):
+    """Extract storage_manager from the request app state.
+
+    Returns:
+        The StorageManager instance, or None if unavailable.
+    """
+    engine = getattr(
+        request.app.state.lmcache_adapter,
+        "lmcache_engine",
+        None,
+    )
+    if engine is None:
+        return None
+    return getattr(engine, "storage_manager", None)
+
+
+def _unavailable_response(endpoint: str) -> PlainTextResponse:
+    """Return a 503 response when the engine is unavailable."""
+    return PlainTextResponse(
+        content=json.dumps(
+            {
+                "error": "%s API is unavailable" % endpoint,
+                "message": "LMCache engine not configured.",
+            },
+            indent=2,
+        ),
+        media_type="application/json",
+        status_code=503,
+    )
+
+
+@router.get("/backends")
+async def list_backends(request: Request):
+    """List all active storage backends.
+
+    Returns:
+        PlainTextResponse: JSON dict mapping backend name
+        to class name.
+
+    Example:
+        .. code-block:: bash
+
+            curl http://localhost:7000/backends
+    """
+    sm = _get_storage_manager(request)
+    if sm is None:
+        return _unavailable_response("/backends")
+
+    try:
+        backends = sm.list_backends()
+        return PlainTextResponse(
+            content=json.dumps(backends, indent=2),
+            media_type="application/json",
+        )
+    except Exception as e:
+        return PlainTextResponse(
+            content=json.dumps(
+                {
+                    "error": "Failed to list backends",
+                    "message": str(e),
+                },
+                indent=2,
+            ),
+            media_type="application/json",
+            status_code=500,
+        )
+
+
+@router.delete("/backends/{backend_name}")
+async def close_backend(request: Request, backend_name: str):
+    """Close and remove a specific storage backend.
+
+    The backend will be closed and removed from the internal
+    dict so that no stale references remain.
+
+    Args:
+        backend_name: Name of the backend to close
+            (e.g. ``RemoteBackend``, ``LocalDiskBackend``).
+
+    Returns:
+        JSONResponse: Status of the close operation.
+
+    Example:
+        .. code-block:: bash
+
+            curl -X DELETE \\
+                http://localhost:7000/backends/RemoteBackend
+    """
+    sm = _get_storage_manager(request)
+    if sm is None:
+        return _unavailable_response("/backends")
+
+    try:
+        success = sm.close_backend(backend_name)
+        if success:
+            return JSONResponse(
+                content={
+                    "status": "success",
+                    "message": "Backend %s closed" % backend_name,
+                    "backends": sm.list_backends(),
+                },
+            )
+        return JSONResponse(
+            content={
+                "status": "not_found",
+                "message": "Backend %s not found" % backend_name,
+                "backends": sm.list_backends(),
+            },
+            status_code=404,
+        )
+    except Exception as e:
+        return JSONResponse(
+            content={
+                "error": "Failed to close backend",
+                "message": str(e),
+            },
+            status_code=500,
+        )
+
+
+@router.post("/backends")
+async def create_backends(request: Request):
+    """Create new storage backends from current config.
+
+    Backends that are already present will be skipped.
+    This allows a workflow of:
+
+    1. ``DELETE /backends/RemoteBackend`` — close old backend
+    2. ``POST /conf`` — update config (e.g. ``remote_url``)
+    3. ``POST /backends`` — create new backends from config
+
+    Returns:
+        JSONResponse: Dict of newly created backends and the
+        full list of active backends.
+
+    Example:
+        .. code-block:: bash
+
+            curl -X POST http://localhost:7000/backends
+    """
+    sm = _get_storage_manager(request)
+    if sm is None:
+        return _unavailable_response("/backends")
+
+    try:
+        created = sm.create_backends()
+        return JSONResponse(
+            content={
+                "status": "success",
+                "created": created,
+                "backends": sm.list_backends(),
+            },
+        )
+    except Exception as e:
+        logger.exception("Failed to create backends")
+        return JSONResponse(
+            content={
+                "error": "Failed to create backends",
+                "message": str(e),
+            },
+            status_code=500,
+        )

--- a/lmcache/v1/internal_api_server/vllm/backend_api.py
+++ b/lmcache/v1/internal_api_server/vllm/backend_api.py
@@ -1,11 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# Standard
-import json
-
 # Third Party
 from fastapi import APIRouter
 from starlette.requests import Request
-from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.responses import JSONResponse
 
 # First Party
 from lmcache.logging import init_logger
@@ -31,17 +28,13 @@ def _get_storage_manager(request: Request):
     return getattr(engine, "storage_manager", None)
 
 
-def _unavailable_response(endpoint: str) -> PlainTextResponse:
+def _unavailable_response(endpoint: str) -> JSONResponse:
     """Return a 503 response when the engine is unavailable."""
-    return PlainTextResponse(
-        content=json.dumps(
-            {
-                "error": "%s API is unavailable" % endpoint,
-                "message": "LMCache engine not configured.",
-            },
-            indent=2,
-        ),
-        media_type="application/json",
+    return JSONResponse(
+        content={
+            "error": "%s API is unavailable" % endpoint,
+            "message": "LMCache engine not configured.",
+        },
         status_code=503,
     )
 
@@ -51,7 +44,7 @@ async def list_backends(request: Request):
     """List all active storage backends.
 
     Returns:
-        PlainTextResponse: JSON dict mapping backend name
+        JSONResponse: JSON dict mapping backend name
         to class name.
 
     Example:
@@ -65,20 +58,14 @@ async def list_backends(request: Request):
 
     try:
         backends = sm.list_backends()
-        return PlainTextResponse(
-            content=json.dumps(backends, indent=2),
-            media_type="application/json",
-        )
+        return JSONResponse(content=backends)
     except Exception as e:
-        return PlainTextResponse(
-            content=json.dumps(
-                {
-                    "error": "Failed to list backends",
-                    "message": str(e),
-                },
-                indent=2,
-            ),
-            media_type="application/json",
+        logger.exception("Failed to list backends")
+        return JSONResponse(
+            content={
+                "error": "Failed to list backends",
+                "message": str(e),
+            },
             status_code=500,
         )
 
@@ -126,6 +113,7 @@ async def close_backend(request: Request, backend_name: str):
             status_code=404,
         )
     except Exception as e:
+        logger.exception("Failed to close backend: %s", backend_name)
         return JSONResponse(
             content={
                 "error": "Failed to close backend",

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, AbstractSet, Optional
 import asyncio
 import importlib  # Added for dynamic import
 
@@ -116,6 +116,8 @@ def CreateStorageBackends(
     loop: asyncio.AbstractEventLoop,
     dst_device: str = "cuda",
     lmcache_worker: Optional["LMCacheWorker"] = None,
+    skip_backends: Optional[AbstractSet[str]] = None,
+    existing_backends: Optional[OrderedDict[str, StorageBackendInterface]] = None,
 ) -> OrderedDict[str, StorageBackendInterface]:
     if is_cuda_worker(metadata):
         dst_device = f"cuda:{torch.cuda.current_device()}"
@@ -124,13 +126,14 @@ def CreateStorageBackends(
     else:
         dst_device = "cpu"
     storage_backends: OrderedDict[str, StorageBackendInterface] = OrderedDict()
+    _skip = skip_backends or set()
 
     extra_config = config.extra_config
     enable_nixl_storage = extra_config is not None and extra_config.get(
         "enable_nixl_storage"
     )
 
-    if config.enable_pd:
+    if config.enable_pd and "PDBackend" not in _skip:
         # First Party
         from lmcache.v1.storage_backend.pd_backend import PDBackend
 
@@ -139,12 +142,21 @@ def CreateStorageBackends(
     # TODO(Jiayi): The hierarchy is fixed for now
     # NOTE(Jiayi): The local_cpu backend is always created because
     # other backends might need it as a buffer.
+    # Reuse existing LocalCPUBackend when available so that
+    # dependent backends (disk, remote, p2p, …) keep working.
     local_cpu_backend: Optional[LocalCPUBackend] = None
+    if existing_backends and "LocalCPUBackend" in existing_backends:
+        _existing_cpu = existing_backends["LocalCPUBackend"]
+        if isinstance(_existing_cpu, LocalCPUBackend):
+            local_cpu_backend = _existing_cpu
+
     if metadata.role == "scheduler":
         # For scheduler role, local_cpu_backend is None
         pass
     elif not config.enable_pd or config.local_cpu:
-        if config.max_local_cpu_size > 0:
+        if "LocalCPUBackend" in _skip:
+            pass  # Skipped — already exists
+        elif config.max_local_cpu_size > 0:
             local_cpu_backend = LocalCPUBackend(
                 config,
                 metadata,
@@ -156,7 +168,7 @@ def CreateStorageBackends(
         else:
             logger.info("No cpu memory is allocated as max_local_cpu_size <= 0")
 
-    if config.enable_p2p:
+    if config.enable_p2p and "P2PBackend" not in _skip:
         assert local_cpu_backend is not None
         assert lmcache_worker is not None
         p2p_backend = P2PBackend(
@@ -169,7 +181,7 @@ def CreateStorageBackends(
         backend_name = str(p2p_backend)
         storage_backends[backend_name] = p2p_backend
 
-    if enable_nixl_storage:
+    if enable_nixl_storage and "NixlStorageBackend" not in _skip:
         # First Party
         from lmcache.v1.storage_backend.nixl_storage_backend import (
             NixlStorageBackend,
@@ -179,19 +191,33 @@ def CreateStorageBackends(
             NixlStorageBackend.CreateNixlStorageBackend(config, loop, metadata)
         )
 
-    if config.local_disk and config.max_local_disk_size > 0:
+    if (
+        config.local_disk
+        and config.max_local_disk_size > 0
+        and "LocalDiskBackend" not in _skip
+    ):
         assert local_cpu_backend is not None
         local_disk_backend = LocalDiskBackend(
-            config, loop, local_cpu_backend, dst_device, lmcache_worker, metadata
+            config,
+            loop,
+            local_cpu_backend,
+            dst_device,
+            lmcache_worker,
+            metadata,
         )
 
         backend_name = str(local_disk_backend)
         storage_backends[backend_name] = local_disk_backend
 
-    if config.gds_path is not None:
-        gds_backend = GdsBackend(config, metadata, loop, dst_device)
+    if config.gds_path is not None and "GdsBackend" not in _skip:
+        gds_backend = GdsBackend(
+            config,
+            metadata,
+            loop,
+            dst_device,
+        )
         storage_backends[str(gds_backend)] = gds_backend
-    if config.remote_url is not None:
+    if config.remote_url is not None and "RemoteBackend" not in _skip:
         remote_backend = RemoteBackend(
             config,
             metadata,

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -1161,38 +1161,31 @@ class StorageManager:
         """
         Create new storage backends based on current config.
 
-        Backends that are already present will be skipped so that
-        only missing backends are created.  This allows callers to
-        close a subset of backends, update config via ``/conf``,
-        and then call this method to bring up the new backends.
+        Backends that are already present will be skipped
+        **before** instantiation so that no unnecessary
+        resources are allocated.  This allows callers to close
+        a subset of backends, update config via ``/conf``,
+        and then call this method to bring up only the missing
+        backends.
 
         Returns:
-            Dict mapping newly created backend name to its class
-            name.
+            Dict mapping newly created backend name to its
+            class name.
         """
         with self.manager_lock:
+            existing_names = set(self.storage_backends)
             new_backends = CreateStorageBackends(
                 self.config,
                 self.metadata,
                 self.loop,
                 dst_device=("cuda" if is_cuda_worker(self.metadata) else "cpu"),
                 lmcache_worker=self.lmcache_worker,
+                skip_backends=existing_names,
+                existing_backends=self.storage_backends,
             )
 
             created: Dict[str, str] = {}
             for name, backend in new_backends.items():
-                if name in self.storage_backends:
-                    # Backend already exists, close the newly
-                    # created one to avoid resource leak.
-                    try:
-                        backend.close()
-                    except Exception:
-                        logger.debug(
-                            "Ignoring error when closing duplicate backend %s",
-                            name,
-                        )
-                    continue
-
                 self.storage_backends[name] = backend
                 created[name] = type(backend).__name__
                 logger.info(

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -1106,6 +1106,109 @@ class StorageManager:
             storage_names.append(backend_name)
         return storage_names
 
+    def list_backends(self) -> Dict[str, str]:
+        """
+        List all active storage backends.
+
+        Returns:
+            Dict mapping backend name to its class name.
+        """
+        with self.manager_lock:
+            return {
+                name: type(backend).__name__
+                for name, backend in self.storage_backends.items()
+            }
+
+    def close_backend(self, backend_name: str) -> bool:
+        """
+        Close and remove a specific storage backend by name.
+
+        The backend will be closed and removed from the internal
+        dict so that no stale references remain.
+
+        Args:
+            backend_name: The name of the backend to close.
+
+        Returns:
+            True if the backend was found and closed, False
+            otherwise.
+        """
+        with self.manager_lock:
+            backend = self.storage_backends.get(backend_name)
+            if backend is None:
+                logger.warning(
+                    "Backend %s not found, cannot close",
+                    backend_name,
+                )
+                return False
+
+            try:
+                logger.info("Closing backend: %s", backend_name)
+                backend.close()
+            except Exception:
+                logger.exception("Error closing backend %s", backend_name)
+
+            del self.storage_backends[backend_name]
+
+            # Update derived references
+            self.non_allocator_backends = self.get_non_allocator_backends()
+            if backend_name == "LocalCPUBackend":
+                self.local_cpu_backend = None
+            logger.info("Backend %s closed and removed", backend_name)
+            return True
+
+    def create_backends(self) -> Dict[str, str]:
+        """
+        Create new storage backends based on current config.
+
+        Backends that are already present will be skipped so that
+        only missing backends are created.  This allows callers to
+        close a subset of backends, update config via ``/conf``,
+        and then call this method to bring up the new backends.
+
+        Returns:
+            Dict mapping newly created backend name to its class
+            name.
+        """
+        with self.manager_lock:
+            new_backends = CreateStorageBackends(
+                self.config,
+                self.metadata,
+                self.loop,
+                dst_device=("cuda" if is_cuda_worker(self.metadata) else "cpu"),
+                lmcache_worker=self.lmcache_worker,
+            )
+
+            created: Dict[str, str] = {}
+            for name, backend in new_backends.items():
+                if name in self.storage_backends:
+                    # Backend already exists, close the newly
+                    # created one to avoid resource leak.
+                    try:
+                        backend.close()
+                    except Exception:
+                        logger.debug(
+                            "Ignoring error when closing duplicate backend %s",
+                            name,
+                        )
+                    continue
+
+                self.storage_backends[name] = backend
+                created[name] = type(backend).__name__
+                logger.info(
+                    "Created backend: %s (%s)",
+                    name,
+                    created[name],
+                )
+
+            # Refresh derived references
+            self.non_allocator_backends = self.get_non_allocator_backends()
+            cpu = self.storage_backends.get("LocalCPUBackend")
+            if cpu is not None:
+                self.local_cpu_backend = cpu
+
+            return created
+
     def close(self):
         logger.info("Closing StorageManager...")
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -1202,6 +1202,70 @@ class StorageManager:
 
             return created
 
+    def recreate_backend(self, backend_name: str) -> Dict[str, str]:
+        """
+        Close a backend and recreate it from current config.
+
+        This is an atomic close-then-create operation that
+        combines :meth:`close_backend` and :meth:`create_backends`
+        into a single step.
+
+        Args:
+            backend_name: Name of the backend to recreate
+                (e.g. ``RemoteBackend``).
+
+        Returns:
+            Dict mapping newly created backend name to its
+            class name.
+
+        Raises:
+            KeyError: If *backend_name* does not exist.
+        """
+        with self.manager_lock:
+            backend = self.storage_backends.get(backend_name)
+            if backend is None:
+                raise KeyError("Backend %s not found" % backend_name)
+
+            # --- close ---
+            try:
+                logger.info("Closing backend: %s", backend_name)
+                backend.close()
+            except Exception:
+                logger.exception("Error closing backend %s", backend_name)
+            del self.storage_backends[backend_name]
+
+            # --- create ---
+            existing_names = set(self.storage_backends)
+            new_backends = CreateStorageBackends(
+                self.config,
+                self.metadata,
+                self.loop,
+                dst_device=("cuda" if is_cuda_worker(self.metadata) else "cpu"),
+                lmcache_worker=self.lmcache_worker,
+                skip_backends=existing_names,
+                existing_backends=self.storage_backends,
+            )
+
+            created: Dict[str, str] = {}
+            for name, be in new_backends.items():
+                self.storage_backends[name] = be
+                created[name] = type(be).__name__
+                logger.info(
+                    "Recreated backend: %s (%s)",
+                    name,
+                    created[name],
+                )
+
+            # Refresh derived references
+            self.non_allocator_backends = self.get_non_allocator_backends()
+            cpu = self.storage_backends.get("LocalCPUBackend")
+            if cpu is not None:
+                self.local_cpu_backend = cpu
+            elif backend_name == "LocalCPUBackend":
+                self.local_cpu_backend = None
+
+            return created
+
     def close(self):
         logger.info("Closing StorageManager...")
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -236,20 +236,13 @@ class StorageManager:
         )
         self.thread.start()
 
-        # For scheduler role, always use CPU device
-        if is_cuda_worker(metadata):
-            dst_device = "cuda"
-        else:
-            dst_device = "cpu"
-        self.storage_backends: OrderedDict[str, StorageBackendInterface] = (
-            CreateStorageBackends(
-                config,
-                metadata,
-                self.loop,
-                dst_device,
-                lmcache_worker,
-            )
-        )
+        self.storage_backends: OrderedDict[str, StorageBackendInterface] = OrderedDict()
+        self.manager_lock = threading.Lock()
+        self.lmcache_worker = lmcache_worker
+
+        # Use the unified create path so that init and
+        # dynamic creation share the same logic.
+        self.create_backends()
 
         # the backend used for actual storage
         self.non_allocator_backends = self.get_non_allocator_backends()
@@ -262,9 +255,6 @@ class StorageManager:
 
         self.local_cpu_backend = self.storage_backends.get("LocalCPUBackend", None)
 
-        self.manager_lock = threading.Lock()
-
-        self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
         self.worker_id = metadata.worker_id
 

--- a/tests/v1/internal_api_server/test_backend_api.py
+++ b/tests/v1/internal_api_server/test_backend_api.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Test cases for the /backends/* API endpoints.
+
+Tests cover:
+- GET /backends  — list active backends
+- DELETE /backends/{name} — close and remove a backend
+- POST /backends — create new backends from current config
+- End-to-end flow: close → conf update → create → verify
+"""
+
+# Standard
+from collections import OrderedDict
+from unittest.mock import MagicMock
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.internal_api_server.api_server import app
+
+# ------------------------------------------------------------------ #
+#  Fixtures
+# ------------------------------------------------------------------ #
+
+
+class FakeBackend:
+    """Minimal fake backend for testing."""
+
+    def __init__(self, name: str = "FakeBackend"):
+        self._name = name
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def __str__(self):
+        return self._name
+
+
+@pytest.fixture
+def mock_storage_manager():
+    """Create a mock StorageManager with two fake backends."""
+    sm = MagicMock()
+    fake_cpu = FakeBackend("LocalCPUBackend")
+    fake_remote = FakeBackend("RemoteBackend")
+    backends = OrderedDict(
+        [
+            ("LocalCPUBackend", fake_cpu),
+            ("RemoteBackend", fake_remote),
+        ]
+    )
+    sm.storage_backends = backends
+
+    # Wire real-ish list_backends
+    sm.list_backends.side_effect = lambda: {
+        n: type(b).__name__ for n, b in sm.storage_backends.items()
+    }
+    return sm
+
+
+@pytest.fixture
+def mock_engine(mock_storage_manager):
+    engine = MagicMock()
+    engine.storage_manager = mock_storage_manager
+    return engine
+
+
+@pytest.fixture
+def client_with_engine(mock_engine):
+    adapter = MagicMock()
+    adapter.lmcache_engine = mock_engine
+    app.state.lmcache_adapter = adapter
+    return TestClient(app)
+
+
+@pytest.fixture
+def client_without_engine():
+    adapter = MagicMock()
+    adapter.lmcache_engine = None
+    app.state.lmcache_adapter = adapter
+    return TestClient(app)
+
+
+# ------------------------------------------------------------------ #
+#  GET /backends
+# ------------------------------------------------------------------ #
+
+
+class TestListBackends:
+    def test_list_success(self, client_with_engine, mock_storage_manager):
+        resp = client_with_engine.get("/backends")
+        assert resp.status_code == 200
+        data = json.loads(resp.text)
+        assert "LocalCPUBackend" in data
+        assert "RemoteBackend" in data
+
+    def test_list_no_engine(self, client_without_engine):
+        resp = client_without_engine.get("/backends")
+        assert resp.status_code == 503
+
+    def test_list_exception(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.list_backends.side_effect = RuntimeError("boom")
+        resp = client_with_engine.get("/backends")
+        assert resp.status_code == 500
+        data = json.loads(resp.text)
+        assert "boom" in data["message"]
+
+
+# ------------------------------------------------------------------ #
+#  DELETE /backends/{name}
+# ------------------------------------------------------------------ #
+
+
+class TestCloseBackend:
+    def test_close_success(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.close_backend.return_value = True
+        resp = client_with_engine.delete("/backends/RemoteBackend")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        mock_storage_manager.close_backend.assert_called_once_with("RemoteBackend")
+
+    def test_close_not_found(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.close_backend.return_value = False
+        resp = client_with_engine.delete("/backends/NonExistent")
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["status"] == "not_found"
+
+    def test_close_no_engine(self, client_without_engine):
+        resp = client_without_engine.delete("/backends/RemoteBackend")
+        assert resp.status_code == 503
+
+    def test_close_exception(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.close_backend.side_effect = RuntimeError("close error")
+        resp = client_with_engine.delete("/backends/RemoteBackend")
+        assert resp.status_code == 500
+        data = resp.json()
+        assert "close error" in data["message"]
+
+
+# ------------------------------------------------------------------ #
+#  POST /backends
+# ------------------------------------------------------------------ #
+
+
+class TestCreateBackends:
+    def test_create_success(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.create_backends.return_value = {"GdsBackend": "GdsBackend"}
+        resp = client_with_engine.post("/backends")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        assert "GdsBackend" in data["created"]
+
+    def test_create_no_engine(self, client_without_engine):
+        resp = client_without_engine.post("/backends")
+        assert resp.status_code == 503
+
+    def test_create_exception(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.create_backends.side_effect = RuntimeError("create error")
+        resp = client_with_engine.post("/backends")
+        assert resp.status_code == 500
+        data = resp.json()
+        assert "create error" in data["message"]
+
+
+# ------------------------------------------------------------------ #
+#  End-to-end flow: close → conf → create
+# ------------------------------------------------------------------ #
+
+
+class TestBackendSwitchFlow:
+    """Simulate the full backend-switch workflow via API."""
+
+    def test_close_update_conf_create_flow(
+        self, client_with_engine, mock_storage_manager
+    ):
+        """
+        1. DELETE /backends/RemoteBackend
+        2. POST /conf to update remote_url
+        3. POST /backends to create new RemoteBackend
+        4. GET /backends to verify
+        """
+        # Step 1: close RemoteBackend
+        mock_storage_manager.close_backend.return_value = True
+        resp = client_with_engine.delete("/backends/RemoteBackend")
+        assert resp.status_code == 200
+
+        # Step 2: update config via /conf (uses conf_api)
+        # We patch the config object on the adapter
+        mock_config = MagicMock()
+        client_with_engine.app.state.lmcache_adapter.config = mock_config
+
+        # Step 3: create new backends
+        mock_storage_manager.create_backends.return_value = {
+            "RemoteBackend": "RemoteBackend"
+        }
+        resp = client_with_engine.post("/backends")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        assert "RemoteBackend" in data["created"]
+
+        # Step 4: list backends
+        resp = client_with_engine.get("/backends")
+        assert resp.status_code == 200

--- a/tests/v1/internal_api_server/test_backend_api.py
+++ b/tests/v1/internal_api_server/test_backend_api.py
@@ -6,6 +6,7 @@ Tests cover:
 - GET /backends  — list active backends
 - DELETE /backends/{name} — close and remove a backend
 - POST /backends — create new backends from current config
+- POST /backends/{name}/recreate — atomic close + create
 - End-to-end flow: close → conf update → create → verify
 """
 
@@ -165,6 +166,46 @@ class TestCreateBackends:
         assert resp.status_code == 500
         data = resp.json()
         assert "create error" in data["message"]
+
+
+# ------------------------------------------------------------------ #
+#  POST /backends/{name}/recreate
+# ------------------------------------------------------------------ #
+
+
+class TestRecreateBackend:
+    def test_recreate_success(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.recreate_backend.return_value = {
+            "RemoteBackend": "RemoteBackend"
+        }
+        resp = client_with_engine.post("/backends/RemoteBackend/recreate")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        assert "RemoteBackend" in data["recreated"]
+        mock_storage_manager.recreate_backend.assert_called_once_with("RemoteBackend")
+
+    def test_recreate_not_found(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.recreate_backend.side_effect = KeyError(
+            "Backend NonExistent not found"
+        )
+        resp = client_with_engine.post("/backends/NonExistent/recreate")
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["status"] == "not_found"
+
+    def test_recreate_no_engine(self, client_without_engine):
+        resp = client_without_engine.post("/backends/RemoteBackend/recreate")
+        assert resp.status_code == 503
+
+    def test_recreate_exception(self, client_with_engine, mock_storage_manager):
+        mock_storage_manager.recreate_backend.side_effect = RuntimeError(
+            "recreate error"
+        )
+        resp = client_with_engine.post("/backends/RemoteBackend/recreate")
+        assert resp.status_code == 500
+        data = resp.json()
+        assert "recreate error" in data["message"]
 
 
 # ------------------------------------------------------------------ #

--- a/tests/v1/internal_api_server/test_backend_api.py
+++ b/tests/v1/internal_api_server/test_backend_api.py
@@ -12,7 +12,6 @@ Tests cover:
 # Standard
 from collections import OrderedDict
 from unittest.mock import MagicMock
-import json
 
 # Third Party
 from fastapi.testclient import TestClient
@@ -93,7 +92,7 @@ class TestListBackends:
     def test_list_success(self, client_with_engine, mock_storage_manager):
         resp = client_with_engine.get("/backends")
         assert resp.status_code == 200
-        data = json.loads(resp.text)
+        data = resp.json()
         assert "LocalCPUBackend" in data
         assert "RemoteBackend" in data
 
@@ -105,7 +104,7 @@ class TestListBackends:
         mock_storage_manager.list_backends.side_effect = RuntimeError("boom")
         resp = client_with_engine.get("/backends")
         assert resp.status_code == 500
-        data = json.loads(resp.text)
+        data = resp.json()
         assert "boom" in data["message"]
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

allow for dynamic management of storage backends. This new functionality provides operators with the flexibility to modify and reconfigure storage solutions, such as switching backend types or updating connectors, without the need to restart the entire serving engine. The changes aim to improve operational agility and reduce downtime during configuration adjustments.

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
