### PR TITLE
[BugFix][Test]Update tests to be able to run on non CUDA environment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,7 @@ steps:
 
       uv pip install -r requirements/common.txt
       uv pip install -r requirements/test.txt
+      uv pip install -r requirements/cuda.txt
       uv pip install -e . --no-build-isolation
       uv pip freeze
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,16 +74,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install vllm
           python -m pip install -r requirements/test.txt
           python -m pip install -r requirements/common.txt
 
       - name: "Run non-CUDA unit tests"
+        # Avoid adding ignore statements here. You should aim to make your tests to run on non-CUDA
+        # by default. Follow pattern in other test files where they check for CUDA and act accordingly.
+        # This is so that users can run unit test from CLI in CUDA and non-CUDA environment with just
+        # pytest command.
         run: |
-          pytest --ignore=tests/disagg --ignore=tests/v1/test_nixl_storage.py \
-            --ignore=tests/v1/multiprocess/ \
-            --ignore=tests/v1/distributed/ \
-            --ignore=tests/v1/mp_observability/ \
-            --ignore=tests/skipped \
-            --ignore=tests/v1/storage_backend/test_eic.py
-
+          pytest

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,16 +1,13 @@
 aiofile
 aiofiles
-blake3
 aiohttp
 awscrt
+blake3
 cufile-python
 fastapi
+httptools
 httpx
 msgspec
-# if nixl decides to support >=3.13 in the future, we can remove this constraint
-nixl; python_version < "3.13"
-# nixl uses numba which requires numpy<=2.2.6
-numpy<=2.2.6
 nvtx
 prometheus_client >= 0.18.0
 psutil
@@ -19,9 +16,8 @@ pyyaml
 pyzmq >= 25.0.0
 redis
 safetensors
-setuptools>=77.0.3,<81.0.0
-setuptools_scm>=8
 sortedcontainers
+
 # 1. avoid pinning torch version in the runtime dependencies so that 
 # installing lmcache (from source or from pypi) will not override
 # the user's preexisting torch version 
@@ -34,8 +30,6 @@ sortedcontainers
 # whatever torch version that they have
 # 4. this torch version may also be overridden inside of LMCache/docker/Dockerfile
 torch
+
 transformers >= 4.51.1
 uvicorn
-httptools
-# Right now we are using cuda 12.x to align with serving engines
-cupy-cuda12x

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,10 +1,12 @@
 # Common project dependencies
 -r common.txt
 
+# Right now we are using cuda 12.x to align with serving engines
+cupy-cuda12x
+
 # Dependencies for NVIDIA GPUs
 ray >= 2.9
 nvidia-ml-py # for pynvml package
-
 
 # do not pin version because the dockerfile requires cuda.txt
 torch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,9 +1,12 @@
+# Common project dependencies
+-r common.txt
+
 buildkite-test-collector
+jinja2<3.2
 pytest>=7.0,<9.1  # avoid some plugins breaking in 8.x
 pytest-asyncio
 pytest-benchmark
 pytest-benchmark[histogram]
 pytest-cov
 pytest-html>=3.2,<5.0  # 4.x requires external assets; 3.2 is stable
-jinja2<3.2
 python-multipart

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -12,16 +12,18 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.config import (
-    EvictionConfig,
-    L1ManagerConfig,
-    L1MemoryManagerConfig,
-    StorageManagerConfig,
-)
-from lmcache.v1.distributed.l2_adapters.config import (
-    L2AdaptersConfig,
-    MockL2AdapterConfig,
-)
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+    )
+    from lmcache.v1.distributed.l2_adapters.config import (
+        L2AdaptersConfig,
+        MockL2AdapterConfig,
+    )
 
 try:
     # First Party
@@ -33,9 +35,7 @@ except ImportError:
     )
 
 # Skip all tests in this module if CUDA is not available
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA is not available"
-)
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 
 def should_use_lazy_alloc() -> bool:

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -14,6 +14,7 @@ import torch
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 
 if torch.cuda.is_available():
+    # First Party
     from lmcache.v1.distributed.config import (
         EvictionConfig,
         L1ManagerConfig,

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -50,10 +50,14 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.config import (
-    L1ManagerConfig,
-    L1MemoryManagerConfig,
-)
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import (
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+    )
+
+# First Party
 from lmcache.v1.distributed.error import L1Error
 
 try:
@@ -66,9 +70,7 @@ except ImportError:
     )
 
 # Skip all tests in this module if CUDA is not available
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA is not available"
-)
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 
 def should_use_lazy_alloc() -> bool:

--- a/tests/v1/distributed/test_l1_memory_manager.py
+++ b/tests/v1/distributed/test_l1_memory_manager.py
@@ -25,7 +25,11 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc
-from lmcache.v1.distributed.config import L1MemoryManagerConfig
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import L1MemoryManagerConfig
+
+# First Party
 from lmcache.v1.distributed.error import L1Error
 
 try:
@@ -38,9 +42,7 @@ except ImportError:
     pytest.skip("L1MemoryManager could not be imported", allow_module_level=True)
 
 # Skip all tests in this module if CUDA is not available
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA is not available"
-)
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 
 def should_use_lazy_alloc() -> bool:

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -11,13 +11,22 @@ These tests verify the basic functionality of the LRUEvictionPolicy:
 """
 
 # Third Party
+import pytest
+import torch
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.eviction_policy import LRUEvictionPolicy
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.eviction_policy import LRUEvictionPolicy
+
+# First Party
 from lmcache.v1.distributed.internal_api import (
     EvictionDestination,
 )
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # =============================================================================
 # Helper Functions

--- a/tests/v1/distributed/test_mock_l2_adapter.py
+++ b/tests/v1/distributed/test_mock_l2_adapter.py
@@ -17,13 +17,20 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+    from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+
+# First Party
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # =============================================================================
 # Test Fixtures
@@ -66,7 +73,12 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     if events:
         # Read and consume the event
         try:
-            os.eventfd_read(event_fd)
+            # Replaces os.eventfd_read(event_fd) as only added in Python 3.12
+            # os.eventfd_read() is a thin wrapper that calls os.read(fd, 8) and
+            # unpacks the result. It is a clean portable solution here as the
+            # return value is unused
+            # Fixes any runtime failures for Python 3.10/3.11
+            os.read(event_fd, 8)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/distributed/test_object_key_parallel.py
+++ b/tests/v1/distributed/test_object_key_parallel.py
@@ -26,14 +26,14 @@ from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
 )
-from lmcache.v1.distributed.config import (
-    EvictionConfig,
-    L1ManagerConfig,
-    L1MemoryManagerConfig,
-    StorageManagerConfig,
-)
 
 if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+    )
     from lmcache.v1.distributed.storage_manager import StorageManager
 
 # First Party

--- a/tests/v1/distributed/test_object_key_parallel.py
+++ b/tests/v1/distributed/test_object_key_parallel.py
@@ -32,8 +32,14 @@ from lmcache.v1.distributed.config import (
     L1MemoryManagerConfig,
     StorageManagerConfig,
 )
-from lmcache.v1.distributed.storage_manager import StorageManager
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.storage_manager import StorageManager
+
+# First Party
 from lmcache.v1.memory_management import MemoryFormat
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # ==============================================================================
 # Test Fixtures

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -19,20 +19,24 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
-from lmcache.v1.distributed.error import L1Error
-from lmcache.v1.distributed.l1_manager import L1Manager
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
-from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
-    PrefetchController,
-)
-from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
-    DefaultPrefetchPolicy,
-)
-from lmcache.v1.distributed.storage_controllers.store_policy import (
-    AdapterDescriptor,
-)
+
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+    from lmcache.v1.distributed.error import L1Error
+    from lmcache.v1.distributed.l1_manager import L1Manager
+    from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+    from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+    from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+        PrefetchController,
+    )
+    from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+        DefaultPrefetchPolicy,
+    )
+    from lmcache.v1.distributed.storage_controllers.store_policy import (
+        AdapterDescriptor,
+    )
+
+# First Party
 from lmcache.v1.memory_management import MemoryObjMetadata, TensorMemoryObj
 
 # Skip all tests in this module if CUDA is not available
@@ -81,60 +85,61 @@ def wait_for_condition(
     return False
 
 
-def wait_for_prefetch_result(
-    ctrl: PrefetchController,
-    req_id: int,
-    timeout: float = 5.0,
-    poll_interval: float = 0.05,
-) -> int | None:
-    """Poll query_prefetch_result until it returns a non-None value."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        result = ctrl.query_prefetch_result(req_id)
-        if result is not None:
-            return result
-        time.sleep(poll_interval)
-    return None
+if torch.cuda.is_available():
 
