### PR TITLE
fix the inconsistent config naming "nixl_pool_size" and "nixl_file_pool_size"

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -303,7 +303,7 @@ Settings for using Nixl as a storage backend instead of disaggregated prefill. T
       enable_nixl_storage: true
       nixl_backend: "POSIX"  # Options: "GDS", "GDS_MT", "POSIX", "HF3FS"
       nixl_path: "/path/to/storage/"
-      nixl_file_pool_size: 64
+      nixl_pool_size: 64
 
 .. list-table::
    :header-rows: 1
@@ -317,7 +317,7 @@ Settings for using Nixl as a storage backend instead of disaggregated prefill. T
      - Storage backend type. Options: "GDS", "GDS_MT", "POSIX", "HF3FS"
    * - nixl_path
      - File system path for Nixl storage
-   * - nixl_file_pool_size
+   * - nixl_pool_size
      - Number of files in the storage pool
 
 

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -71,7 +71,7 @@ def create_test_config(
     config.extra_config = {
         "enable_nixl_storage": True,
         "nixl_backend": backend,
-        "nixl_file_pool_size": 10,
+        "nixl_pool_size": 10,
         "nixl_path": tempfile.mkdtemp(),  # Create a temporary directory for testing
     }
     return config
@@ -106,7 +106,7 @@ def test_nixl_storage_config():
     assert nixl_config.buffer_size == config.nixl_buffer_size
     assert nixl_config.buffer_device == config.nixl_buffer_device
     assert nixl_config.backend == config.extra_config["nixl_backend"]
-    assert nixl_config.file_pool_size == config.extra_config["nixl_file_pool_size"]
+    assert nixl_config.pool_size == config.extra_config["nixl_pool_size"]
     assert nixl_config.path == config.extra_config["nixl_path"]
 
     # Test validation


### PR DESCRIPTION
This PR is used to fix the inconsistent config naming between "nixl_pool_size" and "nixl_file_pool_size". unify to use "nixl_pool_size"

Some UTs use the nixl_file_pool_size extra config but others use nixl_pool_size. Unify them to avoid the UT failure of nixl_storage_backend.py:from_cache_engine_config.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix inconsistent parameter naming

**If applicable**:

- [x] this PR contains user facing changes - docs updated
- [ ] this PR contains unit tests
