### PR TITLE
Fix race condition in FSConnector tmp file naming

### DIFF
--- a/lmcache/v1/storage_backend/connector/fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/fs_connector.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, no_type_check
 import asyncio
 import os
+import uuid
 
 # Third Party
 import aiofiles
@@ -134,7 +135,8 @@ class FSConnector(RemoteConnector):
         if self.relative_tmp_dir is not None:
             tmp_path = base_path / self.relative_tmp_dir / file_name
         else:
-            tmp_path = file_path.with_suffix(".tmp")
+            tmp_file_name = f"{file_name}.{uuid.uuid4().hex}.tmp"
+            tmp_path = file_path.with_name(tmp_file_name)
         return file_path, tmp_path
 
     async def exists(self, key: CacheEngineKey) -> bool:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -121,7 +121,7 @@ class LocalDiskBackend(StorageBackendInterface):
         assert config.local_disk is not None
         self.path: str = config.local_disk
         if not os.path.exists(self.path):
-            os.makedirs(self.path)
+            os.makedirs(self.path, exist_ok=True)
             logger.info(f"Created local disk cache directory: {self.path}")
 
         self.loop = loop

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-# TODO(Jiayi): handle cases where cache is repetitvely prefetched.
+# TODO(Jiayi): handle cases where cache is repeatedly prefetched.
 class LocalDiskWorker:
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self.put_lock = threading.Lock()


### PR DESCRIPTION
## Summary

- Added UUID to temporary filename in `_get_file_and_tmp_path` to prevent collisions when multiple processes try to write the same cache key concurrently
- Changed from `.tmp` suffix to `.{uuid}.tmp` format

## Problem (Issue #2517)

When multiple vLLM instances write to the same cache key simultaneously:
1. Process A opens temp file and writes data
2. Process A calls `os.replace()` (atomic rename)
3. Process B tries to open the same temp file but it no longer exists
4. Process B fails, and worse, enters an inconsistent state in memory

## Fix

Generate a unique temporary filename using UUID to ensure each process has its own temp file:

```python
# Before
tmp_path = file_path.with_suffix(".tmp")

# After  
tmp_file_name = f"{file_name}.{uuid.uuid4().hex}.tmp"
tmp_path = file_path.with_name(tmp_file_name)
```

## Fixes

Fixes #2517

## Testing

This is a targeted fix that adds randomness to temp file naming to prevent collisions.