### PR TITLE
[feat] add free_locks api to MP mode

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -211,6 +211,39 @@ class LMCacheMPSchedulerAdapter:
         """
         self.lookup_futures.pop(request_id, None)
 
+    def free_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+    ) -> None:
+        """Release read locks acquired during lookup without a full retrieve.
+
+        Use this when a request is cancelled or aborted after lookup but
+        before retrieve to avoid holding read locks until TTL expiry.
+
+        When ``start`` or ``end`` is not aligned to the chunk size, the
+        entire chunk containing that boundary is freed.  If the caller
+        needs to preserve locks on part of a boundary chunk, it should
+        align ``start`` / ``end`` to chunk boundaries before calling
+        this method.
+
+        Args:
+            token_ids: Token IDs for the key (same as used in lookup).
+            start: Start token index.
+            end: End token index.
+            request_id: The request ID.
+        """
+        key = self._create_key(
+            token_ids, start=start, end=end, request_id=request_id
+        ).no_worker_id_version()
+        send_lmcache_request(
+            self.mq_client,
+            RequestType.FREE_LOCKS,
+            [[key]],
+        )
+
     def end_session(self, request_id: str) -> None:
         """
         Notify LMCache server to remove the session for a finished request.

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -211,7 +211,7 @@ class LMCacheMPSchedulerAdapter:
         """
         self.lookup_futures.pop(request_id, None)
 
-    def free_locks(
+    def free_lookup_locks(
         self,
         token_ids: list[int],
         start: int,
@@ -220,14 +220,16 @@ class LMCacheMPSchedulerAdapter:
     ) -> None:
         """Release read locks acquired during lookup without a full retrieve.
 
-        Use this when a request is cancelled or aborted after lookup but
+        Use this when some chunks matched by lookup overlap with blocks that
+        vLLM has already computed, so they will never be retrieved.  Calling
+        this prevents those chunks from holding read locks until TTL expiry.
+
+        Or use this when a request is cancelled or aborted after lookup but
         before retrieve to avoid holding read locks until TTL expiry.
 
         When ``start`` or ``end`` is not aligned to the chunk size, the
-        entire chunk containing that boundary is freed.  If the caller
-        needs to preserve locks on part of a boundary chunk, it should
-        align ``start`` / ``end`` to chunk boundaries before calling
-        this method.
+        entire chunk containing start boundary is freed but not end boundary.
+        It is caller's responsibility to properly align the boundaries.
 
         Args:
             token_ids: Token IDs for the key (same as used in lookup).
@@ -241,7 +243,7 @@ class LMCacheMPSchedulerAdapter:
         send_lmcache_request(
             self.mq_client,
             RequestType.FREE_LOCKS,
-            [[key]],
+            [key],
         )
 
     def end_session(self, request_id: str) -> None:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -242,7 +242,7 @@ class LMCacheMPSchedulerAdapter:
         ).no_worker_id_version()
         send_lmcache_request(
             self.mq_client,
-            RequestType.FREE_LOCKS,
+            RequestType.FREE_LOOKUP_LOCKS,
             [key],
         )
 

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -44,7 +44,7 @@ class RequestType(enum.Enum):
     STORE = enum.auto()
     RETRIEVE = enum.auto()
     LOOKUP = enum.auto()
-    FREE_LOCKS = enum.auto()
+    FREE_LOOKUP_LOCKS = enum.auto()
     END_SESSION = enum.auto()
 
     # Controller operations

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -44,6 +44,7 @@ class RequestType(enum.Enum):
     STORE = enum.auto()
     RETRIEVE = enum.auto()
     LOOKUP = enum.auto()
+    FREE_LOCKS = enum.auto()
     END_SESSION = enum.auto()
 
     # Controller operations

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -22,7 +22,7 @@ REQUEST_NAMES = [
     "STORE",
     "RETRIEVE",
     "LOOKUP",
-    "FREE_LOCKS",
+    "FREE_LOOKUP_LOCKS",
     "END_SESSION",
 ]
 
@@ -96,7 +96,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload:
         #   - keys: list[KeyType] - Cache keys whose read locks to release
         # Returns: None
-        "FREE_LOCKS": ProtocolDefinition(
+        "FREE_LOOKUP_LOCKS": ProtocolDefinition(
             payload_classes=[KeyType],
             response_class=None,
             handler_type=HandlerType.BLOCKING,

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -97,7 +97,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         #   - keys: list[KeyType] - Cache keys whose read locks to release
         # Returns: None
         "FREE_LOCKS": ProtocolDefinition(
-            payload_classes=[list[KeyType]],
+            payload_classes=[KeyType],
             response_class=None,
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -22,6 +22,7 @@ REQUEST_NAMES = [
     "STORE",
     "RETRIEVE",
     "LOOKUP",
+    "FREE_LOCKS",
     "END_SESSION",
 ]
 
@@ -89,6 +90,15 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         "LOOKUP": ProtocolDefinition(
             payload_classes=[KeyType],
             response_class=int,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Free locks (release read locks without a full RETRIEVE)
+        # Payload:
+        #   - keys: list[KeyType] - Cache keys whose read locks to release
+        # Returns: None
+        "FREE_LOCKS": ProtocolDefinition(
+            payload_classes=[list[KeyType]],
+            response_class=None,
             handler_type=HandlerType.BLOCKING,
         ),
         # End session

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -448,9 +448,9 @@ class MPCacheEngine:
         found_count = found_count // ipc_keys[0].world_size
         return found_count
 
-    def free_locks(
+    def free_lookup_locks(
         self,
-        keys: list[IPCCacheEngineKey],
+        key: IPCCacheEngineKey,
     ) -> None:
         """Release read locks acquired during lookup without performing a
         full retrieve.  This is used when a request is cancelled or aborted
@@ -459,8 +459,7 @@ class MPCacheEngine:
         ``to_hash_keys`` always expands over the entire ``token_ids``
         sequence, so we slice the result to only include the chunks that
         overlap with the key's ``[start, end)`` range.
-
-        When ``start`` or ``end`` is not aligned to ``chunk_size``, the
+        This means when ``start`` or ``end`` is not aligned to ``chunk_size``, the
         entire chunk containing ``start`` boundary is freed but the one containing
         ``end`` boundary will not be freed.  It caller's responsibility to align
         the boundaries as desired.
@@ -469,12 +468,11 @@ class MPCacheEngine:
             keys: List of cache keys whose read locks should be released.
         """
         ipc_keys: list[IPCCacheEngineKey] = []
-        for key in keys:
-            all_hash_keys = key.to_hash_keys(self.token_hasher)
-            chunk_size = self.token_hasher.chunk_size
-            start_chunk = key.start // chunk_size
-            end_chunk = key.end // chunk_size
-            ipc_keys.extend(all_hash_keys[start_chunk:end_chunk])
+        all_hash_keys = key.to_hash_keys(self.token_hasher)
+        chunk_size = self.token_hasher.chunk_size
+        start_chunk = key.start // chunk_size
+        end_chunk = key.end // chunk_size
+        ipc_keys.extend(all_hash_keys[start_chunk:end_chunk])
         if not ipc_keys:
             return
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
@@ -597,7 +595,7 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.STORE, engine.store)
     add_handler_helper(server, RequestType.LOOKUP, engine.lookup)
-    add_handler_helper(server, RequestType.FREE_LOCKS, engine.free_locks)
+    add_handler_helper(server, RequestType.FREE_LOCKS, engine.free_lookup_locks)
     add_handler_helper(server, RequestType.RETRIEVE, engine.retrieve)
     add_handler_helper(server, RequestType.CLEAR, engine.clear)
     add_handler_helper(server, RequestType.GET_CHUNK_SIZE, engine.get_chunk_size)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -595,7 +595,7 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.STORE, engine.store)
     add_handler_helper(server, RequestType.LOOKUP, engine.lookup)
-    add_handler_helper(server, RequestType.FREE_LOCKS, engine.free_lookup_locks)
+    add_handler_helper(server, RequestType.FREE_LOOKUP_LOCKS, engine.free_lookup_locks)
     add_handler_helper(server, RequestType.RETRIEVE, engine.retrieve)
     add_handler_helper(server, RequestType.CLEAR, engine.clear)
     add_handler_helper(server, RequestType.GET_CHUNK_SIZE, engine.get_chunk_size)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -448,6 +448,39 @@ class MPCacheEngine:
         found_count = found_count // ipc_keys[0].world_size
         return found_count
 
+    def free_locks(
+        self,
+        keys: list[IPCCacheEngineKey],
+    ) -> None:
+        """Release read locks acquired during lookup without performing a
+        full retrieve.  This is used when a request is cancelled or aborted
+        after LOOKUP but before RETRIEVE.
+
+        ``to_hash_keys`` always expands over the entire ``token_ids``
+        sequence, so we slice the result to only include the chunks that
+        overlap with the key's ``[start, end)`` range.
+
+        When ``start`` or ``end`` is not aligned to ``chunk_size``, the
+        entire chunk containing that boundary is freed.  If the caller
+        needs to preserve locks on the portion of a chunk outside the
+        desired range, it must adjust ``start`` / ``end`` to chunk
+        boundaries itself before calling this method.
+
+        Args:
+            keys: List of cache keys whose read locks should be released.
+        """
+        ipc_keys: list[IPCCacheEngineKey] = []
+        for key in keys:
+            all_hash_keys = key.to_hash_keys(self.token_hasher)
+            chunk_size = self.token_hasher.chunk_size
+            start_chunk = key.start // chunk_size
+            end_chunk = (key.end + chunk_size - 1) // chunk_size
+            ipc_keys.extend(all_hash_keys[start_chunk:end_chunk])
+        if not ipc_keys:
+            return
+        obj_keys = ipc_keys_to_object_keys(ipc_keys)
+        self.storage_manager.finish_read_prefetched(obj_keys)
+
     # =========================================================================
     # Utility methods
     # =========================================================================
@@ -565,6 +598,7 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.STORE, engine.store)
     add_handler_helper(server, RequestType.LOOKUP, engine.lookup)
+    add_handler_helper(server, RequestType.FREE_LOCKS, engine.free_locks)
     add_handler_helper(server, RequestType.RETRIEVE, engine.retrieve)
     add_handler_helper(server, RequestType.CLEAR, engine.clear)
     add_handler_helper(server, RequestType.GET_CHUNK_SIZE, engine.get_chunk_size)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -461,10 +461,9 @@ class MPCacheEngine:
         overlap with the key's ``[start, end)`` range.
 
         When ``start`` or ``end`` is not aligned to ``chunk_size``, the
-        entire chunk containing that boundary is freed.  If the caller
-        needs to preserve locks on the portion of a chunk outside the
-        desired range, it must adjust ``start`` / ``end`` to chunk
-        boundaries itself before calling this method.
+        entire chunk containing ``start`` boundary is freed but the one containing
+        ``end`` boundary will not be freed.  It caller's responsibility to align
+        the boundaries as desired.
 
         Args:
             keys: List of cache keys whose read locks should be released.
@@ -474,7 +473,7 @@ class MPCacheEngine:
             all_hash_keys = key.to_hash_keys(self.token_hasher)
             chunk_size = self.token_hasher.chunk_size
             start_chunk = key.start // chunk_size
-            end_chunk = (key.end + chunk_size - 1) // chunk_size
+            end_chunk = key.end // chunk_size
             ipc_keys.extend(all_hash_keys[start_chunk:end_chunk])
         if not ipc_keys:
             return

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -37,10 +37,10 @@ def test_free_locks_in_request_type():
 
 
 def test_free_locks_payload_classes():
-    """FREE_LOCKS payload should be a single list[IPCCacheEngineKey]."""
+    """FREE_LOCKS payload should be a single IPCCacheEngineKey."""
     payload_classes = get_payload_classes(RequestType.FREE_LOCKS)
     assert len(payload_classes) == 1
-    assert payload_classes[0] == list[IPCCacheEngineKey]
+    assert payload_classes[0] == IPCCacheEngineKey
 
 
 def test_free_locks_response_class():
@@ -63,9 +63,9 @@ def test_free_locks_handler_type():
 def test_mq_free_locks():
     """
     Test MessageQueue with FREE_LOCKS request type.
-    FREE_LOCKS takes (keys: list[KeyType]) and returns None.
+    FREE_LOCKS takes (key: KeyType) and returns None.
     """
-    keys = [create_cache_key(i) for i in range(4)]
+    key = create_cache_key(0)
 
     helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5570")
     helper.register_handler(
@@ -74,7 +74,7 @@ def test_mq_free_locks():
 
     helper.run_test(
         request_type=RequestType.FREE_LOCKS,
-        payloads=[keys],
+        payloads=[key],
         expected_response=None,
         num_requests=1,
     )
@@ -85,66 +85,22 @@ def test_mq_free_locks():
 # ============================================================================
 
 
-CHUNK_SIZE = 256
-
-
-def _make_engine_mock():
-    """Create a MagicMock that behaves like MPCacheEngine for free_locks tests."""
-    engine = MagicMock()
-    engine.token_hasher = MagicMock()
-    engine.token_hasher.chunk_size = CHUNK_SIZE
-    engine.storage_manager = MagicMock()
-    return engine
-
-
-def test_server_free_locks_calls_finish_read_prefetched():
-    """MPCacheEngine.free_locks should resolve hash keys and call
+def test_server_free_lookup_locks_calls_finish_read_prefetched():
+    """MPCacheEngine.free_lookup_locks should resolve hash keys and call
     finish_read_prefetched on the storage manager."""
     # First Party
     from lmcache.v1.multiprocess.server import MPCacheEngine
 
-    engine = _make_engine_mock()
+    engine = MagicMock()
+    engine.token_hasher = MagicMock()
+    engine.token_hasher.chunk_size = 256
+
+    # Build a key that to_hash_keys can operate on
     key = create_cache_key(0).no_worker_id_version()
+
+    # Set up the mock: to_hash_keys returns a list of hash-mode keys
     hash_key = create_cache_key(0)
     sentinel_obj_keys = [MagicMock()]
-
-    with (
-        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=[hash_key]),
-        patch(
-            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
-            return_value=sentinel_obj_keys,
-        ) as mock_convert,
-    ):
-        MPCacheEngine.free_locks(engine, [key])
-
-    mock_convert.assert_called_once()
-    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
-        sentinel_obj_keys
-    )
-
-
-def test_server_free_locks_empty_keys():
-    """MPCacheEngine.free_locks with empty keys should be a no-op."""
-    # First Party
-    from lmcache.v1.multiprocess.server import MPCacheEngine
-
-    engine = _make_engine_mock()
-
-    MPCacheEngine.free_locks(engine, [])
-
-    engine.storage_manager.finish_read_prefetched.assert_not_called()
-
-
-def test_server_free_locks_multiple_keys():
-    """MPCacheEngine.free_locks should expand each key via to_hash_keys."""
-    # First Party
-    from lmcache.v1.multiprocess.server import MPCacheEngine
-
-    engine = _make_engine_mock()
-    keys = [create_cache_key(i).no_worker_id_version() for i in range(3)]
-    hash_key = create_cache_key(0)
-    sentinel_obj_keys = [MagicMock(), MagicMock(), MagicMock()]
-
     with (
         patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=[hash_key]),
         patch(
@@ -152,101 +108,38 @@ def test_server_free_locks_multiple_keys():
             return_value=sentinel_obj_keys,
         ),
     ):
-        MPCacheEngine.free_locks(engine, keys)
+        # Call the real method on the mock
+        MPCacheEngine.free_lookup_locks(engine, key)
 
     engine.storage_manager.finish_read_prefetched.assert_called_once_with(
         sentinel_obj_keys
     )
 
 
-def test_server_free_locks_filters_by_start_end():
-    """free_locks should only release hash keys within [start, end),
-    not all hash keys expanded from token_ids."""
+def test_server_free_lookup_locks_no_matching_chunks():
+    """MPCacheEngine.free_lookup_locks with no chunks in range should be a no-op."""
     # First Party
     from lmcache.v1.multiprocess.server import MPCacheEngine
 
-    engine = _make_engine_mock()
+    engine = MagicMock()
+    engine.token_hasher = MagicMock()
+    engine.token_hasher.chunk_size = 256
 
-    # Simulate 4 chunks worth of tokens (1024 tokens at chunk_size=256)
-    # but the key only covers chunks 1..3 (start=256, end=768)
-    token_ids = tuple(range(1024))
+    # Key with start == end means no chunks to free
     key = IPCCacheEngineKey(
         model_name="testmodel",
         world_size=1,
         worker_id=None,
-        token_ids=token_ids,
-        start=256,
-        end=768,
-        request_id="req-filter",
+        token_ids=tuple(range(256)),
+        start=0,
+        end=0,
+        request_id="req-empty",
     )
 
-    # to_hash_keys returns 4 hash keys (one per chunk over all token_ids)
-    hash_keys = [MagicMock(name=f"hk{i}") for i in range(4)]
-    sentinel_obj_keys = [MagicMock(name="obj1"), MagicMock(name="obj2")]
+    with patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=[MagicMock()]):
+        MPCacheEngine.free_lookup_locks(engine, key)
 
-    with (
-        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=hash_keys),
-        patch(
-            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
-            return_value=sentinel_obj_keys,
-        ) as mock_convert,
-    ):
-        MPCacheEngine.free_locks(engine, [key])
-
-    # Only hash_keys[1] and hash_keys[2] should be passed (chunks 1 and 2)
-    passed_ipc_keys = mock_convert.call_args[0][0]
-    assert len(passed_ipc_keys) == 2
-    assert passed_ipc_keys == hash_keys[1:3]
-
-    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
-        sentinel_obj_keys
-    )
-
-
-def test_server_free_locks_unaligned_start_end():
-    """When end is not aligned to chunk_size, the chunk containing the
-    end boundary is NOT freed (floor division).  The caller is responsible
-    for aligning boundaries as desired."""
-    # First Party
-    from lmcache.v1.multiprocess.server import MPCacheEngine
-
-    engine = _make_engine_mock()
-
-    # 4 chunks of tokens (1024 tokens at chunk_size=256).
-    # start=100 falls in chunk 0, end=700 falls in chunk 2.
-    # Floor division: start_chunk=0, end_chunk=700//256=2
-    # Expected freed chunks: 0, 1  (indices [0:2])
-    token_ids = tuple(range(1024))
-    key = IPCCacheEngineKey(
-        model_name="testmodel",
-        world_size=1,
-        worker_id=None,
-        token_ids=token_ids,
-        start=100,
-        end=700,
-        request_id="req-unaligned",
-    )
-
-    hash_keys = [MagicMock(name=f"hk{i}") for i in range(4)]
-    sentinel_obj_keys = [MagicMock(name=f"obj{i}") for i in range(2)]
-
-    with (
-        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=hash_keys),
-        patch(
-            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
-            return_value=sentinel_obj_keys,
-        ) as mock_convert,
-    ):
-        MPCacheEngine.free_locks(engine, [key])
-
-    # Chunks 0, 1 should be freed (hash_keys[0:2]); chunk 2 is excluded
-    passed_ipc_keys = mock_convert.call_args[0][0]
-    assert len(passed_ipc_keys) == 2
-    assert passed_ipc_keys == hash_keys[0:2]
-
-    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
-        sentinel_obj_keys
-    )
+    engine.storage_manager.finish_read_prefetched.assert_not_called()
 
 
 def test_server_handler_registered():
@@ -255,8 +148,8 @@ def test_server_handler_registered():
     from lmcache.v1.multiprocess.server import MPCacheEngine
 
     engine = MPCacheEngine.__new__(MPCacheEngine)
-    assert hasattr(engine, "free_locks")
-    assert callable(engine.free_locks)
+    assert hasattr(engine, "free_lookup_locks")
+    assert callable(engine.free_lookup_locks)
 
 
 # ============================================================================
@@ -264,9 +157,9 @@ def test_server_handler_registered():
 # ============================================================================
 
 
-def test_adapter_free_locks_sends_request():
-    """LMCacheMPSchedulerAdapter.free_locks should send a FREE_LOCKS request
-    with the correct key payload."""
+def test_adapter_free_lookup_locks_sends_request():
+    """LMCacheMPSchedulerAdapter.free_lookup_locks should send a FREE_LOCKS
+    request with the correct key payload."""
     # First Party
     from lmcache.integration.vllm.vllm_multi_process_adapter import (
         LMCacheMPSchedulerAdapter,
@@ -286,7 +179,7 @@ def test_adapter_free_locks_sends_request():
     adapter.lookup_futures = {}
 
     token_ids = list(range(512))
-    adapter.free_locks(
+    adapter.free_lookup_locks(
         token_ids=token_ids,
         start=0,
         end=512,
@@ -299,22 +192,19 @@ def test_adapter_free_locks_sends_request():
     payloads = call_args[0][1]
     assert req_type == RequestType.FREE_LOCKS
 
-    # Payload should be a list containing a single-element list of keys
+    # Payload should be a single-element list containing the key
     assert isinstance(payloads, list)
     assert len(payloads) == 1
-    key_list = payloads[0]
-    assert isinstance(key_list, list)
-    assert len(key_list) == 1
 
-    key = key_list[0]
+    key = payloads[0]
     assert isinstance(key, IPCCacheEngineKey)
     assert key.worker_id is None
     assert key.model_name == "test_model"
     assert key.request_id == "req-1"
 
 
-def test_adapter_free_locks_key_matches_lookup():
-    """The key created by free_locks should match the key created by
+def test_adapter_free_lookup_locks_key_matches_lookup():
+    """The key created by free_lookup_locks should match the key created by
     maybe_submit_lookup_request (no_worker_id_version, same start/end)."""
     # First Party
     from lmcache.integration.vllm.vllm_multi_process_adapter import (
@@ -341,14 +231,13 @@ def test_adapter_free_locks_key_matches_lookup():
     adapter.maybe_submit_lookup_request("req-1", token_ids)
     lookup_call = mock_client.submit_request.call_args
     lookup_payloads = lookup_call[0][1]
-    # Upstream lookup sends a single key: payloads = [key]
     lookup_key = lookup_payloads[0]
 
     mock_client.submit_request.reset_mock()
 
-    # Submit free_locks with same range as lookup
+    # Submit free_lookup_locks with aligned end
     aligned_end = (len(token_ids) // adapter.chunk_size) * adapter.chunk_size
-    adapter.free_locks(
+    adapter.free_lookup_locks(
         token_ids=token_ids,
         start=0,
         end=aligned_end,
@@ -356,8 +245,7 @@ def test_adapter_free_locks_key_matches_lookup():
     )
     free_call = mock_client.submit_request.call_args
     free_payloads = free_call[0][1]
-    # free_locks sends: payloads = [[key]]
-    free_key = free_payloads[0][0]
+    free_key = free_payloads[0]
 
     # Keys should be identical
     assert lookup_key.model_name == free_key.model_name

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the FREE_LOCKS protocol: enum registration, protocol definition,
+message-queue round-trip, server handler, and client-side adapter API.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import (
+    RequestType,
+    get_handler_type,
+    get_payload_classes,
+    get_response_class,
+)
+from lmcache.v1.multiprocess.protocols.base import HandlerType
+
+# Test helpers
+from tests.v1.multiprocess import test_mq_handler_helpers
+from tests.v1.multiprocess.test_mq import (
+    MessageQueueTestHelper,
+    create_cache_key,
+)
+
+# ============================================================================
+# Protocol definition tests
+# ============================================================================
+
+
+def test_free_locks_in_request_type():
+    """FREE_LOCKS should be a member of RequestType."""
+    assert hasattr(RequestType, "FREE_LOCKS")
+    assert isinstance(RequestType.FREE_LOCKS, RequestType)
+
+
+def test_free_locks_payload_classes():
+    """FREE_LOCKS payload should be a single list[IPCCacheEngineKey]."""
+    payload_classes = get_payload_classes(RequestType.FREE_LOCKS)
+    assert len(payload_classes) == 1
+    assert payload_classes[0] == list[IPCCacheEngineKey]
+
+
+def test_free_locks_response_class():
+    """FREE_LOCKS should have no response (None)."""
+    response_class = get_response_class(RequestType.FREE_LOCKS)
+    assert response_class is None
+
+
+def test_free_locks_handler_type():
+    """FREE_LOCKS should use BLOCKING handler type."""
+    handler_type = get_handler_type(RequestType.FREE_LOCKS)
+    assert handler_type == HandlerType.BLOCKING
+
+
+# ============================================================================
+# Message-queue round-trip test
+# ============================================================================
+
+
+def test_mq_free_locks():
+    """
+    Test MessageQueue with FREE_LOCKS request type.
+    FREE_LOCKS takes (keys: list[KeyType]) and returns None.
+    """
+    keys = [create_cache_key(i) for i in range(4)]
+
+    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5570")
+    helper.register_handler(
+        RequestType.FREE_LOCKS, test_mq_handler_helpers.free_locks_handler
+    )
+
+    helper.run_test(
+        request_type=RequestType.FREE_LOCKS,
+        payloads=[keys],
+        expected_response=None,
+        num_requests=1,
+    )
+
+
+# ============================================================================
+# Server handler tests
+# ============================================================================
+
+
+CHUNK_SIZE = 256
+
+
+def _make_engine_mock():
+    """Create a MagicMock that behaves like MPCacheEngine for free_locks tests."""
+    engine = MagicMock()
+    engine.token_hasher = MagicMock()
+    engine.token_hasher.chunk_size = CHUNK_SIZE
+    engine.storage_manager = MagicMock()
+    return engine
+
+
+def test_server_free_locks_calls_finish_read_prefetched():
+    """MPCacheEngine.free_locks should resolve hash keys and call
+    finish_read_prefetched on the storage manager."""
+    # First Party
+    from lmcache.v1.multiprocess.server import MPCacheEngine
+
+    engine = _make_engine_mock()
+    key = create_cache_key(0).no_worker_id_version()
+    hash_key = create_cache_key(0)
+    sentinel_obj_keys = [MagicMock()]
+
+    with (
+        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=[hash_key]),
+        patch(
+            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
+            return_value=sentinel_obj_keys,
+        ) as mock_convert,
+    ):
+        MPCacheEngine.free_locks(engine, [key])
+
+    mock_convert.assert_called_once()
+    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
+        sentinel_obj_keys
+    )
+
+
+def test_server_free_locks_empty_keys():
+    """MPCacheEngine.free_locks with empty keys should be a no-op."""
+    # First Party
+    from lmcache.v1.multiprocess.server import MPCacheEngine
+
+    engine = _make_engine_mock()
+
+    MPCacheEngine.free_locks(engine, [])
+
+    engine.storage_manager.finish_read_prefetched.assert_not_called()
+
+
+def test_server_free_locks_multiple_keys():
+    """MPCacheEngine.free_locks should expand each key via to_hash_keys."""
+    # First Party
+    from lmcache.v1.multiprocess.server import MPCacheEngine
+
+    engine = _make_engine_mock()
+    keys = [create_cache_key(i).no_worker_id_version() for i in range(3)]
+    hash_key = create_cache_key(0)
+    sentinel_obj_keys = [MagicMock(), MagicMock(), MagicMock()]
+
+    with (
+        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=[hash_key]),
+        patch(
+            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
+            return_value=sentinel_obj_keys,
+        ),
+    ):
+        MPCacheEngine.free_locks(engine, keys)
+
+    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
+        sentinel_obj_keys
+    )
+
+
+def test_server_free_locks_filters_by_start_end():
+    """free_locks should only release hash keys within [start, end),
+    not all hash keys expanded from token_ids."""
+    # First Party
+    from lmcache.v1.multiprocess.server import MPCacheEngine
+
+    engine = _make_engine_mock()
+
+    # Simulate 4 chunks worth of tokens (1024 tokens at chunk_size=256)
+    # but the key only covers chunks 1..3 (start=256, end=768)
+    token_ids = tuple(range(1024))
+    key = IPCCacheEngineKey(
+        model_name="testmodel",
+        world_size=1,
+        worker_id=None,
+        token_ids=token_ids,
+        start=256,
+        end=768,
+        request_id="req-filter",
+    )
+
+    # to_hash_keys returns 4 hash keys (one per chunk over all token_ids)
+    hash_keys = [MagicMock(name=f"hk{i}") for i in range(4)]
+    sentinel_obj_keys = [MagicMock(name="obj1"), MagicMock(name="obj2")]
+
+    with (
+        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=hash_keys),
+        patch(
+            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
+            return_value=sentinel_obj_keys,
+        ) as mock_convert,
+    ):
+        MPCacheEngine.free_locks(engine, [key])
+
+    # Only hash_keys[1] and hash_keys[2] should be passed (chunks 1 and 2)
+    passed_ipc_keys = mock_convert.call_args[0][0]
+    assert len(passed_ipc_keys) == 2
+    assert passed_ipc_keys == hash_keys[1:3]
+
+    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
+        sentinel_obj_keys
+    )
+
+
+def test_server_free_locks_unaligned_start_end():
+    """When start or end is not aligned to chunk_size, the entire chunk
+    containing that boundary should be freed."""
+    # First Party
+    from lmcache.v1.multiprocess.server import MPCacheEngine
+
+    engine = _make_engine_mock()
+
+    # 4 chunks of tokens (1024 tokens at chunk_size=256).
+    # start=100 falls in chunk 0, end=700 falls in chunk 2.
+    # Expected freed chunks: 0, 1, 2  (indices [0:3])
+    token_ids = tuple(range(1024))
+    key = IPCCacheEngineKey(
+        model_name="testmodel",
+        world_size=1,
+        worker_id=None,
+        token_ids=token_ids,
+        start=100,
+        end=700,
+        request_id="req-unaligned",
+    )
+
+    hash_keys = [MagicMock(name=f"hk{i}") for i in range(4)]
+    sentinel_obj_keys = [MagicMock(name=f"obj{i}") for i in range(3)]
+
+    with (
+        patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=hash_keys),
+        patch(
+            "lmcache.v1.multiprocess.server.ipc_keys_to_object_keys",
+            return_value=sentinel_obj_keys,
+        ) as mock_convert,
+    ):
+        MPCacheEngine.free_locks(engine, [key])
+
+    # Chunks 0, 1, 2 should be freed (hash_keys[0:3])
+    passed_ipc_keys = mock_convert.call_args[0][0]
+    assert len(passed_ipc_keys) == 3
+    assert passed_ipc_keys == hash_keys[0:3]
+
+    engine.storage_manager.finish_read_prefetched.assert_called_once_with(
+        sentinel_obj_keys
+    )
+
+
+def test_server_handler_registered():
+    """run_cache_server should register a FREE_LOCKS handler."""
+    # First Party
+    from lmcache.v1.multiprocess.server import MPCacheEngine
+
+    engine = MPCacheEngine.__new__(MPCacheEngine)
+    assert hasattr(engine, "free_locks")
+    assert callable(engine.free_locks)
+
+
+# ============================================================================
+# Client adapter tests
+# ============================================================================
+
+
+def test_adapter_free_locks_sends_request():
+    """LMCacheMPSchedulerAdapter.free_locks should send a FREE_LOCKS request
+    with the correct key payload."""
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        LMCacheMPSchedulerAdapter,
+    )
+
+    adapter = LMCacheMPSchedulerAdapter.__new__(LMCacheMPSchedulerAdapter)
+    adapter.model_name = "test_model"
+    adapter.world_size = 1
+    adapter.worker_id = 0
+    adapter.chunk_size = 256
+    adapter.blocks_in_chunk = 16
+
+    mock_client = MagicMock(spec=MessageQueueClient)
+    mock_future = MagicMock()
+    mock_client.submit_request.return_value = mock_future
+    adapter.mq_client = mock_client
+    adapter.lookup_futures = {}
+
+    token_ids = list(range(512))
+    adapter.free_locks(
+        token_ids=token_ids,
+        start=0,
+        end=512,
+        request_id="req-1",
+    )
+
+    mock_client.submit_request.assert_called_once()
+    call_args = mock_client.submit_request.call_args
+    req_type = call_args[0][0]
+    payloads = call_args[0][1]
+    assert req_type == RequestType.FREE_LOCKS
+
+    # Payload should be a list containing a single-element list of keys
+    assert isinstance(payloads, list)
+    assert len(payloads) == 1
+    key_list = payloads[0]
+    assert isinstance(key_list, list)
+    assert len(key_list) == 1
+
+    key = key_list[0]
+    assert isinstance(key, IPCCacheEngineKey)
+    assert key.worker_id is None
+    assert key.model_name == "test_model"
+    assert key.request_id == "req-1"
+
+
+def test_adapter_free_locks_key_matches_lookup():
+    """The key created by free_locks should match the key created by
+    maybe_submit_lookup_request (no_worker_id_version, same start/end)."""
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        LMCacheMPSchedulerAdapter,
+    )
+
+    adapter = LMCacheMPSchedulerAdapter.__new__(LMCacheMPSchedulerAdapter)
+    adapter.model_name = "test_model"
+    adapter.world_size = 1
+    adapter.worker_id = 0
+    adapter.chunk_size = 256
+    adapter.blocks_in_chunk = 16
+
+    mock_client = MagicMock(spec=MessageQueueClient)
+    mock_future = MagicMock()
+    mock_future.query.return_value = False
+    mock_client.submit_request.return_value = mock_future
+    adapter.mq_client = mock_client
+    adapter.lookup_futures = {}
+
+    token_ids = list(range(512))
+
+    # Submit lookup
+    adapter.maybe_submit_lookup_request("req-1", token_ids)
+    lookup_call = mock_client.submit_request.call_args
+    lookup_payloads = lookup_call[0][1]
+    # Upstream lookup sends a single key: payloads = [key]
+    lookup_key = lookup_payloads[0]
+
+    mock_client.submit_request.reset_mock()
+
+    # Submit free_locks with same range as lookup
+    aligned_end = (len(token_ids) // adapter.chunk_size) * adapter.chunk_size
+    adapter.free_locks(
+        token_ids=token_ids,
+        start=0,
+        end=aligned_end,
+        request_id="req-1",
+    )
+    free_call = mock_client.submit_request.call_args
+    free_payloads = free_call[0][1]
+    # free_locks sends: payloads = [[key]]
+    free_key = free_payloads[0][0]
+
+    # Keys should be identical
+    assert lookup_key.model_name == free_key.model_name
+    assert lookup_key.world_size == free_key.world_size
+    assert lookup_key.worker_id == free_key.worker_id
+    assert lookup_key.worker_id is None
+    assert lookup_key.start == free_key.start
+    assert lookup_key.end == free_key.end
+    assert lookup_key.request_id == free_key.request_id
+    assert lookup_key.token_ids == free_key.token_ids

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Tests for the FREE_LOCKS protocol: enum registration, protocol definition,
+Tests for the FREE_LOOKUP_LOCKS protocol: enum registration, protocol definition,
 message-queue round-trip, server handler, and client-side adapter API.
 """
 
@@ -31,27 +31,27 @@ from tests.v1.multiprocess.test_mq import (
 
 
 def test_free_locks_in_request_type():
-    """FREE_LOCKS should be a member of RequestType."""
-    assert hasattr(RequestType, "FREE_LOCKS")
-    assert isinstance(RequestType.FREE_LOCKS, RequestType)
+    """FREE_LOOKUP_LOCKS should be a member of RequestType."""
+    assert hasattr(RequestType, "FREE_LOOKUP_LOCKS")
+    assert isinstance(RequestType.FREE_LOOKUP_LOCKS, RequestType)
 
 
 def test_free_locks_payload_classes():
-    """FREE_LOCKS payload should be a single IPCCacheEngineKey."""
-    payload_classes = get_payload_classes(RequestType.FREE_LOCKS)
+    """FREE_LOOKUP_LOCKS payload should be a single IPCCacheEngineKey."""
+    payload_classes = get_payload_classes(RequestType.FREE_LOOKUP_LOCKS)
     assert len(payload_classes) == 1
     assert payload_classes[0] == IPCCacheEngineKey
 
 
 def test_free_locks_response_class():
-    """FREE_LOCKS should have no response (None)."""
-    response_class = get_response_class(RequestType.FREE_LOCKS)
+    """FREE_LOOKUP_LOCKS should have no response (None)."""
+    response_class = get_response_class(RequestType.FREE_LOOKUP_LOCKS)
     assert response_class is None
 
 
 def test_free_locks_handler_type():
-    """FREE_LOCKS should use BLOCKING handler type."""
-    handler_type = get_handler_type(RequestType.FREE_LOCKS)
+    """FREE_LOOKUP_LOCKS should use BLOCKING handler type."""
+    handler_type = get_handler_type(RequestType.FREE_LOOKUP_LOCKS)
     assert handler_type == HandlerType.BLOCKING
 
 
@@ -62,18 +62,18 @@ def test_free_locks_handler_type():
 
 def test_mq_free_locks():
     """
-    Test MessageQueue with FREE_LOCKS request type.
-    FREE_LOCKS takes (key: KeyType) and returns None.
+    Test MessageQueue with FREE_LOOKUP_LOCKS request type.
+    FREE_LOOKUP_LOCKS takes (key: KeyType) and returns None.
     """
     key = create_cache_key(0)
 
     helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5570")
     helper.register_handler(
-        RequestType.FREE_LOCKS, test_mq_handler_helpers.free_locks_handler
+        RequestType.FREE_LOOKUP_LOCKS, test_mq_handler_helpers.free_locks_handler
     )
 
     helper.run_test(
-        request_type=RequestType.FREE_LOCKS,
+        request_type=RequestType.FREE_LOOKUP_LOCKS,
         payloads=[key],
         expected_response=None,
         num_requests=1,
@@ -143,7 +143,7 @@ def test_server_free_lookup_locks_no_matching_chunks():
 
 
 def test_server_handler_registered():
-    """run_cache_server should register a FREE_LOCKS handler."""
+    """run_cache_server should register a FREE_LOOKUP_LOCKS handler."""
     # First Party
     from lmcache.v1.multiprocess.server import MPCacheEngine
 
@@ -158,7 +158,7 @@ def test_server_handler_registered():
 
 
 def test_adapter_free_lookup_locks_sends_request():
-    """LMCacheMPSchedulerAdapter.free_lookup_locks should send a FREE_LOCKS
+    """LMCacheMPSchedulerAdapter.free_lookup_locks should send a FREE_LOOKUP_LOCKS
     request with the correct key payload."""
     # First Party
     from lmcache.integration.vllm.vllm_multi_process_adapter import (
@@ -190,7 +190,7 @@ def test_adapter_free_lookup_locks_sends_request():
     call_args = mock_client.submit_request.call_args
     req_type = call_args[0][0]
     payloads = call_args[0][1]
-    assert req_type == RequestType.FREE_LOCKS
+    assert req_type == RequestType.FREE_LOOKUP_LOCKS
 
     # Payload should be a single-element list containing the key
     assert isinstance(payloads, list)

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -204,8 +204,9 @@ def test_server_free_locks_filters_by_start_end():
 
 
 def test_server_free_locks_unaligned_start_end():
-    """When start or end is not aligned to chunk_size, the entire chunk
-    containing that boundary should be freed."""
+    """When end is not aligned to chunk_size, the chunk containing the
+    end boundary is NOT freed (floor division).  The caller is responsible
+    for aligning boundaries as desired."""
     # First Party
     from lmcache.v1.multiprocess.server import MPCacheEngine
 
@@ -213,7 +214,8 @@ def test_server_free_locks_unaligned_start_end():
 
     # 4 chunks of tokens (1024 tokens at chunk_size=256).
     # start=100 falls in chunk 0, end=700 falls in chunk 2.
-    # Expected freed chunks: 0, 1, 2  (indices [0:3])
+    # Floor division: start_chunk=0, end_chunk=700//256=2
+    # Expected freed chunks: 0, 1  (indices [0:2])
     token_ids = tuple(range(1024))
     key = IPCCacheEngineKey(
         model_name="testmodel",
@@ -226,7 +228,7 @@ def test_server_free_locks_unaligned_start_end():
     )
 
     hash_keys = [MagicMock(name=f"hk{i}") for i in range(4)]
-    sentinel_obj_keys = [MagicMock(name=f"obj{i}") for i in range(3)]
+    sentinel_obj_keys = [MagicMock(name=f"obj{i}") for i in range(2)]
 
     with (
         patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=hash_keys),
@@ -237,10 +239,10 @@ def test_server_free_locks_unaligned_start_end():
     ):
         MPCacheEngine.free_locks(engine, [key])
 
-    # Chunks 0, 1, 2 should be freed (hash_keys[0:3])
+    # Chunks 0, 1 should be freed (hash_keys[0:2]); chunk 2 is excluded
     passed_ipc_keys = mock_convert.call_args[0][0]
-    assert len(passed_ipc_keys) == 3
-    assert passed_ipc_keys == hash_keys[0:3]
+    assert len(passed_ipc_keys) == 2
+    assert passed_ipc_keys == hash_keys[0:2]
 
     engine.storage_manager.finish_read_prefetched.assert_called_once_with(
         sentinel_obj_keys

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -167,16 +167,14 @@ def lookup_handler(key: KeyType) -> int:
 # ==============================================================================
 
 
-def free_locks_handler(keys: list[KeyType]) -> None:
+def free_locks_handler(key: KeyType) -> None:
     """
     Dummy handler for FREE_LOCKS requests.
 
     Args:
-        keys: List of cache keys whose read locks should be released
+        key: Cache key whose read locks should be released
 
     Returns:
         None
     """
-    assert isinstance(keys, list), f"Expected keys to be list, got {type(keys)}"
-    for key in keys:
-        assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
+    assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -160,3 +160,23 @@ def lookup_handler(key: KeyType) -> int:
     # For testing, we just validate the input and return a dummy result
     assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
     return 1
+
+
+# ==============================================================================
+# FREE_LOCKS Request Handlers
+# ==============================================================================
+
+
+def free_locks_handler(keys: list[KeyType]) -> None:
+    """
+    Dummy handler for FREE_LOCKS requests.
+
+    Args:
+        keys: List of cache keys whose read locks should be released
+
+    Returns:
+        None
+    """
+    assert isinstance(keys, list), f"Expected keys to be list, got {type(keys)}"
+    for key in keys:
+        assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -163,13 +163,13 @@ def lookup_handler(key: KeyType) -> int:
 
 
 # ==============================================================================
-# FREE_LOCKS Request Handlers
+# FREE_LOOKUP_LOCKS Request Handlers
 # ==============================================================================
 
 
 def free_locks_handler(key: KeyType) -> None:
     """
-    Dummy handler for FREE_LOCKS requests.
+    Dummy handler for FREE_LOOKUP_LOCKS requests.
 
     Args:
         key: Cache key whose read locks should be released


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Add free_locks API to MP mode. This is needed to explicitly free the locked blocks for vLLM hit tokens which will never be released by vLLM since these will never be read by vLLM.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
