### PR TITLE
Refactor remote plugin to accept multiply connector

### DIFF
--- a/docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst
+++ b/docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst
@@ -68,8 +68,7 @@ Mixing different connector types:
     remote_storage_plugins: ["fs.local", "mooncakestore"]
     extra_config:
       remote_storage_plugin.fs.local.base_path: /data/cache
-      remote_storage_plugin.mooncakestore.host: localhost
-      remote_storage_plugin.mooncakestore.port: 50051
+      remote_storage_plugin.mooncakestore.master_server_address: "localhost:50051"
 
 How to Integrate Custom Remote Storage with LMCache
 ---------------------------------------------------
@@ -242,9 +241,12 @@ The adapter module (``adapter.py``):
     from lmcache.v1.storage_backend.connector import (
         ConnectorAdapter,
         ConnectorContext,
+        extract_plugin_type,
     )
     from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
     from .connector import MyStoreConnector
+
+    PLUGIN_TYPE = "mystore"
 
     class MyStoreConnectorAdapter(ConnectorAdapter):
         def __init__(self) -> None:
@@ -254,12 +256,8 @@ The adapter module (``adapter.py``):
             if url.startswith(self.schema):
                 return True
             if url.startswith("plugin://"):
-                from lmcache.v1.storage_backend.connector import (
-                    extract_plugin_type,
-                )
-                return extract_plugin_type(
-                    url[len("plugin://"):]
-                ) == "mystore"
+                pname = url[len("plugin://"):]
+                return extract_plugin_type(pname) == PLUGIN_TYPE
             return False
 
         def create_connector(self, context: ConnectorContext) -> RemoteConnector:

--- a/docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst
+++ b/docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst
@@ -4,6 +4,11 @@ Remote Storage Plugins
 LMCache supports built-in remote storage connectors for Redis, InfiniStore, MooncakeStore, S3, and more.
 The remote storage plugin system provides the ability to add custom storage connectors through dynamic loading. This enables extending remote storage capabilities without modifying core code.
 
+.. note::
+
+   The ``remote_url`` configuration is **deprecated** and will be removed in a future release.
+   Please use ``remote_storage_plugins`` instead.
+
 Connector Definition Requirements
 ---------------------------------
 A custom remote storage connector requires two classes:
@@ -23,10 +28,51 @@ A custom remote storage connector requires two classes:
 
    The ``ConnectorAdapter`` constructor receives no arguments from LMCache. The scheme should be set by calling the parent constructor with the scheme string.
 
-   The ``create_connector`` method receives a ``ConnectorContext`` object containing the URL, event loop, local CPU backend, config, and metadata.
+   The ``create_connector`` method receives a ``ConnectorContext`` object containing the URL, event loop, local CPU backend, config, metadata, and ``plugin_name``.
 
-How to Integrate Remote Storage with LMCache
-----------------------------------------------
+Plugin Naming Convention
+-----------------------
+Plugin names follow the format ``{type}`` or ``{type}.{instance}``:
+
+- ``{type}`` — a single instance of that connector type (e.g. ``fs``, ``mooncakestore``)
+- ``{type}.{instance}`` — a named instance, allowing **multiple instances of the same type** (e.g. ``fs.primary``, ``fs.backup``)
+
+The framework extracts the *type* portion (everything before the first ``.``) to locate the matching ``ConnectorAdapter``. The full plugin name is used as the configuration key prefix.
+
+Using Built-in Connectors via Plugins
+-------------------------------------
+Built-in connectors (``fs``, ``mooncakestore``, etc.) can be used directly via ``remote_storage_plugins`` without specifying ``module_path`` or ``class_name``. Their configuration is placed under ``extra_config``:
+
+.. code-block:: yaml
+
+    chunk_size: 64
+    local_cpu: False
+    max_local_cpu_size: 5
+    remote_storage_plugins: ["fs"]
+    extra_config:
+      remote_storage_plugin.fs.base_path: /tmp/lmcache
+
+Multiple instances of the same connector type:
+
+.. code-block:: yaml
+
+    remote_storage_plugins: ["fs.primary", "fs.backup"]
+    extra_config:
+      remote_storage_plugin.fs.primary.base_path: /data/cache1
+      remote_storage_plugin.fs.backup.base_path: /data/cache2
+
+Mixing different connector types:
+
+.. code-block:: yaml
+
+    remote_storage_plugins: ["fs.local", "mooncakestore"]
+    extra_config:
+      remote_storage_plugin.fs.local.base_path: /data/cache
+      remote_storage_plugin.mooncakestore.host: localhost
+      remote_storage_plugin.mooncakestore.port: 50051
+
+How to Integrate Custom Remote Storage with LMCache
+---------------------------------------------------
 1. Install your connector package in the LMCache environment
 2. Add ``remote_storage_plugins`` and its related ``module_path`` and ``class_name`` to the ``extra_config`` section of LMCache configuration as follows:
 
@@ -35,30 +81,40 @@ How to Integrate Remote Storage with LMCache
     chunk_size: 64
     local_cpu: False
     max_local_cpu_size: 5
-    remote_url: "mystore://localhost:8080"
     remote_storage_plugins: ["mystore"]
     extra_config:
       remote_storage_plugin.mystore.module_path: <module_path>
       remote_storage_plugin.mystore.class_name: <adapter_class_name>
 
-An example configuration for a custom remote storage connector is as follows:
+An example configuration for a custom remote storage connector:
 
 .. code-block:: yaml
 
     chunk_size: 64
     local_cpu: False
     max_local_cpu_size: 5
-    remote_url: "mystore://localhost:8080/data"
     remote_storage_plugins: ["mystore"]
     extra_config:
       remote_storage_plugin.mystore.module_path: my_package.my_connector
       remote_storage_plugin.mystore.class_name: MyStoreConnectorAdapter
 
+Multiple instances of a custom connector:
+
+.. code-block:: yaml
+
+    remote_storage_plugins: ["mystore.region_a", "mystore.region_b"]
+    extra_config:
+      remote_storage_plugin.mystore.region_a.module_path: my_package.my_connector
+      remote_storage_plugin.mystore.region_a.class_name: MyStoreConnectorAdapter
+      remote_storage_plugin.mystore.region_b.module_path: my_package.my_connector
+      remote_storage_plugin.mystore.region_b.class_name: MyStoreConnectorAdapter
+
 .. note::
 
-   - The ``remote_url`` scheme must match the scheme registered by your ``ConnectorAdapter``
-   - ``remote_storage_plugin.<connector_name>`` distinguishes different dynamically loaded connectors
+   - ``remote_url`` is **deprecated**; use ``remote_storage_plugins`` instead
+   - ``remote_storage_plugin.<plugin_name>`` uses the full plugin name (including instance suffix) as the key prefix
    - Multiple remote storage plugins can be loaded simultaneously
+   - Built-in connectors do not require ``module_path`` / ``class_name``
 
 ConnectorAdapter Implementation
 -------------------------------
@@ -75,12 +131,25 @@ The ``ConnectorAdapter`` class is responsible for:
     )
     from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 
+    from lmcache.v1.storage_backend.connector import extract_plugin_type
+
+    PLUGIN_TYPE = "mystore"
+
     class MyStoreConnectorAdapter(ConnectorAdapter):
         """Adapter for MyStore remote storage."""
 
         def __init__(self) -> None:
             # Register the URL scheme this adapter handles
             super().__init__("mystore://")
+
+        def can_parse(self, url: str) -> bool:
+            """Match legacy URL or plugin://{type}[.{instance}] format."""
+            if url.startswith(self.schema):
+                return True
+            if url.startswith("plugin://"):
+                pname = url[len("plugin://"):]
+                return extract_plugin_type(pname) == PLUGIN_TYPE
+            return False
 
         def create_connector(self, context: ConnectorContext) -> RemoteConnector:
             """Create and return a MyStoreConnector instance."""
@@ -89,7 +158,13 @@ The ``ConnectorAdapter`` class is responsible for:
             # - context.loop: asyncio event loop
             # - context.config: LMCacheEngineConfig
             # - context.metadata: LMCacheEngineMetadata
-            return MyStoreConnector(context.config, context.metadata)
+            # - context.plugin_name: plugin instance name
+            #   (e.g. "mystore", "mystore.region_a")
+            return MyStoreConnector(
+                context.config,
+                context.metadata,
+                plugin_name=context.plugin_name,
+            )
 
 RemoteConnector Implementation
 ------------------------------
@@ -175,11 +250,23 @@ The adapter module (``adapter.py``):
         def __init__(self) -> None:
             super().__init__("mystore://")
 
+        def can_parse(self, url: str) -> bool:
+            if url.startswith(self.schema):
+                return True
+            if url.startswith("plugin://"):
+                from lmcache.v1.storage_backend.connector import (
+                    extract_plugin_type,
+                )
+                return extract_plugin_type(
+                    url[len("plugin://"):]
+                ) == "mystore"
+            return False
+
         def create_connector(self, context: ConnectorContext) -> RemoteConnector:
             return MyStoreConnector(
-                context.url,
                 context.config,
-                context.metadata
+                context.metadata,
+                plugin_name=context.plugin_name,
             )
 
 Configuration would then reference the adapter:

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -17,7 +17,7 @@ from lmcache.v1.storage_backend.gds_backend import GdsBackend
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 from lmcache.v1.storage_backend.p2p_backend import P2PBackend
-from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+from lmcache.v1.storage_backend.remote_backend import RemoteBackend  # noqa: F401
 
 if TYPE_CHECKING:
     # First Party
@@ -218,6 +218,38 @@ def CreateStorageBackends(
         )
         storage_backends[str(gds_backend)] = gds_backend
 
+    # Handle remote storage plugins (new way)
+    if config.remote_storage_plugins and "RemoteBackend" not in _skip:
+        for plugin_name in config.remote_storage_plugins:
+            assert local_cpu_backend is not None, (
+                "Remote backend requires local CPU backend as a buffer."
+                "Please turn on local cpu backend with max_local_cpu_size > 0"
+            )
+            try:
+                remote_backend = RemoteBackend(
+                    config,
+                    metadata,
+                    loop,
+                    local_cpu_backend,
+                    dst_device,
+                    plugin_name=plugin_name,
+                )
+                backend_name = "RemoteBackend-%s" % plugin_name
+                storage_backends[backend_name] = remote_backend
+                logger.info(
+                    "Created remote backend for plugin: %s",
+                    plugin_name,
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to create remote backend for plugin %s: %s",
+                    plugin_name,
+                    e,
+                )
+
+    # Handle legacy remote_url (deprecated but still supported)
+>>>>>>> 01afc8d8 (Refactor remote plugin to accept multiply connector.)
+=======
     if config.maru_path is not None and "MaruBackend" not in _skip:
         try:
             # First Party
@@ -232,10 +264,73 @@ def CreateStorageBackends(
         maru_backend = MaruBackend(config, metadata, loop, dst_device)
         storage_backends[str(maru_backend)] = maru_backend
 
+    # Handle remote storage plugins (new way)
+    if config.remote_storage_plugins and "RemoteBackend" not in _skip:
+        for plugin_name in config.remote_storage_plugins:
+            assert local_cpu_backend is not None, (
+                "Remote backend requires local CPU backend as a buffer."
+                "Please turn on local cpu backend with max_local_cpu_size > 0"
+            )
+            try:
+                remote_backend = RemoteBackend(
+                    config,
+                    metadata,
+                    loop,
+                    local_cpu_backend,
+                    dst_device,
+                    plugin_name=plugin_name,
+                )
+                backend_name = "RemoteBackend-%s" % plugin_name
+                storage_backends[backend_name] = remote_backend
+                logger.info(
+                    "Created remote backend for plugin: %s",
+                    plugin_name,
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to create remote backend for plugin %s: %s",
+                    plugin_name,
+                    e,
+                )
+
+    # Handle legacy remote_url (deprecated but still supported)
+=======
+    # Handle remote storage plugins (new way)
+    if config.remote_storage_plugins and "RemoteBackend" not in _skip:
+        for plugin_name in config.remote_storage_plugins:
+            assert local_cpu_backend is not None, (
+                "Remote backend requires local CPU backend as a buffer."
+                "Please turn on local cpu backend with max_local_cpu_size > 0"
+            )
+            try:
+                remote_backend = RemoteBackend(
+                    config,
+                    metadata,
+                    loop,
+                    local_cpu_backend,
+                    dst_device,
+                    plugin_name=plugin_name,
+                )
+                backend_name = "RemoteBackend-%s" % plugin_name
+                storage_backends[backend_name] = remote_backend
+                logger.info(
+                    "Created remote backend for plugin: %s",
+                    plugin_name,
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to create remote backend for plugin %s: %s",
+                    plugin_name,
+                    e,
+                )
+
+    # Handle legacy remote_url (deprecated but still supported)
+>>>>>>> 01afc8d8 (Refactor remote plugin to accept multiply connector.)
     if config.remote_url is not None and "RemoteBackend" not in _skip:
-        assert local_cpu_backend is not None, (
-            "Remote backend requires local CPU backend as a buffer."
-            "Please turn on local cpu backend with max_local_cpu_size > 0"
+        # Log deprecation warning
+        logger.warning(
+            "remote_url is deprecated and will be removed in a future release. "
+            "Please use remote_storage_plugins instead."
         )
         remote_backend = RemoteBackend(
             config,

--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -218,38 +218,6 @@ def CreateStorageBackends(
         )
         storage_backends[str(gds_backend)] = gds_backend
 
-    # Handle remote storage plugins (new way)
-    if config.remote_storage_plugins and "RemoteBackend" not in _skip:
-        for plugin_name in config.remote_storage_plugins:
-            assert local_cpu_backend is not None, (
-                "Remote backend requires local CPU backend as a buffer."
-                "Please turn on local cpu backend with max_local_cpu_size > 0"
-            )
-            try:
-                remote_backend = RemoteBackend(
-                    config,
-                    metadata,
-                    loop,
-                    local_cpu_backend,
-                    dst_device,
-                    plugin_name=plugin_name,
-                )
-                backend_name = "RemoteBackend-%s" % plugin_name
-                storage_backends[backend_name] = remote_backend
-                logger.info(
-                    "Created remote backend for plugin: %s",
-                    plugin_name,
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to create remote backend for plugin %s: %s",
-                    plugin_name,
-                    e,
-                )
-
-    # Handle legacy remote_url (deprecated but still supported)
->>>>>>> 01afc8d8 (Refactor remote plugin to accept multiply connector.)
-=======
     if config.maru_path is not None and "MaruBackend" not in _skip:
         try:
             # First Party
@@ -294,38 +262,6 @@ def CreateStorageBackends(
                 )
 
     # Handle legacy remote_url (deprecated but still supported)
-=======
-    # Handle remote storage plugins (new way)
-    if config.remote_storage_plugins and "RemoteBackend" not in _skip:
-        for plugin_name in config.remote_storage_plugins:
-            assert local_cpu_backend is not None, (
-                "Remote backend requires local CPU backend as a buffer."
-                "Please turn on local cpu backend with max_local_cpu_size > 0"
-            )
-            try:
-                remote_backend = RemoteBackend(
-                    config,
-                    metadata,
-                    loop,
-                    local_cpu_backend,
-                    dst_device,
-                    plugin_name=plugin_name,
-                )
-                backend_name = "RemoteBackend-%s" % plugin_name
-                storage_backends[backend_name] = remote_backend
-                logger.info(
-                    "Created remote backend for plugin: %s",
-                    plugin_name,
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to create remote backend for plugin %s: %s",
-                    plugin_name,
-                    e,
-                )
-
-    # Handle legacy remote_url (deprecated but still supported)
->>>>>>> 01afc8d8 (Refactor remote plugin to accept multiply connector.)
     if config.remote_url is not None and "RemoteBackend" not in _skip:
         # Log deprecation warning
         logger.warning(

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -94,6 +94,21 @@ class SafeLocalCPUBackend(LocalCPUBackend):
         return "SafeLocalCPUBackend(dummy)"
 
 
+def extract_plugin_type(plugin_name: str) -> str:
+    """Extract the type portion from a plugin name.
+
+    Plugin name format: ``{type}`` or ``{type}.{instance}``.
+    Returns the *type* part so that adapters can match by type.
+
+    Examples:
+        >>> extract_plugin_type("fs")
+        'fs'
+        >>> extract_plugin_type("fs.primary")
+        'fs'
+    """
+    return plugin_name.split(".", 1)[0]
+
+
 class ConnectorContext:
     """
     Context for creating a connector.
@@ -104,7 +119,8 @@ class ConnectorContext:
         local_cpu_backend: The local CPU backend
             (wrapped as SafeLocalCPUBackend if None)
         config: Optional LMCache engine configuration
-        parsed_url: Parsed representation of the URL
+        plugin_name: Optional plugin instance name
+            (e.g. "fs", "fs.primary")
     """
 
     def __init__(
@@ -114,6 +130,7 @@ class ConnectorContext:
         local_cpu_backend: Optional[LocalCPUBackend],
         config: Optional[LMCacheEngineConfig],
         metadata: Optional[LMCacheMetadata],
+        plugin_name: Optional[str] = None,
     ):
         self.url = url
         self.loop = loop
@@ -126,6 +143,7 @@ class ConnectorContext:
         )
         self.config = config
         self.metadata = metadata
+        self.plugin_name = plugin_name
 
     def get_full_chunk_size_bytes(self) -> int:
         """
@@ -168,6 +186,7 @@ class ConnectorManager:
         local_cpu_backend: Optional[LocalCPUBackend],
         config: Optional[LMCacheEngineConfig] = None,
         metadata: Optional[LMCacheMetadata] = None,
+        plugin_name: Optional[str] = None,
     ) -> None:
         logger.info("Initializing ConnectorManager")
         self.context = ConnectorContext(
@@ -176,6 +195,7 @@ class ConnectorManager:
             local_cpu_backend=local_cpu_backend,
             config=config,
             metadata=metadata,
+            plugin_name=plugin_name,
         )
         self.adapters: List[ConnectorAdapter] = []
         self._remote_adapters_builtin_launcher()
@@ -298,6 +318,7 @@ def CreateConnector(
     local_cpu_backend: Optional[LocalCPUBackend],
     config: Optional[LMCacheEngineConfig] = None,
     metadata: Optional[LMCacheMetadata] = None,
+    plugin_name: Optional[str] = None,
 ) -> InstrumentedRemoteConnector:
     """
     Create a remote connector from the given URL.
@@ -351,7 +372,9 @@ def CreateConnector(
     if "://" not in url:
         raise ValueError(f"Invalid remote url {url}: missing scheme")
 
-    manager = ConnectorManager(url, loop, local_cpu_backend, config, metadata)
+    manager = ConnectorManager(
+        url, loop, local_cpu_backend, config, metadata, plugin_name
+    )
     connector = manager.create_connector()
 
     return InstrumentedRemoteConnector(connector)

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -171,6 +171,46 @@ class ConnectorAdapter(ABC):
         pass
 
 
+class DynamicConnectorAdapter(ConnectorAdapter):
+    """Adapter that wraps a RemoteConnector class loaded
+    dynamically from plugin config.
+
+    When ``class_name`` points to a ``RemoteConnector`` subclass
+    rather than a ``ConnectorAdapter``, this wrapper is used to
+    instantiate the connector with the proper context.
+    """
+
+    def __init__(
+        self,
+        plugin_name: str,
+        connector_class: type,
+    ) -> None:
+        schema = "plugin://%s" % extract_plugin_type(plugin_name)
+        super().__init__(schema)
+        self._plugin_name = plugin_name
+        self._connector_class = connector_class
+
+    def can_parse(self, url: str) -> bool:
+        if url.startswith(self.schema):
+            return True
+        if url.startswith("plugin://"):
+            pname = url[len("plugin://") :]
+            return extract_plugin_type(pname) == extract_plugin_type(self._plugin_name)
+        return False
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        logger.info(
+            "Creating dynamic connector %s via %s",
+            self._plugin_name,
+            self._connector_class.__name__,
+        )
+        return self._connector_class(
+            loop=context.loop,
+            local_cpu_backend=context.local_cpu_backend,
+            config=context.config,
+        )
+
+
 class ConnectorManager:
     """
     Manager for creating connectors based on URL.
@@ -287,17 +327,33 @@ class ConnectorManager:
                 # Dynamically import the module
                 module = importlib.import_module(module_path)
                 # Get the class from the module
-                adapter_class = getattr(module, class_name)
-                adapter_instance = adapter_class()
-                if not isinstance(adapter_instance, ConnectorAdapter):
-                    logger.warning(
-                        f"Remote connector {remote_storage_plugin} adapter does not "
-                        f"implement the 'ConnectorAdapter' interface"
+                loaded_class = getattr(module, class_name)
+
+                if inspect.isclass(loaded_class) and issubclass(
+                    loaded_class, ConnectorAdapter
+                ):
+                    adapter_instance = loaded_class()
+                elif inspect.isclass(loaded_class) and issubclass(
+                    loaded_class, RemoteConnector
+                ):
+                    adapter_instance = DynamicConnectorAdapter(
+                        plugin_name=remote_storage_plugin,
+                        connector_class=loaded_class,
                     )
-                    adapter_instance = None
+                else:
+                    logger.warning(
+                        "Remote connector %s class %s is "
+                        "neither a ConnectorAdapter nor a "
+                        "RemoteConnector subclass",
+                        remote_storage_plugin,
+                        class_name,
+                    )
                     continue
                 self.adapters.append(adapter_instance)
-                logger.info(f"Discovered adapter: {adapter_class.__name__}")
+                logger.info(
+                    "Discovered adapter: %s",
+                    loaded_class.__name__,
+                )
             except (ImportError, AttributeError) as e:
                 logger.error(
                     f"Failed to load remote connector {remote_storage_plugin} due to "

--- a/lmcache/v1/storage_backend/connector/__init__.py
+++ b/lmcache/v1/storage_backend/connector/__init__.py
@@ -256,24 +256,31 @@ class ConnectorManager:
         for remote_storage_plugin in remote_storage_plugins:
             try:
                 extra_config = config.extra_config
-                if extra_config is None:
-                    logger.warning(
-                        f"Remote connector {remote_storage_plugin} configuration is "
-                        f"missing 'extra_config'."
-                    )
-                    continue
 
-                module_path = extra_config.get(
-                    f"remote_storage_plugin.{remote_storage_plugin}.module_path"
+                module_path = (
+                    extra_config.get(
+                        "remote_storage_plugin.%s.module_path" % remote_storage_plugin
+                    )
+                    if extra_config
+                    else None
                 )
-                class_name = extra_config.get(
-                    f"remote_storage_plugin.{remote_storage_plugin}.class_name"
+                class_name = (
+                    extra_config.get(
+                        "remote_storage_plugin.%s.class_name" % remote_storage_plugin
+                    )
+                    if extra_config
+                    else None
                 )
 
                 if not module_path or not class_name:
+                    # Skip silently when a builtin adapter
+                    # already handles this plugin type.
+                    plugin_url = "plugin://%s" % remote_storage_plugin
+                    if any(a.can_parse(plugin_url) for a in self.adapters):
+                        continue
                     logger.warning(
-                        f"Remote connector {remote_storage_plugin} missing adapter "
-                        f"module_path or class_name"
+                        "Remote connector %s missing adapter module_path or class_name",
+                        remote_storage_plugin,
                     )
                     continue
 

--- a/lmcache/v1/storage_backend/connector/fs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/fs_adapter.py
@@ -4,11 +4,16 @@ from lmcache.logging import init_logger
 from lmcache.v1.storage_backend.connector import (
     ConnectorAdapter,
     ConnectorContext,
+    extract_plugin_type,
     parse_remote_url,
 )
-from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.connector.base_connector import (
+    RemoteConnector,
+)
 
 logger = init_logger(__name__)
+
+PLUGIN_TYPE = "fs"
 
 
 class FsConnectorAdapter(ConnectorAdapter):
@@ -17,13 +22,30 @@ class FsConnectorAdapter(ConnectorAdapter):
     def __init__(self) -> None:
         super().__init__("fs://")
 
+    def can_parse(self, url: str) -> bool:
+        if url.startswith(self.schema):
+            return True
+        if url.startswith("plugin://"):
+            pname = url[len("plugin://") :]
+            return extract_plugin_type(pname) == PLUGIN_TYPE
+        return False
+
     def create_connector(self, context: ConnectorContext) -> RemoteConnector:
         # Local
         from .fs_connector import FSConnector
 
-        logger.info(f"Creating FS connector for URL: {context.url}")
-        parse_url = parse_remote_url(context.url)
+        logger.info("Creating FS connector")
+
+        # Legacy URL mode: extract base_path from URL
+        base_paths_str = None
+        if context.plugin_name is None:
+            parsed = parse_remote_url(context.url)
+            base_paths_str = parsed.path
 
         return FSConnector(
-            parse_url.path, context.loop, context.local_cpu_backend, context.config
+            context.loop,
+            context.local_cpu_backend,
+            context.config,
+            plugin_name=context.plugin_name,
+            base_paths_str=base_paths_str,
         )

--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -31,26 +31,51 @@ class FSConnector(RemoteConnector):
 
     def __init__(
         self,
-        base_paths_str: str,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
         config: Optional[LMCacheEngineConfig],
+        plugin_name: Optional[str] = None,
+        base_paths_str: Optional[str] = None,
     ):
         """
         Args:
-            base_paths_str: Comma separated storage paths
             loop: Asyncio event loop
             local_cpu_backend: Memory allocator interface
             config: Lmcache engine config
+            plugin_name: Plugin instance name
+                (e.g. "fs", "fs.primary")
+            base_paths_str: Comma-separated base paths
+                (legacy, passed from adapter when using
+                fs:// URL)
         """
-        # initialize base class, which includes some common attributes
-        super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
+        # initialize base class
+        super().__init__(
+            local_cpu_backend.config,
+            local_cpu_backend.metadata,
+        )
+
+        base_path = base_paths_str
+        if base_path is None:
+            # Resolve from extra_config
+            extra_config = config.extra_config if config else None
+            if extra_config is not None:
+                key_prefix = plugin_name or "fs"
+                base_path = extra_config.get(
+                    "remote_storage_plugin.%s.base_path" % key_prefix
+                )
+            if base_path is None:
+                if extra_config is not None:
+                    base_path = extra_config.get("fs_base_path")
+            if base_path is None:
+                raise ValueError(
+                    "FS connector requires base_path via URL or extra_config"
+                )
 
         # Parse comma separated paths
         self.base_paths = (
-            [Path(p.strip()) for p in base_paths_str.split(",")]
-            if "," in base_paths_str
-            else [Path(base_paths_str)]
+            [Path(p.strip()) for p in base_path.split(",")]
+            if "," in base_path
+            else [Path(base_path)]
         )
 
         self.loop = loop

--- a/lmcache/v1/storage_backend/connector/mooncakestore_adapter.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_adapter.py
@@ -4,11 +4,15 @@ from lmcache.logging import init_logger
 from lmcache.v1.storage_backend.connector import (
     ConnectorAdapter,
     ConnectorContext,
-    parse_remote_url,
+    extract_plugin_type,
 )
-from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.connector.base_connector import (
+    RemoteConnector,
+)
 
 logger = init_logger(__name__)
+
+PLUGIN_TYPE = "mooncakestore"
 
 
 class MooncakestoreConnectorAdapter(ConnectorAdapter):
@@ -17,24 +21,23 @@ class MooncakestoreConnectorAdapter(ConnectorAdapter):
     def __init__(self) -> None:
         super().__init__("mooncakestore://")
 
+    def can_parse(self, url: str) -> bool:
+        if url.startswith(self.schema):
+            return True
+        if url.startswith("plugin://"):
+            pname = url[len("plugin://") :]
+            return extract_plugin_type(pname) == PLUGIN_TYPE
+        return False
+
     def create_connector(self, context: ConnectorContext) -> RemoteConnector:
         # Local
         from .mooncakestore_connector import MooncakestoreConnector
 
-        logger.info(f"Creating Mooncakestore connector for URL: {context.url}")
-        hosts = context.url.split(",")
-        if len(hosts) > 1:
-            raise ValueError(
-                f"Only one host is supported for mooncakestore, but got {hosts}"
-            )
+        logger.info("Creating Mooncakestore connector")
 
-        parse_url = parse_remote_url(context.url)
-        device_name = parse_url.query_params.get("device", [""])[0]
         return MooncakestoreConnector(
-            host=parse_url.host,
-            port=parse_url.port,
-            dev_name=device_name,
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
             lmcache_config=context.config,
+            plugin_name=context.plugin_name,
         )

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -94,12 +94,10 @@ class MooncakeStoreConfig:
 class MooncakestoreConnector(RemoteConnector):
     def __init__(
         self,
-        host: str,
-        port: int,
-        dev_name,
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: LocalCPUBackend,
         lmcache_config: Optional[LMCacheEngineConfig],
+        plugin_name: Optional[str] = None,
     ):
         # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
@@ -129,11 +127,6 @@ class MooncakestoreConnector(RemoteConnector):
             else:
                 raise ValueError("MOONCAKE_CONFIG_PATH/lmcache_config must be provided")
 
-            if not self.config.master_server_address:
-                if host != "" and port != 0:
-                    self.config.master_server_address = host + ":" + str(port)
-            if dev_name != "":
-                self.config.device_name = dev_name
             logger.info("Mooncake Configuration loaded. config: %s", self.config)
 
             # Check if storage_root_dir exists and set environment variable

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -31,14 +31,26 @@ class RemoteBackend(StorageBackendInterface):
         loop: asyncio.AbstractEventLoop,
         local_cpu_backend: Optional[LocalCPUBackend],
         dst_device: str = "cuda",
+        plugin_name: Optional[str] = None,
     ):
         super().__init__(dst_device=dst_device)
         self.put_tasks: Set[CacheEngineKey] = set()
         self.lock = threading.Lock()
 
-        assert config.remote_url is not None
+        self.plugin_name = plugin_name
 
-        self.remote_url = config.remote_url
+        # Determine if we're using legacy remote_url or new plugin-based approach
+        if plugin_name is not None:
+            # Using plugin-based approach
+            self.remote_url = f"plugin://{plugin_name}"
+            logger.info(f"Creating RemoteBackend for plugin: {plugin_name}")
+        else:
+            # Legacy remote_url approach
+            if config.remote_url is None:
+                raise ValueError(
+                    "remote_url must be provided when not using plugin_name"
+                )
+            self.remote_url = config.remote_url
 
         self.local_cpu_backend = local_cpu_backend
 
@@ -116,17 +128,29 @@ class RemoteBackend(StorageBackendInterface):
             )
             return
         try:
-            assert self.config.remote_url is not None
+            # Determine the URL to use for connection
+            if self.plugin_name is not None:
+                # Using plugin-based approach
+                # Create a virtual URL that the adapter can recognize
+                url = f"plugin://{self.plugin_name}"
+                logger.info(f"Creating connector for plugin: {self.plugin_name}")
+            else:
+                # Legacy remote_url approach
+                if self.config.remote_url is None:
+                    raise ValueError(
+                        "remote_url must be provided when not using plugin_name"
+                    )
+                url = self.config.remote_url
+
             self.connection = CreateConnector(
-                self.config.remote_url,
+                url,
                 self.loop,
                 self.local_cpu_backend,
                 self.config,
                 self.metadata,
+                plugin_name=self.plugin_name,
             )
-            logger.info(
-                f"Connection initialized/re-established at {self.config.remote_url}"
-            )
+            logger.info(f"Connection initialized/re-established at {url}")
         except IrrecoverableException:
             logger.error("Irrecoverable error during connection initialization")
             raise

--- a/tests/v1/storage_backend/test_fs_connector.py
+++ b/tests/v1/storage_backend/test_fs_connector.py
@@ -30,6 +30,35 @@ def create_test_config(fs_path: str):
     return config
 
 
+def create_test_config_with_plugin(fs_path: str):
+    """Create a test configuration for FSConnector using remote_storage_plugins."""
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        remote_storage_plugins=["fs"],
+        remote_serde="naive",
+        lmcache_instance_id="test_instance",
+        extra_config={
+            "remote_storage_plugin.fs.base_path": fs_path,
+        },
+    )
+    return config
+
+
+def create_test_config_with_dual_plugins(fs_path1: str, fs_path2: str):
+    """Create config with two fs_connector instances."""
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        remote_storage_plugins=["fs.primary", "fs.backup"],
+        remote_serde="naive",
+        lmcache_instance_id="test_instance",
+        extra_config={
+            "remote_storage_plugin.fs.primary.base_path": fs_path1,
+            "remote_storage_plugin.fs.backup.base_path": fs_path2,
+        },
+    )
+    return config
+
+
 def create_test_metadata():
     """Create a test metadata for LMCacheMetadata."""
     return LMCacheMetadata(
@@ -138,6 +167,82 @@ class TestFSConnector:
 
         local_cpu_backend.memory_allocator.close()
         backend.close()
+
+    def test_init_with_plugin(self, temp_fs_path, async_loop, local_cpu_backend):
+        """Test FSConnector init via RemoteBackend
+        using remote_storage_plugins."""
+        config = create_test_config_with_plugin(temp_fs_path)
+        metadata = create_test_metadata()
+        backend = RemoteBackend(
+            config=config,
+            metadata=metadata,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cpu",
+            plugin_name="fs",
+        )
+
+        assert backend.dst_device == "cpu"
+        assert backend.local_cpu_backend == local_cpu_backend
+        assert backend.plugin_name == "fs"
+        assert os.path.exists(temp_fs_path)
+        assert backend.config.remote_serde == "naive"
+
+        local_cpu_backend.memory_allocator.close()
+        backend.close()
+
+    def test_dual_fs_instances(self, async_loop, local_cpu_backend):
+        """Test two fs_connector instances with different paths."""
+        dir1 = tempfile.mkdtemp()
+        dir2 = tempfile.mkdtemp()
+        try:
+            config = create_test_config_with_dual_plugins(dir1, dir2)
+            metadata = create_test_metadata()
+
+            backend1 = RemoteBackend(
+                config=config,
+                metadata=metadata,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cpu",
+                plugin_name="fs.primary",
+            )
+            backend2 = RemoteBackend(
+                config=config,
+                metadata=metadata,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cpu",
+                plugin_name="fs.backup",
+            )
+
+            key = create_test_key(99)
+            memory_obj = create_test_memory_obj()
+
+            # Put to backend1 only
+            future = backend1.submit_put_task(key, memory_obj)
+            if future:
+                future.result(timeout=5.0)
+
+            # backend1 has the key, backend2 does not
+            assert backend1.contains(key)
+            assert not backend2.contains(key)
+
+            # Put to backend2 as well
+            future2 = backend2.submit_put_task(key, memory_obj)
+            if future2:
+                future2.result(timeout=5.0)
+
+            assert backend2.contains(key)
+
+            backend1.close()
+            backend2.close()
+            local_cpu_backend.memory_allocator.close()
+        finally:
+            if os.path.exists(dir1):
+                shutil.rmtree(dir1)
+            if os.path.exists(dir2):
+                shutil.rmtree(dir2)
 
     def test_contains_key_not_exists(self, remote_backend_with_fs):
         """Test contains() when key doesn't exist in filesystem."""


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote connector selection and `RemoteBackend` initialization/reconnect paths; misconfiguration or adapter matching bugs could break remote storage connectivity, though legacy `remote_url` remains supported.
> 
> **Overview**
> Adds first-class support for configuring **multiple remote backends** via `remote_storage_plugins`, including instance-qualified names like `fs.primary`/`fs.backup`, and routes each entry to its own `RemoteBackend` (using `plugin://...` URLs internally).
> 
> Extends the connector/plugin system to understand plugin naming (`extract_plugin_type`, `ConnectorContext.plugin_name`), updates built-in adapters (`fs`, `mooncakestore`) and `RemoteBackend` to work in plugin mode while keeping legacy `remote_url` working with a deprecation warning, and allows dynamic plugins to specify either a `ConnectorAdapter` *or* a `RemoteConnector` via a new `DynamicConnectorAdapter`. Docs and FS connector tests are updated to cover the new configuration patterns and multi-instance behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e653f65befa2b8dd7b27ac34d53f27734eb5c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->