### PR TITLE
Add filesystem-backed L2 adapter with auto-discovery plugin mechanism

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -174,13 +174,12 @@ Examples:
 ``fs`` -- File-system backed storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A pure file-system L2 adapter using async I/O.  Does not require NIXL.
+A pure file-system L2 adapter using async I/O.
 
 Fields:
 
 - ``base_path`` *(required)*: Directory for storing KV cache files.
 - ``relative_tmp_dir`` *(optional)*: Relative sub-dir for temp files.
-- ``scan_on_startup`` *(optional)*: Scan existing files on startup (default ``false``).
 - ``read_ahead_size`` *(optional)*: Trigger read-ahead by reading this many bytes first.
 - ``use_odirect`` *(optional)*: Bypass page cache via ``O_DIRECT`` (default ``false``).
 
@@ -191,8 +190,8 @@ Examples:
     # Basic FS adapter
     --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2"}'
 
-    # With startup scan and temp directory
-    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "scan_on_startup": true, "relative_tmp_dir": ".tmp"}'
+    # With temp directory
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "relative_tmp_dir": ".tmp"}'
 
 ``mock`` -- Mock adapter for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -139,7 +139,7 @@ L2 adapters are configured via repeatable ``--l2-adapter <JSON>`` arguments.
 Each JSON object must include a ``"type"`` field that selects the adapter type.
 The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
-Registered adapter types: ``nixl_store``, ``mock``.
+Registered adapter types: ``nixl_store``, ``fs``, ``mock``.
 
 ``nixl_store`` -- NIXL-based persistent storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -170,6 +170,29 @@ Examples:
 
     # OBJ backend (object store -- no file_path needed)
     --l2-adapter '{"type": "nixl_store", "backend": "OBJ", "backend_params": {}, "pool_size": 32}'
+
+``fs`` -- File-system backed storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A pure file-system L2 adapter using async I/O.  Does not require NIXL.
+
+Fields:
+
+- ``base_path`` *(required)*: Directory for storing KV cache files.
+- ``relative_tmp_dir`` *(optional)*: Relative sub-dir for temp files.
+- ``scan_on_startup`` *(optional)*: Scan existing files on startup (default ``false``).
+- ``read_ahead_size`` *(optional)*: Trigger read-ahead by reading this many bytes first.
+- ``use_odirect`` *(optional)*: Bypass page cache via ``O_DIRECT`` (default ``false``).
+
+Examples:
+
+.. code-block:: bash
+
+    # Basic FS adapter
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2"}'
+
+    # With startup scan and temp directory
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "scan_on_startup": true, "relative_tmp_dir": ".tmp"}'
 
 ``mock`` -- Mock adapter for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -110,8 +110,6 @@ object is stored as a raw ``.data`` file whose name encodes the full
 
 - ``relative_tmp_dir``: Relative sub-directory for temporary files during
   writes (atomic rename on completion).
-- ``scan_on_startup``: ``true`` or ``false`` (default ``false``) -- scan
-  existing files at startup to rebuild the in-memory index.
 - ``read_ahead_size``: Trigger file-system read-ahead by reading this many
   bytes first (positive integer, optional).
 - ``use_odirect``: ``true`` or ``false`` (default ``false``) -- bypass the
@@ -124,8 +122,8 @@ object is stored as a raw ``.data`` file whose name encodes the full
     # Basic FS adapter
     --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2"}'
 
-    # With startup scan and temp directory
-    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "scan_on_startup": true, "relative_tmp_dir": ".tmp"}'
+    # With temp directory
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "relative_tmp_dir": ".tmp"}'
 
     # With O_DIRECT for bypassing page cache
     --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "use_odirect": true}'

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -5,9 +5,10 @@ LMCache multiprocess mode supports a two-tier storage architecture:
 
 - **L1 (in-memory)** -- Fast CPU memory managed by the L1 Manager.  All KV
   cache chunks live here during active use.
-- **L2 (persistent)** -- Durable storage backends accessed through NIXL.
-  The StoreController asynchronously pushes data from L1 to L2, and the
-  PrefetchController loads data from L2 back into L1 on cache misses.
+- **L2 (persistent)** -- Durable storage backends (NIXL-based or plain
+  file-system).  The StoreController asynchronously pushes data from L1
+  to L2, and the PrefetchController loads data from L2 back into L1 on
+  cache misses.
 
 .. contents::
    :local:
@@ -93,6 +94,41 @@ The ``OBJ`` backend (object store) does not require ``file_path``.
 
     # OBJ backend
     --l2-adapter '{"type": "nixl_store", "backend": "OBJ", "backend_params": {}, "pool_size": 32}'
+
+``fs`` -- File-system backed storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A pure file-system L2 adapter using async I/O (``aiofiles``).  Each KV cache
+object is stored as a raw ``.data`` file whose name encodes the full
+``ObjectKey``.  Does **not** require NIXL -- works on any POSIX file system.
+
+**Required fields:**
+
+- ``base_path``: Directory for storing KV cache files.
+
+**Optional fields:**
+
+- ``relative_tmp_dir``: Relative sub-directory for temporary files during
+  writes (atomic rename on completion).
+- ``scan_on_startup``: ``true`` or ``false`` (default ``false``) -- scan
+  existing files at startup to rebuild the in-memory index.
+- ``read_ahead_size``: Trigger file-system read-ahead by reading this many
+  bytes first (positive integer, optional).
+- ``use_odirect``: ``true`` or ``false`` (default ``false``) -- bypass the
+  page cache via ``O_DIRECT``.
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Basic FS adapter
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2"}'
+
+    # With startup scan and temp directory
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "scan_on_startup": true, "relative_tmp_dir": ".tmp"}'
+
+    # With O_DIRECT for bypassing page cache
+    --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "use_odirect": true}'
 
 ``mock`` -- Mock adapter for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/distributed/l2_adapters/__init__.py
+++ b/lmcache/v1/distributed/l2_adapters/__init__.py
@@ -1,59 +1,57 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-L2 adapter factory.
+L2 adapter factory with automatic module discovery.
 
-Provides ``create_l2_adapter`` to instantiate an L2 adapter from its config.
+All adapter modules under this package that call
+``register_l2_adapter_type`` and ``register_l2_adapter_factory``
+at import time are discovered automatically.  To add a new
+adapter, simply create a new module in this directory -- **no
+changes to any existing file are needed**.
 """
+
+# Standard
+import importlib
+import pkgutil
 
 # First Party
 from lmcache.v1.distributed.internal_api import L1MemoryDesc
-from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.l2_adapters.base import (
+    L2AdapterInterface,
+)
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
-    MockL2AdapterConfig,
-    NixlStoreL2AdapterConfig,
+    create_l2_adapter_from_registry,
 )
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+
+# Auto-discover and import every module in this package so
+# that each adapter's self-registration code runs.
+_PACKAGE_PATH = __path__  # type: ignore[name-defined]
+_PACKAGE_NAME = __name__
+for _finder, _mod_name, _is_pkg in pkgutil.iter_modules(_PACKAGE_PATH):
+    importlib.import_module(f".{_mod_name}", _PACKAGE_NAME)
 
 
 def create_l2_adapter(
     config: L2AdapterConfigBase,
     l1_memory_desc: L1MemoryDesc | None = None,
 ) -> L2AdapterInterface:
-    """
-    Create an L2 adapter instance from its config.
-
-    The concrete config type determines which adapter class to instantiate.
+    """Create an L2 adapter from its config via the
+    factory registry.
 
     Args:
         config: The adapter-specific config object.
-        l1_memory_desc: Descriptor of the L1 memory buffer, required for adapters
-            that register L1 memory with an external backend (e.g. Nixl).
+        l1_memory_desc: Descriptor of the L1 memory buffer,
+            required for adapters that register L1 memory
+            with an external backend (e.g. Nixl).
 
     Returns:
         L2AdapterInterface: A new adapter instance.
 
     Raises:
-        ValueError: If the config type is not recognized, or if a required
-            argument (e.g. l1_memory_desc) is missing for the given config type.
+        ValueError: If no factory is registered for
+            the config type.
     """
-    if isinstance(config, MockL2AdapterConfig):
-        return MockL2Adapter(config)
-
-    if isinstance(config, NixlStoreL2AdapterConfig):
-        # Lazy import nixl
-        # First Party
-        from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (
-            NixlStoreL2Adapter,
-        )
-
-        if l1_memory_desc is None:
-            raise ValueError(
-                "l1_memory_desc is required to create a NixlStoreL2Adapter."
-            )
-        return NixlStoreL2Adapter(config, l1_memory_desc)
-
-    raise ValueError(
-        f"Unknown L2 adapter config type: {type(config).__name__}. "
-        f"Add a branch in create_l2_adapter() for this config type."
+    return create_l2_adapter_from_registry(
+        config,
+        l1_memory_desc=l1_memory_desc,
     )

--- a/lmcache/v1/distributed/l2_adapters/__init__.py
+++ b/lmcache/v1/distributed/l2_adapters/__init__.py
@@ -20,6 +20,8 @@ from lmcache.v1.distributed.l2_adapters.base import (
 )
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
     create_l2_adapter_from_registry,
 )
 

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -404,9 +404,7 @@ class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
 register_l2_adapter_type("nixl_store", NixlStoreL2AdapterConfig)
 
 
-def _create_nixl_store_adapter(
-    config: NixlStoreL2AdapterConfig, **kwargs: Any
-) -> Any:
+def _create_nixl_store_adapter(config: NixlStoreL2AdapterConfig, **kwargs: Any) -> Any:
     """Lazy-import and create a NixlStoreL2Adapter."""
     # First Party
     from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (
@@ -415,13 +413,8 @@ def _create_nixl_store_adapter(
 
     l1_memory_desc = kwargs.get("l1_memory_desc")
     if l1_memory_desc is None:
-        raise ValueError(
-            "l1_memory_desc is required to create a "
-            "NixlStoreL2Adapter."
-        )
+        raise ValueError("l1_memory_desc is required to create a NixlStoreL2Adapter.")
     return NixlStoreL2Adapter(config, l1_memory_desc)
 
 
-register_l2_adapter_factory(
-    "nixl_store", _create_nixl_store_adapter
-)
+register_l2_adapter_factory("nixl_store", _create_nixl_store_adapter)

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -14,11 +14,14 @@ from __future__ import annotations
 # Standard
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 import argparse
 import json
 
 if TYPE_CHECKING:
+    from lmcache.v1.distributed.internal_api import (
+        L1MemoryDesc,
+    )
     from lmcache.v1.distributed.l2_adapters.base import (
         L2AdapterInterface,
     )
@@ -35,7 +38,15 @@ T = TypeVar("T", bound="L2AdapterConfigBase")
 # -----------------------------------------------------------------------------
 
 _L2_ADAPTER_CONFIG_REGISTRY: dict[str, type[L2AdapterConfigBase]] = {}
-_L2_ADAPTER_FACTORY_REGISTRY: dict[str, Callable[..., Any]] = {}
+# Factory signature:
+#   (config, l1_memory_desc) -> L2AdapterInterface
+_L2_ADAPTER_FACTORY_REGISTRY: dict[
+    str,
+    Callable[
+        ["L2AdapterConfigBase", "Optional[L1MemoryDesc]"],
+        "L2AdapterInterface",
+    ],
+] = {}
 
 
 def register_l2_adapter_type(
@@ -72,8 +83,8 @@ def register_l2_adapter_factory(
     Args:
         name: Adapter type name (must match the name used
             in ``register_l2_adapter_type``).
-        factory: A callable that accepts a config instance
-            and returns an ``L2AdapterInterface``.
+        factory: A callable ``(config, l1_memory_desc)``
+            that returns an ``L2AdapterInterface``.
     """
     if name in _L2_ADAPTER_FACTORY_REGISTRY:
         raise ValueError(f"L2 adapter factory already registered: {name!r}")
@@ -82,7 +93,7 @@ def register_l2_adapter_factory(
 
 def create_l2_adapter_from_registry(
     config: L2AdapterConfigBase,
-    **kwargs: Any,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
 ) -> "L2AdapterInterface":
     """
     Create an L2 adapter using the factory registry.
@@ -92,8 +103,9 @@ def create_l2_adapter_from_registry(
 
     Args:
         config: An adapter config instance.
-        **kwargs: Extra arguments forwarded to the factory
-            (e.g. ``l1_memory_desc`` for Nixl adapters).
+        l1_memory_desc: Optional L1 memory descriptor,
+            required by adapters that register L1 memory
+            with an external backend (e.g. Nixl).
 
     Returns:
         A new ``L2AdapterInterface`` instance.
@@ -110,7 +122,7 @@ def create_l2_adapter_from_registry(
             f"{name!r}. Make sure the adapter module is "
             f"imported."
         )
-    return factory(config, **kwargs)
+    return factory(config, l1_memory_desc)
 
 
 def get_registered_l2_adapter_types() -> list[str]:
@@ -404,14 +416,16 @@ class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
 register_l2_adapter_type("nixl_store", NixlStoreL2AdapterConfig)
 
 
-def _create_nixl_store_adapter(config: NixlStoreL2AdapterConfig, **kwargs: Any) -> Any:
+def _create_nixl_store_adapter(
+    config: NixlStoreL2AdapterConfig,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> Any:
     """Lazy-import and create a NixlStoreL2Adapter."""
     # First Party
     from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (
         NixlStoreL2Adapter,
     )
 
-    l1_memory_desc = kwargs.get("l1_memory_desc")
     if l1_memory_desc is None:
         raise ValueError("l1_memory_desc is required to create a NixlStoreL2Adapter.")
     return NixlStoreL2Adapter(config, l1_memory_desc)

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 # Standard
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, Callable, TypeVar
 import argparse
 import json
 
@@ -30,22 +30,82 @@ T = TypeVar("T", bound="L2AdapterConfigBase")
 # -----------------------------------------------------------------------------
 
 _L2_ADAPTER_CONFIG_REGISTRY: dict[str, type[L2AdapterConfigBase]] = {}
+_L2_ADAPTER_FACTORY_REGISTRY: dict[str, Callable[..., Any]] = {}
 
 
-def register_l2_adapter_type(name: str, config_cls: type[L2AdapterConfigBase]) -> None:
+def register_l2_adapter_type(
+    name: str,
+    config_cls: type[L2AdapterConfigBase],
+) -> None:
     """
     Register an L2 adapter config class under a type name.
 
-    The type name is used in JSON specs as the "type" field. Each adapter
-    module should call this at import time.
+    The type name is used in JSON specs as the "type" field.
+    Each adapter config module should call this at import time.
 
     Args:
-        name: Adapter type name (e.g. "disk", "redis").
-        config_cls: Config class that can parse from dict via from_dict().
+        name: Adapter type name (e.g. "fs", "mock").
+        config_cls: Config class that can parse from dict
+            via ``from_dict()``.
     """
     if name in _L2_ADAPTER_CONFIG_REGISTRY:
         raise ValueError(f"L2 adapter type already registered: {name!r}")
     _L2_ADAPTER_CONFIG_REGISTRY[name] = config_cls
+
+
+def register_l2_adapter_factory(
+    name: str,
+    factory: Callable[..., Any],
+) -> None:
+    """
+    Register an adapter factory for the given type name.
+
+    Each adapter module should call this at import time
+    **after** its config class has been registered via
+    ``register_l2_adapter_type``.
+
+    Args:
+        name: Adapter type name (must match the name used
+            in ``register_l2_adapter_type``).
+        factory: A callable that accepts a config instance
+            and returns an ``L2AdapterInterface``.
+    """
+    if name in _L2_ADAPTER_FACTORY_REGISTRY:
+        raise ValueError(f"L2 adapter factory already registered: {name!r}")
+    _L2_ADAPTER_FACTORY_REGISTRY[name] = factory
+
+
+def create_l2_adapter_from_registry(
+    config: L2AdapterConfigBase,
+    **kwargs: Any,
+) -> Any:
+    """
+    Create an L2 adapter using the factory registry.
+
+    Looks up the type name for *config* via the config
+    registry, then calls the matching factory.
+
+    Args:
+        config: An adapter config instance.
+        **kwargs: Extra arguments forwarded to the factory
+            (e.g. ``l1_memory_desc`` for Nixl adapters).
+
+    Returns:
+        A new ``L2AdapterInterface`` instance.
+
+    Raises:
+        ValueError: If no factory is registered for this
+            config type.
+    """
+    name = get_type_name_for_config(config)
+    factory = _L2_ADAPTER_FACTORY_REGISTRY.get(name)
+    if factory is None:
+        raise ValueError(
+            f"No adapter factory registered for type "
+            f"{name!r}. Make sure the adapter module is "
+            f"imported."
+        )
+    return factory(config, **kwargs)
 
 
 def get_registered_l2_adapter_types() -> list[str]:
@@ -53,15 +113,18 @@ def get_registered_l2_adapter_types() -> list[str]:
     return list(_L2_ADAPTER_CONFIG_REGISTRY)
 
 
-def get_type_name_for_config(config: L2AdapterConfigBase) -> str:
+def get_type_name_for_config(
+    config: L2AdapterConfigBase,
+) -> str:
     """
-    Reverse-lookup the registered type name for a config instance.
+    Reverse-lookup the registered type name for a config
+    instance.
 
     Args:
         config: An L2 adapter config instance.
 
     Returns:
-        The registered type name string (e.g., "mock", "disk").
+        The registered type name (e.g., "mock", "fs").
 
     Raises:
         ValueError: If the config's class is not registered.
@@ -121,122 +184,6 @@ class L2AdapterConfigBase(ABC):
         """
         ...
 
-
-### Detailed config classes for each L2 adapter
-class MockL2AdapterConfig(L2AdapterConfigBase):
-    """
-    Config for a mock L2 adapter (for testing).
-
-    Fields:
-    - max_size_gb: maximum size of the adapter in GB.
-    - mock_bandwidth_gb: simulated bandwidth in GB/sec (for testing load times).
-    """
-
-    def __init__(self, max_size_gb: float, mock_bandwidth_gb: float):
-        self.max_size_gb = max_size_gb
-        self.mock_bandwidth_gb = mock_bandwidth_gb
-
-    @classmethod
-    def from_dict(cls, d: dict) -> MockL2AdapterConfig:
-        max_size_gb = d.get("max_size_gb")
-        if not isinstance(max_size_gb, (int, float)) or max_size_gb <= 0:
-            raise ValueError("max_size_gb must be a positive number")
-
-        mock_bandwidth_gb = d.get("mock_bandwidth_gb")
-        if not isinstance(mock_bandwidth_gb, (int, float)) or mock_bandwidth_gb <= 0:
-            raise ValueError("mock_bandwidth_gb must be a positive number")
-
-        return cls(max_size_gb=max_size_gb, mock_bandwidth_gb=mock_bandwidth_gb)
-
-    @classmethod
-    def help(cls) -> str:
-        return (
-            "Mock L2 adapter config fields:\n"
-            "- max_size_gb (float): maximum size of the adapter in GB (required, >0)\n"
-            "- mock_bandwidth_gb (float): simulated bandwidth in GB/sec (required, >0)"
-        )
-
-
-register_l2_adapter_type("mock", MockL2AdapterConfig)
-
-
-_VALID_NIXL_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ")
-_FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS")
-
-
-class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
-    """
-    Config for a Nixl-store-based L2 adapter.
-
-    Fields:
-    - backend: Nixl storage backend (GDS, GDS_MT, POSIX, HF3FS, OBJ).
-    - backend_params: Backend-specific parameters as a dict of string key-value
-      pairs. For file-based backends (GDS, GDS_MT, POSIX, HF3FS), must include
-      "file_path". May also include "use_direct_io" (default "false") and other
-      backend-specific keys.
-    - pool_size: Number of storage descriptors to pre-allocate (must be > 0).
-    """
-
-    def __init__(
-        self,
-        backend: str,
-        backend_params: dict[str, str],
-        pool_size: int,
-    ):
-        if backend in _FILE_BACKENDS:
-            if "file_path" not in backend_params:
-                raise ValueError(
-                    f"backend_params must include 'file_path' "
-                    f"for file-based backend {backend!r}"
-                )
-            if "use_direct_io" not in backend_params:
-                raise ValueError(
-                    f"backend_params must include 'use_direct_io' "
-                    f"for file-based backend {backend!r}"
-                )
-        self.backend = backend
-        self.backend_params = backend_params
-        self.pool_size = pool_size
-
-    @classmethod
-    def from_dict(cls, d: dict) -> NixlStoreL2AdapterConfig:
-        backend = d.get("backend")
-        if backend not in _VALID_NIXL_BACKENDS:
-            raise ValueError(
-                f"backend must be one of {_VALID_NIXL_BACKENDS}, got {backend!r}"
-            )
-
-        backend_params = d.get("backend_params", {})
-        if not isinstance(backend_params, dict):
-            raise ValueError("backend_params must be a dict of string key-value pairs")
-
-        pool_size = d.get("pool_size")
-        if not isinstance(pool_size, int) or pool_size <= 0:
-            raise ValueError("pool_size must be a positive integer")
-
-        return cls(
-            backend=backend,
-            backend_params=backend_params,
-            pool_size=pool_size,
-        )
-
-    @classmethod
-    def help(cls) -> str:
-        return (
-            "Nixl store L2 adapter config fields:\n"
-            "- backend (str): Nixl storage backend, one of "
-            f"{_VALID_NIXL_BACKENDS} (required)\n"
-            "- backend_params (dict): backend-specific string key-value pairs "
-            "(optional, default {}). File-based backends require file_path. "
-            "Optional keys include 'use_direct_io' (default 'false') and "
-            "'file_size' (int, size in bytes of each storage file slot; "
-            "defaults to the L1 page size if not set).\n"
-            "- pool_size (int): number of storage descriptors to pre-allocate "
-            "(required, >0)"
-        )
-
-
-register_l2_adapter_type("nixl_store", NixlStoreL2AdapterConfig)
 
 # -----------------------------------------------------------------------------
 # Main config: list of adapter configs (order = adapter order)
@@ -371,3 +318,105 @@ def parse_args_to_l2_adapters_config(args: argparse.Namespace) -> L2AdaptersConf
             raise ValueError(f"--l2-adapter #{i + 1} ({type_name!r}): {e}") from e
 
     return L2AdaptersConfig(adapters=adapter_configs)
+
+
+_VALID_NIXL_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ")
+_FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS")
+
+
+class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
+    """
+    Config for a Nixl-store-based L2 adapter.
+
+    Fields:
+    - backend: Nixl storage backend (GDS, GDS_MT, POSIX, HF3FS, OBJ).
+    - backend_params: Backend-specific parameters as a dict of string key-value
+      pairs. For file-based backends (GDS, GDS_MT, POSIX, HF3FS), must include
+      "file_path". May also include "use_direct_io" (default "false") and other
+      backend-specific keys.
+    - pool_size: Number of storage descriptors to pre-allocate (must be > 0).
+    """
+
+    def __init__(
+        self,
+        backend: str,
+        backend_params: dict[str, str],
+        pool_size: int,
+    ):
+        if backend in _FILE_BACKENDS:
+            if "file_path" not in backend_params:
+                raise ValueError(
+                    f"backend_params must include 'file_path' "
+                    f"for file-based backend {backend!r}"
+                )
+            if "use_direct_io" not in backend_params:
+                raise ValueError(
+                    f"backend_params must include 'use_direct_io' "
+                    f"for file-based backend {backend!r}"
+                )
+        self.backend = backend
+        self.backend_params = backend_params
+        self.pool_size = pool_size
+
+    @classmethod
+    def from_dict(cls, d: dict) -> NixlStoreL2AdapterConfig:
+        backend = d.get("backend")
+        if backend not in _VALID_NIXL_BACKENDS:
+            raise ValueError(
+                f"backend must be one of {_VALID_NIXL_BACKENDS}, got {backend!r}"
+            )
+
+        backend_params = d.get("backend_params", {})
+        if not isinstance(backend_params, dict):
+            raise ValueError("backend_params must be a dict of string key-value pairs")
+
+        pool_size = d.get("pool_size")
+        if not isinstance(pool_size, int) or pool_size <= 0:
+            raise ValueError("pool_size must be a positive integer")
+
+        return cls(
+            backend=backend,
+            backend_params=backend_params,
+            pool_size=pool_size,
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "Nixl store L2 adapter config fields:\n"
+            "- backend (str): Nixl storage backend, one of "
+            f"{_VALID_NIXL_BACKENDS} (required)\n"
+            "- backend_params (dict): backend-specific string key-value pairs "
+            "(optional, default {}). File-based backends require file_path. "
+            "Optional keys include 'use_direct_io' (default 'false') and "
+            "'file_size' (int, size in bytes of each storage file slot; "
+            "defaults to the L1 page size if not set).\n"
+            "- pool_size (int): number of storage descriptors to pre-allocate "
+            "(required, >0)"
+        )
+
+
+register_l2_adapter_type("nixl_store", NixlStoreL2AdapterConfig)
+
+
+def _create_nixl_store_adapter(
+    config: NixlStoreL2AdapterConfig, **kwargs: Any
+) -> Any:
+    """Lazy-import and create a NixlStoreL2Adapter."""
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (
+        NixlStoreL2Adapter,
+    )
+
+    l1_memory_desc = kwargs.get("l1_memory_desc")
+    if l1_memory_desc is None:
+        raise ValueError(
+            "l1_memory_desc is required to create a "
+            "NixlStoreL2Adapter."
+        )
+    return NixlStoreL2Adapter(config, l1_memory_desc)
+
+
+register_l2_adapter_factory(
+    "nixl_store", _create_nixl_store_adapter
+)

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -14,17 +14,9 @@ from __future__ import annotations
 # Standard
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+from typing import TypeVar
 import argparse
 import json
-
-if TYPE_CHECKING:
-    from lmcache.v1.distributed.internal_api import (
-        L1MemoryDesc,
-    )
-    from lmcache.v1.distributed.l2_adapters.base import (
-        L2AdapterInterface,
-    )
 
 # First Party
 from lmcache.logging import init_logger
@@ -38,15 +30,6 @@ T = TypeVar("T", bound="L2AdapterConfigBase")
 # -----------------------------------------------------------------------------
 
 _L2_ADAPTER_CONFIG_REGISTRY: dict[str, type[L2AdapterConfigBase]] = {}
-# Factory signature:
-#   (config, l1_memory_desc) -> L2AdapterInterface
-_L2_ADAPTER_FACTORY_REGISTRY: dict[
-    str,
-    Callable[
-        ["L2AdapterConfigBase", "Optional[L1MemoryDesc]"],
-        "L2AdapterInterface",
-    ],
-] = {}
 
 
 def register_l2_adapter_type(
@@ -67,62 +50,6 @@ def register_l2_adapter_type(
     if name in _L2_ADAPTER_CONFIG_REGISTRY:
         raise ValueError(f"L2 adapter type already registered: {name!r}")
     _L2_ADAPTER_CONFIG_REGISTRY[name] = config_cls
-
-
-def register_l2_adapter_factory(
-    name: str,
-    factory: Callable[..., Any],
-) -> None:
-    """
-    Register an adapter factory for the given type name.
-
-    Each adapter module should call this at import time
-    **after** its config class has been registered via
-    ``register_l2_adapter_type``.
-
-    Args:
-        name: Adapter type name (must match the name used
-            in ``register_l2_adapter_type``).
-        factory: A callable ``(config, l1_memory_desc)``
-            that returns an ``L2AdapterInterface``.
-    """
-    if name in _L2_ADAPTER_FACTORY_REGISTRY:
-        raise ValueError(f"L2 adapter factory already registered: {name!r}")
-    _L2_ADAPTER_FACTORY_REGISTRY[name] = factory
-
-
-def create_l2_adapter_from_registry(
-    config: L2AdapterConfigBase,
-    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
-) -> "L2AdapterInterface":
-    """
-    Create an L2 adapter using the factory registry.
-
-    Looks up the type name for *config* via the config
-    registry, then calls the matching factory.
-
-    Args:
-        config: An adapter config instance.
-        l1_memory_desc: Optional L1 memory descriptor,
-            required by adapters that register L1 memory
-            with an external backend (e.g. Nixl).
-
-    Returns:
-        A new ``L2AdapterInterface`` instance.
-
-    Raises:
-        ValueError: If no factory is registered for this
-            config type.
-    """
-    name = get_type_name_for_config(config)
-    factory = _L2_ADAPTER_FACTORY_REGISTRY.get(name)
-    if factory is None:
-        raise ValueError(
-            f"No adapter factory registered for type "
-            f"{name!r}. Make sure the adapter module is "
-            f"imported."
-        )
-    return factory(config, l1_memory_desc)
 
 
 def get_registered_l2_adapter_types() -> list[str]:
@@ -335,100 +262,3 @@ def parse_args_to_l2_adapters_config(args: argparse.Namespace) -> L2AdaptersConf
             raise ValueError(f"--l2-adapter #{i + 1} ({type_name!r}): {e}") from e
 
     return L2AdaptersConfig(adapters=adapter_configs)
-
-
-_VALID_NIXL_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ")
-_FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS")
-
-
-class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
-    """
-    Config for a Nixl-store-based L2 adapter.
-
-    Fields:
-    - backend: Nixl storage backend (GDS, GDS_MT, POSIX, HF3FS, OBJ).
-    - backend_params: Backend-specific parameters as a dict of string key-value
-      pairs. For file-based backends (GDS, GDS_MT, POSIX, HF3FS), must include
-      "file_path". May also include "use_direct_io" (default "false") and other
-      backend-specific keys.
-    - pool_size: Number of storage descriptors to pre-allocate (must be > 0).
-    """
-
-    def __init__(
-        self,
-        backend: str,
-        backend_params: dict[str, str],
-        pool_size: int,
-    ):
-        if backend in _FILE_BACKENDS:
-            if "file_path" not in backend_params:
-                raise ValueError(
-                    f"backend_params must include 'file_path' "
-                    f"for file-based backend {backend!r}"
-                )
-            if "use_direct_io" not in backend_params:
-                raise ValueError(
-                    f"backend_params must include 'use_direct_io' "
-                    f"for file-based backend {backend!r}"
-                )
-        self.backend = backend
-        self.backend_params = backend_params
-        self.pool_size = pool_size
-
-    @classmethod
-    def from_dict(cls, d: dict) -> NixlStoreL2AdapterConfig:
-        backend = d.get("backend")
-        if backend not in _VALID_NIXL_BACKENDS:
-            raise ValueError(
-                f"backend must be one of {_VALID_NIXL_BACKENDS}, got {backend!r}"
-            )
-
-        backend_params = d.get("backend_params", {})
-        if not isinstance(backend_params, dict):
-            raise ValueError("backend_params must be a dict of string key-value pairs")
-
-        pool_size = d.get("pool_size")
-        if not isinstance(pool_size, int) or pool_size <= 0:
-            raise ValueError("pool_size must be a positive integer")
-
-        return cls(
-            backend=backend,
-            backend_params=backend_params,
-            pool_size=pool_size,
-        )
-
-    @classmethod
-    def help(cls) -> str:
-        return (
-            "Nixl store L2 adapter config fields:\n"
-            "- backend (str): Nixl storage backend, one of "
-            f"{_VALID_NIXL_BACKENDS} (required)\n"
-            "- backend_params (dict): backend-specific string key-value pairs "
-            "(optional, default {}). File-based backends require file_path. "
-            "Optional keys include 'use_direct_io' (default 'false') and "
-            "'file_size' (int, size in bytes of each storage file slot; "
-            "defaults to the L1 page size if not set).\n"
-            "- pool_size (int): number of storage descriptors to pre-allocate "
-            "(required, >0)"
-        )
-
-
-register_l2_adapter_type("nixl_store", NixlStoreL2AdapterConfig)
-
-
-def _create_nixl_store_adapter(
-    config: NixlStoreL2AdapterConfig,
-    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
-) -> Any:
-    """Lazy-import and create a NixlStoreL2Adapter."""
-    # First Party
-    from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (
-        NixlStoreL2Adapter,
-    )
-
-    if l1_memory_desc is None:
-        raise ValueError("l1_memory_desc is required to create a NixlStoreL2Adapter.")
-    return NixlStoreL2Adapter(config, l1_memory_desc)
-
-
-register_l2_adapter_factory("nixl_store", _create_nixl_store_adapter)

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -14,9 +14,14 @@ from __future__ import annotations
 # Standard
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 import argparse
 import json
+
+if TYPE_CHECKING:
+    from lmcache.v1.distributed.l2_adapters.base import (
+        L2AdapterInterface,
+    )
 
 # First Party
 from lmcache.logging import init_logger
@@ -78,7 +83,7 @@ def register_l2_adapter_factory(
 def create_l2_adapter_from_registry(
     config: L2AdapterConfigBase,
     **kwargs: Any,
-) -> Any:
+) -> "L2AdapterInterface":
     """
     Create an L2 adapter using the factory registry.
 

--- a/lmcache/v1/distributed/l2_adapters/factory.py
+++ b/lmcache/v1/distributed/l2_adapters/factory.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Factory registry for L2 adapters.
+
+Each adapter module self-registers a factory callable via
+``register_l2_adapter_factory`` at import time.  The factory
+signature is
+``(L2AdapterConfigBase, Optional[L1MemoryDesc]) -> L2AdapterInterface``.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:
+    from lmcache.v1.distributed.internal_api import (
+        L1MemoryDesc,
+    )
+    from lmcache.v1.distributed.l2_adapters.base import (
+        L2AdapterInterface,
+    )
+    from lmcache.v1.distributed.l2_adapters.config import (
+        L2AdapterConfigBase,
+    )
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+# Type alias for factory callables:
+#   (config, l1_memory_desc) -> L2AdapterInterface
+L2AdapterFactory = Callable[
+    ["L2AdapterConfigBase", "Optional[L1MemoryDesc]"],
+    "L2AdapterInterface",
+]
+
+# -----------------------------------------------------------------
+# Registry: adapter type name -> factory callable
+# -----------------------------------------------------------------
+
+_L2_ADAPTER_FACTORY_REGISTRY: dict[str, L2AdapterFactory] = {}
+
+
+def register_l2_adapter_factory(
+    name: str,
+    factory: L2AdapterFactory,
+) -> None:
+    """Register an adapter factory for the given type
+    name.
+
+    Each adapter module should call this at import time
+    **after** its config class has been registered via
+    ``register_l2_adapter_type``.
+
+    Args:
+        name: Adapter type name (must match the name used
+            in ``register_l2_adapter_type``).
+        factory: ``(config, l1_memory_desc)``
+            -> ``L2AdapterInterface``.
+    """
+    if name in _L2_ADAPTER_FACTORY_REGISTRY:
+        raise ValueError("L2 adapter factory already registered: %s" % name)
+    _L2_ADAPTER_FACTORY_REGISTRY[name] = factory
+
+
+def create_l2_adapter_from_registry(
+    config: "L2AdapterConfigBase",
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> "L2AdapterInterface":
+    """Create an L2 adapter using the factory registry.
+
+    Looks up the type name for *config* via the config
+    registry, then calls the matching factory.
+
+    Args:
+        config: An adapter config instance.
+        l1_memory_desc: Optional L1 memory descriptor,
+            required by adapters that register L1 memory
+            with an external backend (e.g. Nixl).
+
+    Returns:
+        A new ``L2AdapterInterface`` instance.
+
+    Raises:
+        ValueError: If no factory is registered for this
+            config type.
+    """
+    # Import here to avoid circular dependency
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.config import (
+        get_type_name_for_config,
+    )
+
+    name = get_type_name_for_config(config)
+    factory = _L2_ADAPTER_FACTORY_REGISTRY.get(name)
+    if factory is None:
+        raise ValueError(
+            "No adapter factory registered for type "
+            "%s. Make sure the adapter module is "
+            "imported." % name
+        )
+    return factory(config, l1_memory_desc)

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -162,6 +162,20 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         read_ahead_size: Optional[int] = None,
         use_odirect: bool = False,
     ):
+        """Initialize FSL2AdapterConfig.
+
+        Args:
+            base_path: Directory for storing KV cache files.
+            relative_tmp_dir: Relative sub-dir under
+                base_path for temp files during writes.
+            read_ahead_size: If set, trigger filesystem
+                readahead by issuing a small initial read
+                of this many bytes before reading the rest.
+            use_odirect: If True, bypass the OS page cache
+                using O_DIRECT for both reads and writes.
+                Requires buffer sizes aligned to the
+                filesystem block size.
+        """
         self.base_path = base_path
         self.relative_tmp_dir = relative_tmp_dir
         self.read_ahead_size = read_ahead_size

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -697,4 +697,7 @@ class FSL2Adapter(L2AdapterInterface):
 
 # Self-register config type and adapter factory
 register_l2_adapter_type("fs", FSL2AdapterConfig)
-register_l2_adapter_factory("fs", lambda config, **kwargs: FSL2Adapter(config))
+register_l2_adapter_factory(
+    "fs",
+    lambda config, l1_memory_desc=None: FSL2Adapter(config),
+)

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -41,6 +41,45 @@ _PATH_SLASH_REPLACEMENT = "-SEP-"
 _FILE_EXT = ".data"
 
 
+def _readinto_full(
+    f,  # typing: IO[bytes]
+    buf: Union[bytearray, memoryview, bytes],
+) -> int:
+    """Loop readinto() until *buf* is full or EOF.
+
+    A single ``readinto()`` may return fewer bytes than
+    *len(buf)* even when more data is available.  This
+    helper keeps reading until the buffer is completely
+    filled or the file reaches EOF.
+
+    Returns:
+        Total number of bytes read.
+    """
+    mv = memoryview(buf) if not isinstance(buf, memoryview) else buf
+    total = 0
+    while total < len(mv):
+        n = f.readinto(mv[total:])
+        if n is None or n == 0:
+            break
+        total += n
+    return total
+
+
+async def _async_readinto_full(
+    f,  # aiofiles async file handle
+    buf: Union[bytearray, memoryview, bytes],
+) -> int:
+    """Async version of :func:`_readinto_full`."""
+    mv = memoryview(buf) if not isinstance(buf, memoryview) else buf
+    total = 0
+    while total < len(mv):
+        n = await f.readinto(mv[total:])
+        if n is None or n == 0:
+            break
+        total += n
+    return total
+
+
 def _object_key_to_filename(key: ObjectKey) -> str:
     """Build a reversible, filesystem-safe filename.
 
@@ -76,21 +115,19 @@ def _filename_to_object_key(
 
     # Split by ``@``.  Layout:
     #   <model_name> @ <kv_rank> @ <chunk_hash_hex>
-    # model_name itself never contains ``@``, but may
-    # contain ``-`` (the slash replacement).  kv_rank and
-    # chunk_hash are always the **last two** tokens.
-    tokens = stem.split(_KEY_SEP)
-    if len(tokens) < 3:
+    # model_name itself may contain ``@``, so we split
+    # from the right to reliably isolate the last two
+    # fields (kv_rank and chunk_hash).
+    parts = stem.rsplit(_KEY_SEP, 2)
+    if len(parts) != 3:
         return None
 
+    safe_model, kv_rank_str, chunk_hash_hex = parts
     try:
-        chunk_hash = bytes.fromhex(tokens[-1])
-        kv_rank = int(tokens[-2], 16)
-    except (ValueError, IndexError):
+        chunk_hash = bytes.fromhex(chunk_hash_hex)
+        kv_rank = int(kv_rank_str, 16)
+    except ValueError:
         return None
-
-    # Everything before the last two tokens is model_name
-    safe_model = _KEY_SEP.join(tokens[:-2])
     model_name = safe_model.replace(_PATH_SLASH_REPLACEMENT, "/")
     return ObjectKey(
         chunk_hash=chunk_hash,
@@ -196,7 +233,11 @@ class FSL2Adapter(L2AdapterInterface):
         self._relative_tmp_dir: Optional[Path] = None
         if config.relative_tmp_dir is not None:
             self._relative_tmp_dir = Path(config.relative_tmp_dir)
-            assert not self._relative_tmp_dir.is_absolute()
+            if (
+                self._relative_tmp_dir.is_absolute()
+                or ".." in self._relative_tmp_dir.parts
+            ):
+                raise ValueError("Invalid relative_tmp_dir: " + config.relative_tmp_dir)
             (self._base_path / self._relative_tmp_dir).mkdir(
                 parents=False, exist_ok=True
             )
@@ -434,8 +475,7 @@ class FSL2Adapter(L2AdapterInterface):
                     file_path,
                 )
                 with open(file_path, "rb") as f:
-                    num_read = f.readinto(dst_buf)
-                return num_read if num_read else 0
+                    return _readinto_full(f, dst_buf)
 
             fd = os.open(
                 str(file_path),
@@ -443,8 +483,7 @@ class FSL2Adapter(L2AdapterInterface):
             )
             with os.fdopen(fd, "rb", buffering=0) as fdo:
                 fd = -1  # now managed by fdopen
-                num_read = fdo.readinto(dst_buf)
-            return num_read if num_read else 0
+                return _readinto_full(fdo, dst_buf)
         except Exception:
             logger.exception("Failed to O_DIRECT read %s", file_path)
             return 0
@@ -488,7 +527,7 @@ class FSL2Adapter(L2AdapterInterface):
     ) -> None:
         success = True
         try:
-            for key, obj in zip(keys, objects, strict=False):
+            for key, obj in zip(keys, objects, strict=True):
                 # Skip if already stored
                 if key in self._known_keys:
                     continue
@@ -581,6 +620,7 @@ class FSL2Adapter(L2AdapterInterface):
             file_path = self._key_to_path(key)
             try:
                 dst_buf = objects[i].byte_array
+                expected = len(dst_buf)
                 num_read: Optional[int] = None
 
                 # O_DIRECT path (sync, via executor)
@@ -591,7 +631,14 @@ class FSL2Adapter(L2AdapterInterface):
                         file_path,
                         dst_buf,
                     )
-                    if num_read and num_read > 0:
+                    if num_read != expected:
+                        logger.warning(
+                            "Incomplete O_DIRECT read for %s: expected %d, got %d",
+                            file_path.name,
+                            expected,
+                            num_read or 0,
+                        )
+                    else:
                         bitmap.set(i)
                         logger.debug(
                             "FSL2Adapter loaded key %s (%d bytes, O_DIRECT)",
@@ -602,25 +649,30 @@ class FSL2Adapter(L2AdapterInterface):
 
                 # Standard async path with optional
                 # read-ahead
+                expected = len(dst_buf)
                 async with aiofiles.open(file_path, "rb") as f:
                     if self._read_ahead_size is None:
-                        num_read = await f.readinto(dst_buf)
+                        num_read = await _async_readinto_full(f, dst_buf)
                     else:
                         if not isinstance(dst_buf, memoryview):
                             dst_buf = memoryview(dst_buf)
                         # Trigger readahead with a
                         # small initial read
                         ra = self._read_ahead_size
-                        n_head = await f.readinto(dst_buf[:ra])
-                        assert n_head is not None
+                        n_head = await _async_readinto_full(f, dst_buf[:ra])
                         if n_head == ra:
-                            n_tail = await f.readinto(dst_buf[ra:])
-                            assert n_tail is not None
+                            n_tail = await _async_readinto_full(f, dst_buf[ra:])
                             num_read = n_head + n_tail
                         else:
                             num_read = n_head
 
-                    if num_read is None or num_read == 0:
+                    if num_read != expected:
+                        logger.warning(
+                            "Incomplete read for %s: expected %d, got %d",
+                            file_path.name,
+                            expected,
+                            num_read,
+                        )
                         continue
 
                     bitmap.set(i)

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -7,12 +7,20 @@ header).  Each ObjectKey maps to a separate ``.data`` file whose
 name encodes all key fields so it can be reversed on startup.
 """
 
+# Future
+from __future__ import annotations
+
 # Standard
 from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 import asyncio
 import os
 import threading
+
+if TYPE_CHECKING:
+    from lmcache.v1.distributed.internal_api import (
+        L1MemoryDesc,
+    )
 
 # Third Party
 import aiofiles
@@ -28,8 +36,10 @@ from lmcache.v1.distributed.l2_adapters.base import (
 )
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
-    register_l2_adapter_factory,
     register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
 )
 from lmcache.v1.memory_management import MemoryObj
 
@@ -350,6 +360,20 @@ class FSL2Adapter(L2AdapterInterface):
             return self._completed_load_tasks.pop(task_id, None)
 
     # ------------------------------------------------------------------
+    # Status Interface
+    # ------------------------------------------------------------------
+
+    def report_status(self) -> dict:
+        """Return a status dict for the FS L2 adapter."""
+        return {
+            "is_healthy": self._loop_thread.is_alive(),
+            "type": "FSL2Adapter",
+            "base_path": str(self._base_path),
+            "use_odirect": self._use_odirect,
+            "event_loop_alive": self._loop_thread.is_alive(),
+        }
+
+    # ------------------------------------------------------------------
     # Cleanup
     # ------------------------------------------------------------------
 
@@ -667,7 +691,14 @@ class FSL2Adapter(L2AdapterInterface):
 
 # Self-register config type and adapter factory
 register_l2_adapter_type("fs", FSL2AdapterConfig)
-register_l2_adapter_factory(
-    "fs",
-    lambda config, l1_memory_desc=None: FSL2Adapter(config),
-)
+
+
+def _create_fs_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> L2AdapterInterface:
+    """Create an FSL2Adapter from config."""
+    return FSL2Adapter(config)  # type: ignore[arg-type]
+
+
+register_l2_adapter_factory("fs", _create_fs_adapter)

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -1,0 +1,650 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+File-system based L2 adapter using aiofiles for async I/O.
+
+Stores KV cache objects as raw tensor bytes on disk (no metadata
+header).  Each ObjectKey maps to a separate ``.data`` file whose
+name encodes all key fields so it can be reversed on startup.
+"""
+
+# Standard
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional, Union
+import asyncio
+import os
+import threading
+
+# Third Party
+import aiofiles
+import aiofiles.os
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.base import (
+    L2AdapterInterface,
+    L2TaskId,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_factory,
+    register_l2_adapter_type,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+logger = init_logger(__name__)
+
+_KEY_SEP = "@"
+_PATH_SLASH_REPLACEMENT = "-SEP-"
+_FILE_EXT = ".data"
+
+
+def _object_key_to_filename(key: ObjectKey) -> str:
+    """Build a reversible, filesystem-safe filename.
+
+    Format follows CacheEngineKey.to_string() convention::
+
+        <model_name>@<kv_rank_hex>@<chunk_hash_hex>.data
+
+    ``kv_rank`` is written in ``0x`` prefixed hex so each byte
+    of the bitmap ``(ws<<24)|(rank<<16)|(local_ws<<8)|local``
+    is directly readable.
+    """
+    safe_model = key.model_name.replace("/", _PATH_SLASH_REPLACEMENT)
+    return (
+        f"{safe_model}"
+        f"{_KEY_SEP}{key.kv_rank:#010x}"
+        f"{_KEY_SEP}{key.chunk_hash.hex()}"
+        f"{_FILE_EXT}"
+    )
+
+
+def _filename_to_object_key(
+    filename: str,
+) -> Optional[ObjectKey]:
+    """Reverse ``_object_key_to_filename``.
+
+    Returns ``None`` when the filename cannot be parsed.
+    """
+    stem = filename
+    if stem.endswith(_FILE_EXT):
+        stem = stem[: -len(_FILE_EXT)]
+    else:
+        return None
+
+    # Split by ``@``.  Layout:
+    #   <model_name> @ <kv_rank> @ <chunk_hash_hex>
+    # model_name itself never contains ``@``, but may
+    # contain ``-`` (the slash replacement).  kv_rank and
+    # chunk_hash are always the **last two** tokens.
+    tokens = stem.split(_KEY_SEP)
+    if len(tokens) < 3:
+        return None
+
+    try:
+        chunk_hash = bytes.fromhex(tokens[-1])
+        kv_rank = int(tokens[-2], 16)
+    except (ValueError, IndexError):
+        return None
+
+    # Everything before the last two tokens is model_name
+    safe_model = _KEY_SEP.join(tokens[:-2])
+    model_name = safe_model.replace(_PATH_SLASH_REPLACEMENT, "/")
+    return ObjectKey(
+        chunk_hash=chunk_hash,
+        model_name=model_name,
+        kv_rank=kv_rank,
+    )
+
+
+class FSL2AdapterConfig(L2AdapterConfigBase):
+    """
+    Config for the filesystem-backed L2 adapter.
+
+    Fields:
+    - base_path: directory for storing KV cache files.
+    - relative_tmp_dir: optional relative sub-dir for
+      temp files (same as fs_connector_relative_tmp_dir).
+    - scan_on_startup: scan existing files on startup
+      to populate the in-memory index. Default False.
+    """
+
+    def __init__(
+        self,
+        base_path: str,
+        relative_tmp_dir: Optional[str] = None,
+        scan_on_startup: bool = False,
+        read_ahead_size: Optional[int] = None,
+        use_odirect: bool = False,
+    ):
+        self.base_path = base_path
+        self.relative_tmp_dir = relative_tmp_dir
+        self.scan_on_startup = scan_on_startup
+        self.read_ahead_size = read_ahead_size
+        self.use_odirect = use_odirect
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "FSL2AdapterConfig":
+        base_path = d.get("base_path")
+        if not isinstance(base_path, str) or not base_path:
+            raise ValueError("base_path must be a non-empty string")
+        relative_tmp_dir = d.get("relative_tmp_dir", None)
+        if relative_tmp_dir is not None:
+            if not isinstance(relative_tmp_dir, str):
+                raise ValueError("relative_tmp_dir must be a string")
+        scan_on_startup = d.get("scan_on_startup", False)
+        if not isinstance(scan_on_startup, bool):
+            raise ValueError("scan_on_startup must be a boolean")
+        read_ahead_size = d.get("read_ahead_size", None)
+        if read_ahead_size is not None:
+            if not isinstance(read_ahead_size, int) or read_ahead_size <= 0:
+                raise ValueError("read_ahead_size must be a positive integer")
+        use_odirect = d.get("use_odirect", False)
+        if not isinstance(use_odirect, bool):
+            raise ValueError("use_odirect must be a boolean")
+        return cls(
+            base_path=base_path,
+            relative_tmp_dir=relative_tmp_dir,
+            scan_on_startup=scan_on_startup,
+            read_ahead_size=read_ahead_size,
+            use_odirect=use_odirect,
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "FS L2 adapter config fields:\n"
+            "- base_path (str): directory for KV cache "
+            "files (required)\n"
+            "- relative_tmp_dir (str): relative sub-dir "
+            "for temp files (optional, same as "
+            "fs_connector_relative_tmp_dir)\n"
+            "- scan_on_startup (bool): scan existing "
+            "files on startup (optional, default false)\n"
+            "- read_ahead_size (int): trigger fs "
+            "readahead by reading this many bytes first "
+            "(optional)\n"
+            "- use_odirect (bool): bypass page cache "
+            "via O_DIRECT (optional, default false)"
+        )
+
+
+class FSL2Adapter(L2AdapterInterface):
+    """
+    File-system backed L2 adapter with async I/O via *aiofiles*.
+
+    Each file stores **only** the raw tensor bytes (no metadata
+    header), which gives maximum I/O throughput.  The file name
+    itself encodes the full ``ObjectKey`` so it is reversible.
+
+    Thread safety is ensured via a lock for shared bookkeeping
+    and an asyncio event loop running on a dedicated daemon
+    thread.
+    """
+
+    def __init__(self, config: FSL2AdapterConfig):
+        self._config = config
+        base = config.base_path
+        self._base_path = Path(base)
+        self._base_path.mkdir(parents=True, exist_ok=True)
+
+        # Temp-file strategy aligned with FSConnector:
+        # if relative_tmp_dir is set, write to a sub-dir;
+        # otherwise fall back to a .tmp suffix.
+        self._relative_tmp_dir: Optional[Path] = None
+        if config.relative_tmp_dir is not None:
+            self._relative_tmp_dir = Path(config.relative_tmp_dir)
+            assert not self._relative_tmp_dir.is_absolute()
+            (self._base_path / self._relative_tmp_dir).mkdir(
+                parents=False, exist_ok=True
+            )
+
+        # I/O tuning options aligned with FSConnector
+        self._read_ahead_size = config.read_ahead_size
+        self._use_odirect = config.use_odirect
+        self._os_disk_bs = 0
+        if self._use_odirect:
+            stat = os.statvfs(self._base_path)
+            self._os_disk_bs = stat.f_bsize
+
+        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+
+        # In-memory index: which keys are on disk
+        self._known_keys: set[ObjectKey] = set()
+        self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+
+        # Task bookkeeping
+        self._next_task_id: L2TaskId = 0
+        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
+        self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
+        self._lock = threading.Lock()
+
+        # Background asyncio event loop
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
+        self._loop_thread.start()
+
+        # Scan existing files to populate _known_keys
+        if config.scan_on_startup:
+            self._scan_existing_files()
+
+        logger.info(
+            "Initialized FSL2Adapter with base_path=%s, "
+            "relative_tmp_dir=%s, scan_on_startup=%s, "
+            "read_ahead_size=%s, use_odirect=%s, "
+            "found %d existing files",
+            self._base_path,
+            self._relative_tmp_dir,
+            config.scan_on_startup,
+            self._read_ahead_size,
+            self._use_odirect,
+            len(self._known_keys),
+        )
+
+    # ------------------------------------------------------------------
+    # Event Fd Interface
+    # ------------------------------------------------------------------
+
+    def get_store_event_fd(self) -> int:
+        return self._store_efd
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        return self._lookup_efd
+
+    def get_load_event_fd(self) -> int:
+        return self._load_efd
+
+    # ------------------------------------------------------------------
+    # Store Interface
+    # ------------------------------------------------------------------
+
+    def submit_store_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        with self._lock:
+            task_id = self._get_next_task_id()
+
+        asyncio.run_coroutine_threadsafe(
+            self._execute_store(keys, objects, task_id),
+            self._loop,
+        )
+        return task_id
+
+    def pop_completed_store_tasks(
+        self,
+    ) -> dict[L2TaskId, bool]:
+        with self._lock:
+            completed = self._completed_store_tasks
+            self._completed_store_tasks = {}
+        return completed
+
+    # ------------------------------------------------------------------
+    # Lookup and Lock Interface
+    # ------------------------------------------------------------------
+
+    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+        with self._lock:
+            task_id = self._get_next_task_id()
+
+        self._loop.call_soon_threadsafe(self._execute_lookup, keys, task_id)
+        return task_id
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        with self._lock:
+            return self._completed_lookup_tasks.pop(task_id, None)
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        def _unlock(ks: list[ObjectKey]) -> None:
+            for k in ks:
+                if k not in self._locked_keys:
+                    continue
+                if self._locked_keys[k] <= 1:
+                    del self._locked_keys[k]
+                else:
+                    self._locked_keys[k] -= 1
+
+        self._loop.call_soon_threadsafe(_unlock, keys)
+
+    # ------------------------------------------------------------------
+    # Load Interface
+    # ------------------------------------------------------------------
+
+    def submit_load_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        with self._lock:
+            task_id = self._get_next_task_id()
+
+        asyncio.run_coroutine_threadsafe(
+            self._execute_load(keys, objects, task_id),
+            self._loop,
+        )
+        return task_id
+
+    def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        with self._lock:
+            return self._completed_load_tasks.pop(task_id, None)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        async def _stop_tasks():
+            tasks = [
+                t
+                for t in asyncio.all_tasks(self._loop)
+                if t is not asyncio.current_task()
+            ]
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        if self._loop.is_running():
+            fut = asyncio.run_coroutine_threadsafe(_stop_tasks(), self._loop)
+            try:
+                fut.result(timeout=5)
+            except Exception:
+                pass
+            self._loop.call_soon_threadsafe(self._loop.stop)
+
+        self._loop_thread.join()
+
+        os.close(self._store_efd)
+        os.close(self._lookup_efd)
+        os.close(self._load_efd)
+        logger.info("FSL2Adapter closed")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_event_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def _get_next_task_id(self) -> L2TaskId:
+        tid = self._next_task_id
+        self._next_task_id += 1
+        return tid
+
+    def _key_to_path(self, key: ObjectKey) -> Path:
+        return self._base_path / _object_key_to_filename(key)
+
+    def _key_to_file_and_tmp_path(self, key: ObjectKey) -> tuple[Path, Path]:
+        """Return ``(final_path, tmp_path)``.
+
+        When ``relative_tmp_dir`` is configured, the temp file
+        is placed under that sub-directory (same behaviour as
+        ``FSConnector._get_file_and_tmp_path``).  Otherwise a
+        ``.tmp`` suffix is used.
+        """
+        fname = _object_key_to_filename(key)
+        final = self._base_path / fname
+        if self._relative_tmp_dir is not None:
+            tmp = self._base_path / self._relative_tmp_dir / fname
+        else:
+            tmp = final.with_suffix(".tmp")
+        return final, tmp
+
+    def _scan_existing_files(self) -> None:
+        """Populate _known_keys from ``.data`` files on disk.
+
+        File names are reversible so we can reconstruct the
+        original ``ObjectKey`` for each file.
+        """
+        for entry in self._base_path.iterdir():
+            if not entry.is_file():
+                continue
+            if not entry.name.endswith(_FILE_EXT):
+                continue
+            key = _filename_to_object_key(entry.name)
+            if key is not None:
+                self._known_keys.add(key)
+
+    # ---- O_DIRECT helpers -----------------------------------------------
+
+    def _read_with_odirect(
+        self,
+        file_path: Path,
+        dst_buf: Union[bytearray, memoryview, bytes],
+    ) -> int:
+        """Synchronous O_DIRECT read into *dst_buf*.
+
+        Returns the number of bytes actually read.
+        Runs in an executor (not on the event loop).
+        """
+        fd = -1
+        size = len(dst_buf)
+        try:
+            aligned = self._os_disk_bs > 0 and size % self._os_disk_bs == 0
+            if not aligned:
+                logger.warning(
+                    "Cannot use O_DIRECT for %s, size is not aligned.",
+                    file_path,
+                )
+                with open(file_path, "rb") as f:
+                    num_read = f.readinto(dst_buf)
+                return num_read if num_read else 0
+
+            fd = os.open(
+                str(file_path),
+                os.O_RDONLY | getattr(os, "O_DIRECT", 0),
+            )
+            with os.fdopen(fd, "rb", buffering=0) as fdo:
+                fd = -1  # now managed by fdopen
+                num_read = fdo.readinto(dst_buf)
+            return num_read if num_read else 0
+        except Exception:
+            logger.exception("Failed to O_DIRECT read %s", file_path)
+            return 0
+        finally:
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+    def _write_with_odirect(self, file_path: Path, buf: bytes) -> None:
+        """Synchronous O_DIRECT write of *buf*.
+
+        Runs in an executor (not on the event loop).
+        """
+        fd = -1
+        try:
+            fd = os.open(
+                str(file_path),
+                os.O_CREAT | os.O_WRONLY | getattr(os, "O_DIRECT", 0),
+                0o644,
+            )
+            os.write(fd, buf)
+        except Exception:
+            logger.exception("Failed to O_DIRECT write %s", file_path)
+            raise
+        finally:
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+    # ---- store ----------------------------------------------------------
+
+    async def _execute_store(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        task_id: L2TaskId,
+    ) -> None:
+        success = True
+        try:
+            for key, obj in zip(keys, objects, strict=False):
+                # Skip if already stored
+                if key in self._known_keys:
+                    continue
+
+                file_path, tmp_path = self._key_to_file_and_tmp_path(key)
+                buf = obj.byte_array
+                size = len(buf)
+
+                try:
+                    # Decide whether O_DIRECT is usable
+                    do_odirect = self._use_odirect
+                    if do_odirect:
+                        aligned = self._os_disk_bs > 0 and size % self._os_disk_bs == 0
+                        if not aligned:
+                            logger.warning(
+                                "Cannot use O_DIRECT for "
+                                "writing size %d, not "
+                                "aligned to block size "
+                                "%d.",
+                                size,
+                                self._os_disk_bs,
+                            )
+                            do_odirect = False
+
+                    if do_odirect:
+                        await self._loop.run_in_executor(
+                            None,
+                            self._write_with_odirect,
+                            tmp_path,
+                            buf,
+                        )
+                    else:
+                        async with aiofiles.open(tmp_path, "wb") as f:
+                            await f.write(buf)
+
+                    await aiofiles.os.replace(tmp_path, file_path)
+                    self._known_keys.add(key)
+                    logger.debug(
+                        "FSL2Adapter stored key %s (%d bytes)",
+                        file_path.name,
+                        size,
+                    )
+                except Exception:
+                    logger.exception(
+                        "FSL2Adapter failed to store %s",
+                        file_path,
+                    )
+                    if await aiofiles.os.path.exists(tmp_path):
+                        await aiofiles.os.unlink(tmp_path)
+                    success = False
+        except Exception:
+            logger.exception(
+                "FSL2Adapter store task %s failed",
+                task_id,
+            )
+            success = False
+
+        with self._lock:
+            self._completed_store_tasks[task_id] = success
+        os.eventfd_write(self._store_efd, 1)
+
+    # ---- lookup ---------------------------------------------------------
+
+    def _execute_lookup(
+        self,
+        keys: list[ObjectKey],
+        task_id: L2TaskId,
+    ) -> None:
+        bitmap = Bitmap(len(keys))
+        for i, key in enumerate(keys):
+            if key not in self._known_keys:
+                continue
+            bitmap.set(i)
+            self._locked_keys[key] += 1
+
+        with self._lock:
+            self._completed_lookup_tasks[task_id] = bitmap
+        os.eventfd_write(self._lookup_efd, 1)
+
+    # ---- load -----------------------------------------------------------
+
+    async def _execute_load(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        task_id: L2TaskId,
+    ) -> None:
+        bitmap = Bitmap(len(keys))
+        for i, key in enumerate(keys):
+            file_path = self._key_to_path(key)
+            try:
+                dst_buf = objects[i].byte_array
+                num_read: Optional[int] = None
+
+                # O_DIRECT path (sync, via executor)
+                if self._use_odirect:
+                    num_read = await self._loop.run_in_executor(
+                        None,
+                        self._read_with_odirect,
+                        file_path,
+                        dst_buf,
+                    )
+                    if num_read and num_read > 0:
+                        bitmap.set(i)
+                        logger.debug(
+                            "FSL2Adapter loaded key %s (%d bytes, O_DIRECT)",
+                            file_path.name,
+                            num_read,
+                        )
+                    continue
+
+                # Standard async path with optional
+                # read-ahead
+                async with aiofiles.open(file_path, "rb") as f:
+                    if self._read_ahead_size is None:
+                        num_read = await f.readinto(dst_buf)
+                    else:
+                        if not isinstance(dst_buf, memoryview):
+                            dst_buf = memoryview(dst_buf)
+                        # Trigger readahead with a
+                        # small initial read
+                        ra = self._read_ahead_size
+                        n_head = await f.readinto(dst_buf[:ra])
+                        assert n_head is not None
+                        if n_head == ra:
+                            n_tail = await f.readinto(dst_buf[ra:])
+                            assert n_tail is not None
+                            num_read = n_head + n_tail
+                        else:
+                            num_read = n_head
+
+                    if num_read is None or num_read == 0:
+                        continue
+
+                    bitmap.set(i)
+                    logger.debug(
+                        "FSL2Adapter loaded key %s (%d bytes)",
+                        file_path.name,
+                        num_read,
+                    )
+            except FileNotFoundError:
+                continue
+            except Exception:
+                logger.exception(
+                    "FSL2Adapter failed to load %s",
+                    file_path,
+                )
+                continue
+
+        with self._lock:
+            self._completed_load_tasks[task_id] = bitmap
+        os.eventfd_write(self._load_efd, 1)
+
+
+# Self-register config type and adapter factory
+register_l2_adapter_type("fs", FSL2AdapterConfig)
+register_l2_adapter_factory(
+    "fs", lambda config, **kwargs: FSL2Adapter(config)
+)

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -697,6 +697,4 @@ class FSL2Adapter(L2AdapterInterface):
 
 # Self-register config type and adapter factory
 register_l2_adapter_type("fs", FSL2AdapterConfig)
-register_l2_adapter_factory(
-    "fs", lambda config, **kwargs: FSL2Adapter(config)
-)
+register_l2_adapter_factory("fs", lambda config, **kwargs: FSL2Adapter(config))

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -8,7 +8,6 @@ name encodes all key fields so it can be reversed on startup.
 """
 
 # Standard
-from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Union
 import asyncio
@@ -144,21 +143,17 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
     - base_path: directory for storing KV cache files.
     - relative_tmp_dir: optional relative sub-dir for
       temp files (same as fs_connector_relative_tmp_dir).
-    - scan_on_startup: scan existing files on startup
-      to populate the in-memory index. Default False.
     """
 
     def __init__(
         self,
         base_path: str,
         relative_tmp_dir: Optional[str] = None,
-        scan_on_startup: bool = False,
         read_ahead_size: Optional[int] = None,
         use_odirect: bool = False,
     ):
         self.base_path = base_path
         self.relative_tmp_dir = relative_tmp_dir
-        self.scan_on_startup = scan_on_startup
         self.read_ahead_size = read_ahead_size
         self.use_odirect = use_odirect
 
@@ -171,9 +166,6 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         if relative_tmp_dir is not None:
             if not isinstance(relative_tmp_dir, str):
                 raise ValueError("relative_tmp_dir must be a string")
-        scan_on_startup = d.get("scan_on_startup", False)
-        if not isinstance(scan_on_startup, bool):
-            raise ValueError("scan_on_startup must be a boolean")
         read_ahead_size = d.get("read_ahead_size", None)
         if read_ahead_size is not None:
             if not isinstance(read_ahead_size, int) or read_ahead_size <= 0:
@@ -184,7 +176,6 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         return cls(
             base_path=base_path,
             relative_tmp_dir=relative_tmp_dir,
-            scan_on_startup=scan_on_startup,
             read_ahead_size=read_ahead_size,
             use_odirect=use_odirect,
         )
@@ -198,8 +189,6 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
             "- relative_tmp_dir (str): relative sub-dir "
             "for temp files (optional, same as "
             "fs_connector_relative_tmp_dir)\n"
-            "- scan_on_startup (bool): scan existing "
-            "files on startup (optional, default false)\n"
             "- read_ahead_size (int): trigger fs "
             "readahead by reading this many bytes first "
             "(optional)\n"
@@ -254,10 +243,6 @@ class FSL2Adapter(L2AdapterInterface):
         self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
         self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
 
-        # In-memory index: which keys are on disk
-        self._known_keys: set[ObjectKey] = set()
-        self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
-
         # Task bookkeeping
         self._next_task_id: L2TaskId = 0
         self._completed_store_tasks: dict[L2TaskId, bool] = {}
@@ -270,21 +255,14 @@ class FSL2Adapter(L2AdapterInterface):
         self._loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
         self._loop_thread.start()
 
-        # Scan existing files to populate _known_keys
-        if config.scan_on_startup:
-            self._scan_existing_files()
-
         logger.info(
             "Initialized FSL2Adapter with base_path=%s, "
-            "relative_tmp_dir=%s, scan_on_startup=%s, "
-            "read_ahead_size=%s, use_odirect=%s, "
-            "found %d existing files",
+            "relative_tmp_dir=%s, "
+            "read_ahead_size=%s, use_odirect=%s",
             self._base_path,
             self._relative_tmp_dir,
-            config.scan_on_startup,
             self._read_ahead_size,
             self._use_odirect,
-            len(self._known_keys),
         )
 
     # ------------------------------------------------------------------
@@ -334,7 +312,10 @@ class FSL2Adapter(L2AdapterInterface):
         with self._lock:
             task_id = self._get_next_task_id()
 
-        self._loop.call_soon_threadsafe(self._execute_lookup, keys, task_id)
+        asyncio.run_coroutine_threadsafe(
+            self._execute_lookup(keys, task_id),
+            self._loop,
+        )
         return task_id
 
     def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
@@ -342,16 +323,9 @@ class FSL2Adapter(L2AdapterInterface):
             return self._completed_lookup_tasks.pop(task_id, None)
 
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
-        def _unlock(ks: list[ObjectKey]) -> None:
-            for k in ks:
-                if k not in self._locked_keys:
-                    continue
-                if self._locked_keys[k] <= 1:
-                    del self._locked_keys[k]
-                else:
-                    self._locked_keys[k] -= 1
-
-        self._loop.call_soon_threadsafe(_unlock, keys)
+        # No-op: FS adapter has no eviction, so locking
+        # between lookup and load is unnecessary.
+        pass
 
     # ------------------------------------------------------------------
     # Load Interface
@@ -422,6 +396,19 @@ class FSL2Adapter(L2AdapterInterface):
     def _key_to_path(self, key: ObjectKey) -> Path:
         return self._base_path / _object_key_to_filename(key)
 
+    async def _key_exists_on_disk(
+        self,
+        key: ObjectKey,
+    ) -> bool:
+        """Check whether the file for *key* exists on disk.
+
+        Uses ``aiofiles.os.path.exists`` so the check is
+        non-blocking and always reflects the real FS state,
+        which is critical for multi-node shared-FS setups.
+        """
+        path = self._key_to_path(key)
+        return await aiofiles.os.path.exists(path)
+
     def _key_to_file_and_tmp_path(self, key: ObjectKey) -> tuple[Path, Path]:
         """Return ``(final_path, tmp_path)``.
 
@@ -437,21 +424,6 @@ class FSL2Adapter(L2AdapterInterface):
         else:
             tmp = final.with_suffix(".tmp")
         return final, tmp
-
-    def _scan_existing_files(self) -> None:
-        """Populate _known_keys from ``.data`` files on disk.
-
-        File names are reversible so we can reconstruct the
-        original ``ObjectKey`` for each file.
-        """
-        for entry in self._base_path.iterdir():
-            if not entry.is_file():
-                continue
-            if not entry.name.endswith(_FILE_EXT):
-                continue
-            key = _filename_to_object_key(entry.name)
-            if key is not None:
-                self._known_keys.add(key)
 
     # ---- O_DIRECT helpers -----------------------------------------------
 
@@ -528,11 +500,11 @@ class FSL2Adapter(L2AdapterInterface):
         success = True
         try:
             for key, obj in zip(keys, objects, strict=True):
-                # Skip if already stored
-                if key in self._known_keys:
-                    continue
-
                 file_path, tmp_path = self._key_to_file_and_tmp_path(key)
+
+                # Skip if already stored on disk
+                if await aiofiles.os.path.exists(file_path):
+                    continue
                 buf = obj.byte_array
                 size = len(buf)
 
@@ -564,7 +536,6 @@ class FSL2Adapter(L2AdapterInterface):
                             await f.write(buf)
 
                     await aiofiles.os.replace(tmp_path, file_path)
-                    self._known_keys.add(key)
                     logger.debug(
                         "FSL2Adapter stored key %s (%d bytes)",
                         file_path.name,
@@ -591,17 +562,16 @@ class FSL2Adapter(L2AdapterInterface):
 
     # ---- lookup ---------------------------------------------------------
 
-    def _execute_lookup(
+    async def _execute_lookup(
         self,
         keys: list[ObjectKey],
         task_id: L2TaskId,
     ) -> None:
         bitmap = Bitmap(len(keys))
         for i, key in enumerate(keys):
-            if key not in self._known_keys:
+            if not await self._key_exists_on_disk(key):
                 continue
             bitmap.set(i)
-            self._locked_keys[key] += 1
 
         with self._lock:
             self._completed_lookup_tasks[task_id] = bitmap

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -475,4 +475,7 @@ class MockL2Adapter(L2AdapterInterface):
 
 # Self-register config type and adapter factory
 register_l2_adapter_type("mock", MockL2AdapterConfig)
-register_l2_adapter_factory("mock", lambda config, **kwargs: MockL2Adapter(config))
+register_l2_adapter_factory(
+    "mock",
+    lambda config, l1_memory_desc=None: MockL2Adapter(config),
+)

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -1,12 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Future
+from __future__ import annotations
+
 # Standard
 from collections import defaultdict
+from typing import TYPE_CHECKING, Optional
 import asyncio
 import copy
 import os
 import threading
 import time
+
+if TYPE_CHECKING:
+    from lmcache.v1.distributed.internal_api import (
+        L1MemoryDesc,
+    )
 
 # First Party
 from lmcache.native_storage_ops import Bitmap
@@ -14,8 +23,10 @@ from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
-    register_l2_adapter_factory,
     register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
 )
 from lmcache.v1.memory_management import MemoryObj, TensorMemoryObj
 
@@ -475,7 +486,14 @@ class MockL2Adapter(L2AdapterInterface):
 
 # Self-register config type and adapter factory
 register_l2_adapter_type("mock", MockL2AdapterConfig)
-register_l2_adapter_factory(
-    "mock",
-    lambda config, l1_memory_desc=None: MockL2Adapter(config),
-)
+
+
+def _create_mock_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> L2AdapterInterface:
+    """Create a MockL2Adapter from config."""
+    return MockL2Adapter(config)  # type: ignore[arg-type]
+
+
+register_l2_adapter_factory("mock", _create_mock_adapter)

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -475,6 +475,4 @@ class MockL2Adapter(L2AdapterInterface):
 
 # Self-register config type and adapter factory
 register_l2_adapter_type("mock", MockL2AdapterConfig)
-register_l2_adapter_factory(
-    "mock", lambda config, **kwargs: MockL2Adapter(config)
-)
+register_l2_adapter_factory("mock", lambda config, **kwargs: MockL2Adapter(config))

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -12,7 +12,11 @@ import time
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_factory,
+    register_l2_adapter_type,
+)
 from lmcache.v1.memory_management import MemoryObj, TensorMemoryObj
 
 # Helper function
@@ -34,6 +38,52 @@ def clone_tensor_memory_obj(obj: MemoryObj) -> TensorMemoryObj:
     )
 
     return new_obj
+
+
+# Config class
+
+
+class MockL2AdapterConfig(L2AdapterConfigBase):
+    """
+    Config for a mock L2 adapter (for testing).
+
+    Fields:
+    - max_size_gb: maximum size in GB.
+    - mock_bandwidth_gb: simulated bandwidth in GB/sec.
+    """
+
+    def __init__(
+        self,
+        max_size_gb: float,
+        mock_bandwidth_gb: float,
+    ):
+        self.max_size_gb = max_size_gb
+        self.mock_bandwidth_gb = mock_bandwidth_gb
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "MockL2AdapterConfig":
+        max_size_gb = d.get("max_size_gb")
+        if not isinstance(max_size_gb, (int, float)) or max_size_gb <= 0:
+            raise ValueError("max_size_gb must be a positive number")
+
+        mock_bandwidth_gb = d.get("mock_bandwidth_gb")
+        if not isinstance(mock_bandwidth_gb, (int, float)) or mock_bandwidth_gb <= 0:
+            raise ValueError("mock_bandwidth_gb must be a positive number")
+
+        return cls(
+            max_size_gb=max_size_gb,
+            mock_bandwidth_gb=mock_bandwidth_gb,
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "Mock L2 adapter config fields:\n"
+            "- max_size_gb (float): maximum size of "
+            "the adapter in GB (required, >0)\n"
+            "- mock_bandwidth_gb (float): simulated "
+            "bandwidth in GB/sec (required, >0)"
+        )
 
 
 # Main class
@@ -421,3 +471,10 @@ class MockL2Adapter(L2AdapterInterface):
         with self._lock:
             self._completed_load_tasks[task_id] = bitmap
         self._signal_load_event()
+
+
+# Self-register config type and adapter factory
+register_l2_adapter_type("mock", MockL2AdapterConfig)
+register_l2_adapter_factory(
+    "mock", lambda config, **kwargs: MockL2Adapter(config)
+)

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Future
+from __future__ import annotations
+
 # Standard
 from dataclasses import dataclass, field
 from typing import Optional
@@ -23,7 +26,13 @@ from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.internal_api import L1MemoryDesc
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
-from lmcache.v1.distributed.l2_adapters.config import NixlStoreL2AdapterConfig
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
+)
 from lmcache.v1.memory_management import MemoryObj
 
 logger = init_logger(__name__)
@@ -782,3 +791,116 @@ class NixlStoreL2Adapter(L2AdapterInterface):
         with self._lock:
             self._completed_load_tasks[task_id] = bitmap
         self._signal_load_event()
+
+
+# ---------------------------------------------------------------------
+# Config and self-registration
+# ---------------------------------------------------------------------
+
+_VALID_NIXL_BACKENDS = (
+    "GDS",
+    "GDS_MT",
+    "POSIX",
+    "HF3FS",
+    "OBJ",
+)
+_FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS")
+
+
+class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
+    """
+    Config for a Nixl-store-based L2 adapter.
+
+    Fields:
+    - backend: Nixl storage backend
+      (GDS, GDS_MT, POSIX, HF3FS, OBJ).
+    - backend_params: Backend-specific parameters as a
+      dict of string key-value pairs. For file-based
+      backends (GDS, GDS_MT, POSIX, HF3FS), must include
+      ``file_path``. May also include ``use_direct_io``
+      (default ``"false"``) and other backend-specific
+      keys.
+    - pool_size: Number of storage descriptors to
+      pre-allocate (must be > 0).
+    """
+
+    def __init__(
+        self,
+        backend: str,
+        backend_params: dict[str, str],
+        pool_size: int,
+    ):
+        if backend in _FILE_BACKENDS:
+            if "file_path" not in backend_params:
+                raise ValueError(
+                    "backend_params must include "
+                    "'file_path' for file-based "
+                    "backend %r" % backend
+                )
+            if "use_direct_io" not in backend_params:
+                raise ValueError(
+                    "backend_params must include "
+                    "'use_direct_io' for file-based "
+                    "backend %r" % backend
+                )
+        self.backend = backend
+        self.backend_params = backend_params
+        self.pool_size = pool_size
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NixlStoreL2AdapterConfig":
+        backend = d.get("backend")
+        if backend not in _VALID_NIXL_BACKENDS:
+            raise ValueError(
+                "backend must be one of %s, got %r" % (_VALID_NIXL_BACKENDS, backend)
+            )
+
+        backend_params = d.get("backend_params", {})
+        if not isinstance(backend_params, dict):
+            raise ValueError("backend_params must be a dict of string key-value pairs")
+
+        pool_size = d.get("pool_size")
+        if not isinstance(pool_size, int) or pool_size <= 0:
+            raise ValueError("pool_size must be a positive integer")
+
+        return cls(
+            backend=backend,
+            backend_params=backend_params,
+            pool_size=pool_size,
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "Nixl store L2 adapter config fields:\n"
+            "- backend (str): Nixl storage backend, "
+            "one of %s (required)\n"
+            "- backend_params (dict): backend-specific "
+            "string key-value pairs (optional, "
+            "default empty). File-based backends "
+            "require file_path. Optional keys include "
+            "'use_direct_io' (default 'false') and "
+            "'file_size' (int, size in bytes of each "
+            "storage file slot; defaults to the L1 "
+            "page size if not set).\n"
+            "- pool_size (int): number of storage "
+            "descriptors to pre-allocate (required, "
+            ">0)" % (_VALID_NIXL_BACKENDS,)
+        )
+
+
+# Self-register config type and adapter factory
+register_l2_adapter_type("nixl_store", NixlStoreL2AdapterConfig)
+
+
+def _create_nixl_store_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: Optional[L1MemoryDesc] = None,
+) -> L2AdapterInterface:
+    """Create a NixlStoreL2Adapter from config."""
+    if l1_memory_desc is None:
+        raise ValueError("l1_memory_desc is required to create a NixlStoreL2Adapter.")
+    return NixlStoreL2Adapter(config, l1_memory_desc)  # type: ignore[arg-type]
+
+
+register_l2_adapter_factory("nixl_store", _create_nixl_store_adapter)

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -20,8 +20,8 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
-    MockL2AdapterConfig,
 )
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 
 try:
     # First Party

--- a/tests/v1/distributed/test_mock_l2_adapter.py
+++ b/tests/v1/distributed/test_mock_l2_adapter.py
@@ -17,8 +17,10 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObjMetadata,

--- a/tests/v1/distributed/test_nixl_store_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_l2_adapter.py
@@ -21,11 +21,9 @@ nixl = pytest.importorskip("nixl")
 # First Party
 from lmcache.v1.distributed.api import ObjectKey  # noqa: E402
 from lmcache.v1.distributed.internal_api import L1MemoryDesc  # noqa: E402
-from lmcache.v1.distributed.l2_adapters.config import (  # noqa: E402
-    NixlStoreL2AdapterConfig,
-)
 from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (  # noqa: E402
     NixlStoreL2Adapter,
+    NixlStoreL2AdapterConfig,
 )
 from lmcache.v1.memory_management import (  # noqa: E402
     MemoryFormat,

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -22,8 +22,10 @@ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
 from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
     PrefetchController,
 )

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -9,7 +9,7 @@ prefetch_policy.py.
 # First Party
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
 )

--- a/tests/v1/distributed/test_report_status.py
+++ b/tests/v1/distributed/test_report_status.py
@@ -19,6 +19,8 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
     MockL2AdapterConfig,
 )
 

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -21,8 +21,10 @@ import torch
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
 from lmcache.v1.distributed.l1_manager import L1Manager
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
-from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2Adapter
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
 from lmcache.v1.distributed.storage_controllers.store_controller import (
     StoreController,
     StoreListener,

--- a/tests/v1/distributed/test_store_policy.py
+++ b/tests/v1/distributed/test_store_policy.py
@@ -9,7 +9,7 @@ Tests are written against the StorePolicy contract defined in store_policy.py.
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.l2_adapters.config import MockL2AdapterConfig
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
     DefaultStorePolicy,


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Add `FSL2Adapter` — a filesystem-backed L2 adapter that stores KV cache chunks
as raw tensor files on disk. This enables persistent L2 caching across restarts.

**What changed:**

- New `fs_l2_adapter.py`: async disk I/O via aiofiles, atomic writes (tmp + rename),
  O_DIRECT support, read-ahead, and startup file scanning.
- Refactored `config.py` and `__init__.py` to use a registry + `pkgutil.iter_modules`
  auto-discovery mechanism. Adding a new L2 adapter no longer requires modifying any
  existing code — just drop a new module in the `l2_adapters/` package.
- Moved `MockL2AdapterConfig` and `FSL2AdapterConfig` into their respective adapter
  modules for self-contained registration.

**Config options (all align with FSConnector naming):**
```json
{ "type": "fs", "base_path": "/path/to/l2_cache", "relative_tmp_dir": ".tmp", "read_ahead_size": 65536, "use_odirect": true }
```

**Test**

- Start.sh
```
#!/bin/bash
# LMCache Server 启动
python3 -m lmcache.v1.multiprocess.server \
    --host localhost \
    --port 15555 \
    --chunk-size 256 \
    --l1-size-gb 5 \
    --eviction-policy LRU \
    --max-workers 1 \
    --l2-adapter '{"type":"fs","base_path":"/data1/baoloongmao/data/20260306/mp_mode/l2_cache"}' \
    2>&1 | tee /data1/LMCache/logs/lmcache_server.log &

# vLLM Server 启动
KV_TRANSFER_CONFIG='{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.port":15555}}'

python3 -m vllm.entrypoints.cli.main serve /data1/model/DeepSeek-V2-Lite-Chat/ \
    -tp 8 \
    --load-format dummy \
    --trust-remote-code \
    --served-model-name vllm_cpu_offload \
    --gpu_memory_utilization 0.5 \
    --max-num-seqs 64 \
    --no-enable-prefix-caching \
    --port 8000 \
    --kv-transfer-config "${KV_TRANSFER_CONFIG}" \
    2>&1 | tee /data1/LMCache/logs/vllm_server.log &
```

- Logs

```

 ls /data1/baoloongmao/data/20260306/mp_mode/l2_cache/
-SEP-data1-SEP-model-SEP-DeepSeek-V2-Lite-Chat-SEP-@0x01000100@f8466387aa1f22723b242e09cfca1311eff3945905bfd40fb67307b6b6fbae8f.data


[2026-03-06 22:09:12,569] LMCache INFO: Initialized FSL2Adapter with base_path=/data1/baoloongmao/data/20260306/mp_mode/l2_cache, relative_tmp_dir=None, scan_on_startup=True, read_ahead_size=None, use_odirect=False, found 1 existing files (fs_l2_adapter.py:277:lmcache.v1.distributed.l2_adapters.fs_l2_adapter)
===
[2026-03-06 22:09:14,842] LMCache INFO: LMCache cache server is running... (server.py:671:__main__)
```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
