### PR TITLE
[MP][Debuggability] Introduce status report subsystem for MP-mode

### DIFF
--- a/lmcache/tools/mp_status_viewer/__init__.py
+++ b/lmcache/tools/mp_status_viewer/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache/tools/mp_status_viewer/__main__.py
+++ b/lmcache/tools/mp_status_viewer/__main__.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+CLI tool to fetch and display the MP cache server status.
+
+Usage:
+    python -m lmcache.tools.mp_status_viewer [--url URL]
+"""
+
+# Standard
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+HEALTHY = "\033[32mHEALTHY\033[0m"
+UNHEALTHY = "\033[31mUNHEALTHY\033[0m"
+
+INDENT = "  "
+
+
+def _health_str(is_healthy: bool) -> str:
+    return HEALTHY if is_healthy else UNHEALTHY
+
+
+def _fmt_bytes(n: int) -> str:
+    if n >= 1024**3:
+        return f"{n / 1024**3:.2f} GB"
+    if n >= 1024**2:
+        return f"{n / 1024**2:.2f} MB"
+    if n >= 1024:
+        return f"{n / 1024:.2f} KB"
+    return f"{n} B"
+
+
+def _print_section(title: str, data: dict, depth: int = 0) -> None:
+    prefix = INDENT * depth
+    health = _health_str(data.get("is_healthy", True))
+    print(f"{prefix}{title}  [{health}]")
+
+    for key, value in data.items():
+        if key == "is_healthy":
+            continue
+        if isinstance(value, dict):
+            _print_section(key, value, depth + 1)
+        elif isinstance(value, list) and value and isinstance(value[0], dict):
+            for i, item in enumerate(value):
+                _print_section(f"{key}[{i}]", item, depth + 1)
+        else:
+            display = value
+            if "bytes" in key.lower() and isinstance(value, (int, float)):
+                display = _fmt_bytes(int(value))
+            elif isinstance(value, float):
+                display = f"{value:.4f}"
+            print(f"{prefix}{INDENT}{key}: {display}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch and display LMCache MP server status"
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:8000/api/status",
+        help="URL of the status endpoint",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output raw JSON instead of formatted view",
+    )
+    args = parser.parse_args()
+
+    try:
+        req = urllib.request.Request(args.url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.URLError as e:
+        print(f"Error connecting to {args.url}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+        return
+
+    print("=" * 60)
+    print("  LMCache MP Server Status")
+    print("=" * 60)
+    _print_section("engine", data)
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -620,6 +620,34 @@ class L1Manager:
 
         self._memory_manager.close()
 
+    # Status reporting
+    @l1_mgr_synchronized
+    def report_status(self) -> dict:
+        """Return a status dict describing L1 cache state."""
+        write_locked = 0
+        read_locked = 0
+        temporary = 0
+        for entry in self._objects.values():
+            if entry.write_lock.is_locked():
+                write_locked += 1
+            if entry.read_lock.is_locked():
+                read_locked += 1
+            if entry.is_temporary:
+                temporary += 1
+        used, total = self._memory_manager.get_memory_usage()
+        return {
+            "is_healthy": self._memory_manager.memcheck(),
+            "total_object_count": len(self._objects),
+            "write_locked_count": write_locked,
+            "read_locked_count": read_locked,
+            "temporary_count": temporary,
+            "memory_used_bytes": used,
+            "memory_total_bytes": total,
+            "memory_usage_ratio": used / total if total > 0 else 0.0,
+            "write_ttl_seconds": self._write_ttl_seconds,
+            "read_ttl_seconds": self._read_ttl_seconds,
+        }
+
     # Debugging APIs
     @l1_mgr_synchronized
     def get_object_state(self, key: ObjectKey) -> L1ObjectState | None:

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -270,3 +270,16 @@ class L2AdapterInterface(ABC):
         the L2 adapter should not be used anymore.
         """
         pass
+
+    #####################
+    # Status Interface
+    #####################
+
+    @abstractmethod
+    def report_status(self) -> dict:
+        """
+        Return a status dict for this adapter.
+
+        Must include at least ``is_healthy: bool``.
+        """
+        pass

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -212,6 +212,18 @@ class MockL2Adapter(L2AdapterInterface):
     # Debug / test-only functions
     ##################
 
+    def report_status(self) -> dict:
+        """Return a status dict for the mock L2 adapter."""
+        with self._lock:
+            return {
+                "is_healthy": True,
+                "type": "MockL2Adapter",
+                "stored_object_count": len(self._memory_objects),
+                "locked_key_count": len(self._locked_keys),
+                "current_size_bytes": self._current_size_bytes,
+                "max_capacity_bytes": self._max_capacity_bytes,
+            }
+
     def debug_get_stored_object_count(self) -> int:
         """
         Return the number of objects currently stored in the mock adapter.

--- a/lmcache/v1/distributed/storage_controller.py
+++ b/lmcache/v1/distributed/storage_controller.py
@@ -47,3 +47,12 @@ class StorageControllerInterface(ABC):
         any running threads or processes.
         """
         pass
+
+    @abstractmethod
+    def report_status(self) -> dict:
+        """
+        Return a status dict for this controller.
+
+        Must include at least ``is_healthy: bool``.
+        """
+        pass

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -39,6 +39,17 @@ class EvictionController(StorageControllerInterface):
             daemon=True,
         )
 
+    def report_status(self) -> dict:
+        """Return a status dict for the eviction controller."""
+        is_healthy = self._thread.is_alive()
+        return {
+            "is_healthy": is_healthy,
+            "thread_alive": is_healthy,
+            "eviction_policy": self._eviction_config.eviction_policy,
+            "trigger_watermark": self._eviction_config.trigger_watermark,
+            "eviction_ratio": self._eviction_config.eviction_ratio,
+        }
+
     def start(self):
         logger.info("Starting EvictionController...")
         self._thread.start()

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -205,6 +205,12 @@ class PrefetchController(StorageControllerInterface):
             tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc]
         ] = []
 
+        # Shadow counters for status reporting (updated in background loop)
+        self._status_in_flight_count: int = 0
+        self._status_pending_count: int = 0
+        self._status_lookup_phase_count: int = 0
+        self._status_load_phase_count: int = 0
+
         # Thread-safe submission queue (external -> background)
         self._submission_lock = threading.Lock()
         self._submission_queue: list[
@@ -286,6 +292,26 @@ class PrefetchController(StorageControllerInterface):
         with self._results_lock:
             return self._completed_results.pop(request_id, None)
 
+    def report_status(self) -> dict:
+        """Return a status dict for the prefetch controller."""
+        is_healthy = self._thread.is_alive()
+        with self._submission_lock:
+            submission_queue_size = len(self._submission_queue)
+        with self._results_lock:
+            completed_results_count = len(self._completed_results)
+        return {
+            "is_healthy": is_healthy,
+            "thread_alive": is_healthy,
+            "max_in_flight": self._max_in_flight,
+            "submission_queue_size": submission_queue_size,
+            "pending_queue_size": self._status_pending_count,
+            "in_flight_request_count": self._status_in_flight_count,
+            "lookup_phase_count": self._status_lookup_phase_count,
+            "load_phase_count": self._status_load_phase_count,
+            "completed_results_count": completed_results_count,
+            "num_l2_adapters": len(self._l2_adapters),
+        }
+
     # =========================================================================
     # Lifecycle
     # =========================================================================
@@ -356,6 +382,7 @@ class PrefetchController(StorageControllerInterface):
             items = self._submission_queue
             self._submission_queue = []
         self._pending_queue.extend(items)
+        self._status_pending_count += len(items)
 
     def _start_pending_requests(self) -> None:
         """Start pending requests up to the max in-flight limit."""
@@ -363,6 +390,7 @@ class PrefetchController(StorageControllerInterface):
             self._pending_queue and len(self._in_flight_requests) < self._max_in_flight
         ):
             request_id, keys, layout_desc = self._pending_queue.pop(0)
+            self._status_pending_count -= 1
             self._start_lookup_phase(request_id, keys, layout_desc)
 
     # =========================================================================
@@ -393,6 +421,8 @@ class PrefetchController(StorageControllerInterface):
             pending_lookup_tasks=pending_lookup_tasks,
         )
         self._in_flight_requests[request_id] = request
