### PR TITLE
[Add] L2 Prefetch Controller and StorageManager integration

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -545,14 +545,59 @@ class L1Manager:
         return ret
 
     @l1_mgr_synchronized
-    def clear(self) -> None:
-        """Clear all objects from L1 cache."""
-        all_keys = list(self._objects.keys())
-        all_memory_objs = [entry.memory_obj for entry in self._objects.values()]
-        self._memory_manager.free(all_memory_objs)
-        self._objects.clear()
-        for listener in self._registered_listeners:
-            listener.on_l1_keys_deleted_by_manager(all_keys)
+    def clear(self, force: bool = False) -> None:
+        """Clear objects from L1 cache.
+
+        Args:
+            force: If True, clear ALL objects including locked ones.
+                This may corrupt in-flight store/prefetch operations.
+                If False (default), only clear unlocked objects, keeping
+                write-locked and read-locked objects intact.
+        """
+        if force:
+            logger.warning(
+                "L1Manager: force-clearing all %d objects "
+                "(including locked ones). This may corrupt in-flight "
+                "store/prefetch operations — use with caution.",
+                len(self._objects),
+            )
+            all_keys = list(self._objects.keys())
+            all_memory_objs = [entry.memory_obj for entry in self._objects.values()]
+            self._memory_manager.free(all_memory_objs)
+            self._objects.clear()
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_deleted_by_manager(all_keys)
+            logger.info(
+                "L1Manager: cleared %d objects, 0 remaining.",
+                len(all_keys),
+            )
+            return
+
+        keys_to_clear: list[ObjectKey] = []
+        objs_to_free: list[MemoryObj] = []
+        locked_count = 0
+
+        for key, entry in list(self._objects.items()):
+            if entry.write_lock.is_locked() or entry.read_lock.is_locked():
+                locked_count += 1
+                continue
+            keys_to_clear.append(key)
+            objs_to_free.append(entry.memory_obj)
+
+        for key in keys_to_clear:
+            del self._objects[key]
+
+        self._memory_manager.free(objs_to_free)
+
+        if keys_to_clear:
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_deleted_by_manager(keys_to_clear)
+
+        logger.info(
+            "L1Manager: cleared %d objects, %d locked objects remaining.",
+            len(keys_to_clear),
+            locked_count,
+        )
 
     def get_memory_usage(self) -> tuple[int, int]:
         """Get the current memory usage of L1 cache.

--- a/lmcache/v1/distributed/l2_adapters/DESIGN.md
+++ b/lmcache/v1/distributed/l2_adapters/DESIGN.md
@@ -1,0 +1,468 @@
+# L2 Store and Prefetch Controller Design
+
+This document describes how the StoreController and PrefetchController interact
+with L2 adapters, the invariants they maintain, and the assumptions they rely on.
+It is intended for developers implementing new L2 adapters or modifying the
+controller logic.
+
+## Architecture Overview
+
+```
+                    ┌────────────────────────┐
+                    │    StorageManager       │
+                    │  submit_prefetch_task   │
+                    │  query_prefetch_status  │
+                    │  reserve/finish_write   │
+                    └────┬──────────┬─────────┘
+                         │          │
+              ┌──────────┘          └──────────┐
+              ▼                                ▼
+   ┌────────────────────┐           ┌────────────────────┐
+   │  StoreController   │           │ PrefetchController  │
+   │  (background thread)│          │  (background thread) │
+   │                    │           │                     │
+   │  L1 write done     │           │  external submit    │
+   │   → store to L2    │           │   → lookup L2       │
+   │   → release locks  │           │   → plan + load     │
+   └────┬───────────────┘           │   → read-lock L1    │
+        │                           └──────┬──────────────┘
+        │                                  │
+        ▼                                  ▼
+   ┌─────────────────────────────────────────────┐
+   │           L2AdapterInterface(s)             │
+   │   store / lookup_and_lock / load / unlock   │
+   │                                             │
+   │  Each adapter has 3 distinct event fds:     │
+   │   store_efd, lookup_efd, load_efd           │
+   └─────────────────────────────────────────────┘
+```
+
+Both controllers run a single background thread each, using `select.poll()`
+on eventfds for event-driven I/O. They share the same set of L2 adapter
+instances (thread-safe by contract) but use different eventfds.
+
+## L2 Adapter Interface
+
+`L2AdapterInterface` (`l2_adapters/base.py`) provides the non-blocking I/O
+primitives that both controllers call. All operations follow a
+**submit → poll eventfd → query result** pattern.
+
+### Event Fds
+
+Each adapter exposes **three distinct** eventfds:
+
+| Method                         | Used by            | Signaled when                |
+|--------------------------------|--------------------|------------------------------|
+| `get_store_event_fd()`         | StoreController    | A store task completes       |
+| `get_lookup_and_lock_event_fd()` | PrefetchController | A lookup task completes    |
+| `get_load_event_fd()`          | PrefetchController | A load task completes        |
+
+**Critical invariant:** All event fds across all adapters must be globally
+unique. The controllers build `fd → adapter_index` maps; duplicate fds would
+silently misroute events.
+
+### Store Operations
+
+```
+submit_store_task(keys, objects) -> L2TaskId
+pop_completed_store_tasks() -> dict[L2TaskId, bool]
+```
+
+- **Caller provides buffers:** The `objects` list contains `MemoryObj` references
+  managed by the caller (StoreController holds L1 read locks on them).
+- **Coarse-grained errors:** A store task either fully succeeds or fully fails.
+  The bool in the completion dict is `True` for success, `False` for failure.
+- **Pop semantics:** `pop_completed_store_tasks()` drains all completed tasks.
+  Each task appears exactly once.
+
+### Lookup and Lock Operations
+
+```
+submit_lookup_and_lock_task(keys) -> L2TaskId
+query_lookup_and_lock_result(task_id) -> Bitmap | None
+submit_unlock(keys) -> None
+```
+
+- **Locking:** `lookup_and_lock` atomically checks which keys exist and acquires
+  L2-side locks on found keys. This prevents L2 eviction between lookup and load.
+- **Fine-grained results:** Returns a `Bitmap` where bit `i` is set if `keys[i]`
+  was found and locked.
+- **One-shot query:** `query_lookup_and_lock_result` returns `None` while pending,
+  then the `Bitmap` exactly once. Subsequent calls return `None`.
+- **Unlock contract:** `submit_unlock` is fire-and-forget. The adapter **must**
+  guarantee eventual success (retry internally if needed). The caller will never
+  retry.
+
+### Load Operations
+
+```
+submit_load_task(keys, objects) -> L2TaskId
+query_load_result(task_id) -> Bitmap | None
+```
+
+- **Caller provides buffers:** The `objects` list contains pre-allocated L1 write
+  buffers. The adapter writes loaded data directly into these buffers.
+- **Fine-grained results:** Returns a `Bitmap` where bit `i` is set if `keys[i]`
+  was successfully loaded.
+- **One-shot query:** Same semantics as lookup — returns the Bitmap exactly once.
+
+### Thread Safety
+
+The adapter must be safe for concurrent calls from the StoreController thread
+and the PrefetchController thread. In practice, the store operations and
+lookup/load operations use separate internal state, so this is usually
+straightforward with per-operation locks or lock-free queues.
+
+### Task ID Scope
+
+`L2TaskId` values are only unique **within a single adapter**. When tracking
+tasks across multiple adapters, use the composite key `(adapter_index, task_id)`.
+
+## StoreController
+
+**Purpose:** Asynchronously replicate L1 data to L2 after writes complete.
+
+**Source:** `storage_controllers/store_controller.py`
+
+### Lifecycle
+
+```
+StorageManager.__init__
+  → StoreController(l1_manager, l2_adapters, descriptors, policy)
+  → controller.start()        # spawns background thread
+  ...
+StorageManager.close()
+  → controller.stop()         # joins thread, releases locks
+```
+
+### Event-Driven Loop
+
+The StoreController's background thread polls on:
+
+1. **StoreListener eventfd** — fired by L1Manager when `finish_write()` completes.
+   The listener is an `L1ManagerListener` registered with L1Manager.
+2. **Per-adapter store eventfds** — fired when L2 store tasks complete.
+
+### Data Flow
+
+```
+L1 finish_write()
+  │
+  ▼ (L1Manager listener callback, inside L1 lock — must be non-blocking)
+StoreListener.on_l1_keys_write_finished(keys)
+  │  appends keys + signals eventfd
+  ▼
+_store_loop: poll wakes up
+  │
+  ▼
+_process_new_keys(keys)
+  │
+  ├─ 1. StorePolicy.select_store_targets(keys, adapters)
+  │     → dict[adapter_index, list[ObjectKey]]
+  │
+  ├─ 2. For each adapter target:
+  │     L1Manager.reserve_read(target_keys)  → get MemoryObj + read lock
+  │     adapter.submit_store_task(keys, objs)
+  │     Track as InFlightStoreTask
+  │
+  ▼ (later, when adapter signals store_efd)
+_process_completed_tasks(adapter_index)
+  │
+  ├─ 3. adapter.pop_completed_store_tasks()
+  │
+  ├─ 4. For each completed task:
+  │     L1Manager.finish_read(read_locked_keys)  → release read locks
+  │     If success: StorePolicy.select_l1_deletions(keys) → delete from L1
+  │     If failure: log warning (best-effort, no retry)
+  │
+  ▼
+Done. Keys remain in L1 unless the policy deletes them.
+```
+
+### Lock Invariants
+
+| Phase             | L1 Lock State | L2 Lock State |
+|-------------------|---------------|---------------|
+| Before store      | Unlocked      | N/A           |
+| During store      | Read-locked   | N/A           |
+| After store       | Unlocked      | N/A           |
+
+- **Read locks during store** prevent eviction from removing L1 data while the
+  adapter is reading it.
+- **Always released:** `stop()` calls `_cleanup_in_flight_tasks()` which releases
+  all in-flight read locks, even if tasks haven't completed.
+
+### StorePolicy
+
+The policy decides two things:
+
+1. **`select_store_targets(keys, adapters) → dict[int, list[ObjectKey]]`**
+   Which adapters get which keys. A key can go to multiple adapters.
+   `DefaultStorePolicy`: all keys → all adapters.
+
+2. **`select_l1_deletions(keys) → list[ObjectKey]`**
+   Which keys to evict from L1 after successful L2 store.
+   `DefaultStorePolicy`: never delete (empty list).
+
+## PrefetchController
+
+**Purpose:** Asynchronously load KV cache data from L2 into L1 ahead of a
+serving request. Called by `StorageManager.submit_prefetch_task()` for keys
+not already in L1.
+
+**Source:** `storage_controllers/prefetch_controller.py`
+
+### Lifecycle
+
+```
+StorageManager.__init__
+  → PrefetchController(l1_manager, l2_adapters, descriptors, policy)
+  → controller.start()        # spawns background thread
+  ...
+StorageManager.close()
+  → controller.stop()         # joins thread, releases all locks
+```
+
+### External API (Thread-Safe)
+
+```python
+# Called from the serving thread
+request_id = controller.submit_prefetch_request(keys, layout_desc)
+
+# Polled by the serving thread
+result = controller.query_prefetch_result(request_id)  # int | None
+```
+
+- `submit_prefetch_request` enqueues the request and signals the background thread
+  via an eventfd. Returns immediately.
+- `query_prefetch_result` returns `None` while in-progress, then the **prefix hit
+  count** exactly once (pop semantics).
+
+### Prefix-Only Loading
+
+**Key invariant:** Only the **contiguous prefix** of found keys is loaded.
+
+If L2 has keys `{0, 1, 3, 4}` but not key `2`, only keys `{0, 1}` are loaded.
+The gap at index 2 means the vLLM engine cannot use keys 3 and 4 (it needs a
+contiguous prefix of computed KV cache). Loading them would waste I/O bandwidth
+and L1 memory.
+
+This is enforced by `trim_load_plan_to_prefix()` after the policy computes the
+raw load plan.
+
+### Event-Driven Loop
+
+The PrefetchController's background thread polls on:
+
+1. **Submission eventfd** — signaled by `submit_prefetch_request()`.
+2. **Per-adapter lookup eventfds** — signaled when lookup tasks complete.
+3. **Per-adapter load eventfds** — signaled when load tasks complete.
+
+### Request State Machine
+
+Each request goes through two phases:
+
+```
+LOOKUP ──────────────────────────► PLAN_AND_LOAD ──────────► COMPLETED
+  │                                    │
+  │ submit lookup_and_lock             │ compute load plan
+  │ to ALL adapters                    │ reserve L1 write buffers
+  │                                    │ submit load tasks
+  │ wait for all lookups               │ wait for all loads
+  │ to complete                        │ finalize
+  ▼                                    ▼
+```
+
+### Data Flow
+
+```
+submit_prefetch_request(keys, layout_desc)
+  │
+  ▼ (cross-thread: submission queue + eventfd signal)
+_drain_submission_queue → _pending_queue
+  │
+  ▼ (if below max_in_flight)
+_start_lookup_phase(request_id, keys, layout_desc)
+  │
+  ├─ Submit lookup_and_lock_task(keys) to EVERY adapter
+  │
+  ▼ (wait for all adapter lookups to complete)
+_process_lookup_completions(adapter_index)
+  │  query each adapter's lookup result
+  │  when all_lookups_done():
+  │
+  ▼
+_transition_to_load_phase(request)
+  │
+  ├─ 1. PrefetchPolicy.select_load_plan(keys, lookup_results, adapters)
+  │     → dict[adapter_index, Bitmap]
+  │
+  ├─ 2. trim_load_plan_to_prefix()
+  │     → only keep contiguous prefix keys
+  │
+  ├─ 3. L1Manager.reserve_write(keys, is_temporary=True, mode="new")
+  │     → allocate L1 write buffers
+  │
+  ├─ 4. Re-trim plan to only successfully reserved keys
+  │
+  ├─ 5. Phase 1 unlock: unlock L2 keys locked in lookup but NOT in load plan
+  │
+  ├─ 6. Submit load_task(keys, objs) per adapter
+  │
+  ▼ (wait for all adapter loads to complete)
+_process_load_completions(adapter_index)
+  │  when all_loads_done():
+  │
+  ▼
+_finalize_load(request)
+  │
+  ├─ 7. Phase 2 unlock: unlock all L2 keys in the load plan
+  │
+  ├─ 8. L1Manager.finish_write_and_reserve_read(loaded_keys)
+  │     → atomically: write unlock + read lock
+  │
+  ├─ 9. L1Manager.finish_write(failed_keys) + delete(failed_keys)
+  │     → clean up partial failures
+  │
+  ├─ 10. Release read locks for loaded keys beyond the prefix
+  │      (partial load failures can create gaps)
+  │
+  ▼
+_complete_request(request_id, prefix_hits)
+  │  store result, remove from in-flight tracking
+```
+
+### Lock Invariants
+
+| Phase             | L1 Lock State                    | L2 Lock State               |
+|-------------------|----------------------------------|-----------------------------|
+| Lookup            | None                             | Found keys are locked       |
+| After plan        | Write-locked (reserved buffers)  | Plan keys locked; others unlocked (phase 1) |
+| During load       | Write-locked                     | Plan keys locked            |
+| After load        | **Read-locked** (prefix keys)    | All unlocked (phase 2)      |
+| After finalize    | Read-locked (prefix only)        | All unlocked                |
+
+- **L1 write buffers are temporary:** `is_temporary=True` allows the eviction
+  controller to reclaim them if needed, although normally they are short-lived.
+- **Atomic write→read transition:** `finish_write_and_reserve_read()` ensures no
+  eviction window between write completion and read lock acquisition.
+- **Post-finalize read locks:** The prefix keys remain read-locked in L1 so the
+  serving engine can consume them. The caller (`StorageManager`) releases these
+  via `finish_read_prefetched()` after use.
+
+### L2 Lock Management
+
+L2 locks prevent adapter-side eviction between lookup and load. They must be
+released in all cases — success, failure, and shutdown.
+
+**Phase 1 unlock** (`_unlock_unneeded_keys`): After the load plan is computed,
+keys that were locked during lookup but are NOT in the final load plan are
+unlocked immediately. This happens when:
+- The policy assigned a key to a different adapter.
+- The key was trimmed by prefix trimming.
+- L1 write reservation failed.
+
+**Phase 2 unlock** (`_unlock_all_plan_keys`): After load completes (regardless
+of success or failure), all keys in the load plan are unlocked.
+
+**Shutdown cleanup** (`_cleanup_in_flight_requests`): Releases all held L1 and
+L2 locks for any in-flight requests.
+
+### PrefetchPolicy
+
+```python
+select_load_plan(keys, lookup_results, adapters) → dict[int, Bitmap]
+```
+
+Receives lookup bitmaps from all adapters and produces a non-overlapping
+assignment of keys to adapters. Each key appears in at most one adapter's bitmap.
+
+`DefaultPrefetchPolicy`: For each key, assign it to the first (lowest-indexed)
+adapter that has it. This is a simple greedy approach.
+
+### Max In-Flight Limiting
+
+The controller limits concurrent prefetch requests to `max_in_flight` (default: 8).
+Requests beyond this limit are queued in `_pending_queue` and dequeued as
+in-flight requests complete.
+
+Note: This is a simple count-based limit. A future improvement would use a
+dynamic admission controller based on L1 memory usage of in-flight requests.
+
+## Integration: StorageManager
+
+`StorageManager` (`storage_manager.py`) is the top-level entry point that wires
+everything together.
+
+### Prefetch Flow (from the serving engine's perspective)
+
+```python
+# 1. Submit: check L1 first, then delegate remainder to L2
+handle = sm.submit_prefetch_task(keys, layout_desc)
+
+# 2. Poll: busy-wait for completion
+while True:
+    found_count = sm.query_prefetch_status(handle)
+    if found_count is not None:
+        break
+
+# 3. Read: access the prefetched data (holds read locks)
+with sm.read_prefetched_results(keys[:found_count]) as objs:
+    # use objs ...
+    pass
+
+# 4. Release: drop read locks
+sm.finish_read_prefetched(keys[:found_count])
+```
+
+### PrefetchHandle
+
+```python
+@dataclass(frozen=True)
+class PrefetchHandle:
+    request_id: int          # -1 if no L2 request needed
+    l1_prefix_hit_count: int # leading keys already in L1
+    total_requested_keys: int
+    submit_time: float       # for latency logging
+```
+
+`submit_prefetch_task` first checks L1 for a contiguous prefix of hits:
+- If all keys hit L1: returns handle with `request_id=-1` (no L2 work).
+- If some keys miss: submits the **remaining** keys to PrefetchController.
+
+`query_prefetch_status` combines L1 hits with L2 results:
+`total_hits = l1_prefix_hit_count + l2_prefix_hits`.
+
+## Assumptions and Invariants Summary
+
+1. **All eventfds are globally unique** across all adapters and all operation
+   types. Violating this corrupts the poll-based dispatch.
+
+2. **L2 task IDs are per-adapter, not global.** Use `(adapter_index, task_id)`
+   as composite keys.
+
+3. **Query results are one-shot.** Both `query_lookup_and_lock_result()` and
+   `query_load_result()` return a non-None value exactly once per task.
+
+4. **`submit_unlock` must eventually succeed.** The controllers will never
+   retry. The adapter must handle retries internally.
+
+5. **Prefix-only loading.** Only the contiguous prefix of found keys is loaded
+   from L2. Gaps break the prefix.
+
+6. **Listener callbacks run inside L1Manager's lock.** `StoreListener` must be
+   non-blocking (append + eventfd signal only). It must never call L1Manager
+   methods (deadlock).
+
+7. **L1 write buffers for prefetch are temporary.** Allocated with
+   `is_temporary=True` to allow eviction if needed.
+
+8. **Atomic write→read transition.** `finish_write_and_reserve_read()` prevents
+   eviction between completing a prefetch write and acquiring the read lock
+   for the serving engine.
+
+9. **Both controllers release all locks on shutdown.** `stop()` always cleans
+   up in-flight tasks, regardless of completion state.
+
+10. **L2 adapters are thread-safe.** Concurrent calls from the StoreController
+    thread and PrefetchController thread are expected.

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -59,6 +59,12 @@ class L2AdapterInterface(ABC):
     # Event Fd Interface
     #####################
 
+    # IMPORTANT: Each of the three event fd methods below MUST return a
+    # distinct file descriptor.  The store controller and prefetch controller
+    # build fd-to-adapter lookup maps; if any two methods return the same fd
+    # (within one adapter or across adapters), poll-based dispatch will
+    # silently misroute events.
+
     @abstractmethod
     def get_store_event_fd(self) -> int:
         """
@@ -67,6 +73,10 @@ class L2AdapterInterface(ABC):
 
         Returns:
             int: the event fd for store operation.
+
+        Note:
+            Must be distinct from the lookup and load event fds of this
+            adapter, and from the event fds of all other adapters.
         """
         pass
 
@@ -78,6 +88,10 @@ class L2AdapterInterface(ABC):
 
         Returns:
             int: the event fd for lookup and lock operation.
+
+        Note:
+            Must be distinct from the store and load event fds of this
+            adapter, and from the event fds of all other adapters.
         """
         pass
 
@@ -89,6 +103,10 @@ class L2AdapterInterface(ABC):
 
         Returns:
             int: the event fd for load operation.
+
+        Note:
+            Must be distinct from the store and lookup event fds of this
+            adapter, and from the event fds of all other adapters.
         """
         pass
 

--- a/lmcache/v1/distributed/storage_controllers/__init__.py
+++ b/lmcache/v1/distributed/storage_controllers/__init__.py
@@ -4,11 +4,15 @@
 from lmcache.v1.distributed.storage_controllers.eviction_controller import (  # noqa: E501
     EvictionController,
 )
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (  # noqa: E501
+    PrefetchController,
+)
 from lmcache.v1.distributed.storage_controllers.store_controller import (
     StoreController,
 )
 
 __all__ = [
     "EvictionController",
+    "PrefetchController",
     "StoreController",
 ]

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -1,0 +1,652 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Prefetch Controller: asynchronously prefetches data from L2 adapters into L1.
+
+The controller runs a background thread with an event-driven loop that:
+1. Accepts prefetch requests from external threads via submit_prefetch_request.
+2. Submits lookup_and_lock tasks to all L2 adapters.
+3. Computes a load plan using the PrefetchPolicy, trimmed to the contiguous
+   prefix of found keys.
+4. Reserves L1 write buffers and submits load tasks to L2 adapters.
+5. On load completion, transitions L1 entries from write-locked to read-locked.
+6. Reports prefix hit count.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from typing import Iterable
+import enum
+import os
+import select
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
+from lmcache.v1.distributed.storage_controller import StorageControllerInterface
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    PrefetchPolicy,
+)
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+logger = init_logger(__name__)
+
+
+# HELPER FUNCTIONS
+def trim_load_plan_to_first_n_keys(
+    load_plan: dict[int, Bitmap],
+    num_keys: int,
+    n: int,
+) -> dict[int, Bitmap]:
+    """
+    Trim the load plan to only include keys with indices < n.
+
+    For example, if n=3 and the combined load plan has keys
+    {0, 1, 3}, the trimmed plan will only include key indices [0, 1]
+    and exclude index 3.
+
+    Args:
+        load_plan: Mapping from adapter index to Bitmap of key indices.
+        num_keys: Total number of keys (bitmap size).
+        n: Number of keys to include in the trimmed plan (prefix length).
+
+    Returns:
+        Trimmed load plan with only key indices < n.
+
+    Note:
+        the adapter index will not appear in the return dict if
+        it has no keys in the prefix.
+    """
+    if n <= 0:
+        return {}
+
+    trimmed_plan: dict[int, Bitmap] = {}
+    mask_bitmap = Bitmap(num_keys, n)
+    for adapter_idx, bitmap in load_plan.items():
+        new_bitmap = bitmap & mask_bitmap
+        if new_bitmap.popcount() == 0:
+            continue
+
+        trimmed_plan[adapter_idx] = new_bitmap
+
+    return trimmed_plan
+
+
+def trim_load_plan_to_prefix(
+    load_plan: dict[int, Bitmap],
+    num_keys: int,
+) -> dict[int, Bitmap]:
+    """
+    Trim the load plan to the longest contiguous prefix of keys.
+
+    For example, if num_keys=5 and the combined load plan has keys
+    {0, 1, 3}, the prefix is 2 (keys 0 and 1), so the trimmed plan
+    will only include key indices [0, 1] and exclude index 3.
+
+    Args:
+        load_plan: Mapping from adapter index to Bitmap of key indices.
+        num_keys: Total number of keys in the request.
+
+    Returns:
+        Trimmed load plan with only prefix key indices.
+
+    Note:
+        the adapter index will not appear in the return dict if
+        it has no keys in the prefix.
+    """
+    merged_plan = Bitmap(num_keys)
+    for bitmap in load_plan.values():
+        merged_plan = merged_plan | bitmap
+
+    prefix_length = merged_plan.count_leading_ones()
+    return trim_load_plan_to_first_n_keys(load_plan, num_keys, prefix_length)
+
+
+def merge_bitmaps(bitmaps: Iterable[Bitmap], num_keys: int) -> Bitmap:
+    """Merge multiple bitmaps with a bitwise OR."""
+    if not bitmaps:
+        return Bitmap(0)
+    merged = Bitmap(num_keys)
+    for bm in bitmaps:
+        merged = merged | bm
+    return merged
+
+
+# Poll timeout in milliseconds for the prefetch loop
+PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+
+PrefetchRequestId = int
+
+
+class PrefetchPhase(enum.Enum):
+    LOOKUP = enum.auto()
+    PLAN_AND_LOAD = enum.auto()
+
+
+@dataclass
+class InFlightPrefetchRequest:
+    """Tracks a single prefetch request across its lifecycle phases."""
+
+    request_id: PrefetchRequestId
+    keys: list[ObjectKey]
+    layout_desc: MemoryLayoutDesc
+    phase: PrefetchPhase
+
+    # Lookup phase: adapter_idx -> task_id (removed as results arrive)
+    pending_lookup_tasks: dict[int, L2TaskId] = field(default_factory=dict)
+    # Lookup phase: adapter_idx -> bitmap (populated as results arrive)
+    lookup_results: dict[int, Bitmap] = field(default_factory=dict)
+
+    # Load phase: adapter_idx -> bitmap of key indices to load
+    load_plan: dict[int, Bitmap] = field(default_factory=dict)
+    # Load phase: adapter_idx -> task_id (removed as results arrive)
+    pending_load_tasks: dict[int, L2TaskId] = field(default_factory=dict)
+    # Load phase: adapter_idx -> bitmap (populated as results arrive)
+    load_results: dict[int, Bitmap] = field(default_factory=dict)
+    # Load phase: keys that were write-reserved in L1
+    write_reserved_keys: list[ObjectKey] = field(default_factory=list)
+    write_reserved_objs: dict[ObjectKey, MemoryObj] = field(default_factory=dict)
+
+    def all_lookups_done(self) -> bool:
+        return len(self.pending_lookup_tasks) == 0
+
+    def all_loads_done(self) -> bool:
+        return len(self.pending_load_tasks) == 0
+
+
+class PrefetchController(StorageControllerInterface):
+    """
+    Asynchronously prefetches data from L2 adapters into L1 memory.
+
+    The controller:
+    1. Accepts prefetch requests via submit_prefetch_request (thread-safe).
+    2. Runs a background thread that submits lookup_and_lock to all adapters.
+    3. Uses PrefetchPolicy to compute a load plan from lookup results.
+    4. Reserves L1 write buffers and submits load tasks to adapters.
+    5. On completion, transitions loaded keys to read-locked state.
+    6. Reports the number of prefix hits via query_prefetch_result.
+
+    Args:
+        l1_manager: The L1 manager instance.
+        l2_adapters: List of L2 adapter instances.
+        adapter_descriptors: Descriptors for each L2 adapter (same order).
+        policy: The prefetch policy for load plan decisions.
+        max_in_flight: Maximum number of concurrent prefetch requests.
+    """
+
+    def __init__(
+        self,
+        l1_manager: L1Manager,
+        l2_adapters: list[L2AdapterInterface],
+        adapter_descriptors: list[AdapterDescriptor],
+        policy: PrefetchPolicy,
+        max_in_flight: int = 8,
+    ) -> None:
+        super().__init__(l1_manager)
+        self._l2_adapters = l2_adapters
+        self._adapter_descriptors = adapter_descriptors
+        self._policy = policy
+        # TODO(ApostaC): max_in_flight should not be a static constant.
+        # Replace with a dynamic admission controller that monitors L1 memory
+        # usage of in-flight prefetch requests. A fixed limit can still blow
+        # up L1 memory when individual requests are large.
+        self._max_in_flight = max_in_flight
+
+        # In-flight request tracking (background thread only)
+        self._in_flight_requests: dict[PrefetchRequestId, InFlightPrefetchRequest] = {}
+        self._pending_queue: list[
+            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc]
+        ] = []
+
+        # Thread-safe submission queue (external -> background)
+        self._submission_lock = threading.Lock()
+        self._submission_queue: list[
+            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc]
+        ] = []
+        self._next_request_id: PrefetchRequestId = 0
+        self._submission_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+
+        # Thread-safe results (background -> external)
+        self._results_lock = threading.Lock()
+        self._completed_results: dict[PrefetchRequestId, int] = {}
+
+        # Map eventfds to adapter indices for quick lookup in poll.
+        # Relies on the L2AdapterInterface contract that every adapter
+        # returns distinct fds for store/lookup/load, and no two adapters
+        # share an fd.  See the docstrings in L2AdapterInterface.
+        self._lookup_efd_to_adapter: dict[int, int] = {}
+        self._load_efd_to_adapter: dict[int, int] = {}
+        for i, adapter in enumerate(self._l2_adapters):
+            self._lookup_efd_to_adapter[adapter.get_lookup_and_lock_event_fd()] = i
+            self._load_efd_to_adapter[adapter.get_load_event_fd()] = i
+
+        self._stop_flag = threading.Event()
+        self._thread = threading.Thread(
+            target=self._prefetch_loop,
+            daemon=True,
+        )
+
+    # =========================================================================
+    # External API (thread-safe)
+    # =========================================================================
+
+    def submit_prefetch_request(
+        self,
+        keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
+    ) -> PrefetchRequestId:
+        """
+        Submit a prefetch request for the given keys.
+
+        Thread-safe. Can be called from any thread.
+
+        Only the **contiguous prefix** of found keys is loaded from L2.
+        If L2 has keys {0, 1, 3, 4} but not key 2, only keys {0, 1} are
+        loaded because the gap at index 2 breaks the prefix.  Keys beyond
+        the prefix are never transferred, saving I/O bandwidth and L1
+        memory.  Use :meth:`query_prefetch_result` to retrieve the number
+        of prefix hits once the request completes.
+
+        Args:
+            keys: List of object keys to prefetch from L2 into L1.
+                The ordering defines the prefix: index 0 is the first key.
+            layout_desc: Memory layout for L1 write buffer allocation.
+
+        Returns:
+            A request ID for tracking via query_prefetch_result.
+        """
+        with self._submission_lock:
+            request_id = self._next_request_id
+            self._next_request_id += 1
+            self._submission_queue.append((request_id, keys, layout_desc))
+        os.eventfd_write(self._submission_efd, 1)
+        return request_id
+
+    def query_prefetch_result(self, request_id: PrefetchRequestId) -> int | None:
+        """
+        Query the result of a prefetch request.
+
+        Thread-safe. Returns the number of prefix hits if the request
+        has completed, None if still in progress. Each result can only
+        be retrieved once (subsequent calls return None).
+
+        Args:
+            request_id: The request ID from submit_prefetch_request.
+
+        Returns:
+            Number of prefix hits, or None if not yet complete.
+        """
+        with self._results_lock:
+            return self._completed_results.pop(request_id, None)
+
+    # =========================================================================
+    # Lifecycle
+    # =========================================================================
+
+    def start(self) -> None:
+        """Start the background prefetch loop thread."""
+        logger.info("Starting PrefetchController...")
+        self._thread.start()
+
+    def stop(self) -> None:
+        """
+        Signal the loop to stop and wait for the thread to join.
+
+        Cleans up any in-flight requests (releases L1 write locks,
+        L2 locks) before returning.
+        """
+        self._stop_flag.set()
+        os.eventfd_write(self._submission_efd, 1)
+        self._thread.join()
+        self._cleanup_in_flight_requests()
+        os.close(self._submission_efd)
+
+    # =========================================================================
+    # Background loop
+    # =========================================================================
+
+    def _prefetch_loop(self) -> None:
+        """
+        Main event-driven loop running in a background thread.
+
+        Uses select.poll() to wait on:
+        - The submission eventfd (new prefetch requests).
+        - Each L2 adapter's lookup eventfd (completed lookups).
+        - Each L2 adapter's load eventfd (completed loads).
+        """
+        poller = select.poll()
+        poller.register(self._submission_efd, select.POLLIN)
+        for efd in self._lookup_efd_to_adapter:
+            poller.register(efd, select.POLLIN)
+        for efd in self._load_efd_to_adapter:
+            poller.register(efd, select.POLLIN)
+
+        while not self._stop_flag.is_set():
+            ready = poller.poll(PREFETCH_LOOP_POLL_TIMEOUT_MS)
+
+            for fd, events in ready:
+                if not (events & select.POLLIN):
+                    continue
+
+                try:
+                    os.eventfd_read(fd)
+                except (OSError, BlockingIOError):
+                    pass
+
+                if fd == self._submission_efd:
+                    self._drain_submission_queue()
+                elif fd in self._lookup_efd_to_adapter:
+                    self._process_lookup_completions(self._lookup_efd_to_adapter[fd])
+                elif fd in self._load_efd_to_adapter:
+                    self._process_load_completions(self._load_efd_to_adapter[fd])
+
+            self._start_pending_requests()
+
+    def _drain_submission_queue(self) -> None:
+        """Move items from the thread-safe submission queue to the
+        pending queue."""
+        with self._submission_lock:
+            items = self._submission_queue
+            self._submission_queue = []
+        self._pending_queue.extend(items)
+
+    def _start_pending_requests(self) -> None:
+        """Start pending requests up to the max in-flight limit."""
+        while (
+            self._pending_queue and len(self._in_flight_requests) < self._max_in_flight
+        ):
+            request_id, keys, layout_desc = self._pending_queue.pop(0)
+            self._start_lookup_phase(request_id, keys, layout_desc)
+
+    # =========================================================================
+    # Lookup phase
+    # =========================================================================
+
+    def _start_lookup_phase(
+        self,
+        request_id: PrefetchRequestId,
+        keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
+    ) -> None:
+        """Submit lookup_and_lock to all adapters for a new request."""
+        if not self._l2_adapters:
+            self._complete_request(request_id, 0)
+            return
+
+        pending_lookup_tasks: dict[int, L2TaskId] = {}
+        for i, adapter in enumerate(self._l2_adapters):
+            task_id = adapter.submit_lookup_and_lock_task(keys)
+            pending_lookup_tasks[i] = task_id
+
+        request = InFlightPrefetchRequest(
+            request_id=request_id,
+            keys=keys,
+            layout_desc=layout_desc,
+            phase=PrefetchPhase.LOOKUP,
+            pending_lookup_tasks=pending_lookup_tasks,
+        )
+        self._in_flight_requests[request_id] = request
+
+    def _process_lookup_completions(self, adapter_index: int) -> None:
+        """Check all LOOKUP-phase requests for completed lookups from
+        this adapter."""
+        ready_to_transition: list[InFlightPrefetchRequest] = []
+
+        for request in list(self._in_flight_requests.values()):
+            if request.phase != PrefetchPhase.LOOKUP:
+                continue
+            if adapter_index not in request.pending_lookup_tasks:
+                continue
+
+            task_id = request.pending_lookup_tasks[adapter_index]
+            result = self._l2_adapters[adapter_index].query_lookup_and_lock_result(
+                task_id
+            )
+
+            if result is not None:
+                request.lookup_results[adapter_index] = result
+                del request.pending_lookup_tasks[adapter_index]
+
+                if request.all_lookups_done():
+                    ready_to_transition.append(request)
+
+        for request in ready_to_transition:
+            self._transition_to_load_phase(request)
+
+    # =========================================================================
+    # Load phase
+    # =========================================================================
+
+    def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+        """Compute load plan, reserve L1 buffers, and submit load tasks."""
+        request.phase = PrefetchPhase.PLAN_AND_LOAD
+
+        # Step 1: get load plan from policy
+        load_plan = self._policy.select_load_plan(
+            request.keys,
+            request.lookup_results,
+            self._adapter_descriptors,
+        )
+
+        # Step 2: trim the load plan to only prefix
+        trimmed_plan = trim_load_plan_to_prefix(load_plan, len(request.keys))
+
+        if not trimmed_plan:
+            # Nothing to load after trimming to prefix. Unlock all lookup locks
+            # and complete with 0 hits.
+            self._unlock_all_lookups(request)
+            self._complete_request(request.request_id, 0)
+            return
+
+        # Step 3: reserve L1 write buffers
+        merged_bitmap = merge_bitmaps(trimmed_plan.values(), len(request.keys))
+        keys_to_reserve = merged_bitmap.gather(request.keys)
+        l1_mgr = self.get_l1_manager()
+
+        write_results = l1_mgr.reserve_write(
+            keys=keys_to_reserve,
+            is_temporary=[True] * len(keys_to_reserve),
+            layout_desc=request.layout_desc,
+            mode="new",
+        )
+
+        # Step 4: filter to successfully reserved keys
+        reserved_key_set: set[ObjectKey] = set()
+        for key, (err, mem_obj) in write_results.items():
+            if err == L1Error.SUCCESS and mem_obj is not None:
+                request.write_reserved_keys.append(key)
+                request.write_reserved_objs[key] = mem_obj
+                reserved_key_set.add(key)
+            else:
+                logger.debug(
+                    "Prefetch request %d: reserve write failed for %s: %s",
+                    request.request_id,
+                    key,
+                    err,
+                )
+
+        # Step 5: recompute load plan excluding failed reservations
+        reserved_bitmap = Bitmap(len(request.keys))
+        for i, key in enumerate(request.keys):
+            if key in reserved_key_set:
+                reserved_bitmap.set(i)
+
+        prefix_length = reserved_bitmap.count_leading_ones()
+        trimmed_plan = trim_load_plan_to_first_n_keys(
+            load_plan, len(request.keys), prefix_length
+        )
+        request.load_plan = trimmed_plan
+
+        ## Step 6: phase 1 unlock — keys locked in lookup but not in plan
+        self._unlock_unneeded_keys(request)
+
+        if not trimmed_plan:
+            # Nothing loadable after filtering
+            if request.write_reserved_keys:
+                l1_mgr.finish_write(request.write_reserved_keys)
+                l1_mgr.delete(request.write_reserved_keys)
+            self._complete_request(request.request_id, 0)
+            return
+
+        ## Step 7: submit load tasks per adapter
+        for adapter_idx, bitmap in trimmed_plan.items():
+            per_adapter_keys = bitmap.gather(request.keys)
+            per_adapter_objs = [
+                request.write_reserved_objs[key] for key in per_adapter_keys
+            ]
+            task_id = self._l2_adapters[adapter_idx].submit_load_task(
+                per_adapter_keys, per_adapter_objs
+            )
+            request.pending_load_tasks[adapter_idx] = task_id
+
+        logger.debug(
+            "Prefetch request %d: submitted load tasks to %d adapters for %d keys",
+            request.request_id,
+            len(trimmed_plan),
+            len(reserved_key_set),
+        )
+
+    def _process_load_completions(self, adapter_index: int) -> None:
+        """Check all PLAN_AND_LOAD-phase requests for completed loads."""
+        ready_to_finalize: list[InFlightPrefetchRequest] = []
+
+        for request in list(self._in_flight_requests.values()):
+            if request.phase != PrefetchPhase.PLAN_AND_LOAD:
+                continue
+            if adapter_index not in request.pending_load_tasks:
+                continue
+
+            task_id = request.pending_load_tasks[adapter_index]
+            result = self._l2_adapters[adapter_index].query_load_result(task_id)
+
+            if result is not None:
+                request.load_results[adapter_index] = result
+                del request.pending_load_tasks[adapter_index]
+
+                if request.all_loads_done():
+                    ready_to_finalize.append(request)
+
+        for request in ready_to_finalize:
+            self._finalize_load(request)
+
+    def _finalize_load(self, request: InFlightPrefetchRequest) -> None:
+        """
+        Finalize a completed load: build result bitmap, transition L1
+        state, release non-prefix read locks, and report prefix hits.
+
+        Only prefix keys are submitted for loading, but partial load
+        failures can create gaps.  Keys beyond the gap that were
+        successfully loaded still need their read locks released.
+        """
+        num_keys = len(request.keys)
+
+        # Scatter per-adapter local load results into global positions.
+        # Each adapter's load bitmap is locally indexed (size == adapter's
+        # key count).  The plan bitmap maps local → global indices via
+        # get_indices_list().
+        result_bitmap = Bitmap(num_keys)
+        for adapter_idx, plan_bitmap in request.load_plan.items():
+            load_bitmap = request.load_results.get(adapter_idx)
+            if load_bitmap is None:
+                continue
+            plan_indices = plan_bitmap.get_indices_list()
+            for global_i in load_bitmap.gather(plan_indices):
+                result_bitmap.set(global_i)
+
+        # Separate loaded vs. failed among write-reserved keys
+        loaded_keys: list[ObjectKey] = result_bitmap.gather(request.keys)
+        loaded_set = set(loaded_keys)
+        failed_keys = [k for k in request.write_reserved_keys if k not in loaded_set]
+
+        # Phase 2 unlock: release L2 locks for all keys in the load plan
+        self._unlock_all_plan_keys(request)
+
+        l1_mgr = self.get_l1_manager()
+
+        # Transition loaded keys: write-locked -> read-locked
+        if loaded_keys:
+            l1_mgr.finish_write_and_reserve_read(loaded_keys)
+
+        # Clean up failed keys
+        if failed_keys:
+            l1_mgr.finish_write(failed_keys)
+            l1_mgr.delete(failed_keys)
+
+        # Partial load failures can create gaps in the prefix.
+        # Release read locks for loaded keys beyond the prefix.
+        prefix_hits = result_bitmap.count_leading_ones()
+        prefix_mask = Bitmap(num_keys, prefix_hits)
+        non_prefix_loaded_bitmap = result_bitmap & (~prefix_mask)
+        non_prefix_loaded = non_prefix_loaded_bitmap.gather(request.keys)
+        if non_prefix_loaded:
+            l1_mgr.finish_read(non_prefix_loaded)
+
+        self._complete_request(request.request_id, prefix_hits)
+
+    # =========================================================================
+    # Unlock helpers
+    # =========================================================================
+
+    def _unlock_unneeded_keys(self, request: InFlightPrefetchRequest) -> None:
+        """Phase 1 unlock: keys locked in lookup but not in the load plan."""
+        for adapter_idx, lookup_bitmap in request.lookup_results.items():
+            plan_bitmap = request.load_plan.get(adapter_idx, Bitmap(len(request.keys)))
+            to_unlock_bitmap = lookup_bitmap & (~plan_bitmap)
+            unlock_keys = to_unlock_bitmap.gather(request.keys)
+            if unlock_keys:
+                self._l2_adapters[adapter_idx].submit_unlock(unlock_keys)
+
+    def _unlock_all_plan_keys(self, request: InFlightPrefetchRequest) -> None:
+        """Phase 2 unlock: release L2 locks for all keys in the load plan."""
+        for adapter_idx, load_bitmap in request.load_plan.items():
+            unlock_keys = load_bitmap.gather(request.keys)
+            self._l2_adapters[adapter_idx].submit_unlock(unlock_keys)
+
+    def _unlock_all_lookups(self, request: InFlightPrefetchRequest) -> None:
+        """Unlock all keys locked during lookup (nothing to load case)."""
+        for adapter_idx, lookup_bitmap in request.lookup_results.items():
+            unlock_keys = lookup_bitmap.gather(request.keys)
+            if unlock_keys:
+                self._l2_adapters[adapter_idx].submit_unlock(unlock_keys)
+
+    # =========================================================================
+    # Completion and cleanup
+    # =========================================================================
+
+    def _complete_request(
+        self, request_id: PrefetchRequestId, prefix_hits: int
+    ) -> None:
+        """Store the result and remove from in-flight tracking."""
+        with self._results_lock:
+            self._completed_results[request_id] = prefix_hits
+        self._in_flight_requests.pop(request_id, None)
+        logger.debug(
+            "Prefetch request %d completed: %d prefix hits",
+            request_id,
+            prefix_hits,
+        )
+
+    def _cleanup_in_flight_requests(self) -> None:
+        """Release resources for any in-flight requests during shutdown."""
+        l1_mgr = self.get_l1_manager()
+        for request in self._in_flight_requests.values():
+            if request.phase == PrefetchPhase.PLAN_AND_LOAD:
+                if request.write_reserved_keys:
+                    l1_mgr.finish_write(request.write_reserved_keys)
+                    l1_mgr.delete(request.write_reserved_keys)
+                self._unlock_all_plan_keys(request)
+            elif request.phase == PrefetchPhase.LOOKUP:
+                self._unlock_all_lookups(request)
+            logger.warning(
+                "Cleaning up in-flight prefetch request %d (%d keys).",
+                request.request_id,
+                len(request.keys),
+            )
+        self._in_flight_requests.clear()

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -7,6 +7,7 @@ Distributed multi-tier storage manager for MP mode
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Iterator, Literal
+import time
 
 # First Party
 from lmcache.logging import init_logger
@@ -22,7 +23,11 @@ from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
 from lmcache.v1.distributed.storage_controllers import (
     EvictionController,
+    PrefetchController,
     StoreController,
+)
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    DefaultPrefetchPolicy,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
@@ -49,6 +54,9 @@ class PrefetchHandle:
 
     total_requested_keys: int
     """Total number of keys originally requested."""
+
+    submit_time: float
+    """Monotonic timestamp when the prefetch task was submitted."""
 
 
 class StorageManager:
@@ -80,6 +88,15 @@ class StorageManager:
             policy=DefaultStorePolicy(),
         )
         self._store_controller.start()
+
+        # Prefetch controller
+        self._prefetch_controller = PrefetchController(
+            l1_manager=self._l1_manager,
+            l2_adapters=self._l2_adapters,
+            adapter_descriptors=adapter_descriptors,
+            policy=DefaultPrefetchPolicy(),
+        )
+        self._prefetch_controller.start()
 
         # Self-register observability logger
         sm_stats_logger = StorageManagerStatsLogger()
@@ -274,10 +291,30 @@ class StorageManager:
         for listener in self._registered_listeners:
             listener.on_sm_read_prefetched(keys[:hit_count], keys[hit_count:])
 
+        # Submit remaining keys to L2 prefetch controller
+        remaining_keys = keys[hit_count:]
+        request_id = -1
+        if remaining_keys and self._l2_adapters:
+            request_id = self._prefetch_controller.submit_prefetch_request(
+                remaining_keys,
+                layout_desc,
+            )
+
+        submit_time = time.monotonic()
+        logger.debug(
+            "Prefetch request submitted: %d total keys, "
+            "%d L1 prefix hits, %d remaining for L2 (request_id=%d)",
+            len(keys),
+            hit_count,
+            len(remaining_keys),
+            request_id,
+        )
+
         return PrefetchHandle(
-            request_id=-1,
+            request_id=request_id,
             l1_prefix_hit_count=hit_count,
             total_requested_keys=len(keys),
+            submit_time=submit_time,
         )
 
     def query_prefetch_status(
@@ -294,18 +331,50 @@ class StorageManager:
             the number of prefix hit chunks if the prefetch is done, None if
             it's still in progress.
         """
-        return handle.l1_prefix_hit_count
+        l2_result: int = 0
 
-    def clear(self):
+        # Have L2 request, need to check the result from prefetch controller
+        if handle.request_id != -1:
+            l2_r = self._prefetch_controller.query_prefetch_result(handle.request_id)
+
+            if l2_r is None:
+                return None
+            l2_result = l2_r  # Just to make linter happy
+
+        total_hits = handle.l1_prefix_hit_count + l2_result
+        elapsed_ms = (time.monotonic() - handle.submit_time) * 1000
+
+        if total_hits > 0:
+            logger.info(
+                "Prefetch request completed (L1+L2): "
+                "%d/%d prefix hits (%d L1, %d L2) in %.1f ms "
+                "(request_id=%d)",
+                total_hits,
+                handle.total_requested_keys,
+                handle.l1_prefix_hit_count,
+                l2_result,
+                elapsed_ms,
+                handle.request_id,
+            )
+        return total_hits
+
+    def clear(self, force: bool = False):
         """
-        Clear all data in the storage manager.
+        Clear data in the storage manager.
+
+        Args:
+            force: If True, clear ALL objects including locked ones.
+                This may corrupt in-flight store/prefetch operations.
+                If False (default), only clear unlocked objects, keeping
+                write-locked and read-locked objects intact.
         """
-        self._l1_manager.clear()
+        self._l1_manager.clear(force=force)
 
     def close(self):
         """
         Close the storage manager and release all resources.
         """
+        self._prefetch_controller.stop()
         self._store_controller.stop()
         self._eviction_controller.stop()
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -478,7 +478,7 @@ class MPCacheEngine:
         """
         with self.lock:
             self.storage_manager.memcheck()
-            self.storage_manager.clear()
+            self.storage_manager.clear(force=True)
             self.storage_manager.memcheck()
 
     def close(self) -> None:

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -4,6 +4,7 @@ Unit tests for StorageManager.
 """
 
 # Standard
+import time
 
 # Third Party
 import pytest
@@ -16,6 +17,10 @@ from lmcache.v1.distributed.config import (
     L1ManagerConfig,
     L1MemoryManagerConfig,
     StorageManagerConfig,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdaptersConfig,
+    MockL2AdapterConfig,
 )
 
 try:
@@ -132,6 +137,36 @@ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: in
     """Helper to create ObjectKey instances."""
     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
     return ObjectKey(chunk_hash=hash_bytes, model_name=model_name, kv_rank=kv_rank)
+
+
+def wait_for_condition(
+    predicate,
+    timeout: float = 5.0,
+    poll_interval: float = 0.05,
+) -> bool:
+    """Poll until a predicate returns True or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+def wait_for_prefetch_status(
+    sm: StorageManager,
+    handle,
+    timeout: float = 10.0,
+    poll_interval: float = 0.05,
+) -> int | None:
+    """Poll query_prefetch_status until it returns a non-None value."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = sm.query_prefetch_status(handle)
+        if result is not None:
+            return result
+        time.sleep(poll_interval)
+    return None
 
 
 # =============================================================================
@@ -318,3 +353,174 @@ class TestStorageManagerBasic:
             assert key in ret
             assert ret[key] is not None
         storage_manager.close()
+
+
+# =============================================================================
+# L2 Prefetch Integration Tests
+# =============================================================================
+
+
+@pytest.fixture
+def l2_storage_manager_config(basic_l1_config):
+    """Create a StorageManagerConfig with one MockL2Adapter."""
+    return StorageManagerConfig(
+        l1_manager_config=basic_l1_config,
+        eviction_config=EvictionConfig(
+            eviction_policy="LRU",
+        ),
+        l2_adapter_config=L2AdaptersConfig(
+            adapters=[
+                MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0),
+            ],
+        ),
+    )
+
+
+class TestStorageManagerL2Prefetch:
+    """Tests for prefetching from L2 through StorageManager."""
+
+    def _write_keys_and_wait_for_l2(
+        self,
+        sm: StorageManager,
+        keys: list[ObjectKey],
+        layout: MemoryLayoutDesc,
+    ) -> None:
+        """Write keys to L1 via StorageManager and wait for L2 store."""
+        ret = sm.reserve_write(keys, layout, mode="new")
+        assert len(ret) == len(keys)
+        sm.finish_write(list(ret.keys()))
+
+        # Wait for StoreController to propagate all keys to L2
+        adapter = sm._l2_adapters[0]
+        ok = wait_for_condition(
+            lambda: all(adapter.debug_has_key(k) for k in keys),  # type: ignore
+            timeout=10.0,
+        )
+        assert ok, "Keys should be stored in L2 by StoreController"
+
+    def test_prefetch_from_l2(self, l2_storage_manager_config, basic_layout):
+        """Write to L1 → store to L2 → clear L1 → prefetch from L2."""
+        sm = StorageManager(l2_storage_manager_config)
+        keys = [make_object_key(i) for i in range(5)]
+
+        self._write_keys_and_wait_for_l2(sm, keys, basic_layout)
+
+        # Brief sleep to let StoreController release read locks
+        # after L2 store completion, then clear L1
+        time.sleep(0.05)
+        sm.clear()
+        used, _ = sm._l1_manager.get_memory_usage()
+        assert used == 0, f"L1 should be empty after clear, but {used} bytes used"
+
+        # Prefetch — L1 has 0 hits, L2 should have all 5
+        handle = sm.submit_prefetch_task(keys, basic_layout)
+        hit_count = wait_for_prefetch_status(sm, handle)
+
+        assert hit_count is not None, "Prefetch should complete"
+        assert hit_count == 5, f"Expected 5 hits from L2, got {hit_count}"
+
+        # Verify keys are read-locked in L1 after prefetch
+        with sm.read_prefetched_results(keys) as objs:
+            assert objs is not None
+            assert len(objs) == len(keys)
+
+        sm.finish_read_prefetched(keys)
+        sm.close()
+
+    def test_prefetch_mixed_l1_l2(self, l2_storage_manager_config, basic_layout):
+        """Some keys in L1, rest in L2 → combined prefix hits."""
+        sm = StorageManager(l2_storage_manager_config)
+
+        # Use distinct hash ranges for L1-only vs L2 keys
+        all_keys = [make_object_key(i) for i in range(5)]
+        l2_only_keys = all_keys[2:]  # keys 2, 3, 4 only in L2
+
+        # Write all keys to L1 (StoreController will push to L2)
+        self._write_keys_and_wait_for_l2(sm, all_keys, basic_layout)
+
+        # Delete only keys 2, 3, 4 from L1 so they must come from L2
+        sm._l1_manager.delete(l2_only_keys)
+
+        # Prefetch all 5 keys: first 2 from L1, next 3 from L2
+        handle = sm.submit_prefetch_task(all_keys, basic_layout)
+        hit_count = wait_for_prefetch_status(sm, handle)
+
+        assert hit_count is not None, "Prefetch should complete"
+        assert hit_count == 5, (
+            f"Expected 5 combined hits (2 L1 + 3 L2), got {hit_count}"
+        )
+
+        # Clean up read locks
+        sm.finish_read_prefetched(all_keys)
+        sm.close()
+
+    def test_prefetch_nothing_in_l2(self, l2_storage_manager_config, basic_layout):
+        """Prefetch keys not in L2 → returns 0 L2 hits."""
+        sm = StorageManager(l2_storage_manager_config)
+
+        # Don't write anything — keys exist nowhere
+        keys = [make_object_key(i) for i in range(3)]
+
+        handle = sm.submit_prefetch_task(keys, basic_layout)
+        hit_count = wait_for_prefetch_status(sm, handle)
+
+        assert hit_count is not None, "Prefetch should complete"
+        assert hit_count == 0, f"Expected 0 hits, got {hit_count}"
+
+        sm.close()
+
+    def test_prefetch_l2_partial_prefix(self, l2_storage_manager_config, basic_layout):
+        """L2 has keys {0,1,3,4} but not 2 → L2 returns prefix of 2."""
+        sm = StorageManager(l2_storage_manager_config)
+
+        all_keys = [make_object_key(i) for i in range(5)]
+        # Write only keys 0, 1, 3, 4 (skip key 2)
+        keys_to_write = [all_keys[i] for i in [0, 1, 3, 4]]
+        self._write_keys_and_wait_for_l2(sm, keys_to_write, basic_layout)
+
+        # Brief sleep to let StoreController release read locks
+        # after L2 store completion, then clear L1
+        time.sleep(0.05)
+        sm.clear()
+        used, _ = sm._l1_manager.get_memory_usage()
+        assert used == 0, f"L1 should be empty after clear, but {used} bytes used"
+
+        handle = sm.submit_prefetch_task(all_keys, basic_layout)
+        hit_count = wait_for_prefetch_status(sm, handle)
+
+        assert hit_count is not None, "Prefetch should complete"
+        assert hit_count == 2, (
+            f"Expected 2 prefix hits from L2 (gap at index 2), got {hit_count}"
+        )
+
+        # Only prefix keys {0, 1} should be readable
+        with sm.read_prefetched_results(all_keys[:2]) as objs:
+            assert objs is not None
+            assert len(objs) == 2
+
+        sm.finish_read_prefetched(all_keys[:2])
+        sm.close()
+
+    def test_prefetch_l1_prefix_plus_l2_continuation(
+        self, l2_storage_manager_config, basic_layout
+    ):
+        """L1 has keys {0,1}, L2 has {2,3,4} → combined prefix of 5."""
+        sm = StorageManager(l2_storage_manager_config)
+
+        all_keys = [make_object_key(i) for i in range(5)]
+
+        # Write all keys → StoreController stores all to L2
+        self._write_keys_and_wait_for_l2(sm, all_keys, basic_layout)
+
+        # Delete keys {2,3,4} from L1 only, keeping them in L2
+        sm._l1_manager.delete(all_keys[2:])
+
+        # Prefetch: L1 prefix hits = 2 (keys 0,1), L2 loads {2,3,4} → total = 5
+        handle = sm.submit_prefetch_task(all_keys, basic_layout)
+        hit_count = wait_for_prefetch_status(sm, handle)
+
+        assert hit_count is not None
+        assert hit_count == 5, f"Expected 5 total hits (2 L1 + 3 L2), got {hit_count}"
+
+        sm.finish_read_prefetched(all_keys)
+        sm.close()

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -1,0 +1,701 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for PrefetchController.
+
+Tests verify the end-to-end prefetch flow: submit request → lookup in L2 →
+compute prefix-trimmed load plan → reserve L1 buffers → load from L2 →
+transition to read-locked → report prefix hits.
+
+Uses a real L1Manager and MockL2Adapter (with debug methods) to exercise
+the full integration without mocking internals.
+"""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+    PrefetchController,
+)
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    DefaultPrefetchPolicy,
+)
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+)
+from lmcache.v1.memory_management import MemoryObjMetadata, TensorMemoryObj
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available"
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_object_key(chunk_id: int) -> ObjectKey:
+    """Create a test ObjectKey with the given chunk ID."""
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def make_layout() -> MemoryLayoutDesc:
+    """Create a small MemoryLayoutDesc for testing."""
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([100, 2, 512])],
+        dtypes=[torch.bfloat16],
+    )
+
+
+def should_use_lazy_alloc() -> bool:
+    return torch.cuda.is_available()
+
+
+def wait_for_condition(
+    predicate,
+    timeout: float = 5.0,
+    poll_interval: float = 0.05,
+) -> bool:
+    """Poll until a predicate returns True or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+def wait_for_prefetch_result(
+    ctrl: PrefetchController,
+    req_id: int,
+    timeout: float = 5.0,
+    poll_interval: float = 0.05,
+) -> int | None:
+    """Poll query_prefetch_result until it returns a non-None value."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = ctrl.query_prefetch_result(req_id)
+        if result is not None:
+            return result
+        time.sleep(poll_interval)
+    return None
+
+
+def make_adapter() -> MockL2Adapter:
+    """Create a MockL2Adapter with fast bandwidth."""
+    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+    return MockL2Adapter(config)
+
+
+def make_descriptor(index: int) -> AdapterDescriptor:
+    """Create an AdapterDescriptor for testing."""
+    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+    return AdapterDescriptor(index=index, config=config)
+
+
+def store_keys_in_l2(
+    adapter: MockL2Adapter,
+    keys: list[ObjectKey],
+    layout: MemoryLayoutDesc,
+) -> None:
+    """Store test data directly in L2 adapter and wait for completion."""
+    if not keys:
+        return
+    objs = []
+    for _ in keys:
+        tensor = torch.randn(layout.shapes[0], dtype=layout.dtypes[0])
+        metadata = MemoryObjMetadata(
+            shape=layout.shapes[0],
+            dtype=layout.dtypes[0],
+            address=0,
+            phy_size=tensor.nelement() * tensor.element_size(),
+            ref_count=0,
+        )
+        obj = TensorMemoryObj(raw_data=tensor, metadata=metadata, parent_allocator=None)
+        objs.append(obj)
+    adapter.submit_store_task(keys, objs)  # type: ignore
+    ok = wait_for_condition(
+        lambda: all(adapter.debug_has_key(k) for k in keys),
+        timeout=5.0,
+    )
+    assert ok, "Failed to store test data in L2 adapter"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def l1_manager():
+    """Create an L1Manager with a reasonable memory config."""
+    config = L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(
+            size_in_bytes=128 * 1024 * 1024,
+            use_lazy=should_use_lazy_alloc(),
+            init_size_in_bytes=64 * 1024 * 1024,
+            align_bytes=0x1000,
+        ),
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+    mgr = L1Manager(config)
+    yield mgr
+    mgr.close()
+
+
+# =============================================================================
+# Lifecycle Tests
+# =============================================================================
+
+
+class TestPrefetchControllerLifecycle:
+    """Test PrefetchController start/stop behavior."""
+
+    def test_start_stop(self, l1_manager):
+        """Controller should start and stop cleanly."""
+        adapter = make_adapter()
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+        ctrl.stop()
+        adapter.close()
+
+    def test_start_stop_no_adapters(self, l1_manager):
+        """Controller should start and stop cleanly with no adapters."""
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+        ctrl.stop()
+
+
+# =============================================================================
+# Single Adapter Prefetch
+# =============================================================================
+
+
+class TestSingleAdapterPrefetch:
+    """Test PrefetchController with one MockL2Adapter."""
+
+    def test_full_prefix_hit(self, l1_manager):
+        """All keys in L2 → all loaded, prefix hits = total keys."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(5)]
+
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 5, f"Expected 5 prefix hits, got {result}"
+
+        # Verify prefix keys are read-locked in L1
+        read_results = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        # Cleanup: release read locks
+        l1_manager.finish_read(keys)
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_prefix_with_gap(self, l1_manager):
+        """L2 has keys {0,1,3,4} but not 2 → only prefix {0,1} loaded."""
+        adapter = make_adapter()
+        layout = make_layout()
+        all_keys = [make_object_key(i) for i in range(5)]
+        # Store only keys 0, 1, 3, 4 (gap at index 2)
+        stored_keys = [all_keys[i] for i in [0, 1, 3, 4]]
+        store_keys_in_l2(adapter, stored_keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(all_keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 2, f"Expected 2 prefix hits (gap at index 2), got {result}"
+
+        # Verify prefix keys {0,1} are read-locked in L1
+        prefix_keys = all_keys[:2]
+        read_results = l1_manager.unsafe_read(prefix_keys)
+        for key in prefix_keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        # Verify keys beyond prefix {2,3,4} are NOT in L1
+        non_prefix_keys = all_keys[2:]
+        read_results = l1_manager.reserve_read(non_prefix_keys)
+        for key in non_prefix_keys:
+            assert read_results[key][0] == L1Error.KEY_NOT_EXIST
+
+        l1_manager.finish_read(prefix_keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_key0_missing(self, l1_manager):
+        """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+        adapter = make_adapter()
+        layout = make_layout()
+        all_keys = [make_object_key(i) for i in range(4)]
+        # Store keys 1, 2, 3 but not 0
+        stored_keys = all_keys[1:]
+        store_keys_in_l2(adapter, stored_keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(all_keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 0, f"Expected 0 prefix hits (key 0 missing), got {result}"
+
+        # Verify no keys are in L1
+        read_results = l1_manager.reserve_read(all_keys)
+        for key in all_keys:
+            assert read_results[key][0] == L1Error.KEY_NOT_EXIST
+
+        ctrl.stop()
+        adapter.close()
+
+
+# =============================================================================
+# Multi Adapter Prefetch
+# =============================================================================
+
+
+class TestMultiAdapterPrefetch:
+    """Test PrefetchController with multiple MockL2Adapters."""
+
+    def test_disjoint_adapters(self, l1_manager):
+        """Adapter 0 has {0,1}, adapter 1 has {2,3} → full prefix of 4."""
+        adapters = [make_adapter(), make_adapter()]
+        descriptors = [make_descriptor(i) for i in range(2)]
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(4)]
+
+        store_keys_in_l2(adapters[0], keys[:2], layout)
+        store_keys_in_l2(adapters[1], keys[2:], layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=adapters,
+            adapter_descriptors=descriptors,
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 4, f"Expected 4 prefix hits, got {result}"
+
+        read_results = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        l1_manager.finish_read(keys)
+        ctrl.stop()
+        for a in adapters:
+            a.close()
+
+    def test_overlap_first_wins(self, l1_manager):
+        """Both adapters have key 1. Adapter 0 (lower index) loads it."""
+        adapters = [make_adapter(), make_adapter()]
+        descriptors = [make_descriptor(i) for i in range(2)]
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+
+        # Adapter 0 has keys {0, 1}, adapter 1 has keys {1, 2}
+        store_keys_in_l2(adapters[0], keys[:2], layout)
+        store_keys_in_l2(adapters[1], keys[1:], layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=adapters,
+            adapter_descriptors=descriptors,
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 3, f"Expected 3 prefix hits, got {result}"
+
+        read_results = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        l1_manager.finish_read(keys)
+        ctrl.stop()
+        for a in adapters:
+            a.close()
+
+
+# =============================================================================
+# No Hits
+# =============================================================================
+
+
+class TestNoHits:
+    """Test PrefetchController when no keys are found in L2."""
+
+    def test_no_keys_in_l2(self, l1_manager):
+        """Prefetch keys not in any L2 → 0 prefix hits."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        # Don't store anything in L2
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 0, f"Expected 0 prefix hits, got {result}"
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_no_adapters(self, l1_manager):
+        """No adapters → 0 prefix hits immediately."""
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 0, f"Expected 0 prefix hits, got {result}"
+
+        ctrl.stop()
+
+
+# =============================================================================
+# Query Result
+# =============================================================================
+
+
+class TestQueryResult:
+    """Test query_prefetch_result semantics."""
+
+    def test_query_returns_int_then_none(self, l1_manager):
+        """Result is consumed on first query; second query returns None."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(2)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+
+        assert result == 2
+        # Second query should return None (already consumed)
+        assert ctrl.query_prefetch_result(req_id) is None
+
+        l1_manager.finish_read(keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_query_before_completion_returns_none(self, l1_manager):
+        """Querying a nonexistent request ID returns None."""
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        assert ctrl.query_prefetch_result(999) is None
+
+        ctrl.stop()
+
+
+# =============================================================================
+# L2 Lock Release
+# =============================================================================
+
+
+class TestPrefetchL2LockRelease:
+    """Test that L2 locks are properly released after prefetch."""
+
+    def test_locks_released_after_full_hit(self, l1_manager):
+        """All L2 locks should be released after a successful prefetch."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 3
+
+        # Wait for L2 unlock operations to be processed
+        ok = wait_for_condition(
+            lambda: adapter.debug_get_locked_key_count() == 0,
+            timeout=5.0,
+        )
+        assert ok, "L2 locks should be released after prefetch completion"
+
+        l1_manager.finish_read(keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_locks_released_after_prefix_trim(self, l1_manager):
+        """L2 locks released for both prefix and non-prefix keys."""
+        adapter = make_adapter()
+        layout = make_layout()
+        all_keys = [make_object_key(i) for i in range(5)]
+        # Store keys 0, 1, 3, 4 (gap at index 2)
+        stored_keys = [all_keys[i] for i in [0, 1, 3, 4]]
+        store_keys_in_l2(adapter, stored_keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(all_keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 2
+
+        # All L2 locks should be released (both prefix and trimmed keys)
+        ok = wait_for_condition(
+            lambda: adapter.debug_get_locked_key_count() == 0,
+            timeout=5.0,
+        )
+        assert ok, "All L2 locks should be released after prefix-trimmed prefetch"
+
+        l1_manager.finish_read(all_keys[:2])
+        ctrl.stop()
+        adapter.close()
+
+    def test_locks_released_after_no_hits(self, l1_manager):
+        """L2 locks released even when nothing is found."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        # Don't store anything
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 0
+
+        ok = wait_for_condition(
+            lambda: adapter.debug_get_locked_key_count() == 0,
+            timeout=5.0,
+        )
+        assert ok, "L2 locks should be 0 when nothing was found"
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_multi_adapter_locks_released(self, l1_manager):
+        """Both adapters' L2 locks released after overlapping prefetch."""
+        adapters = [make_adapter(), make_adapter()]
+        descriptors = [make_descriptor(i) for i in range(2)]
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+
+        # Adapter 0 has {0, 1}, adapter 1 has {1, 2}
+        store_keys_in_l2(adapters[0], keys[:2], layout)
+        store_keys_in_l2(adapters[1], keys[1:], layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=adapters,
+            adapter_descriptors=descriptors,
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 3
+
+        # Both adapters should have all locks released
+        for i, adapter in enumerate(adapters):
+            ok = wait_for_condition(
+                lambda a=adapter: a.debug_get_locked_key_count() == 0,
+                timeout=5.0,
+            )
+            assert ok, f"Adapter {i} should have all L2 locks released"
+
+        l1_manager.finish_read(keys)
+        ctrl.stop()
+        for a in adapters:
+            a.close()
+
+
+# =============================================================================
+# Max In-Flight
+# =============================================================================
+
+
+class TestMaxInFlight:
+    """Test PrefetchController max in-flight request limiting."""
+
+    def test_queuing_beyond_max_in_flight(self, l1_manager):
+        """Submit more requests than max_in_flight → all eventually complete."""
+        adapter = make_adapter()
+        layout = make_layout()
+
+        # Store keys for 4 separate requests (2 keys each)
+        all_keys = [make_object_key(i) for i in range(8)]
+        store_keys_in_l2(adapter, all_keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            max_in_flight=2,
+        )
+        ctrl.start()
+
+        # Submit 4 requests (max_in_flight=2, so 2 queued)
+        req_ids = []
+        for i in range(4):
+            batch_keys = all_keys[i * 2 : (i + 1) * 2]
+            req_id = ctrl.submit_prefetch_request(batch_keys, layout)
+            req_ids.append(req_id)
+
+        # All 4 requests should eventually complete
+        results = []
+        for req_id in req_ids:
+            result = wait_for_prefetch_result(ctrl, req_id, timeout=10.0)
+            assert result is not None, f"Request {req_id} should complete"
+            results.append(result)
+
+        assert results == [2, 2, 2, 2]
+
+        # Release read locks for all keys
+        l1_manager.finish_read(all_keys)
+
+        ctrl.stop()
+        adapter.close()
+
+
+# =============================================================================
+# Multiple Sequential Requests
+# =============================================================================
+
+
+class TestMultipleRequests:
+    """Test multiple sequential prefetch requests."""
+
+    def test_two_sequential_requests(self, l1_manager):
+        """Two back-to-back requests should both complete correctly."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys1 = [make_object_key(i) for i in range(3)]
+        keys2 = [make_object_key(i) for i in range(10, 14)]
+
+        store_keys_in_l2(adapter, keys1, layout)
+        store_keys_in_l2(adapter, keys2, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req1 = ctrl.submit_prefetch_request(keys1, layout)
+        result1 = wait_for_prefetch_result(ctrl, req1)
+        assert result1 == 3
+
+        req2 = ctrl.submit_prefetch_request(keys2, layout)
+        result2 = wait_for_prefetch_result(ctrl, req2)
+        assert result2 == 4
+
+        l1_manager.finish_read(keys1)
+        l1_manager.finish_read(keys2)
+        ctrl.stop()
+        adapter.close()


### PR DESCRIPTION
## Summary

- **PrefetchController**: New event-driven background controller that asynchronously prefetches KV cache data from L2 adapters into L1 memory. Uses a two-phase state machine (LOOKUP → PLAN_AND_LOAD) with `select.poll()` on adapter eventfds, max-in-flight request limiting, and comprehensive L1/L2 lock management.
- **PrefetchPolicy ABC + DefaultPrefetchPolicy**: Policy interface for deciding which adapter loads which key when multiple adapters have the same data. Default policy assigns each key to the first (lowest-indexed) adapter that has it.
- **StorageManager integration**: Wires PrefetchController into StorageManager. `submit_prefetch_task` now checks L1 for prefix hits first, then delegates remaining keys to PrefetchController for L2 prefetch. `query_prefetch_status` combines L1 + L2 results with latency logging.
- **`L1Manager.finish_write_and_reserve_read()`**: Atomic write-to-read lock transition, preventing eviction between L2 load completion and read lock acquisition.
- **`L1Manager.clear(force=False)`**: Safe clear that skips locked objects by default, protecting in-flight store/prefetch operations.
- **L2 adapter eventfd contract**: Added docstrings requiring globally unique event fds across all adapters and operation types.
- **Design doc**: `l2_adapters/DESIGN.md` documenting the full store/prefetch controller architecture, data flows, lock invariants, and assumptions.

## Key Design Decisions

- **Prefix-only loading**: Only the contiguous prefix of found keys is loaded from L2. Gaps break the prefix since vLLM requires contiguous KV cache. This is enforced by `trim_load_plan_to_prefix()`.
- **Two-phase L2 unlock**: Phase 1 unlocks keys not in the load plan (after planning); Phase 2 unlocks all plan keys (after load completes). Ensures L2 locks are always released.
- **Temporary L1 write buffers**: Prefetch write reservations use `is_temporary=True` to allow eviction controller reclaim if needed.
- **Fire-and-forget unlock**: `submit_unlock` is never retried by the controller — the adapter must guarantee eventual success internally.

## Files Changed

| File | Change |
|------|--------|
| `storage_controllers/prefetch_controller.py` | New: full PrefetchController implementation (675 lines) |
| `storage_controllers/prefetch_policy.py` | New: PrefetchPolicy ABC + DefaultPrefetchPolicy |
| `storage_controllers/__init__.py` | Export PrefetchController |
| `storage_manager.py` | Wire PrefetchController, update submit/query/close, add timing logs, safe clear() |
| `l1_manager.py` | Add `finish_write_and_reserve_read()`, safe `clear(force)` |
| `l2_adapters/base.py` | Add eventfd uniqueness contract docstrings |
| `l2_adapters/DESIGN.md` | New: architecture and invariants design doc |
| `tests/.../test_prefetch_controller.py` | New: 18 unit tests for PrefetchController |
| `tests/.../test_distributed_storage_manager.py` | Add 5 L2 prefetch integration tests |

## Test Plan

- [x] `pytest -xvs tests/v1/distributed/test_prefetch_controller.py` — 18 tests covering lifecycle, single/multi adapter prefetch, overlap dedup, no-hits, max-in-flight queuing, partial load failure, query result pop semantics
- [x] `pytest -xvs tests/v1/distributed/test_distributed_storage_manager.py` — 5 new integration tests: L2 round-trip, mixed L1/L2 hits, no L2 hits, partial prefix, L1+L2 continuation
- [x] `pytest -xvs tests/v1/distributed/` — all 208 tests pass
- [x] E2E test with vLLM + LMCache MP server + mock L2 adapter: 3.7x TTFT speedup (0.910s cold → 0.246s warm)
