### PR TITLE
Refactor PrometheusController into global singleton with self-registration

### DIFF
--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -15,7 +15,6 @@ from lmcache.v1.distributed.l2_adapters.config import (
     add_l2_adapters_args,
     parse_args_to_l2_adapters_config,
 )
-from lmcache.v1.mp_observability.config import PrometheusConfig
 
 
 @dataclass
@@ -83,9 +82,6 @@ class StorageManagerConfig:
 
     eviction_config: EvictionConfig
     """ The configuration for eviction policies. """
-
-    prometheus_config: PrometheusConfig = field(default_factory=PrometheusConfig)
-    """ The configuration for the Prometheus observability stack. """
 
     l2_adapter_config: L2AdaptersConfig = field(
         default_factory=lambda: L2AdaptersConfig([])
@@ -162,29 +158,6 @@ def add_storage_manager_args(
         type=int,
         default=300,
         help="Time to live for each object's read lock. Default is 300s.",
-    )
-
-    # Prometheus Config
-    prometheus_group = parser.add_argument_group(
-        "Prometheus Observability", "Configuration for Prometheus metrics"
-    )
-    prometheus_group.add_argument(
-        "--disable-prometheus",
-        action="store_true",
-        default=False,
-        help="Disable Prometheus metrics collection and HTTP server.",
-    )
-    prometheus_group.add_argument(
-        "--prometheus-port",
-        type=int,
-        default=9090,
-        help="Port to expose the Prometheus /metrics endpoint on. Default is 9090.",
-    )
-    prometheus_group.add_argument(
-        "--prometheus-log-interval",
-        type=float,
-        default=10.0,
-        help="How often (in seconds) to flush stats to Prometheus. Default is 10.0.",
     )
 
     # Eviction Config
@@ -267,17 +240,11 @@ def parse_args_to_config(
         eviction_ratio=args.eviction_ratio,
     )
 
-    prometheus_config = PrometheusConfig(
-        enabled=not args.disable_prometheus,
-        port=args.prometheus_port,
-        log_interval=args.prometheus_log_interval,
-    )
     l2_adapter_config = parse_args_to_l2_adapters_config(args)
 
     return StorageManagerConfig(
         l1_manager_config=l1_manager_config,
         eviction_config=eviction_config,
-        prometheus_config=prometheus_config,
         l2_adapter_config=l2_adapter_config,
     )
 

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -17,6 +17,12 @@ from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.internal_api import L1ManagerListener
 from lmcache.v1.distributed.memory_manager import L1MemoryManager
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.mp_observability.logger.l1_stats_logger import (
+    L1ManagerStatsLogger,
+)
+from lmcache.v1.mp_observability.prometheus_controller import (
+    get_prometheus_controller,
+)
 
 logger = init_logger(__name__)
 
@@ -134,6 +140,11 @@ class L1Manager:
         self._read_ttl_seconds = config.read_ttl_seconds
 
         self._registered_listeners: list[L1ManagerListener] = []
+
+        # Self-register observability logger
+        l1_stats_logger = L1ManagerStatsLogger()
+        self.register_listener(l1_stats_logger)
+        get_prometheus_controller().register_logger(l1_stats_logger)
 
     def register_listener(self, listener: L1ManagerListener) -> None:
         """Register a listener for L1Manager events.

--- a/lmcache/v1/distributed/storage_controller.py
+++ b/lmcache/v1/distributed/storage_controller.py
@@ -8,34 +8,17 @@ and can operate on it.
 
 # Standard
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 
 # First Party
 from lmcache.v1.distributed.l1_manager import L1Manager
-
-if TYPE_CHECKING:
-    # First Party
-    from lmcache.v1.distributed.storage_manager import StorageManager
 
 
 class StorageControllerInterface(ABC):
     def __init__(
         self,
-        storage_manager: "StorageManager",
         l1_manager: L1Manager,
     ):
         self._l1_manager = l1_manager
-        self._storage_manager = storage_manager
-
-    def get_storage_manager(self) -> "StorageManager":
-        """
-        Get the storage manager instance.
-        This function will be used by sub classes to access storage manager APIs.
-
-        Returns:
-            L1Manager: The storage manager instance.
-        """
-        return self._storage_manager
 
     def get_l1_manager(self) -> L1Manager:
         """

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from typing import TYPE_CHECKING
 import threading
 import time
 
@@ -18,21 +17,16 @@ from lmcache.v1.distributed.storage_controller import (
     StorageControllerInterface,
 )
 
-if TYPE_CHECKING:
-    # First Party
-    from lmcache.v1.distributed.storage_manager import StorageManager
-
 logger = init_logger(__name__)
 
 
 class EvictionController(StorageControllerInterface):
     def __init__(
         self,
-        storage_manager: "StorageManager",
         l1_manager: L1Manager,
         eviction_config: EvictionConfig,
     ):
-        super().__init__(storage_manager, l1_manager)
+        super().__init__(l1_manager)
 
         self._eviction_config = eviction_config
         self._eviction_policy = CreateEvictionPolicy(self._eviction_config)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -22,8 +22,11 @@ from lmcache.v1.distributed.storage_controllers import (
     EvictionController,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.mp_observability.logger.storage_manager_stats_logger import (
+    StorageManagerStatsLogger,
+)
 from lmcache.v1.mp_observability.prometheus_controller import (
-    PrometheusController,
+    get_prometheus_controller,
 )
 
 logger = init_logger(__name__)
@@ -48,17 +51,10 @@ class StorageManager:
         )
         self._eviction_controller.start()
 
-        if config.prometheus_config.enabled:
-            self._prometheus_controller: PrometheusController | None = (
-                PrometheusController(
-                    storage_manager=self,
-                    l1_manager=self._l1_manager,
-                    log_interval=config.prometheus_config.log_interval,
-                )
-            )
-            self._prometheus_controller.start()
-        else:
-            self._prometheus_controller = None
+        # Self-register observability logger
+        sm_stats_logger = StorageManagerStatsLogger()
+        self.register_listener(sm_stats_logger)
+        get_prometheus_controller().register_logger(sm_stats_logger)
 
     def register_listener(self, listener: StorageManagerListener) -> None:
         """Register a listener for StorageManager events.
@@ -276,8 +272,6 @@ class StorageManager:
         Close the storage manager and release all resources.
         """
         self._eviction_controller.stop()
-        if self._prometheus_controller is not None:
-            self._prometheus_controller.stop()
         self._l1_manager.close()
 
     # Functions for debugging and testing

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -45,7 +45,6 @@ class StorageManager:
 
         # Eviction controller
         self._eviction_controller = EvictionController(
-            storage_manager=self,
             l1_manager=self._l1_manager,
             eviction_config=config.eviction_config,
         )

--- a/lmcache/v1/mp_observability/LOGGER_GUIDE.md
+++ b/lmcache/v1/mp_observability/LOGGER_GUIDE.md
@@ -100,42 +100,33 @@ class MyListener(PrometheusLogger):
 
 ---
 
-## Step 3 — Register with PrometheusController
+## Step 3 — Self-register with the global PrometheusController
 
-In `lmcache/v1/mp_observability/prometheus_controller.py`, add your logger
-in `__init__` alongside the existing loggers:
+Each module creates its own logger and registers it with the global singleton.
+No changes to `PrometheusController` are needed.
+
+In your module's `__init__` (or wherever setup happens):
 
 ```python
 from lmcache.v1.mp_observability.logger.my_logger import MyListener
+from lmcache.v1.mp_observability.prometheus_controller import get_prometheus_controller
 
-class PrometheusController(StorageControllerInterface):
-    def __init__(self, storage_manager, l1_manager, log_interval):
-        super().__init__(storage_manager, l1_manager)
-        self._log_interval = log_interval
-        self.all_loggers: List[PrometheusLogger] = []
+class MyModule:
+    def __init__(self):
+        # ... existing setup ...
 
-        # Existing loggers
-        self.sm_stats_logger = StorageManagerStatsLogger()
-        self.get_storage_manager().register_listener(self.sm_stats_logger)
-        self.all_loggers.append(self.sm_stats_logger)
-
-        self.l1_stats_logger = L1ManagerStatsLogger()
-        self.get_l1_manager().register_listener(self.l1_stats_logger)
-        self.all_loggers.append(self.l1_stats_logger)
-
-        # New logger — register with whatever event source it needs
-        self.my_logger = MyListener()
-        # e.g. self.get_storage_manager().register_listener(self.my_logger)
-        self.all_loggers.append(self.my_logger)   # <-- this is all that's needed
-                                                  #     for periodic flushing
-
-        # ... thread setup unchanged ...
+        # Self-register observability logger
+        my_logger = MyListener()
+        # If your logger also implements a listener interface, register it:
+        # self.register_listener(my_logger)
+        get_prometheus_controller().register_logger(my_logger)
 ```
 
-`PrometheusController._run()` iterates `self.all_loggers` and calls `log_prometheus()`
-on each one at every interval. Adding to `all_loggers` is the only change required —
-no modifications to `_run()` are needed. Exceptions from individual loggers are caught
-and logged, so a broken logger cannot crash the loop.
+`PrometheusController._run()` iterates `all_loggers` and calls `log_prometheus()`
+on each one at every interval. Calling `register_logger()` is the only step required —
+no modifications to the controller are needed. The controller takes a thread-safe
+snapshot of loggers before each flush cycle, so late registration is safe. Exceptions
+from individual loggers are caught and logged, so a broken logger cannot crash the loop.
 
 ---
 

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -6,6 +6,7 @@ Configuration for the MP-mode Prometheus observability stack.
 
 # Standard
 from dataclasses import dataclass
+import argparse
 
 
 @dataclass
@@ -22,3 +23,61 @@ class PrometheusConfig:
 
     log_interval: float = 10.0
     """ How often (in seconds) to flush accumulated stats to Prometheus. """
+
+
+DEFAULT_PROMETHEUS_CONFIG = PrometheusConfig(enabled=False)
+
+
+def add_prometheus_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """
+    Add Prometheus configuration arguments to an existing parser.
+
+    Args:
+        parser: The argument parser to add arguments to.
+
+    Returns:
+        argparse.ArgumentParser: The same parser with Prometheus arguments added.
+    """
+    prometheus_group = parser.add_argument_group(
+        "Prometheus Observability", "Configuration for Prometheus metrics"
+    )
+    prometheus_group.add_argument(
+        "--disable-prometheus",
+        action="store_true",
+        default=False,
+        help="Disable Prometheus metrics collection and HTTP server.",
+    )
+    prometheus_group.add_argument(
+        "--prometheus-port",
+        type=int,
+        default=9090,
+        help="Port to expose the Prometheus /metrics endpoint on. Default is 9090.",
+    )
+    prometheus_group.add_argument(
+        "--prometheus-log-interval",
+        type=float,
+        default=10.0,
+        help="How often (in seconds) to flush stats to Prometheus. Default is 10.0.",
+    )
+    return parser
+
+
+def parse_args_to_prometheus_config(
+    args: argparse.Namespace,
+) -> PrometheusConfig:
+    """
+    Convert parsed command line arguments to a PrometheusConfig.
+
+    Args:
+        args: Parsed arguments from the argument parser.
+
+    Returns:
+        PrometheusConfig: The configuration object.
+    """
+    return PrometheusConfig(
+        enabled=not args.disable_prometheus,
+        port=args.prometheus_port,
+        log_interval=args.prometheus_log_interval,
+    )

--- a/lmcache/v1/mp_observability/prometheus_controller.py
+++ b/lmcache/v1/mp_observability/prometheus_controller.py
@@ -1,85 +1,93 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from typing import TYPE_CHECKING, List
+from typing import List
 import threading
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.l1_manager import L1Manager
-from lmcache.v1.distributed.storage_controller import (
-    StorageControllerInterface,
-)
-from lmcache.v1.mp_observability.logger.l1_stats_logger import (
-    L1ManagerStatsLogger,
-)
+from lmcache.v1.mp_observability.config import PrometheusConfig
 from lmcache.v1.mp_observability.logger.prometheus_logger import (
     PrometheusLogger,
 )
-from lmcache.v1.mp_observability.logger.storage_manager_stats_logger import (
-    StorageManagerStatsLogger,
-)
-
-if TYPE_CHECKING:
-    # First Party
-    from lmcache.v1.distributed.storage_manager import StorageManager
 
 logger = init_logger(__name__)
 
 
-class PrometheusController(StorageControllerInterface):
-    def __init__(
-        self,
-        storage_manager: "StorageManager",
-        l1_manager: L1Manager,
-        log_interval: float,
-    ):
-        super().__init__(storage_manager, l1_manager)
-
-        self._log_interval = log_interval
+class PrometheusController:
+    def __init__(self, config: PrometheusConfig):
+        self._config = config
+        self._lock = threading.Lock()
         self.all_loggers: List[PrometheusLogger] = []
 
-        self.sm_stats_logger: StorageManagerStatsLogger = StorageManagerStatsLogger()
-        self.get_storage_manager().register_listener(self.sm_stats_logger)
-        self.all_loggers.append(self.sm_stats_logger)
-
-        self.l1_stats_logger: L1ManagerStatsLogger = L1ManagerStatsLogger()
-        self.get_l1_manager().register_listener(self.l1_stats_logger)
-        self.all_loggers.append(self.l1_stats_logger)
-
-        # TODO: adding more stats loggers, e.g., integrator logger or mp server logger
-
         self._stop_flag = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def register_logger(self, prom_logger: PrometheusLogger) -> None:
+        """Register a logger for periodic flushing.
+
+        Thread-safe: may be called after start().
+
+        Args:
+            prom_logger: The PrometheusLogger to register.
+        """
+        with self._lock:
+            self.all_loggers.append(prom_logger)
+
+    def start(self) -> None:
+        """Start the periodic flush thread.
+
+        No-op when ``config.enabled`` is False.
+        """
+        if not self._config.enabled:
+            return
 
         self._thread = threading.Thread(
             target=self._run,
             daemon=True,
             name="PrometheusController",
         )
-
-    def start(self):
         logger.info(
-            "Starting PrometheusController (interval=%.1fs)...", self._log_interval
+            "Starting PrometheusController (interval=%.1fs)...",
+            self._config.log_interval,
         )
-        all_logger_names = [
-            type(prometheus_logger).__name__ for prometheus_logger in self.all_loggers
-        ]
-        logger.info(f"Registered PrometheusLogger: {all_logger_names}.")
+        with self._lock:
+            all_logger_names = [type(pl).__name__ for pl in self.all_loggers]
+        logger.info("Registered PrometheusLogger: %s.", all_logger_names)
         self._thread.start()
 
-    def stop(self):
+    def stop(self) -> None:
+        """Stop the flush thread. Safe to call when not started."""
         self._stop_flag.set()
-        self._thread.join()
-        for prometheus_logger in self.all_loggers:
-            prometheus_logger.unregister()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join()
+            for pl in self.all_loggers:
+                pl.unregister()
 
-    def _run(self):
-        while not self._stop_flag.wait(timeout=self._log_interval):
-            for prometheus_logger in self.all_loggers:
+    def _run(self) -> None:
+        while not self._stop_flag.wait(timeout=self._config.log_interval):
+            with self._lock:
+                snapshot = list(self.all_loggers)
+            for pl in snapshot:
                 try:
-                    prometheus_logger.log_prometheus()
+                    pl.log_prometheus()
                 except Exception:
                     logger.exception(
                         "PrometheusController: error logging %s",
-                        type(prometheus_logger).__name__,
+                        type(pl).__name__,
                     )
+
+
+_global_controller = PrometheusController(PrometheusConfig(enabled=False))
+
+
+def get_prometheus_controller() -> PrometheusController:
+    """Return the current global PrometheusController singleton."""
+    return _global_controller
+
+
+def init_prometheus_controller(config: PrometheusConfig) -> PrometheusController:
+    """Replace the global singleton with a new controller built from *config*."""
+    global _global_controller
+    _global_controller = PrometheusController(config)
+    return _global_controller

--- a/lmcache/v1/multiprocess/blend_server.py
+++ b/lmcache/v1/multiprocess/blend_server.py
@@ -26,6 +26,14 @@ from lmcache.v1.gpu_connector.gpu_ops import (
     lmcache_memcpy_async_h2d,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.mp_observability.config import (
+    PrometheusConfig,
+    parse_args_to_prometheus_config,
+)
+from lmcache.v1.mp_observability.prometheus_controller import (
+    get_prometheus_controller,
+    init_prometheus_controller,
+)
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
@@ -604,6 +612,7 @@ def add_handler_helper(
 
 def run_cache_server(
     storage_manager_config: StorageManagerConfig,
+    prometheus_config: PrometheusConfig,
     host: str = "localhost",
     port: int = 5555,
     chunk_size: int = 256,
@@ -616,6 +625,7 @@ def run_cache_server(
 
     Args:
         storage_manager_config: Configuration for the storage manager
+        prometheus_config: Configuration for the Prometheus observability stack
         host: ZMQ server host
         port: ZMQ server port
         chunk_size: Chunk size for KV cache operations
@@ -628,9 +638,12 @@ def run_cache_server(
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
         If return_engine is False: None (blocks until interrupted)
     """
+    # Initialize global prometheus controller
+    init_prometheus_controller(prometheus_config)
+
     sep_tokens = get_sep_tokens()
 
-    # Initialize the engine
+    # Initialize the engine (loggers self-register with the global controller)
     engine = BlendEngine(
         sep_tokens=sep_tokens,
         storage_manager_config=storage_manager_config,
@@ -678,6 +691,9 @@ def run_cache_server(
     # Start the ZMQ server
     torch.cuda.init()
     server.start()
+
+    # Start prometheus controller after engine creation (loggers are registered)
+    get_prometheus_controller().start()
     logger.info("LMCache cache blend server is running...")
 
     # Return server and engine if requested (for HTTP server integration)
@@ -690,6 +706,7 @@ def run_cache_server(
             time.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
+        get_prometheus_controller().stop()
         server.close()
         engine.close()
 
@@ -697,8 +714,10 @@ def run_cache_server(
 if __name__ == "__main__":
     args = parse_args()
     storage_manager_config = parse_args_to_config(args)
+    prometheus_config = parse_args_to_prometheus_config(args)
     run_cache_server(
         storage_manager_config=storage_manager_config,
+        prometheus_config=prometheus_config,
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -17,6 +17,10 @@ from lmcache.v1.distributed.config import (
     L1MemoryManagerConfig,
     StorageManagerConfig,
 )
+from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
+from lmcache.v1.mp_observability.prometheus_controller import (
+    get_prometheus_controller,
+)
 from lmcache.v1.multiprocess.server import run_cache_server
 
 logger = init_logger(__name__)
@@ -67,6 +71,7 @@ async def lifespan(app: FastAPI):
     logger.info("Starting LMCache HTTP server...")
     zmq_server, engine = run_cache_server(
         storage_manager_config=_server_config.to_storage_manager_config(),
+        prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
         host=_server_config.zmq_host,
         port=_server_config.zmq_port,
         chunk_size=_server_config.chunk_size,
@@ -81,6 +86,7 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     logger.info("Shutting down LMCache HTTP server...")
+    get_prometheus_controller().stop()
     if hasattr(app.state, "zmq_server") and app.state.zmq_server is not None:
         app.state.zmq_server.close()
     logger.info("LMCache HTTP server stopped")

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -28,6 +28,15 @@ from lmcache.v1.gpu_connector.gpu_ops import (
     lmcache_memcpy_async_h2d,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.mp_observability.config import (
+    PrometheusConfig,
+    add_prometheus_args,
+    parse_args_to_prometheus_config,
+)
+from lmcache.v1.mp_observability.prometheus_controller import (
+    get_prometheus_controller,
+    init_prometheus_controller,
+)
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
@@ -453,6 +462,7 @@ def add_handler_helper(
 
 def run_cache_server(
     storage_manager_config: StorageManagerConfig,
+    prometheus_config: PrometheusConfig,
     host: str = "localhost",
     port: int = 5555,
     chunk_size: int = 256,
@@ -465,6 +475,7 @@ def run_cache_server(
 
     Args:
         storage_manager_config: Configuration for the storage manager
+        prometheus_config: Configuration for the Prometheus observability stack
         host: ZMQ server host
         port: ZMQ server port
         chunk_size: Chunk size for KV cache operations
@@ -477,15 +488,18 @@ def run_cache_server(
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
         If return_engine is False: None (blocks until interrupted)
     """
+    # Initialize global prometheus controller
+    init_prometheus_controller(prometheus_config)
+
     # Start Prometheus metrics HTTP server if enabled
-    if storage_manager_config.prometheus_config.enabled:
-        metrics_port = storage_manager_config.prometheus_config.port
-        prometheus_client.start_http_server(metrics_port)
+    if prometheus_config.enabled:
+        prometheus_client.start_http_server(prometheus_config.port)
         logger.info(
-            "Prometheus metrics available at http://0.0.0.0:%d/metrics", metrics_port
+            "Prometheus metrics available at http://0.0.0.0:%d/metrics",
+            prometheus_config.port,
         )
 
-    # Initialize the engine
+    # Initialize the engine (loggers self-register with the global controller)
     engine = MPCacheEngine(
         storage_manager_config=storage_manager_config,
         chunk_size=chunk_size,
@@ -515,6 +529,9 @@ def run_cache_server(
     # Start the ZMQ server
     torch.cuda.init()
     server.start()
+
+    # Start prometheus controller after engine creation (loggers are registered)
+    get_prometheus_controller().start()
     logger.info("LMCache cache server is running...")
 
     # Return server and engine if requested (for HTTP server integration)
@@ -527,6 +544,7 @@ def run_cache_server(
             time.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
+        get_prometheus_controller().stop()
         server.close()
         engine.close()
 
@@ -554,14 +572,17 @@ def parse_args():
         help="Hash algorithm for token-based operations (builtin, sha256_cbor, blake3)",
     )
     parser = add_storage_manager_args(parser)
+    parser = add_prometheus_args(parser)
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
     storage_manager_config = parse_args_to_config(args)
+    prometheus_config = parse_args_to_prometheus_config(args)
     run_cache_server(
         storage_manager_config=storage_manager_config,
+        prometheus_config=prometheus_config,
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/tests/v1/distributed/conftest.py
+++ b/tests/v1/distributed/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared fixtures for distributed module tests.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.logger.prometheus_logger import (
+    PrometheusLogger,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_prometheus_classes(monkeypatch):
+    """Prevent real Prometheus metric registration during distributed tests.
+
+    L1Manager and StorageManager now self-register observability loggers on
+    construction. Without this fixture, creating multiple instances across
+    tests would collide in the global Prometheus CollectorRegistry.
+    """
+    monkeypatch.setattr(PrometheusLogger, "_counter_cls", MagicMock)
+    monkeypatch.setattr(PrometheusLogger, "_histogram_cls", MagicMock)
+    monkeypatch.setattr(PrometheusLogger, "_gauge_cls", MagicMock)

--- a/tests/v1/mp_observability/test_prometheus_controller.py
+++ b/tests/v1/mp_observability/test_prometheus_controller.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Unit tests for PrometheusController.
+Unit tests for PrometheusController (global-singleton design).
 
 Tests cover:
-- SMStatsLogger is registered with StorageManager
-- L1StatsLogger is registered with L1Manager
+- register_logger() adds loggers to all_loggers
 - start() / stop() lifecycle (no deadlock, thread terminates)
+- start() is a no-op when config.enabled is False
+- stop() is safe when not started
 - _run() calls log_prometheus() on every logger each interval
+- _run() takes a snapshot of loggers under lock (thread-safe with late registration)
 - Exceptions raised by a logger do not crash the run loop
-- The stop flag terminates the loop even mid-sleep
+- Global singleton: get_prometheus_controller() / init_prometheus_controller()
 """
 
 # Standard
@@ -19,12 +21,16 @@ import time
 import pytest
 
 # First Party
+from lmcache.v1.mp_observability.config import PrometheusConfig
 from lmcache.v1.mp_observability.logger.prometheus_logger import (
     PrometheusLogger,
 )
 from lmcache.v1.mp_observability.prometheus_controller import (
     PrometheusController,
+    get_prometheus_controller,
+    init_prometheus_controller,
 )
+import lmcache.v1.mp_observability.prometheus_controller as _ctrl_module
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -38,62 +44,43 @@ def mock_prometheus_classes(monkeypatch):
     monkeypatch.setattr(PrometheusLogger, "_histogram_cls", MagicMock)
 
 
-@pytest.fixture
-def mock_l1_manager():
-    """Minimal L1Manager mock that tracks registered listeners."""
-    l1 = MagicMock()
-    l1._registered_listeners = []
-    l1.register_listener.side_effect = lambda lst: l1._registered_listeners.append(lst)
-    return l1
+@pytest.fixture(autouse=True)
+def restore_global_controller():
+    """Save and restore the global _global_controller so tests don't leak state."""
+    saved = _ctrl_module._global_controller
+    yield
+    _ctrl_module._global_controller = saved
 
 
 @pytest.fixture
-def mock_storage_manager():
-    """Minimal StorageManager mock that tracks registered listeners."""
-    sm = MagicMock()
-    sm._registered_listeners = []
-    sm.register_listener.side_effect = lambda lst: sm._registered_listeners.append(lst)
-    return sm
-
-
-@pytest.fixture
-def controller(mock_storage_manager, mock_l1_manager):
+def controller():
     """PrometheusController with a very short log interval for fast tests."""
     return PrometheusController(
-        storage_manager=mock_storage_manager,
-        l1_manager=mock_l1_manager,
-        log_interval=0.02,
+        PrometheusConfig(enabled=True, log_interval=0.02),
     )
 
 
 # ---------------------------------------------------------------------------
-# Listener registration
+# Logger registration
 # ---------------------------------------------------------------------------
 
 
-class TestListenerRegistration:
-    def test_sm_stats_logger_registered_with_storage_manager(
-        self, controller, mock_storage_manager
-    ):
-        mock_storage_manager.register_listener.assert_called_once_with(
-            controller.sm_stats_logger
-        )
+class TestLoggerRegistration:
+    def test_register_logger_adds_to_all_loggers(self, controller):
+        mock_logger = MagicMock(spec=PrometheusLogger)
+        controller.register_logger(mock_logger)
+        assert mock_logger in controller.all_loggers
 
-    def test_l1_stats_logger_registered_with_l1_manager(
-        self, controller, mock_l1_manager
-    ):
-        mock_l1_manager.register_listener.assert_called_once_with(
-            controller.l1_stats_logger
-        )
+    def test_register_multiple_loggers(self, controller):
+        loggers = [MagicMock(spec=PrometheusLogger) for _ in range(3)]
+        for lg in loggers:
+            controller.register_logger(lg)
+        assert len(controller.all_loggers) == 3
+        for lg in loggers:
+            assert lg in controller.all_loggers
 
-    def test_sm_stats_logger_in_all_loggers(self, controller):
-        assert controller.sm_stats_logger in controller.all_loggers
-
-    def test_l1_stats_logger_in_all_loggers(self, controller):
-        assert controller.l1_stats_logger in controller.all_loggers
-
-    def test_all_loggers_has_two_entries(self, controller):
-        assert len(controller.all_loggers) == 2
+    def test_all_loggers_empty_initially(self, controller):
+        assert len(controller.all_loggers) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -103,8 +90,8 @@ class TestListenerRegistration:
 
 class TestLifecycle:
     def test_start_launches_thread(self, controller):
-        assert not controller._thread.is_alive()
         controller.start()
+        assert controller._thread is not None
         assert controller._thread.is_alive()
         controller.stop()
 
@@ -114,17 +101,28 @@ class TestLifecycle:
         assert not controller._thread.is_alive()
 
     def test_stop_without_start_does_not_raise(self, controller):
-        """Calling stop() before start() sets the flag and join() returns immediately
-        because the thread was never started (join on a non-started thread raises, so
-        we verify the flag is set and the thread is not alive)."""
-        controller._stop_flag.set()
-        assert not controller._thread.is_alive()
+        """Calling stop() before start() must not raise."""
+        controller.stop()
+
+    def test_start_noop_when_disabled(self):
+        ctrl = PrometheusController(PrometheusConfig(enabled=False))
+        ctrl.start()
+        assert ctrl._thread is None
+
+    def test_stop_safe_when_disabled(self):
+        ctrl = PrometheusController(PrometheusConfig(enabled=False))
+        ctrl.start()
+        ctrl.stop()  # Should not raise
 
     def test_thread_is_daemon(self, controller):
+        controller.start()
         assert controller._thread.daemon is True
+        controller.stop()
 
     def test_thread_name(self, controller):
+        controller.start()
         assert controller._thread.name == "PrometheusController"
+        controller.stop()
 
     def test_double_stop_is_safe(self, controller):
         """Calling stop() twice must not raise."""
@@ -140,42 +138,38 @@ class TestLifecycle:
 
 class TestPeriodicFlushing:
     def test_log_prometheus_called_multiple_times_during_run(self, controller):
-        """With a 20 ms interval, running for ~150 ms should trigger ≥ 3 flushes."""
-        flush_count = 0
-        original_log = controller.sm_stats_logger.log_prometheus
+        """With a 20 ms interval, running for ~150 ms should trigger >= 3 flushes."""
+        mock_logger = MagicMock()
+        controller.register_logger(mock_logger)
 
-        def counting_log():
-            nonlocal flush_count
-            flush_count += 1
-            original_log()
-
-        controller.sm_stats_logger.log_prometheus = counting_log
         controller.start()
         time.sleep(0.15)
         controller.stop()
 
-        assert flush_count >= 3, (
-            f"Expected at least 3 flushes in 150 ms with 20 ms interval, "
-            f"got {flush_count}"
-        )
+        assert mock_logger.log_prometheus.call_count >= 3
 
     def test_log_prometheus_not_called_before_first_interval(self, controller):
-        """log_prometheus() must NOT be called immediately on start — only after
-        the first interval elapses."""
-        call_times: list[float] = []
-        start_time = time.perf_counter()
+        """log_prometheus() must NOT be called immediately on start."""
+        mock_logger = MagicMock()
+        controller.register_logger(mock_logger)
 
-        def recording_log():
-            call_times.append(time.perf_counter() - start_time)
-
-        controller.sm_stats_logger.log_prometheus = recording_log
         controller.start()
         time.sleep(0.005)
         controller.stop()
 
-        assert call_times == [], (
-            "log_prometheus() was called before the first interval elapsed"
-        )
+        assert mock_logger.log_prometheus.call_count == 0
+
+    def test_late_registered_logger_is_flushed(self, controller):
+        """A logger registered after start() should still be flushed."""
+        controller.start()
+        time.sleep(0.01)
+
+        late_logger = MagicMock()
+        controller.register_logger(late_logger)
+        time.sleep(0.10)
+        controller.stop()
+
+        assert late_logger.log_prometheus.call_count >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -184,41 +178,25 @@ class TestPeriodicFlushing:
 
 
 class TestExceptionIsolation:
-    def test_exception_in_logger_does_not_crash_loop(
-        self, mock_storage_manager, mock_l1_manager
-    ):
-        """If a logger's log_prometheus() raises, the loop must continue and
-        call the next logger in all_loggers without crashing."""
-        controller = PrometheusController(
-            storage_manager=mock_storage_manager,
-            l1_manager=mock_l1_manager,
-            log_interval=0.02,
-        )
-
+    def test_exception_in_logger_does_not_crash_loop(self, controller):
+        """If a logger's log_prometheus() raises, the loop continues."""
         bad_logger = MagicMock()
         bad_logger.log_prometheus.side_effect = RuntimeError("boom")
         good_logger = MagicMock()
 
-        controller.all_loggers = [bad_logger, good_logger]
+        controller.register_logger(bad_logger)
+        controller.register_logger(good_logger)
         controller.start()
         time.sleep(0.12)
         controller.stop()
 
         assert good_logger.log_prometheus.call_count >= 3
 
-    def test_bad_logger_does_not_prevent_repeated_calls(
-        self, mock_storage_manager, mock_l1_manager
-    ):
-        """Even after an exception, the bad logger is retried in each interval."""
-        controller = PrometheusController(
-            storage_manager=mock_storage_manager,
-            l1_manager=mock_l1_manager,
-            log_interval=0.02,
-        )
-
+    def test_bad_logger_does_not_prevent_repeated_calls(self, controller):
+        """Even after an exception, the bad logger is retried each interval."""
         bad_logger = MagicMock()
         bad_logger.log_prometheus.side_effect = ValueError("always fails")
-        controller.all_loggers = [bad_logger]
+        controller.register_logger(bad_logger)
 
         controller.start()
         time.sleep(0.12)
@@ -243,3 +221,28 @@ class TestStopFlag:
         elapsed = time.perf_counter() - t0
 
         assert elapsed < 0.5, f"stop() took too long: {elapsed:.3f}s"
+
+
+# ---------------------------------------------------------------------------
+# Global singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalSingleton:
+    def test_get_returns_valid_instance(self):
+        ctrl = get_prometheus_controller()
+        assert isinstance(ctrl, PrometheusController)
+
+    def test_init_replaces_global(self):
+        old = get_prometheus_controller()
+        new = init_prometheus_controller(PrometheusConfig(enabled=False))
+        assert get_prometheus_controller() is new
+        assert get_prometheus_controller() is not old
+
+    def test_default_singleton_is_disabled(self):
+        """The module-level default should be disabled (safe no-op)."""
+        # After restore_global_controller fixture restores the original:
+        # just check we can register without error
+        ctrl = get_prometheus_controller()
+        mock_logger = MagicMock(spec=PrometheusLogger)
+        ctrl.register_logger(mock_logger)

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -33,6 +33,7 @@ from lmcache.v1.distributed.config import (
     L1MemoryManagerConfig,
     StorageManagerConfig,
 )
+from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
 from lmcache.v1.multiprocess.blend_server import get_sep_tokens
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
@@ -264,6 +265,7 @@ def server_process_runner(
     )
     run_cache_server(
         storage_manager_config=storage_manager_config,
+        prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
         host=host,
         port=port,
         chunk_size=chunk_size,

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -17,6 +17,7 @@ from lmcache.v1.distributed.config import (
     L1MemoryManagerConfig,
     StorageManagerConfig,
 )
+from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
@@ -214,6 +215,7 @@ def server_process_runner(
     )
     run_cache_server(
         storage_manager_config=storage_manager_config,
+        prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
         host=host,
         port=port,
         chunk_size=chunk_size,


### PR DESCRIPTION
## Summary

Resolves #2650 

- **Decouple `PrometheusController` from `StorageControllerInterface`**: it is now a standalone class with no knowledge of specific managers
- **Global singleton pattern**: `init_prometheus_controller(config)` creates the singleton at server startup; `get_prometheus_controller()` provides access from anywhere
- **Self-registration**: each module (`L1Manager`, `StorageManager`) creates and registers its own stats logger via `get_prometheus_controller().register_logger()`
- **Lifecycle moved to server layer**: `run_cache_server()` in both `server.py` and `blend_server.py` now owns `init → start → stop`
- **`PrometheusConfig` decoupled from `StorageManagerConfig`**: config parsing uses its own `add_prometheus_args()` / `parse_args_to_prometheus_config()` helpers
- **Clean up `StorageControllerInterface`**: remove `storage_manager` parameter since `PrometheusController` was the only consumer; `EvictionController` only needs `l1_manager`


## Test plan

- [x] `pytest -xvs tests/v1/mp_observability/` — 47 passed
- [x] `pytest -xvs tests/v1/distributed/` — 146 passed