### PR TITLE
Fix to support mla multiple tp failed to read issue

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -104,6 +104,7 @@ class LMCacheMPSchedulerAdapter:
         world_size: int,
         kv_rank: int,
         vllm_block_size: int,
+        tp_size: int = 1,
     ):
         """
         Args:
@@ -114,6 +115,8 @@ class LMCacheMPSchedulerAdapter:
             world_size: The world size used for LMCache keys
             kv_rank: The kv rank used for LMCache keys
             vllm_block_size: The block size used in vLLM
+            tp_size: Tensor-parallel size for MLA
+                multi-reader locking (default 1).
         """
         self.mq_client = MessageQueueClient(server_url, context)
 
@@ -122,6 +125,7 @@ class LMCacheMPSchedulerAdapter:
 
         self.model_name = model_name
         self.world_size = world_size
+        self.tp_size = tp_size
 
         # Read chunk size from lmcache
         self.chunk_size = get_lmcache_chunk_size(self.mq_client)
@@ -174,7 +178,7 @@ class LMCacheMPSchedulerAdapter:
         future = send_lmcache_request(
             self.mq_client,
             RequestType.LOOKUP,
-            [key],
+            [key, self.tp_size],
         )
         job_id = future.result()
         self._lookup_job_ids[request_id] = job_id
@@ -260,7 +264,7 @@ class LMCacheMPSchedulerAdapter:
         send_lmcache_request(
             self.mq_client,
             RequestType.FREE_LOOKUP_LOCKS,
-            [key],
+            [key, self.tp_size],
         )
 
     def end_session(self, request_id: str) -> None:

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -83,6 +83,38 @@ def l1_mgr_synchronized(func):
 
 L1OperationResult = tuple[L1Error, MemoryObj | None]
 
+# Upper bound for the count parameter in reserve_read / finish_read
+# to prevent a single call from holding the global lock for too long.
+MAX_READ_LOCK_COUNT = 128
+
+
+def _validate_extra_count(extra_count: int) -> int:
+    """Validate and clamp extra_count.
+
+    Args:
+        extra_count: Extra lock count on top of the
+            default 1 lock.
+
+    Returns:
+        Clamped value in [0, MAX_READ_LOCK_COUNT - 1].
+    """
+    if extra_count < 0:
+        logger.warning(
+            "L1Manager: extra_count=%d is invalid, clamping to 0",
+            extra_count,
+        )
+        return 0
+    upper = MAX_READ_LOCK_COUNT - 1
+    if extra_count > upper:
+        logger.warning(
+            "L1Manager: extra_count=%d exceeds limit=%d, clamping",
+            extra_count,
+            upper,
+        )
+        return upper
+    return extra_count
+
+
 # Main classes
 
 
@@ -159,20 +191,30 @@ class L1Manager:
     def reserve_read(
         self,
         keys: list[ObjectKey],
+        extra_count: int = 0,
     ) -> dict[ObjectKey, L1OperationResult]:
         """Reserve read access for the given keys.
 
         Args:
-            keys: The list of object keys to reserve read access for.
+            keys: The list of object keys to reserve
+                read access for.
+            extra_count: Extra read locks on top of the
+                default 1 lock.  Total locks acquired per
+                key = 1 + extra_count.  Useful when multiple
+                workers each consume one read lock for the
+                same key (e.g. MLA models with TP > 1).
 
         Returns:
-            A dictionary mapping each object key to a tuple of
-            (L1Error, Optional[MemoryObj]).
+            A dictionary mapping each object key to a tuple
+            of (L1Error, Optional[MemoryObj]).
 
         Errors:
             KEY_NOT_EXIST: The key does not exist.
-            KEY_NOT_READABLE: The key exists but is not readable.
+            KEY_NOT_READABLE: The key exists but is not
+                readable.
         """
+        extra_count = _validate_extra_count(extra_count)
+        total = 1 + extra_count
         ret: dict[ObjectKey, L1OperationResult] = {}
         successful_keys: list[ObjectKey] = []
         for key in keys:
@@ -185,7 +227,11 @@ class L1Manager:
                 ret[key] = (L1Error.KEY_NOT_READABLE, None)
                 continue
 
-            entry.read_lock.lock()
+            # TODO(perf): support a count argument in
+            # TTLLock.lock() to avoid Python for-loop
+            # overhead (TTLLock is C++ std::atomic).
+            for _ in range(total):
+                entry.read_lock.lock()
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
             successful_keys.append(key)
 
@@ -232,22 +278,36 @@ class L1Manager:
         return ret
 
     @l1_mgr_synchronized
-    def finish_read(self, keys: list[ObjectKey]) -> dict[ObjectKey, L1Error]:
+    def finish_read(
+        self,
+        keys: list[ObjectKey],
+        extra_count: int = 0,
+    ) -> dict[ObjectKey, L1Error]:
         """Finish read access for the given keys.
 
-        Will delete the object if it is temporary and read count reaches zero.
+        Will delete the object if it is temporary and read
+        count reaches zero.
 
         Args:
-            keys: The list of object keys to finish read access for.
+            keys: The list of object keys to finish read
+                access for.
+            extra_count: Extra read locks to release on top
+                of the default 1.  Must match the
+                ``extra_count`` used in the corresponding
+                ``reserve_read`` call.
 
         Returns:
-            A dictionary mapping each object key to an L1Error.
+            A dictionary mapping each object key to an
+            L1Error.
 
         Errors:
             KEY_NOT_EXIST: The key does not exist.
-            KEY_IN_WRONG_STATE: The key is write-locked or non-read-locked,
-                which means the reader may read inconsistent data.
+            KEY_IN_WRONG_STATE: The key is write-locked or
+                non-read-locked, which means the reader may
+                read inconsistent data.
         """
+        extra_count = _validate_extra_count(extra_count)
+        total = 1 + extra_count
         need_to_free: list[MemoryObj] = []
         need_to_free_keys: list[ObjectKey] = []
         ret: dict[ObjectKey, L1Error] = {}
@@ -282,7 +342,11 @@ class L1Manager:
                 ret[key] = L1Error.KEY_IN_WRONG_STATE
                 continue
 
-            entry.read_lock.unlock()
+            # TODO(perf): support a count argument in
+            # TTLLock.unlock() to avoid Python for-loop
+            # overhead (TTLLock is C++ std::atomic).
+            for _ in range(total):
+                entry.read_lock.unlock()
             if entry.is_temporary and not entry.read_lock.is_locked():
                 # NOTE: temporary objects shouldn't have write-locks
                 need_to_free.append(entry.memory_obj)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -234,14 +234,16 @@ class StorageManager:
     def finish_read_prefetched(
         self,
         keys: list[ObjectKey],
+        extra_count: int = 0,
     ) -> None:
-        """
-        Finish reading of the prefetched objects, releasing their read locks.
+        """Finish reading prefetched objects.
 
         Args:
-            keys (list[ObjectKey]): List of object keys that have been read.
+            keys: Object keys that have been read.
+            extra_count: Extra read locks to release per key
+                (on top of the default 1).
         """
-        finish_result = self._l1_manager.finish_read(keys)
+        finish_result = self._l1_manager.finish_read(keys, extra_count=extra_count)
         successful_keys = [k for k, e in finish_result.items() if e == L1Error.SUCCESS]
         failed_keys = [k for k, e in finish_result.items() if e != L1Error.SUCCESS]
         for listener in self._registered_listeners:
@@ -251,21 +253,24 @@ class StorageManager:
         self,
         keys: list[ObjectKey],
         layout_desc: MemoryLayoutDesc,
+        extra_readers: int = 0,
     ) -> PrefetchHandle:
-        """
-        Prefetch the objects into L1 memory asynchronously. The prefetched object
-        will be added with read locks.
+        """Prefetch objects into L1 asynchronously.
 
         Args:
-            keys (list[ObjectKey]): List of object keys to prefetch.
+            keys: Object keys to prefetch.
+            layout_desc: Memory layout description.
+            extra_readers: Extra workers (on top of the default
+                1) that will independently retrieve the same
+                key.  Total locks = 1 + extra_readers.
 
         Returns:
-            PrefetchHandle: A handle to track the prefetch task.
+            PrefetchHandle to track the task.
         """
         # NOTE: now we only have L1, so the prefetch is essentially checking how many
         # objects are already in L1, and adding read locks to them.
 
-        l1_read_result = self._l1_manager.reserve_read(keys)
+        l1_read_result = self._l1_manager.reserve_read(keys, extra_count=extra_readers)
         hit_count = 0
         for key in keys:
             entry = l1_read_result.get(key, None)
@@ -288,7 +293,7 @@ class StorageManager:
                 skipped_keys.append(key)
 
         if skipped_keys:
-            self._l1_manager.finish_read(skipped_keys)
+            self._l1_manager.finish_read(skipped_keys, extra_count=extra_readers)
 
         for listener in self._registered_listeners:
             listener.on_sm_read_prefetched(keys[:hit_count], keys[hit_count:])

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -253,16 +253,16 @@ class StorageManager:
         self,
         keys: list[ObjectKey],
         layout_desc: MemoryLayoutDesc,
