### PR TITLE
[MP][Hotfix] add default implementation for report_status

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -275,11 +275,14 @@ class L2AdapterInterface(ABC):
     # Status Interface
     #####################
 
-    @abstractmethod
     def report_status(self) -> dict:
         """
         Return a status dict for this adapter.
 
         Must include at least ``is_healthy: bool``.
+        Subclasses should override this with adapter-specific metrics.
         """
-        pass
+        return {
+            "is_healthy": True,
+            "extra_warning": "report_status is not implemented and runs default impl",
+        }

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -563,6 +563,31 @@ class NixlStoreL2Adapter(L2AdapterInterface):
         os.close(self._lookup_efd)
         os.close(self._load_efd)
 
+    #####################
+    # Status Interface
+    #####################
+
+    def report_status(self) -> dict:
+        """Return a status dict for the Nixl L2 adapter."""
+        with self._lock:
+            stored_object_count = len(self._memory_objects)
+            pinned_object_count = sum(
+                1 for obj in self._memory_objects.values() if obj.pin_count > 0
+            )
+        pool = self.nixl_agent.pool
+        with pool._lock:
+            pool_free_slots = len(pool.indices)
+        return {
+            "is_healthy": self._loop_thread.is_alive(),
+            "type": "NixlStoreL2Adapter",
+            "backend": self._config.backend,
+            "stored_object_count": stored_object_count,
+            "pinned_object_count": pinned_object_count,
+            "pool_size": self._config.pool_size,
+            "pool_free_slots": pool_free_slots,
+            "event_loop_alive": self._loop_thread.is_alive(),
+        }
+
     ##################
     # Helper functions
     ##################

--- a/tests/v1/distributed/test_nixl_store_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_l2_adapter.py
@@ -726,3 +726,82 @@ class TestCloseInterface:
         # Should not raise
         adpt.close()
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# =============================================================================
+# Report Status Tests
+# =============================================================================
+
+
+class TestReportStatus:
+    """Tests for NixlStoreL2Adapter.report_status()."""
+
+    def test_report_status_shape(self, adapter):
+        """report_status() should return all expected keys with correct types."""
+        adpt, _ = adapter
+        status = adpt.report_status()
+
+        assert status["is_healthy"] is True
+        assert status["type"] == "NixlStoreL2Adapter"
+        assert status["backend"] == "POSIX"
+        assert isinstance(status["stored_object_count"], int)
+        assert isinstance(status["pinned_object_count"], int)
+        assert isinstance(status["pool_size"], int)
+        assert isinstance(status["pool_free_slots"], int)
+        assert isinstance(status["event_loop_alive"], bool)
+
+    def test_report_status_initial_state(self, adapter):
+        """Fresh adapter should report zero stored objects and full pool."""
+        adpt, _ = adapter
+        status = adpt.report_status()
+
+        assert status["stored_object_count"] == 0
+        assert status["pinned_object_count"] == 0
+        assert status["pool_size"] == POOL_SIZE
+        assert status["pool_free_slots"] > 0
+        assert status["event_loop_alive"] is True
+
+    def test_report_status_after_store(self, adapter):
+        """stored_object_count should increase after a store completes."""
+        adpt, buffer = adapter
+        store_fd = adpt.get_store_event_fd()
+
+        key = create_object_key(42)
+        obj = create_memory_obj(buffer, page_index=0)
+        adpt.submit_store_task([key], [obj])
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adpt.pop_completed_store_tasks()
+
+        status = adpt.report_status()
+        assert status["stored_object_count"] == 1
+        assert status["pool_free_slots"] < status["pool_size"]
+
+    def test_report_status_after_close(self):
+        """is_healthy should become False after close()."""
+        tmp_dir = tempfile.mkdtemp(prefix="nixl_l2_status_test_")
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        l1_memory = L1MemoryDesc(
+            ptr=buffer.data_ptr(),
+            size=buffer.numel(),
+            align_bytes=PAGE_SIZE,
+        )
+        config = NixlStoreL2AdapterConfig(
+            backend="POSIX",
+            backend_params={"file_path": tmp_dir, "use_direct_io": "false"},
+            pool_size=POOL_SIZE,
+        )
+        adpt = NixlStoreL2Adapter(config, l1_memory)
+
+        # Healthy before close
+        assert adpt.report_status()["is_healthy"] is True
+
+        adpt.close()
+
+        # Unhealthy after close
+        status = adpt.report_status()
+        assert status["is_healthy"] is False
+        assert status["event_loop_alive"] is False
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
**What this PR does / why we need it**:

The recently merged report_status subsystem (PR #2699) requires all L2 adapters to implement `report_status()`. This PR:

1. Adds a proper `report_status()` implementation to `NixlStoreL2Adapter`, reporting health status, backend type, stored/pinned object counts, and pool utilization.
2. Changes `L2AdapterInterface.report_status()` from an abstract method to a default implementation that returns `is_healthy: True` with an `extra_warning` field, so future L2 adapters won't crash if they haven't implemented it yet.

**Special notes for your reviewers**:

The default base class implementation includes `"extra_warning": "report_status is not implemented and runs default impl"` to signal to developers checking status output that a proper override is needed.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests