### PR TITLE
[MP] Enable layout desc in MP lookup and prefetch

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -118,6 +118,8 @@ class LMCacheMPSchedulerAdapter:
 
         self.model_name = model_name
         self.world_size = world_size
+
+        # NOTE: this worker_id should not be used
         self.worker_id = kv_rank
 
         # Read chunk size from lmcache
@@ -157,19 +159,17 @@ class LMCacheMPSchedulerAdapter:
 
         aligned_end = (len(token_ids) // self.chunk_size) * self.chunk_size
 
-        keys = [
-            self._create_key(
-                token_ids,
-                start=0,
-                end=aligned_end,
-                request_id=request_id,
-            ).no_worker_id_version()
-        ]
+        key = self._create_key(
+            token_ids,
+            start=0,
+            end=aligned_end,
+            request_id=request_id,
+        ).no_worker_id_version()
 
         future = send_lmcache_request(
             self.mq_client,
             RequestType.LOOKUP,
-            [keys],
+            [key],
         )
         self.lookup_futures[request_id] = future
 
@@ -235,10 +235,12 @@ class LMCacheMPSchedulerAdapter:
         request_id: str,
     ) -> IPCCacheEngineKey:
         """Convert token IDs to an IPC cache engine key"""
+        # NOTE: for the scheduler adapter, we don't have a worker id,
+        # so we set it to None in the key.
         return IPCCacheEngineKey(
             model_name=self.model_name,
             world_size=self.world_size,
-            worker_id=self.worker_id,
+            worker_id=None,
             token_ids=tuple(token_ids),
             start=start,
             end=end,
@@ -313,7 +315,12 @@ class LMCacheMPWorkerAdapter:
         future = send_lmcache_request(
             self.mq_client,
             RequestType.REGISTER_KV_CACHE,
-            [self.instance_id, wrap_kv_caches(kv_caches)],
+            [
+                self.instance_id,
+                wrap_kv_caches(kv_caches),
+                self.model_name,
+                self.world_size,
+            ],
         )
         future.result()
 

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -119,9 +119,6 @@ class LMCacheMPSchedulerAdapter:
         self.model_name = model_name
         self.world_size = world_size
 
-        # NOTE: this worker_id should not be used
-        self.worker_id = kv_rank
-
         # Read chunk size from lmcache
         self.chunk_size = get_lmcache_chunk_size(self.mq_client)
         assert self.chunk_size % vllm_block_size == 0, (

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -206,6 +206,7 @@ class StorageManager:
     def submit_prefetch_task(
         self,
         keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
     ) -> PrefetchHandle:
         """
         Prefetch the objects into L1 memory asynchronously. The prefetched object

--- a/lmcache/v1/multiprocess/blend_server.py
+++ b/lmcache/v1/multiprocess/blend_server.py
@@ -107,20 +107,33 @@ class BlendEngine(MPCacheEngine):
 
         self._cb_gpu_contexts: dict[int, PlainGPUCacheContext] = {}
 
+        # CB GPU ID -> (model name, world size) as metadata
+        # NOTE: This is mainly for determining the layout desc during prefetch
+        self._cb_gpu_context_meta: dict[int, tuple[str, int]] = {}
+
         # self._sep_token_len = len(sep_tokens)
         # self._token_matcher = ParallelPatternMatcher(sep_tokens)
         self._token_matcher = RangePatternMatcher(sep_tokens[0], sep_tokens[1])
 
-    def cb_register_kv_cache(self, instance_id: int, kv_caches: KVCache) -> None:
+    def cb_register_kv_cache(
+        self,
+        instance_id: int,
+        kv_caches: KVCache,
+        model_name: str,
+        world_size: int,
+    ) -> None:
         """
         Register the KV cache buffer from the blend engine
 
         Args:
             instance_id: Unique identifier for the blend engine instance
             kv_caches: KVCache object containing the GPU buffer pointers
+            model_name: The name of the model associated with this KV cache.
+            world_size: The world size associated with this KV cache.
         """
         gpu_context = PlainGPUCacheContext(kv_caches, self.chunk_size)
         self._cb_gpu_contexts[instance_id] = gpu_context
+        self._cb_gpu_context_meta[instance_id] = (model_name, world_size)
         logger.info(
             "Registered CB KV cache for instance_id %d with %d layers",
             instance_id,
@@ -136,6 +149,7 @@ class BlendEngine(MPCacheEngine):
         """
         if instance_id in self._cb_gpu_contexts:
             del self._cb_gpu_contexts[instance_id]
+            del self._cb_gpu_context_meta[instance_id]
             logger.info("Unregistered CB KV cache for instance_id %d", instance_id)
         else:
             logger.warning(
@@ -164,7 +178,27 @@ class BlendEngine(MPCacheEngine):
         expected_found_count: list[int] = []
         found_ranges: list[tuple[int, int]] = []
         ranges = self._separate_tokens_by_pattern(key.token_ids)
-        world_size = key.world_size
+        model_name, world_size = key.model_name, key.world_size
+
+        # Find the cb gpu context and calculate the layout desc
+        layout_desc: MemoryLayoutDesc | None = None
+        for gpu_id, (m_name, w_size) in self._cb_gpu_context_meta.items():
+            if m_name == model_name and w_size == world_size:
+                cb_ctx = self._cb_gpu_contexts[gpu_id]
+                layout_desc = MemoryLayoutDesc(
+                    shapes=[cb_ctx.get_kv_buffer_shape(self.chunk_size)],
+                    dtypes=[cb_ctx.dtype],
+                )
+                break
+
+        if layout_desc is None:
+            logger.error(
+                "No CB GPU context found for model %s with world size %d "
+                "during cb_lookup_pre_computed!",
+                model_name,
+                world_size,
+            )
+            return []
 
         # Submit Lookup for each paragraph
         for start, end in ranges:
@@ -176,7 +210,7 @@ class BlendEngine(MPCacheEngine):
             )
 
             obj_keys = ipc_keys_to_object_keys(ipc_keys)
-            handle = self.storage_manager.submit_prefetch_task(obj_keys)
+            handle = self.storage_manager.submit_prefetch_task(obj_keys, layout_desc)
 
             prefetch_handles.append(handle)
             expected_found_count.append(len(ipc_keys))

--- a/lmcache/v1/multiprocess/protocols/blend.py
+++ b/lmcache/v1/multiprocess/protocols/blend.py
@@ -89,9 +89,11 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload:
         #   - instance_id: int - Unique identifier for the vLLM instance
         #   - kv_cache: KVCache - The CB KV cache configuration
+        #   - model_name: str - Name of the model associated with the engine
+        #   - world_size: int - World size of the engine
         # Returns: None
         "CB_REGISTER_KV_CACHE": ProtocolDefinition(
-            payload_classes=[int, KVCache],
+            payload_classes=[int, KVCache, str, int],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -41,9 +41,11 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload:
         #   - instance_id: int - Unique identifier for the vLLM instance
         #   - kv_cache: KVCache - The KV cache configuration
+        #   - model_name: str - Name of the model associated with the engine
+        #   - world_size: int - World size of the engine
         # Returns: None
         "REGISTER_KV_CACHE": ProtocolDefinition(
-            payload_classes=[int, KVCache],
+            payload_classes=[int, KVCache, str, int],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),
@@ -82,10 +84,10 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         ),
         # Lookup keys in cache
         # Payload:
-        #   - keys: list[KeyType] - Cache keys to look up
+        #   - key: KeyType - Cache key to look up
         # Returns: int - Number of keys found in cache
         "LOOKUP": ProtocolDefinition(
-            payload_classes=[list[KeyType]],
+            payload_classes=[KeyType],
             response_class=int,
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -104,6 +104,21 @@ def resolve_key(
     ]
 
 
+def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
+    """Get the memory layout description for a given GPU context and number of tokens.
+
+    Args:
+        gpu_context: The GPU cache context containing the KV cache information.
+        num_tokens: The number of tokens to determine the layout for.
+
+    Returns:
+        MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
+    """
+    shape = gpu_context.get_kv_buffer_shape(num_tokens)
+    dtype = gpu_context.dtype
+    return MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+
+
 # Main class for the mp cache engine
 class MPCacheEngine:
     def __init__(
@@ -114,6 +129,12 @@ class MPCacheEngine:
     ):
         # GPU ID -> KV cache tensors
         self.gpu_contexts: dict[int, GPUCacheContext] = {}
+
+        # GPU ID -> (model name, world size) as metadata
+        # NOTE: This is mainly for determining the layout desc during prefetch
+        # We assume that if the (model name, world size) is the same, then
+        # the layout desc returned by the gpu context is the same.
+        self.gpu_context_meta: dict[int, tuple[str, int]] = {}
 
         # chunk size
         self.chunk_size = chunk_size
@@ -130,16 +151,25 @@ class MPCacheEngine:
         )
         self.session_manager = SessionManager(self.token_hasher)
 
-    def register_kv_cache(self, instance_id: int, kv_caches: KVCache) -> None:
+    def register_kv_cache(
+        self,
+        instance_id: int,
+        kv_caches: KVCache,
+        model_name: str,
+        world_size: int,
+    ) -> None:
         """
         Registers the KV cache tensors for a given GPU instance ID.
 
         Args:
             instance_id (int): The GPU instance ID (such as PID).
             kv_caches (KVCache): The KV cache tensor wrappers from vLLM.
+            model_name (str): The name of the model associated with this KV cache.
+            world_size (int): The world size associated with this KV cache.
         """
         gpu_context = GPUCacheContext(kv_caches, self.chunk_size)
         self.gpu_contexts[instance_id] = gpu_context
+        self.gpu_context_meta[instance_id] = (model_name, world_size)
         logger.info(
             "Registered KV cache for GPU ID %d with %d layers",
             instance_id,
@@ -155,6 +185,7 @@ class MPCacheEngine:
         """
         if instance_id in self.gpu_contexts:
             del self.gpu_contexts[instance_id]
+            del self.gpu_context_meta[instance_id]
             logger.info("Unregistered KV cache for GPU ID %d", instance_id)
             torch.cuda.empty_cache()
         else:
@@ -211,11 +242,7 @@ class MPCacheEngine:
             )
             vllm_event.wait(stream=gpu_context.stream)
 
-            num_tokens = self.chunk_size
-            cpu_shape = gpu_context.get_kv_buffer_shape(num_tokens)
-            layout_desc = MemoryLayoutDesc(
-                shapes=[cpu_shape], dtypes=[gpu_context.dtype]
-            )
+            layout_desc = get_layout_desc(gpu_context, self.chunk_size)
             reserved_dict = self.storage_manager.reserve_write(
                 obj_keys, layout_desc, "new"
             )
@@ -231,7 +258,7 @@ class MPCacheEngine:
                 slot_mapping = slot_mapping_tensor[start:end]
 
                 # Copy from GPU to CPU
-                tmp_buffer = gpu_context.get_tmp_gpu_buffer(num_tokens)
+                tmp_buffer = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
                 with self.lock:
                     lmc_ops.multi_layer_kv_transfer(
                         tmp_buffer,
@@ -364,7 +391,7 @@ class MPCacheEngine:
 
     def lookup(
         self,
-        keys: list[IPCCacheEngineKey],
+        key: IPCCacheEngineKey,
     ) -> int:
         """Lookup prefix cache hits for the given keys.
 
@@ -376,13 +403,32 @@ class MPCacheEngine:
             Number of matched chunks (prefix match count).
         """
         ipc_keys: list[IPCCacheEngineKey] = []
-        for key in keys:
-            ipc_keys.extend(key.to_hash_keys(self.token_hasher))
+        model_name, world_size = key.model_name, key.world_size
+
+        # Find the gpu context and calculate the layout desc
+        layout_desc: MemoryLayoutDesc | None = None
+        for gpu_id, (m_name, w_size) in self.gpu_context_meta.items():
+            if m_name == model_name and w_size == world_size:
+                layout_desc = get_layout_desc(
+                    self.gpu_contexts[gpu_id], self.chunk_size
+                )
+                break
+
+        if layout_desc is None:
+            logger.error(
+                "No GPU context found for model %s with world size %d during lookup!",
+                model_name,
+                world_size,
+            )
+            return 0
+
+        # Prepare for the obj keys
+        ipc_keys.extend(key.to_hash_keys(self.token_hasher))
         if not ipc_keys:
             return 0
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
 
-        handle = self.storage_manager.submit_prefetch_task(obj_keys)
+        handle = self.storage_manager.submit_prefetch_task(obj_keys, layout_desc)
         while True:
             found_count = self.storage_manager.query_prefetch_status(handle)
             if found_count is not None:

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -207,7 +207,7 @@ class TestStorageManagerBasic:
         storage_manager.finish_write(list(ret.keys()))
 
         # Prefetch all the objects
-        handle = storage_manager.submit_prefetch_task(object_keys)
+        handle = storage_manager.submit_prefetch_task(object_keys, basic_layout)
 
         hit_count = storage_manager.query_prefetch_status(handle)
         assert hit_count is not None
@@ -233,7 +233,7 @@ class TestStorageManagerBasic:
         storage_manager.finish_write(list(ret.keys()))
 
         # Prefetch all the objects
-        handle = storage_manager.submit_prefetch_task(object_keys)
+        handle = storage_manager.submit_prefetch_task(object_keys, basic_layout)
 
         hit_count = storage_manager.query_prefetch_status(handle)
         assert hit_count is not None
@@ -263,7 +263,7 @@ class TestStorageManagerBasic:
         storage_manager.finish_write(list(ret.keys()))
 
         # Prefetch all the objects
-        handle = storage_manager.submit_prefetch_task(object_keys)
+        handle = storage_manager.submit_prefetch_task(object_keys, basic_layout)
 
         hit_count = storage_manager.query_prefetch_status(handle)
         assert hit_count is not None
@@ -301,7 +301,7 @@ class TestStorageManagerBasic:
         storage_manager.finish_write(list(ret.keys()))
 
         # Prefetch objects except the first one
-        handle = storage_manager.submit_prefetch_task(object_keys[1:])
+        handle = storage_manager.submit_prefetch_task(object_keys[1:], basic_layout)
         hit_count = storage_manager.query_prefetch_status(handle)
         assert hit_count is not None
         assert hit_count == len(object_keys) - 1

--- a/tests/v1/distributed/test_object_key_parallel.py
+++ b/tests/v1/distributed/test_object_key_parallel.py
@@ -181,7 +181,7 @@ class TestStorageManagerTPLookup:
 
         # Create interleaved lookup keys for scheduler-style lookup
         lookup_keys = create_interleaved_lookup_keys(num_chunks, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # All keys should be found (5 chunks * 2 workers = 10)
@@ -209,7 +209,7 @@ class TestStorageManagerTPLookup:
 
         # Create interleaved lookup keys for scheduler-style lookup
         lookup_keys = create_interleaved_lookup_keys(num_chunks, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # Only worker 0's first chunk is found, then lookup stops
@@ -241,7 +241,7 @@ class TestStorageManagerTPLookup:
 
         # Create interleaved lookup keys for scheduler-style lookup
         lookup_keys = create_interleaved_lookup_keys(num_chunks, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # First lookup key is chunk0_worker0 which is missing
@@ -275,7 +275,7 @@ class TestStorageManagerTPLookup:
 
         # Request 5 chunks with scheduler-style interleaved lookup
         lookup_keys = create_interleaved_lookup_keys(num_requested_chunks, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # First 3 chunks * 2 workers = 6 keys found, then stops at chunk3_worker0
@@ -318,7 +318,7 @@ class TestStorageManagerTPLookup:
 
         # Request 5 chunks with scheduler-style interleaved lookup
         lookup_keys = create_interleaved_lookup_keys(5, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # Lookup order:
@@ -358,7 +358,7 @@ class TestStorageManagerTPLookup:
 
         # Scheduler-style interleaved lookup
         lookup_keys = create_interleaved_lookup_keys(num_chunks, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # All keys found: 3 chunks * 4 workers = 12
@@ -390,7 +390,7 @@ class TestStorageManagerTPLookup:
 
         # Scheduler-style interleaved lookup
         lookup_keys = create_interleaved_lookup_keys(num_chunks, world_size)
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # Lookup order: chunk0_w0, chunk0_w1, chunk0_w2, chunk0_w3, ...
@@ -437,7 +437,7 @@ class TestStorageManagerTPStoreRetrieve:
         storage_manager.finish_write(list(reserved_dict1.keys()))
 
         # Prefetch to secure both entries
-        handle = storage_manager.submit_prefetch_task([key_w0, key_w1])
+        handle = storage_manager.submit_prefetch_task([key_w0, key_w1], test_layout)
         _ = storage_manager.query_prefetch_status(handle)
 
         # Both should be retrievable independently
@@ -467,7 +467,7 @@ class TestStorageManagerTPStoreRetrieve:
             all_keys.extend(keys)
 
         # Prefetch to secure all entries
-        handle = storage_manager.submit_prefetch_task(all_keys)
+        handle = storage_manager.submit_prefetch_task(all_keys, test_layout)
         _ = storage_manager.query_prefetch_status(handle)
 
         # Retrieve only worker 0's data
@@ -516,7 +516,7 @@ class TestTPEdgeCases:
         storage_manager.finish_write(list(reserved_dict.keys()))
 
         # Lookup should find all chunks
-        handle = storage_manager.submit_prefetch_task(storage_keys)
+        handle = storage_manager.submit_prefetch_task(storage_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
         assert found_count == num_chunks
 
@@ -559,7 +559,7 @@ class TestTPEdgeCases:
                 )
 
         # All keys should be found
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
         assert found_count == num_chunks * world_size
 
@@ -597,7 +597,7 @@ class TestTPEdgeCases:
         storage_manager.finish_write(list(reserved_dict.keys()))
 
         # Lookup all keys
-        handle = storage_manager.submit_prefetch_task(storage_keys)
+        handle = storage_manager.submit_prefetch_task(storage_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
         assert found_count == world_size
 
@@ -661,7 +661,7 @@ class TestTPIntegration:
                         world_size=world_size,
                     )
                 )
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
 
         # Step 4: Verify hit count
@@ -729,6 +729,6 @@ class TestTPIntegration:
                         world_size=world_size,
                     )
                 )
-        handle = storage_manager.submit_prefetch_task(lookup_keys)
+        handle = storage_manager.submit_prefetch_task(lookup_keys, test_layout)
         found_count = storage_manager.query_prefetch_status(handle)
         assert found_count == num_chunks * world_size

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -369,7 +369,7 @@ def cb_registered_instance(
     # Register CB KV cache
     future = client.submit_request(
         RequestType.CB_REGISTER_KV_CACHE,
-        [instance_id, cb_client_context.get_kv_cache()],
+        [instance_id, cb_client_context.get_kv_cache(), "testmodel", 1],
         get_response_class(RequestType.CB_REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -405,7 +405,7 @@ def registered_instance(
     # Register KV cache
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache()],
+        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -492,7 +492,7 @@ def test_cb_register_unregister_kv_cache(
     # Register
     future = client.submit_request(
         RequestType.CB_REGISTER_KV_CACHE,
-        [instance_id, cb_client_context.get_kv_cache()],
+        [instance_id, cb_client_context.get_kv_cache(), "testmodel", 1],
         get_response_class(RequestType.CB_REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -525,7 +525,7 @@ def test_cb_register_multiple_instances(
     for instance_id in instance_ids:
         future = client.submit_request(
             RequestType.CB_REGISTER_KV_CACHE,
-            [instance_id, cb_client_context.get_kv_cache()],
+            [instance_id, cb_client_context.get_kv_cache(), "testmodel", 1],
             get_response_class(RequestType.CB_REGISTER_KV_CACHE),
         )
         result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -1313,7 +1313,7 @@ def test_cb_store_final_then_normal_lookup_retrieve(
 
     lookup_future = client.submit_request(
         RequestType.LOOKUP,
-        [[lookup_key]],
+        [lookup_key],
         get_response_class(RequestType.LOOKUP),
     )
     lookup_result = lookup_future.result(timeout=DEFAULT_TIMEOUT)

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -143,12 +143,26 @@ def create_cache_key(index: int, model: str = "testmodel") -> IPCCacheEngineKey:
     )
 
 
-def lookup_keys(keys: list[IPCCacheEngineKey]) -> list[IPCCacheEngineKey]:
-    """Create lookup keys: worker_id=None."""
-    return [k.no_worker_id_version() for k in keys]
-
-
 BLOCKS_PER_KEY = 16
+
+
+def lookup_all(
+    client: MessageQueueClient,
+    keys: list[IPCCacheEngineKey],
+    timeout: float = DEFAULT_TIMEOUT,
+) -> int:
+    """Lookup all keys individually and return total found count."""
+    total = 0
+    for key in keys:
+        lookup_key = key.no_worker_id_version()
+        future = client.submit_request(
+            RequestType.LOOKUP,
+            [lookup_key],
+            get_response_class(RequestType.LOOKUP),
+        )
+        result = future.result(timeout=timeout)
+        total += result
+    return total
 
 
 def store_keys(
@@ -302,7 +316,7 @@ def registered_instance(
     # Register KV cache
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache()],
+        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -352,7 +366,7 @@ def test_register_unregister_kv_cache(
     # Register
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache()],
+        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -390,22 +404,12 @@ def test_store_and_lookup(
     store_keys(client, keys, registered_instance, gpu_block_ids, event)
 
     # Lookup - keys that exist
-    lookup_future = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(keys)],
-        get_response_class(RequestType.LOOKUP),
-    )
-    lookup_result = lookup_future.result(timeout=DEFAULT_TIMEOUT)
+    lookup_result = lookup_all(client, keys)
     assert lookup_result == num_keys, "All stored keys should exist"
 
     # Lookup - keys that don't exist
     non_existent_keys = [create_cache_key(i + 1000) for i in range(5)]
-    lookup_future2 = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(non_existent_keys)],
-        get_response_class(RequestType.LOOKUP),
-    )
-    lookup_result2 = lookup_future2.result(timeout=DEFAULT_TIMEOUT)
+    lookup_result2 = lookup_all(client, non_existent_keys)
     assert lookup_result2 == 0, "Non-existent keys should not be found"
 
 
@@ -434,12 +438,7 @@ def test_store_retrieve_verify(
     event.record()
 
     # Call look up to ensure the data is ready to be retrieved
-    lookup_future = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(keys)],
-        get_response_class(RequestType.LOOKUP),
-    )
-    lookup_result = lookup_future.result(timeout=DEFAULT_TIMEOUT)
+    lookup_result = lookup_all(client, keys)
     assert lookup_result == num_keys
 
     # Retrieve to a different location in the cache
@@ -494,12 +493,7 @@ def test_retrieve_partial_miss(
     store_keys(client, stored_keys, registered_instance, store_block_ids, event)
 
     # Lookup to ensure keys are stored
-    lookup_future = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(stored_keys)],
-        get_response_class(RequestType.LOOKUP),
-    )
-    lookup_result = lookup_future.result(timeout=DEFAULT_TIMEOUT)
+    lookup_result = lookup_all(client, stored_keys)
     assert lookup_result == num_stored
 
     # Try to retrieve 60 keys (only first 30 exist)
@@ -527,12 +521,7 @@ def test_retrieve_partial_miss(
     )
 
     # Doing look up again to ensure data is ready
-    lookup_future_2 = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(stored_keys)],
-        get_response_class(RequestType.LOOKUP),
-    )
-    lookup_result_2 = lookup_future_2.result(timeout=DEFAULT_TIMEOUT)
+    lookup_result_2 = lookup_all(client, stored_keys)
     assert lookup_result_2 == num_stored
 
     # Try to retrieve the first 30 keys only (all exist)
@@ -593,13 +582,7 @@ def test_multiple_retrieve_operations(
         for batch_idx in range(num_batches)
         for i in range(keys_per_batch)
     ]
-    lookup_future = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(all_keys)],
-        get_response_class(RequestType.LOOKUP),
-    )
-
-    lookup_result = lookup_future.result(timeout=DEFAULT_TIMEOUT)
+    lookup_result = lookup_all(client, all_keys)
     assert lookup_result == num_batches * keys_per_batch, "All stored keys should exist"
 
     # Retrieve in batches
@@ -667,12 +650,7 @@ def test_multiple_store_operations(
 
     # Verify all keys exist
     all_keys = keys1 + keys2
-    lookup_result = client.submit_request(
-        RequestType.LOOKUP,
-        [lookup_keys(all_keys)],
-        get_response_class(RequestType.LOOKUP),
-    ).result(timeout=DEFAULT_TIMEOUT)
-
+    lookup_result = lookup_all(client, all_keys)
     assert lookup_result == 50, "All stored keys from both batches should exist"
 
 

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -368,7 +368,7 @@ def test_mq_register_kv_cache():
     # Run test with REGISTER_KV_CACHE request
     helper.run_test(
         request_type=RequestType.REGISTER_KV_CACHE,
-        payloads=[gpu_id, kv_cache],
+        payloads=[gpu_id, kv_cache, "testmodel", 1],
         expected_response=None,
         num_requests=1,
     )
@@ -476,13 +476,13 @@ def test_mq_retrieve():
 def test_mq_lookup():
     """
     Test MessageQueue with LOOKUP request type.
-    LOOKUP takes (keys: list[KeyType]) and returns int.
+    LOOKUP takes (key: KeyType) and returns int.
     """
-    # Create test keys
-    keys = [create_cache_key(i) for i in range(4)]
+    # Create a single test key
+    key = create_cache_key(0)
 
-    # Expected response: count of even-indexed keys (0, 2) = 2
-    expected_response = 2
+    # Expected response: 1 (dummy handler always returns 1)
+    expected_response = 1
 
     # Create test helper and register handler
     helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5564")
@@ -491,22 +491,22 @@ def test_mq_lookup():
     # Run test with LOOKUP request
     helper.run_test(
         request_type=RequestType.LOOKUP,
-        payloads=[keys],
+        payloads=[key],
         expected_response=expected_response,
         num_requests=1,
     )
 
 
-def test_mq_lookup_with_different_key_count():
+def test_mq_lookup_with_different_key():
     """
-    Test MessageQueue with LOOKUP request type with different number of keys.
-    Tests that the handler correctly counts matched keys.
+    Test MessageQueue with LOOKUP request type with a different key.
+    Tests that the handler correctly processes a single key.
     """
-    # Create test keys
-    keys = [create_cache_key(i) for i in range(3)]
+    # Create a different test key
+    key = create_cache_key(42)
 
-    # Expected response: count of even-indexed keys (0, 2) = 2
-    expected_response = 2
+    # Expected response: 1 (dummy handler always returns 1)
+    expected_response = 1
 
     # Create test helper and register handler
     helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5565")
@@ -515,7 +515,7 @@ def test_mq_lookup_with_different_key_count():
     # Run test with LOOKUP request
     helper.run_test(
         request_type=RequestType.LOOKUP,
-        payloads=[keys],
+        payloads=[key],
         expected_response=expected_response,
         num_requests=1,
     )

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -28,13 +28,17 @@ def noop_handler() -> str:
 # ==============================================================================
 
 
-def register_kv_cache_handler(gpu_id: int, kv_cache: KVCache) -> None:
+def register_kv_cache_handler(
+    gpu_id: int, kv_cache: KVCache, model_name: str, world_size: int
+) -> None:
     """
     Dummy handler for REGISTER_KV_CACHE requests.
 
     Args:
         gpu_id: GPU device ID
         kv_cache: List of CudaIPCWrapper objects representing KV cache
+        model_name: Name of the model associated with this KV cache
+        world_size: World size associated with this KV cache
 
     Returns:
         None
@@ -44,6 +48,12 @@ def register_kv_cache_handler(gpu_id: int, kv_cache: KVCache) -> None:
     assert isinstance(gpu_id, int), f"Expected gpu_id to be int, got {type(gpu_id)}"
     assert isinstance(kv_cache, list), (
         f"Expected kv_cache to be list, got {type(kv_cache)}"
+    )
+    assert isinstance(model_name, str), (
+        f"Expected model_name to be str, got {type(model_name)}"
+    )
+    assert isinstance(world_size, int), (
+        f"Expected world_size to be int, got {type(world_size)}"
     )
     # No return value (returns None implicitly)
 
@@ -136,18 +146,17 @@ def retrieve_handler(
 # ==============================================================================
 
 
-def lookup_handler(keys: list[KeyType]) -> int:
+def lookup_handler(key: KeyType) -> int:
     """
     Dummy handler for LOOKUP requests.
 
     Args:
-        keys: List of cache keys to look up (request_id embedded in each key)
+        key: Cache key to look up (request_id embedded in the key)
 
     Returns:
-        int: Number of matched keys (count of even-indexed keys for testing)
+        int: Number of matched chunks (always returns 1 for testing)
     """
-    # In a real implementation, this would look up keys in the cache
-    # For testing, we just validate the inputs and return dummy results
-    assert isinstance(keys, list), f"Expected keys to be list, got {type(keys)}"
-    # Return count of "found" keys (alternating pattern for testing)
-    return sum(1 for i in range(len(keys)) if i % 2 == 0)
+    # In a real implementation, this would look up the key in the cache
+    # For testing, we just validate the input and return a dummy result
+    assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
+    return 1


### PR DESCRIPTION
## Summary
- Pass `layout_desc` to `storage_manager.submit_prefetch_task()` in both `MPCacheEngine.lookup` and `BlendEngine.cb_lookup_pre_computed`, preparing for future PrefetchController implementation
- Add `gpu_context_meta` dict to `MPCacheEngine` and `_cb_gpu_context_meta` to `BlendEngine` to track `(model_name, world_size)` per registered GPU instance, enabling layout desc derivation during lookup/prefetch
- Update `REGISTER_KV_CACHE` and `CB_REGISTER_KV_CACHE` protocols to carry `model_name` and `world_size`
- Change `LOOKUP` protocol from `list[KeyType]` to single `KeyType` payload
- Extract `get_layout_desc()` helper to replace inline layout construction in `store()`
- Update `vllm_multi_process_adapter.py` to pass `model_name`/`world_size` during registration and use single-key LOOKUP

## Test plan
- [x] `pytest tests/v1/multiprocess/test_mq.py` — 10/10 passed
- [x] `pytest tests/v1/multiprocess/test_cache_server.py` — 8/8 passed
- [x] `pytest tests/v1/multiprocess/test_blend_server.py` — 21/21 passed

