### PR TITLE
[CI]: 5 day maximum for Comprehensive Test flexibility

### DIFF
--- a/.buildkite/k3_harness/install-agent-stack.sh
+++ b/.buildkite/k3_harness/install-agent-stack.sh
@@ -28,13 +28,13 @@ kubectl create secret generic buildkite-git-creds \
 
 # Install or upgrade agent-stack-k8s
 # - git-credentials-secret: checkout container uses HTTPS instead of SSH
-# - pod-spec-patch: injects GITHUB_TOKEN into job containers for push operations
+# - GITHUB_TOKEN is injected per-step in pipeline.yml (not via global pod-spec-patch)
 helm upgrade --install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-k8s \
+    --version 0.38.0 \
     --namespace buildkite --create-namespace \
     --set agentToken="${TOKEN}" \
     --set config.queue="${QUEUE}" \
     --set-json 'config.git-credentials-secret={"name":"buildkite-git-creds","key":"git-credentials"}' \
-    --set-json 'config.pod-spec-patch={"containers":[{"name":"container-0","env":[{"name":"GITHUB_TOKEN","valueFrom":{"secretKeyRef":{"name":"buildkite-git-creds","key":"GITHUB_TOKEN"}}}]}]}' \
     --wait --timeout 3m
 
 echo "agent-stack-k8s installed (queue=${QUEUE})"

--- a/.buildkite/k3_tests/comprehensive/pipeline.yml
+++ b/.buildkite/k3_tests/comprehensive/pipeline.yml
@@ -118,3 +118,9 @@ steps:
                 image: lmcache/ci-base:latest
                 imagePullPolicy: Never
                 resources: { limits: { cpu: "1", memory: "2Gi" } }
+                env:
+                  - name: GITHUB_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: buildkite-git-creds
+                        key: GITHUB_TOKEN

--- a/.buildkite/k3_tests/comprehensive/scripts/run-single-config.sh
+++ b/.buildkite/k3_tests/comprehensive/scripts/run-single-config.sh
@@ -374,11 +374,28 @@ elif [[ "$test_mode" == "long_doc_qa" ]]; then
             return 0
         fi
 
+        # Adaptive threshold: with fewer baselines the worst-case max is less
+        # representative, so we allow more headroom.
+        #   5+ baselines → 1.2x (20% tolerance, full confidence)
+        #   4  baselines → 1.3x
+        #   3  baselines → 1.4x
+        #   2  baselines → 1.5x
+        #   1  baseline  → 1.6x (60% tolerance, low confidence)
+        local num_baselines=${#baseline_files[@]}
+        local threshold
+        threshold=$(awk -v n="$num_baselines" 'BEGIN {
+            gap = (5 - n); if (gap < 0) gap = 0
+            printf "%.1f", 1.2 + gap * 0.1
+        }')
+        local pct
+        pct=$(awk -v t="$threshold" 'BEGIN { printf "%d", (t - 1) * 100 }')
+        echo "[INFO] Baselines: ${num_baselines}/5 — using ${pct}% tolerance (threshold=${threshold}x)"
+
         if [[ "$check_ttft" == "true" ]]; then
             echo "Worst-case baseline query ttft per prompt: $expected_query_ttft"
             echo "Actual query ttft per prompt: $query_ttft_per_prompt"
-            awk -v expected="$expected_query_ttft" -v actual="$query_ttft_per_prompt" 'BEGIN {
-                if (actual > expected * 1.2) { print "FAIL: Query ttft per prompt >20% worse than rolling baseline"; exit 1 }
+            awk -v expected="$expected_query_ttft" -v actual="$query_ttft_per_prompt" -v t="$threshold" -v pct="$pct" 'BEGIN {
+                if (actual > expected * t) { printf "FAIL: Query ttft per prompt >%d%% worse than rolling baseline\n", pct; exit 1 }
                 else { print "PASS: Query ttft per prompt within threshold" }
             }'
         fi
@@ -386,8 +403,8 @@ elif [[ "$test_mode" == "long_doc_qa" ]]; then
         if [[ "$check_round" == "true" ]]; then
             echo "Worst-case baseline query round time per prompt: $expected_query_round"
             echo "Actual query round time per prompt: $query_round_time_per_prompt"
-            awk -v expected="$expected_query_round" -v actual="$query_round_time_per_prompt" 'BEGIN {
-                if (actual > expected * 1.2) { print "FAIL: Query round time per prompt >20% worse than rolling baseline"; exit 1 }
+            awk -v expected="$expected_query_round" -v actual="$query_round_time_per_prompt" -v t="$threshold" -v pct="$pct" 'BEGIN {
+                if (actual > expected * t) { printf "FAIL: Query round time per prompt >%d%% worse than rolling baseline\n", pct; exit 1 }
                 else { print "PASS: Query round time per prompt within threshold" }
             }'
         fi
@@ -395,8 +412,8 @@ elif [[ "$test_mode" == "long_doc_qa" ]]; then
         if [[ "$check_warmup" == "true" ]]; then
             echo "Worst-case baseline warmup round time per prompt: $expected_warmup"
             echo "Actual warmup round time per prompt: $warmup_round_time_per_prompt"
-            awk -v expected="$expected_warmup" -v actual="$warmup_round_time_per_prompt" 'BEGIN {
-                if (actual > expected * 1.2) { print "FAIL: Warmup round time per prompt >20% worse than rolling baseline"; exit 1 }
+            awk -v expected="$expected_warmup" -v actual="$warmup_round_time_per_prompt" -v t="$threshold" -v pct="$pct" 'BEGIN {
+                if (actual > expected * t) { printf "FAIL: Warmup round time per prompt >%d%% worse than rolling baseline\n", pct; exit 1 }
                 else { print "PASS: Warmup round time per prompt within threshold" }
             }'
         fi

--- a/.buildkite/k3_tests/correctness/scripts/run-correctness.sh
+++ b/.buildkite/k3_tests/correctness/scripts/run-correctness.sh
@@ -99,7 +99,6 @@ vllm serve "${MODEL}" \
     --enforce-eager \
     --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
-    -cc.level=0 \
     >"${VLLM_LOG}" 2>&1 &
 VLLM_PID=$!
 
@@ -144,7 +143,6 @@ vllm serve "${MODEL}" \
     --enforce-eager \
     --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
-    -cc.level=0 \
     --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \
     >>"${VLLM_LOG}" 2>&1 &
 VLLM_PID=$!

--- a/.buildkite/scripts/vllm-correctness.sh
+++ b/.buildkite/scripts/vllm-correctness.sh
@@ -140,7 +140,6 @@ vllm serve "${MODEL}" \
     --enforce-eager \
     --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
-    -cc.level=0 \
     >"${VLLM_LOG}" 2>&1 &
 VLLM_PID=$!
 
@@ -191,7 +190,6 @@ vllm serve "${MODEL}" \
     --enforce-eager \
     --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
-    -cc.level=0 \
     --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \
     >>"${VLLM_LOG}" 2>&1 &
 VLLM_PID=$!


### PR DESCRIPTION
Proposal: If we have fewer than 5 baselines for any reason, we should be slightly more flexible

2 more ad hoc fixes: 
1. fix the newly redundant flag for compilation level for vllm serve
2. pass in the GITHUB_TOKEN properly for the nightly push of the comprehensive test results