### PR TITLE
[MP][UX] Unified config + argparse for multiprocess mode

### DIFF
--- a/lmcache/v1/multiprocess/blend_server.py
+++ b/lmcache/v1/multiprocess/blend_server.py
@@ -34,6 +34,10 @@ from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
     init_prometheus_controller,
 )
+from lmcache.v1.multiprocess.config import (
+    MPServerConfig,
+    parse_args_to_mp_server_config,
+)
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
@@ -645,28 +649,20 @@ def add_handler_helper(
 
 
 def run_cache_server(
+    mp_config: MPServerConfig,
     storage_manager_config: StorageManagerConfig,
     prometheus_config: PrometheusConfig,
-    host: str = "localhost",
-    port: int = 5555,
-    chunk_size: int = 256,
-    max_workers: int = 1,
     return_engine: bool = False,
-    hash_algorithm: str = "blake3",
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
 
     Args:
+        mp_config: Configuration for the ZMQ multiprocess server
         storage_manager_config: Configuration for the storage manager
         prometheus_config: Configuration for the Prometheus observability stack
-        host: ZMQ server host
-        port: ZMQ server port
-        chunk_size: Chunk size for KV cache operations
-        max_workers: Maximum number of worker threads for ZMQ server
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
-        hash_algorithm: Hash algorithm for token-based operations
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
@@ -681,13 +677,15 @@ def run_cache_server(
     engine = BlendEngine(
         sep_tokens=sep_tokens,
         storage_manager_config=storage_manager_config,
-        chunk_size=chunk_size,
+        chunk_size=mp_config.chunk_size,
     )
 
     # Initialize the message queue server
     context = zmq.Context.instance()
     server = MessageQueueServer(
-        bind_url=f"tcp://{host}:{port}", context=context, max_workers=max_workers
+        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
+        context=context,
+        max_workers=mp_config.max_workers,
     )
 
     # Add handlers for original server
@@ -721,7 +719,11 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.CB_STORE_FINAL, engine.cb_store_final)
 
-    logger.info("LMCache ZMQ cache server is running on tcp://%s:%d", host, port)
+    logger.info(
+        "LMCache ZMQ cache server is running on tcp://%s:%d",
+        mp_config.host,
+        mp_config.port,
+    )
     # Start the ZMQ server
     torch.cuda.init()
     server.start()
@@ -747,14 +749,11 @@ def run_cache_server(
 
 if __name__ == "__main__":
     args = parse_args()
+    mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
     run_cache_server(
+        mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
-        host=args.host,
-        port=args.port,
-        chunk_size=args.chunk_size,
-        max_workers=args.max_workers,
-        hash_algorithm=args.hash_algorithm,
     )

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Configuration for the multiprocess (ZMQ) server and HTTP frontend.
+"""
+
+# Standard
+from dataclasses import dataclass
+import argparse
+
+
+@dataclass
+class MPServerConfig:
+    """Configuration for the ZMQ-based multiprocess cache server."""
+
+    host: str = "localhost"
+    """ZMQ server host."""
+
+    port: int = 5555
+    """ZMQ server port."""
+
+    chunk_size: int = 256
+    """Chunk size for KV cache operations."""
+
+    max_workers: int = 1
+    """Maximum number of worker threads for ZMQ server."""
+
+    hash_algorithm: str = "blake3"
+    """Hash algorithm for token-based operations (builtin, sha256_cbor, blake3)."""
+
+
+DEFAULT_MP_SERVER_CONFIG = MPServerConfig()
+
+
+@dataclass
+class HTTPFrontendConfig:
+    """Configuration for the HTTP frontend (uvicorn/FastAPI)."""
+
+    http_host: str = "0.0.0.0"
+    """HTTP server host."""
+
+    http_port: int = 8000
+    """HTTP server port."""
+
+
+DEFAULT_HTTP_FRONTEND_CONFIG = HTTPFrontendConfig()
+
+
+def add_mp_server_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """
+    Add MP server configuration arguments to an existing parser.
+
+    Args:
+        parser: The argument parser to add arguments to.
+
+    Returns:
+        The same parser with MP server arguments added.
+    """
+    mp_group = parser.add_argument_group(
+        "MP Server", "Configuration for the ZMQ multiprocess cache server"
+    )
+    mp_group.add_argument(
+        "--host",
+        type=str,
+        default="localhost",
+        help="Host to bind the ZMQ server. Default is localhost.",
+    )
+    mp_group.add_argument(
+        "--port",
+        type=int,
+        default=5555,
+        help="Port to bind the ZMQ server. Default is 5555.",
+    )
+    mp_group.add_argument(
+        "--chunk-size",
+        type=int,
+        default=256,
+        help="Chunk size for KV cache operations. Default is 256.",
+    )
+    mp_group.add_argument(
+        "--max-workers",
+        type=int,
+        default=1,
+        help="Maximum number of worker threads. Default is 1.",
+    )
+    mp_group.add_argument(
+        "--hash-algorithm",
+        type=str,
+        default="blake3",
+        help="Hash algorithm for token-based operations "
+        "(builtin, sha256_cbor, blake3). Default is blake3.",
+    )
+    return parser
+
+
+def parse_args_to_mp_server_config(
+    args: argparse.Namespace,
+) -> MPServerConfig:
+    """
+    Convert parsed command line arguments to an MPServerConfig.
+
+    Args:
+        args: Parsed arguments from the argument parser.
+
+    Returns:
+        MPServerConfig: The configuration object.
+    """
+    return MPServerConfig(
+        host=args.host,
+        port=args.port,
+        chunk_size=args.chunk_size,
+        max_workers=args.max_workers,
+        hash_algorithm=args.hash_algorithm,
+    )
+
+
+def add_http_frontend_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """
+    Add HTTP frontend configuration arguments to an existing parser.
+
+    Args:
+        parser: The argument parser to add arguments to.
+
+    Returns:
+        The same parser with HTTP frontend arguments added.
+    """
+    http_group = parser.add_argument_group(
+        "HTTP Frontend", "Configuration for the HTTP frontend server"
+    )
+    http_group.add_argument(
+        "--http-host",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind the HTTP server. Default is 0.0.0.0.",
+    )
+    http_group.add_argument(
+        "--http-port",
+        type=int,
+        default=8000,
+        help="Port to bind the HTTP server. Default is 8000.",
+    )
+    return parser
+
+
+def parse_args_to_http_frontend_config(
+    args: argparse.Namespace,
+) -> HTTPFrontendConfig:
+    """
+    Convert parsed command line arguments to an HTTPFrontendConfig.
+
+    Args:
+        args: Parsed arguments from the argument parser.
+
+    Returns:
+        HTTPFrontendConfig: The configuration object.
+    """
+    return HTTPFrontendConfig(
+        http_host=args.http_host,
+        http_port=args.http_port,
+    )

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -1,59 +1,45 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 import argparse
 
 # Third Party
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+import torch
 import uvicorn
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.config import (
-    EvictionConfig,
-    L1ManagerConfig,
-    L1MemoryManagerConfig,
     StorageManagerConfig,
+    add_storage_manager_args,
+    parse_args_to_config,
 )
-from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
+from lmcache.v1.mp_observability.config import (
+    PrometheusConfig,
+    add_prometheus_args,
+    parse_args_to_prometheus_config,
+)
 from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
+)
+from lmcache.v1.multiprocess.config import (
+    HTTPFrontendConfig,
+    MPServerConfig,
+    add_http_frontend_args,
+    add_mp_server_args,
+    parse_args_to_http_frontend_config,
+    parse_args_to_mp_server_config,
 )
 from lmcache.v1.multiprocess.server import run_cache_server
 
 logger = init_logger(__name__)
 
 
-# ----------------------------
-# Server configuration
-# ----------------------------
-@dataclass
-class ServerConfig:
-    """Configuration for the HTTP server and ZMQ backend."""
-
-    zmq_host: str = "localhost"
-    zmq_port: int = 5555
-    chunk_size: int = 256
-    cpu_buffer_size: float = 5.0
-    max_workers: int = 1
-
-    def to_storage_manager_config(self) -> StorageManagerConfig:
-        return StorageManagerConfig(
-            l1_manager_config=L1ManagerConfig(
-                memory_config=L1MemoryManagerConfig(
-                    size_in_bytes=int(self.cpu_buffer_size * 1024**3),
-                    use_lazy=True,
-                ),
-            ),
-            eviction_config=EvictionConfig(
-                eviction_policy="LRU",
-            ),
-        )
-
-
-_server_config = ServerConfig()
+# Module-level config holders, set by run_http_server() before FastAPI startup.
+# Stored in a dict so the lifespan closure captures the mutable container.
+_configs: dict = {}
 
 
 # ----------------------------
@@ -68,14 +54,14 @@ async def lifespan(app: FastAPI):
     On shutdown: Clean up ZMQ server resources.
     """
     # Startup
-    logger.info("Starting LMCache HTTP server...")
+    logger.info(
+        "Starting LMCache HTTP server... (CUDA available: %s)",
+        torch.cuda.is_available(),
+    )
     zmq_server, engine = run_cache_server(
-        storage_manager_config=_server_config.to_storage_manager_config(),
-        prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
-        host=_server_config.zmq_host,
-        port=_server_config.zmq_port,
-        chunk_size=_server_config.chunk_size,
-        max_workers=_server_config.max_workers,
+        mp_config=_configs["mp"],
+        storage_manager_config=_configs["storage_manager"],
+        prometheus_config=_configs["prometheus"],
         return_engine=True,
     )
     app.state.zmq_server = zmq_server
@@ -126,44 +112,38 @@ async def healthcheck(request: Request):
 
 
 def run_http_server(
-    host: str = "0.0.0.0",
-    port: int = 8000,
-    zmq_host: str = "localhost",
-    zmq_port: int = 5555,
-    chunk_size: int = 256,
-    cpu_buffer_size: float = 5.0,
-    max_workers: int = 1,
-):
+    http_config: HTTPFrontendConfig,
+    mp_config: MPServerConfig,
+    storage_manager_config: StorageManagerConfig,
+    prometheus_config: PrometheusConfig,
+) -> None:
     """
     Run the LMCache HTTP server with integrated MP (ZMQ) server.
 
     Args:
-        host: HTTP server host
-        port: HTTP server port
-        zmq_host: ZMQ server host
-        zmq_port: ZMQ server port
-        chunk_size: Chunk size for KV cache operations
-        cpu_buffer_size: CPU buffer size in GB
-        max_workers: Maximum number of worker threads for ZMQ server
+        http_config: Configuration for the HTTP frontend
+        mp_config: Configuration for the ZMQ multiprocess server
+        storage_manager_config: Configuration for the storage manager
+        prometheus_config: Configuration for the Prometheus observability stack
     """
-    global _server_config
-
-    _server_config.zmq_host = zmq_host
-    _server_config.zmq_port = zmq_port
-    _server_config.chunk_size = chunk_size
-    _server_config.cpu_buffer_size = cpu_buffer_size
-    _server_config.max_workers = max_workers
+    _configs["mp"] = mp_config
+    _configs["storage_manager"] = storage_manager_config
+    _configs["prometheus"] = prometheus_config
 
     config = uvicorn.Config(
         app=app,
-        host=host,
-        port=port,
+        host=http_config.http_host,
+        port=http_config.http_port,
         log_level="info",
         access_log=True,
     )
     server = uvicorn.Server(config)
 
-    logger.info("Starting LMCache HTTP server on http://%s:%d", host, port)
+    logger.info(
+        "Starting LMCache HTTP server on http://%s:%d",
+        http_config.http_host,
+        http_config.http_port,
+    )
     server.run()
 
 
@@ -171,38 +151,22 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="LMCache HTTP Server with integrated MP Cache Server"
     )
-    parser.add_argument(
-        "--host", type=str, default="0.0.0.0", help="Host to bind the HTTP server"
-    )
-    parser.add_argument(
-        "--port", type=int, default=8000, help="Port to bind the HTTP server"
-    )
-    parser.add_argument(
-        "--zmq-host", type=str, default="localhost", help="Host to bind the ZMQ server"
-    )
-    parser.add_argument(
-        "--zmq-port", type=int, default=5555, help="Port to bind the ZMQ server"
-    )
-    parser.add_argument(
-        "--chunk-size", type=int, default=256, help="Chunk size for KV cache operations"
-    )
-    parser.add_argument(
-        "--cpu-buffer-size", type=float, default=5.0, help="CPU buffer size in GB"
-    )
-    parser.add_argument(
-        "--max-workers", type=int, default=1, help="Maximum number of worker threads"
-    )
+    add_http_frontend_args(parser)
+    add_mp_server_args(parser)
+    add_storage_manager_args(parser)
+    add_prometheus_args(parser)
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
+    http_config = parse_args_to_http_frontend_config(args)
+    mp_config = parse_args_to_mp_server_config(args)
+    storage_manager_config = parse_args_to_config(args)
+    prometheus_config = parse_args_to_prometheus_config(args)
     run_http_server(
-        host=args.host,
-        port=args.port,
-        zmq_host=args.zmq_host,
-        zmq_port=args.zmq_port,
-        chunk_size=args.chunk_size,
-        cpu_buffer_size=args.cpu_buffer_size,
-        max_workers=args.max_workers,
+        http_config=http_config,
+        mp_config=mp_config,
+        storage_manager_config=storage_manager_config,
+        prometheus_config=prometheus_config,
     )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -37,6 +37,11 @@ from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
     init_prometheus_controller,
 )
+from lmcache.v1.multiprocess.config import (
+    MPServerConfig,
+    add_mp_server_args,
+    parse_args_to_mp_server_config,
+)
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
@@ -537,28 +542,20 @@ def add_handler_helper(
 
 
 def run_cache_server(
+    mp_config: MPServerConfig,
     storage_manager_config: StorageManagerConfig,
     prometheus_config: PrometheusConfig,
-    host: str = "localhost",
-    port: int = 5555,
-    chunk_size: int = 256,
-    max_workers: int = 1,
     return_engine: bool = False,
-    hash_algorithm: str = "blake3",
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
 
     Args:
+        mp_config: Configuration for the ZMQ multiprocess server
         storage_manager_config: Configuration for the storage manager
         prometheus_config: Configuration for the Prometheus observability stack
-        host: ZMQ server host
-        port: ZMQ server port
-        chunk_size: Chunk size for KV cache operations
-        max_workers: Maximum number of worker threads for ZMQ server
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
-        hash_algorithm: Hash algorithm for token-based operations
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
@@ -578,14 +575,16 @@ def run_cache_server(
     # Initialize the engine (loggers self-register with the global controller)
     engine = MPCacheEngine(
         storage_manager_config=storage_manager_config,
-        chunk_size=chunk_size,
-        hash_algorithm=hash_algorithm,
+        chunk_size=mp_config.chunk_size,
+        hash_algorithm=mp_config.hash_algorithm,
     )
 
     # Initialize the message queue server
     context = zmq.Context.instance()
     server = MessageQueueServer(
-        bind_url=f"tcp://{host}:{port}", context=context, max_workers=max_workers
+        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
+        context=context,
+        max_workers=mp_config.max_workers,
     )
 
     # Add handlers
@@ -602,7 +601,11 @@ def run_cache_server(
     add_handler_helper(server, RequestType.END_SESSION, engine.end_session)
     add_handler_helper(server, RequestType.NOOP, engine.debug)
 
-    logger.info("LMCache ZMQ cache server is running on tcp://%s:%d", host, port)
+    logger.info(
+        "LMCache ZMQ cache server is running on tcp://%s:%d",
+        mp_config.host,
+        mp_config.port,
+    )
     # Start the ZMQ server
     torch.cuda.init()
     server.start()
@@ -630,39 +633,19 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="LMCache ZMQ Cache Server (without HTTP)"
     )
-    parser.add_argument(
-        "--host", type=str, default="localhost", help="Host to bind the ZMQ server"
-    )
-    parser.add_argument(
-        "--port", type=int, default=5555, help="Port to bind the ZMQ server"
-    )
-    parser.add_argument(
-        "--chunk-size", type=int, default=256, help="Chunk size for KV cache operations"
-    )
-    parser.add_argument(
-        "--max-workers", type=int, default=1, help="Maximum number of worker threads"
-    )
-    parser.add_argument(
-        "--hash-algorithm",
-        type=str,
-        default="blake3",
-        help="Hash algorithm for token-based operations (builtin, sha256_cbor, blake3)",
-    )
-    parser = add_storage_manager_args(parser)
-    parser = add_prometheus_args(parser)
+    add_mp_server_args(parser)
+    add_storage_manager_args(parser)
+    add_prometheus_args(parser)
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
+    mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
     run_cache_server(
+        mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
-        host=args.host,
-        port=args.port,
-        chunk_size=args.chunk_size,
-        max_workers=args.max_workers,
-        hash_algorithm=args.hash_algorithm,
     )

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -35,6 +35,7 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
 from lmcache.v1.multiprocess.blend_server import get_sep_tokens
+from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
@@ -254,6 +255,7 @@ def server_process_runner(
     # First Party
     from lmcache.v1.multiprocess.blend_server import run_cache_server
 
+    mp_config = MPServerConfig(host=host, port=port, chunk_size=chunk_size)
     storage_manager_config = StorageManagerConfig(
         l1_manager_config=L1ManagerConfig(
             memory_config=L1MemoryManagerConfig(
@@ -264,11 +266,9 @@ def server_process_runner(
         eviction_config=EvictionConfig(eviction_policy="LRU"),
     )
     run_cache_server(
+        mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
-        host=host,
-        port=port,
-        chunk_size=chunk_size,
     )
 
 

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -18,6 +18,7 @@ from lmcache.v1.distributed.config import (
     StorageManagerConfig,
 )
 from lmcache.v1.mp_observability.config import DEFAULT_PROMETHEUS_CONFIG
+from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
@@ -218,6 +219,7 @@ def server_process_runner(
     """
     Entry point for the server process.
     """
+    mp_config = MPServerConfig(host=host, port=port, chunk_size=chunk_size)
     storage_manager_config = StorageManagerConfig(
         l1_manager_config=L1ManagerConfig(
             memory_config=L1MemoryManagerConfig(
@@ -228,11 +230,9 @@ def server_process_runner(
         eviction_config=EvictionConfig(eviction_policy="LRU"),
     )
     run_cache_server(
+        mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
-        host=host,
-        port=port,
-        chunk_size=chunk_size,
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The multiprocess module (`server.py`, `blend_server.py`, `http_server.py`) has fragmented config and argument parsing:

- `server.py` defines 5 inline `add_argument` calls, and `run_cache_server()` takes 8 individual parameters.
- `http_server.py` has a standalone `ServerConfig` dataclass with a `to_storage_manager_config()` method that hardcodes L1 settings and eviction policy. It does not support L2 adapters, hash algorithm, or Prometheus from CLI. It also uses `--zmq-host`/`--zmq-port` instead of the `--host`/`--port` convention used everywhere else.
- `blend_server.py` reuses `parse_args` from `server.py` (good), but still passes 8 individual params to its own `run_cache_server()`.

This PR creates `lmcache/v1/multiprocess/config.py` following the established composable `(DataclassConfig, add_*_args, parse_args_to_*_config)` triple pattern from `lmcache/v1/distributed/config.py`, unifying the scattered config.

**User-facing changes:**

- `--zmq-host` / `--zmq-port` (http_server.py only) are replaced by `--host` / `--port` (consistent across all servers). HTTP-specific args are now `--http-host` / `--http-port`.
- `--cpu-buffer-size` is removed from http_server.py. Users now use `--l1-size-gb` (from the storage manager arg group) instead.
- `http_server.py` now supports the full set of CLI args: L2 adapters, hash algorithm, Prometheus, eviction tuning — previously hardcoded or missing.
- All three servers (`server.py`, `blend_server.py`, `http_server.py`) now show organized argument groups in `--help`: MP Server, L1 Memory, Eviction, L2 Adapters, Prometheus (and HTTP Frontend for http_server.py).

**Special notes for your reviewers**:

- `MPCacheEngine` constructor is unchanged — it doesn't need host/port/max_workers (those are ZMQ transport concerns). `run_cache_server()` extracts the relevant fields from `MPServerConfig`.
- The `_configs` dict pattern in `http_server.py` replaces the old `_server_config` global; it avoids the need for uninitialized `StorageManagerConfig` sentinels since `run_http_server()` always populates it before FastAPI's lifespan starts.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
