### PR TITLE
Support notify quick healthy check while error happened

### DIFF
--- a/docs/source/production/observability/health_monitor.rst
+++ b/docs/source/production/observability/health_monitor.rst
@@ -84,6 +84,32 @@ The health monitor runs in a background thread:
 3. When unhealthy, store/retrieve operations are blocked with a warning log
 4. Once all checks pass again, the system is marked as healthy and operations resume
 
+Quick Health Check (Fast-Fail)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to periodic health checks, the Health Monitor supports **quick health checks** for fast failure detection:
+
+**How it works:**
+
+1. When a remote operation fails (e.g., ``get_blocking`` returns None), the backend calls a failure callback
+2. The callback triggers ``run_quick_checks()`` on the Health Monitor
+3. Each health check's ``quick_check()`` method is executed (lightweight, no network I/O)
+4. If quick check fails (e.g., failure count exceeds threshold), the system is immediately marked as unhealthy
+
+**Benefits:**
+
+- **Faster detection**: Failures are detected immediately, not waiting for the next ping interval
+- **Lower overhead**: Quick checks are lightweight (counter checks only, no ping operations)
+- **Automatic integration**: RemoteBackend automatically registers failure callbacks with the Health Monitor
+
+**Failure threshold mechanism:**
+
+The ``get_blocking_failed_threshold`` configuration controls how many consecutive failures trigger an unhealthy state:
+
+- Each ``get_blocking`` or ``batched_get_blocking`` failure increments a counter
+- When counter reaches the threshold within a check interval, quick check fails
+- System enters degraded mode and waits ``waiting_time_for_recovery`` seconds before retrying
+
 Initialization Failure Handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -121,11 +147,25 @@ This check monitors the connectivity to remote storage backends (e.g., Redis, Va
 - Pings the remote connector to verify it's reachable
 - Measures ping latency
 - Reports error codes for failures
+- Tracks ``get_blocking`` failure counts (via quick check)
 
 **When it's active:**
 
 - Only when a remote backend is configured (``remote_url`` is set)
 - Only if the connector supports the ``ping()`` operation
+
+**Quick check behavior:**
+
+- Monitors ``get_blocking_failed_count`` from the RemoteBackend
+- If failures exceed ``get_blocking_failed_threshold``, quick check fails immediately
+- After failure, waits ``waiting_time_for_recovery`` seconds before attempting recovery
+- Recovery is validated by a put-and-get test before resuming normal operations
+
+**Failure callback integration:**
+
+- Registers a failure callback with RemoteBackend during initialization
+- RemoteBackend calls the callback when ``get_blocking`` or ``batched_get_blocking`` fails
+- This triggers immediate ``quick_check()`` instead of waiting for the next ping interval
 
 **Metrics reported:**
 

--- a/lmcache/v1/health_monitor/base.py
+++ b/lmcache/v1/health_monitor/base.py
@@ -604,7 +604,7 @@ class HealthMonitor(PeriodicThread):
         This is thread-safe and non-blocking.
         """
         # Skip if already unhealthy
-        if not self._healthy:
+        if not self.is_healthy():
             return
 
         for check in self._health_checks:

--- a/lmcache/v1/health_monitor/base.py
+++ b/lmcache/v1/health_monitor/base.py
@@ -5,7 +5,7 @@ Base classes for health monitoring.
 
 # Standard
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 import threading
 
 # First Party
@@ -111,6 +111,22 @@ class HealthCheck(ABC):
         """
         return False
 
+    def quick_check(self) -> bool:  # noqa: B027
+        """
+        Perform a lightweight quick health check.
+
+        This method is called on every failure callback and should be
+        very fast (no network calls, no I/O operations). It's designed
+        for checking counters, thresholds, and other in-memory state.
+
+        Default implementation returns True (healthy). Override this
+        method to implement custom quick check logic.
+
+        Returns:
+            bool: True if quick check passes, False otherwise
+        """
+        return True
+
     def get_bypass_backend_name(self) -> Optional[str]:
         """
         Return the backend name to bypass when this health check fails
@@ -122,6 +138,26 @@ class HealthCheck(ABC):
             Optional[str]: The backend name to bypass, or None if not applicable
         """
         return None
+
+    def set_trigger_callback(  # noqa: B027
+        self,
+        callback: Callable[[], None],
+    ) -> None:
+        """
+        Set a callback to trigger immediate health check.
+
+        This method is called by HealthMonitor after discovery to allow
+        health checks to register callbacks with their monitored
+        components.
+
+        Override this method to implement custom callback registration
+        logic.
+
+        Args:
+            callback: A callable that triggers an immediate
+                health check.
+        """
+        pass
 
     @classmethod
     @abstractmethod
@@ -262,6 +298,8 @@ class HealthMonitor(PeriodicThread):
                                 self._health_checks.append(instance)
                                 # Initialize previous status as healthy
                                 self._previous_check_status[instance.name()] = True
+                                # Set trigger callback for immediate check
+                                instance.set_trigger_callback(self.run_quick_checks)
                                 logger.info(
                                     f"Registered health check: {instance.name()} "
                                     f"with fallback_policy: {instance.fallback_policy}"
@@ -547,6 +585,56 @@ class HealthMonitor(PeriodicThread):
         PeriodicThreadRegistry.get_instance().unregister(self.name)
         # Use base class stop method
         super().stop(timeout)
+
+    def run_quick_checks(self) -> None:
+        """
+        Run quick_check() on all health checks.
+
+        This method is called from external components
+        (e.g., RemoteBackend) when a failure occurs. It runs
+        lightweight quick_check() on all health checks. If any
+        quick check fails, the system is immediately marked as
+        unhealthy.
+
+        Quick checks are designed to be fast (no network I/O)
+        and can be called frequently. Full checks (ping, etc.)
+        only run on the regular interval to avoid excessive
+        overhead.
+
+        This is thread-safe and non-blocking.
+        """
+        # Skip if already unhealthy
+        if not self._healthy:
+            return
+
+        for check in self._health_checks:
+            if check.should_skip():
+                continue
+
+            check_name = check.name()
+
+            try:
+                is_healthy = check.quick_check()
+            except Exception as e:
+                logger.error(
+                    "Quick check %s raised exception: %s",
+                    check_name,
+                    e,
+                )
+                is_healthy = False
+
+            if not is_healthy:
+                # Quick check failed
+                logger.warning(
+                    "Quick health check failed: %s",
+                    check_name,
+                )
+                self._previous_check_status[check_name] = False
+
+                if check.fallback_policy == FallbackPolicy.RECOMPUTE:
+                    self._set_healthy(False)
+                elif check.fallback_policy == FallbackPolicy.LOCAL_CPU:
+                    self._apply_local_cpu_fallback(check)
 
     def _execute(self) -> ThreadRunSummary:
         """

--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -5,7 +5,7 @@ Health check for RemoteBackend.
 
 # Standard
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 import asyncio
 import time
 
@@ -81,6 +81,27 @@ class RemoteBackendHealthCheck(HealthCheck):
         self._backend_name: Optional[str] = None
         self._last_get_blocking_failed_count = 0
 
+    def set_trigger_callback(
+        self,
+        callback: Callable[[], None],
+    ) -> None:
+        """
+        Set a callback to trigger immediate health check.
+
+        This registers the callback with the backend so that
+        failures can trigger immediate health checks instead
+        of waiting for the next check interval.
+
+        Args:
+            callback: A callable that triggers an immediate
+                health check.
+        """
+        self.backend.set_on_failure_callback(callback)
+        logger.info(
+            "Registered failure callback for %s",
+            self.backend.remote_url,
+        )
+
     @classmethod
     def create(cls, manager: "LMCacheManager") -> List[HealthCheck]:
         """
@@ -136,6 +157,64 @@ class RemoteBackendHealthCheck(HealthCheck):
         """Get the ping timeout from the backend config."""
         return self.backend.config.get_extra_config_value(
             PING_TIMEOUT_CONFIG_KEY, DEFAULT_PING_TIMEOUT
+        )
+
+    def _check_get_blocking_failed_threshold(
+        self,
+        clear_count: bool = False,
+    ) -> bool:
+        """
+        Check if get_blocking failed count exceeds threshold.
+
+        Args:
+            clear_count: If True, update the last count after
+                reading. If False, just peek without updating.
+
+        Returns:
+            bool: True if within threshold, False if exceeded
+        """
+
+        # Check read failed
+        current = self.backend.get_blocking_failed_count
+        count = (
+            current - self._last_get_blocking_failed_count
+        )
+        if clear_count:
+            self._last_get_blocking_failed_count = current
+
+        threshold = self.backend.config.get_extra_config_value(
+            GET_BLOCKING_FAILED_THRESHOLD_CONFIG_KEY,
+            DEFAULT_GET_BLOCKING_FAILED_THRESHOLD,
+        )
+        if count >= threshold:
+            logger.warning(
+                "Detected %s get blocking failed in interval, threshold: %s",
+                count,
+                threshold,
+            )
+            self.failure_time = time.time()
+            return False
+        return True
+
+    def quick_check(self) -> bool:
+        """
+        Perform a lightweight quick health check.
+
+        This checks the get_blocking_failed_count against the
+        threshold. It's designed to be called frequently (on
+        every failure) and completes very quickly without any
+        network I/O.
+
+        Returns:
+            bool: True if check passes, False if failures
+                exceed threshold
+        """
+        # Skip if already in failure recovery mode
+        if self.failure_time is not None:
+            return False
+
+        return self._check_get_blocking_failed_threshold(
+            clear_count=False,
         )
 
     def _try_reinitialize_connection(self) -> bool:
@@ -201,24 +280,11 @@ class RemoteBackendHealthCheck(HealthCheck):
                 )
                 return False
 
-        # Check read failed
-        current_get_blocking_failed_count = self.backend.get_blocking_failed_count
-        get_blocking_failed_count = (
-            current_get_blocking_failed_count - self._last_get_blocking_failed_count
-        )
-        self._last_get_blocking_failed_count = current_get_blocking_failed_count
-        threshold = self.backend.config.get_extra_config_value(
-            GET_BLOCKING_FAILED_THRESHOLD_CONFIG_KEY,
-            DEFAULT_GET_BLOCKING_FAILED_THRESHOLD,
-        )
-        if get_blocking_failed_count >= threshold:
-            logger.warning(
-                "Detected %s get blocking failed in interval, threshold: %s",
-                get_blocking_failed_count,
-                threshold,
-            )
-            self.failure_time = time.time()
-            return False
+
+        # Check read failed count and clear it
+        if not self._check_get_blocking_failed_threshold(
+            clear_count=True,
+        ):
 
         # If connector doesn't support ping, assume it's healthy
         if not connector.support_ping():

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -88,6 +88,11 @@ class RemoteBackend(StorageBackendInterface):
         self._get_blocking_failed_count = 0
         self._put_failed_count = 0
 
+        # Callback to notify external components (e.g., HealthMonitor)
+        # when a remote failure occurs. This allows immediate health
+        # check without waiting for the next check interval.
+        self._on_failure_callback: Optional[Callable[[], None]] = None
+
     def _setup_metrics(self):
         prometheus_logger = PrometheusLogger.GetInstanceOrNone()
         if prometheus_logger is not None:
@@ -351,7 +356,7 @@ class RemoteBackend(StorageBackendInterface):
         t2 = time.perf_counter()
         self.stats_monitor.update_interval_remote_time_to_get_sync((t2 - t1) * 1000)
         if memory_obj is None:
-            self._get_blocking_failed_count += 1
+            self._record_failure()
             return None
         decompressed_memory_obj = self.deserializer.deserialize(memory_obj)
         t3 = time.perf_counter()
@@ -369,6 +374,35 @@ class RemoteBackend(StorageBackendInterface):
     @property
     def put_failed_count(self):
         return self._put_failed_count
+
+    def set_on_failure_callback(
+        self,
+        callback: Optional[Callable[[], None]],
+    ) -> None:
+        """
+        Set a callback to be invoked when a remote failure occurs.
+
+        This allows external components (e.g., HealthMonitor) to be
+        notified immediately when failures happen, enabling faster
+        health status updates.
+
+        Args:
+            callback: A callable that takes no arguments and
+                returns None. Pass None to remove the callback.
+        """
+        self._on_failure_callback = callback
+
+    def _record_failure(self) -> None:
+        """
+        Record a remote failure by incrementing the failure count
+        and notifying external components.
+        """
+        self._get_blocking_failed_count += 1
+        if self._on_failure_callback is not None:
+            try:
+                self._on_failure_callback()
+            except Exception as e:
+                logger.warning("Error in on_failure_callback: %s", e)
 
     def batched_get_blocking(
         self,
@@ -472,7 +506,7 @@ class RemoteBackend(StorageBackendInterface):
                     self.deserializer.deserialize(memory_obj)
                 )
         if error_happened:
-            self._get_blocking_failed_count += 1
+            self._record_failure()
 
         assert len(decompressed_memory_objs) == len(keys), (
             f"keys length: {len(keys)}, "

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -397,7 +397,8 @@ class RemoteBackend(StorageBackendInterface):
         Record a remote failure by incrementing the failure count
         and notifying external components.
         """
-        self._get_blocking_failed_count += 1
+        with self.lock:
+            self._get_blocking_failed_count += 1
         if self._on_failure_callback is not None:
             try:
                 self._on_failure_callback()

--- a/tests/v1/test_health_monitor.py
+++ b/tests/v1/test_health_monitor.py
@@ -31,12 +31,17 @@ class SimpleHealthCheck(HealthCheck):
     ):
         self._name, self._healthy, self._skip = name, healthy, skip
         self.check_count = 0
+        self.quick_check_count = 0
 
     def name(self) -> str:
         return self._name
 
     def check(self) -> bool:
         self.check_count += 1
+        return self._healthy
+
+    def quick_check(self) -> bool:
+        self.quick_check_count += 1
         return self._healthy
 
     def should_skip(self) -> bool:
@@ -230,6 +235,36 @@ class TestHealthMonitor:
         reader_thread.join()
         assert len(results) > 0
 
+    def test_run_quick_checks(self, monitor):
+        """Test that run_quick_checks runs quick_check."""
+        toggle = SimpleHealthCheck(healthy=True)
+        monitor._health_checks = [toggle]
+
+        # run_quick_checks runs quick_check synchronously
+        initial_quick_count = toggle.quick_check_count
+        monitor.run_quick_checks()
+
+        # Verify that quick_check was called (not full check)
+        assert toggle.quick_check_count > initial_quick_count
+        assert toggle.check_count == 0  # full check not called
+
+    def test_run_quick_checks_updates_health_status(self, monitor):
+        """Test that run_quick_checks updates health status."""
+        toggle = SimpleHealthCheck(healthy=True)
+        monitor._health_checks = [toggle]
+
+        # Initial state should be healthy
+        assert monitor.is_healthy() is True
+
+        # Set check to unhealthy
+        toggle.set_healthy(False)
+
+        # Run quick checks synchronously
+        monitor.run_quick_checks()
+
+        # Status should be updated to unhealthy immediately
+        assert monitor.is_healthy() is False
+
 
 # ============================================================================
 # Tests for RemoteBackendHealthCheck
@@ -270,6 +305,43 @@ class TestRemoteBackendHealthCheck:
         mock_manager.lmcache_engine.storage_manager = MagicMock()
         mock_manager.lmcache_engine.storage_manager.storage_backends = {}
         assert len(RemoteBackendHealthCheck.create(mock_manager)) == 0
+
+    def test_set_trigger_callback(self, mock_backend):
+        """Test set_trigger_callback registers callback with backend."""
+        check = RemoteBackendHealthCheck(mock_backend)
+
+        callback_called = False
+
+        def callback():
+            nonlocal callback_called
+            callback_called = True
+
+        check.set_trigger_callback(callback)
+        mock_backend.set_on_failure_callback.assert_called_once_with(callback)
+
+    def test_quick_check_passes_when_below_threshold(self, mock_backend):
+        """Test quick_check returns True when below threshold."""
+        mock_backend.get_blocking_failed_count = 0
+        mock_backend.config.get_extra_config_value.return_value = 5
+
+        check = RemoteBackendHealthCheck(mock_backend)
+        assert check.quick_check() is True
+
+    def test_quick_check_fails_when_exceeds_threshold(self, mock_backend):
+        """Test quick_check returns False when above threshold."""
+        mock_backend.get_blocking_failed_count = 10
+        mock_backend.config.get_extra_config_value.return_value = 5
+
+        check = RemoteBackendHealthCheck(mock_backend)
+        assert check.quick_check() is False
+        assert check.failure_time is not None
+
+    def test_quick_check_returns_false_in_failure_recovery(self, mock_backend):
+        """Test quick_check returns False when failure_time is set."""
+        check = RemoteBackendHealthCheck(mock_backend)
+        check.failure_time = 12345.0  # Simulate previous failure
+
+        assert check.quick_check() is False
 
 
 # ============================================================================


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This pull request enhances the health monitoring system by introducing a mechanism for immediate, lightweight health checks triggered upon detecting failures in remote backend operations. This allows the system to react more quickly to unhealthy states without waiting for the regular, full health check interval, thereby improving system resilience and responsiveness.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
