### PR TITLE
[CI][MP] Enable async scheduling in multiprocessing test

### DIFF
--- a/.buildkite/scripts/multiprocessing-test/launch-containers.sh
+++ b/.buildkite/scripts/multiprocessing-test/launch-containers.sh
@@ -93,7 +93,6 @@ docker run -d \
     --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT}}" \
     --attention-backend FLASH_ATTN \
     --port "$VLLM_PORT" \
-    --no-async-scheduling \
     $GPU_MEMORY_UTIL_ARG
 
 echo "vLLM container started"
@@ -116,7 +115,6 @@ docker run -d \
     "$MODEL" \
     --port "$VLLM_BASELINE_PORT" \
     --attention-backend FLASH_ATTN \
-    --no-async-scheduling \
     $GPU_MEMORY_UTIL_ARG
 
 echo "vLLM baseline container started"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `--no-async-scheduling` from both the vLLM and baseline containers in the multiprocessing CI test script (`launch-containers.sh`). This enables async scheduling in MP CI tests, which better reflects production configurations.

**Special notes for your reviewers**:

Two-line deletion only — removes the `--no-async-scheduling` flag from both container launch commands.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests