### PR TITLE
[MP][UX][Docs] Enhance http server and its docs for MP mode

### DIFF
--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -56,7 +56,9 @@ which adds CacheBlend operations (``CB_REGISTER_KV_CACHE``,
 cache reuse across document paragraphs.
 
 **``http_server.py``** -- Wraps ``run_cache_server()`` (from ``server.py``)
-inside a FastAPI application.  Adds ``/api/healthcheck`` for Kubernetes probes.
+inside a FastAPI application.  Adds ``/api/healthcheck`` for Kubernetes probes,
+``POST /api/clear-cache`` for clearing all KV cache data in L1 (CPU) memory,
+and ``/api/status`` for inspecting detailed internal state.
 The ZMQ server runs as part of the same process.
 
 ZMQ Protocol
@@ -343,7 +345,7 @@ Key Source Files
    * - ``lmcache/v1/multiprocess/blend_server.py``
      - BlendEngine (extends MPCacheEngine)
    * - ``lmcache/v1/multiprocess/http_server.py``
-     - FastAPI wrapper with healthcheck
+     - FastAPI wrapper with health check and many other useful APIs
    * - ``lmcache/v1/multiprocess/protocols/base.py``
      - RequestType, HandlerType, ProtocolDefinition
    * - ``lmcache/v1/distributed/storage_manager.py``

--- a/docs/source/mp/deployment.rst
+++ b/docs/source/mp/deployment.rst
@@ -44,8 +44,8 @@ Required Docker flags:
 
 **HTTP server variant:**
 
-For health-check support (useful with container orchestrators), use the HTTP
-server entry point:
+For health-check and cache management API support (useful with container
+orchestrators), use the HTTP server entry point:
 
 .. code-block:: bash
 

--- a/docs/source/mp/quickstart.rst
+++ b/docs/source/mp/quickstart.rst
@@ -127,9 +127,8 @@ Docker Quick Start
 HTTP Server Quick Start
 -----------------------
 
-The HTTP server wraps the ZMQ server with a FastAPI frontend, adding an
-``/api/healthcheck`` endpoint suitable for Kubernetes liveness and readiness
-probes.
+The HTTP server wraps the ZMQ server with a FastAPI frontend, adding HTTP
+management endpoints for health checking and cache administration.
 
 .. code-block:: bash
 
@@ -139,12 +138,43 @@ probes.
 The HTTP server listens on ``0.0.0.0:8000`` by default (configurable with
 ``--http-host`` and ``--http-port``).
 
-Health check:
+**Endpoints:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 25 60
+
+   * - Method
+     - Path
+     - Description
+   * - GET
+     - ``/api/healthcheck``
+     - Returns ``{"status": "healthy"}`` when the engine is initialized and
+       memory checks pass. Suitable for Kubernetes liveness/readiness probes.
+   * - POST
+     - ``/api/clear-cache``
+     - Force-clears all KV cache data stored in L1 (CPU) memory, including
+       objects with active read/write locks. Returns ``{"status": "ok"}`` on
+       success.
+   * - GET
+     - ``/api/status``
+     - Returns detailed internal state of all MP components including L1 cache,
+       L2 adapters, controllers, registered GPUs, and active sessions.
+
+Examples:
 
 .. code-block:: bash
 
+    # Health check
     curl http://localhost:8000/api/healthcheck
     # {"status": "healthy"}
+
+    # Clear all KV cache data in L1 (CPU) memory
+    curl -X POST http://localhost:8000/api/clear-cache
+    # {"status": "ok"}
+
+    # Inspect detailed internal state
+    curl http://localhost:8000/api/status
 
 The ZMQ server runs on the same default port (5555) and accepts vLLM
 connections exactly as in the local quick start.

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -69,6 +69,18 @@ from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
     init_prometheus_controller,
 )
+from lmcache.v1.mp_observability.telemetry import (
+    TelemetryConfig,
+    get_telemetry_controller,
+    init_telemetry_controller,
+)
+from lmcache.v1.mp_observability.telemetry.config import (
+    DEFAULT_TELEMETRY_CONFIG,
+)
+from lmcache.v1.multiprocess.config import (
+    MPServerConfig,
+    parse_args_to_mp_server_config,
+)
 from lmcache.v1.multiprocess.custom_types import (
     CBMatchResult,
     IPCCacheEngineKey,
@@ -727,47 +739,46 @@ def add_handler_helper(
 
 
 def run_cache_server(
+    mp_config: MPServerConfig,
     storage_manager_config: StorageManagerConfig,
     prometheus_config: PrometheusConfig,
-    host: str = "localhost",
-    port: int = 5555,
-    chunk_size: int = 256,
-    max_workers: int = 1,
+    telemetry_config: TelemetryConfig = DEFAULT_TELEMETRY_CONFIG,
     return_engine: bool = False,
-    hash_algorithm: str = "blake3",
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
 
     Args:
+        mp_config: Configuration for the ZMQ multiprocess server
         storage_manager_config: Configuration for the storage manager
         prometheus_config: Configuration for the Prometheus observability stack
-        host: ZMQ server host
-        port: ZMQ server port
-        chunk_size: Chunk size for KV cache operations
-        max_workers: Maximum number of worker threads for ZMQ server
+        telemetry_config: Configuration for the telemetry event system
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
-        hash_algorithm: Hash algorithm for token-based operations
 
     Returns:
-        If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
+        If return_engine is True: tuple of (MessageQueueServer, BlendEngineV2)
         If return_engine is False: None (blocks until interrupted)
     """
     # Initialize global prometheus controller
     init_prometheus_controller(prometheus_config)
 
+    # Initialize global telemetry controller
+    init_telemetry_controller(telemetry_config)
+
     # Initialize the engine (loggers self-register with the global controller)
     engine = BlendEngineV2(
         storage_manager_config=storage_manager_config,
-        chunk_size=chunk_size,
-        hash_algorithm=hash_algorithm,
+        chunk_size=mp_config.chunk_size,
+        hash_algorithm=mp_config.hash_algorithm,
     )
 
     # Initialize the message queue server
     context = zmq.Context.instance()
     server = MessageQueueServer(
-        bind_url=f"tcp://{host}:{port}", context=context, max_workers=max_workers
+        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
+        context=context,
+        max_workers=mp_config.max_workers,
     )
 
     # Add handlers for original server
@@ -805,13 +816,20 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.CB_STORE_FINAL, engine.cb_store_final)
 
-    logger.info("LMCache ZMQ cache server is running on tcp://%s:%d", host, port)
+    logger.info(
+        "LMCache ZMQ cache server is running on tcp://%s:%d",
+        mp_config.host,
+        mp_config.port,
+    )
     # Start the ZMQ server
     torch.cuda.init()
     server.start()
 
     # Start prometheus controller after engine creation (loggers are registered)
     get_prometheus_controller().start()
+
+    # Start telemetry controller
+    get_telemetry_controller().start()
     logger.info("LMCache cache blend v2 server is running...")
 
     # Return server and engine if requested (for HTTP server integration)
@@ -824,6 +842,7 @@ def run_cache_server(
             time.sleep(1)
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
+        get_telemetry_controller().stop()
         get_prometheus_controller().stop()
         server.close()
         engine.close()
@@ -831,14 +850,11 @@ def run_cache_server(
 
 if __name__ == "__main__":
     args = parse_args()
+    mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
     run_cache_server(
+        mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
-        host=args.host,
-        port=args.port,
-        chunk_size=args.chunk_size,
-        max_workers=args.max_workers,
-        hash_algorithm=args.hash_algorithm,
     )

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -28,6 +28,11 @@ class MPServerConfig:
     hash_algorithm: str = "blake3"
     """Hash algorithm for token-based operations (builtin, sha256_cbor, blake3)."""
 
+    engine_type: str = "default"
+    """Cache engine backend type 
+    ('default' for MPCacheEngine, 'blend' for BlendEngineV2).
+    """
+
 
 DEFAULT_MP_SERVER_CONFIG = MPServerConfig()
 
@@ -92,6 +97,15 @@ def add_mp_server_args(
         help="Hash algorithm for token-based operations "
         "(builtin, sha256_cbor, blake3). Default is blake3.",
     )
+    mp_group.add_argument(
+        "--engine-type",
+        type=str,
+        default="default",
+        choices=["default", "blend"],
+        help="Cache engine backend type. 'default' uses MPCacheEngine, "
+        "'blend' uses BlendEngineV2 for cross-request KV reuse. "
+        "Default is 'default'.",
+    )
     return parser
 
 
@@ -113,6 +127,7 @@ def parse_args_to_mp_server_config(
         chunk_size=args.chunk_size,
         max_workers=args.max_workers,
         hash_algorithm=args.hash_algorithm,
+        engine_type=args.engine_type,
     )
 
 

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -102,13 +102,27 @@ async def healthcheck(request: Request):
             content={"status": "unhealthy", "reason": "engine not initialized"},
         )
 
-    if not engine.storage_manager.memcheck():
+    return {"status": "healthy"}
+
+
+@app.post("/api/clear-cache")
+async def clear_cache(request: Request):
+    """
+    Force-clear all KV cache data stored in L1 (CPU) memory.
+
+    This clears all objects including those with active read/write locks.
+    In-flight store or prefetch operations may be corrupted.
+    """
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None:
         return JSONResponse(
             status_code=503,
-            content={"status": "unhealthy", "reason": "memory check failed"},
+            content={"status": "error", "reason": "engine not initialized"},
         )
 
-    return {"status": "healthy"}
+    engine.clear()
+    logger.info("Cache cleared via HTTP API")
+    return {"status": "ok"}
 
 
 @app.get("/api/status")

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -32,7 +32,6 @@ from lmcache.v1.multiprocess.config import (
     parse_args_to_http_frontend_config,
     parse_args_to_mp_server_config,
 )
-from lmcache.v1.multiprocess.server import run_cache_server
 
 logger = init_logger(__name__)
 
@@ -58,8 +57,16 @@ async def lifespan(app: FastAPI):
         "Starting LMCache HTTP server... (CUDA available: %s)",
         torch.cuda.is_available(),
     )
+    mp_config = _configs["mp"]
+    if mp_config.engine_type == "blend":
+        # First Party
+        from lmcache.v1.multiprocess.blend_server_v2 import run_cache_server
+    else:
+        # First Party
+        from lmcache.v1.multiprocess.server import run_cache_server
+
     zmq_server, engine = run_cache_server(
-        mp_config=_configs["mp"],
+        mp_config=mp_config,
         storage_manager_config=_configs["storage_manager"],
         prometheus_config=_configs["prometheus"],
         return_engine=True,

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -413,7 +413,14 @@ def server_process_runner_v2(
     """Entry point for the server process running BlendEngineV2."""
     # First Party
     from lmcache.v1.multiprocess.blend_server_v2 import run_cache_server
+    from lmcache.v1.multiprocess.config import MPServerConfig
 
+    mp_config = MPServerConfig(
+        host=host,
+        port=port,
+        chunk_size=chunk_size,
+        engine_type="blend",
+    )
     storage_manager_config = StorageManagerConfig(
         l1_manager_config=L1ManagerConfig(
             memory_config=L1MemoryManagerConfig(
@@ -424,11 +431,9 @@ def server_process_runner_v2(
         eviction_config=EvictionConfig(eviction_policy="LRU"),
     )
     run_cache_server(
+        mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=DEFAULT_PROMETHEUS_CONFIG,
-        host=host,
-        port=port,
-        chunk_size=chunk_size,
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `POST /api/clear-cache` endpoint to the MP mode HTTP server that force-clears all KV cache data stored in L1 (CPU) memory. Also simplifies the `/api/healthcheck` endpoint by removing the expensive `memcheck()` call — it now only checks that the engine is initialized.

Updates the MP mode documentation (quickstart, architecture, deployment) to cover all HTTP API endpoints including the new `clear-cache`, the upstream `status` endpoint, and the simplified healthcheck.

**Special notes for your reviewers**:

The `/api/status` endpoint was added upstream — this PR only adds its documentation.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests