### PR TITLE
[feat] Add unified `lmcache` CLI entry point with `server` subcommand

### DIFF
--- a/lmcache/cli/__init__.py
+++ b/lmcache/cli/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unified ``lmcache`` CLI entry point."""
+
+# Standard
+import argparse
+import sys
+
+# First Party
+from lmcache.cli.server import register_server_command
+
+
+def main() -> None:
+    """Parse CLI arguments and dispatch to the appropriate subcommand.
+
+    This is the entry point for the unified ``lmcache`` console script.
+    If no subcommand is given, the help message is printed and the
+    process exits with code 1.
+
+    Raises:
+        SystemExit: When no subcommand is provided.
+    """
+    parser = argparse.ArgumentParser(prog="lmcache", description="LMCache CLI")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Register subcommands
+    register_server_command(subparsers)
+
+    args = parser.parse_args()
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+    args.func(args)

--- a/lmcache/cli/server.py
+++ b/lmcache/cli/server.py
@@ -5,30 +5,10 @@
 import argparse
 
 # First Party
-from lmcache.v1.distributed.config import parse_args_to_config
-from lmcache.v1.multiprocess.server import add_server_args, run_cache_server
-
-
-def _handle_server(args: argparse.Namespace) -> None:
-    """Start the ZMQ cache server from parsed CLI arguments.
-
-    Converts the flat argparse namespace into a
-    :class:`StorageManagerConfig` and delegates to
-    :func:`run_cache_server`.
-
-    Args:
-        args: Parsed CLI arguments containing server and storage-manager
-            options.
-    """
-    storage_manager_config = parse_args_to_config(args)
-    run_cache_server(
-        storage_manager_config=storage_manager_config,
-        host=args.host,
-        port=args.port,
-        chunk_size=args.chunk_size,
-        max_workers=args.max_workers,
-        hash_algorithm=args.hash_algorithm,
-    )
+from lmcache.v1.multiprocess.server import (
+    add_server_args,
+    run_server_from_args,
+)
 
 
 def register_server_command(
@@ -37,7 +17,7 @@ def register_server_command(
     """Register the ``server`` subcommand on *subparsers*.
 
     Adds a ``server`` sub-parser with all server and storage-manager
-    arguments and wires it to :func:`_handle_server`.
+    arguments and wires it to :func:`run_server_from_args`.
 
     Args:
         subparsers (argparse._SubParsersAction): The subparsers action
@@ -48,4 +28,4 @@ def register_server_command(
         help="Start the LMCache ZMQ cache server",
     )
     add_server_args(server_parser)
-    server_parser.set_defaults(func=_handle_server)
+    server_parser.set_defaults(func=run_server_from_args)

--- a/lmcache/cli/server.py
+++ b/lmcache/cli/server.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache server`` subcommand — starts the ZMQ multiprocess cache server."""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.v1.distributed.config import parse_args_to_config
+from lmcache.v1.multiprocess.server import add_server_args, run_cache_server
+
+
+def _handle_server(args: argparse.Namespace) -> None:
+    """Start the ZMQ cache server from parsed CLI arguments.
+
+    Converts the flat argparse namespace into a
+    :class:`StorageManagerConfig` and delegates to
+    :func:`run_cache_server`.
+
+    Args:
+        args: Parsed CLI arguments containing server and storage-manager
+            options.
+    """
+    storage_manager_config = parse_args_to_config(args)
+    run_cache_server(
+        storage_manager_config=storage_manager_config,
+        host=args.host,
+        port=args.port,
+        chunk_size=args.chunk_size,
+        max_workers=args.max_workers,
+        hash_algorithm=args.hash_algorithm,
+    )
+
+
+def register_server_command(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Register the ``server`` subcommand on *subparsers*.
+
+    Adds a ``server`` sub-parser with all server and storage-manager
+    arguments and wires it to :func:`_handle_server`.
+
+    Args:
+        subparsers (argparse._SubParsersAction): The subparsers action
+            returned by :meth:`argparse.ArgumentParser.add_subparsers`.
+    """
+    server_parser = subparsers.add_parser(
+        "server",
+        help="Start the LMCache ZMQ cache server",
+    )
+    add_server_args(server_parser)
+    server_parser.set_defaults(func=_handle_server)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -567,6 +567,27 @@ def add_server_args(
     return parser
 
 
+def run_server_from_args(args: argparse.Namespace) -> None:
+    """Convert parsed CLI arguments into config and start the cache server.
+
+    This is the shared entry point used by both the standalone
+    ``__main__`` runner and the unified ``lmcache server`` CLI.
+
+    Args:
+        args: Parsed CLI arguments containing server and storage-manager
+            options.
+    """
+    storage_manager_config = parse_args_to_config(args)
+    run_cache_server(
+        storage_manager_config=storage_manager_config,
+        host=args.host,
+        port=args.port,
+        chunk_size=args.chunk_size,
+        max_workers=args.max_workers,
+        hash_algorithm=args.hash_algorithm,
+    )
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments for the standalone ZMQ cache server.
 
@@ -581,13 +602,4 @@ def parse_args() -> argparse.Namespace:
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    storage_manager_config = parse_args_to_config(args)
-    run_cache_server(
-        storage_manager_config=storage_manager_config,
-        host=args.host,
-        port=args.port,
-        chunk_size=args.chunk_size,
-        max_workers=args.max_workers,
-        hash_algorithm=args.hash_algorithm,
-    )
+    run_server_from_args(parse_args())

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -531,10 +531,20 @@ def run_cache_server(
         engine.close()
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description="LMCache ZMQ Cache Server (without HTTP)"
-    )
+def add_server_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Add server-specific CLI arguments to an existing argument parser.
+
+    This allows other modules (e.g. the unified ``lmcache`` CLI) to reuse
+    the same argument definitions without duplication.
+
+    Args:
+        parser: The argument parser to add arguments to.
+
+    Returns:
+        argparse.ArgumentParser: The same parser with server arguments added.
+    """
     parser.add_argument(
         "--host", type=str, default="localhost", help="Host to bind the ZMQ server"
     )
@@ -553,7 +563,20 @@ def parse_args():
         default="blake3",
         help="Hash algorithm for token-based operations (builtin, sha256_cbor, blake3)",
     )
-    parser = add_storage_manager_args(parser)
+    add_storage_manager_args(parser)
+    return parser
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the standalone ZMQ cache server.
+
+    Returns:
+        argparse.Namespace: The parsed arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="LMCache ZMQ Cache Server (without HTTP)"
+    )
+    add_server_args(parser)
     return parser.parse_args()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ requires-python = ">=3.10,<3.14"
 dynamic = ["dependencies", "version"]
 
 [project.scripts]
+lmcache="lmcache.cli:main"
 lmcache_v0_server="lmcache.server.__main__:main"
 lmcache_server="lmcache.v1.server.__main__:main"
 lmcache_controller="lmcache.v1.api_server.__main__:main"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Introduces `lmcache` CLI. The first functionality is `lmcache server`. This will make memorizing the lmcache mp server launch command much more easier.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
