### PR TITLE
[MP][Observability] Add telemetry subsystem for multiprocess mode

### DIFF
--- a/lmcache/v1/mp_observability/telemetry/DESIGN.md
+++ b/lmcache/v1/mp_observability/telemetry/DESIGN.md
@@ -1,0 +1,315 @@
+# Telemetry Event System — Design
+
+## Overview
+
+The telemetry system provides per-event tracing for LMCache's multiprocess (MP)
+mode. It complements the existing Prometheus-based metrics (aggregated
+counters/histograms) by capturing individual operation events that downstream
+processors can use to reconstruct spans, build traces, or feed into
+observability backends like OpenTelemetry.
+
+The system uses a **START/END event model with session IDs**. A caller emits a
+`START` event when an operation begins and an `END` event when it completes.
+Both events share the same `session_id`, allowing processors to correlate them
+into a span. This two-event design is necessary because start and end happen at
+different call sites in LMCache's async submit/check/complete patterns.
+
+## Architecture
+
+```
+ Call site                     TelemetryController              Processors
+ ─────────                     ───────────────────              ──────────
+   log_telemetry(event) ──►  deque.append(event)
+                                     │
+                              drain thread (daemon)
+                                     │
+                              deque.popleft() ──────►  proc.on_new_event(event)
+                                                       proc.on_new_event(event)
+                                                       ...
+```
+
+**Hot path** (`log_telemetry` / `controller.log`): Lock-free append to a
+`collections.deque`. CPython's GIL guarantees atomic `append()`/`popleft()`.
+A `threading.Event` wakes the drain thread immediately.
+
+**Drain thread**: A single daemon thread waits on the wake signal (with a 0.1 s
+timeout as a safety net), pops all queued events, and dispatches each to every
+registered processor. Exceptions in one processor do not block others.
+
+**Backpressure**: When the queue reaches `max_queue_size` (default 10,000),
+new events are silently discarded (tail-drop) with a rate-limited WARNING log
+(at most once per second).
+
+## Module Layout
+
+```
+lmcache/v1/mp_observability/telemetry/
+├── DESIGN.md                      # this file
+├── __init__.py                    # public API re-exports
+├── event.py                       # EventType enum + TelemetryEvent dataclass
+├── config.py                      # TelemetryConfig + argparse helpers
+├── controller.py                  # TelemetryController + singleton + factory
+└── processors/
+    ├── __init__.py                # imports submodules to trigger registration
+    ├── base.py                    # TelemetryProcessor ABC, TelemetryProcessorConfig ABC, registry
+    └── logging_processor.py       # built-in LoggingProcessor + LoggingProcessorConfig
+```
+
+## Key Components
+
+### `TelemetryEvent` (event.py)
+
+```python
+@dataclass
+class TelemetryEvent:
+    name: str                                        # e.g. "mp.store", "mp.lookup"
+    event_type: EventType                            # START or END
+    session_id: str                                  # correlates START/END pairs
+    metadata: dict[str, str | int | float | bool]    # flat, OTel-compatible
+```
+
+**No timestamp field.** In async code, event creation time is not the same as
+the time the event is logged. Processors record time on receipt if they need it.
+
+**Metadata values** are restricted to `str | int | float | bool` for
+compatibility with OpenTelemetry attribute types.
+
+### `TelemetryProcessor` (processors/base.py)
+
+Abstract base class that all processors implement:
+
+```python
+class TelemetryProcessor(ABC):
+    @abstractmethod
+    def on_new_event(self, event: TelemetryEvent) -> None: ...
+
+    @abstractmethod
+    def shutdown(self) -> None: ...
+```
+
+- `on_new_event` is called from the drain thread — implementations should be
+  fast or offload heavy work.
+- `shutdown` is called once when the controller stops, for resource cleanup.
+- Exceptions are caught and logged; a failing processor never blocks others.
+
+### `TelemetryProcessorConfig` (processors/base.py)
+
+Abstract base class for processor configuration, following the same pattern as
+L2 adapter configs (`lmcache/v1/distributed/l2_adapters/config.py`):
+
+```python
+class TelemetryProcessorConfig(ABC):
+    @classmethod
+    @abstractmethod
+    def from_dict(cls, d: dict) -> Self: ...
+
+    @classmethod
+    @abstractmethod
+    def help(cls) -> str: ...
+```
+
+Each config class is registered at import time via
+`register_telemetry_processor_type(name, config_cls)`, mapping a string type
+name (used in CLI JSON specs) to the config class.
+
+### `TelemetryController` (controller.py)
+
+Manages the event queue, drain thread, and processor dispatch. Key methods:
+
+| Method | Description |
+|--------|-------------|
+| `log(event)` | Non-blocking hot path. Appends to deque or discards on overflow. |
+| `register_processor(proc)` | Thread-safe registration (protected by lock). |
+| `start()` | Launches the daemon drain thread. No-op when disabled. |
+| `stop()` | Signals stop, joins thread, final drain, shuts down processors. |
+
+### Singleton & Convenience Functions (controller.py)
+
+```python
+init_telemetry_controller(config)   # replace global singleton, create & register processors
+get_telemetry_controller()          # return current singleton
+log_telemetry(event)                # convenience — logs to the global controller
+```
+
+The default singleton is disabled (no thread, `log()` is a no-op) until
+`init_telemetry_controller` is called with `enabled=True`.
+
+### Configuration & CLI (config.py)
+
+```python
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    max_queue_size: int = 10000
+    processor_configs: list[TelemetryProcessorConfig] = field(default_factory=list)
+```
+
+CLI arguments (composable argparse pattern):
+
+```
+--enable-telemetry                   Enable the telemetry system
+--telemetry-max-queue-size N         Queue capacity before tail-drop (default 10000)
+--telemetry-processor JSON           Processor spec, repeatable
+```
+
+Processor specs are JSON objects with a `"type"` field that maps to a
+registered processor type name, plus any type-specific fields:
+
+```bash
+--telemetry-processor '{"type": "logging"}'
+--telemetry-processor '{"type": "logging", "log_level": "INFO"}'
+```
+
+## How to Implement a New Telemetry Processor
+
+Follow these steps to add a new processor (e.g., an OpenTelemetry exporter).
+
+### 1. Create the processor module
+
+Create a new file under `processors/`, e.g.
+`processors/otel_processor.py`.
+
+### 2. Define the config class
+
+Subclass `TelemetryProcessorConfig` and implement `from_dict` and `help`:
+
+```python
+# processors/otel_processor.py
+
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessorConfig,
+    register_telemetry_processor_type,
+)
+
+
+class OtelProcessorConfig(TelemetryProcessorConfig):
+    """Config for the OpenTelemetry processor."""
+
+    def __init__(self, endpoint: str = "http://localhost:4317"):
+        self.endpoint = endpoint
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "OtelProcessorConfig":
+        return cls(endpoint=d.get("endpoint", "http://localhost:4317"))
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "OpenTelemetry processor: exports telemetry events as OTel spans.\n"
+            "Fields:\n"
+            '  "endpoint" (str): OTel collector endpoint. '
+            'Default: "http://localhost:4317"\n'
+            'Example: \'{"type": "otel", "endpoint": "http://collector:4317"}\''
+        )
+
+
+register_telemetry_processor_type("otel", OtelProcessorConfig)
+```
+
+Key points:
+- `from_dict` receives the full JSON dict (including the `"type"` key).
+  Extract any type-specific fields you need.
+- Call `register_telemetry_processor_type` at module level so the type name
+  is available as soon as the module is imported.
+
+### 3. Define the processor class
+
+Subclass `TelemetryProcessor` and implement `on_new_event` and `shutdown`:
+
+```python
+# processors/otel_processor.py (continued)
+
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessor,
+)
+from lmcache.v1.mp_observability.telemetry.event import (
+    EventType,
+    TelemetryEvent,
+)
+
+
+class OtelProcessor(TelemetryProcessor):
+    """Processor that exports events as OpenTelemetry spans."""
+
+    def __init__(self, config: OtelProcessorConfig):
+        self._endpoint = config.endpoint
+        # Initialize OTel SDK resources here...
+
+    def on_new_event(self, event: TelemetryEvent) -> None:
+        # Called from the drain thread for every event.
+        # Reconstruct spans from correlated START/END pairs,
+        # then export via OTel SDK.
+        pass
+
+    def shutdown(self) -> None:
+        # Flush any pending spans and release resources.
+        pass
+```
+
+`on_new_event` is called from a single drain thread, so the processor does
+not need to be thread-safe internally. However, it should be fast — if
+export is slow, consider buffering and flushing in batches.
+
+### 4. Register the import
+
+Add an import to `processors/__init__.py` so the module is loaded (and the
+type is registered) at startup:
+
+```python
+# processors/__init__.py
+
+from lmcache.v1.mp_observability.telemetry.processors import otel_processor  # noqa: F401
+```
+
+### 5. Add the factory branch
+
+In `controller.py`, add an `isinstance` branch in `create_processors`:
+
+```python
+from lmcache.v1.mp_observability.telemetry.processors.otel_processor import (
+    OtelProcessor,
+    OtelProcessorConfig,
+)
+
+def create_processors(config: TelemetryConfig) -> list[TelemetryProcessor]:
+    processors: list[TelemetryProcessor] = []
+    for proc_config in config.processor_configs:
+        if isinstance(proc_config, LoggingProcessorConfig):
+            processors.append(LoggingProcessor(proc_config))
+        elif isinstance(proc_config, OtelProcessorConfig):
+            processors.append(OtelProcessor(proc_config))
+        else:
+            raise ValueError(...)
+    return processors
+```
+
+### 6. Add tests
+
+Create `tests/v1/mp_observability/telemetry/test_otel_processor.py` with
+tests for:
+- Config parsing: `from_dict` with defaults and custom values
+- `help()` returns a non-empty string
+- `on_new_event` processes events correctly
+- `shutdown` cleans up without errors
+
+### 7. Use it from the CLI
+
+```bash
+python -m lmcache.v1.multiprocess.server \
+    --enable-telemetry \
+    --telemetry-processor '{"type": "otel", "endpoint": "http://collector:4317"}'
+```
+
+## Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| No timestamp in `TelemetryEvent` | Creation time != log time in async code. Processors record time on receipt. |
+| `collections.deque` without lock | CPython GIL makes `append()`/`popleft()` atomic. Single consumer thread. |
+| `threading.Event` wake signal | Immediate drain on new events, unlike timer-based polling. |
+| 0.1 s timeout on wake wait | Safety net so drain thread checks stop flag even with no events. |
+| Tail-drop backpressure | Discard newest events when queue full; rate-limited WARNING (1/sec). |
+| Default disabled singleton | Safe no-op — no thread, no allocations until explicitly enabled. |
+| Config-based `isinstance` dispatch | Follows L2 adapter pattern; avoids string-based dispatch in the factory. |
+| Narrow public API | Call sites depend only on `log_telemetry()`. Internal classes are not exported. |
+| Processor exception isolation | A crashing processor never blocks event delivery to other processors. |

--- a/lmcache/v1/mp_observability/telemetry/DESIGN.md
+++ b/lmcache/v1/mp_observability/telemetry/DESIGN.md
@@ -66,10 +66,14 @@ class TelemetryEvent:
     event_type: EventType                            # START or END
     session_id: str                                  # correlates START/END pairs
     metadata: dict[str, str | int | float | bool]    # flat, OTel-compatible
+    timestamp: float = 0.0                           # set by controller.log()
 ```
 
-**No timestamp field.** In async code, event creation time is not the same as
-the time the event is logged. Processors record time on receipt if they need it.
+**Timestamp** is stamped by `TelemetryController.log()` using `time.time()`
+(wall-clock), not at event construction time. This ensures the timestamp
+reflects when the event was actually ingested, which matters for GPU callback
+call sites where event objects are created earlier but logged later via
+`launch_host_func`.
 
 **Metadata values** are restricted to `str | int | float | bool` for
 compatibility with OpenTelemetry attribute types.
@@ -304,7 +308,7 @@ python -m lmcache.v1.multiprocess.server \
 
 | Decision | Rationale |
 |---|---|
-| No timestamp in `TelemetryEvent` | Creation time != log time in async code. Processors record time on receipt. |
+| Timestamp set at log time, not construction | Creation time != log time in async code (GPU callbacks). `controller.log()` stamps `time.time()`. |
 | `collections.deque` without lock | CPython GIL makes `append()`/`popleft()` atomic. Single consumer thread. |
 | `threading.Event` wake signal | Immediate drain on new events, unlike timer-based polling. |
 | 0.1 s timeout on wake wait | Safety net so drain thread checks stop flag even with no events. |

--- a/lmcache/v1/mp_observability/telemetry/__init__.py
+++ b/lmcache/v1/mp_observability/telemetry/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry event system for MP observability.
+
+Public API — intentionally narrow so call sites only depend on what they need.
+"""
+
+# First Party
+from lmcache.v1.mp_observability.telemetry.config import (
+    TelemetryConfig,
+    add_telemetry_args,
+    parse_args_to_telemetry_config,
+)
+from lmcache.v1.mp_observability.telemetry.controller import (
+    get_telemetry_controller,
+    init_telemetry_controller,
+    log_telemetry,
+)
+from lmcache.v1.mp_observability.telemetry.event import (
+    EventType,
+    TelemetryEvent,
+)
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessor,
+    TelemetryProcessorConfig,
+)
+from lmcache.v1.mp_observability.telemetry.processors.logging_processor import (
+    LoggingProcessorConfig,
+)
+
+__all__ = [
+    "EventType",
+    "TelemetryEvent",
+    "TelemetryProcessor",
+    "TelemetryProcessorConfig",
+    "TelemetryConfig",
+    "LoggingProcessorConfig",
+    "init_telemetry_controller",
+    "get_telemetry_controller",
+    "log_telemetry",
+    "add_telemetry_args",
+    "parse_args_to_telemetry_config",
+]

--- a/lmcache/v1/mp_observability/telemetry/__init__.py
+++ b/lmcache/v1/mp_observability/telemetry/__init__.py
@@ -15,6 +15,8 @@ from lmcache.v1.mp_observability.telemetry.controller import (
     get_telemetry_controller,
     init_telemetry_controller,
     log_telemetry,
+    make_end_event,
+    make_start_event,
 )
 from lmcache.v1.mp_observability.telemetry.event import (
     EventType,
@@ -38,6 +40,8 @@ __all__ = [
     "init_telemetry_controller",
     "get_telemetry_controller",
     "log_telemetry",
+    "make_start_event",
+    "make_end_event",
     "add_telemetry_args",
     "parse_args_to_telemetry_config",
 ]

--- a/lmcache/v1/mp_observability/telemetry/config.py
+++ b/lmcache/v1/mp_observability/telemetry/config.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the telemetry event system."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass, field
+import argparse
+import json
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    _PROCESSOR_CONFIG_REGISTRY,
+    TelemetryProcessorConfig,
+    get_registered_telemetry_processor_types,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class TelemetryConfig:
+    """Configuration for the telemetry event system.
+
+    Attributes:
+        enabled: Whether telemetry is enabled.
+        max_queue_size: Maximum number of events in the queue before tail-drop.
+        processor_configs: Ordered list of processor configs.
+    """
+
+    enabled: bool = False
+    max_queue_size: int = 10000
+    processor_configs: list[TelemetryProcessorConfig] = field(default_factory=list)
+
+
+DEFAULT_TELEMETRY_CONFIG = TelemetryConfig()
+
+_TELEMETRY_PROCESSOR_ARG_DEST = "telemetry_processor"
+
+
+def add_telemetry_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Add telemetry configuration arguments to an existing parser.
+
+    Args:
+        parser: The argument parser to add arguments to.
+
+    Returns:
+        The same parser with telemetry arguments added.
+    """
+    # Force registration of built-in processors so help text is accurate
+    # First Party
+    import lmcache.v1.mp_observability.telemetry.processors  # noqa: F401
+
+    group = parser.add_argument_group(
+        "Telemetry", "Configuration for the telemetry event system"
+    )
+    group.add_argument(
+        "--enable-telemetry",
+        action="store_true",
+        default=False,
+        help="Enable the telemetry event system.",
+    )
+    group.add_argument(
+        "--telemetry-max-queue-size",
+        type=int,
+        default=10000,
+        help="Maximum number of events in the telemetry queue before "
+        "tail-drop. Default is 10000.",
+    )
+    group.add_argument(
+        "--telemetry-processor",
+        dest=_TELEMETRY_PROCESSOR_ARG_DEST,
+        action="append",
+        default=[],
+        type=str,
+        metavar="JSON",
+        help='Processor spec as JSON with a "type" field and processor-specific '
+        'configs, e.g. \'{"type":"logging"}\'. '
+        "Repeat for multiple processors. "
+        "Supported processors: ["
+        + ", ".join(sorted(get_registered_telemetry_processor_types()))
+        + "].",
+    )
+    return parser
+
+
+def parse_args_to_telemetry_config(
+    args: argparse.Namespace,
+) -> TelemetryConfig:
+    """Build TelemetryConfig from parsed command-line arguments.
+
+    Args:
+        args: Parsed arguments (e.g. from ``parser.parse_args()``).
+
+    Returns:
+        TelemetryConfig with one processor config per ``--telemetry-processor``.
+
+    Raises:
+        ValueError: If JSON is invalid or a processor type is unknown.
+    """
+    raw_list = getattr(args, _TELEMETRY_PROCESSOR_ARG_DEST, None)
+    if raw_list is None:
+        raw_list = []
+
+    processor_configs: list[TelemetryProcessorConfig] = []
+    for i, raw in enumerate(raw_list):
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Invalid JSON for --telemetry-processor #{i + 1}: {e}"
+            ) from e
+
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"--telemetry-processor #{i + 1}: expected a JSON object, "
+                f"got {type(d).__name__}"
+            )
+
+        type_name = d.get("type")
+        if type_name is None:
+            raise ValueError(f"--telemetry-processor #{i + 1}: missing 'type' field")
+        if type_name not in _PROCESSOR_CONFIG_REGISTRY:
+            known = ", ".join(sorted(_PROCESSOR_CONFIG_REGISTRY)) or "(none)"
+            raise ValueError(
+                f"--telemetry-processor #{i + 1}: unknown processor type "
+                f"{type_name!r}. Known: {known}"
+            )
+
+        config_cls = _PROCESSOR_CONFIG_REGISTRY[type_name]
+        try:
+            processor_configs.append(config_cls.from_dict(d))
+        except (TypeError, ValueError) as e:
+            logger.error(
+                "Error parsing --telemetry-processor #%d (type %r): %s",
+                i + 1,
+                type_name,
+                e,
+            )
+            logger.error(
+                "Processor config help for %s processor:\n"
+                "---------------------\n"
+                "%s\n"
+                "---------------------\n\n",
+                type_name,
+                config_cls.help(),
+            )
+            raise ValueError(
+                f"--telemetry-processor #{i + 1} ({type_name!r}): {e}"
+            ) from e
+
+    return TelemetryConfig(
+        enabled=args.enable_telemetry,
+        max_queue_size=args.telemetry_max_queue_size,
+        processor_configs=processor_configs,
+    )

--- a/lmcache/v1/mp_observability/telemetry/controller.py
+++ b/lmcache/v1/mp_observability/telemetry/controller.py
@@ -79,8 +79,11 @@ class TelemetryController:
             self._processors.append(processor)
 
     def start(self) -> None:
-        """Start the drain thread. No-op when disabled."""
+        """Start the drain thread. No-op when disabled or already started."""
         if not self._config.enabled:
+            return
+
+        if self._thread is not None and self._thread.is_alive():
             return
 
         self._thread = threading.Thread(

--- a/lmcache/v1/mp_observability/telemetry/controller.py
+++ b/lmcache/v1/mp_observability/telemetry/controller.py
@@ -69,6 +69,7 @@ class TelemetryController:
                 self._last_discard_warning = now
             return
 
+        event.timestamp = time.time()
         self._queue.append(event)
         self._wake.set()
 

--- a/lmcache/v1/mp_observability/telemetry/controller.py
+++ b/lmcache/v1/mp_observability/telemetry/controller.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry controller: queue, drain thread, singleton."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import collections
+import threading
+import time
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_observability.telemetry.config import TelemetryConfig
+from lmcache.v1.mp_observability.telemetry.event import TelemetryEvent
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessor,
+)
+from lmcache.v1.mp_observability.telemetry.processors.logging_processor import (
+    LoggingProcessor,
+    LoggingProcessorConfig,
+)
+
+logger = init_logger(__name__)
+
+
+class TelemetryController:
+    """Manages telemetry event ingestion, queueing, and dispatch to processors.
+
+    Events are appended to a lock-free deque on the hot path and drained by a
+    background thread that dispatches to registered processors.
+    """
+
+    def __init__(self, config: TelemetryConfig):
+        self._config = config
+        self._queue: collections.deque[TelemetryEvent] = collections.deque()
+        self._wake = threading.Event()
+        self._stop_flag = threading.Event()
+        self._lock = threading.Lock()
+        self._processors: list[TelemetryProcessor] = []
+        self._thread: threading.Thread | None = None
+        self._discard_count: int = 0
+        self._last_discard_warning: float = 0.0
+
+    def log(self, event: TelemetryEvent) -> None:
+        """Enqueue a telemetry event (non-blocking hot path).
+
+        When the queue is full, the event is silently discarded with a
+        rate-limited WARNING log (at most once per second).
+        """
+        if not self._config.enabled:
+            return
+
+        if len(self._queue) >= self._config.max_queue_size:
+            self._discard_count += 1
+            now = time.monotonic()
+            if now - self._last_discard_warning >= 1.0:
+                logger.warning(
+                    "Telemetry queue full (max_queue_size=%d), "
+                    "%d event(s) discarded so far",
+                    self._config.max_queue_size,
+                    self._discard_count,
+                )
+                self._last_discard_warning = now
+            return
+
+        self._queue.append(event)
+        self._wake.set()
+
+    def register_processor(self, processor: TelemetryProcessor) -> None:
+        """Register a processor for event dispatch (thread-safe)."""
+        with self._lock:
+            self._processors.append(processor)
+
+    def start(self) -> None:
+        """Start the drain thread. No-op when disabled."""
+        if not self._config.enabled:
+            return
+
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="TelemetryController",
+        )
+        logger.debug("Starting TelemetryController...")
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the drain thread. Safe to call when not started."""
+        self._stop_flag.set()
+        self._wake.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join()
+
+        # Final drain
+        self._drain_all()
+
+        # Shutdown processors
+        with self._lock:
+            snapshot = list(self._processors)
+        for proc in snapshot:
+            try:
+                proc.shutdown()
+            except Exception:
+                logger.exception(
+                    "TelemetryController: error shutting down %s",
+                    type(proc).__name__,
+                )
+
+    def _run(self) -> None:
+        """Drain loop: wait for wake signal or timeout, then drain."""
+        while not self._stop_flag.is_set():
+            self._wake.wait(timeout=0.1)
+            self._wake.clear()
+            self._drain_all()
+
+    def _drain_all(self) -> None:
+        """Pop all queued events and dispatch to processors."""
+        with self._lock:
+            snapshot = list(self._processors)
+
+        while True:
+            try:
+                event = self._queue.popleft()
+            except IndexError:
+                break
+            for proc in snapshot:
+                try:
+                    proc.on_new_event(event)
+                except Exception:
+                    logger.exception(
+                        "TelemetryController: error in processor %s",
+                        type(proc).__name__,
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_processors(config: TelemetryConfig) -> list[TelemetryProcessor]:
+    """Create processor instances from a TelemetryConfig.
+
+    Uses ``isinstance()`` dispatch on processor config types.
+
+    Args:
+        config: The telemetry config containing processor configs.
+
+    Returns:
+        List of instantiated processors.
+
+    Raises:
+        ValueError: If a processor config type is unrecognized.
+    """
+    processors: list[TelemetryProcessor] = []
+    for proc_config in config.processor_configs:
+        if isinstance(proc_config, LoggingProcessorConfig):
+            processors.append(LoggingProcessor(proc_config))
+        else:
+            raise ValueError(
+                f"Unknown telemetry processor config type: "
+                f"{type(proc_config).__name__}. "
+                f"Add a branch in create_processors() for this config type."
+            )
+    return processors
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_global_controller = TelemetryController(TelemetryConfig())
+
+
+def get_telemetry_controller() -> TelemetryController:
+    """Return the current global TelemetryController singleton."""
+    return _global_controller
+
+
+def init_telemetry_controller(config: TelemetryConfig) -> TelemetryController:
+    """Replace the global singleton with a new controller built from *config*.
+
+    Creates processors from ``config.processor_configs`` and registers them.
+    """
+    global _global_controller
+    _global_controller = TelemetryController(config)
+    for proc in create_processors(config):
+        _global_controller.register_processor(proc)
+    return _global_controller
+
+
+def log_telemetry(event: TelemetryEvent) -> None:
+    """Convenience: log an event to the global controller."""
+    _global_controller.log(event)

--- a/lmcache/v1/mp_observability/telemetry/controller.py
+++ b/lmcache/v1/mp_observability/telemetry/controller.py
@@ -13,7 +13,7 @@ import time
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.telemetry.config import TelemetryConfig
-from lmcache.v1.mp_observability.telemetry.event import TelemetryEvent
+from lmcache.v1.mp_observability.telemetry.event import EventType, TelemetryEvent
 from lmcache.v1.mp_observability.telemetry.processors.base import (
     TelemetryProcessor,
 )
@@ -42,6 +42,10 @@ class TelemetryController:
         self._thread: threading.Thread | None = None
         self._discard_count: int = 0
         self._last_discard_warning: float = 0.0
+
+    def is_enabled(self) -> bool:
+        """Return True if telemetry is enabled (i.e. controller is active)."""
+        return self._config.enabled
 
     def log(self, event: TelemetryEvent) -> None:
         """Enqueue a telemetry event (non-blocking hot path).
@@ -194,3 +198,27 @@ def init_telemetry_controller(config: TelemetryConfig) -> TelemetryController:
 def log_telemetry(event: TelemetryEvent) -> None:
     """Convenience: log an event to the global controller."""
     _global_controller.log(event)
+
+
+def make_start_event(
+    name: str, session_id: str, **metadata: str | int | float | bool
+) -> TelemetryEvent:
+    """Create a START telemetry event."""
+    return TelemetryEvent(
+        name=name,
+        event_type=EventType.START,
+        session_id=session_id,
+        metadata=metadata,
+    )
+
+
+def make_end_event(
+    name: str, session_id: str, **metadata: str | int | float | bool
+) -> TelemetryEvent:
+    """Create an END telemetry event."""
+    return TelemetryEvent(
+        name=name,
+        event_type=EventType.END,
+        session_id=session_id,
+        metadata=metadata,
+    )

--- a/lmcache/v1/mp_observability/telemetry/event.py
+++ b/lmcache/v1/mp_observability/telemetry/event.py
@@ -26,9 +26,14 @@ class TelemetryEvent:
         event_type: Whether this is the START or END of the operation.
         session_id: Caller-provided ID that correlates START/END pairs.
         metadata: Flat key-value pairs compatible with OTel attributes.
+        timestamp: Wall-clock time (``time.time()``) set by
+            ``TelemetryController.log()`` when the event is ingested.
+            Defaults to ``0.0`` at construction; call sites should NOT
+            set this — it is stamped automatically.
     """
 
     name: str
     event_type: EventType
     session_id: str
     metadata: dict[str, str | int | float | bool] = field(default_factory=dict)
+    timestamp: float = 0.0

--- a/lmcache/v1/mp_observability/telemetry/event.py
+++ b/lmcache/v1/mp_observability/telemetry/event.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry event data model."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class EventType(Enum):
+    """Type of telemetry event: START or END of a traced operation."""
+
+    START = "START"
+    END = "END"
+
+
+@dataclass
+class TelemetryEvent:
+    """A single telemetry event for tracing operations across async boundaries.
+
+    Attributes:
+        name: Operation name, e.g. ``"mp.store"``, ``"mp.lookup"``.
+        event_type: Whether this is the START or END of the operation.
+        session_id: Caller-provided ID that correlates START/END pairs.
+        metadata: Flat key-value pairs compatible with OTel attributes.
+    """
+
+    name: str
+    event_type: EventType
+    session_id: str
+    metadata: dict[str, str | int | float | bool] = field(default_factory=dict)

--- a/lmcache/v1/mp_observability/telemetry/processors/__init__.py
+++ b/lmcache/v1/mp_observability/telemetry/processors/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry processors package.
+
+Imports submodules to trigger registration of built-in processor types.
+Re-exports base classes for convenience.
+"""
+
+# First Party
+# Import submodules to trigger registration
+from lmcache.v1.mp_observability.telemetry.processors import (  # noqa: F401
+    logging_processor,
+)
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessor,
+    TelemetryProcessorConfig,
+    get_registered_telemetry_processor_types,
+    register_telemetry_processor_type,
+)
+
+__all__ = [
+    "TelemetryProcessor",
+    "TelemetryProcessorConfig",
+    "get_registered_telemetry_processor_types",
+    "register_telemetry_processor_type",
+]

--- a/lmcache/v1/mp_observability/telemetry/processors/base.py
+++ b/lmcache/v1/mp_observability/telemetry/processors/base.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Telemetry processor ABCs and config registry."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+# First Party
+from lmcache.v1.mp_observability.telemetry.event import TelemetryEvent
+
+T = TypeVar("T", bound="TelemetryProcessorConfig")
+
+# ---------------------------------------------------------------------------
+# Registry: processor type name -> config class
+# ---------------------------------------------------------------------------
+
+_PROCESSOR_CONFIG_REGISTRY: dict[str, type[TelemetryProcessorConfig]] = {}
+
+
+def register_telemetry_processor_type(
+    name: str, config_cls: type[TelemetryProcessorConfig]
+) -> None:
+    """Register a telemetry processor config class under a type name.
+
+    Args:
+        name: Processor type name (e.g. ``"logging"``).
+        config_cls: Config class that can parse from dict via ``from_dict()``.
+    """
+    if name in _PROCESSOR_CONFIG_REGISTRY:
+        raise ValueError(f"Telemetry processor type already registered: {name!r}")
+    _PROCESSOR_CONFIG_REGISTRY[name] = config_cls
+
+
+def get_registered_telemetry_processor_types() -> list[str]:
+    """Return the list of registered processor type names."""
+    return list(_PROCESSOR_CONFIG_REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# Base config class for a single processor
+# ---------------------------------------------------------------------------
+
+
+class TelemetryProcessorConfig(ABC):
+    """Base class for per-processor configs.
+
+    Each processor type defines a config class that:
+    - Subclasses this base.
+    - Implements ``from_dict()`` to parse a dict (from JSON) into an instance.
+    - Is registered via ``register_telemetry_processor_type()``.
+    """
+
+    @classmethod
+    @abstractmethod
+    def from_dict(cls: type[T], d: dict) -> T:
+        """Build a config instance from a dict (e.g. from parsed JSON).
+
+        Args:
+            d: Processor spec dict (may include type-specific keys).
+
+        Returns:
+            An instance of the config class.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def help(cls) -> str:
+        """Return a help string describing this processor type."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Processor ABC
+# ---------------------------------------------------------------------------
+
+
+class TelemetryProcessor(ABC):
+    """Abstract base class for telemetry event processors."""
+
+    @abstractmethod
+    def on_new_event(self, event: TelemetryEvent) -> None:
+        """Handle a new telemetry event.
+
+        Called from the drain thread — implementations should be fast.
+
+        Args:
+            event: The telemetry event to process.
+        """
+        ...
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Clean up resources when the controller stops."""
+        ...

--- a/lmcache/v1/mp_observability/telemetry/processors/logging_processor.py
+++ b/lmcache/v1/mp_observability/telemetry/processors/logging_processor.py
@@ -49,10 +49,11 @@ class LoggingProcessor(TelemetryProcessor):
 
     def on_new_event(self, event: TelemetryEvent) -> None:
         self.log_func(
-            "Telemetry: %s %s session=%s metadata=%s",
+            "Telemetry: %s %s session=%s ts=%.6f metadata=%s",
             event.name,
             event.event_type.value,
             event.session_id,
+            event.timestamp,
             event.metadata,
         )
 

--- a/lmcache/v1/mp_observability/telemetry/processors/logging_processor.py
+++ b/lmcache/v1/mp_observability/telemetry/processors/logging_processor.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in logging telemetry processor."""
+
+# Future
+from __future__ import annotations
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_observability.telemetry.event import TelemetryEvent
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessor,
+    TelemetryProcessorConfig,
+    register_telemetry_processor_type,
+)
+
+logger = init_logger(__name__)
+
+
+class LoggingProcessorConfig(TelemetryProcessorConfig):
+    """Config for the built-in logging processor (no extra fields)."""
+
+    def __init__(self, log_level: str) -> None:
+        self.log_level = log_level
+
+    @classmethod
+    def from_dict(cls, d: dict) -> LoggingProcessorConfig:
+        log_level = d.get("log_level", "DEBUG").upper()
+        return cls(log_level=log_level)
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "Logging processor: logs telemetry events at specified level.\n"
+            "Config fields:\n"
+            "  log_level: Log level to use (DEBUG, INFO, WARNING, ERROR, CRITICAL). "
+            "Default is DEBUG."
+        )
+
+
+register_telemetry_processor_type("logging", LoggingProcessorConfig)
+
+
+class LoggingProcessor(TelemetryProcessor):
+    """Processor that logs telemetry events at DEBUG level."""
+
+    def __init__(self, config: LoggingProcessorConfig) -> None:
+        self.log_func = getattr(logger, config.log_level.lower(), logger.debug)
+
+    def on_new_event(self, event: TelemetryEvent) -> None:
+        self.log_func(
+            "Telemetry: %s %s session=%s metadata=%s",
+            event.name,
+            event.event_type.value,
+            event.session_id,
+            event.metadata,
+        )
+
+    def shutdown(self) -> None:
+        pass

--- a/lmcache/v1/multiprocess/blend_server.py
+++ b/lmcache/v1/multiprocess/blend_server.py
@@ -34,6 +34,15 @@ from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
     init_prometheus_controller,
 )
+from lmcache.v1.mp_observability.telemetry import (
+    TelemetryConfig,
+    get_telemetry_controller,
+    init_telemetry_controller,
+    parse_args_to_telemetry_config,
+)
+from lmcache.v1.mp_observability.telemetry.config import (
+    DEFAULT_TELEMETRY_CONFIG,
+)
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
@@ -647,6 +656,7 @@ def add_handler_helper(
 def run_cache_server(
     storage_manager_config: StorageManagerConfig,
     prometheus_config: PrometheusConfig,
+    telemetry_config: TelemetryConfig = DEFAULT_TELEMETRY_CONFIG,
     host: str = "localhost",
     port: int = 5555,
     chunk_size: int = 256,
@@ -660,6 +670,7 @@ def run_cache_server(
     Args:
         storage_manager_config: Configuration for the storage manager
         prometheus_config: Configuration for the Prometheus observability stack
+        telemetry_config: Configuration for the telemetry event system
         host: ZMQ server host
         port: ZMQ server port
         chunk_size: Chunk size for KV cache operations
@@ -674,6 +685,9 @@ def run_cache_server(
     """
     # Initialize global prometheus controller
     init_prometheus_controller(prometheus_config)
+
+    # Initialize global telemetry controller
+    init_telemetry_controller(telemetry_config)
 
     sep_tokens = get_sep_tokens()
 
@@ -728,6 +742,9 @@ def run_cache_server(
 
     # Start prometheus controller after engine creation (loggers are registered)
     get_prometheus_controller().start()
+
+    # Start telemetry controller
+    get_telemetry_controller().start()
     logger.info("LMCache cache blend server is running...")
 
     # Return server and engine if requested (for HTTP server integration)
@@ -740,6 +757,7 @@ def run_cache_server(
             time.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
+        get_telemetry_controller().stop()
         get_prometheus_controller().stop()
         server.close()
         engine.close()
@@ -749,9 +767,11 @@ if __name__ == "__main__":
     args = parse_args()
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
+    telemetry_config = parse_args_to_telemetry_config(args)
     run_cache_server(
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
+        telemetry_config=telemetry_config,
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/lmcache/v1/multiprocess/blend_server.py
+++ b/lmcache/v1/multiprocess/blend_server.py
@@ -42,6 +42,7 @@ from lmcache.v1.mp_observability.telemetry import (
 )
 from lmcache.v1.mp_observability.telemetry.config import (
     DEFAULT_TELEMETRY_CONFIG,
+)
 from lmcache.v1.multiprocess.config import (
     MPServerConfig,
     parse_args_to_mp_server_config,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -264,13 +264,14 @@ class MPCacheEngine:
             )
             vllm_event.wait(stream=gpu_context.stream)
 
-            if get_telemetry_controller().is_enabled():
-                # NOTE: need to double check whether pytorch event wait
-                # can also work on cupy launch_host_func callback.
-                gpu_context.cupy_stream.launch_host_func(
-                    log_telemetry,
-                    make_start_event("store", key.request_id),
-                )
+            # NOTE (ApostaC): this will hang the whole process in some special
+            # environments, need to investigate more. Temporarily disable telemetry
+            # for store operation.
+            # if get_telemetry_controller().is_enabled():
+            #    gpu_context.cupy_stream.launch_host_func(
+            #        log_telemetry,
+            #        make_start_event("store", key.request_id),
+            #    )
 
             layout_desc = get_layout_desc(gpu_context, self.chunk_size)
             reserved_dict = self.storage_manager.reserve_write(
@@ -311,13 +312,16 @@ class MPCacheEngine:
             list(reserved_dict.keys()),
         )
 
-        if get_telemetry_controller().is_enabled():
-            self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
-                log_telemetry,
-                make_end_event(
-                    "store", key.request_id, stored_count=len(reserved_dict)
-                ),
-            )
+        # NOTE (ApostaC): As stated above, the telemetry for store operation is
+        # temporarily disabled due to hanging issue in some special environments.
+        # Need to investigate more before enabling it again.
+        # if get_telemetry_controller().is_enabled():
+        #    self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
+        #        log_telemetry,
+        #        make_end_event(
+        #            "store", key.request_id, stored_count=len(reserved_dict)
+        #        ),
+        #    )
 
         ed = time.perf_counter()
         if length := len(reserved_dict):

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -37,6 +37,16 @@ from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
     init_prometheus_controller,
 )
+from lmcache.v1.mp_observability.telemetry import (
+    TelemetryConfig,
+    add_telemetry_args,
+    get_telemetry_controller,
+    init_telemetry_controller,
+    parse_args_to_telemetry_config,
+)
+from lmcache.v1.mp_observability.telemetry.config import (
+    DEFAULT_TELEMETRY_CONFIG,
+)
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
@@ -539,6 +549,7 @@ def add_handler_helper(
 def run_cache_server(
     storage_manager_config: StorageManagerConfig,
     prometheus_config: PrometheusConfig,
+    telemetry_config: TelemetryConfig = DEFAULT_TELEMETRY_CONFIG,
     host: str = "localhost",
     port: int = 5555,
     chunk_size: int = 256,
@@ -552,6 +563,7 @@ def run_cache_server(
     Args:
         storage_manager_config: Configuration for the storage manager
         prometheus_config: Configuration for the Prometheus observability stack
+        telemetry_config: Configuration for the telemetry event system
         host: ZMQ server host
         port: ZMQ server port
         chunk_size: Chunk size for KV cache operations
@@ -566,6 +578,9 @@ def run_cache_server(
     """
     # Initialize global prometheus controller
     init_prometheus_controller(prometheus_config)
+
+    # Initialize global telemetry controller
+    init_telemetry_controller(telemetry_config)
 
     # Start Prometheus metrics HTTP server if enabled
     if prometheus_config.enabled:
@@ -609,6 +624,9 @@ def run_cache_server(
 
     # Start prometheus controller after engine creation (loggers are registered)
     get_prometheus_controller().start()
+
+    # Start telemetry controller
+    get_telemetry_controller().start()
     logger.info("LMCache cache server is running...")
 
     # Return server and engine if requested (for HTTP server integration)
@@ -621,6 +639,7 @@ def run_cache_server(
             time.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
+        get_telemetry_controller().stop()
         get_prometheus_controller().stop()
         server.close()
         engine.close()
@@ -650,6 +669,7 @@ def parse_args():
     )
     parser = add_storage_manager_args(parser)
     parser = add_prometheus_args(parser)
+    parser = add_telemetry_args(parser)
     return parser.parse_args()
 
 
@@ -657,9 +677,11 @@ if __name__ == "__main__":
     args = parse_args()
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
+    telemetry_config = parse_args_to_telemetry_config(args)
     run_cache_server(
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
+        telemetry_config=telemetry_config,
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -49,6 +49,7 @@ from lmcache.v1.mp_observability.telemetry import (
 )
 from lmcache.v1.mp_observability.telemetry.config import (
     DEFAULT_TELEMETRY_CONFIG,
+)
 from lmcache.v1.multiprocess.config import (
     MPServerConfig,
     add_mp_server_args,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -42,6 +42,9 @@ from lmcache.v1.mp_observability.telemetry import (
     add_telemetry_args,
     get_telemetry_controller,
     init_telemetry_controller,
+    log_telemetry,
+    make_end_event,
+    make_start_event,
     parse_args_to_telemetry_config,
 )
 from lmcache.v1.mp_observability.telemetry.config import (
@@ -261,6 +264,14 @@ class MPCacheEngine:
             )
             vllm_event.wait(stream=gpu_context.stream)
 
+            if get_telemetry_controller().is_enabled():
+                # NOTE: need to double check whether pytorch event wait
+                # can also work on cupy launch_host_func callback.
+                gpu_context.cupy_stream.launch_host_func(
+                    log_telemetry,
+                    make_start_event("store", key.request_id),
+                )
+
             layout_desc = get_layout_desc(gpu_context, self.chunk_size)
             reserved_dict = self.storage_manager.reserve_write(
                 obj_keys, layout_desc, "new"
@@ -299,6 +310,15 @@ class MPCacheEngine:
             self.storage_manager.finish_write,
             list(reserved_dict.keys()),
         )
+
+        if get_telemetry_controller().is_enabled():
+            self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
+                log_telemetry,
+                make_end_event(
+                    "store", key.request_id, stored_count=len(reserved_dict)
+                ),
+            )
+
         ed = time.perf_counter()
         if length := len(reserved_dict):
             logger.info(
@@ -345,6 +365,12 @@ class MPCacheEngine:
             f"KV cache not registered for GPU ID {instance_id}"
         )
         gpu_context = self.gpu_contexts[instance_id]
+
+        if get_telemetry_controller().is_enabled():
+            gpu_context.cupy_stream.launch_host_func(
+                log_telemetry,
+                make_start_event("retrieve", key.request_id),
+            )
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
             for idx, (key, memory_obj) in enumerate(
@@ -397,6 +423,15 @@ class MPCacheEngine:
                     self.storage_manager.finish_read_prefetched,
                     prefetched_keys,
                 )
+                if get_telemetry_controller().is_enabled():
+                    gpu_context.cupy_stream.launch_host_func(
+                        log_telemetry,
+                        make_end_event(
+                            "retrieve",
+                            key.request_id,
+                            retrieved_count=len(prefetched_keys),
+                        ),
+                    )
 
         tokens_retrieved = len(obj_keys) * self.chunk_size
         ed = time.perf_counter()
@@ -423,6 +458,7 @@ class MPCacheEngine:
         """
         ipc_keys: list[IPCCacheEngineKey] = []
         model_name, world_size = key.model_name, key.world_size
+        log_telemetry(make_start_event("lookup", key.request_id))
 
         # Find the gpu context and calculate the layout desc
         layout_desc: MemoryLayoutDesc | None = None
@@ -439,12 +475,27 @@ class MPCacheEngine:
                 model_name,
                 world_size,
             )
+            log_telemetry(
+                make_end_event(
+                    "lookup",
+                    key.request_id,
+                    error="no_gpu_context_found",
+                )
+            )
             return 0
 
         # Prepare for the obj keys
         ipc_keys.extend(key.to_hash_keys(self.token_hasher))
         if not ipc_keys:
+            log_telemetry(
+                make_end_event(
+                    "lookup",
+                    key.request_id,
+                    error="no_ipc_keys_generated",
+                )
+            )
             return 0
+
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
 
         handle = self.storage_manager.submit_prefetch_task(obj_keys, layout_desc)
@@ -456,6 +507,14 @@ class MPCacheEngine:
         # 1. the world size is the same between keys
         # 2. the lookup sort the keys in prefix order and breaks at the first failure
         found_count = found_count // ipc_keys[0].world_size
+
+        log_telemetry(
+            make_end_event(
+                "lookup",
+                key.request_id,
+                found_count=found_count,
+            )
+        )
         return found_count
 
     def free_lookup_locks(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -270,7 +270,10 @@ class MPCacheEngine:
             # if get_telemetry_controller().is_enabled():
             #    gpu_context.cupy_stream.launch_host_func(
             #        log_telemetry,
-            #        make_start_event("store", key.request_id),
+            #        make_start_event(
+            #            "store", key.request_id,
+            #            device=str(gpu_context.device),
+            #        ),
             #    )
 
             layout_desc = get_layout_desc(gpu_context, self.chunk_size)
@@ -319,7 +322,9 @@ class MPCacheEngine:
         #    self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
         #        log_telemetry,
         #        make_end_event(
-        #            "store", key.request_id, stored_count=len(reserved_dict)
+        #            "store", key.request_id,
+        #            stored_count=len(reserved_dict),
+        #            device=str(gpu_context.device),
         #        ),
         #    )
 
@@ -373,7 +378,11 @@ class MPCacheEngine:
         if get_telemetry_controller().is_enabled():
             gpu_context.cupy_stream.launch_host_func(
                 log_telemetry,
-                make_start_event("retrieve", key.request_id),
+                make_start_event(
+                    "retrieve",
+                    key.request_id,
+                    device=str(gpu_context.device),
+                ),
             )
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
@@ -434,6 +443,7 @@ class MPCacheEngine:
                             "retrieve",
                             key.request_id,
                             retrieved_count=len(prefetched_keys),
+                            device=str(gpu_context.device),
                         ),
                     )
 

--- a/tests/v1/mp_observability/telemetry/test_controller.py
+++ b/tests/v1/mp_observability/telemetry/test_controller.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TelemetryController, singleton, and create_processors."""
+
+# Standard
+from unittest.mock import MagicMock
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.telemetry.config import TelemetryConfig
+from lmcache.v1.mp_observability.telemetry.controller import (
+    TelemetryController,
+    create_processors,
+    get_telemetry_controller,
+    init_telemetry_controller,
+    log_telemetry,
+)
+from lmcache.v1.mp_observability.telemetry.event import (
+    EventType,
+    TelemetryEvent,
+)
+from lmcache.v1.mp_observability.telemetry.processors.base import (
+    TelemetryProcessor,
+)
+from lmcache.v1.mp_observability.telemetry.processors.logging_processor import (
+    LoggingProcessor,
+    LoggingProcessorConfig,
+)
+import lmcache.v1.mp_observability.telemetry.controller as _ctrl_module
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    name: str = "test.op",
+    event_type: EventType = EventType.START,
+    session_id: str = "s1",
+) -> TelemetryEvent:
+    return TelemetryEvent(name=name, event_type=event_type, session_id=session_id)
+
+
+class _RecordingProcessor(TelemetryProcessor):
+    """Test processor that records events."""
+
+    def __init__(self):
+        self.events: list[TelemetryEvent] = []
+        self.shutdown_called = False
+
+    def on_new_event(self, event: TelemetryEvent) -> None:
+        self.events.append(event)
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def restore_global_controller():
+    """Save and restore the global singleton so tests don't leak state."""
+    saved = _ctrl_module._global_controller
+    yield
+    _ctrl_module._global_controller = saved
+
+
+@pytest.fixture
+def controller():
+    """Enabled TelemetryController with small queue for fast tests."""
+    return TelemetryController(TelemetryConfig(enabled=True, max_queue_size=100))
+
+
+# ---------------------------------------------------------------------------
+# Processor registration
+# ---------------------------------------------------------------------------
+
+
+class TestProcessorRegistration:
+    def test_register_processor(self, controller):
+        proc = _RecordingProcessor()
+        controller.register_processor(proc)
+        assert proc in controller._processors
+
+    def test_register_multiple_processors(self, controller):
+        procs = [_RecordingProcessor() for _ in range(3)]
+        for p in procs:
+            controller.register_processor(p)
+        assert len(controller._processors) == 3
+
+    def test_empty_initially(self, controller):
+        assert len(controller._processors) == 0
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_start_launches_thread(self, controller):
+        controller.start()
+        assert controller._thread is not None
+        assert controller._thread.is_alive()
+        controller.stop()
+
+    def test_disabled_noop(self):
+        ctrl = TelemetryController(TelemetryConfig(enabled=False))
+        ctrl.start()
+        assert ctrl._thread is None
+
+    def test_thread_is_daemon(self, controller):
+        controller.start()
+        assert controller._thread.daemon is True
+        controller.stop()
+
+    def test_thread_name(self, controller):
+        controller.start()
+        assert controller._thread.name == "TelemetryController"
+        controller.stop()
+
+    def test_double_stop(self, controller):
+        controller.start()
+        controller.stop()
+        controller.stop()
+
+    def test_stop_without_start(self, controller):
+        controller.stop()
+
+
+# ---------------------------------------------------------------------------
+# Event processing
+# ---------------------------------------------------------------------------
+
+
+class TestEventProcessing:
+    def test_event_reaches_processor(self, controller):
+        proc = _RecordingProcessor()
+        controller.register_processor(proc)
+        controller.start()
+
+        controller.log(_make_event())
+        time.sleep(0.15)
+        controller.stop()
+
+        assert len(proc.events) == 1
+        assert proc.events[0].name == "test.op"
+
+    def test_multiple_events_in_order(self, controller):
+        proc = _RecordingProcessor()
+        controller.register_processor(proc)
+        controller.start()
+
+        for i in range(5):
+            controller.log(_make_event(session_id=str(i)))
+        time.sleep(0.15)
+        controller.stop()
+
+        assert len(proc.events) == 5
+        for i, ev in enumerate(proc.events):
+            assert ev.session_id == str(i)
+
+    def test_late_registered_processor(self, controller):
+        controller.start()
+        time.sleep(0.05)
+
+        proc = _RecordingProcessor()
+        controller.register_processor(proc)
+
+        controller.log(_make_event())
+        time.sleep(0.15)
+        controller.stop()
+
+        assert len(proc.events) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Exception isolation
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionIsolation:
+    def test_bad_processor_doesnt_block_good(self, controller):
+        bad = MagicMock(spec=TelemetryProcessor)
+        bad.on_new_event.side_effect = RuntimeError("boom")
+        good = _RecordingProcessor()
+
+        controller.register_processor(bad)
+        controller.register_processor(good)
+        controller.start()
+
+        controller.log(_make_event())
+        time.sleep(0.15)
+        controller.stop()
+
+        assert len(good.events) == 1
+
+    def test_shutdown_exception_isolated(self, controller):
+        bad = MagicMock(spec=TelemetryProcessor)
+        bad.shutdown.side_effect = RuntimeError("shutdown boom")
+        good = _RecordingProcessor()
+
+        controller.register_processor(bad)
+        controller.register_processor(good)
+        controller.start()
+        controller.stop()
+
+        assert good.shutdown_called
+
+
+# ---------------------------------------------------------------------------
+# Backpressure
+# ---------------------------------------------------------------------------
+
+
+class TestBackpressure:
+    def test_events_discarded_when_queue_full(self):
+        ctrl = TelemetryController(TelemetryConfig(enabled=True, max_queue_size=5))
+        # Don't start — nothing drains
+        for _ in range(10):
+            ctrl.log(_make_event())
+
+        assert len(ctrl._queue) == 5
+        assert ctrl._discard_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Global singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalSingleton:
+    def test_get_returns_instance(self):
+        ctrl = get_telemetry_controller()
+        assert isinstance(ctrl, TelemetryController)
+
+    def test_init_replaces_global(self):
+        old = get_telemetry_controller()
+        new = init_telemetry_controller(TelemetryConfig(enabled=False))
+        assert get_telemetry_controller() is new
+        assert get_telemetry_controller() is not old
+
+    def test_default_singleton_is_disabled(self):
+        ctrl = get_telemetry_controller()
+        assert ctrl._config.enabled is False
+
+    def test_log_telemetry_convenience(self):
+        config = TelemetryConfig(enabled=True, max_queue_size=100)
+        init_telemetry_controller(config)
+        log_telemetry(_make_event())
+        assert len(get_telemetry_controller()._queue) == 1
+
+
+# ---------------------------------------------------------------------------
+# Disabled controller
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledController:
+    def test_log_is_noop_when_disabled(self):
+        ctrl = TelemetryController(TelemetryConfig(enabled=False))
+        ctrl.log(_make_event())
+        assert len(ctrl._queue) == 0
+
+
+# ---------------------------------------------------------------------------
+# create_processors factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProcessors:
+    def test_creates_logging_processor(self):
+        config = TelemetryConfig(
+            processor_configs=[LoggingProcessorConfig.from_dict({})]
+        )
+        procs = create_processors(config)
+        assert len(procs) == 1
+        assert isinstance(procs[0], LoggingProcessor)
+
+    def test_creates_multiple(self):
+        config = TelemetryConfig(
+            processor_configs=[
+                LoggingProcessorConfig.from_dict({}),
+                LoggingProcessorConfig.from_dict({}),
+            ]
+        )
+        procs = create_processors(config)
+        assert len(procs) == 2
+
+    def test_empty_config(self):
+        config = TelemetryConfig()
+        procs = create_processors(config)
+        assert procs == []

--- a/tests/v1/mp_observability/telemetry/test_controller.py
+++ b/tests/v1/mp_observability/telemetry/test_controller.py
@@ -152,6 +152,20 @@ class TestEventProcessing:
         assert len(proc.events) == 1
         assert proc.events[0].name == "test.op"
 
+    def test_log_stamps_timestamp(self, controller):
+        proc = _RecordingProcessor()
+        controller.register_processor(proc)
+        controller.start()
+
+        before = time.time()
+        controller.log(_make_event())
+        after = time.time()
+        time.sleep(0.15)
+        controller.stop()
+
+        assert len(proc.events) == 1
+        assert before <= proc.events[0].timestamp <= after
+
     def test_multiple_events_in_order(self, controller):
         proc = _RecordingProcessor()
         controller.register_processor(proc)

--- a/tests/v1/mp_observability/telemetry/test_controller.py
+++ b/tests/v1/mp_observability/telemetry/test_controller.py
@@ -125,6 +125,13 @@ class TestLifecycle:
         assert controller._thread.name == "TelemetryController"
         controller.stop()
 
+    def test_double_start_is_idempotent(self, controller):
+        controller.start()
+        thread = controller._thread
+        controller.start()
+        assert controller._thread is thread
+        controller.stop()
+
     def test_double_stop(self, controller):
         controller.start()
         controller.stop()

--- a/tests/v1/mp_observability/telemetry/test_event.py
+++ b/tests/v1/mp_observability/telemetry/test_event.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TelemetryEvent and EventType."""
+
+# First Party
+from lmcache.v1.mp_observability.telemetry.event import (
+    EventType,
+    TelemetryEvent,
+)
+
+
+class TestEventType:
+    def test_has_start_and_end(self):
+        assert EventType.START.value == "START"
+        assert EventType.END.value == "END"
+
+    def test_exactly_two_members(self):
+        assert len(EventType) == 2
+
+
+class TestTelemetryEvent:
+    def test_default_metadata_is_empty_dict(self):
+        event = TelemetryEvent(
+            name="mp.store",
+            event_type=EventType.START,
+            session_id="abc",
+        )
+        assert event.metadata == {}
+
+    def test_metadata_independence(self):
+        e1 = TelemetryEvent(name="mp.store", event_type=EventType.START, session_id="a")
+        e2 = TelemetryEvent(name="mp.store", event_type=EventType.START, session_id="b")
+        e1.metadata["key"] = "value"
+        assert "key" not in e2.metadata
+
+    def test_custom_metadata(self):
+        event = TelemetryEvent(
+            name="mp.lookup",
+            event_type=EventType.END,
+            session_id="xyz",
+            metadata={"tokens": 256, "hit": True, "ratio": 0.95, "model": "llama"},
+        )
+        assert event.metadata["tokens"] == 256
+        assert event.metadata["hit"] is True
+        assert event.metadata["ratio"] == 0.95
+        assert event.metadata["model"] == "llama"
+
+    def test_no_timestamp_field(self):
+        event = TelemetryEvent(
+            name="mp.store", event_type=EventType.START, session_id="t"
+        )
+        assert not hasattr(event, "timestamp")

--- a/tests/v1/mp_observability/telemetry/test_event.py
+++ b/tests/v1/mp_observability/telemetry/test_event.py
@@ -45,8 +45,8 @@ class TestTelemetryEvent:
         assert event.metadata["ratio"] == 0.95
         assert event.metadata["model"] == "llama"
 
-    def test_no_timestamp_field(self):
+    def test_timestamp_defaults_to_zero(self):
         event = TelemetryEvent(
             name="mp.store", event_type=EventType.START, session_id="t"
         )
-        assert not hasattr(event, "timestamp")
+        assert event.timestamp == 0.0

--- a/tests/v1/mp_observability/telemetry/test_logging_processor.py
+++ b/tests/v1/mp_observability/telemetry/test_logging_processor.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for LoggingProcessor and LoggingProcessorConfig."""
+
+# Standard
+import logging
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.telemetry.event import (
+    EventType,
+    TelemetryEvent,
+)
+from lmcache.v1.mp_observability.telemetry.processors import logging_processor
+from lmcache.v1.mp_observability.telemetry.processors.logging_processor import (
+    LoggingProcessor,
+    LoggingProcessorConfig,
+)
+
+_LOGGER_NAME = logging_processor.__name__
+
+
+@pytest.fixture(autouse=True)
+def _enable_propagation():
+    """Temporarily enable propagation so caplog can capture."""
+    lg = logging.getLogger(_LOGGER_NAME)
+    old = lg.propagate
+    lg.propagate = True
+    yield
+    lg.propagate = old
+
+
+class TestLoggingProcessor:
+    def test_on_new_event_logs_at_debug(self, caplog):
+        proc = LoggingProcessor(LoggingProcessorConfig.from_dict({}))
+        event = TelemetryEvent(
+            name="mp.store",
+            event_type=EventType.START,
+            session_id="sess-1",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            proc.on_new_event(event)
+
+        assert "Telemetry:" in caplog.text
+        assert "mp.store" in caplog.text
+        assert "START" in caplog.text
+        assert "sess-1" in caplog.text
+
+    def test_metadata_appears_in_log(self, caplog):
+        proc = LoggingProcessor(LoggingProcessorConfig.from_dict({}))
+        event = TelemetryEvent(
+            name="mp.lookup",
+            event_type=EventType.END,
+            session_id="sess-2",
+            metadata={"tokens": 512},
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            proc.on_new_event(event)
+
+        assert "512" in caplog.text
+
+    def test_custom_log_level(self, caplog):
+        proc = LoggingProcessor(LoggingProcessorConfig.from_dict({"log_level": "INFO"}))
+        event = TelemetryEvent(
+            name="mp.store",
+            event_type=EventType.START,
+            session_id="sess-3",
+        )
+
+        with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+            proc.on_new_event(event)
+
+        assert "Telemetry:" in caplog.text
+        assert "mp.store" in caplog.text
+
+    def test_shutdown_does_not_raise(self):
+        proc = LoggingProcessor(LoggingProcessorConfig.from_dict({}))
+        proc.shutdown()
+
+
+class TestLoggingProcessorConfig:
+    def test_from_dict_empty(self):
+        config = LoggingProcessorConfig.from_dict({})
+        assert isinstance(config, LoggingProcessorConfig)
+        assert config.log_level == "DEBUG"
+
+    def test_from_dict_custom_log_level(self):
+        config = LoggingProcessorConfig.from_dict({"log_level": "info"})
+        assert config.log_level == "INFO"
+
+    def test_help_returns_string(self):
+        h = LoggingProcessorConfig.help()
+        assert isinstance(h, str)
+        assert len(h) > 0


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an event-based telemetry framework for MP mode observability, complementing the existing Prometheus metrics (aggregated counters/histograms) with per-operation event tracing.

**Design:** Uses a START/END event model with session IDs. Call sites emit a `START` event when an operation begins and an `END` event when it completes, sharing the same `session_id` to correlate them into spans. This two-event design is necessary because start and end happen at different call sites in LMCache's async submit/check/complete patterns. See `DESIGN.md` for full architecture details and how to implement new processors.

**Key components:**
- `TelemetryEvent` dataclass (name, event_type, session_id, metadata)
- `TelemetryProcessor` / `TelemetryProcessorConfig` ABCs with a registry pattern (same as L2 adapters)
- `LoggingProcessor` built-in processor with configurable log level
- `TelemetryController` with lock-free deque, daemon drain thread, tail-drop backpressure
- Disabled-by-default singleton — no thread or overhead until explicitly enabled
- `make_start_event()` / `make_end_event()` convenience functions for concise call sites

**User-facing changes:**
- New CLI args: `--enable-telemetry`, `--telemetry-max-queue-size`, `--telemetry-processor JSON`
- Example: `--enable-telemetry --telemetry-processor '{"type": "logging", "log_level": "INFO"}'`
- Telemetry events emitted for `store`, `retrieve`, and `lookup` operations in `server.py`
- Wired into both `server.py` and `blend_server.py` startup/shutdown lifecycle

**Special notes for your reviewers**:

- The processor registry + factory pattern mirrors `lmcache/v1/distributed/l2_adapters/config.py`
- `collections.deque` is used without a lock — CPython GIL guarantees atomic `append()`/`popleft()` with a single consumer thread
- GPU-stream call sites use `launch_host_func` with `is_enabled()` guards to avoid registering unnecessary CUDA callbacks when telemetry is disabled
- This PR implements the framework only. Adding more call sites (e.g., blend operations, L2 store/retrieve) is a follow-up

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests