### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -43,7 +43,7 @@ jobs:
             auth.docker.io:443
 
       - name: "Checkout"
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -35,7 +35,7 @@ jobs:
                   objects.githubusercontent.com:443
 
             - name: Checkout code
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               with:
                 fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
               run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$' | xargs -r git tag -d
 
             - name: Setup Python 3.13
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
               with:
                 python-version: "3.13"
 
@@ -68,7 +68,7 @@ jobs:
                 lmcache --help
 
             - name: Upload CLI release artifacts to GHA
-              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
               with:
                 name: release-cli-artifacts
                 path: dist/

--- a/.github/workflows/build_cu130_artifacts.yml
+++ b/.github/workflows/build_cu130_artifacts.yml
@@ -47,7 +47,7 @@ jobs:
                   pypi.nvidia.com:443
 
             - name: Checkout code
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               with:
                 fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
               uses: ./.github/actions/free-disk-space
 
             - name: Setup Python 3.13
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
               with:
                 python-version: "3.13"
 
@@ -109,7 +109,7 @@ jobs:
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload cu130 release artifacts to GHA
-              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
               with:
                 name: release-cu130-artifacts
                 path: dist/

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -22,7 +22,7 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Full git history needed for sphinx-multiversion to detect all tags/branches
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
 
@@ -53,7 +53,7 @@ jobs:
           rm -rf output/dev
 
       - name: Upload doc artifacts to GHA
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: doc-artifacts
           path: output/
@@ -69,13 +69,13 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: Fetch doc artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
             name: doc-artifacts
             path: output
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: LM-Cache-Website/lm-cache-website.github.io
           token: ${{ secrets.LMCACHE_DOC }}

--- a/.github/workflows/build_main_artifacts.yml
+++ b/.github/workflows/build_main_artifacts.yml
@@ -42,7 +42,7 @@ jobs:
                   releases.githubusercontent.com:443
 
             - name: Checkout code
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               with:
                 # for setuptools-scm
                 fetch-depth: 0
@@ -54,7 +54,7 @@ jobs:
               uses: ./.github/actions/free-disk-space
 
             - name: Setup Python 3.13
-              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
               with:
                 python-version: "3.13"
 
@@ -82,7 +82,7 @@ jobs:
                 python -m cibuildwheel --output-dir dist
 
             - name: Upload release artifacts to GHA