+    def wait_for_prefetch_result(
+        ctrl: PrefetchController,
+        req_id: int,
+        timeout: float = 5.0,
+        poll_interval: float = 0.05,
+    ) -> int | None:
+        """Poll query_prefetch_result until it returns a non-None value."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            result = ctrl.query_prefetch_result(req_id)
+            if result is not None:
+                return result
+            time.sleep(poll_interval)
+        return None
 
-def make_adapter() -> MockL2Adapter:
-    """Create a MockL2Adapter with fast bandwidth."""
-    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
-    return MockL2Adapter(config)
+    def make_adapter() -> MockL2Adapter:
+        """Create a MockL2Adapter with fast bandwidth."""
+        config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+        return MockL2Adapter(config)
 
+    def make_descriptor(index: int) -> AdapterDescriptor:
+        """Create an AdapterDescriptor for testing."""
+        config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+        return AdapterDescriptor(index=index, config=config)
 
-def make_descriptor(index: int) -> AdapterDescriptor:
-    """Create an AdapterDescriptor for testing."""
-    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
-    return AdapterDescriptor(index=index, config=config)
-
-
-def store_keys_in_l2(
-    adapter: MockL2Adapter,
-    keys: list[ObjectKey],
-    layout: MemoryLayoutDesc,
-) -> None:
-    """Store test data directly in L2 adapter and wait for completion."""
-    if not keys:
-        return
-    objs = []
-    for _ in keys:
-        tensor = torch.randn(layout.shapes[0], dtype=layout.dtypes[0])
-        metadata = MemoryObjMetadata(
-            shape=layout.shapes[0],
-            dtype=layout.dtypes[0],
-            address=0,
-            phy_size=tensor.nelement() * tensor.element_size(),
-            ref_count=0,
+    def store_keys_in_l2(
+        adapter: MockL2Adapter,
+        keys: list[ObjectKey],
+        layout: MemoryLayoutDesc,
+    ) -> None:
+        """Store test data directly in L2 adapter and wait for completion."""
+        if not keys:
+            return
+        objs = []
+        for _ in keys:
+            tensor = torch.randn(layout.shapes[0], dtype=layout.dtypes[0])
+            metadata = MemoryObjMetadata(
+                shape=layout.shapes[0],
+                dtype=layout.dtypes[0],
+                address=0,
+                phy_size=tensor.nelement() * tensor.element_size(),
+                ref_count=0,
+            )
+            obj = TensorMemoryObj(
+                raw_data=tensor, metadata=metadata, parent_allocator=None
+            )
+            objs.append(obj)
+        adapter.submit_store_task(keys, objs)  # type: ignore
+        ok = wait_for_condition(
+            lambda: all(adapter.debug_has_key(k) for k in keys),
+            timeout=5.0,
         )
-        obj = TensorMemoryObj(raw_data=tensor, metadata=metadata, parent_allocator=None)
-        objs.append(obj)
-    adapter.submit_store_task(keys, objs)  # type: ignore
-    ok = wait_for_condition(
-        lambda: all(adapter.debug_has_key(k) for k in keys),
-        timeout=5.0,
-    )
-    assert ok, "Failed to store test data in L2 adapter"
+        assert ok, "Failed to store test data in L2 adapter"
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -6,16 +6,28 @@ Tests are written against the PrefetchPolicy contract defined in
 prefetch_policy.py.
 """
 
+# Third Party
+import pytest
+import torch
+
+if torch.cuda.is_available():
+    from lmcache.native_storage_ops import Bitmap
+
 # First Party
-from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
-    DefaultPrefetchPolicy,
-)
-from lmcache.v1.distributed.storage_controllers.store_policy import (
-    AdapterDescriptor,
-)
+
+if torch.cuda.is_available():
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+    from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+        DefaultPrefetchPolicy,
+    )
+    from lmcache.v1.distributed.storage_controllers.store_policy import (
+        AdapterDescriptor,
+    )
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # =============================================================================
 # Helpers
@@ -31,25 +43,32 @@ def make_object_key(chunk_id: int) -> ObjectKey:
     )
 
 
-def make_descriptor(index: int) -> AdapterDescriptor:
-    """Create an AdapterDescriptor for testing."""
-    config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
-    return AdapterDescriptor(index=index, config=config)
+if torch.cuda.is_available():
+
+    def make_descriptor(index: int) -> AdapterDescriptor:
+        """Create an AdapterDescriptor for testing."""
+        config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+        return AdapterDescriptor(index=index, config=config)
 
 
-def make_bitmap(size: int, set_bits: list[int]) -> Bitmap:
-    """Create a Bitmap with specific bits set."""
-    bitmap = Bitmap(size)
-    for i in set_bits:
-        bitmap.set(i)
-    return bitmap
+if torch.cuda.is_available():
+
+    def make_bitmap(size: int, set_bits: list[int]) -> Bitmap:
+        """Create a Bitmap with specific bits set."""
+        bitmap = Bitmap(size)
+        for i in set_bits:
+            bitmap.set(i)
+        return bitmap
 
 
-def plan_to_indices(plan: dict[int, Bitmap]) -> dict[int, list[int]]:
-    """Convert a Bitmap-based load plan to index lists for easy assertion."""
-    return {
-        adapter_idx: bitmap.get_indices_list() for adapter_idx, bitmap in plan.items()
-    }
+if torch.cuda.is_available():
+
+    def plan_to_indices(plan: dict[int, Bitmap]) -> dict[int, list[int]]:
+        """Convert a Bitmap-based load plan to index lists for easy assertion."""
+        return {
+            adapter_idx: bitmap.get_indices_list()
+            for adapter_idx, bitmap in plan.items()
+        }
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -19,24 +19,25 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
-from lmcache.v1.distributed.l1_manager import L1Manager
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
-from lmcache.v1.distributed.storage_controllers.store_controller import (
-    StoreController,
-    StoreListener,
-)
-from lmcache.v1.distributed.storage_controllers.store_policy import (
-    AdapterDescriptor,
-    DefaultStorePolicy,
-    StorePolicy,
-)
+
+if torch.cuda.is_available():
+    # First Party
+    from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+    from lmcache.v1.distributed.l1_manager import L1Manager
+    from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+    from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+    from lmcache.v1.distributed.storage_controllers.store_controller import (
+        StoreController,
+        StoreListener,
+    )
+    from lmcache.v1.distributed.storage_controllers.store_policy import (
+        AdapterDescriptor,
+        DefaultStorePolicy,
+        StorePolicy,
+    )
 
 # Skip all tests in this module if CUDA is not available
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA is not available"
-)
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 
 # =============================================================================
@@ -90,32 +91,34 @@ def wait_for_condition(
     return False
 
 
-def write_keys_to_l1(
-    l1_manager: L1Manager,
-    keys: list[ObjectKey],
-    layout: MemoryLayoutDesc,
-) -> list[ObjectKey]:
-    """
-    Write keys to L1 (reserve_write + finish_write).
+if torch.cuda.is_available():
 
-    Args:
-        l1_manager: The L1 manager to write to.
-        keys: Object keys to write.
-        layout: Memory layout description.
+    def write_keys_to_l1(
+        l1_manager: L1Manager,
+        keys: list[ObjectKey],
+        layout: MemoryLayoutDesc,
+    ) -> list[ObjectKey]:
+        """
+        Write keys to L1 (reserve_write + finish_write).
 
-    Returns:
-        List of keys that were successfully written.
-    """
-    results = l1_manager.reserve_write(
-        keys=keys,
-        is_temporary=[False] * len(keys),
-        layout_desc=layout,
-        mode="new",
-    )
-    written = [k for k, (e, m) in results.items() if m is not None]
-    if written:
-        l1_manager.finish_write(written)
-    return written
+        Args:
+            l1_manager: The L1 manager to write to.
+            keys: Object keys to write.
+            layout: Memory layout description.
+
+        Returns:
+            List of keys that were successfully written.
+        """
+        results = l1_manager.reserve_write(
+            keys=keys,
+            is_temporary=[False] * len(keys),
+            layout_desc=layout,
+            mode="new",
+        )
+        written = [k for k, (e, m) in results.items() if m is not None]
+        if written:
+            l1_manager.finish_write(written)
+        return written
 
 
 # =============================================================================
@@ -141,19 +144,23 @@ def l1_manager():
     mgr.close()
 
 
-def make_adapter() -> MockL2Adapter:
-    """Create a MockL2Adapter with fast bandwidth."""
-    config = MockL2AdapterConfig(
-        max_size_gb=0.01,
-        mock_bandwidth_gb=10.0,
-    )
-    return MockL2Adapter(config)
+if torch.cuda.is_available():
+
+    def make_adapter() -> MockL2Adapter:
+        """Create a MockL2Adapter with fast bandwidth."""
+        config = MockL2AdapterConfig(
+            max_size_gb=0.01,
+            mock_bandwidth_gb=10.0,
+        )
+        return MockL2Adapter(config)
 
 
-def make_descriptor(index: int) -> AdapterDescriptor:
-    """Create an AdapterDescriptor for testing."""
-    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
-    return AdapterDescriptor(index=index, config=config)
+if torch.cuda.is_available():
+
+    def make_descriptor(index: int) -> AdapterDescriptor:
+        """Create an AdapterDescriptor for testing."""
+        config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+        return AdapterDescriptor(index=index, config=config)
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_store_policy.py
+++ b/tests/v1/distributed/test_store_policy.py
@@ -6,14 +6,22 @@ Tests are written against the StorePolicy contract defined in store_policy.py.
 """
 
 # Third Party
+import pytest
+import torch
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.storage_controllers.store_policy import (
-    AdapterDescriptor,
-    DefaultStorePolicy,
-)
+
+if torch.cuda.is_available():
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+    from lmcache.v1.distributed.storage_controllers.store_policy import (
+        AdapterDescriptor,
+        DefaultStorePolicy,
+    )
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # =============================================================================
 # Helpers
@@ -29,10 +37,12 @@ def make_object_key(chunk_id: int) -> ObjectKey:
     )
 
 
-def make_descriptor(index: int) -> AdapterDescriptor:
-    """Create an AdapterDescriptor for testing."""
-    config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
-    return AdapterDescriptor(index=index, config=config)
+if torch.cuda.is_available():
+
+    def make_descriptor(index: int) -> AdapterDescriptor:
+        """Create an AdapterDescriptor for testing."""
+        config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+        return AdapterDescriptor(index=index, config=config)
 
 
 # =============================================================================

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -34,8 +34,13 @@ from lmcache.v1.distributed.config import (
     StorageManagerConfig,
 )
 from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
-from lmcache.v1.multiprocess.blend_server import get_sep_tokens
+
+if torch.cuda.is_available():
+    from lmcache.v1.multiprocess.blend_server import get_sep_tokens
+
 from lmcache.v1.multiprocess.config import MPServerConfig
+
+# First Party
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
@@ -46,6 +51,8 @@ from lmcache.v1.multiprocess.protocol import (
     RequestType,
     get_response_class,
 )
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # Configuration constants
 SERVER_HOST = "localhost"

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -40,9 +40,8 @@ from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
 if torch.cuda.is_available():
     from lmcache.v1.multiprocess.blend_server import get_sep_tokens
 
-from lmcache.v1.multiprocess.config import MPServerConfig
-
 # First Party
+from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -26,13 +26,15 @@ import pytest
 import torch
 import zmq
 
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+    )
+
 # First Party
-from lmcache.v1.distributed.config import (
-    EvictionConfig,
-    L1ManagerConfig,
-    L1MemoryManagerConfig,
-    StorageManagerConfig,
-)
 from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
 
 if torch.cuda.is_available():

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -34,8 +34,6 @@ if torch.cuda.is_available():
     # First Party
     from lmcache.v1.multiprocess.server import run_cache_server
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
-
 # Configuration constants
 SERVER_HOST = "localhost"
 SERVER_PORT = 5599

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -10,13 +10,15 @@ import pytest
 import torch
 import zmq
 
+if torch.cuda.is_available():
+    from lmcache.v1.distributed.config import (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+    )
+
 # First Party
-from lmcache.v1.distributed.config import (
-    EvictionConfig,
-    L1ManagerConfig,
-    L1MemoryManagerConfig,
-    StorageManagerConfig,
-)
 from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
 from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.custom_types import (

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -29,7 +29,12 @@ from lmcache.v1.multiprocess.protocol import (
     RequestType,
     get_response_class,
 )
-from lmcache.v1.multiprocess.server import run_cache_server
+
+if torch.cuda.is_available():
+    # First Party
+    from lmcache.v1.multiprocess.server import run_cache_server
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
 
 # Configuration constants
 SERVER_HOST = "localhost"

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -7,6 +7,10 @@ message-queue round-trip, server handler, and client-side adapter API.
 # Standard
 from unittest.mock import MagicMock, patch
 
+# Third Party
+import pytest
+import torch
+
 # First Party
 from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
@@ -85,6 +89,10 @@ def test_mq_free_locks():
 # ============================================================================
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for MPCacheEngine",
+)
 def test_server_free_lookup_locks_calls_finish_read_prefetched():
     """MPCacheEngine.free_lookup_locks should resolve hash keys and call
     finish_read_prefetched on the storage manager."""
@@ -116,6 +124,10 @@ def test_server_free_lookup_locks_calls_finish_read_prefetched():
     )
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for MPCacheEngine",
+)
 def test_server_free_lookup_locks_no_matching_chunks():
     """MPCacheEngine.free_lookup_locks with no chunks in range should be a no-op."""
     # First Party
@@ -142,6 +154,10 @@ def test_server_free_lookup_locks_no_matching_chunks():
     engine.storage_manager.finish_read_prefetched.assert_not_called()
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for MPCacheEngine",
+)
 def test_server_handler_registered():
     """run_cache_server should register a FREE_LOOKUP_LOCKS handler."""
     # First Party

--- a/tests/v1/test_pos_kernels.py
+++ b/tests/v1/test_pos_kernels.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+pytest.importorskip("vllm", reason="vllm package is required for positional_encoding")
+
 # First Party
 from lmcache.v1.compute.positional_encoding import get_fused_rope
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Unit tests that are non-CUDA should be able to run on non-CUDA environment but they are currently broken. This PR updates the tests to be able to run for non CUDA environment.

**Special notes for your reviewers**:

1. Updates to the Python requirement files as follows:

- Test requires dependencies from `common.txt`, so add reference to `test.txt`
- Removed `cupy-cuda12x` `numpy` and `nixl` dependencies from `common.txt`
- Moved cuda (`cupy-cuda12x`) dependency to `cuda.txt` from `common.txt`
- `nixl` removed completely as previously agreed it should to be installed outside of LMCache

2. Update to the GH unit test job to make it run with `ignore` of tests directories. The idea is that each test should contain check for CUDA and skip if not available. This way a user can just run `pytest` and not have to know what directories and files are CUDA specific.

@ApostaC @YaoJiayi @maobaolong @sammshen Can you pls. look at the change to the requirements files in particular? I have made changes and want to better understand any consequences.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
