### PR TITLE
[6/N][Feat] This PR adds io_uring support to the Rust raw block backend.

### DIFF
--- a/benchmarks/storage_backend_io/README.md
+++ b/benchmarks/storage_backend_io/README.md
@@ -1,11 +1,19 @@
 # Storage Backend I/O Benchmark
 
 This microbenchmark compares **LocalDiskBackend** vs **RustRawBlockBackend** under high write-concurrency.
+For **RustRawBlockBackend** this also supports write and read performance testing for **posix** and **io_uring** backends.
 
 ## What It Measures
 
+### Write Benchmark
 - Total time to submit and complete `num_ops` write (put) operations
 - Effective ops/sec under concurrent submission
+
+### Read Benchmark (`--backend rust_raw_block_read`)
+- Write phase: Time to write `num_ops` memory objects to the raw block device
+- Read phase: Time to read back all `num_ops` objects using concurrent batched blocking reads
+- Data integrity verification (optional with `--verify-integrity`)
+- Separate metrics for write and read performance
 
 ## Usage
 
@@ -30,7 +38,8 @@ python benchmarks/storage_backend_io/storage_backend_io_benchmark.py \
 - `--raw-odirect` should only be used with a real block device that supports O_DIRECT.
 - When `--local-disk-odirect` is enabled, the benchmark allocates **page-aligned** buffers to avoid EINVAL from O_DIRECT.
 - Local disk backend uses its internal worker pool; completion is tracked via callbacks.
-- Rust raw block benchmark uses a unique manifest path per run to avoid stale-index reuse between runs.
+- Read benchmark (`rust_raw_block_read`) performs a write phase followed by a read phase, measuring both separately.
+- Use `--verify-integrity` with read benchmark to ensure data correctness (compares read data with original written data).
 
 ## How To Compare On Real NVMe
 
@@ -94,6 +103,58 @@ print(f"rust vs local: {(rust / local - 1.0) * 100.0:+.2f}%")
 PY
 ```
 
+## Use io_uring on Real NVMe
+
+### Compare posix vs io_uring write and read performance
+
+```bash
+# Run posix write & read benchmark. To enable data integrity `--verify-integrity`
+python benchmarks/storage_backend_io/storage_backend_io_benchmark.py \
+  --num-ops 1024 \
+  --concurrency 4 \
+  --backend rust_raw_block_read \
+  --raw-device /dev/nvme1n1 \
+  --chunk-size 256 \
+  --alignement 4096 \
+  --raw-odirect \
+  --output-json /tmp/rust_raw_block_read_posix.json
+
+# Run io_uring write & read benchmark. To enable data integrity `--verify-integrity`
+python benchmarks/storage_backend_io/storage_backend_io_benchmark.py \
+  --num-ops 1024 \
+  --concurrency 4 \
+  --backend rust_raw_block_read \
+  --raw-device /dev/nvme1n1 \
+  --raw-odirect \
+  --chunk-size 256 \
+  --alignement 4096 \
+  --use-uring \
+  --output-json /tmp/rust_raw_block_read_uring.json
+
+# Compute comparison
+python - <<'PY'
+import json
+
+with open("/tmp/rust_raw_block_read_posix.json") as f:
+    posix = json.load(f)[0]
+with open("/tmp/rust_raw_block_read_uring.json") as f:
+    uring = json.load(f)[0]
+
+print(f"posix read ops/sec: {posix['read_ops_per_sec']:.2f}")
+print(f"uring read ops/sec: {uring['read_ops_per_sec']:.2f}")
+print(f"uring vs posix read: {(uring['read_ops_per_sec'] / posix['read_ops_per_sec'] - 1.0) * 100.0:+.2f}%")
+print(f"posix write ops/sec: {posix['write_ops_per_sec']:.2f}")
+print(f"uring write ops/sec: {uring['write_ops_per_sec']:.2f}")
+print(f"uring vs posix write: {(uring['write_ops_per_sec'] / posix['write_ops_per_sec'] - 1.0) * 100.0:+.2f}%")
+PY
+```
+### Notes
+
+- There is a limit on the number of fixed buffers that can be registered. For unprivileged users its 16384.
+- Buffer registration and de-registration is time consuming.
+
 ## Output
 
 The script prints a summary and optionally writes JSON results if `--output-json` is provided.
+```
+

--- a/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
+++ b/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
@@ -331,9 +331,10 @@ def _bench_rust_raw_block(
     keys = _make_keys(num_ops)
     # Use the memory allocator from LocalCPUBackend
     shapes = metadata.get_shapes()
+    use_aligned = use_odirect and not use_uring
     objs = _make_memory_objs(
         num_ops,
-        False,
+        use_aligned,
         alignment,
         [],
         memory_allocator=local_cpu.memory_allocator,
@@ -506,9 +507,10 @@ def _bench_rust_raw_block_read(
 
     keys = _make_keys(num_ops)
     shapes = metadata.get_shapes()
+    use_aligned = use_odirect and not use_uring
     objs = _make_memory_objs(
         num_ops,
-        False,
+        use_aligned,
         alignment,
         [],
         memory_allocator=local_cpu.memory_allocator,

--- a/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
+++ b/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
@@ -24,7 +24,9 @@ from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
     AdHocMemoryAllocator,
+    MemoryAllocatorInterface,
     MemoryFormat,
+    MemoryObj,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
@@ -37,6 +39,7 @@ from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
 
 DEFAULT_SHAPE = torch.Size([2, 16, 8, 128])
 DEFAULT_DTYPE = torch.bfloat16
+DEFAULT_CHUNK_SIZE = 4
 
 
 def _start_loop() -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
@@ -60,7 +63,8 @@ def _build_metadata() -> LMCacheMetadata:
         worker_id=0,
         local_worker_id=0,
         kv_dtype=DEFAULT_DTYPE,
-        kv_shape=(4, 2, 256, 8, 128),
+        kv_shape=(4, 2, DEFAULT_CHUNK_SIZE, 8, 128),
+        chunk_size=DEFAULT_CHUNK_SIZE,
     )
 
 
@@ -69,12 +73,19 @@ def _make_memory_objs(
     use_aligned: bool,
     alignment: int,
     keepalive: list[torch.Tensor],
+    memory_allocator: Optional[MemoryAllocatorInterface] = None,
+    shapes: Optional[list[torch.Size]] = None,
+    start_idx: int = 0,
 ) -> list:
-    allocator = AdHocMemoryAllocator(device="cpu")
-    objs = []
-    for _ in range(num_ops):
+    if memory_allocator is None:
+        memory_allocator = AdHocMemoryAllocator(device="cpu")
+    # Use provided shapes or default to DEFAULT_SHAPE
+    if shapes is None:
+        shapes = [DEFAULT_SHAPE]
+    objs: list[TensorMemoryObj] = []
+    for i in range(num_ops):
         if use_aligned:
-            num_bytes = DEFAULT_SHAPE.numel() * DEFAULT_DTYPE.itemsize
+            num_bytes = shapes[0].numel() * DEFAULT_DTYPE.itemsize
             base = torch.empty(
                 torch.Size([num_bytes + alignment]),
                 dtype=torch.uint8,
@@ -86,27 +97,28 @@ def _make_memory_objs(
             obj = TensorMemoryObj(
                 raw_data=aligned,
                 metadata=MemoryObjMetadata(
-                    shape=DEFAULT_SHAPE,
+                    shape=shapes[0],
                     dtype=DEFAULT_DTYPE,
                     address=0,
                     phy_size=0,
                     ref_count=1,
                     pin_count=0,
                     fmt=MemoryFormat.KV_T2D,
-                    shapes=[DEFAULT_SHAPE],
+                    shapes=shapes,
                     dtypes=[DEFAULT_DTYPE],
                 ),
-                parent_allocator=allocator,
+                parent_allocator=memory_allocator,
             )
         else:
-            obj = allocator.allocate(
-                [DEFAULT_SHAPE],
+            allocated_obj = memory_allocator.allocate(
+                shapes,
                 [DEFAULT_DTYPE],
                 fmt=MemoryFormat.KV_T2D,
             )
-            assert obj is not None
+            assert allocated_obj is not None
+            obj = allocated_obj  # type: ignore[assignment]
         assert obj.tensor is not None
-        obj.tensor.fill_(7)
+        obj.tensor.fill_(start_idx + i)
         objs.append(obj)
     return objs
 
@@ -138,7 +150,7 @@ def _bench_local_disk(
     loop, t = _start_loop()
     metadata = _build_metadata()
     config = LMCacheEngineConfig.from_defaults(
-        chunk_size=256,
+        chunk_size=DEFAULT_CHUNK_SIZE,
         local_cpu=True,
         max_local_cpu_size=0.1,
         lmcache_instance_id="bench_local_disk",
@@ -227,15 +239,42 @@ def _bench_rust_raw_block(
     raw_device: str,
     raw_device_size_gb: float,
     use_odirect: bool,
+    use_uring: bool,
     alignment: int,
     cleanup_raw_device: bool,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
 ) -> dict:
     loop, t = _start_loop()
-    metadata = _build_metadata()
+
+    # Build metadata with the provided chunk_size
+    metadata = LMCacheMetadata(
+        model_name="benchmark_model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=DEFAULT_DTYPE,
+        kv_shape=(4, 2, chunk_size, 8, 128),
+        chunk_size=chunk_size,
+    )
+
+    # For fixed buffer support, we need a larger CPU buffer that's aligned to chunk size
+    # Calculate chunk size from metadata
+    chunk_size_bytes = (
+        metadata.kv_shape[0]
+        * metadata.kv_shape[1]
+        * chunk_size
+        * metadata.kv_shape[3]
+        * metadata.kv_shape[4]
+        * metadata.kv_dtype.itemsize
+    )
+    # Calculate required buffer size (num_ops * chunk_size with some margin)
+    required_buffer_gb = max(0.01, (num_ops * chunk_size_bytes) / (1024**3))
+
     config = LMCacheEngineConfig.from_defaults(
-        chunk_size=256,
+        chunk_size=chunk_size,
         local_cpu=True,
-        max_local_cpu_size=0.1,
+        max_local_cpu_size=required_buffer_gb,
         lmcache_instance_id="bench_rust_raw_block",
     )
 
@@ -257,25 +296,30 @@ def _bench_rust_raw_block(
         with open(raw_device, "wb") as f:
             f.truncate(int(raw_device_size_gb * 1024**3))
 
-    manifest_path = os.path.join(
-        tempfile.gettempdir(),
-        f"lmcache_rust_raw_block_bench_{os.getpid()}_{time.time_ns()}.manifest.json",
-    )
     config.extra_config = {
         "rust_raw_block.device_path": raw_device,
         "rust_raw_block.block_align": alignment,
         "rust_raw_block.header_bytes": alignment,
         "rust_raw_block.use_odirect": use_odirect,
-        "rust_raw_block.manifest_path": manifest_path,
-        "rust_raw_block.manifest_write_interval": 0,
+        "rust_raw_block.use_uring": use_uring,
     }
 
-    local_cpu = LocalCPUBackend(
-        config=config,
-        metadata=metadata,
-        dst_device="cpu",
-        memory_allocator=AdHocMemoryAllocator(device="cpu"),
-    )
+    # Use MixedMemoryAllocator with use_paging=True for fixed buffer support
+    if use_uring:
+        # LocalCPUBackend will automatically create MixedMemoryAllocator with
+        # use_paging=True when use_uring is enabled
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+        )
+    else:
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=AdHocMemoryAllocator(device="cpu"),
+        )
     backend = RustRawBlockBackend(
         config=config,
         metadata=metadata,
@@ -285,8 +329,16 @@ def _bench_rust_raw_block(
     )
 
     keys = _make_keys(num_ops)
-    keepalive: list[torch.Tensor] = []
-    objs = _make_memory_objs(num_ops, use_odirect, alignment, keepalive)
+    # Use the memory allocator from LocalCPUBackend
+    shapes = metadata.get_shapes()
+    objs = _make_memory_objs(
+        num_ops,
+        False,
+        alignment,
+        [],
+        memory_allocator=local_cpu.memory_allocator,
+        shapes=shapes,
+    )
 
     futures = []
     fut_lock = threading.Lock()
@@ -327,10 +379,6 @@ def _bench_rust_raw_block(
                 os.rmdir(temp_dir)
             except Exception:
                 pass
-    try:
-        os.remove(manifest_path)
-    except Exception:
-        pass
 
     return {
         "backend": "rust_raw_block",
@@ -339,7 +387,234 @@ def _bench_rust_raw_block(
         "elapsed_sec": elapsed,
         "ops_per_sec": num_ops / elapsed if elapsed > 0 else 0.0,
         "use_odirect": use_odirect,
+        "use_uring": use_uring,
         "raw_device": raw_device,
+    }
+
+
+def _bench_rust_raw_block_read(
+    num_ops: int,
+    concurrency: int,
+    raw_device: str,
+    raw_device_size_gb: float,
+    use_odirect: bool,
+    use_uring: bool,
+    alignment: int,
+    cleanup_raw_device: bool,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    verify_integrity: bool = False,
+) -> dict:
+    """Benchmark RustRawBlockBackend write & read performance.
+
+    This function first writes memory objects to the raw block device, then
+    performs read benchmarks with concurrent batched blocking reads. Optionally
+    verifies data integrity by comparing read data with original written data.
+
+    Args:
+        num_ops: Number of operations to perform (both write and read).
+        concurrency: Number of concurrent threads for batched operations.
+        raw_device: Path to raw block device (empty for temp file).
+        raw_device_size_gb: Size of raw device in GB (for temp file creation).
+        use_odirect: Enable O_DIRECT for I/O operations.
+        use_uring: Enable io_uring for I/O operations.
+        alignment: Buffer alignment in bytes.
+        cleanup_raw_device: Whether to clean up the raw device after benchmark.
+        chunk_size: Chunk size for io_uring case.
+        verify_integrity: Whether to verify data integrity after reads.
+
+    Returns:
+        Dictionary containing benchmark results including write and read metrics.
+    """
+    loop, t = _start_loop()
+
+    # Build metadata with the provided chunk_size
+    metadata = LMCacheMetadata(
+        model_name="benchmark_model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=DEFAULT_DTYPE,
+        kv_shape=(4, 2, chunk_size, 8, 128),
+        chunk_size=chunk_size,
+    )
+
+    # For fixed buffer support, we need a larger CPU buffer that's aligned to chunk size
+    chunk_size_bytes = (
+        metadata.kv_shape[0]
+        * metadata.kv_shape[1]
+        * chunk_size
+        * metadata.kv_shape[3]
+        * metadata.kv_shape[4]
+        * metadata.kv_dtype.itemsize
+    )
+    required_buffer_gb = max(0.01, (num_ops * chunk_size_bytes) / (1024**3))
+
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=chunk_size,
+        local_cpu=True,
+        max_local_cpu_size=required_buffer_gb,
+        lmcache_instance_id="bench_rust_raw_block_read",
+    )
+
+    # Create a backing file if raw_device is not provided
+    temp_dir: Optional[str] = None
+    is_block_device = False
+    if not raw_device:
+        temp_dir = tempfile.mkdtemp(prefix="raw_block_read_bench_")
+        raw_device = os.path.join(temp_dir, "raw_block.bin")
+    else:
+        try:
+            st_mode = os.stat(raw_device).st_mode
+            is_block_device = stat.S_ISBLK(st_mode)
+        except FileNotFoundError:
+            is_block_device = False
+
+    if raw_device and not is_block_device:
+        with open(raw_device, "wb") as f:
+            f.truncate(int(raw_device_size_gb * 1024**3))
+
+    config.extra_config = {
+        "rust_raw_block.device_path": raw_device,
+        "rust_raw_block.block_align": alignment,
+        "rust_raw_block.header_bytes": alignment,
+        "rust_raw_block.use_odirect": use_odirect,
+        "rust_raw_block.use_uring": use_uring,
+    }
+
+    # Use MixedMemoryAllocator with use_paging=True for fixed buffer support
+    if use_uring:
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+        )
+    else:
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=AdHocMemoryAllocator(device="cpu"),
+        )
+    backend = RustRawBlockBackend(
+        config=config,
+        metadata=metadata,
+        local_cpu_backend=local_cpu,
+        loop=loop,
+        dst_device="cpu",
+    )
+
+    keys = _make_keys(num_ops)
+    shapes = metadata.get_shapes()
+    objs = _make_memory_objs(
+        num_ops,
+        False,
+        alignment,
+        [],
+        memory_allocator=local_cpu.memory_allocator,
+        shapes=shapes,
+    )
+
+    # Store original data for integrity verification, keyed by CacheEngineKey
+    original_data: dict[CacheEngineKey, torch.Tensor] = {}
+    if verify_integrity:
+        for key, obj in zip(keys, objs, strict=False):
+            assert obj.tensor is not None
+            original_data[key] = obj.tensor.clone()
+
+    # Write phase
+    write_futures = []
+    write_fut_lock = threading.Lock()
+
+    def submit_write_slice(start: int, end: int) -> None:
+        futs = backend.batched_submit_put_task(keys[start:end], objs[start:end])
+        if futs:
+            with write_fut_lock:
+                write_futures.extend(futs)
+
+    slice_size = max(1, num_ops // concurrency)
+    slices = []
+    for i in range(0, num_ops, slice_size):
+        slices.append((i, min(i + slice_size, num_ops)))
+
+    write_start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+        for s in slices:
+            ex.submit(submit_write_slice, s[0], s[1])
+
+    for fut in write_futures:
+        fut.result(timeout=120)
+    write_elapsed = time.perf_counter() - write_start
+
+    _release_memory_objs(objs)
+
+    # Read phase
+    read_start = time.perf_counter()
+    read_results: list[tuple[CacheEngineKey, Optional[MemoryObj]]] = []
+    read_lock = threading.Lock()
+
+    def submit_read_slice(start: int, end: int) -> None:
+        batch_keys = keys[start:end]
+        loaded = backend.batched_get_blocking(batch_keys)
+        with read_lock:
+            read_results.extend(zip(batch_keys, loaded, strict=False))
+
+    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+        for s in slices:
+            ex.submit(submit_read_slice, s[0], s[1])
+
+    read_elapsed = time.perf_counter() - read_start
+
+    # Data integrity verification using key-based lookup
+    integrity_errors = 0
+    if verify_integrity:
+        for key, read_obj in read_results:
+            if read_obj is None:
+                integrity_errors += 1
+                continue
+            assert read_obj.tensor is not None
+            if key not in original_data:
+                integrity_errors += 1
+                continue
+            if not torch.equal(read_obj.tensor, original_data[key]):
+                integrity_errors += 1
+
+    for _, read_obj in read_results:
+        if read_obj is not None:
+            try:
+                read_obj.ref_count_down()
+            except Exception:
+                pass
+    backend.close()
+    _stop_loop(loop, t)
+
+    # Best-effort cleanup for temp file or requested cleanup
+    if cleanup_raw_device or temp_dir:
+        try:
+            os.remove(raw_device)
+        except Exception:
+            pass
+        if temp_dir:
+            try:
+                os.rmdir(temp_dir)
+            except Exception:
+                pass
+
+    return {
+        "backend": "rust_raw_block_read",
+        "num_ops": num_ops,
+        "concurrency": concurrency,
+        "write_elapsed_sec": write_elapsed,
+        "write_ops_per_sec": num_ops / write_elapsed if write_elapsed > 0 else 0.0,
+        "read_elapsed_sec": read_elapsed,
+        "read_ops_per_sec": num_ops / read_elapsed if read_elapsed > 0 else 0.0,
+        "total_elapsed_sec": write_elapsed + read_elapsed,
+        "use_odirect": use_odirect,
+        "use_uring": use_uring,
+        "raw_device": raw_device,
+        "verify_integrity": verify_integrity,
+        "integrity_errors": integrity_errors,
+        "integrity_passed": integrity_errors == 0,
     }
 
 
@@ -347,7 +622,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
             "Benchmark LocalDiskBackend vs RustRawBlockBackend "
-            "under high write concurrency."
+            "under high write concurrency. "
         )
     )
     parser.add_argument("--num-ops", type=int, default=256, help="Total put ops")
@@ -356,8 +631,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--backend",
-        choices=["local_disk", "rust_raw_block", "both"],
+        choices=["local_disk", "rust_raw_block", "both", "rust_raw_block_read"],
         default="both",
+        help=(
+            "Backend to benchmark. "
+            "rust_raw_block_read performs write then read benchmark "
+            "with optional integrity check."
+        ),
     )
     parser.add_argument(
         "--local-disk-dir",
@@ -382,7 +662,23 @@ def main() -> None:
         action="store_true",
         help="Enable O_DIRECT for raw block backend",
     )
+    parser.add_argument(
+        "--use-uring",
+        action="store_true",
+        help="Enable io_uring for raw block backend",
+    )
     parser.add_argument("--alignment", type=int, default=4096)
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=DEFAULT_CHUNK_SIZE,
+        help=f"Chunk size for io_uring case (default: {DEFAULT_CHUNK_SIZE})",
+    )
+    parser.add_argument(
+        "--verify-integrity",
+        action="store_true",
+        help="Verify data integrity after reads (only for rust_raw_block_read backend)",
+    )
     parser.add_argument(
         "--output-json",
         type=str,
@@ -419,18 +715,58 @@ def main() -> None:
                 raw_device=raw_device,
                 raw_device_size_gb=args.raw_device_size_gb,
                 use_odirect=args.raw_odirect,
+                use_uring=args.use_uring,
                 alignment=args.alignment,
                 cleanup_raw_device=cleanup_raw_device,
+                chunk_size=args.chunk_size,
+            )
+        )
+
+    if args.backend == "rust_raw_block_read":
+        raw_device = args.raw_device
+        cleanup_raw_device = False
+        if not raw_device:
+            # Use the same filesystem as local disk backend for apples-to-apples.
+            raw_device = os.path.join(args.local_disk_dir, "raw_block_read.bin")
+            cleanup_raw_device = True
+        results.append(
+            _bench_rust_raw_block_read(
+                num_ops=args.num_ops,
+                concurrency=args.concurrency,
+                raw_device=raw_device,
+                raw_device_size_gb=args.raw_device_size_gb,
+                use_odirect=args.raw_odirect,
+                use_uring=args.use_uring,
+                alignment=args.alignment,
+                cleanup_raw_device=cleanup_raw_device,
+                chunk_size=args.chunk_size,
+                verify_integrity=args.verify_integrity,
             )
         )
 
     for result in results:
-        print(
-            f"{result['backend']}: ops={result['num_ops']} "
-            f"concurrency={result['concurrency']} "
-            f"elapsed={result['elapsed_sec']:.3f}s "
-            f"ops/sec={result['ops_per_sec']:.2f}"
-        )
+        if result["backend"] == "rust_raw_block_read":
+            print(
+                f"{result['backend']}: ops={result['num_ops']} "
+                f"concurrency={result['concurrency']} "
+                f"write_elapsed={result['write_elapsed_sec']:.3f}s "
+                f"write_ops/sec={result['write_ops_per_sec']:.2f} "
+                f"read_elapsed={result['read_elapsed_sec']:.3f}s "
+                f"read_ops/sec={result['read_ops_per_sec']:.2f} "
+                f"total_elapsed={result['total_elapsed_sec']:.3f}s"
+            )
+            if result["verify_integrity"]:
+                status = "PASSED" if result["integrity_passed"] else "FAILED"
+                print(
+                    f"  Integrity check: {status} (errors={result['integrity_errors']})"
+                )
+        else:
+            print(
+                f"{result['backend']}: ops={result['num_ops']} "
+                f"concurrency={result['concurrency']} "
+                f"elapsed={result['elapsed_sec']:.3f}s "
+                f"ops/sec={result['ops_per_sec']:.2f}"
+            )
 
     if args.output_json:
         output_path = args.output_json

--- a/examples/kv_cache_reuse/local_backends/README.md
+++ b/examples/kv_cache_reuse/local_backends/README.md
@@ -6,3 +6,9 @@ LMCache should be able to reduce the generation time of the second and following
 ## Disk offloading
 - `python offload.py -v v0 --use-disk` - Disk offloading implementation for vLLM v0
 - `python offload.py -v v1 --use-disk` - Disk offloading implementation for vLLM v1
+
+## RUST raw block based Disk offloading
+
+   # WARNING: This will erase the content of target device.
+- `python rust_backend_offload.py --disk_path=/dev/nvme0n1` - posix disk offloading
+- `python rust_backend_offload.py --disk_path=/dev/nvme0n1 --use_uring` - io_uring disk offloading

--- a/examples/kv_cache_reuse/local_backends/rust_backend_offload.py
+++ b/examples/kv_cache_reuse/local_backends/rust_backend_offload.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from dataclasses import asdict
+import argparse
+import contextlib
+import json
+import os
+import time
+
+# Third Party
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+from vllm.engine.arg_utils import EngineArgs
+
+# First Party
+from lmcache.integration.vllm.utils import ENGINE_NAME
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+
+
+def setup_environment_variables(raw_block_path: str, use_uring: bool = False) -> None:
+    """Set up LMCache-related environment variables for the Rust raw block backend.
+
+    Configures environment variables for LMCache including chunk size, storage
+    plugins, and Rust raw block backend specific settings.
+
+    Args:
+        raw_block_path: Path to the raw block device for storage.
+        use_uring: Whether to enable io_uring path
+
+    Returns:
+        None
+    """
+    # LMCache-related environment variables
+
+    # LMCache is set to use 256 tokens per chunk
+    os.environ["LMCACHE_CHUNK_SIZE"] = "256"
+
+    # Disable local CPU backend in LMCache
+    os.environ["LMCACHE_LOCAL_CPU"] = "False"
+
+    # Set the maximum size of the local disk size to 5GB
+    os.environ["LMCACHE_MAX_LOCAL_DISK_SIZE"] = "5"
+
+    os.environ["LMCACHE_STORAGE_PLUGINS"] = "raw_block"
+
+    # Raw block specific extra config
+    os.environ["LMCACHE_EXTRA_CONFIG"] = json.dumps(
+        {
+            "storage_plugin.raw_block.module_path": "lmcache.v1.storage_backend.plugins.rust_raw_block_backend",  # noqa: E501
+            "storage_plugin.raw_block.class_name": "RustRawBlockBackend",
+            "rust_raw_block.device_path": raw_block_path,
+            "rust_raw_block.use_odirect": True,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+            "rust_raw_block.use_uring": use_uring,
+        }
+    )
+
+
+@contextlib.contextmanager
+def build_llm_with_lmcache(lmcache_connector: str, model: str):
+    """Build a vLLM LLM instance with LMCache integration.
+
+    Creates a context manager that builds a vLLM LLM instance configured with
+    LMCache for KV cache management. The LLM is yielded and cleaned up on exit.
+
+    Args:
+        lmcache_connector: The LMCache connector name to use
+        model: The model name.
+    """
+    ktc = KVTransferConfig(
+        kv_connector=lmcache_connector,
+        kv_role="kv_both",
+    )
+    # Set GPU memory utilization to 0.5 for an A100 GPU with 40GB
+    # memory. Update it accordingly for different GPU.
+    llm_args = EngineArgs(
+        model=model,
+        kv_transfer_config=ktc,
+        max_model_len=8000,
+        gpu_memory_utilization=0.5,
+    )
+    llm = LLM(**asdict(llm_args))
+    try:
+        yield llm
+    finally:
+        # Clean up the LMCache backend
+        LMCacheEngineBuilder.destroy(ENGINE_NAME)
+
+
+def print_output(
+    llm: LLM,
+    prompt: list[str],
+    sampling_params: SamplingParams,
+    req_str: str,
+) -> None:
+    """Generate text using the LLM and print the output with timing information.
+
+    Args:
+        llm: The vLLM LLM instance to use for generation.
+        prompt: The input prompt(s) as a list of strings.
+        sampling_params: Sampling parameters for generation.
+        req_str: A string identifier for the request.
+
+    Returns:
+        None
+    """
+    start = time.time()
+    outputs = llm.generate(prompt, sampling_params)
+    print("-" * 50)
+    for output in outputs:
+        generated_text = output.outputs[0].text
+        print(f"Generated text: {generated_text!r}")
+    print(f"Generation took {time.time() - start:.2f} seconds, {req_str} request done.")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the script.
+
+    Returns:
+        argparse.Namespace: Parsed arguments containing:
+            - disk_path: Path to the raw block device for storage.
+            - use_uring: Whether to enable io_uring path.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--disk_path",
+        type=str,
+    )
+    parser.add_argument(
+        "--use_uring",
+        action="store_true",
+        help="Enable io_uring path (requires Linux kernel >= 5.1)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main entry point for the Rust backend offload example.
+
+    Sets up environment variables, builds an LLM with LMCache integration,
+    and runs two requests with a shared prefix to demonstrate KV cache reuse.
+
+    Returns:
+        None
+    """
+    args = parse_args()
+
+    connector = "LMCacheConnectorV1"
+    model = "Qwen/Qwen3-8B"
+
+    setup_environment_variables(args.disk_path, args.use_uring)
+
+    with build_llm_with_lmcache(connector, model) as llm:
+        # This example script runs two requests with a shared prefix.
+        # Define the shared prompt and specific prompts
+        shared_prompt = "Hello, how are you?" * 1000
+        first_prompt = [
+            shared_prompt + "Hello, my name is",
+        ]
+        second_prompt = [
+            shared_prompt + "Tell me a very long story",
+        ]
+
+        sampling_params = SamplingParams(temperature=0, top_p=0.95, max_tokens=10)
+
+        # Print the first output
+        print_output(llm, first_prompt, sampling_params, "first")
+
+        time.sleep(1)
+
+        # print the second output
+        print_output(llm, second_prompt, sampling_params, "second")
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1811,6 +1811,16 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     def __str__(self):
         return "PagedTensorMemoryAllocator"
 
+    def get_paged_buffers(self) -> list[torch.Tensor]:
+        """
+        Get the list of paged buffers for fixed buffer registration.
+
+        Returns:
+            List of paged buffer tensors that can be registered with io_uring
+            for true zero copy operations.
+        """
+        return self.paged_buffers
+
     def __del__(self):
         # FIXME: NIXL-related memory leak should be handled somewhere (else).
         del self.buffer
@@ -2198,6 +2208,18 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
                 self.shm_name,
             )
             self._unregistered = True
+
+    def get_paged_buffers(self) -> Optional[list[torch.Tensor]]:
+        """
+        Get the list of paged buffers for fixed buffer registration.
+
+        Returns:
+            List of paged buffer tensors if using paged allocator, None otherwise.
+            These buffers can be registered with io_uring for true zero copy operations.
+        """
+        if isinstance(self.pin_allocator, PagedTensorMemoryAllocator):
+            return self.pin_allocator.get_paged_buffers()
+        return None
 
     def __str__(self):
         return "MixedMemoryAllocator"

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -405,6 +405,11 @@ class LocalCPUBackend(AllocatorBackendInterface):
             )
             return paged_mem_allocator
         else:
+            # Check if io_uring is enabled for fixed buffer support
+            use_uring = bool(
+                config.get_extra_config_value("rust_raw_block.use_uring", False)
+            )
+
             # Check if lazy memory allocator should be enabled
             use_lazy = (
                 config.enable_lazy_memory_allocator
@@ -425,6 +430,53 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     f"({config.lazy_memory_safe_size:.2f} GB). "
                     f"Using MixedMemoryAllocator instead."
                 )
+
+            # For io_uring, use paged memory allocator so that fixed buffer support
+            # can be enabled
+            if use_uring and metadata is not None:
+                shapes = metadata.get_shapes()
+                dtypes = metadata.get_dtypes()
+                # Determine memory format based on layerwise and blending settings
+                if config.use_layerwise:
+                    if config.enable_blending:
+                        fmt = MemoryFormat.KV_2TD
+                    else:
+                        fmt = MemoryFormat.KV_T2D
+                else:
+                    fmt = MemoryFormat.KV_2LTD
+
+                # Calculate chunk size for alignment
+                chunk_size_bytes = get_size_bytes(shapes, dtypes)
+                origin_cpu_size_bytes = cpu_size_bytes
+                # Align cpu_size_bytes to be a multiple of chunk_size_bytes
+                align_cpu_size_bytes = (
+                    origin_cpu_size_bytes // chunk_size_bytes * chunk_size_bytes
+                )
+                logger.info(
+                    "LocalCPUBackend: using MixedMemoryAllocator with use_paging=True "
+                    "for io_uring fixed buffer support. "
+                    f"Auto align cpu size bytes, origin: {origin_cpu_size_bytes}, "
+                    f"aligned: {align_cpu_size_bytes}, chunk size: {chunk_size_bytes}"
+                )
+
+                kwargs = {
+                    "numa_mapping": numa_mapping,
+                    "shapes": shapes,
+                    "dtypes": dtypes,
+                    "fmt": fmt,
+                    **(
+                        {"align_bytes": allocator_align_bytes}
+                        if allocator_align_bytes is not None
+                        else {}
+                    ),
+                }
+                return MixedMemoryAllocator(
+                    align_cpu_size_bytes,
+                    use_paging=True,
+                    **kwargs,
+                )
+
+            # Default: use non-paged allocator
             if allocator_align_bytes is not None:
                 return MixedMemoryAllocator(
                     cpu_size_bytes,
@@ -451,7 +503,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         1) explicit override: extra_config["local_cpu.pinned_align_bytes"]
         2) rust raw block auto mode:
            - rust_raw_block.device_path is set
-           - rust_raw_block.use_odirect is true
+           - rust_raw_block.use_odirect is true or rust_raw_block.use_uring is true
            - rust_raw_block.align_local_cpu_allocator is true (default)
            -> use rust_raw_block.block_align
         3) None (use allocator default)
@@ -470,18 +522,27 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         rust_device_path = extra.get("rust_raw_block.device_path")
         rust_use_odirect = bool(extra.get("rust_raw_block.use_odirect", False))
+        rust_use_uring = bool(extra.get("rust_raw_block.use_uring", False))
         rust_auto_align = bool(
             extra.get("rust_raw_block.align_local_cpu_allocator", True)
         )
 
-        if not rust_device_path or not rust_use_odirect or not rust_auto_align:
+        if not rust_device_path:
+            return None
+
+        # Alignment is needed if either O_DIRECT is set or io_uring is enabled
+        if not rust_use_odirect and not rust_use_uring:
+            return None
+
+        # For non io_uring_case, respect the auto_align flag
+        if not rust_use_uring and not rust_auto_align:
             return None
 
         rust_block_align = int(extra.get("rust_raw_block.block_align", 4096))
         if not self._is_power_of_two(rust_block_align):
             raise ValueError(
                 "extra_config['rust_raw_block.block_align'] must be a positive "
-                "power of two when O_DIRECT alignment is enabled"
+                "power of two when O_DIRECT or io_uring alignment is enabled"
             )
         return rust_block_align
 

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -82,7 +82,7 @@ class _Inflight:
 class RustRawBlockBackend(StoragePluginInterface):
     """
     A storage plugin backend that stores KV chunks into a block device (raw)
-    using a Rust extension for pread/pwrite.
+    using a Rust extension for pread/pwrite or io_uring.
 
     Features:
     - High-throughput I/O via direct block device access
@@ -179,6 +179,7 @@ class RustRawBlockBackend(StoragePluginInterface):
         self.enable_zero_copy: bool = bool(
             extra.get("rust_raw_block.enable_zero_copy", True)
         )
+        self.use_uring: bool = bool(extra.get("rust_raw_block.use_uring", False))
 
         # On-device metadata region config.
         self.meta_total_bytes: int = int(
@@ -319,6 +320,10 @@ class RustRawBlockBackend(StoragePluginInterface):
             self.enable_zero_copy,
         )
 
+        # Register paged buffers with io_uring for fixed buffer support
+        if self.use_uring:
+            self._register_paged_buffers()
+
         # Load latest checkpoint from device (no JSON fallback).
         self._load_checkpoint_from_device()
 
@@ -363,8 +368,48 @@ class RustRawBlockBackend(StoragePluginInterface):
                 writable=True,
                 use_odirect=self.use_odirect,
                 alignment=self.block_align,
+                use_iouring=self.use_uring,
             )
         return self._raw
+
+    def _register_paged_buffers(self) -> None:
+        """Register paged buffers with io_uring for fixed buffer support."""
+        try:
+            assert self.local_cpu_backend is not None
+            memory_allocator = self.local_cpu_backend.get_memory_allocator()
+            paged_buffers = getattr(memory_allocator, "get_paged_buffers", None)
+
+            if paged_buffers is not None and callable(paged_buffers):
+                buffers = paged_buffers()
+                if buffers is not None and len(buffers) > 0:
+                    raw_dev = self._rawdev()
+                    # Register buffers with io_uring
+                    buffer_ptrs = [buf.data_ptr() for buf in buffers]
+                    buffer_sizes = [buf.numel() * buf.element_size() for buf in buffers]
+
+                    raw_dev.register_fixed_buffers(buffer_ptrs, buffer_sizes)
+
+                    logger.info(
+                        "RustRawBlockBackend: registered %d paged buffers with "
+                        "io_uring for fixed buffer support (true zero copy)",
+                        len(buffers),
+                    )
+                else:
+                    logger.warning(
+                        "RustRawBlockBackend: no paged buffers available for "
+                        "io_uring fixed buffer registration"
+                    )
+            else:
+                logger.warning(
+                    "RustRawBlockBackend: memory allocator does not support "
+                    "paged buffers for io_uring fixed buffer registration"
+                )
+        except Exception as e:
+            logger.warning(
+                "RustRawBlockBackend: failed to register paged buffers with "
+                "io_uring: %s. Falling back to non-fixed buffer mode.",
+                e,
+            )
 
     def _build_direct_odirect_view(
         self,
@@ -540,6 +585,19 @@ class RustRawBlockBackend(StoragePluginInterface):
                     len(self._index),
                 )
 
+        # Use io_uring path if enabled
+        if self.use_uring:
+            # TODO(Ankit): Find a better way to handle this.
+            for obj in objs:
+                obj.ref_count_up()
+
+            assert self.loop is not None
+            fut = asyncio.run_coroutine_threadsafe(
+                self._batched_submit_put_task_uring(keys, objs, on_complete_callback),
+                self.loop,
+            )
+            return [fut]
+
         futures = []
         for key, obj in zip(keys, objs, strict=False):
             with self._put_lock:
@@ -588,6 +646,161 @@ class RustRawBlockBackend(StoragePluginInterface):
             )
             futures.append(fut)
         return futures or None
+
+    async def _batched_submit_put_task_uring(
+        self,
+        keys: Sequence[CacheEngineKey],
+        objs: List[MemoryObj],
+        on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
+    ):
+        """Batched put using io_uring"""
+
+        if self._raw is None:
+            raise RuntimeError("device is closed")
+
+        # Collect all write requests
+        write_requests = []
+        valid_keys = []
+        valid_objs = []
+
+        # Track which items had inflight_io_count incremented
+        successfully_submitted = []
+
+        write_error: Optional[Exception] = None
+        try:
+            for key, obj in zip(keys, objs, strict=False):
+                with self._put_lock:
+                    if key in self._put_tasks:
+                        obj.ref_count_down()
+                        continue
+                    self._put_tasks.add(key)
+
+                with self._lock:
+                    if key in self._index or key in self._inflight:
+                        with self._put_lock:
+                            self._put_tasks.discard(key)
+                        obj.ref_count_down()
+                        continue
+                    while True:
+                        try:
+                            offset = self._allocate_slot()
+                            break
+                        except RuntimeError:
+                            if not self._evict_one():
+                                with self._put_lock:
+                                    self._put_tasks.discard(key)
+                                raise
+
+                    meta = DiskCacheMetadata(
+                        path=f"{self.device_path}@{offset}",
+                        size=len(obj.byte_array),
+                        shape=obj.metadata.shape,
+                        dtype=obj.metadata.dtype,
+                        cached_positions=obj.metadata.cached_positions,
+                        fmt=obj.metadata.fmt,
+                        pin_count=0,
+                    )
+                    self._inflight[key] = _Inflight(offset=offset, meta=meta)
+
+                header = self._encode_header(key, meta.size)
+                write_requests.append((key, offset, header, obj))
+                valid_keys.append(key)
+                valid_objs.append(obj)
+
+            if not write_requests:
+                return None
+
+            raw_dev = self._rawdev()
+            offsets = []
+            buffers = []
+            total_lens = []
+
+            for key, offset, header, obj in write_requests:
+                # Prepare payload with proper O_DIRECT alignment and zero-copy handling.
+                try:
+                    buf, payload_len, total_len = self._prepare_write_payload(obj)
+                    assert payload_len == total_len
+                except Exception as e:
+                    write_error = e
+                    logger.error(f"Failed to prepare payload for key {key}: {e}")
+                    raise
+
+                hdr_total = (
+                    _round_up(len(header), self.block_align)
+                    if self.use_odirect
+                    else len(header)
+                )
+                header_bytes = bytearray(header)
+                if self.use_odirect and len(header_bytes) < hdr_total:
+                    header_bytes.extend(b"\x00" * (hdr_total - len(header_bytes)))
+
+                offsets.append(offset)
+                buffers.append(header_bytes)
+                total_lens.append(hdr_total)
+                offsets.append(offset + self.header_bytes)
+                buffers.append(buf)
+                total_lens.append(total_len)
+
+                with self._lock:
+                    self._inflight_io_count += 1
+                successfully_submitted.append(key)
+
+            batch_id = raw_dev.batched_write(offsets, buffers, total_lens)
+            # Wait for headers and payloads to complete. Buffer lifetime is managed by
+            # Rust via Py_buffer views.
+            # Pass batch_id to capture any error from this batch completions.
+            # TODO(Ankit): Add a way to capture specific write failures.
+            await asyncio.to_thread(raw_dev.wait_iouring, batch_id)
+        except Exception as e:
+            if write_error is None:
+                write_error = e
+            logger.error(f"Batched write failed for keys {valid_keys}: {e}")
+        finally:
+            with self._lock:
+                for key in successfully_submitted:
+                    self._inflight_io_count -= 1
+                    self._last_io_ts = time.monotonic()
+
+            for obj in valid_objs:
+                obj.ref_count_down()
+
+            with self._put_lock:
+                for key in valid_keys:
+                    self._put_tasks.discard(key)
+
+            if write_error is None:
+                with self._lock:
+                    for key, offset, header, obj in write_requests:
+                        inflight = self._inflight.pop(key, None)
+                        if inflight is not None and not inflight.canceled:
+                            self._index[key] = _Entry(
+                                offset=inflight.offset,
+                                size=inflight.meta.size,
+                                meta=inflight.meta,
+                            )
+                            self._touch(key)
+                            self._meta_dirty_total += 1
+
+                if on_complete_callback is not None:
+                    for key in valid_keys:
+                        try:
+                            on_complete_callback(key)
+                        except Exception as e:
+                            logger.warning(
+                                f"on_complete_callback failed for key {key}: {e}"
+                            )
+            else:
+                with self._lock:
+                    for key in valid_keys:
+                        inflight = self._inflight.pop(key, None)
+                        if inflight is not None:
+                            self._append_free_slot_locked(
+                                self._offset_to_slot(int(inflight.offset))
+                            )
+                            self._meta_dirty_total += 1
+            if write_error is not None:
+                raise write_error
+        return None
 
     def _prepare_write_payload(self, memory_obj: MemoryObj) -> tuple[Any, int, int]:
         """Prepare payload view and aligned lengths for write path."""
@@ -708,7 +921,10 @@ class RustRawBlockBackend(StoragePluginInterface):
         try:
             with self._lock:
                 self._inflight_io_count += 1
-            raw.pread_into(offset, buf, self.header_bytes, self.header_bytes)
+            if self.use_uring:
+                raw.read_uring(offset, buf, self.header_bytes, self.header_bytes)
+            else:
+                raw.pread_into(offset, buf, self.header_bytes, self.header_bytes)
             return self._decode_slot_header(buf)
         except Exception:
             return None
@@ -716,6 +932,122 @@ class RustRawBlockBackend(StoragePluginInterface):
             with self._lock:
                 self._inflight_io_count -= 1
                 self._last_io_ts = time.monotonic()
+
+    async def _batched_get_prefix_uring(
+        self, keys: Sequence[CacheEngineKey]
+    ) -> list[MemoryObj]:
+        """Batched get using io_uring"""
+        if not keys:
+            return []
+
+        if self._raw is None:
+            raise RuntimeError("device is closed")
+
+        items: list[tuple[CacheEngineKey, _Entry]] = []
+        with self._lock:
+            for key in keys:
+                entry = self._index.get(key)
+                if entry is None:
+                    break
+                items.append((key, entry))
+            if not items:
+                return []
+            self._inflight_io_count += 1
+
+        loaded: list[MemoryObj] = []
+        touched: list[CacheEngineKey] = []
+        offsets = []
+        buffers = []
+        total_lens = []
+        valid_keys = []
+        valid_objs = []
+        try:
+            raw_dev = self._rawdev()
+
+            for key, entry in items:
+                meta = entry.meta
+                assert meta.shape is not None and meta.dtype is not None
+                assert self.local_cpu_backend is not None
+                memory_obj = self.local_cpu_backend.allocate(
+                    meta.shape, meta.dtype, meta.fmt
+                )
+                if memory_obj is None:
+                    logger.error(
+                        "Failed to allocate memory for key %s",
+                        self._dbg_key_short(key),
+                    )
+                    break
+
+                total_len = int(meta.size)
+                assert (total_len % self.block_align) == 0
+                if logger.isEnabledFor(10):
+                    self._dbg_get_calls += 1
+                    self._dbg_get_bytes += total_len
+                    if self._dbg_should_log(self._dbg_get_calls):
+                        logger.debug(
+                            "RustRawBlockBackend GET (uring): %s offset=%d size=%d",
+                            self._dbg_key_short(key),
+                            int(entry.offset),
+                            total_len,
+                        )
+
+                buf = memory_obj.byte_array
+                try:
+                    buf = buf.cast("B")
+                except Exception:
+                    pass
+
+                direct_view = self._build_direct_odirect_view(
+                    memory_obj=memory_obj,
+                    payload_len=total_len,
+                    total_len=total_len,
+                    buffer_len=len(buf),
+                    zero_tail=False,
+                )
+
+                if direct_view is not None:
+                    offsets.append(entry.offset + self.header_bytes)
+                    buffers.append(direct_view)
+                    total_lens.append(total_len)
+                else:
+                    offsets.append(entry.offset + self.header_bytes)
+                    buffers.append(buf)
+                    total_lens.append(total_len)
+
+                valid_keys.append(key)
+                valid_objs.append(memory_obj)
+
+            if not offsets:
+                return []
+
+            batch_id = raw_dev.batched_read(offsets, buffers, total_lens)
+            # Wait for all reads to complete.
+            # Pass batch_id to capture any error from this batch completions.
+            # TODO(Ankit): Add a way to capture specific read failures.
+            await asyncio.to_thread(raw_dev.wait_iouring, batch_id)
+
+            # Update metadata for successfully loaded items
+            for key, obj in zip(valid_keys, valid_objs, strict=False):
+                entry = next((e for k, e in items if k == key), None)
+                if entry is not None:
+                    obj.metadata.cached_positions = entry.meta.cached_positions
+                loaded.append(obj)
+                touched.append(key)
+
+        except Exception as e:
+            for memory_obj in valid_objs:
+                memory_obj.ref_count_down()
+            loaded.clear()
+            touched.clear()
+            logger.error("Batched io_uring read failed: %s", e)
+            raise
+        finally:
+            with self._lock:
+                for key in touched:
+                    self._touch(key)
+                self._inflight_io_count -= 1
+                self._last_io_ts = time.monotonic()
+        return loaded
 
     def _batched_get_prefix(self, keys: Sequence[CacheEngineKey]) -> list[MemoryObj]:
         if not keys:
@@ -820,6 +1152,13 @@ class RustRawBlockBackend(StoragePluginInterface):
         return loaded
 
     def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        if self.use_uring:
+            assert self.loop is not None
+            loaded = asyncio.run_coroutine_threadsafe(
+                self._batched_get_prefix_uring([key]),
+                self.loop,
+            ).result()
+            return loaded[0] if loaded else None
         loaded = self._batched_get_prefix([key])
         return loaded[0] if loaded else None
 
@@ -839,6 +1178,14 @@ class RustRawBlockBackend(StoragePluginInterface):
         """
         if not keys:
             return []
+
+        if self.use_uring:
+            assert self.loop is not None
+            loaded = asyncio.run_coroutine_threadsafe(
+                self._batched_get_prefix_uring(keys),
+                self.loop,
+            ).result()
+            return [*loaded, *([None] * (len(keys) - len(loaded)))]
 
         loaded = self._batched_get_prefix(keys)
         return [*loaded, *([None] * (len(keys) - len(loaded)))]
@@ -878,6 +1225,8 @@ class RustRawBlockBackend(StoragePluginInterface):
         :raises Exception: Propagates raw-device initialization or read failures.
         """
         del lookup_id, transfer_spec
+        if self.use_uring:
+            return await self._batched_get_prefix_uring(keys)
         return await asyncio.to_thread(self._batched_get_prefix, keys)
 
     def get_allocator_backend(self) -> "AllocatorBackendInterface":
@@ -946,7 +1295,14 @@ class RustRawBlockBackend(StoragePluginInterface):
         raw = self._rawdev()
         buf = bytearray(self.block_align)
         try:
-            raw.pread_into(container_offset, buf, self.block_align, self.block_align)
+            if self.use_uring:
+                raw.read_uring(
+                    container_offset, buf, self.block_align, self.block_align
+                )
+            else:
+                raw.pread_into(
+                    container_offset, buf, self.block_align, self.block_align
+                )
         except Exception:
             return None
 
@@ -973,7 +1329,10 @@ class RustRawBlockBackend(StoragePluginInterface):
         total_len = _round_up(payload_len, self.block_align)
         buf = bytearray(total_len)
         try:
-            raw.pread_into(payload_off, buf, payload_len, total_len)
+            if self.use_uring:
+                raw.read_uring(payload_off, buf, payload_len, total_len)
+            else:
+                raw.pread_into(payload_off, buf, payload_len, total_len)
         except Exception:
             return None
 

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -655,16 +655,19 @@ class RustRawBlockBackend(StoragePluginInterface):
     ):
         """Batched put using io_uring"""
 
-        if self._raw is None:
-            raise RuntimeError("device is closed")
-
         # Collect all write requests
-        write_requests = []
-        valid_keys = []
-        valid_objs = []
+        write_requests: list[tuple[CacheEngineKey, int, bytes, MemoryObj]] = []
+        valid_keys: list[CacheEngineKey] = []
+        valid_objs: list[MemoryObj] = []
 
         # Track which items had inflight_io_count incremented
-        successfully_submitted = []
+        successfully_submitted: list[CacheEngineKey] = []
+
+        # Track which objects have incremented ref counts
+        objs_with_inc_ref = list(objs)
+
+        if self._raw is None:
+            raise RuntimeError("device is closed")
 
         write_error: Optional[Exception] = None
         try:
@@ -672,6 +675,7 @@ class RustRawBlockBackend(StoragePluginInterface):
                 with self._put_lock:
                     if key in self._put_tasks:
                         obj.ref_count_down()
+                        objs_with_inc_ref.remove(obj)
                         continue
                     self._put_tasks.add(key)
 
@@ -680,6 +684,7 @@ class RustRawBlockBackend(StoragePluginInterface):
                         with self._put_lock:
                             self._put_tasks.discard(key)
                         obj.ref_count_down()
+                        objs_with_inc_ref.remove(obj)
                         continue
                     while True:
                         try:
@@ -761,7 +766,7 @@ class RustRawBlockBackend(StoragePluginInterface):
                     self._inflight_io_count -= 1
                     self._last_io_ts = time.monotonic()
 
-            for obj in valid_objs:
+            for obj in objs_with_inc_ref:
                 obj.ref_count_down()
 
             with self._put_lock:
@@ -976,7 +981,10 @@ class RustRawBlockBackend(StoragePluginInterface):
                         "Failed to allocate memory for key %s",
                         self._dbg_key_short(key),
                     )
-                    break
+
+                    for obj in valid_objs:
+                        obj.ref_count_down()
+                    return []
 
                 total_len = int(meta.size)
                 assert (total_len % self.block_align) == 0

--- a/rust/raw_block/Cargo.toml
+++ b/rust/raw_block/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module"] }
 libc = "0.2"
-
+io-uring = "0.7"

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -16,8 +16,14 @@ This crate provides raw block I/O for LMCache via Rust + PyO3.
    - skip `truncate()` for real block devices (`/dev/...`)
    - unique manifest per run (avoid stale-index reuse)
    - timeout guard for local disk completion waits (scales with `num_ops`)
+5. **io_uring support**: Added asynchronous I/O backend using Linux io_uring API:
+   - Dedicated worker thread drives the io_uring submission/completion loop
+   - Batch write, read support to reduce syscall overhead and improve throughput
+   - Fixed buffer registration for true zero-copy I/O operations
 
 ## Zero-Copy Data Path
+
+### Synchronous Path (pread/pwrite)
 
 ```text
 LMCache LocalCPUBackend (aligned pinned CPU tensor)
@@ -35,6 +41,54 @@ RawBlockDevice::pwrite_from_buffer / pread_into
 Block device or file
 ```
 
+### Asynchronous Path (io_uring)
+
+```text
+LMCache LocalCPUBackend (aligned pinned CPU tensor)
+                 |
+                 |  Python buffer / memoryview (no payload memcpy)
+                 v
+RustRawBlockBackend (PyO3 boundary)
+                 |
+                 |  enqueue to worker thread queue
+                 v
+io_uring worker thread (batching & submission)
+                 |
+                 |  direct pointer path when O_DIRECT constraints are met
+                 |  and fixed buffer path for true zero-copy
+                 v
+io_uring submission queue (kernel)
+                 |
+                 v
+Block device or file
+```
+
+```text
+Python Thread(s)              Worker Thread (io_uring)
+===============               =======================
+batched_write() /  --push-->   [queue]
+batched_read()                [worker loop]
+    |                               |
+    |                               v
+    |                         process queue
+    |                               |
+    v                               v
+[IoCompletion]  <--signal--   submit to kernel
+    |                               |
+wait_iouring() GIL-release    completions
+    |                               |
+    v                               v
+wait() non-blocking           wake up waiters
+```
+
+### Fixed Buffer Zero-Copy (io_uring)
+
+io_uring with registered fixed buffers:
+- Buffers are pre-registered with the kernel via `register_fixed_buffers()`
+- Eliminates memory copies between user and kernel space
+- Avoids kernel pin/unpin overhead on each I/O operation
+- Particularly beneficial for repeated I/O operations on the same buffers
+
 ## How To Compare Performance
 
 To compare `local_disk` vs `rust_raw_block` on a real NVMe device:
@@ -49,9 +103,48 @@ No fixed numbers are included here because results are host/device/workload depe
 
 ## Limitations
 
-- Linux only (`pread` / `pwrite`, O_DIRECT semantics).
-- Synchronous I/O only (no async kernel interface, no `io_uring` in this crate).
+- Linux only (`pread` / `pwrite`, O_DIRECT semantics, io_uring).
 - O_DIRECT requires aligned offset, size, and user buffer address.
+- io_uring backend requires Linux kernel 5.1+.
+
+## io_uring Dependencies
+
+The io_uring backend requires specific kernel configuration and versions:
+
+### Kernel Version
+
+- **Minimum version**: Linux kernel 5.1+
+- **Recommended version**: Linux kernel 5.19+ for full feature support
+
+### Kernel Configuration
+
+The following kernel configuration options must be enabled:
+
+```
+CONFIG_IO_URING=y
+```
+
+To check if io_uring is enabled on your system:
+
+```bash
+# Check kernel config
+grep -i uring /boot/config-$(uname -r)
+
+# Or check the presence of io_uring setup function in kernel's symbol table
+grep io_uring_setup /proc/kallsyms
+```
+
+### Rust io-uring Crate
+
+- **Crate version**: `io-uring = "0.7"`
+- **Source**: [io-uring crate on crates.io](https://crates.io/crates/io-uring)
+
+The crate provides safe Rust bindings to the Linux io_uring API and is included in the project's `Cargo.toml`:
+
+```toml
+[dependencies]
+io-uring = "0.7"
+```
 
 ## Build
 
@@ -63,6 +156,8 @@ maturin develop --release
 
 ## Minimal Usage
 
+### Synchronous I/O (pread/pwrite)
+
 ```python
 from lmcache_rust_raw_block_io import RawBlockDevice
 
@@ -71,4 +166,46 @@ dev.pwrite_from_buffer(offset=0, data=b"hello", total_len=4096)
 
 buf = bytearray(4096)
 dev.pread_into(offset=0, out=buf, payload_len=5, total_len=4096)
+```
+
+### Asynchronous I/O (io_uring)
+
+```python
+from lmcache_rust_raw_block_io import RawBlockDevice
+
+# Create device with io_uring enabled
+dev = RawBlockDevice(
+    "/dev/nvme0n1",
+    writable=True,
+    use_odirect=True,
+    alignment=4096,
+    use_iouring=True
+)
+
+buf1 = bytearray(4096)
+buf2 = bytearray(4096)
+buffer_ptrs = [ctypes.addressof(ctypes.c_char.from_buffer(buf1)), ctypes.addressof(ctypes.c_char.from_buffer(buf2))]
+buffer_sizes = [len(buf1), len(buf2)]
+dev.register_fixed_buffers(buffer_ptrs, buffer_sizes)
+
+offsets = [0, 4096]
+buffers = [buf1, buf2]
+lens = [4096, 4096]
+# Batched write submit multiple writes at once
+batch_id = dev.batched_write(offsets, buffers, lens)
+
+# Wait for all in-flight I/O to complete
+dev.wait_iouring(batch_id)
+
+# Single read using io_uring
+buf = bytearray(4096)
+dev.read_uring(offset=0, data=buf, payload_len=5, total_len=4096)
+
+# Batched read submit multiple reads at once
+batch_id = dev.batched_read(offsets, buffers, lens)
+
+# Wait for all in-flight I/O to complete
+dev.wait_iouring(batch_id)
+
+dev.close()
 ```

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -590,7 +590,7 @@ impl RawBlockDevice {
                                     in_flight_cvar_clone.notify_all();
                                 }
                                 // Decrement per-batch in-flight count and notify if batch is complete
-                                {
+                                if batch_id != 0 {
                                     let batch_map = batch_in_flight_clone.lock().unwrap();
                                     if let Some((batch_count, batch_cvar)) =
                                         batch_map.get(&batch_id)
@@ -753,7 +753,7 @@ impl RawBlockDevice {
                                                 in_flight_cvar_clone.notify_all();
                                             }
                                             // Decrement per-batch in-flight count and notify if batch is complete
-                                            {
+                                            if batch_id != 0 {
                                                 let batch_map =
                                                     batch_in_flight_clone.lock().unwrap();
                                                 if let Some((batch_count, batch_cvar)) =
@@ -789,7 +789,7 @@ impl RawBlockDevice {
                             "io_uring worker shutting down",
                         )));
                         // Decrement per-batch in-flight count and notify if batch is complete
-                        {
+                        if batch_id != 0 {
                             let batch_map = batch_in_flight_clone.lock().unwrap();
                             if let Some((batch_count, batch_cvar)) = batch_map.get(&batch_id) {
                                 let prev_batch = batch_count.fetch_sub(1, Ordering::Relaxed);
@@ -858,7 +858,7 @@ impl RawBlockDevice {
                                 in_flight_cvar_clone.notify_all();
                             }
                             // Decrement per-batch in-flight count and notify if batch is complete
-                            {
+                            if batch_id != 0 {
                                 let batch_map = batch_in_flight_clone.lock().unwrap();
                                 if let Some((batch_count, batch_cvar)) = batch_map.get(&batch_id) {
                                     let prev_batch = batch_count.fetch_sub(1, Ordering::Relaxed);
@@ -883,7 +883,7 @@ impl RawBlockDevice {
                         "io_uring worker shutting down - request cancelled",
                     )));
                     // Decrement per-batch in-flight count and notify if batch is complete
-                    {
+                    if batch_id != 0 {
                         let batch_map = batch_in_flight_clone.lock().unwrap();
                         if let Some((batch_count, batch_cvar)) = batch_map.get(&batch_id) {
                             let prev_batch = batch_count.fetch_sub(1, Ordering::Relaxed);

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -11,13 +11,24 @@
 //! - When O_DIRECT is enabled, Linux requires aligned offsets and I/O sizes.
 //!   If Python buffers are aligned, we use them directly; otherwise we fallback
 //!   to a bounce buffer (aligned via `posix_memalign`) for safety.
+//! - For io_uring case a dedicated worker thread drives the io_uring
+//!   submission/completion loop. All alignment checks are performed before
+//!   enqueuing; violations result in an immediate Python `ValueError`.
 
 use pyo3::exceptions::{PyOSError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::unix::io::RawFd;
 use std::slice;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use io_uring::types::Fd;
+use io_uring::{opcode, IoUring};
 
 // Linux ioctl for block device size in bytes.
 // Defined in <linux/fs.h>: BLKGETSIZE64 _IOR(0x12,114,size_t)
@@ -34,6 +45,10 @@ const PYBUF_ANY_CONTIGUOUS: i32 = 0x0080 | PYBUF_STRIDES; // accept any contiguo
 const O_DIRECT: i32 = libc::O_DIRECT;
 #[cfg(not(target_os = "linux"))]
 const O_DIRECT: i32 = 0;
+const RING_SIZE: usize = 256;
+
+///Per batch tracking for in flight I/O operation
+type BatchTracking = (Arc<AtomicU64>, Arc<Condvar>);
 
 /// Round up to nearest multiple of alignment (required for O_DIRECT).
 #[allow(clippy::manual_div_ceil)]
@@ -147,6 +162,9 @@ struct AlignedBuf {
     align: usize,
 }
 
+unsafe impl Send for AlignedBuf {}
+unsafe impl Sync for AlignedBuf {}
+
 impl AlignedBuf {
     // Allocate an aligned buffer suitable for O_DIRECT.
     fn new(len: usize, align: usize) -> Result<Self, PyErr> {
@@ -222,23 +240,156 @@ fn release_pybuffer(mut view: pyo3::ffi::Py_buffer) {
     }
 }
 
-/// Single-FD synchronous raw block device interface.
-/// This is intentionally minimal: open -> pread/pwrite -> close.
+/// Completion primitive for synchronous io_uring operations.
+///
+/// When a Python call needs to wait for an I/O operation to complete,
+/// we use this primitive. The worker thread will call `set()` with the
+/// result, and the caller calls `wait()` to block until the result is ready.
+///
+/// Fields:
+/// - `result`: Stores the completion status (Ok or Err)
+/// - `cvar`: Condition variable for signaling when result is available
+struct IoCompletion {
+    result: Mutex<Option<PyResult<()>>>,
+    cvar: Condvar,
+}
+
+impl IoCompletion {
+    fn new() -> Self {
+        Self {
+            result: Mutex::new(None),
+            cvar: Condvar::new(),
+        }
+    }
+    fn set(&self, r: PyResult<()>) {
+        let mut guard = self
+            .result
+            .lock()
+            .expect("IoCompletion: mutex poisoned in set()");
+        *guard = Some(r);
+        self.cvar.notify_one();
+    }
+    fn wait(&self) -> PyResult<()> {
+        let mut guard = self
+            .result
+            .lock()
+            .expect("IoCompletion: mutex poisoned in wait()");
+        while guard.is_none() {
+            guard = self
+                .cvar
+                .wait(guard)
+                .expect("IoCompletion: condition variable wait failed");
+        }
+        guard.take().unwrap()
+    }
+}
+
+/// Represents a single I/O submission to io_uring.
+///
+/// This struct is sent from Python threads to the worker thread via a queue.
+/// It contains all information needed to perform the I/O operation.
+///
+/// Fields:
+/// - `fd`: File descriptor for the block device
+/// - `offset`: Byte offset on the device to read/write
+/// - `len`: Number of bytes to transfer
+/// - `ptr_addr`: Memory address of the buffer (as usize for Send)
+/// - `is_write`: true for write, false for read
+/// - `completion`: Shared completion primitive for signaling result
+/// - `fixed_buffer_idx`: Index into registered fixed buffers (if using zero-copy)
+/// - `bounce`: optional bounce buffer when O_DIRECT requires alignment.
+/// - `original_ptr`: For reads with bounce buffer, the original destination pointer.
+/// - `payload_len`: For reads with bounce buffer, the actual payload length to copy back.
+/// - `batch_id`: The batch ID this submission belongs to (for per-batch tracking)
+#[derive(Clone)]
+struct IoSubmission {
+    fd: RawFd,
+    offset: u64,
+    len: usize,
+    ptr_addr: usize,
+    is_write: bool,
+    completion: Arc<IoCompletion>,
+    fixed_buffer_idx: Option<u16>,
+    bounce: Option<std::sync::Arc<AlignedBuf>>,
+    original_ptr: Option<usize>, // For bounce buffer reads
+    payload_len: Option<usize>,  // For bounce buffer reads
+    batch_id: u64,               // Batch ID for per-batch tracking
+}
+
+impl Default for IoSubmission {
+    fn default() -> Self {
+        IoSubmission {
+            fd: -1 as RawFd,
+            offset: 0,
+            len: 0,
+            ptr_addr: 0,
+            is_write: false,
+            completion: Arc::new(IoCompletion::new()),
+            fixed_buffer_idx: None,
+            bounce: None,
+            original_ptr: None,
+            payload_len: None,
+            batch_id: 0,
+        }
+    }
+}
+
+/// Raw block device I/O interface for Python.
+///
+/// - Synchronous I/O (pread/pwrite) - always available
+/// - Asynchronous I/O via io_uring - optional, enabled with use_iouring flag
 /// Higher-level policies (slotting, manifests, etc.) live in Python.
 #[pyclass]
 struct RawBlockDevice {
-    fd: RawFd,         // raw file descriptor
-    size: u64,         // cached device size in bytes
-    closed: bool,      // avoid double-close
-    use_odirect: bool, // enforce alignment + bypass page cache
-    alignment: usize,  // required alignment in bytes
+    fd: RawFd,          // raw file descriptor
+    size: u64,          // cached device size in bytes
+    closed: AtomicBool, // avoid double-close
+    use_odirect: bool,  // enforce alignment + bypass page cache
+    alignment: usize,   // required alignment in bytes
+    use_iouring: bool,  // Enable io_uring
+    // io_uring ring instance (only when use_iouring=true)
+    ring: Option<Arc<Mutex<IoUring>>>,
+    // Queue for sending I/O requests from Python to worker thread
+    queue: Option<Arc<Mutex<Vec<IoSubmission>>>>,
+    // Background worker thread handle
+    worker: Option<thread::JoinHandle<()>>,
+    // Shutdown signal for worker thread
+    shutdown: Option<Arc<AtomicBool>>,
+    // Map from buffer pointer address to registered fixed buffer index
+    // Used for zero-copy I/O with pre-registered buffers
+    fixed_buffer_map: Arc<Mutex<HashMap<usize, (u16, usize)>>>,
+    // Flag indicating if fixed buffers have been registered
+    fixed_buffers_registered: Arc<AtomicBool>,
+    // Count of currently in-flight I/O operations (global)
+    // Used for shutdown and cleanup
+    in_flight_count: Arc<AtomicU64>,
+    // Condition variable for signaling when in_flight_count reaches 0
+    in_flight_cvar: Arc<Condvar>,
+    // Per-batch in-flight count tracking
+    // Maps batch_id -> (in_flight_count, condition_variable)
+    batch_in_flight: Arc<Mutex<HashMap<u64, BatchTracking>>>,
+    // Signal to wake up worker when new requests are available
+    batch_ready: Option<Arc<Condvar>>,
+    // Store Python buffer objects for writes, reads to keep them alive until they complete
+    // This prevents premature garbage collection while io_uring is using the buffers
+    // Keyed by batch_id to isolate concurrent batches
+    batched_buffer_objs: Arc<Mutex<HashMap<u64, Vec<Py<PyAny>>>>>,
+    // Store IoCompletion objects for batched operations to check for I/O errors
+    // Keyed by batch_id to isolate concurrent batches
+    batched_completions: Arc<Mutex<HashMap<u64, Vec<Arc<IoCompletion>>>>>,
+    // Counter for generating unique batch IDs
+    next_batch_id: Arc<AtomicU64>,
 }
 
-#[pymethods]
 impl RawBlockDevice {
-    #[new]
-    #[pyo3(signature=(path, writable, use_odirect=false, alignment=4096))]
-    fn new(path: String, writable: bool, use_odirect: bool, alignment: usize) -> PyResult<Self> {
+    /// Internal constructor performs all low level setup.
+    fn new_internal(
+        path: String,
+        writable: bool,
+        use_odirect: bool,
+        alignment: usize,
+        use_iouring: bool,
+    ) -> PyResult<Self> {
         let cpath = CString::new(path).map_err(|_| PyValueError::new_err("path contains NUL"))?;
         let mut flags = if writable {
             libc::O_RDWR
@@ -254,18 +405,1168 @@ impl RawBlockDevice {
             return Err(os_err("open failed"));
         }
         let size = fd_size_bytes(fd)?;
+
+        let (
+            ring_opt,
+            queue_opt,
+            shutdown_opt,
+            worker_opt,
+            batch_ready_opt,
+            in_flight_count_opt,
+            in_flight_cvar_opt,
+            batched_buffer_objs_opt,
+            batched_completions_opt,
+            next_batch_id_opt,
+            batch_in_flight_opt,
+        ) = if use_iouring {
+            let ring = IoUring::new(RING_SIZE as u32)
+                .map_err(|e| PyRuntimeError::new_err(format!("io_uring init failed: {}", e)))?;
+            let ring = Arc::new(Mutex::new(ring));
+            let queue = Arc::new(Mutex::new(Vec::<IoSubmission>::new()));
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let batch_ready = Arc::new(Condvar::new());
+            let in_flight_count = Arc::new(AtomicU64::new(0));
+            let in_flight_cvar = Arc::new(Condvar::new());
+            let batched_buffer_objs = Arc::new(Mutex::new(HashMap::<u64, Vec<Py<PyAny>>>::new()));
+            let batched_completions =
+                Arc::new(Mutex::new(HashMap::<u64, Vec<Arc<IoCompletion>>>::new()));
+            let next_batch_id = Arc::new(AtomicU64::new(1));
+            let batch_in_flight = Arc::new(Mutex::new(HashMap::<u64, BatchTracking>::new()));
+
+            let ring_clone = Arc::clone(&ring);
+            let queue_clone = Arc::clone(&queue);
+            let shutdown_clone = Arc::clone(&shutdown);
+            let batch_ready_clone = Arc::clone(&batch_ready);
+            let in_flight_count_clone = Arc::clone(&in_flight_count);
+            let in_flight_cvar_clone = Arc::clone(&in_flight_cvar);
+            let batch_in_flight_clone = Arc::clone(&batch_in_flight);
+
+            // Worker thread that handles io_uring submissions and completions.
+            //
+            // Runs a continuous loop that:
+            // - Processes completion queue events (CQ) from the kernel
+            // - Waits for new I/O requests from Python via the queue
+            // - Submits new requests to the kernel (SQ)
+            //
+            // On shutdown, we must process ALL pending requests to avoid deadlocks:
+            // - Requests still in the queue
+            // - Requests already submitted to kernel (in_flight)
+            // Each waiting Python thread must be woken up with an error.
+            //
+            // Thread safety: All access to shared state (ring, queue, in_flight)
+            // is protected by mutexes. The worker is the only thread that:
+            // - Reads from the submission queue
+            // - Submits to io_uring
+            // - Processes completions
+            let worker = thread::spawn(move || {
+                let mut in_flight: HashMap<u64, IoSubmission> = HashMap::new();
+                let mut next_user_data: u64 = 1;
+
+                while !shutdown_clone.load(Ordering::Relaxed) {
+                    // This drains all completed I/O operations from the completion queue (CQ).
+                    // For each completion:
+                    //   - Remove the request from our in_flight tracking HashMap
+                    //   - Signal the waiting Python thread via IoCompletion
+                    //   - Decrement the in_flight_count atomic
+                    //   - Wake up any threads waiting for all I/O to complete
+                    {
+                        let mut ring = ring_clone.lock().unwrap();
+                        for cqe in ring.completion() {
+                            let user_data = cqe.user_data();
+                            if let Some(mut sub) = in_flight.remove(&user_data) {
+                                let batch_id = sub.batch_id;
+                                if cqe.result() < 0 {
+                                    let code = -cqe.result();
+                                    // Drop any bounce buffer associated with this submission.
+                                    let _ = sub.bounce.take();
+                                    sub.completion
+                                        .set(Err(PyOSError::new_err((code, "io_uring I/O error"))));
+                                } else {
+                                    // For reads with bounce buffer, copy data back to original buffer
+                                    if !sub.is_write {
+                                        if let (Some(bounce), Some(orig_ptr), Some(payload_len)) =
+                                            (sub.bounce.take(), sub.original_ptr, sub.payload_len)
+                                        {
+                                            unsafe {
+                                                libc::memcpy(
+                                                    orig_ptr as *mut libc::c_void,
+                                                    bounce.as_ptr() as *const libc::c_void,
+                                                    payload_len,
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        // Drop any bounce buffer associated with this submission.
+                                        let _ = sub.bounce.take();
+                                    }
+                                    sub.completion.set(Ok(()));
+                                }
+                                let prev = in_flight_count_clone.fetch_sub(1, Ordering::Relaxed);
+                                if prev == 1 {
+                                    in_flight_cvar_clone.notify_all();
+                                }
+                                // Decrement per-batch in-flight count and notify if batch is complete
+                                {
+                                    let batch_map = batch_in_flight_clone.lock().unwrap();
+                                    if let Some((batch_count, batch_cvar)) =
+                                        batch_map.get(&batch_id)
+                                    {
+                                        let prev_batch =
+                                            batch_count.fetch_sub(1, Ordering::Relaxed);
+                                        if prev_batch == 1 {
+                                            batch_cvar.notify_all();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        ring.submission().sync();
+                    }
+
+                    // We use a condition variable with a short timeout (10 microseconds).
+                    // This allows us to:
+                    //   - Quickly respond to new requests (batched from Python)
+                    //   - Periodically check for shutdown signal
+                    //   - Not spin aggressively (which would waste CPU)
+                    let timeout = Duration::from_micros(10);
+                    let q = queue_clone.lock().unwrap();
+                    let (mut q, _) = batch_ready_clone
+                        .wait_timeout_while(q, timeout, |q| {
+                            q.is_empty() && !shutdown_clone.load(Ordering::Relaxed)
+                        })
+                        .unwrap();
+
+                    if !q.is_empty() {
+                        // Take all pending requests from our queue and submit them to io_uring.
+                        //
+                        // - Remove all pending requests from queue
+                        // - Check how much space is available in the ring (max 256 entries)
+                        // - If batch is larger than available space, put excess back in queue
+                        // - Increment in_flight_count for each request we're about to submit
+                        // - Build SQE (Submission Queue Entry) for each request
+                        // - Push SQEs to the ring
+                        // - Call submit() to send them to the kernel
+                        //
+                        // Fixed Buffer Support:
+                        // - If the buffer was pre-registered with register_fixed_buffers(),
+                        //   we use ReadFixed/WriteFixed for true zero-copy I/O
+                        // - Otherwise we use regular Read/Write with user-space pointers
+                        let mut batch: Vec<IoSubmission> = std::mem::take(&mut *q);
+                        let batch_len = batch.len();
+
+                        let mut ring = ring_clone.lock().unwrap();
+
+                        let available = RING_SIZE - ring.submission().len();
+                        let to_submit_count = std::cmp::min(available, batch_len);
+
+                        if to_submit_count < batch_len {
+                            let remaining: Vec<_> = batch[to_submit_count..].to_vec();
+                            if !remaining.is_empty() {
+                                q.extend(remaining);
+                            }
+                        }
+
+                        drop(q);
+
+                        // Track user_data values for each submission to clean up in_flight entries
+                        // if submit() fails or returns partial count
+                        let mut user_data_list: Vec<u64> = Vec::with_capacity(to_submit_count);
+                        for sub in batch.iter().take(to_submit_count) {
+                            let user_data = next_user_data;
+                            next_user_data = next_user_data.wrapping_add(1);
+                            user_data_list.push(user_data);
+                            in_flight.insert(user_data, sub.clone());
+
+                            let ptr = sub.ptr_addr as *mut u8;
+                            let sqe = if sub.is_write {
+                                if let Some(idx) = sub.fixed_buffer_idx {
+                                    opcode::WriteFixed::new(
+                                        Fd(sub.fd),
+                                        ptr as *const u8,
+                                        sub.len as u32,
+                                        idx,
+                                    )
+                                    .offset(sub.offset)
+                                    .build()
+                                } else {
+                                    opcode::Write::new(Fd(sub.fd), ptr as *const u8, sub.len as u32)
+                                        .offset(sub.offset)
+                                        .build()
+                                }
+                            } else if let Some(idx) = sub.fixed_buffer_idx {
+                                opcode::ReadFixed::new(Fd(sub.fd), ptr, sub.len as u32, idx)
+                                    .offset(sub.offset)
+                                    .build()
+                            } else {
+                                opcode::Read::new(Fd(sub.fd), ptr, sub.len as u32)
+                                    .offset(sub.offset)
+                                    .build()
+                            };
+                            let sqe = sqe.user_data(user_data);
+                            unsafe {
+                                ring.submission().push(&sqe).expect("failed to push sqe");
+                            }
+                        }
+
+                        let submit_result = ring.submitter().submit();
+                        // Handle EAGAIN (ring full) and EINTR (interrupted syscall)
+                        match submit_result {
+                            Ok(submitted) => {
+                                // Any remaining requests in batch that weren't submitted
+                                // will be retried in the next iteration of the loop
+                                if submitted < to_submit_count {
+                                    // Remove in_flight entries for unsubmitted requests
+                                    for user_data in user_data_list[submitted..].iter() {
+                                        in_flight.remove(user_data);
+                                    }
+                                    // Put unsubmitted requests back in the queue for retry
+                                    let unsubmitted: Vec<_> =
+                                        batch[submitted..to_submit_count].to_vec();
+                                    if !unsubmitted.is_empty() {
+                                        drop(ring);
+                                        let mut q = queue_clone.lock().unwrap();
+                                        // Insert unsubmitted requests back at the front preserving order
+                                        q.splice(0..0, unsubmitted);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                // Handle submission errors
+                                let error_code = e.raw_os_error();
+                                match error_code {
+                                    Some(libc::EAGAIN) | Some(libc::EINTR) => {
+                                        // Ring is full, or the operation was interrupted due
+                                        // to signal. We need to wait for completions and then retry
+                                        // Remove in_flight entries for all submissions in this batch
+                                        for user_data in user_data_list.iter() {
+                                            in_flight.remove(user_data);
+                                        }
+                                        // Put unsubmitted requests back in queue for next iteration
+                                        if to_submit_count > 0 {
+                                            let unsubmitted: Vec<_> =
+                                                batch[..to_submit_count].to_vec();
+                                            drop(ring);
+                                            let mut q = queue_clone.lock().unwrap();
+                                            // Insert unsubmitted requests back at the front preserving order
+                                            q.splice(0..0, unsubmitted);
+                                        }
+                                    }
+                                    _ => {
+                                        // Error: fail all pending submissions in this batch.
+                                        // Remove in_flight entries since these won't generate completions
+                                        for user_data in user_data_list.iter() {
+                                            in_flight.remove(user_data);
+                                        }
+                                        for sub in batch.iter_mut().take(to_submit_count) {
+                                            let batch_id = sub.batch_id;
+                                            sub.completion.set(Err(PyRuntimeError::new_err(
+                                                format!("io_uring submit error: {:?}", e),
+                                            )));
+                                            let _ = sub.bounce.take();
+                                            let prev = in_flight_count_clone
+                                                .fetch_sub(1, Ordering::Relaxed);
+                                            if prev == 1 {
+                                                in_flight_cvar_clone.notify_all();
+                                            }
+                                            // Decrement per-batch in-flight count and notify if batch is complete
+                                            {
+                                                let batch_map =
+                                                    batch_in_flight_clone.lock().unwrap();
+                                                if let Some((batch_count, batch_cvar)) =
+                                                    batch_map.get(&batch_id)
+                                                {
+                                                    let prev_batch =
+                                                        batch_count.fetch_sub(1, Ordering::Relaxed);
+                                                    if prev_batch == 1 {
+                                                        batch_cvar.notify_all();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // SHUTDOWN: Wake up all waiting Python threads
+                // Drain the queue and wake up all waiting threads with error
+                {
+                    let mut q = queue_clone
+                        .lock()
+                        .expect("Worker: queue mutex poisoned during shutdown");
+                    while let Some(mut sub) = q.pop() {
+                        let batch_id = sub.batch_id;
+                        // Drop any bounce buffer associated with this submission.
+                        let _ = sub.bounce.take();
+                        in_flight_count_clone.fetch_sub(1, Ordering::Relaxed);
+                        sub.completion.set(Err(PyRuntimeError::new_err(
+                            "io_uring worker shutting down",
+                        )));
+                        // Decrement per-batch in-flight count and notify if batch is complete
+                        {
+                            let batch_map = batch_in_flight_clone.lock().unwrap();
+                            if let Some((batch_count, batch_cvar)) = batch_map.get(&batch_id) {
+                                let prev_batch = batch_count.fetch_sub(1, Ordering::Relaxed);
+                                if prev_batch == 1 {
+                                    batch_cvar.notify_all();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Process any remaining in-flight requests
+                // Wait for kernel to complete the requests or force-cancel them
+                // Note: This 1000 milliseconds is a rough estimate
+                let graceful_shutdown = Duration::from_millis(1000);
+                thread::sleep(graceful_shutdown);
+                {
+                    let mut ring = ring_clone
+                        .lock()
+                        .expect("Worker: ring mutex poisoned during shutdown");
+                    for cqe in ring.completion() {
+                        let user_data = cqe.user_data();
+                        if let Some(mut sub) = in_flight.remove(&user_data) {
+                            let batch_id = sub.batch_id;
+                            if cqe.result() < 0 {
+                                let code = -cqe.result();
+                                // Drop any bounce buffer associated with this submission.
+                                let _ = sub.bounce.take();
+                                sub.completion
+                                    .set(Err(PyOSError::new_err((code, "io_uring I/O error"))));
+                            } else {
+                                // For reads with bounce buffer, copy data back to original buffer
+                                if !sub.is_write {
+                                    if let (Some(bounce), Some(orig_ptr), Some(payload_len)) =
+                                        (sub.bounce.take(), sub.original_ptr, sub.payload_len)
+                                    {
+                                        unsafe {
+                                            libc::memcpy(
+                                                orig_ptr as *mut libc::c_void,
+                                                bounce.as_ptr() as *const libc::c_void,
+                                                payload_len,
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    // Drop any bounce buffer associated with this submission.
+                                    let _ = sub.bounce.take();
+                                }
+                                sub.completion.set(Ok(()));
+                            }
+                            let prev = in_flight_count_clone.fetch_sub(1, Ordering::Relaxed);
+                            if prev == 1 {
+                                in_flight_cvar_clone.notify_all();
+                            }
+                            // Decrement per-batch in-flight count and notify if batch is complete
+                            {
+                                let batch_map = batch_in_flight_clone.lock().unwrap();
+                                if let Some((batch_count, batch_cvar)) = batch_map.get(&batch_id) {
+                                    let prev_batch = batch_count.fetch_sub(1, Ordering::Relaxed);
+                                    if prev_batch == 1 {
+                                        batch_cvar.notify_all();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    ring.submission().sync();
+                }
+
+                // Any remaining in_flight requests, force wake with error
+                // (these were submitted to kernel but won't get completions)
+                for (_user_data, mut sub) in in_flight.drain() {
+                    let batch_id = sub.batch_id;
+                    // Drop any bounce buffer associated with this submission.
+                    let _ = sub.bounce.take();
+                    in_flight_count_clone.fetch_sub(1, Ordering::Relaxed);
+                    sub.completion.set(Err(PyRuntimeError::new_err(
+                        "io_uring worker shutting down - request cancelled",
+                    )));
+                    // Decrement per-batch in-flight count and notify if batch is complete
+                    {
+                        let batch_map = batch_in_flight_clone.lock().unwrap();
+                        if let Some((batch_count, batch_cvar)) = batch_map.get(&batch_id) {
+                            let prev_batch = batch_count.fetch_sub(1, Ordering::Relaxed);
+                            if prev_batch == 1 {
+                                batch_cvar.notify_all();
+                            }
+                        }
+                    }
+                }
+
+                // Final notification in case any thread is waiting on in_flight_count
+                in_flight_cvar_clone.notify_all();
+            });
+
+            (
+                Some(ring),
+                Some(queue),
+                Some(shutdown),
+                Some(worker),
+                Some(batch_ready),
+                Some(in_flight_count),
+                Some(in_flight_cvar),
+                Some(batched_buffer_objs),
+                Some(batched_completions),
+                Some(next_batch_id),
+                Some(batch_in_flight),
+            )
+        } else {
+            (
+                None, None, None, None, None, None, None, None, None, None, None,
+            )
+        };
+
         Ok(Self {
             fd,
             size,
-            closed: false,
+            closed: AtomicBool::new(false),
             use_odirect,
             alignment,
+            use_iouring,
+            ring: ring_opt,
+            queue: queue_opt,
+            worker: worker_opt,
+            shutdown: shutdown_opt,
+            fixed_buffer_map: Arc::new(Mutex::new(HashMap::new())),
+            fixed_buffers_registered: Arc::new(AtomicBool::new(false)),
+            in_flight_count: in_flight_count_opt.unwrap_or_else(|| Arc::new(AtomicU64::new(0))),
+            in_flight_cvar: in_flight_cvar_opt.unwrap_or_else(|| Arc::new(Condvar::new())),
+            batch_ready: batch_ready_opt,
+            batched_buffer_objs: batched_buffer_objs_opt
+                .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new()))),
+            batched_completions: batched_completions_opt
+                .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new()))),
+            next_batch_id: next_batch_id_opt.unwrap_or_else(|| Arc::new(AtomicU64::new(1))),
+            batch_in_flight: batch_in_flight_opt
+                .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new()))),
         })
+    }
+}
+
+#[pymethods]
+impl RawBlockDevice {
+    #[new]
+    #[pyo3(
+        signature = (path, writable, use_odirect = false, use_iouring = false, alignment = 4096)
+    )]
+    fn new(
+        path: String,
+        writable: bool,
+        use_odirect: bool,
+        use_iouring: bool,
+        alignment: usize,
+    ) -> PyResult<Self> {
+        Self::new_internal(path, writable, use_odirect, alignment, use_iouring)
     }
 
     // Expose cached size to Python.
     fn size_bytes(&self) -> PyResult<u64> {
         Ok(self.size)
+    }
+
+    /// Register fixed buffers for zero-copy io_uring operations.
+    ///
+    /// - Pre-registering memory buffers with the kernel
+    /// - Using indexed descriptors (instead of pointers) in I/O operations
+    /// - The kernel then does DMA directly from/to the registered buffers
+    ///
+    /// This is more efficient than regular I/O because:
+    /// - No buffer copying between user space and kernel
+    /// - The kernel can pin the memory pages for the duration of I/O
+    ///
+    /// Registration must happen BEFORE any I/O using these buffers.
+    /// The buffers must remain valid (not freed) until unregistered.
+    #[pyo3(signature = (buffer_ptrs, buffer_sizes))]
+    fn register_fixed_buffers(
+        &self,
+        buffer_ptrs: Vec<usize>,
+        buffer_sizes: Vec<usize>,
+    ) -> PyResult<()> {
+        if !self.use_iouring {
+            return Err(PyRuntimeError::new_err("io_uring not enabled"));
+        }
+        if buffer_ptrs.len() != buffer_sizes.len() {
+            return Err(PyValueError::new_err(
+                "buffer_ptrs and buffer_sizes must have same length",
+            ));
+        }
+        if buffer_ptrs.is_empty() {
+            return Err(PyValueError::new_err(
+                "at least one buffer must be provided",
+            ));
+        }
+
+        {
+            let mut map = self.fixed_buffer_map.lock().unwrap();
+            map.clear();
+            for (idx, (ptr, size)) in buffer_ptrs.iter().zip(buffer_sizes.iter()).enumerate() {
+                map.insert(*ptr, (idx as u16, *size));
+            }
+        }
+
+        if let Some(ring) = &self.ring {
+            let ring = ring.lock().unwrap();
+            let mut iovecs: Vec<libc::iovec> = Vec::new();
+            for (ptr, size) in buffer_ptrs.iter().zip(buffer_sizes.iter()) {
+                iovecs.push(libc::iovec {
+                    iov_base: *ptr as *mut libc::c_void,
+                    iov_len: *size,
+                });
+            }
+            unsafe {
+                match ring.submitter().register_buffers(&iovecs) {
+                    Ok(_) => {
+                        self.fixed_buffers_registered.store(true, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        return Err(PyRuntimeError::new_err(format!(
+                            "register_buffers failed: {}",
+                            e
+                        )))
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Batched write: submit multiple writes at once via io_uring.
+    /// All writes are queued to the worker thread, which processes them
+    /// in batches to maximize throughput.
+    ///
+    /// Returns a batch_id that must be passed to wait_iouring() to wait
+    /// for completions for that batch.
+    #[pyo3(signature = (offsets, buffers, total_lens))]
+    fn batched_write(
+        &self,
+        py: Python<'_>,
+        offsets: Vec<u64>,
+        buffers: Vec<Bound<'_, PyAny>>,
+        total_lens: Vec<usize>,
+    ) -> PyResult<u64> {
+        if !self.use_iouring {
+            return Err(PyRuntimeError::new_err("io_uring not enabled"));
+        }
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+
+        let n = offsets.len();
+        if n == 0 {
+            // Return a valid batch_id even for empty batches
+            return Ok(self.next_batch_id.fetch_add(1, Ordering::Relaxed));
+        }
+        if buffers.len() != n || total_lens.len() != n {
+            return Err(PyValueError::new_err("All vectors must have same length"));
+        }
+
+        // Acquire buffer views to keep them alive until wait_iouring() completes
+        let mut views = Vec::with_capacity(n);
+        for buffer in &buffers {
+            let view = get_pybuffer(py, buffer, false)?;
+            if view.buf.is_null() {
+                for v in views {
+                    release_pybuffer(v);
+                }
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("null buffer pointer"));
+            }
+            views.push(view);
+        }
+
+        // Generate a unique batch ID for this batch
+        let batch_id = self.next_batch_id.fetch_add(1, Ordering::Relaxed);
+
+        // Initialize per-batch tracking for this batch
+        {
+            let mut batch_map = self.batch_in_flight.lock().unwrap();
+            batch_map.insert(
+                batch_id,
+                (Arc::new(AtomicU64::new(0)), Arc::new(Condvar::new())),
+            );
+        }
+
+        // Store buffer objects to keep them alive until they are complete
+        {
+            let mut stored_objs = self.batched_buffer_objs.lock().unwrap();
+            let batch_buffers = stored_objs.entry(batch_id).or_default();
+            for buffer in &buffers {
+                batch_buffers.push(buffer.clone().unbind());
+            }
+        }
+
+        // Extract pointers as usize before releasing GIL (raw pointers are not Send)
+        let mut ptrs = Vec::with_capacity(n);
+        for view in &views {
+            ptrs.push(view.buf as usize);
+        }
+
+        for view in views {
+            release_pybuffer(view);
+        }
+
+        let fd = self.fd;
+        let use_odirect = self.use_odirect;
+        let alignment = self.alignment;
+        let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        // Clone the fixed buffer map before releasing GIL to avoid lock contention
+        let fixed_buffer_map: HashMap<usize, (u16, usize)> = if fixed_buffers_registered {
+            let map = self.fixed_buffer_map.lock().unwrap();
+            map.clone()
+        } else {
+            HashMap::new()
+        };
+        let in_flight_count = Arc::clone(&self.in_flight_count);
+        let queue = Arc::clone(self.queue.as_ref().unwrap());
+        let batch_ready = Arc::clone(self.batch_ready.as_ref().unwrap());
+        let batched_completions = Arc::clone(&self.batched_completions);
+        let batch_in_flight = Arc::clone(&self.batch_in_flight);
+        // Additional clones for cleanup on error path
+        let batch_in_flight_cleanup = Arc::clone(&batch_in_flight);
+        let batched_completions_cleanup = Arc::clone(&batched_completions);
+        let batched_buffer_objs_cleanup = Arc::clone(&self.batched_buffer_objs);
+
+        // Release the GIL while submitting I/O operations
+        let res = py.allow_threads(move || {
+            let mut submissions: Vec<(IoSubmission, Arc<IoCompletion>)> = Vec::with_capacity(n);
+
+            // Prepare all requests, bounce buffers (if needed) and collect submission data.
+            for i in 0..n {
+                let ptr = ptrs[i] as *const u8;
+                let total_len = total_lens[i];
+                let offset = offsets[i];
+
+                let comp = Arc::new(IoCompletion::new());
+
+                // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
+                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+
+                // Ensure O_DIRECT buffers are aligned
+                let (final_ptr, bounce_opt, fixed_idx) = if use_odirect {
+                    let align = alignment;
+                    #[allow(clippy::manual_is_multiple_of)]
+                    if ptrs[i] % align != 0 {
+                        let bounce = AlignedBuf::new(total_len, align)?;
+                        unsafe {
+                            libc::memcpy(
+                                bounce.as_mut_ptr() as *mut libc::c_void,
+                                ptr as *const libc::c_void,
+                                total_len,
+                            );
+                        }
+                        let bounce_arc = std::sync::Arc::new(bounce);
+                        let bounce_ptr = bounce_arc.as_ptr();
+                        (bounce_ptr, Some(bounce_arc), None)
+                    } else {
+                        (ptr, None, fixed_idx)
+                    }
+                } else {
+                    (ptr, None, fixed_idx)
+                };
+
+                let sub = IoSubmission {
+                    fd,
+                    offset,
+                    len: total_len,
+                    ptr_addr: final_ptr as usize,
+                    is_write: true,
+                    completion: comp.clone(),
+                    fixed_buffer_idx: fixed_idx,
+                    bounce: bounce_opt,
+                    original_ptr: None,
+                    payload_len: None,
+                    batch_id,
+                };
+
+                submissions.push((sub, comp));
+            }
+
+            // Queue all submissions atomically. At this point no further errors can
+            // occur during queuing.
+            for (sub, comp) in submissions {
+                in_flight_count.fetch_add(1, Ordering::Relaxed);
+
+                // Increment per-batch in-flight count
+                {
+                    let batch_map = batch_in_flight.lock().unwrap();
+                    if let Some((batch_count, _)) = batch_map.get(&batch_id) {
+                        batch_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                {
+                    let mut q = queue.lock().unwrap();
+                    q.push(sub);
+                }
+                batch_ready.notify_one();
+
+                // Store completion for error checking in wait_iouring
+                {
+                    let mut completions = batched_completions.lock().unwrap();
+                    let batch_completions = completions.entry(batch_id).or_default();
+                    batch_completions.push(comp);
+                }
+            }
+            Ok::<(), PyErr>(())
+        });
+
+        // Preparation failed, clean up the tracking entries to prevent leaks
+        if let Err(e) = res {
+            {
+                let mut batch_map = batch_in_flight_cleanup.lock().unwrap();
+                batch_map.remove(&batch_id);
+            }
+            {
+                let mut stored_objs = batched_buffer_objs_cleanup.lock().unwrap();
+                stored_objs.remove(&batch_id);
+            }
+            {
+                let mut completions = batched_completions_cleanup.lock().unwrap();
+                completions.remove(&batch_id);
+            }
+            return Err(e);
+        }
+
+        Ok(batch_id)
+    }
+
+    /// Wait for all in-flight I/O for a specific batch to complete.
+    /// The method waits on a per-batch condition variable that gets signaled
+    /// when the batch's in-flight count reaches 0.
+    ///
+    /// Args:
+    ///     batch_id: The batch ID returned by batched_write() or batched_read().
+    ///               Only completions from this batch are checked.
+    ///
+    /// Returns an error if any I/O operation in this batch failed. The error message
+    /// includes details about the first failure encountered.
+    #[pyo3(signature = (batch_id))]
+    fn wait_iouring(&self, py: Python<'_>, batch_id: u64) -> PyResult<()> {
+        if !self.use_iouring {
+            return Ok(());
+        }
+
+        // Get the per-batch tracking for this batch
+        let (batch_count, batch_cvar) = {
+            let batch_map = self.batch_in_flight.lock().unwrap();
+            match batch_map.get(&batch_id) {
+                Some((count, cvar)) => (Arc::clone(count), Arc::clone(cvar)),
+                None => {
+                    // Batch not found. This could be an empty batch or already completed
+                    // Check if there are any completions for this batch
+                    let mut completions = self.batched_completions.lock().unwrap();
+                    let batch_completions = completions.remove(&batch_id);
+                    let mut first_error: Option<PyErr> = None;
+                    if let Some(comp_vec) = batch_completions {
+                        for comp in comp_vec.iter() {
+                            if let Err(e) = comp.wait() {
+                                if first_error.is_none() {
+                                    first_error = Some(e);
+                                }
+                            }
+                        }
+                    }
+                    // Clear stored buffer objects for this batch
+                    let mut stored_objs = self.batched_buffer_objs.lock().unwrap();
+                    stored_objs.remove(&batch_id);
+                    return if let Some(e) = first_error {
+                        Err(e)
+                    } else {
+                        Ok(())
+                    };
+                }
+            }
+        };
+
+        // Release the GIL while waiting for I/O to complete
+        py.allow_threads(move || {
+            let mutex = Mutex::new(());
+            let mut guard = mutex.lock().unwrap();
+            while batch_count.load(Ordering::Relaxed) > 0 {
+                let (g, _) = batch_cvar
+                    .wait_timeout(guard, Duration::from_micros(10))
+                    .unwrap();
+                guard = g;
+            }
+        });
+
+        // Check all completion results for errors for this specific batch
+        let mut completions = self.batched_completions.lock().unwrap();
+        let batch_completions = completions.remove(&batch_id);
+        let mut first_error: Option<PyErr> = None;
+        if let Some(comp_vec) = batch_completions {
+            for comp in comp_vec.iter() {
+                if let Err(e) = comp.wait() {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        // Clear stored buffer objects for this batch now that I/O is complete
+        let mut stored_objs = self.batched_buffer_objs.lock().unwrap();
+        stored_objs.remove(&batch_id);
+
+        // Clean up per-batch tracking
+        let mut batch_map = self.batch_in_flight.lock().unwrap();
+        batch_map.remove(&batch_id);
+
+        if let Some(e) = first_error {
+            Err(e)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Synchronous read using io_uring.
+    #[pyo3(signature = (offset, data, payload_len, total_len = None))]
+    fn read_uring(
+        &self,
+        py: Python<'_>,
+        offset: u64,
+        data: &Bound<'_, PyAny>,
+        payload_len: usize,
+        total_len: Option<usize>,
+    ) -> PyResult<()> {
+        if !self.use_iouring {
+            return Err(PyRuntimeError::new_err("io_uring not enabled"));
+        }
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+
+        let view = get_pybuffer(py, data, true)?;
+        if view.readonly != 0 {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("output buffer is readonly"));
+        }
+        let ptr = view.buf as *mut u8;
+        if ptr.is_null() {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("null buffer pointer"));
+        }
+
+        let cap = view.len as usize;
+        let total_len = total_len.unwrap_or(payload_len);
+        if cap < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err(format!(
+                "output buffer too small: cap={cap} need={payload_len}"
+            )));
+        }
+        if total_len < payload_len {
+            release_pybuffer(view);
+            return Err(PyValueError::new_err("total_len must be >= payload_len"));
+        }
+
+        let align = self.alignment;
+        if self.use_odirect {
+            #[allow(clippy::manual_is_multiple_of)]
+            if (offset as usize) % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+            }
+            #[allow(clippy::manual_is_multiple_of)]
+            if total_len % align != 0 {
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+            }
+        }
+
+        // Check if the buffer is aligned for O_DIRECT
+        let ptr_aligned = if self.use_odirect {
+            (ptr as usize).is_multiple_of(align)
+        } else {
+            true
+        };
+
+        // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
+        let use_fixed = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        let fixed_idx = if use_fixed && ptr_aligned {
+            let map = self.fixed_buffer_map.lock().unwrap();
+            let ptr_addr = ptr as usize;
+            map.get(&ptr_addr).map(|(idx, _)| *idx)
+        } else {
+            None
+        };
+
+        // Use bounce buffer if:
+        // Buffer is not aligned (O_DIRECT requirement)
+        // Buffer capacity is less than total_len
+        let use_bounce = !ptr_aligned || cap < total_len;
+
+        let res = if !use_bounce {
+            self.in_flight_count.fetch_add(1, Ordering::Relaxed);
+            let comp = Arc::new(IoCompletion::new());
+            let sub = IoSubmission {
+                fd: self.fd,
+                offset,
+                len: total_len,
+                ptr_addr: ptr as usize,
+                is_write: false,
+                completion: comp.clone(),
+                fixed_buffer_idx: fixed_idx,
+                bounce: None,
+                original_ptr: None,
+                payload_len: None,
+                batch_id: 0,
+            };
+            {
+                let q = self.queue.as_ref().expect("queue must exist");
+                let mut q = q.lock().unwrap();
+                q.push(sub);
+            }
+            if let Some(batch_ready) = &self.batch_ready {
+                batch_ready.notify_one();
+            }
+            py.allow_threads(move || comp.wait())
+        } else {
+            let bounce = AlignedBuf::new(total_len, align)?;
+            let bounce_arc = std::sync::Arc::new(bounce);
+            let bounce_ptr = bounce_arc.as_mut_ptr();
+            self.in_flight_count.fetch_add(1, Ordering::Relaxed);
+            let comp = Arc::new(IoCompletion::new());
+            let sub = IoSubmission {
+                fd: self.fd,
+                offset,
+                len: total_len,
+                ptr_addr: bounce_ptr as usize,
+                is_write: false,
+                completion: comp.clone(),
+                fixed_buffer_idx: None,
+                bounce: Some(bounce_arc),
+                original_ptr: Some(ptr as usize),
+                payload_len: Some(payload_len),
+                batch_id: 0,
+            };
+            {
+                let q = self.queue.as_ref().expect("queue must exist");
+                let mut q = q.lock().unwrap();
+                q.push(sub);
+            }
+            if let Some(batch_ready) = &self.batch_ready {
+                batch_ready.notify_one();
+            }
+            py.allow_threads(move || comp.wait())
+        };
+
+        release_pybuffer(view);
+        res?;
+        Ok(())
+    }
+
+    /// Batched read: submit multiple reads at once via io_uring.
+    /// All reads are queued to the worker thread, which processes them
+    /// in batches to maximize throughput.
+    ///
+    /// Returns a batch_id that must be passed to wait_iouring() to wait
+    /// for completions for that batch
+    #[pyo3(signature = (offsets, buffers, total_lens))]
+    fn batched_read(
+        &self,
+        py: Python<'_>,
+        offsets: Vec<u64>,
+        buffers: Vec<Bound<'_, PyAny>>,
+        total_lens: Vec<usize>,
+    ) -> PyResult<u64> {
+        if !self.use_iouring {
+            return Err(PyRuntimeError::new_err("io_uring not enabled"));
+        }
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+
+        let n = offsets.len();
+        if n == 0 {
+            // Return a valid batch_id even for empty batches
+            return Ok(self.next_batch_id.fetch_add(1, Ordering::Relaxed));
+        }
+        if buffers.len() != n || total_lens.len() != n {
+            return Err(PyValueError::new_err("All vectors must have same length"));
+        }
+
+        // Acquire buffer views to keep them alive until wait_iouring() completes
+        let mut views = Vec::with_capacity(n);
+        let mut caps = Vec::with_capacity(n);
+        for buffer in &buffers {
+            let view = get_pybuffer(py, buffer, true)?;
+            if view.readonly != 0 {
+                for v in views {
+                    release_pybuffer(v);
+                }
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("output buffer is readonly"));
+            }
+            if view.buf.is_null() {
+                for v in views {
+                    release_pybuffer(v);
+                }
+                release_pybuffer(view);
+                return Err(PyValueError::new_err("null buffer pointer"));
+            }
+            caps.push(view.len as usize);
+            views.push(view);
+        }
+
+        // Generate a unique batch ID for this batch
+        let batch_id = self.next_batch_id.fetch_add(1, Ordering::Relaxed);
+
+        // Initialize per-batch tracking for this batch
+        {
+            let mut batch_map = self.batch_in_flight.lock().unwrap();
+            batch_map.insert(
+                batch_id,
+                (Arc::new(AtomicU64::new(0)), Arc::new(Condvar::new())),
+            );
+        }
+
+        // Store buffer objects to keep them alive until they complete
+        {
+            let mut stored_objs = self.batched_buffer_objs.lock().unwrap();
+            let batch_buffers = stored_objs.entry(batch_id).or_default();
+            for buffer in &buffers {
+                batch_buffers.push(buffer.clone().unbind());
+            }
+        }
+
+        // Extract pointers as usize before releasing GIL (raw pointers are not Send)
+        let mut ptrs = Vec::with_capacity(n);
+        for view in &views {
+            ptrs.push(view.buf as usize);
+        }
+
+        for view in views {
+            release_pybuffer(view);
+        }
+
+        let fd = self.fd;
+        let use_odirect = self.use_odirect;
+        let alignment = self.alignment;
+        let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        // Clone the fixed buffer map before releasing GIL to avoid lock contention
+        let fixed_buffer_map: HashMap<usize, (u16, usize)> = if fixed_buffers_registered {
+            let map = self.fixed_buffer_map.lock().unwrap();
+            map.clone()
+        } else {
+            HashMap::new()
+        };
+        let in_flight_count = Arc::clone(&self.in_flight_count);
+        let queue = Arc::clone(self.queue.as_ref().unwrap());
+        let batch_ready = Arc::clone(self.batch_ready.as_ref().unwrap());
+        let batched_completions = Arc::clone(&self.batched_completions);
+        let batch_in_flight = Arc::clone(&self.batch_in_flight);
+
+        // Additional clones for cleanup on error path
+        let batch_in_flight_cleanup = Arc::clone(&batch_in_flight);
+        let batched_completions_cleanup = Arc::clone(&batched_completions);
+        let batched_buffer_objs_cleanup = Arc::clone(&self.batched_buffer_objs);
+
+        // Release the GIL while submitting I/O operations
+        let res = py.allow_threads(move || {
+            let mut submissions: Vec<(IoSubmission, Arc<IoCompletion>)> = Vec::with_capacity(n);
+
+            // Prepare all requests, validate buffers and collect submission data.
+            for i in 0..n {
+                let total_len = total_lens[i];
+                let offset = offsets[i];
+                let cap = caps[i];
+
+                // Validate buffer capacity
+                if cap < total_len {
+                    return Err(PyValueError::new_err(format!(
+                        "output buffer too small: cap={} need={}",
+                        cap, total_len
+                    )));
+                }
+
+                if use_odirect {
+                    #[allow(clippy::manual_is_multiple_of)]
+                    if (offset as usize) % alignment != 0 {
+                        return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+                    }
+                    #[allow(clippy::manual_is_multiple_of)]
+                    if total_len % alignment != 0 {
+                        return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+                    }
+                    #[allow(clippy::manual_is_multiple_of)]
+                    if ptrs[i] % alignment != 0 {
+                        return Err(PyValueError::new_err("O_DIRECT requires aligned buffers"));
+                    }
+                }
+
+                let comp = Arc::new(IoCompletion::new());
+
+                // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
+                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+
+                let sub = IoSubmission {
+                    fd,
+                    offset,
+                    len: total_len,
+                    ptr_addr: ptrs[i],
+                    is_write: false, // read operation
+                    completion: comp.clone(),
+                    fixed_buffer_idx: fixed_idx,
+                    bounce: None,
+                    original_ptr: None,
+                    payload_len: None,
+                    batch_id,
+                };
+
+                submissions.push((sub, comp));
+            }
+
+            // Queue all submissions atomically. At this point no further errors can
+            // occur during queuing.
+            for (sub, comp) in submissions {
+                in_flight_count.fetch_add(1, Ordering::Relaxed);
+
+                // Increment per-batch in-flight count
+                {
+                    let batch_map = batch_in_flight.lock().unwrap();
+                    if let Some((batch_count, _)) = batch_map.get(&batch_id) {
+                        batch_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+
+                {
+                    let mut q = queue.lock().unwrap();
+                    q.push(sub);
+                }
+                batch_ready.notify_one();
+
+                // Store completion for error checking in wait_iouring
+                {
+                    let mut completions = batched_completions.lock().unwrap();
+                    let batch_completions = completions.entry(batch_id).or_default();
+                    batch_completions.push(comp);
+                }
+            }
+            Ok::<(), PyErr>(())
+        });
+
+        // Preparation failed, clean up the tracking entries to prevent leaks
+        if let Err(e) = res {
+            {
+                let mut batch_map = batch_in_flight_cleanup.lock().unwrap();
+                batch_map.remove(&batch_id);
+            }
+            {
+                let mut stored_objs = batched_buffer_objs_cleanup.lock().unwrap();
+                stored_objs.remove(&batch_id);
+            }
+            {
+                let mut completions = batched_completions_cleanup.lock().unwrap();
+                completions.remove(&batch_id);
+            }
+            return Err(e);
+        }
+
+        Ok(batch_id)
     }
 
     /// Write bytes from any Python buffer object into the device.
@@ -280,7 +1581,7 @@ impl RawBlockDevice {
         payload_len: Option<usize>,
         total_len: Option<usize>,
     ) -> PyResult<()> {
-        if self.closed {
+        if self.closed.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("device is closed"));
         }
         let fd = self.fd;
@@ -417,7 +1718,7 @@ impl RawBlockDevice {
         payload_len: usize,
         total_len: Option<usize>,
     ) -> PyResult<()> {
-        if self.closed {
+        if self.closed.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("device is closed"));
         }
         let fd = self.fd;
@@ -529,15 +1830,52 @@ impl RawBlockDevice {
         Ok(())
     }
 
-    // Explicit close from Python. Drop also closes if needed.
-    fn close(&mut self) -> PyResult<()> {
-        if !self.closed {
-            // SAFETY: close fd once.
-            let rc = unsafe { libc::close(self.fd) };
-            if rc != 0 {
-                return Err(os_err("close failed"));
+    /// Internal function to perform the cleanup operation.
+    fn do_close(&mut self) -> Result<(), PyErr> {
+        if self.use_iouring {
+            if let Some(shutdown) = &self.shutdown {
+                shutdown.store(true, Ordering::Relaxed);
             }
-            self.closed = true;
+            if let Some(batch_ready) = &self.batch_ready {
+                batch_ready.notify_all();
+            }
+
+            let mutex = Mutex::new(());
+            let mut guard = mutex.lock().unwrap();
+            while self.in_flight_count.load(Ordering::Relaxed) > 0 {
+                let (g, _) = self
+                    .in_flight_cvar
+                    .wait_timeout(guard, Duration::from_millis(10))
+                    .unwrap();
+                guard = g;
+            }
+
+            if self.fixed_buffers_registered.load(Ordering::Relaxed) {
+                if let Some(ring) = &self.ring {
+                    let ring = ring.lock().unwrap();
+                    let _ = ring.submitter().unregister_buffers();
+                }
+                self.fixed_buffers_registered
+                    .store(false, Ordering::Relaxed);
+                self.fixed_buffer_map.lock().unwrap().clear();
+            }
+        }
+
+        if let Some(handle) = self.worker.take() {
+            let _ = handle.join();
+        }
+
+        let rc = unsafe { libc::close(self.fd) };
+        if rc != 0 {
+            return Err(os_err("close failed"));
+        }
+        self.closed.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn close(&mut self) -> PyResult<()> {
+        if !self.closed.load(Ordering::Relaxed) {
+            self.do_close()?;
         }
         Ok(())
     }
@@ -545,11 +1883,8 @@ impl RawBlockDevice {
 
 impl Drop for RawBlockDevice {
     fn drop(&mut self) {
-        if !self.closed {
-            unsafe {
-                libc::close(self.fd);
-            }
-            self.closed = true;
+        if !self.closed.load(Ordering::Relaxed) {
+            let _ = self.do_close();
         }
     }
 }

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -471,7 +471,8 @@ impl RawBlockDevice {
                     //   - Wake up any threads waiting for all I/O to complete
                     {
                         let mut ring = ring_clone.lock().unwrap();
-                        for cqe in ring.completion() {
+                        let completions: Vec<_> = ring.completion().collect();
+                        for cqe in completions {
                             let user_data = cqe.user_data();
                             if let Some(mut sub) = in_flight.remove(&user_data) {
                                 let batch_id = sub.batch_id;
@@ -482,6 +483,89 @@ impl RawBlockDevice {
                                     sub.completion
                                         .set(Err(PyOSError::new_err((code, "io_uring I/O error"))));
                                 } else {
+                                    let bytes_transferred = cqe.result() as usize;
+                                    if bytes_transferred < sub.len {
+                                        // Short read/write: update offset and length, then resubmit
+                                        sub.offset += bytes_transferred as u64;
+                                        sub.len -= bytes_transferred;
+                                        // Update buffer pointer for writes and direct reads
+                                        if sub.is_write || sub.bounce.is_none() {
+                                            sub.ptr_addr += bytes_transferred;
+                                        }
+                                        // For read with bounce buffer, copy partial data back
+                                        if !sub.is_write {
+                                            if let (
+                                                Some(bounce),
+                                                Some(orig_ptr),
+                                                Some(payload_len),
+                                            ) = (
+                                                sub.bounce.as_ref(),
+                                                sub.original_ptr,
+                                                sub.payload_len,
+                                            ) {
+                                                unsafe {
+                                                    libc::memcpy(
+                                                        orig_ptr as *mut libc::c_void,
+                                                        bounce.as_ptr() as *const libc::c_void,
+                                                        bytes_transferred.min(payload_len),
+                                                    );
+                                                }
+                                                sub.original_ptr =
+                                                    Some(orig_ptr + bytes_transferred);
+                                                sub.payload_len = Some(
+                                                    payload_len.saturating_sub(bytes_transferred),
+                                                );
+                                            }
+                                        }
+                                        // Re-insert into in_flight with updated values
+                                        // Don't decrement in_flight_count since we're resubmitting
+                                        in_flight.insert(user_data, sub.clone());
+                                        // Push a new SQE for the remaining data
+                                        let ptr = sub.ptr_addr as *mut u8;
+                                        let sqe = if sub.is_write {
+                                            if let Some(idx) = sub.fixed_buffer_idx {
+                                                opcode::WriteFixed::new(
+                                                    Fd(sub.fd),
+                                                    ptr as *const u8,
+                                                    sub.len as u32,
+                                                    idx,
+                                                )
+                                                .offset(sub.offset)
+                                                .build()
+                                            } else {
+                                                opcode::Write::new(
+                                                    Fd(sub.fd),
+                                                    ptr as *const u8,
+                                                    sub.len as u32,
+                                                )
+                                                .offset(sub.offset)
+                                                .build()
+                                            }
+                                        } else if let Some(idx) = sub.fixed_buffer_idx {
+                                            opcode::ReadFixed::new(
+                                                Fd(sub.fd),
+                                                ptr,
+                                                sub.len as u32,
+                                                idx,
+                                            )
+                                            .offset(sub.offset)
+                                            .build()
+                                        } else {
+                                            opcode::Read::new(Fd(sub.fd), ptr, sub.len as u32)
+                                                .offset(sub.offset)
+                                                .build()
+                                        };
+                                        let sqe = sqe.user_data(user_data);
+                                        unsafe {
+                                            ring.submission()
+                                                .push(&sqe)
+                                                .expect("failed to push sqe for short read/write");
+                                        }
+                                        // Submit the new SQE to the kernel
+                                        let _ = ring.submitter().submit();
+                                        continue;
+                                    }
+                                    // Full completion
                                     // For reads with bounce buffer, copy data back to original buffer
                                     if !sub.is_write {
                                         if let (Some(bounce), Some(orig_ptr), Some(payload_len)) =
@@ -737,24 +821,37 @@ impl RawBlockDevice {
                                 sub.completion
                                     .set(Err(PyOSError::new_err((code, "io_uring I/O error"))));
                             } else {
-                                // For reads with bounce buffer, copy data back to original buffer
-                                if !sub.is_write {
-                                    if let (Some(bounce), Some(orig_ptr), Some(payload_len)) =
-                                        (sub.bounce.take(), sub.original_ptr, sub.payload_len)
-                                    {
-                                        unsafe {
-                                            libc::memcpy(
-                                                orig_ptr as *mut libc::c_void,
-                                                bounce.as_ptr() as *const libc::c_void,
-                                                payload_len,
-                                            );
-                                        }
-                                    }
-                                } else {
+                                let bytes_transferred = cqe.result() as usize;
+                                if bytes_transferred < sub.len {
+                                    // Short read/write during shutdown: fail the request
+                                    // We cannot resubmit because the worker is about to exit
                                     // Drop any bounce buffer associated with this submission.
                                     let _ = sub.bounce.take();
+                                    sub.completion.set(Err(PyRuntimeError::new_err(
+                                        "io_uring worker shutting down - short I/O during shutdown",
+                                    )));
+                                    // Continue to decrement in_flight_count below
+                                } else {
+                                    // Full completion
+                                    // For reads with bounce buffer, copy data back to original buffer
+                                    if !sub.is_write {
+                                        if let (Some(bounce), Some(orig_ptr), Some(payload_len)) =
+                                            (sub.bounce.take(), sub.original_ptr, sub.payload_len)
+                                        {
+                                            unsafe {
+                                                libc::memcpy(
+                                                    orig_ptr as *mut libc::c_void,
+                                                    bounce.as_ptr() as *const libc::c_void,
+                                                    payload_len,
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        // Drop any bounce buffer associated with this submission.
+                                        let _ = sub.bounce.take();
+                                    }
+                                    sub.completion.set(Ok(()));
                                 }
-                                sub.completion.set(Ok(()));
                             }
                             let prev = in_flight_count_clone.fetch_sub(1, Ordering::Relaxed);
                             if prev == 1 {

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -11,6 +11,7 @@ import os
 import struct
 import tempfile
 import threading
+import time
 
 # Third Party
 import pytest
@@ -1424,3 +1425,368 @@ def test_rust_raw_block_backend_warns_on_cross_rank_metadata_load(
             assert matched, "Expected cross-rank metadata warning was not emitted"
         finally:
             backend_tp1.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_uring_put_get_roundtrip(
+    memory_allocator, loop_in_thread
+):
+    """Test batched write with io_uring and verify data integrity on read.
+
+    Writes 128 items asynchronously, then reads them back and verifies
+    the data matches what was written.
+    """
+    NUM_OPS = 128
+
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(1024 * 1024 * 1024)  # 1G
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=1,
+            lmcache_instance_id="test_rust_raw_block_uring",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.use_uring": True,  # Enable io_uring
+            "rust_raw_block.use_odirect": True,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+            chunk_size=256,
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = local_cpu.memory_allocator
+
+            # Create keys and memory objects with unique data patterns
+            keys = []
+            objs = []
+            expected_data = []
+
+            for i in range(NUM_OPS):
+                key = CacheEngineKey("test_model", 1, 0, i, torch.bfloat16)
+                keys.append(key)
+
+                # Each object gets a unique fill value
+                obj = allocator.allocate(
+                    [torch.Size([2, 16, 8, 128])],
+                    [torch.bfloat16],
+                    fmt=MemoryFormat.KV_T2D,
+                )
+                assert obj is not None
+                assert obj.tensor is not None
+
+                # Use unique pattern: (i + 1) as fill value
+                obj.tensor.fill_(float(i + 1))
+                expected_data.append(bytes(obj.byte_array))
+                objs.append(obj)
+
+            # Submit all writes using io_uring batched write
+            futs = backend.batched_submit_put_task(keys, objs)
+            assert futs is not None
+            futs[0].result(timeout=10)
+
+            # Read back and verify data integrity
+            for i, key in enumerate(keys):
+                out = backend.get_blocking(key)
+                assert out is not None, f"Failed to read key {i}"
+                actual_data = bytes(out.byte_array)
+                assert actual_data == expected_data[i], (
+                    f"Data mismatch for key {i}: "
+                    f"expected first bytes {expected_data[i][:16]}, "
+                    f"got {actual_data[:16]}"
+                )
+
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_close_with_inflight(memory_allocator, loop_in_thread):
+    """Test that closing the backend while writes are queued / inflight
+    is handled gracefully (uring)."""
+    NUM_OPS = 128
+
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(1024 * 1024 * 1024)  # 1G
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=1,
+            lmcache_instance_id="test_rust_raw_block_uring",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.use_uring": True,
+            "rust_raw_block.use_odirect": True,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+            chunk_size=256,
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        # Dummy raw that simulates few operations.
+        class DummyRaw:
+            def __init__(self):
+                self._inner = backend._rawdev()
+
+            def batched_write(self, offsets, buffers, total_lens):
+                return self._inner.batched_write(offsets, buffers, total_lens)
+
+            def read_uring(self, offset, data, payload_len, total_len):
+                return self._inner.read_uring(offset, data, payload_len, total_len)
+
+            def wait_iouring(self, batch_id):
+                self._inner.wait_iouring(batch_id)
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+            def close(self):
+                self._inner.close()
+
+        backend._raw = DummyRaw()
+
+        try:
+            allocator = local_cpu.memory_allocator
+
+            # Create keys and memory objects with unique data patterns
+            keys = []
+            objs = []
+            expected_data = []
+            offsets = []
+            buffers = []
+            total_lens = []
+
+            for i in range(NUM_OPS):
+                key = CacheEngineKey("test_model", 1, 0, i, torch.bfloat16)
+                keys.append(key)
+
+                obj = allocator.allocate(
+                    [torch.Size([2, 16, 8, 128])],
+                    [torch.bfloat16],
+                    fmt=MemoryFormat.KV_T2D,
+                )
+                assert obj is not None
+                assert obj.tensor is not None
+
+                obj.tensor.fill_(float(i + 1))
+                expected_data.append(bytes(obj.byte_array))
+                objs.append(obj)
+
+                offset = i * len(obj.byte_array)
+                total_len = len(obj.byte_array)
+                buf = obj.byte_array
+                offsets.append(offset)
+                buffers.append(buf)
+                total_lens.append(total_len)
+            backend._raw.batched_write(offsets, buffers, total_lens)
+            time.sleep(0.001)
+            # close while writes may still be in progress.
+            backend.close()
+
+            backend = RustRawBlockBackend(
+                config=config,
+                metadata=metadata,
+                local_cpu_backend=local_cpu,
+                loop=loop_in_thread,
+                dst_device="cpu",
+            )
+            # Read back and verify data integrity
+            for i, key in enumerate(keys):
+                obj = allocator.allocate(
+                    [torch.Size([2, 16, 8, 128])],
+                    [torch.bfloat16],
+                    fmt=MemoryFormat.KV_T2D,
+                )
+                assert obj is not None
+                assert obj.tensor is not None
+
+                offset = i * len(obj.byte_array)
+                total_len = len(obj.byte_array)
+                buf = obj.byte_array
+                backend._raw.read_uring(offset, buf, total_len, total_len)
+                actual_data = bytes(obj.byte_array)
+                assert actual_data == expected_data[i], (
+                    f"Data mismatch for key {i}: "
+                    f"expected first bytes {expected_data[i][:16]}, "
+                    f"got {actual_data[:16]}"
+                )
+
+        finally:
+            try:
+                backend.close()
+            except Exception:
+                pass
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_batched_get_with_uring(
+    memory_allocator, loop_in_thread
+):
+    """Test batched_get_blocking and batched_get_non_blocking with io_uring enabled."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_batched_get_uring",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+            "rust_raw_block.use_uring": True,  # Enable io_uring
+            "rust_raw_block.use_odirect": True,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = local_cpu.memory_allocator
+            key1 = CacheEngineKey("test_model", 1, 0, 4001, torch.bfloat16)
+            key2 = CacheEngineKey("test_model", 1, 0, 4002, torch.bfloat16)
+            key_miss = CacheEngineKey("test_model", 1, 0, 4003, torch.bfloat16)
+            key3 = CacheEngineKey("test_model", 1, 0, 4004, torch.bfloat16)
+
+            obj1 = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            obj2 = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            obj3 = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            assert obj1 is not None and obj1.tensor is not None
+            assert obj2 is not None and obj2.tensor is not None
+            assert obj3 is not None and obj3.tensor is not None
+            obj1.tensor.fill_(41)
+            obj2.tensor.fill_(42)
+            obj3.tensor.fill_(43)
+            expected1 = bytes(obj1.byte_array)
+            expected2 = bytes(obj2.byte_array)
+
+            # Put keys 1, 2, and 3
+            for key, obj in ((key1, obj1), (key2, obj2), (key3, obj3)):
+                futs = backend.batched_submit_put_task([key], [obj])
+                assert futs is not None
+                futs[0].result(timeout=10)
+                obj.ref_count_down()
+
+            # Test batched_get_blocking with uring. It should stop at first miss
+            blocking_results = backend.batched_get_blocking(
+                [key1, key2, key_miss, key3]
+            )
+            assert len(blocking_results) == 4
+            assert blocking_results[0] is not None
+            assert bytes(blocking_results[0].byte_array) == expected1
+            assert blocking_results[1] is not None
+            assert bytes(blocking_results[1].byte_array) == expected2
+            assert blocking_results[2] is None  # Miss
+            assert blocking_results[3] is None  # After miss
+            blocking_results[0].ref_count_down()
+            blocking_results[1].ref_count_down()
+
+            # Test batched_get_non_blocking with uring.
+            # It should return only successful prefix
+            future = asyncio.run_coroutine_threadsafe(
+                backend.batched_get_non_blocking(
+                    "lookup-uring", [key1, key2, key_miss, key3]
+                ),
+                loop_in_thread,
+            )
+            async_results = future.result(timeout=10)
+            assert len(async_results) == 2  # Only key1 and key2
+            assert bytes(async_results[0].byte_array) == expected1
+            assert bytes(async_results[1].byte_array) == expected2
+            async_results[0].ref_count_down()
+            async_results[1].ref_count_down()
+
+        finally:
+            backend.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds io_uring support to the Rust raw block backend. This PR uses io_uring's fixed buffer registration process for true zero copy support. Thus removing any user to kernel copy and vice versa.

Main changes:
- io_uring backend with dedicated worker thread for submission/completion loop (```--use-uring```)
- Implicit write batching to reduce io_uring_enter syscalls
- Synchonous Read path
- Use PagedTensorMemoryAllocator if io_uring is enabled and fixed buffer support is requested (```--fixed-buffer```)
- Update docs with io_uring section with data path diagram and benchmark summary tables
- Add reviewer-focused comments in Rust I/O code paths for maintainability

**Special notes for your reviewers**:

- No significant changes to the rust raw block plugin i.e. no async path, no multi io-workers. Major performance benefits observed because of batching and fixed buffers.
- Fixed buffer consumes time and there is a limit on number of iovecs that can be registered. These are added as notes in the README section of benchmark script. 

**If applicable**:

- this PR contains user facing changes - docs added, and updated the benchmark script for comparison.

**Performance comparison posix pwrite vs uring_write with fixed buffer**

chunk_size = 4 (64 KB write), concurrency=4
| num_ops=16384  | posix  | uring, fixed_buffer |
| ------------- | ------------- | ------------- |
| ops / sec  | 3144.8 | 11245.8 |
| Elapsed time (sec) | 5.21  | 1.45  |

chunk_size = 256 (4 MB write), concurrency=4
| num_ops=4096  | posix  | uring, fixed_buffer |
| ------------- | ------------- | ------------- |
| ops / sec  | 742 | 748.5 |
| Elapsed time (sec) | 5.52  | 5.47  |

- For small chunks (64KB write) io_uring improves **~3X** compared to the posix implementation
- For large chunks (4 MB write) io_uring performs similar compared to the posix implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new io_uring-based async I/O path with fixed-buffer registration and modifies allocator selection/alignment; failures could cause data corruption, deadlocks, or resource leaks due to low-level concurrency and unsafe buffer handling across Python/Rust.
> 
> **Overview**
> Enables an optional **io_uring** fast path for `RustRawBlockBackend`, including fixed-buffer registration for *true zero-copy* and new batched read/write operations that run through a dedicated Rust worker thread.
> 
> Updates `LocalCPUBackend`/allocators to support io_uring by using paged pinned buffers (and alignment auto-selection) and exposes paged-buffer accessors for registration.
> 
> Extends the benchmark harness with `--use-uring`, configurable `--chunk-size`, and a new `rust_raw_block_read` mode (write+read with optional `--verify-integrity`), adds a vLLM offload example for the raw-block backend, and adds io_uring-focused tests plus updated docs/README guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd363127436adaeb3df91a48686d5a4092f90d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->