-              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
               with:
                 name: release-artifacts
                 path: dist/

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       lmcache: ${{ github.event_name == 'release' || steps.filter.outputs.lmcache == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: github.event_name == 'push'
         with:
           fetch-depth: 2
@@ -57,13 +57,13 @@ jobs:
               static.crates.io:443
 
         - name: Checkout code
-          uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
           with:
             # for setuptools-scm
             fetch-depth: 0
 
         - name: Setup Python 3.13
-          uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
           with:
             python-version: "3.13"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,7 +90,7 @@ jobs:
           storage.googleapis.com:443
 
     - name: Checkout repository
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         # for setuptools-scm
         fetch-depth: 0

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -38,7 +38,7 @@ jobs:
             pypi.nvidia.com:443
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
 
@@ -171,7 +171,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # for setuptools-scm
           fetch-depth: 0
@@ -183,7 +183,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/operator_ci.yml
+++ b/.github/workflows/operator_ci.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       operator: ${{ steps.filter.outputs.operator == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: github.event_name == 'push'
         with:
           fetch-depth: 2
@@ -53,10 +53,10 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: operator/go.mod
 

--- a/.github/workflows/operator_nightly.yml
+++ b/.github/workflows/operator_nightly.yml
@@ -27,7 +27,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -56,7 +56,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:nightly
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: operator/go.mod
 

--- a/.github/workflows/operator_release.yml
+++ b/.github/workflows/operator_release.yml
@@ -27,7 +27,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -56,7 +56,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: operator/go.mod
 

--- a/.github/workflows/operator_test_e2e.yml
+++ b/.github/workflows/operator_test_e2e.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       operator: ${{ steps.filter.outputs.operator == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: github.event_name == 'push'
         with:
           fetch-depth: 2
@@ -53,10 +53,10 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: operator/go.mod
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         outputs:
             lmcache: ${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags/') || steps.filter.outputs.lmcache == 'true' }}
         steps:
-            - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
               with:
                 fetch-depth: 2
@@ -128,7 +128,7 @@ jobs:
                   rekor.sigstore.dev:443
 
             - name: Fetch release artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: release-artifacts
                   path: dist
@@ -167,7 +167,7 @@ jobs:
                   rekor.sigstore.dev:443
 
             - name: Fetch CLI release artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: release-cli-artifacts
                   path: dist
@@ -212,7 +212,7 @@ jobs:
                     rekor.sigstore.dev:443
 
             - name: Fetch release artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: release-artifacts
                   path: dist
@@ -257,7 +257,7 @@ jobs:
                     rekor.sigstore.dev:443
 
             - name: Fetch CLI release artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: release-cli-artifacts
                   path: dist
@@ -296,7 +296,7 @@ jobs:
                     uploads.github.com:443
 
             - name: Fetch cu130 release artifacts
-              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: release-cu130-artifacts
                   path: dist
@@ -369,7 +369,7 @@ jobs:
               uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
             - name: Checkout code
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
               with:
                 # for setuptools-scm
                 fetch-depth: 0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,7 +53,7 @@ jobs:
             api.scorecard.dev:443
 
       - name: "Checkout code"
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -83,7 +83,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -30,7 +30,7 @@ jobs:
             api.github.com:443
 
       - name: "Stale Action"
-        uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
         with:
           stale-issue-label: 'stale'
           stale-issue-message: >

--- a/.github/workflows/sync_torch_version.yml
+++ b/.github/workflows/sync_torch_version.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out dev branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: dev
           token: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       lmcache: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' || steps.filter.outputs.lmcache == 'true' }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         if: github.event_name == 'push'
         with:
           fetch-depth: 2
@@ -73,7 +73,7 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -82,7 +82,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
   
       - name: Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/setup-go@v5, actions/checkout@v4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`de0fac2`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd) | [Diff](https://github.com/actions/checkout/compare/8e8c483db84b...de0fac2e4500) | actionlint.yml, build_cli_artifacts.yml, build_cu130_artifacts.yml, build_doc.yml, build_main_artifacts.yml, code_quality_checks.yml, codeql.yml, nightly_build.yml, operator_ci.yml, operator_nightly.yml, operator_release.yml, operator_test_e2e.yml, publish.yml, scorecard.yml, sync_torch_version.yml, test.yml |
| `actions/download-artifact` | [`37930b1`](https://github.com/actions/download-artifact/commit/37930b1c2abaa49bbe596cd826c3c89aef350131) | [`3e5f45b`](https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) | [Diff](https://github.com/actions/download-artifact/compare/37930b1c2aba...3e5f45b2cfb9) | build_doc.yml, publish.yml |
| `actions/setup-go` | [`v5`](https://github.com/actions/setup-go/releases/tag/v5) | [`4a36011`](https://github.com/actions/setup-go/commit/4a3601121dd01d1626a1e23e37211e3254c1c06c) | [Diff](https://github.com/actions/setup-go/compare/v5...4a3601121dd0) | operator_ci.yml, operator_nightly.yml, operator_release.yml, operator_test_e2e.yml |
| `actions/setup-python` | [`83679a8`](https://github.com/actions/setup-python/commit/83679a892e2d95755f2dac6acb0bfd1e9ac5d548) | [`a309ff8`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) | [Diff](https://github.com/actions/setup-python/compare/83679a892e2d...a309ff8b426b) | build_cli_artifacts.yml, build_cu130_artifacts.yml, build_doc.yml, build_main_artifacts.yml, code_quality_checks.yml, nightly_build.yml, test.yml |
| `actions/stale` | [`9971854`](https://github.com/actions/stale/commit/997185467fa4f803885201cee163a9f38240193d) | [`b5d41d4`](https://github.com/actions/stale/commit/b5d41d4e1d5dceea10e7104786b73624c18a190f) | [Diff](https://github.com/actions/stale/compare/997185467fa4...b5d41d4e1d5d) | stale_bot.yml |
| `actions/upload-artifact` | [`b7c566a`](https://github.com/actions/upload-artifact/commit/b7c566a772e6b6bfb58ed0dc250532a479d7789f) | [`043fb46`](https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) | [Diff](https://github.com/actions/upload-artifact/compare/b7c566a772e6...043fb46d1a93) | build_cli_artifacts.yml, build_cu130_artifacts.yml, build_doc.yml, build_main_artifacts.yml, scorecard.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Notes

All actions are pinned to commit SHAs for supply-chain security. Version comments are included for readability (e.g. `actions/checkout@abc123 # v6`).

Worth running the workflows on a branch before merging to make sure everything still works.