-        extra_readers: int = 0,
+        extra_count: int = 0,
     ) -> PrefetchHandle:
         """Prefetch objects into L1 asynchronously.
 
         Args:
             keys: Object keys to prefetch.
             layout_desc: Memory layout description.
-            extra_readers: Extra workers (on top of the default
+            extra_count: Extra workers (on top of the default
                 1) that will independently retrieve the same
-                key.  Total locks = 1 + extra_readers.
+                key.  Total locks = 1 + extra_count.
 
         Returns:
             PrefetchHandle to track the task.
@@ -270,7 +270,7 @@ class StorageManager:
         # NOTE: now we only have L1, so the prefetch is essentially checking how many
         # objects are already in L1, and adding read locks to them.
 
-        l1_read_result = self._l1_manager.reserve_read(keys, extra_count=extra_readers)
+        l1_read_result = self._l1_manager.reserve_read(keys, extra_count=extra_count)
         hit_count = 0
         for key in keys:
             entry = l1_read_result.get(key, None)
@@ -293,7 +293,7 @@ class StorageManager:
                 skipped_keys.append(key)
 
         if skipped_keys:
-            self._l1_manager.finish_read(skipped_keys, extra_count=extra_readers)
+            self._l1_manager.finish_read(skipped_keys, extra_count=extra_count)
 
         for listener in self._registered_listeners:
             listener.on_sm_read_prefetched(keys[:hit_count], keys[hit_count:])

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -90,9 +90,11 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Submit a prefix lookup and return a prefetch job ID
         # Payload:
         #   - key: KeyType - Cache key to look up
+        #   - tp_size: int - Tensor-parallel size for
+        #       MLA multi-reader locking
         # Returns: int - Prefetch job ID for polling via QUERY_PREFETCH_STATUS
         "LOOKUP": ProtocolDefinition(
-            payload_classes=[KeyType],
+            payload_classes=[KeyType, int],
             response_class=int,
             handler_type=HandlerType.BLOCKING,
         ),
@@ -107,10 +109,13 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         ),
         # Free locks (release read locks without a full RETRIEVE)
         # Payload:
-        #   - keys: list[KeyType] - Cache keys whose read locks to release
+        #   - key: KeyType - Cache key whose read locks
+        #       to release
+        #   - tp_size: int - Tensor-parallel size for
+        #       MLA multi-reader locking
         # Returns: None
         "FREE_LOOKUP_LOCKS": ProtocolDefinition(
-            payload_classes=[KeyType],
+            payload_classes=[KeyType, int],
             response_class=None,
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -618,9 +618,8 @@ class MPCacheEngine:
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
 
         handle = self.storage_manager.submit_prefetch_task(
-            obj_keys,
-            layout_desc,
-            extra_readers=extra_readers)
+            obj_keys, layout_desc, extra_readers=extra_readers
+        )
         return self._register_prefetch_job(
             _PrefetchJob(
                 handle=handle,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -132,6 +132,46 @@ def resolve_key(
     ]
 
 
+def compute_extra_readers(
+    tp_size: int,
+    world_size: int,
+) -> int:
+    """Compute extra reader count for MLA multi-reader locking.
+
+    Non-MLA: each TP worker owns a distinct KV shard,
+      so each ObjectKey is retrieved by exactly 1
+      worker -> extra_readers = 0.
+    MLA: TP does not split KV caches, all TP workers
+      share the same object. vLLM passes world_size
+      already divided by tp_size (e.g. world_size=1
+      for TP=4 PP=1), so ipc_keys_to_object_keys
+      only produces 1 ObjectKey per chunk.  All TP
+      workers retrieve that same ObjectKey, hence
+      extra_readers = tp_size - 1.
+
+    Detection: tp > world_size means MLA (world_size
+    was divided by tp on the vLLM side).
+
+    Fallback: old vLLM (<= 0.8.5) does not send
+    tp_size (defaults to 1); we fall back to
+    world_size which gives extra_readers = 0
+    (safe but may under-lock for MLA).
+
+    TODO: world_size currently carries an overloaded
+    meaning (total ranks for non-MLA vs total/tp for
+    MLA). Consider a dedicated field in the future.
+
+    Args:
+        tp_size: Tensor-parallel size from the client.
+        world_size: World size from the cache key.
+
+    Returns:
+        Number of extra readers (0 for non-MLA).
+    """
+    tp = tp_size if tp_size > 1 else world_size
+    return tp - 1 if tp > world_size else 0
+
+
 def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
     """Get the memory layout description for a given GPU context and number of tokens.
 
@@ -498,9 +538,29 @@ class MPCacheEngine:
         self._can_log_store = True
         return event.ipc_handle(), True
 
+    def _find_layout_desc(
+        self,
+        model_name: str,
+        world_size: int,
+    ) -> MemoryLayoutDesc | None:
+        """Find layout desc from a matching GPU context.
+
+        Returns:
+            The layout descriptor, or None if no context
+            matches (model_name, world_size).
+        """
+        for gpu_id, (m, w) in self.gpu_context_meta.items():
+            if m == model_name and w == world_size:
+                return get_layout_desc(
+                    self.gpu_contexts[gpu_id],
+                    self.chunk_size,
+                )
+        return None
+
     def lookup(
         self,
         key: IPCCacheEngineKey,
+        tp_size: int,
     ) -> int:
         """Submit a prefix lookup and return a prefetch job ID.
 
@@ -517,15 +577,7 @@ class MPCacheEngine:
         model_name, world_size = key.model_name, key.world_size
         log_telemetry(make_start_event("lookup_and_prefetch", key.request_id))
 
-        # Find the gpu context and calculate the layout desc
-        layout_desc: MemoryLayoutDesc | None = None
-        for gpu_id, (m_name, w_size) in self.gpu_context_meta.items():
-            if m_name == model_name and w_size == world_size:
-                layout_desc = get_layout_desc(
-                    self.gpu_contexts[gpu_id], self.chunk_size
-                )
-                break
-
+        layout_desc = self._find_layout_desc(model_name, world_size)
         if layout_desc is None:
             logger.error(
                 "No GPU context found for model %s with world size %d during lookup!",
@@ -545,6 +597,8 @@ class MPCacheEngine:
                 )
             )
 
+        extra_readers = compute_extra_readers(tp_size, world_size)
+
         # Prepare for the obj keys
         ipc_keys.extend(key.to_hash_keys(self.token_hasher))
         if not ipc_keys:
@@ -563,7 +617,10 @@ class MPCacheEngine:
 
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
 
-        handle = self.storage_manager.submit_prefetch_task(obj_keys, layout_desc)
+        handle = self.storage_manager.submit_prefetch_task(
+            obj_keys,
+            layout_desc,
+            extra_readers=extra_readers)
         return self._register_prefetch_job(
             _PrefetchJob(
                 handle=handle,
@@ -632,21 +689,18 @@ class MPCacheEngine:
     def free_lookup_locks(
         self,
         key: IPCCacheEngineKey,
+        tp_size: int,
     ) -> None:
-        """Release read locks acquired during lookup without performing a
-        full retrieve.  This is used when a request is cancelled or aborted
-        after LOOKUP but before RETRIEVE.
+        """Release read locks acquired during lookup.
 
-        ``to_hash_keys`` always expands over the entire ``token_ids``
-        sequence, so we slice the result to only include the chunks that
-        overlap with the key's ``[start, end)`` range.
-        This means when ``start`` or ``end`` is not aligned to ``chunk_size``, the
-        entire chunk containing ``start`` boundary is freed but the one containing
-        ``end`` boundary will not be freed.  It caller's responsibility to align
-        the boundaries as desired.
+        Computes the extra reader count from ``tp_size`` and
+        ``world_size`` the same way :meth:`lookup` does, so
+        the correct number of locks is released.
 
         Args:
-            keys: List of cache keys whose read locks should be released.
+            key: Cache key whose read locks should be released.
+            tp_size: Tensor-parallel size for MLA
+                multi-reader locking.
         """
         ipc_keys: list[IPCCacheEngineKey] = []
         all_hash_keys = key.to_hash_keys(self.token_hasher)
@@ -657,7 +711,10 @@ class MPCacheEngine:
         if not ipc_keys:
             return
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
-        self.storage_manager.finish_read_prefetched(obj_keys)
+
+        extra_readers = compute_extra_readers(tp_size, key.world_size)
+
+        self.storage_manager.finish_read_prefetched(obj_keys, extra_count=extra_readers)
 
     # =========================================================================
     # Utility methods

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -132,29 +132,29 @@ def resolve_key(
     ]
 
 
-def compute_extra_readers(
+def compute_extra_count(
     tp_size: int,
     world_size: int,
 ) -> int:
-    """Compute extra reader count for MLA multi-reader locking.
+    """Compute extra count for MLA multi-reader locking.
 
     Non-MLA: each TP worker owns a distinct KV shard,
       so each ObjectKey is retrieved by exactly 1
-      worker -> extra_readers = 0.
+      worker -> extra_count = 0.
     MLA: TP does not split KV caches, all TP workers
       share the same object. vLLM passes world_size
       already divided by tp_size (e.g. world_size=1
       for TP=4 PP=1), so ipc_keys_to_object_keys
       only produces 1 ObjectKey per chunk.  All TP
       workers retrieve that same ObjectKey, hence
-      extra_readers = tp_size - 1.
+      extra_count = tp_size - 1.
 
     Detection: tp > world_size means MLA (world_size
     was divided by tp on the vLLM side).
 
     Fallback: old vLLM (<= 0.8.5) does not send
     tp_size (defaults to 1); we fall back to
-    world_size which gives extra_readers = 0
+    world_size which gives extra_count = 0
     (safe but may under-lock for MLA).
 
     TODO: world_size currently carries an overloaded
@@ -166,7 +166,7 @@ def compute_extra_readers(
         world_size: World size from the cache key.
 
     Returns:
-        Number of extra readers (0 for non-MLA).
+        Number of extra count (0 for non-MLA).
     """
     tp = tp_size if tp_size > 1 else world_size
     return tp - 1 if tp > world_size else 0
@@ -597,7 +597,7 @@ class MPCacheEngine:
                 )
             )
 
-        extra_readers = compute_extra_readers(tp_size, world_size)
+        extra_count = compute_extra_count(tp_size, world_size)
 
         # Prepare for the obj keys
         ipc_keys.extend(key.to_hash_keys(self.token_hasher))
@@ -618,7 +618,7 @@ class MPCacheEngine:
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
 
         handle = self.storage_manager.submit_prefetch_task(
-            obj_keys, layout_desc, extra_readers=extra_readers
+            obj_keys, layout_desc, extra_count=extra_count
         )
         return self._register_prefetch_job(
             _PrefetchJob(
@@ -711,9 +711,9 @@ class MPCacheEngine:
             return
         obj_keys = ipc_keys_to_object_keys(ipc_keys)
 
-        extra_readers = compute_extra_readers(tp_size, key.world_size)
+        extra_count = compute_extra_count(tp_size, key.world_size)
 
-        self.storage_manager.finish_read_prefetched(obj_keys, extra_count=extra_readers)
+        self.storage_manager.finish_read_prefetched(obj_keys, extra_count=extra_count)
 
     # =========================================================================
     # Utility methods

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -368,10 +368,10 @@ class TestStorageManagerMultiReader:
     prefetched object.
     """
 
-    def test_prefetch_with_extra_readers(
+    def test_prefetch_with_extra_count(
         self, basic_storage_manager_config, basic_layout
     ):
-        """submit_prefetch_task(extra_readers=N-1) acquires N locks."""
+        """submit_prefetch_task(extra_count=N-1) acquires N locks."""
         sm = StorageManager(basic_storage_manager_config)
         keys = [make_object_key(i) for i in range(3)]
 
@@ -380,15 +380,13 @@ class TestStorageManagerMultiReader:
         assert len(ret) == len(keys)
         sm.finish_write(list(ret.keys()))
 
-        extra_readers = 2  # total = 1 + 2 = 3 locks
-        handle = sm.submit_prefetch_task(
-            keys, basic_layout, extra_readers=extra_readers
-        )
+        extra_count = 2  # total = 1 + 2 = 3 locks
+        handle = sm.submit_prefetch_task(keys, basic_layout, extra_count=extra_count)
         hit = sm.query_prefetch_status(handle)
         assert hit == len(keys)
 
         # Release with matching extra_count
-        sm.finish_read_prefetched(keys, extra_count=extra_readers)
+        sm.finish_read_prefetched(keys, extra_count=extra_count)
 
         # All locks released -> objects writable again
         ret = sm.reserve_write(keys, basic_layout, mode="update")
@@ -406,10 +404,8 @@ class TestStorageManagerMultiReader:
         ret = sm.reserve_write(keys, basic_layout, mode="new")
         sm.finish_write(list(ret.keys()))
 
-        extra_readers = 3  # total = 1 + 3 = 4 locks
-        handle = sm.submit_prefetch_task(
-            keys, basic_layout, extra_readers=extra_readers
-        )
+        extra_count = 3  # total = 1 + 3 = 4 locks
+        handle = sm.submit_prefetch_task(keys, basic_layout, extra_count=extra_count)
         hit = sm.query_prefetch_status(handle)
         assert hit == len(keys)
 
@@ -445,9 +441,9 @@ class TestStorageManagerMultiReader:
         ret = sm.reserve_write(existing, basic_layout, mode="new")
         sm.finish_write(list(ret.keys()))
 
-        extra_readers = 1  # total = 1 + 1 = 2 locks
+        extra_count = 1  # total = 1 + 1 = 2 locks
         handle = sm.submit_prefetch_task(
-            all_keys, basic_layout, extra_readers=extra_readers
+            all_keys, basic_layout, extra_count=extra_count
         )
         hit = sm.query_prefetch_status(handle)
         # Only prefix {0,1} count as hits
@@ -455,7 +451,7 @@ class TestStorageManagerMultiReader:
         assert hit == 2
 
         # Finish the prefix hits
-        sm.finish_read_prefetched(all_keys[:2], extra_count=extra_readers)
+        sm.finish_read_prefetched(all_keys[:2], extra_count=extra_count)
 
         # Keys {3,4} should be writable (skipped locks released)
         ret = sm.reserve_write(
@@ -467,10 +463,10 @@ class TestStorageManagerMultiReader:
 
         sm.close()
 
-    def test_extra_readers_default_is_zero(
+    def test_extra_count_default_is_zero(
         self, basic_storage_manager_config, basic_layout
     ):
-        """Default extra_readers=0 behaves same as before."""
+        """Default extra_count=0 behaves same as before."""
         sm = StorageManager(basic_storage_manager_config)
         keys = [make_object_key(i) for i in range(3)]
 

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -356,6 +356,141 @@ class TestStorageManagerBasic:
 
 
 # =============================================================================
+# Tests for multi-reader (count / num_readers) support
+# =============================================================================
+
+
+class TestStorageManagerMultiReader:
+    """Tests for the num_readers / count parameters.
+
+    These parameters allow multiple workers (e.g. MLA with
+    TP > 1) to each hold an independent read lock on the same
+    prefetched object.
+    """
+
+    def test_prefetch_with_extra_readers(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """submit_prefetch_task(extra_readers=N-1) acquires N locks."""
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i) for i in range(3)]
+
+        # Write keys
+        ret = sm.reserve_write(keys, basic_layout, mode="new")
+        assert len(ret) == len(keys)
+        sm.finish_write(list(ret.keys()))
+
+        extra_readers = 2  # total = 1 + 2 = 3 locks
+        handle = sm.submit_prefetch_task(
+            keys, basic_layout, extra_readers=extra_readers
+        )
+        hit = sm.query_prefetch_status(handle)
+        assert hit == len(keys)
+
+        # Release with matching extra_count
+        sm.finish_read_prefetched(keys, extra_count=extra_readers)
+
+        # All locks released -> objects writable again
+        ret = sm.reserve_write(keys, basic_layout, mode="update")
+        assert len(ret) == len(keys)
+
+        sm.close()
+
+    def test_finish_read_prefetched_partial_extra_count(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """Partial extra_count release leaves locks held."""
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i) for i in range(2)]
+
+        ret = sm.reserve_write(keys, basic_layout, mode="new")
+        sm.finish_write(list(ret.keys()))
+
+        extra_readers = 3  # total = 1 + 3 = 4 locks
+        handle = sm.submit_prefetch_task(
+            keys, basic_layout, extra_readers=extra_readers
+        )
+        hit = sm.query_prefetch_status(handle)
+        assert hit == len(keys)
+
+        # Release 2 of 4 (1 + extra_count=1)
+        sm.finish_read_prefetched(keys, extra_count=1)
+
+        # Objects should NOT be writable (2 locks remain)
+        ret = sm.reserve_write(keys, basic_layout, mode="update")
+        assert len(ret) == 0
+
+        # Release remaining 2 (1 + extra_count=1)
+        sm.finish_read_prefetched(keys, extra_count=1)
+
+        # Now writable
+        ret = sm.reserve_write(keys, basic_layout, mode="update")
+        assert len(ret) == len(keys)
+
+        sm.close()
+
+    def test_prefetch_skipped_keys_released_with_extra(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """Non-prefix L1 hits are released with correct extra.
+
+        Keys {0,1,3,4} exist, key 2 is missing.  The prefix
+        hits are {0,1}; keys {3,4} must have their N locks
+        released to avoid dangling locks.
+        """
+        sm = StorageManager(basic_storage_manager_config)
+        all_keys = [make_object_key(i) for i in range(5)]
+        existing = [all_keys[i] for i in [0, 1, 3, 4]]
+
+        ret = sm.reserve_write(existing, basic_layout, mode="new")
+        sm.finish_write(list(ret.keys()))
+
+        extra_readers = 1  # total = 1 + 1 = 2 locks
+        handle = sm.submit_prefetch_task(
+            all_keys, basic_layout, extra_readers=extra_readers
+        )
+        hit = sm.query_prefetch_status(handle)
+        # Only prefix {0,1} count as hits
+        assert hit is not None
+        assert hit == 2
+
+        # Finish the prefix hits
+        sm.finish_read_prefetched(all_keys[:2], extra_count=extra_readers)
+
+        # Keys {3,4} should be writable (skipped locks released)
+        ret = sm.reserve_write(
+            [all_keys[3], all_keys[4]],
+            basic_layout,
+            mode="update",
+        )
+        assert len(ret) == 2
+
+        sm.close()
+
+    def test_extra_readers_default_is_zero(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """Default extra_readers=0 behaves same as before."""
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i) for i in range(3)]
+
+        ret = sm.reserve_write(keys, basic_layout, mode="new")
+        sm.finish_write(list(ret.keys()))
+
+        handle = sm.submit_prefetch_task(keys, basic_layout)
+        hit = sm.query_prefetch_status(handle)
+        assert hit == len(keys)
+
+        # Single finish is enough
+        sm.finish_read_prefetched(keys)
+
+        ret = sm.reserve_write(keys, basic_layout, mode="update")
+        assert len(ret) == len(keys)
+
+        sm.close()
+
+
+# =============================================================================
 # L2 Prefetch Integration Tests
 # =============================================================================
 

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -282,6 +282,58 @@ class TestReserveRead:
 
         manager.close()
 
+    def test_reserve_read_with_extra_count(self, basic_l1_config, basic_layout):
+        """Test reserve_read(extra_count=N) acquires 1+N locks."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Create ready object
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        # Reserve with extra_count=2 -> total 3 locks
+        result = manager.reserve_read([key], extra_count=2)
+        assert result[key][0] == L1Error.SUCCESS
+        assert result[key][1] is not None
+
+        # Need 3 finish_read() to fully release
+        manager.finish_read([key])
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert state.read_lock.is_locked()
+
+        manager.finish_read([key])
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert state.read_lock.is_locked()
+
+        manager.finish_read([key])
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert not state.read_lock.is_locked()
+
+        manager.close()
+
+    def test_reserve_read_extra_count_default_is_zero(
+        self, basic_l1_config, basic_layout
+    ):
+        """Default extra_count=0 acquires exactly 1 lock."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        manager.reserve_read([key])
+        manager.finish_read([key])
+
+        # Lock fully released after single finish_read
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert not state.read_lock.is_locked()
+
+        manager.close()
+
 
 # =============================================================================
 # Tests for L1Manager.unsafe_read()
@@ -621,6 +673,102 @@ class TestFinishRead:
 
         # Finish read third time - temporary object should be deleted
         manager.finish_read([key])
+        assert manager.get_object_state(key) is None
+
+        manager.close()
+
+    def test_finish_read_with_extra_count_releases_multiple(
+        self, basic_l1_config, basic_layout
+    ):
+        """finish_read(extra_count=2) releases 3 locks at once."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Create ready object
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        # Acquire 3 read locks (1 + extra_count=2)
+        manager.reserve_read([key], extra_count=2)
+
+        # Release all 3 at once
+        result = manager.finish_read([key], extra_count=2)
+        assert result[key] == L1Error.SUCCESS
+
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert not state.read_lock.is_locked()
+
+        manager.close()
+
+    def test_finish_read_extra_count_partial_release(
+        self, basic_l1_config, basic_layout
+    ):
+        """Partial extra_count release leaves remaining locks."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        # 3 locks total (1 + extra_count=2)
+        manager.reserve_read([key], extra_count=2)
+
+        # Release 2 of 3 (1 + extra_count=1)
+        manager.finish_read([key], extra_count=1)
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert state.read_lock.is_locked()
+
+        # Release last one (1 + extra_count=0)
+        manager.finish_read([key])
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert not state.read_lock.is_locked()
+
+        manager.close()
+
+    def test_finish_read_extra_count_deletes_temporary(
+        self, basic_l1_config, basic_layout
+    ):
+        """Temp objects deleted when extra_count releases all."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        # Create temporary object
+        manager.reserve_write([key], [True], basic_layout)
+        manager.finish_write([key])
+
+        # Acquire 3 read locks at once (1 + extra_count=2)
+        manager.reserve_read([key], extra_count=2)
+        assert manager.get_object_state(key) is not None
+
+        # Release all 3 at once -> temp deleted
+        result = manager.finish_read([key], extra_count=2)
+        assert result[key] == L1Error.SUCCESS
+        assert manager.get_object_state(key) is None
+
+        manager.close()
+
+    def test_finish_read_extra_count_temp_survives_partial(
+        self, basic_l1_config, basic_layout
+    ):
+        """Temp object survives partial extra_count release."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        manager.reserve_write([key], [True], basic_layout)
+        manager.finish_write([key])
+
+        # 4 locks total (1 + extra_count=3)
+        manager.reserve_read([key], extra_count=3)
+
+        # Release 2 of 4 -> still locked
+        manager.finish_read([key], extra_count=1)
+        assert manager.get_object_state(key) is not None
+
+        # Release remaining 2 -> deleted
+        manager.finish_read([key], extra_count=1)
         assert manager.get_object_state(key) is None
 
         manager.close()
@@ -1411,6 +1559,59 @@ class TestStateMachineTransitions:
 
         # Single finish_read should delete the object
         manager.finish_read([key])
+        assert manager.get_object_state(key) is None
+
+        manager.close()
+
+    def test_multi_reader_lifecycle_with_extra_count(
+        self, basic_l1_config, basic_layout
+    ):
+        """Full lifecycle using extra_count (MLA TP>1 scenario).
+
+        Simulates multiple workers sharing the same key:
+        reserve_read(extra_count=N-1) acquires N locks,
+        finish_read(extra_count=N-1) releases them all.
+        """
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+        extra = 3  # total locks = 1 + 3 = 4
+
+        # write -> ready
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        # reserve_read with extra_count
+        result = manager.reserve_read([key], extra_count=extra)
+        assert result[key][0] == L1Error.SUCCESS
+
+        # unsafe_read should work while read-locked
+        ur = manager.unsafe_read([key])
+        assert ur[key][0] == L1Error.SUCCESS
+
+        # finish_read with same extra_count
+        fr = manager.finish_read([key], extra_count=extra)
+        assert fr[key] == L1Error.SUCCESS
+
+        # All locks released -> writable again
+        state = manager.get_object_state(key)
+        assert state is not None
+        assert state.available_for_write() is True
+
+        manager.close()
+
+    def test_temp_object_multi_reader_deletion(self, basic_l1_config, basic_layout):
+        """Temporary object deleted after extra_count release."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+        extra = 2  # total locks = 1 + 2 = 3
+
+        manager.reserve_write([key], [True], basic_layout)
+        manager.finish_write([key])
+
+        manager.reserve_read([key], extra_count=extra)
+        assert manager.get_object_state(key) is not None
+
+        manager.finish_read([key], extra_count=extra)
         assert manager.get_object_state(key) is None
 
         manager.close()

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -1316,7 +1316,7 @@ def test_cb_store_final_then_normal_lookup_retrieve(
     # Phase 1: Get prefetch job ID
     job_id = client.submit_request(
         RequestType.LOOKUP,
-        [lookup_key],
+        [lookup_key, 1],
         get_response_class(RequestType.LOOKUP),
     ).result(timeout=DEFAULT_TIMEOUT)
 

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -164,7 +164,7 @@ def lookup_all(
         # Phase 1: Get prefetch job ID
         job_id = client.submit_request(
             RequestType.LOOKUP,
-            [lookup_key],
+            [lookup_key, 1],
             get_response_class(RequestType.LOOKUP),
         ).result(timeout=timeout)
         # Phase 2: Poll until done

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -37,10 +37,11 @@ def test_free_locks_in_request_type():
 
 
 def test_free_locks_payload_classes():
-    """FREE_LOOKUP_LOCKS payload should be a single IPCCacheEngineKey."""
+    """FREE_LOOKUP_LOCKS payload should be [IPCCacheEngineKey, int]."""
     payload_classes = get_payload_classes(RequestType.FREE_LOOKUP_LOCKS)
-    assert len(payload_classes) == 1
-    assert payload_classes[0] == IPCCacheEngineKey
+    assert len(payload_classes) == 2
+    assert payload_classes[0] is IPCCacheEngineKey
+    assert payload_classes[1] is int
 
 
 def test_free_locks_response_class():
@@ -74,7 +75,7 @@ def test_mq_free_locks():
 
     helper.run_test(
         request_type=RequestType.FREE_LOOKUP_LOCKS,
-        payloads=[key],
+        payloads=[key, 1],
         expected_response=None,
         num_requests=1,
     )
@@ -109,10 +110,10 @@ def test_server_free_lookup_locks_calls_finish_read_prefetched():
         ),
     ):
         # Call the real method on the mock
-        MPCacheEngine.free_lookup_locks(engine, key)
+        MPCacheEngine.free_lookup_locks(engine, key, 1)
 
     engine.storage_manager.finish_read_prefetched.assert_called_once_with(
-        sentinel_obj_keys
+        sentinel_obj_keys, extra_count=0
     )
 
 
@@ -137,7 +138,7 @@ def test_server_free_lookup_locks_no_matching_chunks():
     )
 
     with patch.object(IPCCacheEngineKey, "to_hash_keys", return_value=[MagicMock()]):
-        MPCacheEngine.free_lookup_locks(engine, key)
+        MPCacheEngine.free_lookup_locks(engine, key, 1)
 
     engine.storage_manager.finish_read_prefetched.assert_not_called()
 
@@ -171,6 +172,7 @@ def test_adapter_free_lookup_locks_sends_request():
     adapter.worker_id = 0
     adapter.chunk_size = 256
     adapter.blocks_in_chunk = 16
+    adapter.tp_size = 1
 
     mock_client = MagicMock(spec=MessageQueueClient)
     mock_future = MagicMock()
@@ -192,15 +194,16 @@ def test_adapter_free_lookup_locks_sends_request():
     payloads = call_args[0][1]
     assert req_type == RequestType.FREE_LOOKUP_LOCKS
 
-    # Payload should be a single-element list containing the key
+    # Payload should be [key, tp_size]
     assert isinstance(payloads, list)
-    assert len(payloads) == 1
+    assert len(payloads) == 2
 
     key = payloads[0]
     assert isinstance(key, IPCCacheEngineKey)
     assert key.worker_id is None
     assert key.model_name == "test_model"
     assert key.request_id == "req-1"
+    assert payloads[1] == 1  # tp_size
 
 
 def test_adapter_free_lookup_locks_key_matches_lookup():
@@ -217,6 +220,7 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     adapter.worker_id = 0
     adapter.chunk_size = 256
     adapter.blocks_in_chunk = 16
+    adapter.tp_size = 1
 
     mock_client = MagicMock(spec=MessageQueueClient)
     mock_future = MagicMock()
@@ -245,7 +249,9 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     )
     free_call = mock_client.submit_request.call_args
     free_payloads = free_call[0][1]
+    assert len(free_payloads) == 2
     free_key = free_payloads[0]
+    assert free_payloads[1] == 1  # tp_size
 
     # Keys should be identical
     assert lookup_key.model_name == free_key.model_name

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -491,7 +491,7 @@ def test_mq_lookup():
     # Run test with LOOKUP request
     helper.run_test(
         request_type=RequestType.LOOKUP,
-        payloads=[key],
+        payloads=[key, 1],
         expected_response=expected_response,
         num_requests=1,
     )
@@ -515,7 +515,7 @@ def test_mq_lookup_with_different_key():
     # Run test with LOOKUP request
     helper.run_test(
         request_type=RequestType.LOOKUP,
-        payloads=[key],
+        payloads=[key, 1],
         expected_response=expected_response,
         num_requests=1,
     )

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -175,14 +175,17 @@ def lookup_handler(key: KeyType) -> int:
 # ==============================================================================
 
 
-def free_locks_handler(key: KeyType) -> None:
+def free_locks_handler(key: KeyType, tp_size: int) -> None:
     """
     Dummy handler for FREE_LOOKUP_LOCKS requests.
 
     Args:
         key: Cache key whose read locks should be released
+        tp_size: Tensor-parallel size for MLA
+            multi-reader locking
 
     Returns:
         None
     """
     assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
+    assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -154,12 +154,14 @@ def retrieve_handler(
 # ==============================================================================
 
 
-def lookup_handler(key: KeyType) -> int:
+def lookup_handler(key: KeyType, tp_size: int) -> int:
     """
     Dummy handler for LOOKUP requests.
 
     Args:
         key: Cache key to look up (request_id embedded in the key)
+        tp_size: Tensor-parallel size for MLA
+            multi-reader locking
 
     Returns:
         int: Number of matched chunks (always returns 1 for testing)
@@ -167,6 +169,7 @@ def lookup_handler(key: KeyType) -> int:
     # In a real implementation, this would look up the key in the cache
     # For testing, we just validate the input and return a dummy result
     assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
+    assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
     return 1
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix the issue when run vllm and lmcache with mp mode for deepseek mla tp=2

<img width="2838" height="982" alt="Clipboard_Screenshot_1772696677" src="https://github.com/user-attachments/assets/af76a7f6-b805-426d-baf0-355817752e48" />

- After fixed, send two same request to verify the store and retrieve flow.
```
[2026-03-05 15:32:00,163] LMCache INFO: Stored 256 tokens in 0.006 seconds (server.py:294:__main__)
(APIServer pid=5070) INFO 03-05-2026-15:32:00.192 [serving.py:1354] Finished request: model=vllm_cpu_offload, request_id=896ea0c7d96c9b31, input_tokens=343, output_tokens=10, cached_tokens=0, total_tokens=353, ttft=0.099s, total_time=0.099s, decode_gen_speed=0.00tokens/s, finish_reason=length

[2026-03-05 15:32:20,788] LMCache INFO: Prefetch request completed (L1+L2): 1/1 prefix hits (1 L1, 0 L2) in 0.0 ms (request_id=-1) (storage_manager.py:357:lmcache.v1.distributed.storage_manager)
[2026-03-05 15:32:20,791] LMCache INFO: Retrieved 256 tokens in 0.001 seconds (server.py:393:__main__)
[2026-03-05 15:32:20,792] LMCache INFO: Retrieved 256 tokens in 0.000 seconds (server.py:393:__main__)
```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
