### PR TITLE
Add Mooncake dummy client mode for MooncakeStore

### DIFF
--- a/csrc/mem_alloc.cpp
+++ b/csrc/mem_alloc.cpp
@@ -145,3 +145,19 @@ void free_shm_pinned_ptr(uintptr_t ptr, size_t size,
   }
   shm_unlink(shm_name.c_str());
 }
+
+void register_pinned_ptr(uintptr_t ptr, size_t size) {
+  cudaError_t st = cudaHostRegister(reinterpret_cast<void*>(ptr), size, 0);
+  if (st != cudaSuccess) {
+    throw std::runtime_error(std::string("cudaHostRegister failed: ") +
+                             cudaGetErrorString(st));
+  }
+}
+
+void unregister_pinned_ptr(uintptr_t ptr, size_t size) {
+  cudaError_t st = cudaHostUnregister(reinterpret_cast<void*>(ptr));
+  if (st != cudaSuccess) {
+    throw std::runtime_error(std::string("cudaHostUnregister failed: ") +
+                             cudaGetErrorString(st));
+  }
+}

--- a/csrc/mem_alloc.h
+++ b/csrc/mem_alloc.h
@@ -11,3 +11,6 @@ void free_numa_ptr(uintptr_t ptr, size_t size);
 void free_pinned_numa_ptr(uintptr_t ptr, size_t size);
 void free_shm_pinned_ptr(uintptr_t ptr, size_t size,
                          const std::string& shm_name);
+
+void register_pinned_ptr(uintptr_t ptr, size_t size);
+void unregister_pinned_ptr(uintptr_t ptr, size_t size);

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -49,6 +49,10 @@ PYBIND11_MODULE(c_ops, m) {
   m.def("alloc_pinned_numa_ptr", &alloc_pinned_numa_ptr,
         py::call_guard<py::gil_scoped_release>());
   m.def("free_pinned_numa_ptr", &free_pinned_numa_ptr);
+  m.def("register_pinned_ptr", &register_pinned_ptr,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("unregister_pinned_ptr", &unregister_pinned_ptr,
+        py::call_guard<py::gil_scoped_release>());
   m.def("alloc_numa_ptr", &alloc_numa_ptr,
         py::call_guard<py::gil_scoped_release>());
   m.def("free_numa_ptr", &free_numa_ptr);

--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -90,7 +90,7 @@ def alloc_shm_pinned_ptr(size: int, shm_name: str = "") -> int:
     shm = shared_memory.SharedMemory(name=name, create=True, size=size)
 
     array_type = ctypes.c_uint8 * size
-    buf = array_type.from_buffer(shm.buf)
+    buf = array_type.from_buffer(shm.buf)  # type: ignore[arg-type]
     ptr = ctypes.addressof(buf)
 
     # Store references to keep them alive
@@ -112,3 +112,15 @@ def free_shm_pinned_ptr(ptr: int, size: int = 0, shm_name: str = "") -> None:
     if shm is not None:
         shm.close()
         shm.unlink()
+
+
+def register_pinned_ptr(ptr: int, size: int) -> None:
+    """Non-CUDA equivalent of registering an existing pointer as pinned.
+    Note: Pinned memory is not supported on non-CUDA, this is a no-op."""
+    pass
+
+
+def unregister_pinned_ptr(ptr: int, size: int) -> None:
+    """Non-CUDA equivalent of unregistering a pinned pointer.
+    Note: Pinned memory is not supported on non-CUDA, this is a no-op."""
+    pass

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -5,7 +5,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import wraps
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 import abc
 import ctypes
 import os
@@ -1952,6 +1952,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
         self.buffer = _allocate_cpu_memory(size, self.numa_mapping, self.shm_name)
 
         self._unregistered = False
+        self._cleanup_fn: Optional[Callable[[], None]] = None
 
         self.pin_allocator: MemoryAllocatorInterface
         if use_paging:
@@ -2066,18 +2067,74 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
         with self.host_mem_lock:
             return self.pin_allocator.memcheck()
 
+    def replace_buffer(self, external_ptr: int, size: int):
+        """Replace the internal pinned buffer with externally allocated memory.
+
+        Handles all low-level details: frees the original pinned buffer,
+        pins the external memory via cudaHostRegister (or HIP equivalent),
+        wraps it as a torch.Tensor, and rebuilds the pin_allocator.
+
+        On close(), the external memory will be unpinned via
+        unregister_pinned_ptr instead of the default free path.
+
+        Can be called multiple times safely — each call properly cleans
+        up the previous buffer using the appropriate free/unregister path.
+
+        Args:
+            external_ptr: Raw pointer to externally allocated memory
+                (e.g. from mooncake alloc_from_mem_pool).
+            size: Size of the external memory in bytes.
+        """
+        # NOTE: Currently only called once during MooncakestoreConnector.__init__
+        # (dummy client mode). The _cleanup_fn check below is defensive in case
+        # this method is ever called multiple times in the future.
+
+        # 1. Free the previous buffer using the correct path
+        if self.buffer.numel() > 0:
+            if hasattr(self, "_cleanup_fn") and self._cleanup_fn:
+                # Previous buffer was from replace_buffer — unregister it
+                self._cleanup_fn()
+            else:
+                _free_cpu_memory(
+                    self.buffer,
+                    self.size,
+                    self.numa_mapping,
+                    self.shm_name,
+                )
+
+        # 2. Pin external memory for GPU DMA
+        lmc_ops.register_pinned_ptr(external_ptr, size)
+
+        # 3. Wrap external pointer as torch.Tensor
+        array_type = ctypes.c_uint8 * size
+        buf = array_type.from_address(external_ptr)
+        new_buffer = torch.frombuffer(buf, dtype=torch.uint8)
+
+        # 4. Rebuild pin_allocator with new buffer
+        self.buffer = new_buffer
+        self.size = size
+        self.pin_allocator = TensorMemoryAllocator(self.buffer)
+
+        # 5. Set cleanup callback for close()
+        _ptr = external_ptr
+        _size = size
+        self._cleanup_fn = lambda: lmc_ops.unregister_pinned_ptr(_ptr, _size)
+
     def close(self):
         if not self._unregistered:
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
             if self.buffer.numel() == 0:
                 return
-            _free_cpu_memory(
-                self.buffer,
-                self.size,
-                self.numa_mapping,
-                self.shm_name,
-            )
+            if hasattr(self, "_cleanup_fn") and self._cleanup_fn:
+                self._cleanup_fn()
+            else:
+                _free_cpu_memory(
+                    self.buffer,
+                    self.size,
+                    self.numa_mapping,
+                    self.shm_name,
+                )
             self._unregistered = True
 
     def __str__(self):

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -38,6 +38,8 @@ class MooncakeStoreConfig:
     transfer_timeout: int
     storage_root_dir: str
     prefer_local_alloc: bool = False
+    use_dummy_client: bool = False
+    dummy_server_address: str = ""
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
@@ -48,16 +50,18 @@ class MooncakeStoreConfig:
         prefer_local_alloc = config.get("mooncake_prefer_local_alloc", False)
 
         return MooncakeStoreConfig(
-            local_hostname=config.get("local_hostname"),
-            metadata_server=config.get("metadata_server"),
+            local_hostname=config.get("local_hostname", ""),
+            metadata_server=config.get("metadata_server", ""),
             global_segment_size=config.get("global_segment_size", 3355443200),
             local_buffer_size=config.get("local_buffer_size", 1073741824),
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),
-            master_server_address=config.get("master_server_address"),
+            master_server_address=config.get("master_server_address", ""),
             transfer_timeout=config.get("transfer_timeout", 1),
             storage_root_dir=config.get("storage_root_dir", ""),
             prefer_local_alloc=prefer_local_alloc,
+            use_dummy_client=config.get("use_dummy_client", False),
+            dummy_server_address=config.get("dummy_server_address", ""),
         )
 
     @staticmethod
@@ -82,16 +86,18 @@ class MooncakeStoreConfig:
         prefer_local_alloc = extra_config.get("mooncake_prefer_local_alloc", False)
 
         return MooncakeStoreConfig(
-            local_hostname=extra_config["local_hostname"],
-            metadata_server=extra_config["metadata_server"],
+            local_hostname=extra_config.get("local_hostname", ""),
+            metadata_server=extra_config.get("metadata_server", ""),
             global_segment_size=extra_config.get("global_segment_size", 3355443200),
             local_buffer_size=extra_config.get("local_buffer_size", 1073741824),
             protocol=extra_config.get("protocol", "tcp"),
             device_name=extra_config.get("device_name", ""),
-            master_server_address=extra_config["master_server_address"],
+            master_server_address=extra_config.get("master_server_address", ""),
             transfer_timeout=extra_config.get("transfer_timeout", 1),
             storage_root_dir=extra_config.get("storage_root_dir", ""),
             prefer_local_alloc=prefer_local_alloc,
+            use_dummy_client=extra_config.get("use_dummy_client", False),
+            dummy_server_address=extra_config.get("dummy_server_address", ""),
         )
 
 
@@ -158,56 +164,89 @@ class MooncakestoreConnector(RemoteConnector):
             logger.info(f"  protocol: {self.config.protocol}")
             logger.info(f"  device_name: {self.config.device_name}")
             logger.info(f"  master_server_address: {self.config.master_server_address}")
-
-            try:
-                numa_mapping = getattr(
-                    local_cpu_backend.memory_allocator, "numa_mapping", None
+            logger.info(f"  use_dummy_client: {self.config.use_dummy_client}")
+            if self.config.use_dummy_client:
+                logger.info(
+                    f"  dummy_server_address: {self.config.dummy_server_address}"
                 )
-                if numa_mapping is None and lmcache_config is not None:
-                    numa_mapping = NUMADetector.get_numa_mapping(lmcache_config)
 
-                if numa_mapping:
-                    current_device_id = torch.cuda.current_device()
-                    gpu_to_numa = getattr(numa_mapping, "gpu_to_numa_mapping", {})
-                    numa_id = gpu_to_numa.get(current_device_id)
-                    logger.info(
-                        f"NUMA mapping detected (pre-Mooncake setup): {gpu_to_numa}"
+            if self.config.use_dummy_client:
+                # Dummy client mode: use setup_dummy with shared memory + IPC
+                if not hasattr(self.store, "setup_dummy"):
+                    raise RuntimeError(
+                        "The installed mooncake version does not support "
+                        "dummy client mode (setup_dummy). Please upgrade "
+                        "mooncake or set use_dummy_client to False."
                     )
-                    try:
-                        # Third Party
-                        from mooncake.store import bind_to_numa_node
-
-                        if numa_id is not None:
-                            bind_to_numa_node(numa_id)
-                            logger.info(
-                                f"GPU {current_device_id}, "
-                                f"NUMA node {numa_id} binding done"
-                            )
-                        else:
-                            logger.info(
-                                f"NUMA mapping not found for GPU {current_device_id}"
-                            )
-                    except ImportError:
-                        logger.warning(
-                            "unable to import bind_to_numa_node from mooncake.store"
-                        )
-                else:
-                    logger.info("NUMA mapping unavailable or disabled")
-            except Exception as e:
-                logger.warning(
-                    f"Failed to determine NUMA mapping before Mooncake setup: {e}"
+                if not self.config.dummy_server_address:
+                    raise ValueError(
+                        "dummy_server_address must be provided when "
+                        "use_dummy_client is True."
+                    )
+                # Skip NUMA binding: RDMA runs in separate Real Client process
+                logger.info("Skipping NUMA binding in dummy client mode")
+                logger.info(
+                    "Using dummy client mode with server address: %s",
+                    self.config.dummy_server_address,
                 )
+                self.store.setup_dummy(
+                    self.config.global_segment_size,
+                    self.config.local_buffer_size,
+                    self.config.dummy_server_address,
+                )
+                logger.info("Mooncake dummy client setup completed successfully")
+            else:
+                # Real client mode: NUMA binding + standard setup
+                try:
+                    numa_mapping = getattr(
+                        local_cpu_backend.memory_allocator, "numa_mapping", None
+                    )
+                    if numa_mapping is None and lmcache_config is not None:
+                        numa_mapping = NUMADetector.get_numa_mapping(lmcache_config)
 
-            self.store.setup(
-                self.config.local_hostname,
-                self.config.metadata_server,
-                self.config.global_segment_size,
-                self.config.local_buffer_size,
-                self.config.protocol,
-                self.config.device_name,
-                self.config.master_server_address,
-            )
-            logger.info("Mooncake store setup completed successfully")
+                    if numa_mapping:
+                        current_device_id = torch.cuda.current_device()
+                        gpu_to_numa = getattr(numa_mapping, "gpu_to_numa_mapping", {})
+                        numa_id = gpu_to_numa.get(current_device_id)
+                        logger.info(
+                            f"NUMA mapping detected (pre-Mooncake setup): {gpu_to_numa}"
+                        )
+                        try:
+                            # Third Party
+                            from mooncake.store import bind_to_numa_node
+
+                            if numa_id is not None:
+                                bind_to_numa_node(numa_id)
+                                logger.info(
+                                    f"GPU {current_device_id}, "
+                                    f"NUMA node {numa_id} binding done"
+                                )
+                            else:
+                                logger.info(
+                                    "NUMA mapping not found "
+                                    f"for GPU {current_device_id}"
+                                )
+                        except ImportError:
+                            logger.warning(
+                                "unable to import bind_to_numa_node from mooncake.store"
+                            )
+                    else:
+                        logger.info("NUMA mapping unavailable or disabled")
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to determine NUMA mapping before Mooncake setup: {e}"
+                    )
+
+                self.store.setup(
+                    self.config.local_hostname,
+                    self.config.metadata_server,
+                    self.config.global_segment_size,
+                    self.config.local_buffer_size,
+                    self.config.protocol,
+                    self.config.device_name,
+                    self.config.master_server_address,
+                )
+                logger.info("Mooncake store setup completed successfully")
 
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -195,6 +195,29 @@ class MooncakestoreConnector(RemoteConnector):
                     self.config.dummy_server_address,
                 )
                 logger.info("Mooncake dummy client setup completed successfully")
+
+                # Replace pin_allocator with shm-backed memory
+                allocator = local_cpu_backend.memory_allocator
+                if hasattr(allocator, "pin_allocator") and hasattr(
+                    allocator.pin_allocator, "buffer"
+                ):
+                    buffer_size = allocator.pin_allocator.buffer.numel()
+
+                    # Allocate shm from mooncake's memory pool
+                    shm_ptr = self.store.alloc_from_mem_pool(buffer_size)
+                    if not shm_ptr:
+                        raise RuntimeError(
+                            "Failed to allocate shared memory from mooncake mem pool"
+                        )
+
+                    # Delegate all pin/wrap/rebuild to the allocator
+                    allocator.replace_buffer(shm_ptr, buffer_size)  # type: ignore[attr-defined]
+
+                    logger.info(
+                        "Replaced pin_allocator with shm buffer: ptr=%s, size=%d",
+                        hex(shm_ptr),
+                        buffer_size,
+                    )
             else:
                 # Real client mode: NUMA binding + standard setup
                 try:

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -217,7 +217,7 @@ class MooncakestoreConnector(RemoteConnector):
             buffer_size = allocator.pin_allocator.buffer.numel()
 
             shm_ptr = self.store.alloc_from_mem_pool(buffer_size)
-            if not shm_ptr:
+            if shm_ptr is None or shm_ptr == 0:
                 raise RuntimeError(
                     "Failed to allocate shared memory from mooncake mem pool"
                 )

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -42,27 +42,29 @@ class MooncakeStoreConfig:
     dummy_server_address: str = ""
 
     @staticmethod
+    def _from_dict(d: dict) -> "MooncakeStoreConfig":
+        """Build a MooncakeStoreConfig from a plain dict."""
+        return MooncakeStoreConfig(
+            local_hostname=d.get("local_hostname", ""),
+            metadata_server=d.get("metadata_server", ""),
+            global_segment_size=d.get("global_segment_size", 3355443200),
+            local_buffer_size=d.get("local_buffer_size", 1073741824),
+            protocol=d.get("protocol", "tcp"),
+            device_name=d.get("device_name", ""),
+            master_server_address=d.get("master_server_address", ""),
+            transfer_timeout=d.get("transfer_timeout", 1),
+            storage_root_dir=d.get("storage_root_dir", ""),
+            prefer_local_alloc=d.get("mooncake_prefer_local_alloc", False),
+            use_dummy_client=d.get("use_dummy_client", False),
+            dummy_server_address=d.get("dummy_server_address", ""),
+        )
+
+    @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         """Load the config from a JSON file."""
         with open(file_path) as fin:
             config = json.load(fin)
-        # Read Mooncake-specific knob
-        prefer_local_alloc = config.get("mooncake_prefer_local_alloc", False)
-
-        return MooncakeStoreConfig(
-            local_hostname=config.get("local_hostname", ""),
-            metadata_server=config.get("metadata_server", ""),
-            global_segment_size=config.get("global_segment_size", 3355443200),
-            local_buffer_size=config.get("local_buffer_size", 1073741824),
-            protocol=config.get("protocol", "tcp"),
-            device_name=config.get("device_name", ""),
-            master_server_address=config.get("master_server_address", ""),
-            transfer_timeout=config.get("transfer_timeout", 1),
-            storage_root_dir=config.get("storage_root_dir", ""),
-            prefer_local_alloc=prefer_local_alloc,
-            use_dummy_client=config.get("use_dummy_client", False),
-            dummy_server_address=config.get("dummy_server_address", ""),
-        )
+        return MooncakeStoreConfig._from_dict(config)
 
     @staticmethod
     def load_from_env() -> "MooncakeStoreConfig":
@@ -78,27 +80,11 @@ class MooncakeStoreConfig:
     def load_from_lmcache_config(
         config: "LMCacheEngineConfig",
     ) -> "MooncakeStoreConfig":
-        """Load config from a file specified in the environment variable."""
+        """Load config from the lmcache engine config's extra_config dict."""
         extra_config = config.extra_config
         if extra_config is None:
             raise ValueError("The extra config is not set.")
-        # Read Mooncake-specific knob
-        prefer_local_alloc = extra_config.get("mooncake_prefer_local_alloc", False)
-
-        return MooncakeStoreConfig(
-            local_hostname=extra_config.get("local_hostname", ""),
-            metadata_server=extra_config.get("metadata_server", ""),
-            global_segment_size=extra_config.get("global_segment_size", 3355443200),
-            local_buffer_size=extra_config.get("local_buffer_size", 1073741824),
-            protocol=extra_config.get("protocol", "tcp"),
-            device_name=extra_config.get("device_name", ""),
-            master_server_address=extra_config.get("master_server_address", ""),
-            transfer_timeout=extra_config.get("transfer_timeout", 1),
-            storage_root_dir=extra_config.get("storage_root_dir", ""),
-            prefer_local_alloc=prefer_local_alloc,
-            use_dummy_client=extra_config.get("use_dummy_client", False),
-            dummy_server_address=extra_config.get("dummy_server_address", ""),
-        )
+        return MooncakeStoreConfig._from_dict(extra_config)
 
 
 class MooncakestoreConnector(RemoteConnector):
@@ -171,105 +157,9 @@ class MooncakestoreConnector(RemoteConnector):
                 )
 
             if self.config.use_dummy_client:
-                # Dummy client mode: use setup_dummy with shared memory + IPC
-                if not hasattr(self.store, "setup_dummy"):
-                    raise RuntimeError(
-                        "The installed mooncake version does not support "
-                        "dummy client mode (setup_dummy). Please upgrade "
-                        "mooncake or set use_dummy_client to False."
-                    )
-                if not self.config.dummy_server_address:
-                    raise ValueError(
-                        "dummy_server_address must be provided when "
-                        "use_dummy_client is True."
-                    )
-                # Skip NUMA binding: RDMA runs in separate Real Client process
-                logger.info("Skipping NUMA binding in dummy client mode")
-                logger.info(
-                    "Using dummy client mode with server address: %s",
-                    self.config.dummy_server_address,
-                )
-                self.store.setup_dummy(
-                    self.config.global_segment_size,
-                    self.config.local_buffer_size,
-                    self.config.dummy_server_address,
-                )
-                logger.info("Mooncake dummy client setup completed successfully")
-
-                # Replace pin_allocator with shm-backed memory
-                allocator = local_cpu_backend.memory_allocator
-                if hasattr(allocator, "pin_allocator") and hasattr(
-                    allocator.pin_allocator, "buffer"
-                ):
-                    buffer_size = allocator.pin_allocator.buffer.numel()
-
-                    # Allocate shm from mooncake's memory pool
-                    shm_ptr = self.store.alloc_from_mem_pool(buffer_size)
-                    if not shm_ptr:
-                        raise RuntimeError(
-                            "Failed to allocate shared memory from mooncake mem pool"
-                        )
-
-                    # Delegate all pin/wrap/rebuild to the allocator
-                    allocator.replace_buffer(shm_ptr, buffer_size)  # type: ignore[attr-defined]
-
-                    logger.info(
-                        "Replaced pin_allocator with shm buffer: ptr=%s, size=%d",
-                        hex(shm_ptr),
-                        buffer_size,
-                    )
+                self._setup_dummy_client(local_cpu_backend)
             else:
-                # Real client mode: NUMA binding + standard setup
-                try:
-                    numa_mapping = getattr(
-                        local_cpu_backend.memory_allocator, "numa_mapping", None
-                    )
-                    if numa_mapping is None and lmcache_config is not None:
-                        numa_mapping = NUMADetector.get_numa_mapping(lmcache_config)
-
-                    if numa_mapping:
-                        current_device_id = torch.cuda.current_device()
-                        gpu_to_numa = getattr(numa_mapping, "gpu_to_numa_mapping", {})
-                        numa_id = gpu_to_numa.get(current_device_id)
-                        logger.info(
-                            f"NUMA mapping detected (pre-Mooncake setup): {gpu_to_numa}"
-                        )
-                        try:
-                            # Third Party
-                            from mooncake.store import bind_to_numa_node
-
-                            if numa_id is not None:
-                                bind_to_numa_node(numa_id)
-                                logger.info(
-                                    f"GPU {current_device_id}, "
-                                    f"NUMA node {numa_id} binding done"
-                                )
-                            else:
-                                logger.info(
-                                    "NUMA mapping not found "
-                                    f"for GPU {current_device_id}"
-                                )
-                        except ImportError:
-                            logger.warning(
-                                "unable to import bind_to_numa_node from mooncake.store"
-                            )
-                    else:
-                        logger.info("NUMA mapping unavailable or disabled")
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to determine NUMA mapping before Mooncake setup: {e}"
-                    )
-
-                self.store.setup(
-                    self.config.local_hostname,
-                    self.config.metadata_server,
-                    self.config.global_segment_size,
-                    self.config.local_buffer_size,
-                    self.config.protocol,
-                    self.config.device_name,
-                    self.config.master_server_address,
-                )
-                logger.info("Mooncake store setup completed successfully")
+                self._setup_real_client(local_cpu_backend, lmcache_config)
 
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
@@ -294,6 +184,106 @@ class MooncakestoreConnector(RemoteConnector):
         self._register_cpu_buffer()
 
         logger.info("MooncakeConnector initialized successfully.")
+
+    def _setup_dummy_client(self, local_cpu_backend: LocalCPUBackend):
+        """Set up dummy client mode: shared memory + IPC with Real Client."""
+        if not hasattr(self.store, "setup_dummy"):
+            raise RuntimeError(
+                "The installed mooncake version does not support "
+                "dummy client mode (setup_dummy). Please upgrade "
+                "mooncake or set use_dummy_client to False."
+            )
+        if not self.config.dummy_server_address:
+            raise ValueError(
+                "dummy_server_address must be provided when use_dummy_client is True."
+            )
+        logger.info("Skipping NUMA binding in dummy client mode")
+        logger.info(
+            "Using dummy client mode with server address: %s",
+            self.config.dummy_server_address,
+        )
+        self.store.setup_dummy(
+            self.config.global_segment_size,
+            self.config.local_buffer_size,
+            self.config.dummy_server_address,
+        )
+        logger.info("Mooncake dummy client setup completed successfully")
+
+        # Replace pin_allocator with shm-backed memory
+        allocator = local_cpu_backend.memory_allocator
+        if hasattr(allocator, "pin_allocator") and hasattr(
+            allocator.pin_allocator, "buffer"
+        ):
+            buffer_size = allocator.pin_allocator.buffer.numel()
+
+            shm_ptr = self.store.alloc_from_mem_pool(buffer_size)
+            if not shm_ptr:
+                raise RuntimeError(
+                    "Failed to allocate shared memory from mooncake mem pool"
+                )
+
+            allocator.replace_buffer(shm_ptr, buffer_size)  # type: ignore[attr-defined]
+
+            logger.info(
+                "Replaced pin_allocator with shm buffer: ptr=%s, size=%d",
+                hex(shm_ptr),
+                buffer_size,
+            )
+
+    def _setup_real_client(
+        self,
+        local_cpu_backend: LocalCPUBackend,
+        lmcache_config: Optional[LMCacheEngineConfig],
+    ):
+        """Set up real client mode: NUMA binding + standard Mooncake setup."""
+        try:
+            numa_mapping = getattr(
+                local_cpu_backend.memory_allocator, "numa_mapping", None
+            )
+            if numa_mapping is None and lmcache_config is not None:
+                numa_mapping = NUMADetector.get_numa_mapping(lmcache_config)
+
+            if numa_mapping:
+                current_device_id = torch.cuda.current_device()
+                gpu_to_numa = getattr(numa_mapping, "gpu_to_numa_mapping", {})
+                numa_id = gpu_to_numa.get(current_device_id)
+                logger.info(
+                    f"NUMA mapping detected (pre-Mooncake setup): {gpu_to_numa}"
+                )
+                try:
+                    # Third Party
+                    from mooncake.store import bind_to_numa_node
+
+                    if numa_id is not None:
+                        bind_to_numa_node(numa_id)
+                        logger.info(
+                            f"GPU {current_device_id}, NUMA node {numa_id} binding done"
+                        )
+                    else:
+                        logger.info(
+                            f"NUMA mapping not found for GPU {current_device_id}"
+                        )
+                except ImportError:
+                    logger.warning(
+                        "unable to import bind_to_numa_node from mooncake.store"
+                    )
+            else:
+                logger.info("NUMA mapping unavailable or disabled")
+        except Exception as e:
+            logger.warning(
+                f"Failed to determine NUMA mapping before Mooncake setup: {e}"
+            )
+
+        self.store.setup(
+            self.config.local_hostname,
+            self.config.metadata_server,
+            self.config.global_segment_size,
+            self.config.local_buffer_size,
+            self.config.protocol,
+            self.config.device_name,
+            self.config.master_server_address,
+        )
+        logger.info("Mooncake store setup completed successfully")
 
     def _register_cpu_buffer(self):
         """Register CPU buffer for zero-copy operations."""

--- a/tests/v1/storage_backend/test_mooncakestore_connector.py
+++ b/tests/v1/storage_backend/test_mooncakestore_connector.py
@@ -8,7 +8,6 @@ import sys
 
 # Third Party
 import pytest
-import torch
 
 # First Party
 from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
@@ -197,40 +196,6 @@ def mock_local_cpu_backend():
 def mock_async_loop():
     """Create a simple event loop for testing."""
     return asyncio.new_event_loop()
-
-
-def _create_connector(
-    mock_mooncake_module,
-    mock_local_cpu_backend,
-    mock_async_loop,
-    mooncake_config,
-    lmcache_config=None,
-):
-    """Helper to create MooncakestoreConnector with all mocks in place."""
-    # We need to patch multiple things:
-    # 1. The mooncake import inside __init__
-    # 2. The RemoteConnector.__init__ (base class has complex deps)
-    # 3. The config loading
-
-    store_instance, store_class, replicate_config_cls = mock_mooncake_module
-
-    # Patch MOONCAKE_CONFIG_PATH to None to force lmcache_config path
-    with patch.dict(os.environ, {}, clear=False):
-        os.environ.pop("MOONCAKE_CONFIG_PATH", None)
-
-        # Patch the base class __init__ to avoid its complex dependencies
-        with patch(
-            "lmcache.v1.storage_backend.connector."
-            "mooncakestore_connector."
-            "MooncakestoreConnector.__init__"
-        ):
-            # We can't easily call the real __init__ with mocks,
-            # so let's test the setup path logic directly instead.
-            pass
-
-    # Instead of trying to instantiate the full class, test the setup logic
-    # by importing and calling with appropriate mocks on the config loading
-    return store_instance
 
 
 class TestMooncakestoreConnectorInit:
@@ -471,202 +436,55 @@ class TestMooncakestoreConnectorInit:
             # NUMADetector.get_numa_mapping should be called in real mode
             mock_numa.get_numa_mapping.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "use_dummy, dummy_addr",
+        [(False, ""), (True, "127.0.0.1:50052")],
+        ids=["real_client", "dummy_client"],
+    )
     def test_register_buffer_called_in_both_modes(
-        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+        self,
+        mock_mooncake_module,
+        mock_local_cpu_backend,
+        mock_async_loop,
+        use_dummy,
+        dummy_addr,
     ):
         """register_buffer should be called in both real and dummy modes."""
         store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(
+            use_dummy_client=use_dummy,
+            dummy_server_address=dummy_addr,
+        )
 
-        for use_dummy in [False, True]:
-            store_instance.reset_mock()
-            config = _make_mooncake_store_config(
-                use_dummy_client=use_dummy,
-                dummy_server_address="127.0.0.1:50052" if use_dummy else "",
+        # First Party
+        from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+            MooncakestoreConnector,
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
             )
 
-            # First Party
-            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
-                MooncakestoreConnector,
+            store_instance.register_buffer.assert_called_once_with(
+                0x7F000000, 1073741824
             )
-
-            with (
-                patch(
-                    "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
-                    return_value=config,
-                ),
-                patch(
-                    "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
-                ),
-                patch(
-                    "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
-                ),
-            ):
-                MooncakestoreConnector(
-                    host="127.0.0.1",
-                    port=50051,
-                    dev_name="",
-                    loop=mock_async_loop,
-                    local_cpu_backend=mock_local_cpu_backend,
-                    lmcache_config=mock_local_cpu_backend.config,
-                )
-
-                store_instance.register_buffer.assert_called_once_with(
-                    0x7F000000, 1073741824
-                )
-
-
-class TestMixedMemoryAllocatorReplaceBuffer:
-    """Test MixedMemoryAllocator.replace_buffer() method."""
-
-    def test_replace_buffer_frees_old_and_pins_new(self):
-        """replace_buffer should free original, pin new, and rebuild allocator."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            old_buf = torch.zeros(1024, dtype=torch.uint8)
-            mock_alloc.return_value = old_buf
-            allocator = MixedMemoryAllocator(1024)
-
-        old_pin_allocator = allocator.pin_allocator
-        external_ptr = 0x7F5500000000
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            allocator.replace_buffer(external_ptr, 2048)
-
-            # Should free old buffer
-            mock_ops.free_pinned_ptr.assert_called_once_with(old_buf.data_ptr())
-            # Should pin new external memory
-            mock_ops.register_pinned_ptr.assert_called_once_with(external_ptr, 2048)
-
-        # pin_allocator should be rebuilt
-        assert allocator.pin_allocator is not old_pin_allocator
-        assert allocator.size == 2048
-
-    def test_replace_buffer_updates_buffer_tensor(self):
-        """replace_buffer should update self.buffer to the new tensor."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
-            allocator = MixedMemoryAllocator(1024)
-
-        # Use a real tensor's data_ptr as the external ptr
-        external_tensor = torch.zeros(2048, dtype=torch.uint8)
-        external_ptr = external_tensor.data_ptr()
-
-        with patch("lmcache.v1.memory_management.lmc_ops"):
-            allocator.replace_buffer(external_ptr, 2048)
-
-        assert allocator.buffer.numel() == 2048
-        assert allocator.buffer.data_ptr() == external_ptr
-
-    def test_close_calls_cleanup_fn_after_replace(self):
-        """close() should call cleanup_fn (unregister) instead of default free."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
-            allocator = MixedMemoryAllocator(1024)
-
-        external_tensor = torch.zeros(2048, dtype=torch.uint8)
-        external_ptr = external_tensor.data_ptr()
-
-        with patch("lmcache.v1.memory_management.lmc_ops"):
-            allocator.replace_buffer(external_ptr, 2048)
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            allocator.close()
-            # Should call unregister, not free
-            mock_ops.unregister_pinned_ptr.assert_called_once_with(external_ptr, 2048)
-            mock_ops.free_pinned_ptr.assert_not_called()
-            mock_ops.free_pinned_numa_ptr.assert_not_called()
-
-    def test_close_without_replace_uses_default_free(self):
-        """close() without replace_buffer should use default free path."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
-            allocator = MixedMemoryAllocator(1024)
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            allocator.close()
-            mock_ops.free_pinned_ptr.assert_called_once()
-
-    def test_close_idempotent(self):
-        """Calling close() twice should be safe."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
-            allocator = MixedMemoryAllocator(1024)
-
-        external_tensor = torch.zeros(2048, dtype=torch.uint8)
-
-        with patch("lmcache.v1.memory_management.lmc_ops"):
-            allocator.replace_buffer(external_tensor.data_ptr(), 2048)
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            allocator.close()
-            allocator.close()  # Second call should be no-op
-            mock_ops.unregister_pinned_ptr.assert_called_once()
-
-    def test_replace_buffer_with_numa(self):
-        """replace_buffer on NUMA allocator should free with free_pinned_numa_ptr."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        mock_numa = MagicMock()
-        mock_numa.gpu_to_numa_mapping = {0: 0}
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
-            allocator = MixedMemoryAllocator(1024, numa_mapping=mock_numa)
-
-        external_tensor = torch.zeros(2048, dtype=torch.uint8)
-
-        old_buf_ptr = allocator.buffer.data_ptr()
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            allocator.replace_buffer(external_tensor.data_ptr(), 2048)
-            mock_ops.free_pinned_numa_ptr.assert_called_once_with(old_buf_ptr, 1024)
-
-    def test_replace_buffer_called_twice_unregisters_first(self):
-        """Calling replace_buffer twice should unregister the first external ptr."""
-        # First Party
-        from lmcache.v1.memory_management import MixedMemoryAllocator
-
-        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
-            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
-            allocator = MixedMemoryAllocator(1024)
-
-        ext1 = torch.zeros(2048, dtype=torch.uint8)
-        ext2 = torch.zeros(4096, dtype=torch.uint8)
-        ext1_ptr = ext1.data_ptr()
-        ext2_ptr = ext2.data_ptr()
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            # First replace: frees original pinned buffer
-            allocator.replace_buffer(ext1_ptr, 2048)
-            mock_ops.free_pinned_ptr.assert_called_once()
-            mock_ops.register_pinned_ptr.assert_called_once_with(ext1_ptr, 2048)
-
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            # Second replace: should unregister ext1 (not free_pinned_ptr)
-            allocator.replace_buffer(ext2_ptr, 4096)
-            mock_ops.unregister_pinned_ptr.assert_called_once_with(ext1_ptr, 2048)
-            mock_ops.free_pinned_ptr.assert_not_called()
-            mock_ops.register_pinned_ptr.assert_called_once_with(ext2_ptr, 4096)
-
-        # close should unregister ext2
-        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
-            allocator.close()
-            mock_ops.unregister_pinned_ptr.assert_called_once_with(ext2_ptr, 4096)
 
 
 class TestDummyClientShmBufferReplacement:

--- a/tests/v1/storage_backend/test_mooncakestore_connector.py
+++ b/tests/v1/storage_backend/test_mooncakestore_connector.py
@@ -1,0 +1,514 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import MagicMock, patch
+import asyncio
+import json
+import os
+import sys
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+    MooncakeStoreConfig,
+)
+
+
+class TestMooncakeStoreConfigDummyClient:
+    """Test MooncakeStoreConfig parsing of dummy client fields."""
+
+    def _make_config_dict(self, **overrides):
+        """Create a base config dict with required fields."""
+        base = {
+            "local_hostname": "127.0.0.1",
+            "metadata_server": "127.0.0.1:2379",
+            "master_server_address": "127.0.0.1:50051",
+        }
+        base.update(overrides)
+        return base
+
+    def _write_config_file(self, config_dict, tmpdir):
+        """Write config dict to a temp JSON file and return the path."""
+        path = os.path.join(tmpdir, "mooncake_config.json")
+        with open(path, "w") as f:
+            json.dump(config_dict, f)
+        return path
+
+    # --- Tests for default values ---
+
+    def test_from_file_defaults_no_dummy_fields(self, tmp_path):
+        """Old config without dummy fields should default to False/empty."""
+        config_dict = self._make_config_dict()
+        path = self._write_config_file(config_dict, str(tmp_path))
+
+        config = MooncakeStoreConfig.from_file(path)
+
+        assert config.use_dummy_client is False
+        assert config.dummy_server_address == ""
+
+    def test_from_file_with_dummy_enabled(self, tmp_path):
+        """Config with use_dummy_client=True and dummy_server_address set."""
+        config_dict = self._make_config_dict(
+            use_dummy_client=True,
+            dummy_server_address="127.0.0.1:50052",
+        )
+        path = self._write_config_file(config_dict, str(tmp_path))
+
+        config = MooncakeStoreConfig.from_file(path)
+
+        assert config.use_dummy_client is True
+        assert config.dummy_server_address == "127.0.0.1:50052"
+
+    def test_from_file_with_dummy_disabled_explicitly(self, tmp_path):
+        """Config with use_dummy_client=False explicitly set."""
+        config_dict = self._make_config_dict(use_dummy_client=False)
+        path = self._write_config_file(config_dict, str(tmp_path))
+
+        config = MooncakeStoreConfig.from_file(path)
+
+        assert config.use_dummy_client is False
+        assert config.dummy_server_address == ""
+
+    # --- Tests for lmcache extra_config path ---
+
+    def test_load_from_lmcache_config_defaults(self):
+        """lmcache extra_config without dummy fields should default."""
+        mock_config = MagicMock()
+        mock_config.extra_config = self._make_config_dict()
+
+        config = MooncakeStoreConfig.load_from_lmcache_config(mock_config)
+
+        assert config.use_dummy_client is False
+        assert config.dummy_server_address == ""
+
+    def test_load_from_lmcache_config_with_dummy(self):
+        """lmcache extra_config with dummy fields set."""
+        mock_config = MagicMock()
+        mock_config.extra_config = self._make_config_dict(
+            use_dummy_client=True,
+            dummy_server_address="10.0.0.1:50052",
+        )
+
+        config = MooncakeStoreConfig.load_from_lmcache_config(mock_config)
+
+        assert config.use_dummy_client is True
+        assert config.dummy_server_address == "10.0.0.1:50052"
+
+    # --- Tests for env path ---
+
+    def test_load_from_env_defaults(self, tmp_path):
+        """load_from_env with old config should default dummy fields."""
+        config_dict = self._make_config_dict()
+        path = self._write_config_file(config_dict, str(tmp_path))
+
+        with patch.dict(os.environ, {"MOONCAKE_CONFIG_PATH": path}):
+            config = MooncakeStoreConfig.load_from_env()
+
+        assert config.use_dummy_client is False
+        assert config.dummy_server_address == ""
+
+    def test_load_from_env_with_dummy(self, tmp_path):
+        """load_from_env with dummy fields in config file."""
+        config_dict = self._make_config_dict(
+            use_dummy_client=True,
+            dummy_server_address="192.168.1.1:50052",
+        )
+        path = self._write_config_file(config_dict, str(tmp_path))
+
+        with patch.dict(os.environ, {"MOONCAKE_CONFIG_PATH": path}):
+            config = MooncakeStoreConfig.load_from_env()
+
+        assert config.use_dummy_client is True
+        assert config.dummy_server_address == "192.168.1.1:50052"
+
+
+# ---- Helpers for connector init tests ----
+
+
+def _make_mooncake_store_config(**overrides):
+    """Create a MooncakeStoreConfig with sensible defaults."""
+    defaults = dict(
+        local_hostname="127.0.0.1",
+        metadata_server="127.0.0.1:2379",
+        global_segment_size=3355443200,
+        local_buffer_size=1073741824,
+        protocol="tcp",
+        device_name="",
+        master_server_address="127.0.0.1:50051",
+        transfer_timeout=1,
+        storage_root_dir="",
+        prefer_local_alloc=False,
+        use_dummy_client=False,
+        dummy_server_address="",
+    )
+    defaults.update(overrides)
+    return MooncakeStoreConfig(**defaults)
+
+
+@pytest.fixture
+def mock_mooncake_module():
+    """Mock the mooncake.store module to avoid real C++ imports."""
+    mock_store_instance = MagicMock()
+    mock_store_instance.setup.return_value = None
+    mock_store_instance.setup_dummy.return_value = 0
+    mock_store_instance.register_buffer.return_value = 0
+    mock_store_instance.unregister_buffer.return_value = 0
+    mock_store_instance.get_hostname.return_value = "test-host"
+
+    mock_store_class = MagicMock(return_value=mock_store_instance)
+    mock_replicate_config = MagicMock()
+
+    mock_module = MagicMock()
+    mock_module.MooncakeDistributedStore = mock_store_class
+    mock_module.ReplicateConfig = mock_replicate_config
+
+    with patch.dict(
+        sys.modules,
+        {"mooncake": MagicMock(), "mooncake.store": mock_module},
+    ):
+        yield mock_store_instance, mock_store_class, mock_replicate_config
+
+
+@pytest.fixture
+def mock_local_cpu_backend():
+    """Mock LocalCPUBackend with memory allocator."""
+    backend = MagicMock()
+    backend.config = MagicMock()
+    backend.config.extra_config = None
+    backend.config.use_layerwise = False
+    backend.metadata = MagicMock()
+    backend.metadata.get_shapes.return_value = []
+    backend.metadata.get_dtypes.return_value = []
+    backend.metadata.use_mla = False
+    backend.metadata.chunk_size = 256
+    backend.metadata.get_num_groups.return_value = 1
+    # Memory allocator with pin_allocator.buffer
+    mock_buffer = MagicMock()
+    mock_buffer.data_ptr.return_value = 0x7F000000
+    mock_buffer.numel.return_value = 1073741824
+    backend.memory_allocator.pin_allocator.buffer = mock_buffer
+    backend.memory_allocator.numa_mapping = None
+    return backend
+
+
+@pytest.fixture
+def mock_async_loop():
+    """Create a simple event loop for testing."""
+    return asyncio.new_event_loop()
+
+
+def _create_connector(
+    mock_mooncake_module,
+    mock_local_cpu_backend,
+    mock_async_loop,
+    mooncake_config,
+    lmcache_config=None,
+):
+    """Helper to create MooncakestoreConnector with all mocks in place."""
+    # We need to patch multiple things:
+    # 1. The mooncake import inside __init__
+    # 2. The RemoteConnector.__init__ (base class has complex deps)
+    # 3. The config loading
+
+    store_instance, store_class, replicate_config_cls = mock_mooncake_module
+
+    # Patch MOONCAKE_CONFIG_PATH to None to force lmcache_config path
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MOONCAKE_CONFIG_PATH", None)
+
+        # Patch the base class __init__ to avoid its complex dependencies
+        with patch(
+            "lmcache.v1.storage_backend.connector."
+            "mooncakestore_connector."
+            "MooncakestoreConnector.__init__"
+        ):
+            # We can't easily call the real __init__ with mocks,
+            # so let's test the setup path logic directly instead.
+            pass
+
+    # Instead of trying to instantiate the full class, test the setup logic
+    # by importing and calling with appropriate mocks on the config loading
+    return store_instance
+
+
+class TestMooncakestoreConnectorInit:
+    """Test MooncakestoreConnector initialization paths (real vs dummy)."""
+
+    def test_real_client_calls_setup(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """When use_dummy_client=False, store.setup() should be called."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(use_dummy_client=False)
+
+        # Patch config loading to return our config
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+
+            store_instance.setup.assert_called_once()
+            store_instance.setup_dummy.assert_not_called()
+
+    def test_dummy_client_calls_setup_dummy(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """When use_dummy_client=True, store.setup_dummy() should be called."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(
+            use_dummy_client=True,
+            dummy_server_address="127.0.0.1:50052",
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+
+            store_instance.setup_dummy.assert_called_once_with(
+                config.global_segment_size,
+                config.local_buffer_size,
+                config.dummy_server_address,
+            )
+            store_instance.setup.assert_not_called()
+
+    def test_dummy_client_not_supported_raises_error(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """When use_dummy_client=True but mooncake has no setup_dummy, raise error."""
+        store_instance, _, _ = mock_mooncake_module
+        # Remove setup_dummy to simulate old mooncake version
+        del store_instance.setup_dummy
+        config = _make_mooncake_store_config(
+            use_dummy_client=True,
+            dummy_server_address="127.0.0.1:50052",
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            with pytest.raises(RuntimeError, match="does not support.*dummy"):
+                MooncakestoreConnector(
+                    host="127.0.0.1",
+                    port=50051,
+                    dev_name="",
+                    loop=mock_async_loop,
+                    local_cpu_backend=mock_local_cpu_backend,
+                    lmcache_config=mock_local_cpu_backend.config,
+                )
+
+    def test_dummy_client_missing_address_raises_error(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """When use_dummy_client=True but dummy_server_address is empty, raise error."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(
+            use_dummy_client=True,
+            dummy_server_address="",
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            with pytest.raises(
+                ValueError, match="dummy_server_address must be provided"
+            ):
+                MooncakestoreConnector(
+                    host="127.0.0.1",
+                    port=50051,
+                    dev_name="",
+                    loop=mock_async_loop,
+                    local_cpu_backend=mock_local_cpu_backend,
+                    lmcache_config=mock_local_cpu_backend.config,
+                )
+
+    def test_dummy_client_skips_numa_binding(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """When use_dummy_client=True, NUMA binding should be skipped."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(
+            use_dummy_client=True,
+            dummy_server_address="127.0.0.1:50052",
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ) as mock_numa,
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+
+            # NUMADetector.get_numa_mapping should NOT be called in dummy mode
+            mock_numa.get_numa_mapping.assert_not_called()
+
+    def test_real_client_does_numa_binding(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """When use_dummy_client=False, NUMA binding should proceed normally."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(use_dummy_client=False)
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ) as mock_numa,
+        ):
+            mock_numa.get_numa_mapping.return_value = None
+
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+
+            # NUMADetector.get_numa_mapping should be called in real mode
+            mock_numa.get_numa_mapping.assert_called_once()
+
+    def test_register_buffer_called_in_both_modes(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """register_buffer should be called in both real and dummy modes."""
+        store_instance, _, _ = mock_mooncake_module
+
+        for use_dummy in [False, True]:
+            store_instance.reset_mock()
+            config = _make_mooncake_store_config(
+                use_dummy_client=use_dummy,
+                dummy_server_address="127.0.0.1:50052" if use_dummy else "",
+            )
+
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            with (
+                patch(
+                    "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                    return_value=config,
+                ),
+                patch(
+                    "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+                ),
+                patch(
+                    "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+                ),
+            ):
+                MooncakestoreConnector(
+                    host="127.0.0.1",
+                    port=50051,
+                    dev_name="",
+                    loop=mock_async_loop,
+                    local_cpu_backend=mock_local_cpu_backend,
+                    lmcache_config=mock_local_cpu_backend.config,
+                )
+
+                store_instance.register_buffer.assert_called_once_with(
+                    0x7F000000, 1073741824
+                )

--- a/tests/v1/storage_backend/test_mooncakestore_connector.py
+++ b/tests/v1/storage_backend/test_mooncakestore_connector.py
@@ -8,6 +8,7 @@ import sys
 
 # Third Party
 import pytest
+import torch
 
 # First Party
 from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
@@ -512,3 +513,372 @@ class TestMooncakestoreConnectorInit:
                 store_instance.register_buffer.assert_called_once_with(
                     0x7F000000, 1073741824
                 )
+
+
+class TestMixedMemoryAllocatorReplaceBuffer:
+    """Test MixedMemoryAllocator.replace_buffer() method."""
+
+    def test_replace_buffer_frees_old_and_pins_new(self):
+        """replace_buffer should free original, pin new, and rebuild allocator."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            old_buf = torch.zeros(1024, dtype=torch.uint8)
+            mock_alloc.return_value = old_buf
+            allocator = MixedMemoryAllocator(1024)
+
+        old_pin_allocator = allocator.pin_allocator
+        external_ptr = 0x7F5500000000
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.replace_buffer(external_ptr, 2048)
+
+            # Should free old buffer
+            mock_ops.free_pinned_ptr.assert_called_once_with(old_buf.data_ptr())
+            # Should pin new external memory
+            mock_ops.register_pinned_ptr.assert_called_once_with(external_ptr, 2048)
+
+        # pin_allocator should be rebuilt
+        assert allocator.pin_allocator is not old_pin_allocator
+        assert allocator.size == 2048
+
+    def test_replace_buffer_updates_buffer_tensor(self):
+        """replace_buffer should update self.buffer to the new tensor."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        # Use a real tensor's data_ptr as the external ptr
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+        external_ptr = external_tensor.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops"):
+            allocator.replace_buffer(external_ptr, 2048)
+
+        assert allocator.buffer.numel() == 2048
+        assert allocator.buffer.data_ptr() == external_ptr
+
+    def test_close_calls_cleanup_fn_after_replace(self):
+        """close() should call cleanup_fn (unregister) instead of default free."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+        external_ptr = external_tensor.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops"):
+            allocator.replace_buffer(external_ptr, 2048)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            # Should call unregister, not free
+            mock_ops.unregister_pinned_ptr.assert_called_once_with(external_ptr, 2048)
+            mock_ops.free_pinned_ptr.assert_not_called()
+            mock_ops.free_pinned_numa_ptr.assert_not_called()
+
+    def test_close_without_replace_uses_default_free(self):
+        """close() without replace_buffer should use default free path."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            mock_ops.free_pinned_ptr.assert_called_once()
+
+    def test_close_idempotent(self):
+        """Calling close() twice should be safe."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+
+        with patch("lmcache.v1.memory_management.lmc_ops"):
+            allocator.replace_buffer(external_tensor.data_ptr(), 2048)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            allocator.close()  # Second call should be no-op
+            mock_ops.unregister_pinned_ptr.assert_called_once()
+
+    def test_replace_buffer_with_numa(self):
+        """replace_buffer on NUMA allocator should free with free_pinned_numa_ptr."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        mock_numa = MagicMock()
+        mock_numa.gpu_to_numa_mapping = {0: 0}
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024, numa_mapping=mock_numa)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+
+        old_buf_ptr = allocator.buffer.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.replace_buffer(external_tensor.data_ptr(), 2048)
+            mock_ops.free_pinned_numa_ptr.assert_called_once_with(old_buf_ptr, 1024)
+
+    def test_replace_buffer_called_twice_unregisters_first(self):
+        """Calling replace_buffer twice should unregister the first external ptr."""
+        # First Party
+        from lmcache.v1.memory_management import MixedMemoryAllocator
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        ext1 = torch.zeros(2048, dtype=torch.uint8)
+        ext2 = torch.zeros(4096, dtype=torch.uint8)
+        ext1_ptr = ext1.data_ptr()
+        ext2_ptr = ext2.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            # First replace: frees original pinned buffer
+            allocator.replace_buffer(ext1_ptr, 2048)
+            mock_ops.free_pinned_ptr.assert_called_once()
+            mock_ops.register_pinned_ptr.assert_called_once_with(ext1_ptr, 2048)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            # Second replace: should unregister ext1 (not free_pinned_ptr)
+            allocator.replace_buffer(ext2_ptr, 4096)
+            mock_ops.unregister_pinned_ptr.assert_called_once_with(ext1_ptr, 2048)
+            mock_ops.free_pinned_ptr.assert_not_called()
+            mock_ops.register_pinned_ptr.assert_called_once_with(ext2_ptr, 4096)
+
+        # close should unregister ext2
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            mock_ops.unregister_pinned_ptr.assert_called_once_with(ext2_ptr, 4096)
+
+
+class TestDummyClientShmBufferReplacement:
+    """Test that dummy client mode replaces pin_allocator with shm buffer."""
+
+    def _create_dummy_connector(
+        self,
+        mock_mooncake_module,
+        mock_local_cpu_backend,
+        mock_async_loop,
+        shm_ptr=0x7F5500000000,
+    ):
+        """Helper: create connector in dummy mode with all mocks."""
+        store_instance, _, _ = mock_mooncake_module
+        store_instance.alloc_from_mem_pool.return_value = shm_ptr
+        config = _make_mooncake_store_config(
+            use_dummy_client=True,
+            dummy_server_address="127.0.0.1:50052",
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            connector = MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+            return connector, store_instance
+
+    def test_dummy_calls_alloc_from_mem_pool(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """Dummy mode should allocate shm from mooncake memory pool."""
+        _, store = self._create_dummy_connector(
+            mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+        )
+        store.alloc_from_mem_pool.assert_called_once_with(1073741824)
+
+    def test_dummy_calls_replace_buffer(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """Dummy mode should call allocator.replace_buffer(ptr, size)."""
+        self._create_dummy_connector(
+            mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+        )
+        allocator = mock_local_cpu_backend.memory_allocator
+        allocator.replace_buffer.assert_called_once_with(0x7F5500000000, 1073741824)
+
+    def test_dummy_registers_buffer_after_replace(
+        self,
+        mock_mooncake_module,
+        mock_local_cpu_backend,
+        mock_async_loop,
+    ):
+        """register_buffer should be called after replace_buffer."""
+        _, store = self._create_dummy_connector(
+            mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+        )
+        store.register_buffer.assert_called_once()
+
+    def test_real_mode_no_alloc_from_mem_pool(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """Real mode should NOT call alloc_from_mem_pool."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(use_dummy_client=False)
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+            store_instance.alloc_from_mem_pool.assert_not_called()
+
+    def test_real_mode_no_replace_buffer(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """Real mode should NOT call replace_buffer."""
+        store_instance, _, _ = mock_mooncake_module
+        config = _make_mooncake_store_config(use_dummy_client=False)
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+            mock_local_cpu_backend.memory_allocator.replace_buffer.assert_not_called()
+
+    def test_dummy_register_buffer_uses_new_shm_ptr(
+        self, mock_mooncake_module, mock_local_cpu_backend, mock_async_loop
+    ):
+        """register_buffer should see the new buffer ptr/size after replace_buffer."""
+        store_instance, _, _ = mock_mooncake_module
+        shm_ptr = 0x7F5500000000
+        shm_size = 1073741824
+        store_instance.alloc_from_mem_pool.return_value = shm_ptr
+
+        # After replace_buffer, the mock allocator's pin_allocator.buffer
+        # should reflect the new ptr. We track call order to verify
+        # replace_buffer is called BEFORE register_buffer.
+        call_order = []
+
+        def track_replace_buffer(ptr, size):
+            call_order.append(("replace_buffer", ptr, size))
+            # Simulate what replace_buffer does: update the mock buffer
+            new_mock_buffer = MagicMock()
+            new_mock_buffer.data_ptr.return_value = ptr
+            new_mock_buffer.numel.return_value = size
+            mock_local_cpu_backend.memory_allocator.pin_allocator.buffer = (
+                new_mock_buffer
+            )
+
+        def track_register_buffer(ptr, size):
+            call_order.append(("register_buffer", ptr, size))
+            return 0
+
+        mock_local_cpu_backend.memory_allocator.replace_buffer.side_effect = (
+            track_replace_buffer
+        )
+        store_instance.register_buffer.side_effect = track_register_buffer
+
+        config = _make_mooncake_store_config(
+            use_dummy_client=True,
+            dummy_server_address="127.0.0.1:50052",
+        )
+
+        with (
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.MooncakeStoreConfig.load_from_lmcache_config",
+                return_value=config,
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.RemoteConnector.__init__"
+            ),
+            patch(
+                "lmcache.v1.storage_backend.connector.mooncakestore_connector.NUMADetector"
+            ),
+        ):
+            # First Party
+            from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+                MooncakestoreConnector,
+            )
+
+            MooncakestoreConnector(
+                host="127.0.0.1",
+                port=50051,
+                dev_name="",
+                loop=mock_async_loop,
+                local_cpu_backend=mock_local_cpu_backend,
+                lmcache_config=mock_local_cpu_backend.config,
+            )
+
+        # Verify replace_buffer was called before register_buffer
+        assert len(call_order) == 2
+        assert call_order[0][0] == "replace_buffer"
+        assert call_order[1][0] == "register_buffer"
+        # register_buffer should see the new shm ptr and size
+        assert call_order[1][1] == shm_ptr
+        assert call_order[1][2] == shm_size

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import MagicMock, patch
 import threading
 import time
 
@@ -885,3 +886,128 @@ class TestLazyMemoryAllocator:
 
         assert allocator.memcheck()
         allocator.close()
+
+
+class TestMixedMemoryAllocatorReplaceBuffer:
+    """Test MixedMemoryAllocator.replace_buffer() method."""
+
+    def test_replace_buffer_frees_old_and_pins_new(self):
+        """replace_buffer should free original, pin new, and rebuild allocator."""
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            old_buf = torch.zeros(1024, dtype=torch.uint8)
+            mock_alloc.return_value = old_buf
+            allocator = MixedMemoryAllocator(1024)
+
+        old_pin_allocator = allocator.pin_allocator
+        external_ptr = 0x7F5500000000
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.replace_buffer(external_ptr, 2048)
+
+            mock_ops.free_pinned_ptr.assert_called_once_with(old_buf.data_ptr())
+            mock_ops.register_pinned_ptr.assert_called_once_with(external_ptr, 2048)
+
+        assert allocator.pin_allocator is not old_pin_allocator
+        assert allocator.size == 2048
+
+    def test_replace_buffer_updates_buffer_tensor(self):
+        """replace_buffer should update self.buffer to the new tensor."""
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+        external_ptr = external_tensor.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops"):
+            allocator.replace_buffer(external_ptr, 2048)
+
+        assert allocator.buffer.numel() == 2048
+        assert allocator.buffer.data_ptr() == external_ptr
+
+    def test_close_calls_cleanup_fn_after_replace(self):
+        """close() should call cleanup_fn (unregister) instead of default free."""
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+        external_ptr = external_tensor.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops"):
+            allocator.replace_buffer(external_ptr, 2048)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            mock_ops.unregister_pinned_ptr.assert_called_once_with(external_ptr, 2048)
+            mock_ops.free_pinned_ptr.assert_not_called()
+            mock_ops.free_pinned_numa_ptr.assert_not_called()
+
+    def test_close_without_replace_uses_default_free(self):
+        """close() without replace_buffer should use default free path."""
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            mock_ops.free_pinned_ptr.assert_called_once()
+
+    def test_close_idempotent(self):
+        """Calling close() twice should be safe."""
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+
+        with patch("lmcache.v1.memory_management.lmc_ops"):
+            allocator.replace_buffer(external_tensor.data_ptr(), 2048)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            allocator.close()  # Second call should be no-op
+            mock_ops.unregister_pinned_ptr.assert_called_once()
+
+    def test_replace_buffer_with_numa(self):
+        """replace_buffer on NUMA allocator should free with free_pinned_numa_ptr."""
+        mock_numa = MagicMock()
+        mock_numa.gpu_to_numa_mapping = {0: 0}
+
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024, numa_mapping=mock_numa)
+
+        external_tensor = torch.zeros(2048, dtype=torch.uint8)
+
+        old_buf_ptr = allocator.buffer.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.replace_buffer(external_tensor.data_ptr(), 2048)
+            mock_ops.free_pinned_numa_ptr.assert_called_once_with(old_buf_ptr, 1024)
+
+    def test_replace_buffer_called_twice_unregisters_first(self):
+        """Calling replace_buffer twice should unregister the first external ptr."""
+        with patch("lmcache.v1.memory_management._allocate_cpu_memory") as mock_alloc:
+            mock_alloc.return_value = torch.zeros(1024, dtype=torch.uint8)
+            allocator = MixedMemoryAllocator(1024)
+
+        ext1 = torch.zeros(2048, dtype=torch.uint8)
+        ext2 = torch.zeros(4096, dtype=torch.uint8)
+        ext1_ptr = ext1.data_ptr()
+        ext2_ptr = ext2.data_ptr()
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.replace_buffer(ext1_ptr, 2048)
+            mock_ops.free_pinned_ptr.assert_called_once()
+            mock_ops.register_pinned_ptr.assert_called_once_with(ext1_ptr, 2048)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.replace_buffer(ext2_ptr, 4096)
+            mock_ops.unregister_pinned_ptr.assert_called_once_with(ext1_ptr, 2048)
+            mock_ops.free_pinned_ptr.assert_not_called()
+            mock_ops.register_pinned_ptr.assert_called_once_with(ext2_ptr, 4096)
+
+        with patch("lmcache.v1.memory_management.lmc_ops") as mock_ops:
+            allocator.close()
+            mock_ops.unregister_pinned_ptr.assert_called_once_with(ext2_ptr, 4096)


### PR DESCRIPTION

## Summary

This PR adds support for Mooncake's dummy client mode in lmcache, enabling a dual-process architecture where RDMA transfers run in a separate real client process, free from Python GIL contention. In dummy mode, lmcache's internal pinned memory is replaced with Mooncake-managed shared memory, allowing both GPU DMA and cross-process RDMA to operate on the same buffer without extra copies.

## Motivation

Mooncake provides a dummy client mode (`setup_dummy`) with a dual-process architecture:
- **Dummy client** (embedded in the vLLM worker): communicates via shared memory + IPC
- **Real client** (separate process): performs actual RDMA/TCP transfers, free from Python GIL

This avoids GIL blocking on RDMA operations, allows the real client to be independently restarted for better availability, and eliminates the need to launch a heavy real client process per vLLM worker in tensor-parallel setups — multiple dummy clients can share a single real client process.

## Approach

### Configuration

Add `use_dummy_client` and `dummy_server_address` fields to `MooncakeStoreConfig`:

```yaml
extra_config:
  use_dummy_client: true
  dummy_server_address: "127.0.0.1:50052"
```

All three config loading paths (JSON file, lmcache extra_config, environment variables) support the new fields. Default is `False` for full backward compatibility.

### Initialization

When `use_dummy_client=True`, the connector calls `store.setup_dummy()` instead of `store.setup()`, and skips NUMA binding (RDMA runs in the real client process). The init logic is refactored into `_setup_dummy_client()` and `_setup_real_client()` for clarity.

### Shared memory integration

Dummy client mode requires `register_buffer` to accept a pointer from Mooncake's shared memory pool (`alloc_from_mem_pool`). Since lmcache's original pinned memory (`cudaHostAlloc`) is not in Mooncake's `ShmHelper::shms_` registry, the connector replaces lmcache's internal CPU buffer with Mooncake shared memory during initialization.

This is implemented across three layers with strict dependency direction (`Connector → MixedMemoryAllocator → lmc_ops → C++`):

**C++ layer** — New `register_pinned_ptr` / `unregister_pinned_ptr` functions wrap `cudaHostRegister` / `cudaHostUnregister` to pin externally allocated memory for GPU DMA. HIP compatible via auto-mapping. Non-CUDA no-op fallbacks provided.

**Memory layer** — New `MixedMemoryAllocator.replace_buffer(external_ptr, size)` method encapsulates all low-level details: frees the original buffer, pins the external memory, wraps it as `torch.Tensor`, rebuilds `pin_allocator`, and registers a cleanup callback so `close()` calls `unregister_pinned_ptr` instead of the default free path.

**Connector layer** — In `_setup_dummy_client()`, after `store.setup_dummy`:
1. `store.alloc_from_mem_pool(buffer_size)` → shared memory pointer
2. `allocator.replace_buffer(shm_ptr, buffer_size)` → memory layer handles the rest
3. `store.register_buffer(ptr, size)` → succeeds because the pointer is in Mooncake's shm registry

### Data flow

```
GPU → cudaMemcpy (DMA) → Mooncake SHM (cudaHostRegistered as pinned)
                           ↑ lmcache pin_allocator allocates from this memory
                           ↓ register_buffer succeeds (pointer found in shms_)
                       Real Client process (zero-copy RDMA)
```

## Performance

Tested with DeepSeek V3.2 (MLA) under TP=8 configuration with a representative workload. No noticeable performance degradation compared to the original real client mode.

`cudaHostRegister(flags=0)` and `cudaHostAlloc(flags=0)` produce equivalent DMA performance — both page-lock the memory via the same PCIe DMA channel. Mooncake's `mmap(MAP_POPULATE)` pre-allocates physical pages, covering the same role as lmcache's `first_touch`. The only theoretical gap is NUMA affinity (Mooncake SHM does not call `mbind`), but this only matters when `numa_mode` is explicitly configured (defaults to `None`).

### Real client mode (baseline)

<img width="2086" height="745" alt="Clipboard_Screenshot_1772190642" src="https://github.com/user-attachments/assets/dc6ad047-a25e-4e53-9c3d-3ccfd3b9609f" />


### Dummy client mode

<img width="2086" height="745" alt="Clipboard_Screenshot_1772190661" src="https://github.com/user-attachments/assets/495dd381-6259-4f3a-94e3-0f72f789ee8a" />


## Changed files

| File | Change |
|------|--------|
| `csrc/mem_alloc.h` | Add `register_pinned_ptr` / `unregister_pinned_ptr` declarations |
| `csrc/mem_alloc.cpp` | Add implementations wrapping `cudaHostRegister` / `cudaHostUnregister` |
| `csrc/pybind.cpp` | Add pybind11 bindings with GIL release |
| `lmcache/non_cuda_equivalents.py` | Add non-CUDA no-op fallbacks |
| `lmcache/v1/memory_management.py` | Add `replace_buffer()` method; modify `close()` to support cleanup callback |
| `mooncakestore_connector.py` | Add dummy client init branch; shm allocation + buffer replacement; refactor into `_from_dict` / `_setup_dummy_client` / `_setup_real_client` |
| `tests/v1/test_memory_management.py` | Add `TestMixedMemoryAllocatorReplaceBuffer` (7 tests) |
| `tests/v1/storage_backend/test_mooncakestore_connector.py` | Add dummy client + shm buffer replacement tests (21 tests total) |

## Backward compatibility

- Config files without `use_dummy_client` load normally (defaults to `False`)
- Setting `use_dummy_client=True` with a Mooncake version that lacks `setup_dummy` raises a clear error
- All existing data operations (`batched_get`, `batched_put`, `exists`) are unchanged

## Testing

- 21 connector tests + 7 memory management tests all pass
- Pre-commit checks (isort, ruff, ruff-format, mypy, clang-format) all pass
