### PR TITLE
fix two bugs in tests/disagg/test_nixl_storage_backend.py

### DIFF
--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 import argparse
 import asyncio
 import os
+import shutil
 import tempfile
 import threading
 import time
@@ -104,7 +105,7 @@ def test_nixl_storage_config():
 
     nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
     assert nixl_config.buffer_size == config.nixl_buffer_size
-    assert nixl_config.buffer_device == config.nixl_buffer_device
+    assert config.nixl_buffer_device in nixl_config.buffer_device
     assert nixl_config.backend == config.extra_config["nixl_backend"]
     assert nixl_config.file_pool_size == config.extra_config["nixl_file_pool_size"]
     assert nixl_config.path == config.extra_config["nixl_path"]
@@ -170,7 +171,7 @@ def test_nixl_storage_backend_basic():
             thread.join()
         # Cleanup temporary directory
         if os.path.exists(config.extra_config["nixl_path"]):
-            os.rmdir(config.extra_config["nixl_path"])
+            shutil.rmtree(config.extra_config["nixl_path"])
 
 
 @pytest.mark.no_shared_allocator
@@ -239,7 +240,7 @@ def test_nixl_storage_backend_put_get():
             thread.join()
         # Cleanup temporary directory
         if os.path.exists(config.extra_config["nixl_path"]):
-            os.rmdir(config.extra_config["nixl_path"])
+            shutil.rmtree(config.extra_config["nixl_path"])
 
 
 @pytest.mark.no_shared_allocator
@@ -296,7 +297,7 @@ def test_nixl_storage_backend_different_backends():
                 thread.join()
             # Cleanup temporary directory
             if os.path.exists(config.extra_config["nixl_path"]):
-                os.rmdir(config.extra_config["nixl_path"])
+                shutil.rmtree(config.extra_config["nixl_path"])
 
 
 if __name__ == "__main__":
@@ -388,4 +389,4 @@ if __name__ == "__main__":
             thread.join()
         # Cleanup temporary directory
         if os.path.exists(config.extra_config["nixl_path"]):
-            os.rmdir(config.extra_config["nixl_path"])
+            shutil.rmtree(config.extra_config["nixl_path"])


### PR DESCRIPTION
This PR fixed two bugs in the UT

1. os.rmdir() couldn't remove non-empty directory
2. NixlStorageConfig's buffer_device is corrected device string but not original one

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix some bugs found in UT

**Special notes for your reviewers**:
N/A

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
