### PR TITLE
[MP][Telemetry] Hot-fix to enable the telemetry logging for store

### DIFF
--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -178,6 +178,11 @@ class MPCacheEngine:
         )
         self.session_manager = SessionManager(self.token_hasher)
 
+        # FIX: fix the problem of telemetry logging in cupy stream
+        # Need to log a retrieve operation before logging any store
+        # operation in the cupy stream
+        self._can_log_store = False
+
     def register_kv_cache(
         self,
         instance_id: int,
@@ -272,14 +277,15 @@ class MPCacheEngine:
             # NOTE (ApostaC): this will hang the whole process in some special
             # environments, need to investigate more. Temporarily disable telemetry
             # for store operation.
-            # if get_telemetry_controller().is_enabled():
-            #    gpu_context.cupy_stream.launch_host_func(
-            #        log_telemetry,
-            #        make_start_event(
-            #            "store", key.request_id,
-            #            device=str(gpu_context.device),
-            #        ),
-            #    )
+            if get_telemetry_controller().is_enabled() and self._can_log_store:
+                gpu_context.cupy_stream.launch_host_func(
+                    log_telemetry,
+                    make_start_event(
+                        "store",
+                        key.request_id,
+                        device=str(gpu_context.device),
+                    ),
+                )
 
             layout_desc = get_layout_desc(gpu_context, self.chunk_size)
             reserved_dict = self.storage_manager.reserve_write(
@@ -323,15 +329,16 @@ class MPCacheEngine:
         # NOTE (ApostaC): As stated above, the telemetry for store operation is
         # temporarily disabled due to hanging issue in some special environments.
         # Need to investigate more before enabling it again.
-        # if get_telemetry_controller().is_enabled():
-        #    self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
-        #        log_telemetry,
-        #        make_end_event(
-        #            "store", key.request_id,
-        #            stored_count=len(reserved_dict),
-        #            device=str(gpu_context.device),
-        #        ),
-        #    )
+        if get_telemetry_controller().is_enabled() and self._can_log_store:
+            self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
+                log_telemetry,
+                make_end_event(
+                    "store",
+                    key.request_id,
+                    stored_count=len(reserved_dict),
+                    device=str(gpu_context.device),
+                ),
+            )
 
         ed = time.perf_counter()
         if length := len(reserved_dict):
@@ -479,6 +486,7 @@ class MPCacheEngine:
             ed - st,
         )
 
+        self._can_log_store = True
         return event.ipc_handle(), True
 
     def lookup(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -274,9 +274,6 @@ class MPCacheEngine:
             )
             vllm_event.wait(stream=gpu_context.stream)
 
-            # NOTE (ApostaC): this will hang the whole process in some special
-            # environments, need to investigate more. Temporarily disable telemetry
-            # for store operation.
             if get_telemetry_controller().is_enabled() and self._can_log_store:
                 gpu_context.cupy_stream.launch_host_func(
                     log_telemetry,
@@ -326,9 +323,6 @@ class MPCacheEngine:
             list(reserved_dict.keys()),
         )
 
-        # NOTE (ApostaC): As stated above, the telemetry for store operation is
-        # temporarily disabled due to hanging issue in some special environments.
-        # Need to investigate more before enabling it again.
         if get_telemetry_controller().is_enabled() and self._can_log_store:
             self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
                 log_telemetry,


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-enables telemetry logging for store operations in the CuPy stream, which was previously disabled due to a hanging issue in certain environments.

The fix introduces a `_can_log_store` flag that gates store telemetry logging until after the first retrieve operation completes. This ensures a retrieve operation is always logged in the CuPy stream before any store operation, which avoids the hanging behavior.

**Special notes for your reviewers**:

The root cause of the hang appears to be related to logging a store telemetry event in the CuPy stream before any retrieve event has been logged. The flag-based ordering constraint is a minimal fix that preserves the telemetry data while avoiding the problematic code path.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests