### PR TITLE
[4/4][MP] L2 Prefetch controller foundation

### DIFF
--- a/csrc/storage_manager/bitmap.cpp
+++ b/csrc/storage_manager/bitmap.cpp
@@ -19,6 +19,23 @@ inline unsigned bit_offset(size_t bit_index) {
 Bitmap::Bitmap(size_t size)
     : size_(size), data_(size == 0 ? 0 : (size - 1) / kBitsPerByte + 1, 0) {}
 
+Bitmap::Bitmap(size_t size, size_t prefix_bits) : Bitmap(size) {
+  if (prefix_bits == 0 || size == 0) return;
+  if (prefix_bits > size) prefix_bits = size;
+
+  // Set full bytes to 0xFF
+  const size_t full_bytes = prefix_bits / kBitsPerByte;
+  for (size_t i = 0; i < full_bytes; ++i) {
+    data_[i] = 0xFF;
+  }
+
+  // Set remaining bits in the partial byte
+  const unsigned remaining = prefix_bits % kBitsPerByte;
+  if (remaining > 0) {
+    data_[full_bytes] = static_cast<uint8_t>((1u << remaining) - 1);
+  }
+}
+
 void Bitmap::set(size_t index) {
   if (index >= size_) return;
   data_[byte_index(index)] |= static_cast<uint8_t>(1u << bit_offset(index));
@@ -101,6 +118,38 @@ Bitmap Bitmap::operator&(const Bitmap& other) const {
     result.data_[i] = data_[i] & other.data_[i];
   }
   return result;
+}
+
+Bitmap Bitmap::operator|(const Bitmap& other) const {
+  const size_t result_size = (size_ <= other.size_) ? size_ : other.size_;
+  Bitmap result(result_size);
+  for (size_t i = 0; i < result.data_.size(); ++i) {
+    result.data_[i] = data_[i] | other.data_[i];
+  }
+  return result;
+}
+
+std::vector<size_t> Bitmap::get_indices() const {
+  std::vector<size_t> indices;
+  indices.reserve(popcount());
+  for (size_t i = 0; i < data_.size(); ++i) {
+    uint8_t byte = data_[i];
+    while (byte != 0) {
+      unsigned bit =
+          static_cast<unsigned>(__builtin_ctz(static_cast<unsigned>(byte)));
+      size_t idx = i * kBitsPerByte + bit;
+      if (idx < size_) {
+        indices.push_back(idx);
+      }
+      byte &= static_cast<uint8_t>(byte - 1);  // clear lowest set bit
+    }
+  }
+  return indices;
+}
+
+std::unordered_set<size_t> Bitmap::get_indices_set() const {
+  auto vec = get_indices();
+  return std::unordered_set<size_t>(vec.begin(), vec.end());
 }
 
 std::string Bitmap::to_string() const {

--- a/csrc/storage_manager/bitmap.h
+++ b/csrc/storage_manager/bitmap.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <vector>
+#include <unordered_set>
 #include <string>
 
 namespace lmcache {
@@ -24,6 +25,15 @@ class Bitmap {
    * @param size The number of bits in the bitmap.
    */
   explicit Bitmap(size_t size);
+
+  /**
+   * @brief Construct a new Bitmap with the specified size and
+   * first N prefix bits set to 1.
+   *
+   * @param size The number of bits in the bitmap.
+   * @param prefix_bits The number of leading bits to set to 1.
+   */
+  explicit Bitmap(size_t size, size_t prefix_bits);
 
   /**
    * @brief set the bit at the specified index to 1.
@@ -74,6 +84,37 @@ class Bitmap {
   Bitmap operator&(const Bitmap& other) const;
 
   /**
+   * @brief bitwise OR operation between two bitmaps.
+   *
+   * @return a new Bitmap that is the result of the bitwise OR operation.
+   *
+   * @note If this and other have different sizes, the result will be truncated
+   * to the smaller size.
+   */
+  Bitmap operator|(const Bitmap& other) const;
+
+  /**
+   * @brief flip the bits in the bitmap (bitwise NOT).
+   *
+   * @return a new Bitmap that is the result of the bitwise NOT operation.
+   */
+  Bitmap operator~() const;
+
+  /**
+   * @brief get the indices of all set bits (value 1) in the bitmap.
+   *
+   * @return a vector of indices where the bit is set to 1, in ascending order.
+   */
+  std::vector<size_t> get_indices() const;
+
+  /**
+   * @brief get the indices of all set bits (value 1) as an unordered set.
+   *
+   * @return an unordered set of indices where the bit is set to 1.
+   */
+  std::unordered_set<size_t> get_indices_set() const;
+
+  /**
    * @brief convert the bitmap to a string representation.
    *
    * @return a string representation of the bitmap, where '1' represents a set
@@ -89,15 +130,6 @@ class Bitmap {
  private:
   size_t size_;
   std::vector<uint8_t> data_;
-
-  // Helper functions
-
-  /**
-   * @brief flip the bits in the bitmap (bitwise NOT).
-   *
-   * @return a new Bitmap that is the result of the bitwise NOT operation.
-   */
-  Bitmap operator~() const;
 };
 
 }  // namespace storage_manager

--- a/csrc/storage_manager/pybind.cpp
+++ b/csrc/storage_manager/pybind.cpp
@@ -33,6 +33,9 @@ PYBIND11_MODULE(native_storage_ops, m) {
   py::class_<Bitmap>(m, "Bitmap")
       .def(py::init<size_t>(), py::arg("size"),
            "Construct a Bitmap with the specified size.")
+      .def(py::init<size_t, size_t>(), py::arg("size"), py::arg("prefix_bits"),
+           "Construct a Bitmap with the specified size and first N prefix "
+           "bits set to 1.")
       .def("set", &Bitmap::set, py::arg("index"),
            "Set the bit at the specified index to 1.")
       .def("clear", &Bitmap::clear, py::arg("index"),
@@ -46,6 +49,28 @@ PYBIND11_MODULE(native_storage_ops, m) {
            "Count the number of leading ones.")
       .def("__and__", &Bitmap::operator&, py::arg("other"),
            "Bitwise AND operation between two bitmaps.")
+      .def("__or__", &Bitmap::operator|, py::arg("other"),
+           "Bitwise OR operation between two bitmaps.")
+      .def("__invert__", &Bitmap::operator~,
+           "Bitwise NOT operation (flip all bits).")
+      .def("get_indices_list", &Bitmap::get_indices,
+           "Return a list of indices where the bit is set to 1.")
+      .def("get_indices_set", &Bitmap::get_indices_set,
+           "Return a set of indices where the bit is set to 1.")
+      .def(
+          "gather",
+          [](const Bitmap& self, const py::list& items) {
+            auto indices = self.get_indices();
+            py::list result;
+            for (auto idx : indices) {
+              if (idx < static_cast<size_t>(py::len(items))) {
+                result.append(items[idx]);
+              }
+            }
+            return result;
+          },
+          py::arg("items"),
+          "Return elements from items at indices where the bit is set to 1.")
       .def("__repr__", &Bitmap::to_string,
            "Convert the bitmap to a string representation.");
 

--- a/lmcache/native_storage_ops.pyi
+++ b/lmcache/native_storage_ops.pyi
@@ -3,6 +3,9 @@
 
 """Native storage operations for LMCache."""
 
+# Standard
+from typing import Any, Set, overload
+
 class TTLLock:
     """
     A thread-safe lock with TTL (Time-To-Live) support.
@@ -52,12 +55,23 @@ class Bitmap:
     Each bit represents the success or failure of a key.
     """
 
+    @overload
     def __init__(self, size: int) -> None:
         """
         Construct a Bitmap with the specified number of bits.
 
         Args:
             size: The number of bits in the bitmap.
+        """
+        ...
+    @overload
+    def __init__(self, size: int, prefix_bits: int) -> None:
+        """
+        Construct a Bitmap with the specified number of bits and prefix.
+
+        Args:
+            size: The number of bits in the bitmap.
+            prefix_bits: The first N bits are set to 1.
         """
         ...
 
@@ -94,6 +108,37 @@ class Bitmap:
         """
         Bitwise AND with another bitmap.
         If sizes differ, the result is truncated to the smaller size.
+        """
+        ...
+
+    def __invert__(self) -> Bitmap:
+        """Bitwise NOT (flip all bits)."""
+        ...
+
+    def __or__(self, other: Bitmap) -> Bitmap:
+        """
+        Bitwise OR with another bitmap.
+        If sizes differ, the result is truncated to the smaller size.
+        """
+        ...
+
+    def get_indices_list(self) -> list[int]:
+        """Return a list of indices where the bit is set to 1, in ascending order."""
+        ...
+
+    def get_indices_set(self) -> Set[int]:
+        """Return a set of indices where the bit is set to 1."""
+        ...
+
+    def gather(self, items: list[Any]) -> list[Any]:
+        """
+        Return elements from items at indices where the bit is set to 1.
+
+        Args:
+            items: A list of objects. Length should match the bitmap size.
+
+        Returns:
+            A list of objects from items at positions where the bitmap bit is 1.
         """
         ...
 

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -500,8 +500,8 @@ class L1Manager:
             successful_keys.append(key)
 
         for listener in self._registered_listeners:
-            listener.on_keys_write_finished(successful_keys)
-            listener.on_keys_reserved_read(successful_keys)
+            listener.on_l1_keys_write_finished(successful_keys)
+            listener.on_l1_keys_reserved_read(successful_keys)
         return ret
 
     @l1_mgr_synchronized

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -445,6 +445,66 @@ class L1Manager:
         return ret
 
     @l1_mgr_synchronized
+    def finish_write_and_reserve_read(
+        self,
+        keys: list[ObjectKey],
+    ) -> dict[ObjectKey, L1OperationResult]:
+        """Atomically finish write and acquire read lock for the given keys.
+
+        This is used by the prefetch controller after successfully loading
+        data from L2 into write-reserved L1 buffers. It transitions the
+        object from write-locked to read-locked in a single atomic step,
+        preventing a race window where eviction could interfere.
+
+        Args:
+            keys: Keys to transition from write-locked to read-locked.
+
+        Returns:
+            A dictionary mapping each object key to a tuple of
+            (L1Error, Optional[MemoryObj]).
+
+        Errors:
+            KEY_NOT_EXIST: The key does not exist.
+            KEY_IN_WRONG_STATE: The key is not write-locked, or it already
+                has read locks.
+        """
+        ret: dict[ObjectKey, L1OperationResult] = {}
+        successful_keys: list[ObjectKey] = []
+
+        for key in keys:
+            entry = self._objects.get(key, None)
+            if entry is None:
+                ret[key] = (L1Error.KEY_NOT_EXIST, None)
+                continue
+
+            if not entry.write_lock.is_locked():
+                logger.warning(
+                    "L1Manager: finish_write_and_reserve_read on "
+                    "non-write-locked key %s",
+                    key,
+                )
+                ret[key] = (L1Error.KEY_IN_WRONG_STATE, None)
+                continue
+
+            if entry.read_lock.is_locked():
+                logger.warning(
+                    "L1Manager: finish_write_and_reserve_read on read-locked key %s",
+                    key,
+                )
+                ret[key] = (L1Error.KEY_IN_WRONG_STATE, None)
+                continue
+
+            entry.write_lock.unlock()
+            entry.read_lock.lock()
+            ret[key] = (L1Error.SUCCESS, entry.memory_obj)
+            successful_keys.append(key)
+
+        for listener in self._registered_listeners:
+            listener.on_keys_write_finished(successful_keys)
+            listener.on_keys_reserved_read(successful_keys)
+        return ret
+
+    @l1_mgr_synchronized
     def delete(self, keys: list[ObjectKey]) -> dict[ObjectKey, L1Error]:
         """Delete the given keys from L1 cache.
 

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Prefetch policy interface and default implementation for L2-to-L1 load decisions.
+
+The prefetch policy decides which L2 adapter should load each key when multiple
+adapters have the same key. It receives lookup results (bitmaps) from all adapters
+and produces a load plan mapping each adapter to the key indices it should load.
+"""
+
+# Standard
+from abc import ABC, abstractmethod
+
+# First Party
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+)
+
+
+class PrefetchPolicy(ABC):
+    """
+    Abstract interface for prefetch load-plan decisions.
+
+    The prefetch policy is called by the PrefetchController after all L2
+    adapters have completed their lookup_and_lock operations. Given the
+    lookup results, it decides which adapter should load which keys.
+    """
+
+    @abstractmethod
+    def select_load_plan(
+        self,
+        keys: list[ObjectKey],
+        lookup_results: dict[int, Bitmap],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[int]]:
+        """
+        Decide which adapter loads which keys.
+
+        Args:
+            keys: Full list of keys being prefetched from L2.
+            lookup_results: Mapping from adapter index to Bitmap.
+                A set bit at position i means the adapter has keys[i].
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from adapter index to list of key indices that
+            adapter should load. Each key index appears in at most
+            one adapter's list. Keys not in any list will NOT be loaded.
+        """
+
+
+class DefaultPrefetchPolicy(PrefetchPolicy):
+    """
+    Default prefetch policy: for each key, pick the first adapter
+    (lowest index) that has it.
+    """
+
+    def select_load_plan(
+        self,
+        keys: list[ObjectKey],
+        lookup_results: dict[int, Bitmap],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[int]]:
+        """
+        Assign each key to the first adapter (by index) that has it.
+
+        Args:
+            keys: Full list of keys being prefetched.
+            lookup_results: Adapter index -> Bitmap of lookup hits.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from adapter index to key indices. Each key goes
+            to the lowest-indexed adapter that reported having it.
+        """
+        plan: dict[int, list[int]] = {}
+        assigned: set[int] = set()
+
+        for ad in sorted(adapters, key=lambda a: a.index):
+            bitmap = lookup_results.get(ad.index)
+            if bitmap is None:
+                continue
+            for i in range(len(keys)):
+                if i not in assigned and bitmap.test(i):
+                    plan.setdefault(ad.index, []).append(i)
+                    assigned.add(i)
+
+        return plan

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -33,7 +33,7 @@ class PrefetchPolicy(ABC):
         keys: list[ObjectKey],
         lookup_results: dict[int, Bitmap],
         adapters: list[AdapterDescriptor],
-    ) -> dict[int, list[int]]:
+    ) -> dict[int, Bitmap]:
         """
         Decide which adapter loads which keys.
 
@@ -44,9 +44,10 @@ class PrefetchPolicy(ABC):
             adapters: Descriptors of available L2 adapters.
 
         Returns:
-            Mapping from adapter index to list of key indices that
-            adapter should load. Each key index appears in at most
-            one adapter's list. Keys not in any list will NOT be loaded.
+            Mapping from adapter index to a bitmap telling which keys that
+            the adapter should load. The returned bitmaps should not
+            overlap, and the union of all returned bitmaps should be a subset
+            of the union of the input bitmaps.
         """
 
 
@@ -61,7 +62,7 @@ class DefaultPrefetchPolicy(PrefetchPolicy):
         keys: list[ObjectKey],
         lookup_results: dict[int, Bitmap],
         adapters: list[AdapterDescriptor],
-    ) -> dict[int, list[int]]:
+    ) -> dict[int, Bitmap]:
         """
         Assign each key to the first adapter (by index) that has it.
 
@@ -71,19 +72,24 @@ class DefaultPrefetchPolicy(PrefetchPolicy):
             adapters: Descriptors of available L2 adapters.
 
         Returns:
-            Mapping from adapter index to key indices. Each key goes
+            Mapping from adapter index to key bitmaps. Each key goes
             to the lowest-indexed adapter that reported having it.
         """
-        plan: dict[int, list[int]] = {}
-        assigned: set[int] = set()
+        plan: dict[int, Bitmap] = {}
+        global_bitmap = Bitmap(len(keys))
+        for bitmap in lookup_results.values():
+            global_bitmap |= bitmap
 
         for ad in sorted(adapters, key=lambda a: a.index):
-            bitmap = lookup_results.get(ad.index)
-            if bitmap is None:
+            curr_bitmap = lookup_results.get(ad.index)
+            if curr_bitmap is None:
                 continue
-            for i in range(len(keys)):
-                if i not in assigned and bitmap.test(i):
-                    plan.setdefault(ad.index, []).append(i)
-                    assigned.add(i)
+
+            local_bitmap = global_bitmap & curr_bitmap
+            global_bitmap &= ~local_bitmap
+            if local_bitmap.popcount() == 0:
+                continue
+
+            plan[ad.index] = local_bitmap
 
         return plan

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -41,8 +41,14 @@ logger = init_logger(__name__)
 
 @dataclass(frozen=True)
 class PrefetchHandle:
-    prefix_hit_chunks: int
-    """ how many chunks are hit in the prefix of the requested keys """
+    request_id: int
+    """Opaque ID for tracking L2 prefetch in the controller. -1 if no L2 request."""
+
+    l1_prefix_hit_count: int
+    """Number of leading keys already in L1 at submission time."""
+
+    total_requested_keys: int
+    """Total number of keys originally requested."""
 
 
 class StorageManager:
@@ -266,7 +272,12 @@ class StorageManager:
 
         for listener in self._registered_listeners:
             listener.on_sm_read_prefetched(keys[:hit_count], keys[hit_count:])
-        return PrefetchHandle(prefix_hit_chunks=hit_count)
+
+        return PrefetchHandle(
+            request_id=-1,
+            l1_prefix_hit_count=hit_count,
+            total_requested_keys=len(keys),
+        )
 
     def query_prefetch_status(
         self,
@@ -282,7 +293,7 @@ class StorageManager:
             the number of prefix hit chunks if the prefetch is done, None if
             it's still in progress.
         """
-        return handle.prefix_hit_chunks
+        return handle.l1_prefix_hit_count
 
     def clear(self):
         """

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -877,6 +877,167 @@ class TestFinishWrite:
 
 
 # =============================================================================
+# Tests for L1Manager.finish_write_and_reserve_read()
+# =============================================================================
+
+
+class TestFinishWriteAndReserveRead:
+    """
+    Tests for L1Manager.finish_write_and_reserve_read() method.
+
+    This method atomically finishes write and acquires read lock,
+    preventing a race window where eviction could interfere.
+
+    Per the docstring:
+    - KEY_NOT_EXIST: The key does not exist.
+    - KEY_IN_WRONG_STATE: Not write-locked, or already read-locked.
+    - SUCCESS: Write unlocked and read lock acquired atomically.
+    """
+
+    def test_normal_transition(self, basic_l1_config, basic_layout):
+        """Test normal write-locked -> read-locked transition."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Reserve write (key is now write-locked)
+        write_result = manager.reserve_write([key], [False], basic_layout)
+        assert write_result[key][0] == L1Error.SUCCESS
+
+        # Atomically finish write and reserve read
+        result = manager.finish_write_and_reserve_read([key])
+
+        assert key in result
+        error, mem_obj = result[key]
+        assert error == L1Error.SUCCESS
+        assert mem_obj is not None
+
+        # Verify state: write unlocked, read locked
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert not state.write_lock.is_locked()
+        assert state.read_lock.is_locked()
+
+        # Should be readable (not write-locked)
+        assert state.available_for_read() is True
+        # Should not be writable (read-locked)
+        assert state.available_for_write() is False
+
+        # Clean up read lock
+        manager.finish_read([key])
+        manager.close()
+
+    def test_key_not_exist(self, basic_l1_config, basic_layout):
+        """Test that non-existing key returns KEY_NOT_EXIST."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        result = manager.finish_write_and_reserve_read([key])
+
+        assert key in result
+        error, mem_obj = result[key]
+        assert error == L1Error.KEY_NOT_EXIST
+        assert mem_obj is None
+
+        manager.close()
+
+    def test_not_write_locked(self, basic_l1_config, basic_layout):
+        """Test that non-write-locked key returns KEY_IN_WRONG_STATE."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Create ready object (not write-locked)
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        result = manager.finish_write_and_reserve_read([key])
+
+        assert key in result
+        error, mem_obj = result[key]
+        assert error == L1Error.KEY_IN_WRONG_STATE
+        assert mem_obj is None
+
+        manager.close()
+
+    def test_already_read_locked(self, basic_l1_config, basic_layout):
+        """Test that key with both write+read locks returns KEY_IN_WRONG_STATE.
+
+        This is an unexpected state — normally a key shouldn't be both
+        write-locked and read-locked simultaneously.
+        """
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Create write-locked object
+        manager.reserve_write([key], [False], basic_layout)
+
+        # Force a read lock via internal state (unusual state)
+        state = manager.get_object_state(key)
+        assert state is not None
+        state.read_lock.lock()
+
+        result = manager.finish_write_and_reserve_read([key])
+
+        assert key in result
+        error, mem_obj = result[key]
+        assert error == L1Error.KEY_IN_WRONG_STATE
+        assert mem_obj is None
+
+        # Clean up
+        state.read_lock.unlock()
+        manager.close()
+
+    def test_multiple_keys_mixed_results(self, basic_l1_config, basic_layout):
+        """Test with multiple keys where some succeed and some fail."""
+        manager = L1Manager(basic_l1_config)
+        key1 = make_object_key(1)
+        key2 = make_object_key(2)  # will not exist
+        key3 = make_object_key(3)
+
+        # key1: write-locked (should succeed)
+        manager.reserve_write([key1], [False], basic_layout)
+
+        # key3: ready, not write-locked (should fail)
+        manager.reserve_write([key3], [False], basic_layout)
+        manager.finish_write([key3])
+
+        result = manager.finish_write_and_reserve_read([key1, key2, key3])
+
+        # key1: SUCCESS
+        assert result[key1][0] == L1Error.SUCCESS
+        assert result[key1][1] is not None
+
+        # key2: KEY_NOT_EXIST
+        assert result[key2][0] == L1Error.KEY_NOT_EXIST
+        assert result[key2][1] is None
+
+        # key3: KEY_IN_WRONG_STATE (not write-locked)
+        assert result[key3][0] == L1Error.KEY_IN_WRONG_STATE
+        assert result[key3][1] is None
+
+        # Clean up
+        manager.finish_read([key1])
+        manager.close()
+
+    def test_can_unsafe_read_after_transition(self, basic_l1_config, basic_layout):
+        """Test that unsafe_read works on the transitioned key."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Write and transition
+        manager.reserve_write([key], [False], basic_layout)
+        result = manager.finish_write_and_reserve_read([key])
+        assert result[key][0] == L1Error.SUCCESS
+
+        # unsafe_read should work (key is read-locked)
+        read_result = manager.unsafe_read([key])
+        assert read_result[key][0] == L1Error.SUCCESS
+        assert read_result[key][1] is not None
+
+        manager.finish_read([key])
+        manager.close()
+
+
+# =============================================================================
 # Tests for L1Manager.delete()
 # =============================================================================
 

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -45,6 +45,13 @@ def make_bitmap(size: int, set_bits: list[int]) -> Bitmap:
     return bitmap
 
 
+def plan_to_indices(plan: dict[int, Bitmap]) -> dict[int, list[int]]:
+    """Convert a Bitmap-based load plan to index lists for easy assertion."""
+    return {
+        adapter_idx: bitmap.get_indices_list() for adapter_idx, bitmap in plan.items()
+    }
+
+
 # =============================================================================
 # DefaultPrefetchPolicy Tests
 # =============================================================================
@@ -62,7 +69,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
-        assert result == {0: [0, 1, 2]}
+        assert plan_to_indices(result) == {0: [0, 1, 2]}
 
     def test_single_adapter_partial_hits(self):
         """Only found keys are in the plan."""
@@ -74,7 +81,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
-        assert result == {0: [0, 2]}
+        assert plan_to_indices(result) == {0: [0, 2]}
 
     def test_multi_adapter_overlap_first_wins(self):
         """When key is in multiple adapters, lowest-index adapter gets it."""
@@ -90,7 +97,7 @@ class TestDefaultPrefetchPolicy:
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
         # key 0 → adapter 0, key 1 → adapter 0 (first wins), key 2 → adapter 1
-        assert result == {0: [0, 1], 1: [2]}
+        assert plan_to_indices(result) == {0: [0, 1], 1: [2]}
 
     def test_multi_adapter_disjoint(self):
         """Each adapter gets its unique keys."""
@@ -104,7 +111,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
-        assert result == {0: [0, 1], 1: [2, 3]}
+        assert plan_to_indices(result) == {0: [0, 1], 1: [2, 3]}
 
     def test_no_hits_returns_empty(self):
         """Empty bitmaps → empty plan."""
@@ -118,7 +125,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
-        assert result == {}
+        assert plan_to_indices(result) == {}
 
     def test_empty_adapters_returns_empty(self):
         """No adapters means no plan."""
@@ -127,7 +134,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan(keys, {}, [])
 
-        assert result == {}
+        assert plan_to_indices(result) == {}
 
     def test_empty_keys_returns_empty(self):
         """Empty keys list → empty plan."""
@@ -137,7 +144,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan([], lookup_results, adapters)
 
-        assert result == {}
+        assert plan_to_indices(result) == {}
 
     def test_adapter_order_matters(self):
         """Adapter with lower index always has priority, regardless of order
@@ -154,7 +161,7 @@ class TestDefaultPrefetchPolicy:
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
         # Adapter 0 gets the key (lower index wins)
-        assert result == {0: [0]}
+        assert plan_to_indices(result) == {0: [0]}
 
     def test_three_adapters_with_overlap(self):
         """Three adapters with partial overlaps."""
@@ -174,7 +181,7 @@ class TestDefaultPrefetchPolicy:
         # key 2 → adapter 1 (lower than adapter 2)
         # key 3 → adapter 0 (lowest that has it)
         # key 4 → adapter 2
-        assert result == {0: [0, 3], 1: [1, 2], 2: [4]}
+        assert plan_to_indices(result) == {0: [0, 3], 1: [1, 2], 2: [4]}
 
     def test_missing_lookup_result_for_adapter(self):
         """Adapter with no lookup result is skipped."""
@@ -186,7 +193,7 @@ class TestDefaultPrefetchPolicy:
 
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
-        assert result == {1: [0, 1]}
+        assert plan_to_indices(result) == {1: [0, 1]}
 
     def test_each_key_appears_at_most_once(self):
         """No key should be assigned to multiple adapters."""
@@ -203,6 +210,6 @@ class TestDefaultPrefetchPolicy:
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
         # All keys should go to adapter 0 only
-        assert result == {0: [0, 1, 2]}
+        assert plan_to_indices(result) == {0: [0, 1, 2]}
         assert 1 not in result
         assert 2 not in result

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for prefetch policy interface and DefaultPrefetchPolicy.
+
+Tests are written against the PrefetchPolicy contract defined in
+prefetch_policy.py.
+"""
+
+# First Party
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    DefaultPrefetchPolicy,
+)
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_object_key(chunk_id: int) -> ObjectKey:
+    """Create a test ObjectKey with the given chunk ID."""
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def make_descriptor(index: int) -> AdapterDescriptor:
+    """Create an AdapterDescriptor for testing."""
+    config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+    return AdapterDescriptor(index=index, config=config)
+
+
+def make_bitmap(size: int, set_bits: list[int]) -> Bitmap:
+    """Create a Bitmap with specific bits set."""
+    bitmap = Bitmap(size)
+    for i in set_bits:
+        bitmap.set(i)
+    return bitmap
+
+
+# =============================================================================
+# DefaultPrefetchPolicy Tests
+# =============================================================================
+
+
+class TestDefaultPrefetchPolicy:
+    """Test DefaultPrefetchPolicy.select_load_plan behavior."""
+
+    def test_single_adapter_all_keys_found(self):
+        """All found keys assigned to the single adapter."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0)]
+        lookup_results = {0: make_bitmap(3, [0, 1, 2])}
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert result == {0: [0, 1, 2]}
+
+    def test_single_adapter_partial_hits(self):
+        """Only found keys are in the plan."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(4)]
+        adapters = [make_descriptor(0)]
+        # Only keys 0 and 2 found
+        lookup_results = {0: make_bitmap(4, [0, 2])}
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert result == {0: [0, 2]}
+
+    def test_multi_adapter_overlap_first_wins(self):
+        """When key is in multiple adapters, lowest-index adapter gets it."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        # Both adapters have key 1
+        lookup_results = {
+            0: make_bitmap(3, [0, 1]),
+            1: make_bitmap(3, [1, 2]),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        # key 0 → adapter 0, key 1 → adapter 0 (first wins), key 2 → adapter 1
+        assert result == {0: [0, 1], 1: [2]}
+
+    def test_multi_adapter_disjoint(self):
+        """Each adapter gets its unique keys."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(4)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        lookup_results = {
+            0: make_bitmap(4, [0, 1]),
+            1: make_bitmap(4, [2, 3]),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert result == {0: [0, 1], 1: [2, 3]}
+
+    def test_no_hits_returns_empty(self):
+        """Empty bitmaps → empty plan."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        lookup_results = {
+            0: make_bitmap(3, []),
+            1: make_bitmap(3, []),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert result == {}
+
+    def test_empty_adapters_returns_empty(self):
+        """No adapters means no plan."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(0)]
+
+        result = policy.select_load_plan(keys, {}, [])
+
+        assert result == {}
+
+    def test_empty_keys_returns_empty(self):
+        """Empty keys list → empty plan."""
+        policy = DefaultPrefetchPolicy()
+        adapters = [make_descriptor(0)]
+        lookup_results = {0: make_bitmap(0, [])}
+
+        result = policy.select_load_plan([], lookup_results, adapters)
+
+        assert result == {}
+
+    def test_adapter_order_matters(self):
+        """Adapter with lower index always has priority, regardless of order
+        in the adapters list."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(0)]
+        # Adapter 1 listed first, but adapter 0 should win
+        adapters = [make_descriptor(1), make_descriptor(0)]
+        lookup_results = {
+            0: make_bitmap(1, [0]),
+            1: make_bitmap(1, [0]),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        # Adapter 0 gets the key (lower index wins)
+        assert result == {0: [0]}
+
+    def test_three_adapters_with_overlap(self):
+        """Three adapters with partial overlaps."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(5)]
+        adapters = [make_descriptor(0), make_descriptor(1), make_descriptor(2)]
+        lookup_results = {
+            0: make_bitmap(5, [0, 3]),  # has keys 0, 3
+            1: make_bitmap(5, [1, 2, 3]),  # has keys 1, 2, 3
+            2: make_bitmap(5, [2, 3, 4]),  # has keys 2, 3, 4
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        # key 0 → adapter 0
+        # key 1 → adapter 1
+        # key 2 → adapter 1 (lower than adapter 2)
+        # key 3 → adapter 0 (lowest that has it)
+        # key 4 → adapter 2
+        assert result == {0: [0, 3], 1: [1, 2], 2: [4]}
+
+    def test_missing_lookup_result_for_adapter(self):
+        """Adapter with no lookup result is skipped."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(2)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        # Only adapter 1 has results
+        lookup_results = {1: make_bitmap(2, [0, 1])}
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert result == {1: [0, 1]}
+
+    def test_each_key_appears_at_most_once(self):
+        """No key should be assigned to multiple adapters."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1), make_descriptor(2)]
+        # All adapters have all keys
+        lookup_results = {
+            0: make_bitmap(3, [0, 1, 2]),
+            1: make_bitmap(3, [0, 1, 2]),
+            2: make_bitmap(3, [0, 1, 2]),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        # All keys should go to adapter 0 only
+        assert result == {0: [0, 1, 2]}
+        assert 1 not in result
+        assert 2 not in result

--- a/tests/v1/native_storage_ops/test_bitmap.py
+++ b/tests/v1/native_storage_ops/test_bitmap.py
@@ -243,6 +243,295 @@ class TestBitmapToString:
         assert "1" in r and "0" in r
 
 
+class TestBitmapOr:
+    """Test bitwise OR between two bitmaps."""
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 16, 17])
+    def test_or_same_size_no_overlap(self, size):
+        a = Bitmap(size)
+        b = Bitmap(size)
+        for i in range(0, size, 2):
+            a.set(i)
+        for i in range(1, size, 2):
+            b.set(i)
+        c = a | b
+        assert c.popcount() == size
+        for i in range(size):
+            assert c.test(i)
+
+    @pytest.mark.parametrize("size", [1, 9, 10])
+    def test_or_same_size_with_overlap(self, size):
+        a = Bitmap(size)
+        b = Bitmap(size)
+        for i in range(size):
+            a.set(i)
+        for i in range(0, size, 2):
+            b.set(i)
+        c = a | b
+        assert c.popcount() == size
+
+    def test_or_different_sizes_result_truncated(self):
+        a = Bitmap(10)
+        b = Bitmap(5)
+        for i in range(0, 10, 2):
+            a.set(i)
+        for i in range(1, 5, 2):
+            b.set(i)
+        c = a | b
+        # Result is min(10,5)=5 bits
+        assert c.popcount() == 5
+        for i in range(5):
+            assert c.test(i)
+
+    def test_or_both_empty(self):
+        a = Bitmap(8)
+        b = Bitmap(8)
+        c = a | b
+        assert c.popcount() == 0
+
+
+class TestBitmapGetIndices:
+    """Test get_indices_list and get_indices_set."""
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 17])
+    def test_get_indices_list_all_zeros(self, size):
+        b = Bitmap(size)
+        assert b.get_indices_list() == []
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 17])
+    def test_get_indices_list_all_ones(self, size):
+        b = Bitmap(size)
+        for i in range(size):
+            b.set(i)
+        assert b.get_indices_list() == list(range(size))
+
+    @pytest.mark.parametrize("size", [9, 10, 17, 25])
+    def test_get_indices_list_even_bits(self, size):
+        b = Bitmap(size)
+        expected = list(range(0, size, 2))
+        for i in expected:
+            b.set(i)
+        assert b.get_indices_list() == expected
+
+    @pytest.mark.parametrize("size", [9, 12, 20])
+    def test_get_indices_list_random(self, size):
+        b = Bitmap(size)
+        positions = sorted(random.sample(range(size), 5))
+        for i in positions:
+            b.set(i)
+        assert b.get_indices_list() == positions
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 17])
+    def test_get_indices_set_all_zeros(self, size):
+        b = Bitmap(size)
+        assert b.get_indices_set() == set()
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 17])
+    def test_get_indices_set_all_ones(self, size):
+        b = Bitmap(size)
+        for i in range(size):
+            b.set(i)
+        assert b.get_indices_set() == set(range(size))
+
+    @pytest.mark.parametrize("size", [9, 12, 20])
+    def test_get_indices_set_random(self, size):
+        b = Bitmap(size)
+        positions = random.sample(range(size), 5)
+        for i in positions:
+            b.set(i)
+        assert b.get_indices_set() == set(positions)
+
+    def test_get_indices_list_and_set_consistent(self):
+        b = Bitmap(17)
+        for i in [0, 3, 8, 15, 16]:
+            b.set(i)
+        assert set(b.get_indices_list()) == b.get_indices_set()
+
+
+class TestBitmapGather:
+    """Test gather operation."""
+
+    def test_gather_basic(self):
+        b = Bitmap(5)
+        b.set(0)
+        b.set(2)
+        b.set(4)
+        items = ["a", "b", "c", "d", "e"]
+        assert b.gather(items) == ["a", "c", "e"]
+
+    def test_gather_all_set(self):
+        b = Bitmap(4)
+        for i in range(4):
+            b.set(i)
+        items = [10, 20, 30, 40]
+        assert b.gather(items) == [10, 20, 30, 40]
+
+    def test_gather_none_set(self):
+        b = Bitmap(3)
+        items = ["x", "y", "z"]
+        assert b.gather(items) == []
+
+    def test_gather_mixed_types(self):
+        b = Bitmap(4)
+        b.set(1)
+        b.set(3)
+        items = [1, "two", 3.0, None]
+        assert b.gather(items) == ["two", None]
+
+    @pytest.mark.parametrize("size", [9, 10, 17])
+    def test_gather_preserves_order(self, size):
+        b = Bitmap(size)
+        positions = sorted(random.sample(range(size), 5))
+        for i in positions:
+            b.set(i)
+        items = list(range(size))
+        assert b.gather(items) == positions
+
+    def test_gather_single_element(self):
+        b = Bitmap(1)
+        b.set(0)
+        assert b.gather(["only"]) == ["only"]
+
+
+class TestBitmapInvert:
+    """Test bitwise NOT (~) operation."""
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 16, 17])
+    def test_invert_all_zeros_gives_all_ones(self, size):
+        b = Bitmap(size)
+        inv = ~b
+        assert inv.popcount() == size
+        for i in range(size):
+            assert inv.test(i)
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 16, 17])
+    def test_invert_all_ones_gives_all_zeros(self, size):
+        b = Bitmap(size)
+        for i in range(size):
+            b.set(i)
+        inv = ~b
+        assert inv.popcount() == 0
+        for i in range(size):
+            assert not inv.test(i)
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 17, 25])
+    def test_invert_flips_each_bit(self, size):
+        b = Bitmap(size)
+        for i in range(0, size, 2):
+            b.set(i)
+        inv = ~b
+        for i in range(size):
+            assert inv.test(i) == (i % 2 == 1)
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 17])
+    def test_double_invert_is_identity(self, size):
+        b = Bitmap(size)
+        positions = [i for i in range(size) if i % 3 == 0]
+        for i in positions:
+            b.set(i)
+        result = ~(~b)
+        for i in range(size):
+            assert result.test(i) == b.test(i)
+
+    def test_invert_does_not_mutate_original(self):
+        b = Bitmap(10)
+        b.set(0)
+        b.set(5)
+        _ = ~b
+        assert b.popcount() == 2
+        assert b.test(0)
+        assert b.test(5)
+
+    @pytest.mark.parametrize("size", [9, 10, 17])
+    def test_invert_popcount_complement(self, size):
+        b = Bitmap(size)
+        for i in range(0, size, 3):
+            b.set(i)
+        inv = ~b
+        assert b.popcount() + inv.popcount() == size
+
+    def test_invert_and_original_gives_zero(self):
+        b = Bitmap(10)
+        for i in [1, 3, 5, 7, 9]:
+            b.set(i)
+        result = b & ~b
+        assert result.popcount() == 0
+
+    def test_invert_or_original_gives_all_ones(self):
+        b = Bitmap(10)
+        for i in [1, 3, 5, 7, 9]:
+            b.set(i)
+        result = b | ~b
+        assert result.popcount() == 10
+
+
+class TestBitmapPrefixConstructor:
+    """Test Bitmap(size, prefix_bits) constructor."""
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 16, 17, 25])
+    def test_prefix_zero(self, size):
+        b = Bitmap(size, 0)
+        assert b.popcount() == 0
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 10, 16, 17, 25])
+    def test_prefix_all(self, size):
+        b = Bitmap(size, size)
+        assert b.popcount() == size
+        assert b.count_leading_ones() == size
+
+    @pytest.mark.parametrize("size", [8, 9, 10, 16, 17, 25])
+    def test_prefix_partial(self, size):
+        prefix = size // 2
+        b = Bitmap(size, prefix)
+        assert b.popcount() == prefix
+        assert b.count_leading_ones() == prefix
+        for i in range(prefix):
+            assert b.test(i)
+        for i in range(prefix, size):
+            assert not b.test(i)
+
+    @pytest.mark.parametrize("size", [1, 7, 8, 9, 16, 17])
+    def test_prefix_one(self, size):
+        b = Bitmap(size, 1)
+        assert b.popcount() == 1
+        assert b.test(0)
+        for i in range(1, size):
+            assert not b.test(i)
+
+    def test_prefix_exceeds_size_clamped(self):
+        b = Bitmap(5, 100)
+        assert b.popcount() == 5
+        assert b.count_leading_ones() == 5
+
+    @pytest.mark.parametrize("size", [8, 16, 24])
+    def test_prefix_exact_byte_boundary(self, size):
+        b = Bitmap(size, 8)
+        assert b.popcount() == 8
+        assert b.count_leading_ones() == 8
+        for i in range(8):
+            assert b.test(i)
+        for i in range(8, size):
+            assert not b.test(i)
+
+    @pytest.mark.parametrize(
+        "size,prefix",
+        [(9, 3), (10, 5), (17, 9), (25, 13)],
+    )
+    def test_prefix_matches_manual_set(self, size, prefix):
+        """Bitmap(size, prefix) should be identical to setting bits 0..prefix-1."""
+        a = Bitmap(size, prefix)
+        b = Bitmap(size)
+        for i in range(prefix):
+            b.set(i)
+        assert a.popcount() == b.popcount()
+        assert a.get_indices_list() == b.get_indices_list()
+        assert str(a) == str(b)
+
+    def test_prefix_zero_size(self):
+        b = Bitmap(0, 0)
+        assert b.popcount() == 0
+
+
 class TestBitmapNonMultipleOfEight:
     """Focused tests when length is not a multiple of 8."""
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Part of #2562

This is the foundation PR for the L2 prefetch controller. It adds the building blocks needed before implementing the full controller (next PR):

1. **`L1Manager.finish_write_and_reserve_read()`** — Atomic transition from write-locked to read-locked state. After loading L2 data into write-reserved L1 buffers, this prevents a race window where eviction could remove the key between separate `finish_write()` + `reserve_read()` calls.

2. **`PrefetchPolicy` ABC + `DefaultPrefetchPolicy`** — Policy interface for deciding which L2 adapter loads which key when multiple adapters have the same data. The default policy assigns each key to the lowest-indexed adapter that has it.

3. **`PrefetchHandle` redesign** — Extended from a single `prefix_hit_chunks` field to include `request_id` (for async L2 tracking), `l1_prefix_hit_count`, and `total_requested_keys`.

4. **More interfaces in `Bitmap`** — Expose more interfaces in Bitmap for the prefetch controller to use.

**Note:** This PR needs to be rebased after #2646 is merged. And it requires #2662 to be merged first.



**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests