### PR TITLE
[CI] Fix mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ from-first = true
 
 [tool.mypy]
 
+platform = "linux"
 modules = ["lmcache", "tests", "benchmarks"]
 
 disable_error_code = [


### PR DESCRIPTION
**What this PR does / why we need it**:

mypy is broken with the following errors:

```bash
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

lmcache/v1/periodic_thread.py:411: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/v1/check/__init__.py:20: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_kv_layer_groups_manager.py:19: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/mp_observability/test_storage_manager_stats_logger.py:197: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/mp_observability/test_storage_manager_stats_logger.py:222: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/mp_observability/test_l1_stats_logger.py:139: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/usage_context.py:343: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:271: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:281: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:282: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:285: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:305: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:306: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:307: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:313: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:316: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:317: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:318: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:319: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/observability.py:320: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:258: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:278: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:456: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:457: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:505: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:544: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:546: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:626: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_address_manager.py:629: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/v1/storage_backend/cache_policy/lru.py:23: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:52: error: Module has no attribute "eventfd"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:52: error: Module has no attribute "EFD_NONBLOCK"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:52: error: Module has no attribute "EFD_CLOEXEC"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:53: error: Module has no attribute "eventfd"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:53: error: Module has no attribute "EFD_NONBLOCK"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:53: error: Module has no attribute "EFD_CLOEXEC"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:54: error: Module has no attribute "eventfd"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:54: error: Module has no attribute "EFD_NONBLOCK"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:54: error: Module has no attribute "EFD_CLOEXEC"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:298: error: Module has no attribute "eventfd_write"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:355: error: Module has no attribute "eventfd_write"  [attr-defined]
lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py:372: error: Module has no attribute "eventfd_write"  [attr-defined]
tests/v1/distributed/test_mock_l2_adapter.py:69: error: Module has no attribute "eventfd_read"  [attr-defined]
lmcache/v1/distributed/storage_controllers/store_controller.py:53: error: Module has no attribute "eventfd"  [attr-defined]
lmcache/v1/distributed/storage_controllers/store_controller.py:53: error: Module has no attribute "EFD_NONBLOCK"  [attr-defined]
lmcache/v1/distributed/storage_controllers/store_controller.py:53: error: Module has no attribute "EFD_CLOEXEC"  [attr-defined]
lmcache/v1/distributed/storage_controllers/store_controller.py:93: error: Module has no attribute "eventfd_write"  [attr-defined]
lmcache/v1/distributed/storage_controllers/store_controller.py:202: error: Module has no attribute "eventfd_write"  [attr-defined]
lmcache/v1/distributed/storage_controllers/store_controller.py:236: error: Module has no attribute "eventfd_read"  [attr-defined]
lmcache/v1/distributed/storage_controllers/prefetch_controller.py:214: error: Module has no attribute "eventfd"  [attr-defined]
lmcache/v1/distributed/storage_controllers/prefetch_controller.py:214: error: Module has no attribute "EFD_NONBLOCK"  [attr-defined]
lmcache/v1/distributed/storage_controllers/prefetch_controller.py:214: error: Module has no attribute "EFD_CLOEXEC"  [attr-defined]
lmcache/v1/distributed/storage_controllers/prefetch_controller.py:269: error: Module has no attribute "eventfd_write"  [attr-defined]
lmcache/v1/distributed/storage_controllers/prefetch_controller.py:306: error: Module has no attribute "eventfd_write"  [attr-defined]
lmcache/v1/distributed/storage_controllers/prefetch_controller.py:339: error: Module has no attribute "eventfd_read"  [attr-defined]
lmcache/v1/storage_backend/batched_message_sender.py:156: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/storage_backend/test_remote_storage_plugin.py:40: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/storage_backend/test_remote_storage_plugin.py:41: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/v1/cache_controller/utils.py:356: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/v1/cache_controller/utils.py:363: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/v1/cache_controller/utils.py:365: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_gpu_connector.py:261: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_gpu_connector.py:262: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_gpu_connector.py:263: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_gpu_connector.py:264: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/storage_backend/test_local_cpu_backend.py:557: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/storage_backend/test_local_cpu_backend.py:592: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/tools/controller_benchmark/benchmark.py:493: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/tools/controller_benchmark/benchmark.py:496: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/tools/controller_benchmark/benchmark.py:497: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
lmcache/tools/controller_benchmark/benchmark.py:500: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_vllm_layerwise_wait_for_save.py:30: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_vllm_layerwise_wait_for_save.py:31: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/v1/test_vllm_layerwise_wait_for_save.py:32: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/tools/test_controller_zmq_benchmark.py:433: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 25 errors in 4 files (checked 458 source files)

```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