+        self._status_in_flight_count += 1
+        self._status_lookup_phase_count += 1
 
     def _process_lookup_completions(self, adapter_index: int) -> None:
         """Check all LOOKUP-phase requests for completed lookups from
@@ -427,6 +457,8 @@ class PrefetchController(StorageControllerInterface):
     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
         """Compute load plan, reserve L1 buffers, and submit load tasks."""
         request.phase = PrefetchPhase.PLAN_AND_LOAD
+        self._status_lookup_phase_count -= 1
+        self._status_load_phase_count += 1
 
         # Step 1: get load plan from policy
         load_plan = self._policy.select_load_plan(
@@ -626,7 +658,13 @@ class PrefetchController(StorageControllerInterface):
         """Store the result and remove from in-flight tracking."""
         with self._results_lock:
             self._completed_results[request_id] = prefix_hits
-        self._in_flight_requests.pop(request_id, None)
+        removed = self._in_flight_requests.pop(request_id, None)
+        if removed is not None:
+            self._status_in_flight_count -= 1
+            if removed.phase == PrefetchPhase.LOOKUP:
+                self._status_lookup_phase_count -= 1
+            elif removed.phase == PrefetchPhase.PLAN_AND_LOAD:
+                self._status_load_phase_count -= 1
         logger.debug(
             "Prefetch request %d completed: %d prefix hits",
             request_id,

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -76,6 +76,11 @@ class StoreListener(L1ManagerListener):
             self._pending_keys = []
         return keys
 
+    def pending_count(self) -> int:
+        """Return the number of pending keys waiting to be processed."""
+        with self._lock:
+            return len(self._pending_keys)
+
     # L1ManagerListener implementation
 
     def on_l1_keys_write_finished(self, keys: list[ObjectKey]) -> None:
@@ -173,6 +178,9 @@ class StoreController(StorageControllerInterface):
         # within a single adapter, not across adapters.
         self._in_flight_tasks: dict[tuple[int, L2TaskId], InFlightStoreTask] = {}
 
+        # Shadow counter for status reporting (updated in background loop)
+        self._status_in_flight_count: int = 0
+
         # Map eventfd -> adapter index for quick lookup in poll results
         self._efd_to_adapter_index: dict[int, int] = {}
         for i, adapter in enumerate(self._l2_adapters):
@@ -203,6 +211,17 @@ class StoreController(StorageControllerInterface):
         self._thread.join()
         self._cleanup_in_flight_tasks()
         self._listener.close()
+
+    def report_status(self) -> dict:
+        """Return a status dict for the store controller."""
+        is_healthy = self._thread.is_alive()
+        return {
+            "is_healthy": is_healthy,
+            "thread_alive": is_healthy,
+            "pending_keys_count": self._listener.pending_count(),
+            "in_flight_task_count": self._status_in_flight_count,
+            "num_l2_adapters": len(self._l2_adapters),
+        }
 
     # Private methods
 
@@ -307,6 +326,7 @@ class StoreController(StorageControllerInterface):
                 keys=successful_keys,
                 read_locked_keys=list(successful_keys),
             )
+            self._status_in_flight_count += 1
 
             logger.debug(
                 "Submitted store task %d to adapter %d with %d keys.",
@@ -337,6 +357,8 @@ class StoreController(StorageControllerInterface):
         for task_id, success in completed.items():
             composite_key = (adapter_index, task_id)
             task = self._in_flight_tasks.pop(composite_key, None)
+            if task is not None:
+                self._status_in_flight_count -= 1
             if task is None:
                 logger.warning(
                     "Completed store task %d (adapter %d) not found in tracking.",

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -383,6 +383,24 @@ class StorageManager:
 
         self._l1_manager.close()
 
+    def report_status(self) -> dict:
+        """Return a status dict aggregating all sub-component statuses."""
+        l1 = self._l1_manager.report_status()
+        store = self._store_controller.report_status()
+        prefetch = self._prefetch_controller.report_status()
+        eviction = self._eviction_controller.report_status()
+        adapters = [a.report_status() for a in self._l2_adapters]
+        children = [l1, store, prefetch, eviction] + adapters
+        return {
+            "is_healthy": all(c["is_healthy"] for c in children),
+            "l1_manager": l1,
+            "store_controller": store,
+            "prefetch_controller": prefetch,
+            "eviction_controller": eviction,
+            "l2_adapters": adapters,
+            "num_l2_adapters": len(self._l2_adapters),
+        }
+
     # Functions for debugging and testing
     def memcheck(self) -> bool:
         """

--- a/lmcache/v1/multiprocess/blend_server.py
+++ b/lmcache/v1/multiprocess/blend_server.py
@@ -123,6 +123,17 @@ class BlendEngine(MPCacheEngine):
         # self._token_matcher = ParallelPatternMatcher(sep_tokens)
         self._token_matcher = RangePatternMatcher(sep_tokens[0], sep_tokens[1])
 
+    def report_status(self) -> dict:
+        """Return a status dict for the blend engine."""
+        status = super().report_status()
+        status["engine_type"] = "BlendEngine"
+        status["cb_registered_gpu_ids"] = list(self._cb_gpu_contexts.keys())
+        status["cb_gpu_context_meta"] = {
+            str(gpu_id): {"model_name": meta[0], "world_size": meta[1]}
+            for gpu_id, meta in self._cb_gpu_context_meta.items()
+        }
+        return status
+
     def cb_register_kv_cache(
         self,
         instance_id: int,

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -125,6 +125,21 @@ async def healthcheck(request: Request):
     return {"status": "healthy"}
 
 
+@app.get("/api/status")
+async def status(request: Request):
+    """
+    Detailed status endpoint for inspecting internal state of all
+    MP components (L1 cache, L2 adapters, controllers, sessions).
+    """
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "engine not initialized"},
+        )
+    return engine.report_status()
+
+
 def run_http_server(
     host: str = "0.0.0.0",
     port: int = 8000,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -499,6 +499,23 @@ class MPCacheEngine:
         """
         self.session_manager.remove(request_id)
 
+    def report_status(self) -> dict:
+        """Return a status dict for the entire cache engine."""
+        sm = self.storage_manager.report_status()
+        return {
+            "is_healthy": sm["is_healthy"],
+            "engine_type": "MPCacheEngine",
+            "chunk_size": self.chunk_size,
+            "hash_algorithm": self.token_hasher.hash_algorithm_name,
+            "registered_gpu_ids": list(self.gpu_contexts.keys()),
+            "gpu_context_meta": {
+                str(gpu_id): {"model_name": meta[0], "world_size": meta[1]}
+                for gpu_id, meta in self.gpu_context_meta.items()
+            },
+            "active_sessions": self.session_manager.active_count(),
+            "storage_manager": sm,
+        }
+
     def debug(self) -> str:
         return "OK"
 

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -147,3 +147,12 @@ class SessionManager:
         if expired:
             logger.info("Cleaned up %d expired sessions", len(expired))
         return len(expired)
+
+    def active_count(self) -> int:
+        """Return the number of active sessions.
+
+        Returns:
+            Number of currently tracked sessions.
+        """
+        with self._lock:
+            return len(self._sessions)

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -57,6 +57,7 @@ class TokenHasher:
 
     def __init__(self, chunk_size: int = 256, hash_algorithm: str = "blake3"):
         self.chunk_size = chunk_size
+        self.hash_algorithm_name = hash_algorithm
         self.hash_func = self._get_hash_func(hash_algorithm)
         self.none_hash = self._init_none_hash()
         logger.info(

--- a/tests/v1/distributed/test_report_status.py
+++ b/tests/v1/distributed/test_report_status.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the report_status() interface across the StorageManager subtree.
+"""
+
+# Standard
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdaptersConfig,
+    MockL2AdapterConfig,
+)
+
+try:
+    # First Party
+    from lmcache.v1.distributed.storage_manager import StorageManager
+except ImportError:
+    pytest.skip(
+        "Skipping because StorageManager cannot be imported", allow_module_level=True
+    )
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available"
+)
+
+
+def should_use_lazy_alloc() -> bool:
+    return torch.cuda.is_available()
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def basic_memory_config():
+    return L1MemoryManagerConfig(
+        size_in_bytes=128 * 1024 * 1024,
+        use_lazy=should_use_lazy_alloc(),
+        init_size_in_bytes=64 * 1024 * 1024,
+        align_bytes=0x1000,
+    )
+
+
+@pytest.fixture
+def basic_l1_config(basic_memory_config):
+    return L1ManagerConfig(
+        memory_config=basic_memory_config,
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+
+
+@pytest.fixture
+def basic_layout():
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([100, 2, 512])],
+        dtypes=[torch.bfloat16],
+    )
+
+
+@pytest.fixture
+def storage_manager_no_l2(basic_l1_config):
+    """StorageManager without L2 adapters."""
+    config = StorageManagerConfig(
+        l1_manager_config=basic_l1_config,
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+    )
+    sm = StorageManager(config)
+    yield sm
+    sm.close()
+
+
+@pytest.fixture
+def storage_manager_with_l2(basic_l1_config):
+    """StorageManager with one mock L2 adapter."""
+    config = StorageManagerConfig(
+        l1_manager_config=basic_l1_config,
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+        l2_adapter_config=L2AdaptersConfig(
+            adapters=[
+                MockL2AdapterConfig(
+                    max_size_gb=0.1,
+                    mock_bandwidth_gb=10.0,
+                ),
+            ]
+        ),
+    )
+    sm = StorageManager(config)
+    yield sm
+    sm.close()
+
+
+def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+    hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+    return ObjectKey(chunk_hash=hash_bytes, model_name=model_name, kv_rank=kv_rank)
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestStorageManagerReportStatus:
+    """Tests for StorageManager.report_status() shape and values."""
+
+    def test_report_status_shape_no_l2(self, storage_manager_no_l2):
+        status = storage_manager_no_l2.report_status()
+
+        # Top-level keys
+        assert "is_healthy" in status
+        assert "l1_manager" in status
+        assert "store_controller" in status
+        assert "prefetch_controller" in status
+        assert "eviction_controller" in status
+        assert "l2_adapters" in status
+        assert "num_l2_adapters" in status
+
+        assert status["is_healthy"] is True
+        assert status["num_l2_adapters"] == 0
+        assert status["l2_adapters"] == []
+
+    def test_report_status_shape_with_l2(self, storage_manager_with_l2):
+        status = storage_manager_with_l2.report_status()
+
+        assert status["is_healthy"] is True
+        assert status["num_l2_adapters"] == 1
+        assert len(status["l2_adapters"]) == 1
+
+        adapter_status = status["l2_adapters"][0]
+        assert adapter_status["is_healthy"] is True
+        assert adapter_status["type"] == "MockL2Adapter"
+        assert "stored_object_count" in adapter_status
+        assert "max_capacity_bytes" in adapter_status
+
+    def test_l1_manager_status_shape(self, storage_manager_no_l2):
+        l1 = storage_manager_no_l2.report_status()["l1_manager"]
+
+        assert l1["is_healthy"] is True
+        assert l1["total_object_count"] == 0
+        assert l1["write_locked_count"] == 0
+        assert l1["read_locked_count"] == 0
+        assert l1["temporary_count"] == 0
+        assert l1["memory_used_bytes"] == 0
+        assert l1["memory_total_bytes"] > 0
+        assert l1["memory_usage_ratio"] == 0.0
+        assert "write_ttl_seconds" in l1
+        assert "read_ttl_seconds" in l1
+
+    def test_store_controller_status_shape(self, storage_manager_no_l2):
+        sc = storage_manager_no_l2.report_status()["store_controller"]
+
+        assert sc["is_healthy"] is True
+        assert sc["thread_alive"] is True
+        assert "pending_keys_count" in sc
+        assert "in_flight_task_count" in sc
+        assert "num_l2_adapters" in sc
+
+    def test_prefetch_controller_status_shape(self, storage_manager_no_l2):
+        pc = storage_manager_no_l2.report_status()["prefetch_controller"]
+
+        assert pc["is_healthy"] is True
+        assert pc["thread_alive"] is True
+        assert "max_in_flight" in pc
+        assert "submission_queue_size" in pc
+        assert "pending_queue_size" in pc
+        assert "in_flight_request_count" in pc
+        assert "lookup_phase_count" in pc
+        assert "load_phase_count" in pc
+        assert "completed_results_count" in pc
+        assert "num_l2_adapters" in pc
+
+    def test_eviction_controller_status_shape(self, storage_manager_no_l2):
+        ec = storage_manager_no_l2.report_status()["eviction_controller"]
+
+        assert ec["is_healthy"] is True
+        assert ec["thread_alive"] is True
+        assert "eviction_policy" in ec
+        assert "trigger_watermark" in ec
+        assert "eviction_ratio" in ec
+
+    def test_l1_status_reflects_writes(self, storage_manager_no_l2, basic_layout):
+        """After writing objects, L1 status should reflect them."""
+        keys = [make_object_key(i) for i in range(3)]
+        reserved = storage_manager_no_l2.reserve_write(keys, basic_layout, "new")
+        assert len(reserved) == 3
+
+        l1 = storage_manager_no_l2.report_status()["l1_manager"]
+        assert l1["total_object_count"] == 3
+        assert l1["write_locked_count"] == 3
+        assert l1["memory_used_bytes"] > 0
+
+        # Finish writes
+        storage_manager_no_l2.finish_write(keys)
+        l1 = storage_manager_no_l2.report_status()["l1_manager"]
+        assert l1["write_locked_count"] == 0
+
+    def test_health_propagation(self, storage_manager_no_l2):
+        """Top-level is_healthy should be True when all children are healthy."""
+        status = storage_manager_no_l2.report_status()
+        assert status["is_healthy"] is True
+
+        # Verify all child components are healthy
+        assert status["l1_manager"]["is_healthy"] is True
+        assert status["store_controller"]["is_healthy"] is True
+        assert status["prefetch_controller"]["is_healthy"] is True
+        assert status["eviction_controller"]["is_healthy"] is True


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a composable `report_status() -> dict` interface across all MP-mode components for production debugging and introspection. Currently the only introspection tools are `memcheck()` (returns bool) and `debug()` (returns "OK"), which are insufficient for diagnosing issues in the multi-tier storage pipeline.

Each component implements `report_status()` returning a dict with `is_healthy: bool` plus component-specific metrics. Parents aggregate children's reports as nested dicts, with health propagating upward (any unhealthy child → parent unhealthy).

**Components instrumented (bottom-up):**
- **L1Manager**: object counts, lock counts (write/read/temporary), memory usage, TTL config
- **L2 adapters**: stored object count, locked keys, capacity (abstract method on interface; MockL2Adapter implemented)
- **StoreController**: thread alive, pending keys, in-flight task count (via shadow counters — no new locks on critical path)
- **PrefetchController**: thread alive, submission/pending/in-flight/completed queue sizes, phase breakdown (lookup vs load)
- **EvictionController**: thread alive, policy config
- **StorageManager**: aggregates all children
- **MPCacheEngine / BlendEngine**: engine type, chunk size, hash algorithm, GPU contexts, active sessions + storage manager subtree

**New HTTP endpoint:** `GET /api/status` returns the full JSON status tree.

**New CLI tool:** `python -m lmcache.tools.mp_status_viewer [--url URL] [--json]` fetches and pretty-prints the status.

**Leaf helpers:** `TokenHasher.hash_algorithm_name`, `SessionManager.active_count()`

**Usage example:**

```bash
# Start LMCache MP mode with http server (default http port 8000)
python3 -m lmcache.v1.multiprocess.http_server --l1-size 70 --eviction-policy LRU 

# Pretty-printed view (default)
python -m lmcache.tools.mp_status_viewer

# Raw JSON (for scripting / monitoring)
python -m lmcache.tools.mp_status_viewer --json | jq '.storage_manager.l1_manager'

# Custom endpoint
python -m lmcache.tools.mp_status_viewer --url http://my-host:9000/api/status

# Or just curl the endpoint directly
curl -s localhost:8000/api/status | jq
```

Screenshot
<img width="870" height="784" alt="image" src="https://github.com/user-attachments/assets/d986a905-48ed-4992-88dc-fc2f146ded77" />


**Special notes for your reviewers**:

- Shadow counters in StoreController and PrefetchController are updated in the background loop thread only — no new locks on the controller critical path. Existing lightweight locks (submission queue, results queue, listener) are reused for the few fields that need them.
- L1Manager's `report_status()` uses the existing `@l1_mgr_synchronized` decorator and iterates `_objects` checking `TTLLock.is_locked()` per entry. This is O(n) but the endpoint is called infrequently (debug use).
- The CLI viewer uses only stdlib (`urllib.request`, `json`) — no `requests` or `rich` dependency.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests