### PR TITLE
[Correctness]: Fix the overlapping race condition for non-MP as well

### DIFF
--- a/.buildkite/k3_tests/correctness/scripts/run-correctness.sh
+++ b/.buildkite/k3_tests/correctness/scripts/run-correctness.sh
@@ -126,7 +126,7 @@ stop_vllm
 
 echo "[INFO] Preparing LMCache config (cpu.yaml)..."
 cat <<EOF > cpu.yaml
-chunk_size: 16
+chunk_size: 256
 local_cpu: true
 max_local_cpu_size: 50
 EOF

--- a/.buildkite/scripts/vllm-correctness.sh
+++ b/.buildkite/scripts/vllm-correctness.sh
@@ -173,8 +173,8 @@ stop_vllm
 #######################################
 echo "[INFO] Preparing LMCache config (cpu.yaml)..."
 cat <<EOF > cpu.yaml
-chunk_size: 16
-local_cpu: true 
+chunk_size: 256
+local_cpu: true
 max_local_cpu_size: 50
 EOF
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -805,13 +805,6 @@ class LMCacheConnectorV1Impl:
             )
             token_mask[:masked_token_count] = False
 
-            # prevent lmcache from overwriting APC-shared blocks:
-            # setting slot_mapping=-1 makes the xfer kernel skip
-            # those tokens (checks slot_idx < 0).
-            vllm_cached_tokens = request.load_spec.vllm_cached_tokens
-            if vllm_cached_tokens > masked_token_count:
-                slot_mapping[masked_token_count:vllm_cached_tokens] = -1
-
             lmcache_cached_tokens = request.load_spec.lmcache_cached_tokens
             if self.use_layerwise:
                 if idx == last_idx:
@@ -826,6 +819,7 @@ class LMCacheConnectorV1Impl:
                         token_mask[:lmcache_cached_tokens],
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
+                        vllm_cached_tokens=request.load_spec.vllm_cached_tokens,
                     )
                 else:
                     layerwise_retriever = self.lmcache_engine.retrieve_layer(
@@ -833,6 +827,7 @@ class LMCacheConnectorV1Impl:
                         token_mask[:lmcache_cached_tokens],
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
+                        vllm_cached_tokens=request.load_spec.vllm_cached_tokens,
                         sync=sync,
                     )
                     # NOTE: retrieve for two layers at the first layer
@@ -845,6 +840,7 @@ class LMCacheConnectorV1Impl:
                     token_mask[:lmcache_cached_tokens],
                     kvcaches=kvcaches,
                     slot_mapping=slot_mapping[:lmcache_cached_tokens],
+                    vllm_cached_tokens=request.load_spec.vllm_cached_tokens,
                     request_configs=request.request_configs,
                     req_id=request.req_id,
                 )

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -805,6 +805,13 @@ class LMCacheConnectorV1Impl:
             )
             token_mask[:masked_token_count] = False
 
+            # prevent lmcache from overwriting APC-shared blocks:
+            # setting slot_mapping=-1 makes the xfer kernel skip
+            # those tokens (checks slot_idx < 0).
+            vllm_cached_tokens = request.load_spec.vllm_cached_tokens
+            if vllm_cached_tokens > masked_token_count:
+                slot_mapping[masked_token_count:vllm_cached_tokens] = -1
+
             lmcache_cached_tokens = request.load_spec.lmcache_cached_tokens
             if self.use_layerwise:
                 if idx == last_idx:

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -287,7 +287,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         # this will only be potentially non-zero for the first
         # block lmcache is transferring back
         vllm_cached = kwargs.get("vllm_cached_tokens", 0)
-        skip_prefix_n_tokens = max(0, vllm_cached - start)
+        skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         lmc_ops.multi_layer_kv_transfer(
             memory_obj.tensor,
@@ -480,7 +480,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         # this will only be potentially non-zero for the first
         # block lmcache is transferring back
         vllm_cached = kwargs.get("vllm_cached_tokens", 0)
-        skip_prefix_n_tokens = max(0, vllm_cached - start)
+        skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
             memory_obj_tensor = memory_obj.get_tensor(i)

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -283,6 +283,12 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 
         kv_cache_pointers = self._initialize_pointers(self.kvcaches)
 
+        # avoid read/write stream race condition for shared block
+        # this will only be potentially non-zero for the first
+        # block lmcache is transferring back
+        vllm_cached = kwargs.get("vllm_cached_tokens", 0)
+        skip_prefix_n_tokens = max(0, vllm_cached - start)
+
         lmc_ops.multi_layer_kv_transfer(
             memory_obj.tensor,
             kv_cache_pointers,
@@ -292,6 +298,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             lmc_ops.TransferDirection.H2D,
             self.gpu_kv_format,
             self.block_size,
+            skip_prefix_n_tokens,
         )
 
     @_lmcache_nvtx_annotate
@@ -468,6 +475,13 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         assert self.kvcaches[0].device == self.device
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
+
+        # avoid read/write stream race condition for shared block
+        # this will only be potentially non-zero for the first
+        # block lmcache is transferring back
+        vllm_cached = kwargs.get("vllm_cached_tokens", 0)
+        skip_prefix_n_tokens = max(0, vllm_cached - start)
+
         for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
             memory_obj_tensor = memory_obj.get_tensor(i)
             assert memory_obj_tensor is not None
@@ -480,6 +494,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 lmc_ops.TransferDirection.H2D,
                 self.gpu_kv_format,
                 self.block_size,
+                skip_prefix_n_tokens,
             )
 
     @_lmcache_nvtx_annotate


### PR DESCRIPTION
essentially the same issue as https://github.com/LMCache/LMCache/pull/2671/ where the read and write stream have a race condition on shared prefix blocks across requests.

Why was this not caught by the previous correctnes tests. 

the high concurrency had the same lmcache chunk size as the vllm block size which avoids this error. 
the single request only had one request which was not enough concurrency to tirgger the race condition.

this PR also changes the chunk size of teh high concucrrency correctness test back to 256