### PR TITLE
Add lookup api to support dynamic recreate lookup client/server

### DIFF
--- a/docs/source/internal_api_server/vllm_apis.rst
+++ b/docs/source/internal_api_server/vllm_apis.rst
@@ -602,6 +602,195 @@ These endpoints manage chunk-level statistics collection via
 ``ChunkStatisticsLookupClient``. They are only available when the
 lookup client supports statistics.
 
+
+Lookup Client/Server Management
+-----------------------------------
+
+These endpoints allow runtime management of the lookup client and server.
+They are useful for dynamically reconfiguring the lookup mechanism without
+restarting the service.
+
+.. important::
+
+    **Configuration Update Required First**
+
+    Before calling ``/lookup/create`` or ``/lookup/recreate``, you **MUST**
+    update the configuration via the ``/conf`` API first. The new lookup
+    client/server will be created using ``LookupClientFactory``.
+
+    For some configurations (e.g., switching ``enable_scheduler_bypass_lookup``),
+    you only need to update the **scheduler's** configuration and recreate its
+    lookup client. The workers don't need changes in this case.
+
+
+``GET /lookup/info`` — Lookup Client/Server Information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Get information about the current lookup client and server status.
+Shows wrapper chain if applicable (e.g., ``HitLimitLookupClient(LMCacheLookupClient)``).
+
+- **Method**: ``GET``
+- **Path**: ``/lookup/info``
+- **Parameters**: None
+- **Response**: ``application/json``
+
+.. code-block:: bash
+
+    curl http://localhost:6999/lookup/info
+
+**Example Response** (scheduler):
+
+.. code-block:: json
+
+    {
+      "client": "HitLimitLookupClient(LMCacheBypassLookupClient)",
+      "server": "None",
+      "role": "scheduler"
+    }
+
+**Example Response** (worker):
+
+.. code-block:: json
+
+    {
+      "client": "None",
+      "server": "LMCacheLookupServer",
+      "role": "worker"
+    }
+
+
+``POST /lookup/close`` — Close Lookup Client/Server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Close the current lookup client (scheduler) or server (worker).
+
+- **Method**: ``POST``
+- **Path**: ``/lookup/close``
+- **Parameters**: None
+- **Response**: ``application/json``
+
+.. code-block:: bash
+
+    curl -X POST http://localhost:6999/lookup/close
+
+**Example Response**:
+
+.. code-block:: json
+
+    {
+      "old": "HitLimitLookupClient(LMCacheBypassLookupClient)",
+      "role": "scheduler"
+    }
+
+
+``POST /lookup/create`` — Create Lookup Client/Server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Create a new lookup client (scheduler) or server (worker) using current config.
+
+- **Method**: ``POST``
+- **Path**: ``/lookup/create``
+- **Parameters**:
+
+  =========== ======= =============================================
+  Name        Type    Description
+  =========== ======= =============================================
+  ``dryrun``  bool    If ``true``, only show what would be created
+  =========== ======= =============================================
+
+- **Response**: ``application/json``
+
+.. code-block:: bash
+
+    # Dryrun - preview what would be created
+    curl -X POST "http://localhost:6999/lookup/create?dryrun=true"
+
+    # Actually create
+    curl -X POST http://localhost:6999/lookup/create
+
+**Example Response** (dryrun):
+
+.. code-block:: json
+
+    {
+      "new": "LMCacheLookupClient",
+      "dryrun": true,
+      "role": "scheduler"
+    }
+
+**Example Response** (actual create):
+
+.. code-block:: json
+
+    {
+      "new": "LMCacheLookupClient",
+      "role": "scheduler"
+    }
+
+
+``POST /lookup/recreate`` — Recreate Lookup Client/Server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Recreate the lookup client or server (equivalent to close + create).
+The endpoint automatically determines which component based on role:
+
+- **scheduler** role: recreates lookup client
+- **worker** role: recreates lookup server
+
+- **Method**: ``POST``
+- **Path**: ``/lookup/recreate``
+- **Parameters**: None
+- **Response**: ``application/json``
+
+**Usage Flow**:
+
+.. code-block:: bash
+
+    # Step 1: Update worker configuration (if needed)
+    curl -X POST "http://localhost:7000/conf" \
+      -H "Content-Type: application/json" \
+      -d '{"enable_async_loading": true}'
+
+    # Step 2: Recreate lookup server on worker
+    curl -X POST "http://localhost:7000/lookup/recreate"
+
+    # Step 3: Update scheduler configuration
+    curl -X POST "http://localhost:6999/conf" \
+      -H "Content-Type: application/json" \
+      -d '{"enable_scheduler_bypass_lookup": true}'
+
+    # Step 4: Recreate lookup client on scheduler
+    curl -X POST "http://localhost:6999/lookup/recreate"
+
+**Example Response** (scheduler):
+
+.. code-block:: json
+
+    {
+      "old": "HitLimitLookupClient(LMCacheBypassLookupClient)",
+      "new": "LMCacheLookupClient",
+      "role": "scheduler"
+    }
+
+**Example Response** (worker):
+
+.. code-block:: json
+
+    {
+      "old": "LMCacheLookupServer",
+      "new": "LMCacheAsyncLookupServer",
+      "role": "worker"
+    }
+
+.. note::
+
+    **Client-only Changes**
+
+    For some configuration changes (e.g., switching ``enable_scheduler_bypass_lookup``),
+    you only need to update the scheduler's configuration and recreate its lookup
+    client. Worker-side lookup servers don't need to be recreated in this case.
+
+
 ``POST /chunk_statistics/start`` — Start Statistics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lmcache/v1/internal_api_server/vllm/lookup_api.py
+++ b/lmcache/v1/internal_api_server/vllm/lookup_api.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import json
+
+# Third Party
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+router = APIRouter()
+
+
+def _json_response(data: dict, status_code: int = 200) -> PlainTextResponse:
+    """Helper to create JSON response."""
+    return PlainTextResponse(
+        content=json.dumps(data, indent=2),
+        media_type="application/json",
+        status_code=status_code,
+    )
+
+
+@router.get("/lookup/info")
+async def get_lookup_info(request: Request):
+    """
+    Get information about the current lookup client and server.
+
+    Example:
+        curl http://localhost:6999/lookup/info
+    """
+    adapter = request.app.state.lmcache_adapter
+    if not hasattr(adapter, "get_lookup_info"):
+        return _json_response({"error": "API unavailable"}, 503)
+    return _json_response(adapter.get_lookup_info())
+
+
+@router.post("/lookup/close")
+async def close_lookup(request: Request):
+    """
+    Close the current lookup client (scheduler) or server (worker).
+
+    Example:
+        curl -X POST http://localhost:6999/lookup/close
+    """
+    adapter = request.app.state.lmcache_adapter
+    role = getattr(adapter, "role", None)
+
+    if role == "scheduler":
+        if not hasattr(adapter, "close_lookup_client"):
+            return _json_response({"error": "API unavailable"}, 503)
+        result = adapter.close_lookup_client()
+    elif role == "worker":
+        if not hasattr(adapter, "close_lookup_server"):
+            return _json_response({"error": "API unavailable"}, 503)
+        result = adapter.close_lookup_server()
+    else:
+        return _json_response({"error": "Unknown role"}, 400)
+
+    result["role"] = role
+    return _json_response(result)
+
+
+@router.post("/lookup/create")
+async def create_lookup(request: Request, dryrun: bool = False):
+    """
+    Create a new lookup client (scheduler) or server (worker).
+
+    Args:
+        dryrun: If true, only show what would be created without creating it.
+
+    Example:
+        # Actually create
+        curl -X POST http://localhost:6999/lookup/create
+
+        # Dryrun - show what would be created
+        curl -X POST "http://localhost:6999/lookup/create?dryrun=true"
+    """
+    adapter = request.app.state.lmcache_adapter
+    role = getattr(adapter, "role", None)
+
+    if role == "scheduler":
+        if not hasattr(adapter, "create_lookup_client"):
+            return _json_response({"error": "API unavailable"}, 503)
+        result = adapter.create_lookup_client(dryrun=dryrun)
+    elif role == "worker":
+        if not hasattr(adapter, "create_lookup_server"):
+            return _json_response({"error": "API unavailable"}, 503)
+        result = adapter.create_lookup_server(dryrun=dryrun)
+    else:
+        return _json_response({"error": "Unknown role"}, 400)
+
+    result["role"] = role
+    if "error" in result:
+        return _json_response(result, 400)
+    return _json_response(result)
+
+
+@router.post("/lookup/recreate")
+async def recreate_lookup(request: Request):
+    """
+    Recreate the lookup client (scheduler) or server (worker).
+
+    This is equivalent to calling /lookup/close + /lookup/create.
+
+    IMPORTANT: Update configuration via /conf API before calling this.
+
+    Example:
+        # Step 1: Update config
+        curl -X PUT http://localhost:6999/conf \\
+            -H "Content-Type: application/json" \\
+            -d '{"enable_scheduler_bypass_lookup": true}'
+
+        # Step 2: Recreate
+        curl -X POST http://localhost:6999/lookup/recreate
+    """
+    adapter = request.app.state.lmcache_adapter
+    role = getattr(adapter, "role", None)
+
+    if role == "scheduler":
+        if not hasattr(adapter, "recreate_lookup_client"):
+            return _json_response({"error": "API unavailable"}, 503)
+        result = adapter.recreate_lookup_client()
+    elif role == "worker":
+        if not hasattr(adapter, "recreate_lookup_server"):
+            return _json_response({"error": "API unavailable"}, 503)
+        result = adapter.recreate_lookup_server()
+    else:
+        return _json_response({"error": "Unknown role"}, 400)
+
+    result["role"] = role
+    if "error" in result:
+        return _json_response(result, 400)
+    return _json_response(result)

--- a/lmcache/v1/internal_api_server/vllm/lookup_api.py
+++ b/lmcache/v1/internal_api_server/vllm/lookup_api.py
@@ -106,7 +106,7 @@ async def recreate_lookup(request: Request):
     Example:
         # Step 1: Update config
         curl -X PUT http://localhost:6999/conf \\
-            -H "Content-Type: application/json" \\
+        curl -X POST http://localhost:6999/conf \\
             -d '{"enable_scheduler_bypass_lookup": true}'
 
         # Step 2: Recreate

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -632,6 +632,194 @@ class LMCacheManager:
         """Get the lookup server instance."""
         return self._lookup_server
 
+    def close_lookup_client(self) -> dict:
+        """
+        Close the current lookup client.
+
+        Returns:
+            dict: Result with old client type info.
+        """
+        old_type = self._get_lookup_type_str(self._lookup_client)
+        if self._lookup_client is not None:
+            try:
+                self._lookup_client.close()
+                self._lookup_client = None
+                logger.info("Closed lookup client: %s", old_type)
+            except Exception as e:
+                logger.warning("Error closing lookup client: %s", e)
+        return {"old": old_type}
+
+    def create_lookup_client(self, dryrun: bool = False) -> dict:
+        """
+        Create a new lookup client using the current configuration.
+
+        Args:
+            dryrun: If True, only return what would be created without
+                actually creating it.
+
+        Returns:
+            dict: Result with new client type info.
+        """
+        # First Party
+        from lmcache.v1.lookup_client.factory import LookupClientFactory
+
+        if self._lmcache_engine_metadata is None:
+            return {"error": "metadata not available"}
+
+        if dryrun:
+            # Create temporarily to get type info, then discard
+            client = LookupClientFactory.create_lookup_client(
+                self._config,
+                self._lmcache_engine_metadata,
+                self._lmcache_engine,
+            )
+            new_type = self._get_lookup_type_str(client)
+            client.close()
+            return {"new": new_type, "dryrun": True}
+
+        self._lookup_client = LookupClientFactory.create_lookup_client(
+            self._config,
+            self._lmcache_engine_metadata,
+            self._lmcache_engine,
+        )
+        new_type = self._get_lookup_type_str(self._lookup_client)
+        logger.info("Created lookup client: %s", new_type)
+        return {"new": new_type}
+
+    def recreate_lookup_client(self) -> dict:
+        """
+        Recreate the lookup client (close + create).
+
+        Returns:
+            dict: Result with old and new client type info.
+        """
+        if self._role != "scheduler":
+            return {"error": "only supported for scheduler role"}
+
+        result = self.close_lookup_client()
+        create_result = self.create_lookup_client()
+        result.update(create_result)
+        return result
+
+    def close_lookup_server(self) -> dict:
+        """
+        Close the current lookup server.
+
+        Returns:
+            dict: Result with old server type info.
+        """
+        old_type = self._get_lookup_type_str(self._lookup_server)
+        if self._lookup_server is not None:
+            try:
+                self._lookup_server.close()
+                self._lookup_server = None
+                logger.info("Closed lookup server: %s", old_type)
+            except Exception as e:
+                logger.warning("Error closing lookup server: %s", e)
+        return {"old": old_type}
+
+    def create_lookup_server(self, dryrun: bool = False) -> dict:
+        """
+        Create a new lookup server using the current configuration.
+
+        Args:
+            dryrun: If True, only return what would be created without
+                actually creating it.
+
+        Returns:
+            dict: Result with new server type info.
+        """
+        # First Party
+        from lmcache.v1.lookup_client.factory import LookupClientFactory
+
+        if self._lmcache_engine is None:
+            return {"error": "engine not available"}
+        if self._lmcache_engine_metadata is None:
+            return {"error": "metadata not available"}
+
+        if dryrun:
+            # Create temporarily to get type info, then discard
+            server = LookupClientFactory.create_lookup_server(
+                self._lmcache_engine,
+                self._lmcache_engine_metadata,
+            )
+            new_type = self._get_lookup_type_str(server)
+            if server is not None:
+                server.close()
+            return {"new": new_type, "dryrun": True}
+
+        self._lookup_server = LookupClientFactory.create_lookup_server(
+            self._lmcache_engine,
+            self._lmcache_engine_metadata,
+        )
+        new_type = self._get_lookup_type_str(self._lookup_server)
+        logger.info("Created lookup server: %s", new_type)
+        return {"new": new_type}
+
+    def recreate_lookup_server(self) -> dict:
+        """
+        Recreate the lookup server (close + create).
+
+        Returns:
+            dict: Result with old and new server type info.
+        """
+        if self._role != "worker":
+            return {"error": "only supported for worker role"}
+
+        result = self.close_lookup_server()
+        create_result = self.create_lookup_server()
+        result.update(create_result)
+        return result
+
+    def _get_lookup_type_str(self, obj) -> str:
+        """
+        Get type string for lookup client/server, including wrapper info.
+
+        Returns format: "OuterWrapper(InnerWrapper(CoreType))" or "None"
+        """
+        if obj is None:
+            return "None"
+
+        # First Party
+        from lmcache.v1.lookup_client.chunk_statistics_lookup_client import (
+            ChunkStatisticsLookupClient,
+        )
+        from lmcache.v1.lookup_client.hit_limit_lookup_client import (
+            HitLimitLookupClient,
+        )
+
+        parts = []
+        current = obj
+        while True:
+            parts.append(type(current).__name__)
+            if isinstance(current, ChunkStatisticsLookupClient):
+                current = current.actual_lookup_client
+            elif isinstance(current, HitLimitLookupClient):
+                current = current.actual_lookup_client
+            else:
+                break
+
+        if len(parts) == 1:
+            return parts[0]
+        # Format: Outer(Inner(Core))
+        result = parts[-1]
+        for wrapper in reversed(parts[:-1]):
+            result = "%s(%s)" % (wrapper, result)
+        return result
+
+    def get_lookup_info(self) -> dict:
+        """
+        Get information about the current lookup client and server.
+
+        Returns:
+            dict: Information about lookup client/server types and role.
+        """
+        return {
+            "client": self._get_lookup_type_str(self._lookup_client),
+            "server": self._get_lookup_type_str(self._lookup_server),
+            "role": self._role,
+        }
+
     @property
     def offload_server(self) -> Optional[ZMQOffloadServer]:
         """Get the offload server instance."""

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -781,20 +781,12 @@ class LMCacheManager:
             return "None"
 
         # First Party
-        from lmcache.v1.lookup_client.chunk_statistics_lookup_client import (
-            ChunkStatisticsLookupClient,
-        )
-        from lmcache.v1.lookup_client.hit_limit_lookup_client import (
-            HitLimitLookupClient,
-        )
-
         parts = []
         current = obj
         while True:
             parts.append(type(current).__name__)
-            if isinstance(current, ChunkStatisticsLookupClient):
-                current = current.actual_lookup_client
-            elif isinstance(current, HitLimitLookupClient):
+            # Check for wrapper by looking for 'actual_lookup_client' attribute
+            if hasattr(current, "actual_lookup_client"):
                 current = current.actual_lookup_client
             else:
                 break

--- a/tests/v1/internal_api_server/test_lookup_api.py
+++ b/tests/v1/internal_api_server/test_lookup_api.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import MagicMock
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.internal_api_server.api_server import app
+
+
+class TestLookupAPI:
+    """Test suite for the /lookup/* API endpoints."""
+
+    @pytest.fixture
+    def mock_scheduler_manager(self):
+        """Create a mock LMCacheManager for scheduler role."""
+        manager = MagicMock()
+        manager.role = "scheduler"
+        manager.get_lookup_info.return_value = {
+            "client": "HitLimitLookupClient(LMCacheBypassLookupClient)",
+            "server": "None",
+            "role": "scheduler",
+        }
+        manager.close_lookup_client.return_value = {
+            "old": "HitLimitLookupClient(LMCacheBypassLookupClient)"
+        }
+        manager.create_lookup_client.return_value = {"new": "LMCacheLookupClient"}
+        manager.recreate_lookup_client.return_value = {
+            "old": "HitLimitLookupClient(LMCacheBypassLookupClient)",
+            "new": "LMCacheLookupClient",
+        }
+        return manager
+
+    @pytest.fixture
+    def mock_worker_manager(self):
+        """Create a mock LMCacheManager for worker role."""
+        manager = MagicMock()
+        manager.role = "worker"
+        manager.get_lookup_info.return_value = {
+            "client": "None",
+            "server": "LMCacheLookupServer",
+            "role": "worker",
+        }
+        manager.close_lookup_server.return_value = {"old": "LMCacheLookupServer"}
+        manager.create_lookup_server.return_value = {"new": "LMCacheAsyncLookupServer"}
+        manager.recreate_lookup_server.return_value = {
+            "old": "LMCacheLookupServer",
+            "new": "LMCacheAsyncLookupServer",
+        }
+        return manager
+
+    @pytest.fixture
+    def scheduler_client(self, mock_scheduler_manager):
+        """Create a test client with mocked scheduler manager."""
+        app.state.lmcache_adapter = mock_scheduler_manager
+        return TestClient(app)
+
+    @pytest.fixture
+    def worker_client(self, mock_worker_manager):
+        """Create a test client with mocked worker manager."""
+        app.state.lmcache_adapter = mock_worker_manager
+        return TestClient(app)
+
+    # ==================== GET /lookup/info Tests ====================
+
+    def test_get_lookup_info_scheduler(self, scheduler_client, mock_scheduler_manager):
+        """Test get lookup info for scheduler role."""
+        response = scheduler_client.get("/lookup/info")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert "LMCacheBypassLookupClient" in data["client"]
+        assert data["server"] == "None"
+        assert data["role"] == "scheduler"
+        mock_scheduler_manager.get_lookup_info.assert_called_once()
+
+    def test_get_lookup_info_worker(self, worker_client, mock_worker_manager):
+        """Test get lookup info for worker role."""
+        response = worker_client.get("/lookup/info")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["client"] == "None"
+        assert data["server"] == "LMCacheLookupServer"
+        assert data["role"] == "worker"
+        mock_worker_manager.get_lookup_info.assert_called_once()
+
+    def test_get_lookup_info_not_supported(self):
+        """Test get lookup info when manager doesn't support it."""
+
+        class SimpleAdapter:
+            pass
+
+        app.state.lmcache_adapter = SimpleAdapter()
+        client = TestClient(app)
+
+        response = client.get("/lookup/info")
+
+        assert response.status_code == 503
+        data = json.loads(response.text)
+        assert "error" in data
+
+    # ==================== POST /lookup/close Tests ====================
+
+    def test_close_lookup_scheduler(self, scheduler_client, mock_scheduler_manager):
+        """Test close lookup client for scheduler."""
+        response = scheduler_client.post("/lookup/close")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert "LMCacheBypassLookupClient" in data["old"]
+        assert data["role"] == "scheduler"
+        mock_scheduler_manager.close_lookup_client.assert_called_once()
+
+    def test_close_lookup_worker(self, worker_client, mock_worker_manager):
+        """Test close lookup server for worker."""
+        response = worker_client.post("/lookup/close")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["old"] == "LMCacheLookupServer"
+        assert data["role"] == "worker"
+        mock_worker_manager.close_lookup_server.assert_called_once()
+
+    # ==================== POST /lookup/create Tests ====================
+
+    def test_create_lookup_scheduler(self, scheduler_client, mock_scheduler_manager):
+        """Test create lookup client for scheduler."""
+        response = scheduler_client.post("/lookup/create")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["new"] == "LMCacheLookupClient"
+        assert data["role"] == "scheduler"
+        mock_scheduler_manager.create_lookup_client.assert_called_once_with(
+            dryrun=False
+        )
+
+    def test_create_lookup_worker(self, worker_client, mock_worker_manager):
+        """Test create lookup server for worker."""
+        response = worker_client.post("/lookup/create")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["new"] == "LMCacheAsyncLookupServer"
+        assert data["role"] == "worker"
+        mock_worker_manager.create_lookup_server.assert_called_once_with(dryrun=False)
+
+    def test_create_lookup_dryrun_scheduler(
+        self, scheduler_client, mock_scheduler_manager
+    ):
+        """Test dryrun create lookup client for scheduler."""
+        mock_scheduler_manager.create_lookup_client.return_value = {
+            "new": "LMCacheLookupClient",
+            "dryrun": True,
+        }
+
+        response = scheduler_client.post("/lookup/create?dryrun=true")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["new"] == "LMCacheLookupClient"
+        assert data["dryrun"] is True
+        mock_scheduler_manager.create_lookup_client.assert_called_once_with(dryrun=True)
+
+    def test_create_lookup_dryrun_worker(self, worker_client, mock_worker_manager):
+        """Test dryrun create lookup server for worker."""
+        mock_worker_manager.create_lookup_server.return_value = {
+            "new": "LMCacheAsyncLookupServer",
+            "dryrun": True,
+        }
+
+        response = worker_client.post("/lookup/create?dryrun=true")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["new"] == "LMCacheAsyncLookupServer"
+        assert data["dryrun"] is True
+        mock_worker_manager.create_lookup_server.assert_called_once_with(dryrun=True)
+
+    def test_create_lookup_error(self, scheduler_client, mock_scheduler_manager):
+        """Test create lookup with error."""
+        mock_scheduler_manager.create_lookup_client.return_value = {
+            "error": "metadata not available"
+        }
+
+        response = scheduler_client.post("/lookup/create")
+
+        assert response.status_code == 400
+        data = json.loads(response.text)
+        assert data["error"] == "metadata not available"
+
+    # ==================== POST /lookup/recreate Tests ====================
+
+    def test_recreate_lookup_scheduler(self, scheduler_client, mock_scheduler_manager):
+        """Test recreate lookup client for scheduler."""
+        response = scheduler_client.post("/lookup/recreate")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert "LMCacheBypassLookupClient" in data["old"]
+        assert data["new"] == "LMCacheLookupClient"
+        assert data["role"] == "scheduler"
+        mock_scheduler_manager.recreate_lookup_client.assert_called_once()
+
+    def test_recreate_lookup_worker(self, worker_client, mock_worker_manager):
+        """Test recreate lookup server for worker."""
+        response = worker_client.post("/lookup/recreate")
+
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["old"] == "LMCacheLookupServer"
+        assert data["new"] == "LMCacheAsyncLookupServer"
+        assert data["role"] == "worker"
+        mock_worker_manager.recreate_lookup_server.assert_called_once()
+
+    def test_recreate_lookup_error(self, scheduler_client, mock_scheduler_manager):
+        """Test recreate lookup with error."""
+        mock_scheduler_manager.recreate_lookup_client.return_value = {
+            "error": "only supported for scheduler role"
+        }
+
+        response = scheduler_client.post("/lookup/recreate")
+
+        assert response.status_code == 400
+        data = json.loads(response.text)
+        assert "error" in data
+
+    def test_recreate_lookup_unknown_role(self):
+        """Test recreation with unknown role."""
+        manager = MagicMock()
+        manager.role = "unknown"
+        app.state.lmcache_adapter = manager
+        client = TestClient(app)
+
+        response = client.post("/lookup/recreate")
+
+        assert response.status_code == 400
+        data = json.loads(response.text)
+        assert data["error"] == "Unknown role"
+
+    def test_recreate_lookup_not_supported(self):
+        """Test recreation when manager doesn't support it."""
+
+        class SimpleAdapter:
+            role = "scheduler"
+
+        app.state.lmcache_adapter = SimpleAdapter()
+        client = TestClient(app)
+
+        response = client.post("/lookup/recreate")
+
+        assert response.status_code == 503
+        data = json.loads(response.text)
+        assert "error" in data
+
+    # ==================== Integration Flow Tests ====================
+
+    def test_full_flow_worker_then_scheduler(
+        self, mock_worker_manager, mock_scheduler_manager
+    ):
+        """
+        Test the complete flow:
+        1. POST /lookup/recreate on worker (recreate server)
+        2. POST /lookup/recreate on scheduler (recreate client)
+
+        Note: Config should be updated via /conf API before each step.
+        """
+        # Step 1: Worker side - recreate server
+        app.state.lmcache_adapter = mock_worker_manager
+        worker_client = TestClient(app)
+
+        response = worker_client.post("/lookup/recreate")
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["old"] == "LMCacheLookupServer"
+        assert data["new"] == "LMCacheAsyncLookupServer"
+        mock_worker_manager.recreate_lookup_server.assert_called_once()
+
+        # Step 2: Scheduler side - recreate client
+        app.state.lmcache_adapter = mock_scheduler_manager
+        scheduler_client = TestClient(app)
+
+        response = scheduler_client.post("/lookup/recreate")
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert "LMCacheBypassLookupClient" in data["old"]
+        assert data["new"] == "LMCacheLookupClient"
+        mock_scheduler_manager.recreate_lookup_client.assert_called_once()
+
+    def test_step_by_step_flow(self, mock_scheduler_manager):
+        """
+        Test step-by-step flow: dryrun -> close -> create.
+        """
+        app.state.lmcache_adapter = mock_scheduler_manager
+        client = TestClient(app)
+
+        # Step 1: Dryrun - check what would be created
+        mock_scheduler_manager.create_lookup_client.return_value = {
+            "new": "LMCacheLookupClient",
+            "dryrun": True,
+        }
+        response = client.post("/lookup/create?dryrun=true")
+        assert response.status_code == 200
+        data = json.loads(response.text)
+        assert data["dryrun"] is True
+
+        # Step 2: Close current client
+        response = client.post("/lookup/close")
+        assert response.status_code == 200
+        mock_scheduler_manager.close_lookup_client.assert_called_once()
+
+        # Step 3: Create new client
+        mock_scheduler_manager.create_lookup_client.return_value = {
+            "new": "LMCacheLookupClient"
+        }
+        response = client.post("/lookup/create")
+        assert response.status_code == 200


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This pull request enhances the system's operational capabilities by introducing a suite of API endpoints that allow for the dynamic management and reconfiguration of lookup clients and servers. This change provides the ability to update and switch lookup strategies on the fly, improving system adaptability and reducing downtime associated with configuration changes.

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
