### PR TITLE
Feature/observability metrics

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -68,6 +68,12 @@ class LMCacheStats:
     interval_local_cpu_evict_count: int  # evict count
     interval_local_cpu_evict_keys_count: int  # evict keys count
     interval_local_cpu_evict_failed_count: int  # evict failed count
+    interval_local_hit_tokens: int = 0  # local tier hit tokens
+    interval_remote_hit_tokens: int = 0  # remote tier hit tokens
+    interval_local_disk_read_bytes: int = 0
+    interval_local_disk_write_bytes: int = 0
+    local_disk_read_latencies: List[float] = field(default_factory=list)
+    local_disk_write_latencies: List[float] = field(default_factory=list)
 
     interval_forced_unpin_count: int  # forced unpin count due to timeout
 
@@ -292,6 +298,12 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_count = 0
         self.interval_local_cpu_evict_keys_count = 0
         self.interval_local_cpu_evict_failed_count = 0
+        self.interval_local_hit_tokens = 0
+        self.interval_remote_hit_tokens = 0
+        self.interval_local_disk_read_bytes = 0
+        self.interval_local_disk_write_bytes = 0
+        self.local_disk_read_latencies: List[float] = []
+        self.local_disk_write_latencies: List[float] = []
 
         self.interval_forced_unpin_count = 0
 
@@ -571,6 +583,18 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_failed_count += evict_failed_count
 
     @thread_safe
+    def record_local_disk_write(self, nbytes: int, latency_s: float):
+        """Called by LocalDiskBackend after each write."""
+        self.interval_local_disk_write_bytes += nbytes
+        self.local_disk_write_latencies.append(latency_s)
+
+    @thread_safe
+    def record_local_disk_read(self, nbytes: int, latency_s: float):
+        """Called by LocalDiskBackend after each read."""
+        self.interval_local_disk_read_bytes += nbytes
+        self.local_disk_read_latencies.append(latency_s)
+
+    @thread_safe
     def update_forced_unpin_count(self, delta: int):
         self.interval_forced_unpin_count += delta
 
@@ -626,6 +650,12 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_count = 0
         self.interval_local_cpu_evict_keys_count = 0
         self.interval_local_cpu_evict_failed_count = 0
+        self.interval_local_hit_tokens = 0
+        self.interval_remote_hit_tokens = 0
+        self.interval_local_disk_read_bytes = 0
+        self.interval_local_disk_write_bytes = 0
+        self.local_disk_read_latencies.clear()
+        self.local_disk_write_latencies.clear()
 
         self.interval_forced_unpin_count = 0
 
@@ -791,6 +821,12 @@ class LMCStatsMonitor:
             interval_local_cpu_evict_count=self.interval_local_cpu_evict_count,
             interval_local_cpu_evict_keys_count=self.interval_local_cpu_evict_keys_count,
             interval_local_cpu_evict_failed_count=self.interval_local_cpu_evict_failed_count,
+            interval_local_hit_tokens=self.interval_local_hit_tokens,
+            interval_remote_hit_tokens=self.interval_remote_hit_tokens,
+            interval_local_disk_read_bytes=self.interval_local_disk_read_bytes,
+            interval_local_disk_write_bytes=self.interval_local_disk_write_bytes,
+            local_disk_read_latencies=self.local_disk_read_latencies.copy(),
+            local_disk_write_latencies=self.local_disk_write_latencies.copy(),
             interval_forced_unpin_count=self.interval_forced_unpin_count,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
@@ -1026,6 +1062,35 @@ class PrometheusLogger:
             name="lmcache:local_cpu_evict_failed_count",
             documentation="Total number of failed eviction in local cpu backend",
             labelnames=labelnames,
+        )
+
+        # Local disk I/O metrics (mirrors remote_* pattern)
+        self.counter_local_disk_read_bytes = self._create_counter(
+            name="lmcache:local_disk_read_bytes_total",
+            documentation="Total bytes read from local disk backend",
+            labelnames=labelnames,
+        )
+        self.counter_local_disk_write_bytes = self._create_counter(
+            name="lmcache:local_disk_write_bytes_total",
+            documentation="Total bytes written to local disk backend",
+            labelnames=labelnames,
+        )
+
+        disk_latency_buckets = [
+            0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1,
+            0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+        ]
+        self.histogram_local_disk_read_latency = self._create_histogram(
+            name="lmcache:local_disk_read_latency",
+            documentation="Local disk read latency (seconds)",
+            labelnames=labelnames,
+            buckets=disk_latency_buckets,
+        )
+        self.histogram_local_disk_write_latency = self._create_histogram(
+            name="lmcache:local_disk_write_latency",
+            documentation="Local disk write latency (seconds)",
+            labelnames=labelnames,
+            buckets=disk_latency_buckets,
         )
 
         self.counter_forced_unpin_count = self._create_counter(
@@ -1705,6 +1770,22 @@ class PrometheusLogger:
         self._log_counter(
             self.counter_local_cpu_evict_failed_count,
             stats.interval_local_cpu_evict_failed_count,
+        )
+        self._log_counter(
+            self.counter_local_disk_read_bytes,
+            stats.interval_local_disk_read_bytes,
+        )
+        self._log_counter(
+            self.counter_local_disk_write_bytes,
+            stats.interval_local_disk_write_bytes,
+        )
+        self._log_histogram(
+            self.histogram_local_disk_read_latency,
+            stats.local_disk_read_latencies,
+        )
+        self._log_histogram(
+            self.histogram_local_disk_write_latency,
+            stats.local_disk_write_latencies,
         )
         self._log_counter(
             self.counter_forced_unpin_count,

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -72,6 +72,7 @@ class LMCacheStats:
     interval_remote_hit_tokens: int = 0  # remote tier hit tokens
     interval_cpu_hit_tokens: int = 0    # PR4: cpu backend hit tokens
     interval_disk_hit_tokens: int = 0   # PR4: disk backend hit tokens
+    per_tier_get_latencies: Dict[str, List[float]] = field(default_factory=dict)
     interval_local_disk_read_bytes: int = 0
     interval_local_disk_write_bytes: int = 0
     local_disk_read_latencies: List[float] = field(default_factory=list)
@@ -307,6 +308,7 @@ class LMCStatsMonitor:
         self.interval_remote_hit_tokens = 0
         self.interval_cpu_hit_tokens = 0
         self.interval_disk_hit_tokens = 0
+        self.per_tier_get_latencies: Dict[str, List[float]] = {"cpu": [], "disk": [], "remote": []}
         self.interval_local_disk_read_bytes = 0
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies: List[float] = []
@@ -430,6 +432,15 @@ class LMCStatsMonitor:
         self.interval_remote_hit_tokens += retrieve_stats.remote_hit_tokens
         self.interval_cpu_hit_tokens += retrieve_stats.cpu_hit_tokens
         self.interval_disk_hit_tokens += retrieve_stats.disk_hit_tokens
+        # Per-tier get latency from detailed_metrics
+        per_backend_time = retrieve_stats.detailed_metrics.get("per_backend_get_time", {})
+        for backend, latency in per_backend_time.items():
+            if backend == "LocalCPUBackend":
+                self.per_tier_get_latencies["cpu"].append(latency)
+            elif backend == "LocalDiskBackend":
+                self.per_tier_get_latencies["disk"].append(latency)
+            elif "Remote" in backend:
+                self.per_tier_get_latencies["remote"].append(latency)
         self.clear_current_retrieve_stats()
 
         time_to_retrieve = retrieve_stats.time_to_retrieve()
@@ -671,6 +682,7 @@ class LMCStatsMonitor:
         self.interval_remote_hit_tokens = 0
         self.interval_cpu_hit_tokens = 0
         self.interval_disk_hit_tokens = 0
+        self.per_tier_get_latencies = {"cpu": [], "disk": [], "remote": []}
         self.interval_local_disk_read_bytes = 0
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies.clear()
@@ -845,6 +857,7 @@ class LMCStatsMonitor:
             interval_remote_hit_tokens=self.interval_remote_hit_tokens,
             interval_cpu_hit_tokens=self.interval_cpu_hit_tokens,
             interval_disk_hit_tokens=self.interval_disk_hit_tokens,
+            per_tier_get_latencies={k: list(v) for k, v in self.per_tier_get_latencies.items()},
             interval_local_disk_read_bytes=self.interval_local_disk_read_bytes,
             interval_local_disk_write_bytes=self.interval_local_disk_write_bytes,
             local_disk_read_latencies=self.local_disk_read_latencies.copy(),
@@ -1120,6 +1133,18 @@ class PrometheusLogger:
             name="lmcache:local_disk_evict_count",
             documentation="Total number of evictions from local disk backend",
             labelnames=labelnames,
+        )
+
+        # Per-tier retrieve get latency histograms
+        tier_get_latency_buckets = [
+            0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1,
+            0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+        ]
+        self.histogram_tier_get_latency = self._create_histogram(
+            name="lmcache:tier_get_latency",
+            documentation="Per-tier batched_get latency (seconds)",
+            labelnames=labelnames + ["tier"],
+            buckets=tier_get_latency_buckets,
         )
 
         self.counter_forced_unpin_count = self._create_counter(
@@ -1832,6 +1857,9 @@ class PrometheusLogger:
             self.counter_local_disk_evict_count,
             stats.interval_local_disk_evict_count,
         )
+        for tier, latencies in stats.per_tier_get_latencies.items():
+            for latency in latencies:
+                self.histogram_tier_get_latency.labels(**self.labels, tier=tier).observe(latency)
         self._log_counter(
             self.counter_forced_unpin_count,
             stats.interval_forced_unpin_count,

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -73,6 +73,8 @@ class LMCacheStats:
     interval_cpu_hit_tokens: int = 0    # PR4: cpu backend hit tokens
     interval_disk_hit_tokens: int = 0   # PR4: disk backend hit tokens
     per_tier_get_latencies: Dict[str, List[float]] = field(default_factory=dict)
+    interval_request_tier_served: Dict[str, int] = field(default_factory=dict)
+    per_tier_request_hit_tokens: Dict[str, List[int]] = field(default_factory=dict)
     interval_local_disk_read_bytes: int = 0
     interval_local_disk_write_bytes: int = 0
     local_disk_read_latencies: List[float] = field(default_factory=list)
@@ -309,6 +311,8 @@ class LMCStatsMonitor:
         self.interval_cpu_hit_tokens = 0
         self.interval_disk_hit_tokens = 0
         self.per_tier_get_latencies: Dict[str, List[float]] = {"cpu": [], "disk": [], "remote": []}
+        self.interval_request_tier_served: Dict[str, int] = {"cpu": 0, "disk": 0, "remote": 0, "mixed": 0, "miss": 0}
+        self.per_tier_request_hit_tokens: Dict[str, List[int]] = {"cpu": [], "disk": [], "remote": []}
         self.interval_local_disk_read_bytes = 0
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies: List[float] = []
@@ -441,6 +445,28 @@ class LMCStatsMonitor:
                 self.per_tier_get_latencies["disk"].append(latency)
             elif "Remote" in backend:
                 self.per_tier_get_latencies["remote"].append(latency)
+        # Per-request tier attribution
+        cpu = retrieve_stats.cpu_hit_tokens
+        disk = retrieve_stats.disk_hit_tokens
+        remote = retrieve_stats.remote_hit_tokens
+        total = cpu + disk + remote
+        if total == 0:
+            self.interval_request_tier_served["miss"] += 1
+        elif cpu >= disk and cpu >= remote and cpu > total * 0.5:
+            self.interval_request_tier_served["cpu"] += 1
+        elif disk >= cpu and disk >= remote and disk > total * 0.5:
+            self.interval_request_tier_served["disk"] += 1
+        elif remote >= cpu and remote >= disk and remote > total * 0.5:
+            self.interval_request_tier_served["remote"] += 1
+        else:
+            self.interval_request_tier_served["mixed"] += 1
+        # Record per-tier token counts as distributions
+        if cpu > 0:
+            self.per_tier_request_hit_tokens["cpu"].append(cpu)
+        if disk > 0:
+            self.per_tier_request_hit_tokens["disk"].append(disk)
+        if remote > 0:
+            self.per_tier_request_hit_tokens["remote"].append(remote)
         self.clear_current_retrieve_stats()
 
         time_to_retrieve = retrieve_stats.time_to_retrieve()
@@ -683,6 +709,8 @@ class LMCStatsMonitor:
         self.interval_cpu_hit_tokens = 0
         self.interval_disk_hit_tokens = 0
         self.per_tier_get_latencies = {"cpu": [], "disk": [], "remote": []}
+        self.interval_request_tier_served = {"cpu": 0, "disk": 0, "remote": 0, "mixed": 0, "miss": 0}
+        self.per_tier_request_hit_tokens = {"cpu": [], "disk": [], "remote": []}
         self.interval_local_disk_read_bytes = 0
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies.clear()
@@ -858,6 +886,8 @@ class LMCStatsMonitor:
             interval_cpu_hit_tokens=self.interval_cpu_hit_tokens,
             interval_disk_hit_tokens=self.interval_disk_hit_tokens,
             per_tier_get_latencies={k: list(v) for k, v in self.per_tier_get_latencies.items()},
+            interval_request_tier_served=dict(self.interval_request_tier_served),
+            per_tier_request_hit_tokens={k: list(v) for k, v in self.per_tier_request_hit_tokens.items()},
             interval_local_disk_read_bytes=self.interval_local_disk_read_bytes,
             interval_local_disk_write_bytes=self.interval_local_disk_write_bytes,
             local_disk_read_latencies=self.local_disk_read_latencies.copy(),
@@ -1145,6 +1175,19 @@ class PrometheusLogger:
             documentation="Per-tier batched_get latency (seconds)",
             labelnames=labelnames + ["tier"],
             buckets=tier_get_latency_buckets,
+        )
+
+        # Per-request tier attribution
+        self.counter_request_tier_served = self._create_counter(
+            name="lmcache:request_tier_served",
+            documentation="Number of retrieve requests served by each tier",
+            labelnames=labelnames + ["tier"],
+        )
+        self.histogram_request_tier_hit_tokens = self._create_histogram(
+            name="lmcache:request_tier_hit_tokens",
+            documentation="Per-request hit token count by tier",
+            labelnames=labelnames + ["tier"],
+            buckets=[1, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
         )
 
         self.counter_forced_unpin_count = self._create_counter(
@@ -1860,6 +1903,12 @@ class PrometheusLogger:
         for tier, latencies in stats.per_tier_get_latencies.items():
             for latency in latencies:
                 self.histogram_tier_get_latency.labels(**self.labels, tier=tier).observe(latency)
+        for tier, count in stats.interval_request_tier_served.items():
+            if count > 0:
+                self.counter_request_tier_served.labels(**self.labels, tier=tier).inc(count)
+        for tier, tokens_list in stats.per_tier_request_hit_tokens.items():
+            for tokens in tokens_list:
+                self.histogram_request_tier_hit_tokens.labels(**self.labels, tier=tier).observe(tokens)
         self._log_counter(
             self.counter_forced_unpin_count,
             stats.interval_forced_unpin_count,

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -81,49 +81,49 @@ class LMCacheStats:
     local_disk_write_latencies: List[float] = field(default_factory=list)
     interval_local_disk_evict_count: int = 0
 
-    interval_forced_unpin_count: int  # forced unpin count due to timeout
+    interval_forced_unpin_count: int = 0  # forced unpin count due to timeout
 
     # Real time value measurements (will be reset after each log)
-    retrieve_hit_rate: float
-    lookup_hit_rate: float
+    retrieve_hit_rate: float = 0.0
+    lookup_hit_rate: float = 0.0
 
-    local_cache_usage_bytes: int  # Size of the used local cache in bytes
-    remote_cache_usage_bytes: int  # Size of the used remote cache in bytes
-    local_storage_usage_bytes: int  # Size of the used local storage in bytes
+    local_cache_usage_bytes: int = 0  # Size of the used local cache in bytes
+    remote_cache_usage_bytes: int = 0  # Size of the used remote cache in bytes
+    local_storage_usage_bytes: int = 0  # Size of the used local storage in bytes
 
-    active_memory_objs_count: int  # the number of active memory objects
-    pinned_memory_objs_count: int  # the number of pinned memory objects
+    active_memory_objs_count: int = 0  # the number of active memory objects
+    pinned_memory_objs_count: int = 0  # the number of pinned memory objects
 
     # Distribution measurements
-    time_to_retrieve: List[float]
-    time_to_store: List[float]
-    time_to_lookup: List[float]
-    retrieve_speed: List[float]  # Tokens per second
-    store_speed: List[float]  # Tokens per second
+    time_to_retrieve: List[float] = field(default_factory=list)
+    time_to_store: List[float] = field(default_factory=list)
+    time_to_lookup: List[float] = field(default_factory=list)
+    retrieve_speed: List[float] = field(default_factory=list)  # Tokens per second
+    store_speed: List[float] = field(default_factory=list)  # Tokens per second
 
     # Granular profiling measurements
-    retrieve_process_tokens_time: List[float]
-    retrieve_broadcast_time: List[float]
-    retrieve_to_gpu_time: List[float]
-    remote_backend_batched_get_blocking_time: List[float]
-    instrumented_connector_batched_get_time: List[float]
-    store_process_tokens_time: List[float]
-    store_from_gpu_time: List[float]
-    store_put_time: List[float]
+    retrieve_process_tokens_time: List[float] = field(default_factory=list)
+    retrieve_broadcast_time: List[float] = field(default_factory=list)
+    retrieve_to_gpu_time: List[float] = field(default_factory=list)
+    remote_backend_batched_get_blocking_time: List[float] = field(default_factory=list)
+    instrumented_connector_batched_get_time: List[float] = field(default_factory=list)
+    store_process_tokens_time: List[float] = field(default_factory=list)
+    store_from_gpu_time: List[float] = field(default_factory=list)
+    store_put_time: List[float] = field(default_factory=list)
 
     # P2P transfer metrics
-    interval_p2p_requests: int
-    interval_p2p_transferred_tokens: int
-    p2p_time_to_transfer: List[float]
-    p2p_transfer_speed: List[float]  # Tokens per second
+    interval_p2p_requests: int = 0
+    interval_p2p_transferred_tokens: int = 0
+    p2p_time_to_transfer: List[float] = field(default_factory=list)
+    p2p_transfer_speed: List[float] = field(default_factory=list)  # Tokens per second
 
     # request lookup hit rates
     # use bucket of interval_lookup_hit_rates to represents non-0 hit requests
     # use interval_lookup_0_hit_requests to represents 0 hit requests
-    interval_lookup_hit_rates: List[float]
-    interval_lookup_0_hit_requests: int
+    interval_lookup_hit_rates: List[float] = field(default_factory=list)
+    interval_lookup_0_hit_requests: int = 0
 
-    interval_request_cache_lifespan: List[float]  # cache lifespan in minutes
+    interval_request_cache_lifespan: List[float] = field(default_factory=list)  # cache lifespan in minutes
 
 
 @dataclass

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -70,8 +70,8 @@ class LMCacheStats:
     interval_local_cpu_evict_failed_count: int  # evict failed count
     interval_local_hit_tokens: int = 0  # local tier hit tokens
     interval_remote_hit_tokens: int = 0  # remote tier hit tokens
-    interval_cpu_hit_tokens: int = 0    # PR4: cpu backend hit tokens
-    interval_disk_hit_tokens: int = 0   # PR4: disk backend hit tokens
+    interval_cpu_hit_tokens: int = 0
+    interval_disk_hit_tokens: int = 0
     per_tier_get_latencies: Dict[str, List[float]] = field(default_factory=dict)
     interval_request_tier_served: Dict[str, int] = field(default_factory=dict)
     per_tier_request_hit_tokens: Dict[str, List[int]] = field(default_factory=dict)
@@ -158,8 +158,8 @@ class RetrieveRequestStats:
     broadcast_time: float = 0
     to_gpu_time: float = 0
     detailed_metrics: Dict[str, Any] = field(default_factory=dict)
-    cpu_hit_tokens: int = 0   # PR4: per-backend hit tokens
-    disk_hit_tokens: int = 0  # PR4: per-backend hit tokens
+    cpu_hit_tokens: int = 0
+    disk_hit_tokens: int = 0
 
     def time_to_retrieve(self):
         if self.end_time == 0:
@@ -1166,15 +1166,11 @@ class PrometheusLogger:
         )
 
         # Per-tier retrieve get latency histograms
-        tier_get_latency_buckets = [
-            0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1,
-            0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
-        ]
         self.histogram_tier_get_latency = self._create_histogram(
             name="lmcache:tier_get_latency",
             documentation="Per-tier batched_get latency (seconds)",
             labelnames=labelnames + ["tier"],
-            buckets=tier_get_latency_buckets,
+            buckets=disk_latency_buckets,
         )
 
         # Per-request tier attribution

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -74,6 +74,7 @@ class LMCacheStats:
     interval_local_disk_write_bytes: int = 0
     local_disk_read_latencies: List[float] = field(default_factory=list)
     local_disk_write_latencies: List[float] = field(default_factory=list)
+    interval_local_disk_evict_count: int = 0
 
     interval_forced_unpin_count: int  # forced unpin count due to timeout
 
@@ -304,6 +305,7 @@ class LMCStatsMonitor:
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies: List[float] = []
         self.local_disk_write_latencies: List[float] = []
+        self.interval_local_disk_evict_count = 0
 
         self.interval_forced_unpin_count = 0
 
@@ -595,6 +597,11 @@ class LMCStatsMonitor:
         self.local_disk_read_latencies.append(latency_s)
 
     @thread_safe
+    def update_local_disk_evict_count(self, delta: int = 1):
+        """Called by LocalDiskBackend when evicting cached entries."""
+        self.interval_local_disk_evict_count += delta
+
+    @thread_safe
     def update_forced_unpin_count(self, delta: int):
         self.interval_forced_unpin_count += delta
 
@@ -656,6 +663,7 @@ class LMCStatsMonitor:
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies.clear()
         self.local_disk_write_latencies.clear()
+        self.interval_local_disk_evict_count = 0
 
         self.interval_forced_unpin_count = 0
 
@@ -827,6 +835,7 @@ class LMCStatsMonitor:
             interval_local_disk_write_bytes=self.interval_local_disk_write_bytes,
             local_disk_read_latencies=self.local_disk_read_latencies.copy(),
             local_disk_write_latencies=self.local_disk_write_latencies.copy(),
+            interval_local_disk_evict_count=self.interval_local_disk_evict_count,
             interval_forced_unpin_count=self.interval_forced_unpin_count,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
@@ -1091,6 +1100,12 @@ class PrometheusLogger:
             documentation="Local disk write latency (seconds)",
             labelnames=labelnames,
             buckets=disk_latency_buckets,
+        )
+
+        self.counter_local_disk_evict_count = self._create_counter(
+            name="lmcache:local_disk_evict_count",
+            documentation="Total number of evictions from local disk backend",
+            labelnames=labelnames,
         )
 
         self.counter_forced_unpin_count = self._create_counter(
@@ -1786,6 +1801,10 @@ class PrometheusLogger:
         self._log_histogram(
             self.histogram_local_disk_write_latency,
             stats.local_disk_write_latencies,
+        )
+        self._log_counter(
+            self.counter_local_disk_evict_count,
+            stats.interval_local_disk_evict_count,
         )
         self._log_counter(
             self.counter_forced_unpin_count,

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -70,6 +70,8 @@ class LMCacheStats:
     interval_local_cpu_evict_failed_count: int  # evict failed count
     interval_local_hit_tokens: int = 0  # local tier hit tokens
     interval_remote_hit_tokens: int = 0  # remote tier hit tokens
+    interval_cpu_hit_tokens: int = 0    # PR4: cpu backend hit tokens
+    interval_disk_hit_tokens: int = 0   # PR4: disk backend hit tokens
     interval_local_disk_read_bytes: int = 0
     interval_local_disk_write_bytes: int = 0
     local_disk_read_latencies: List[float] = field(default_factory=list)
@@ -153,6 +155,8 @@ class RetrieveRequestStats:
     broadcast_time: float = 0
     to_gpu_time: float = 0
     detailed_metrics: Dict[str, Any] = field(default_factory=dict)
+    cpu_hit_tokens: int = 0   # PR4: per-backend hit tokens
+    disk_hit_tokens: int = 0  # PR4: per-backend hit tokens
 
     def time_to_retrieve(self):
         if self.end_time == 0:
@@ -163,7 +167,7 @@ class RetrieveRequestStats:
         if self.time_to_retrieve() == 0:
             return 0
         return (
-            self.local_hit_tokens + self.remote_hit_tokens
+            self.cpu_hit_tokens + self.disk_hit_tokens + self.remote_hit_tokens
         ) / self.time_to_retrieve()
 
     @contextmanager
@@ -301,6 +305,8 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_failed_count = 0
         self.interval_local_hit_tokens = 0
         self.interval_remote_hit_tokens = 0
+        self.interval_cpu_hit_tokens = 0
+        self.interval_disk_hit_tokens = 0
         self.interval_local_disk_read_bytes = 0
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies: List[float] = []
@@ -420,6 +426,10 @@ class LMCStatsMonitor:
         if retrieve_stats.end_time == 0:
             retrieve_stats.end_time = curr_time
         self.interval_hit_tokens += num_retrieved_tokens
+        self.interval_local_hit_tokens += retrieve_stats.local_hit_tokens
+        self.interval_remote_hit_tokens += retrieve_stats.remote_hit_tokens
+        self.interval_cpu_hit_tokens += retrieve_stats.cpu_hit_tokens
+        self.interval_disk_hit_tokens += retrieve_stats.disk_hit_tokens
         self.clear_current_retrieve_stats()
 
         time_to_retrieve = retrieve_stats.time_to_retrieve()
@@ -659,6 +669,8 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_failed_count = 0
         self.interval_local_hit_tokens = 0
         self.interval_remote_hit_tokens = 0
+        self.interval_cpu_hit_tokens = 0
+        self.interval_disk_hit_tokens = 0
         self.interval_local_disk_read_bytes = 0
         self.interval_local_disk_write_bytes = 0
         self.local_disk_read_latencies.clear()
@@ -831,6 +843,8 @@ class LMCStatsMonitor:
             interval_local_cpu_evict_failed_count=self.interval_local_cpu_evict_failed_count,
             interval_local_hit_tokens=self.interval_local_hit_tokens,
             interval_remote_hit_tokens=self.interval_remote_hit_tokens,
+            interval_cpu_hit_tokens=self.interval_cpu_hit_tokens,
+            interval_disk_hit_tokens=self.interval_disk_hit_tokens,
             interval_local_disk_read_bytes=self.interval_local_disk_read_bytes,
             interval_local_disk_write_bytes=self.interval_local_disk_write_bytes,
             local_disk_read_latencies=self.local_disk_read_latencies.copy(),
@@ -1750,7 +1764,19 @@ class PrometheusLogger:
         self._log_counter(
             self.counter_num_requested_tokens, stats.interval_requested_tokens
         )
-        self._log_counter(self.counter_num_hit_tokens, stats.interval_hit_tokens)
+        # Per-tier hit token logging
+        if stats.interval_cpu_hit_tokens > 0:
+            self.counter_num_hit_tokens.labels(**self.labels, tier="cpu").inc(
+                stats.interval_cpu_hit_tokens
+            )
+        if stats.interval_disk_hit_tokens > 0:
+            self.counter_num_hit_tokens.labels(**self.labels, tier="disk").inc(
+                stats.interval_disk_hit_tokens
+            )
+        if stats.interval_remote_hit_tokens > 0:
+            self.counter_num_hit_tokens.labels(**self.labels, tier="remote").inc(
+                stats.interval_remote_hit_tokens
+            )
         self._log_counter(self.counter_num_stored_tokens, stats.interval_stored_tokens)
         self._log_counter(self.counter_num_lookup_tokens, stats.interval_lookup_tokens)
         self._log_counter(self.counter_num_lookup_hits, stats.interval_lookup_hits)

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -445,7 +445,6 @@ class LMCStatsMonitor:
                 self.per_tier_get_latencies["disk"].append(latency)
             elif "Remote" in backend:
                 self.per_tier_get_latencies["remote"].append(latency)
-        # Per-request tier attribution
         cpu = retrieve_stats.cpu_hit_tokens
         disk = retrieve_stats.disk_hit_tokens
         remote = retrieve_stats.remote_hit_tokens
@@ -1130,7 +1129,6 @@ class PrometheusLogger:
             labelnames=labelnames,
         )
 
-        # Local disk I/O metrics (mirrors remote_* pattern)
         self.counter_local_disk_read_bytes = self._create_counter(
             name="lmcache:local_disk_read_bytes_total",
             documentation="Total bytes read from local disk backend",
@@ -1165,7 +1163,6 @@ class PrometheusLogger:
             labelnames=labelnames,
         )
 
-        # Per-tier retrieve get latency histograms
         self.histogram_tier_get_latency = self._create_histogram(
             name="lmcache:tier_get_latency",
             documentation="Per-tier batched_get latency (seconds)",
@@ -1173,7 +1170,6 @@ class PrometheusLogger:
             buckets=disk_latency_buckets,
         )
 
-        # Per-request tier attribution
         self.counter_request_tier_served = self._create_counter(
             name="lmcache:request_tier_served",
             documentation="Number of retrieve requests served by each tier",
@@ -1828,7 +1824,6 @@ class PrometheusLogger:
         self._log_counter(
             self.counter_num_requested_tokens, stats.interval_requested_tokens
         )
-        # Per-tier hit token logging
         if stats.interval_cpu_hit_tokens > 0:
             self.counter_num_hit_tokens.labels(**self.labels, tier="cpu").inc(
                 stats.interval_cpu_hit_tokens

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1020,6 +1020,15 @@ class LMCacheEngine:
         next(mem_obj_consumer)
 
         retrieved_tokens = torch.sum(ret_mask)
+        # Set per-tier hit tokens based on which backend served this request
+        if location is not None:
+            total = int(retrieved_tokens)
+            if location == "LocalCPUBackend":
+                monitor_req_id.cpu_hit_tokens = total
+            elif location == "LocalDiskBackend":
+                monitor_req_id.disk_hit_tokens = total
+            elif "Remote" in location:
+                monitor_req_id.remote_hit_tokens = total
         self.stats_monitor.on_retrieve_finished(monitor_req_id, retrieved_tokens)
         if not self._is_passive():
             logger.info(
@@ -1282,11 +1291,11 @@ class LMCacheEngine:
 
             # Get memory objects from the future result
             memory_objs = future.result()
-            # Flatten nested lists (each backend returns a list of chunks)
-            memory_objs_flat = [mm for m in memory_objs for mm in m]
+            # Flatten nested lists (each backend returns (name, [(key, memobj)]))
+            memory_objs_flat = [mm for _name, m in memory_objs for mm in m]
 
             # Release each memory object
-            for key, memory_obj in memory_objs_flat:
+            for _key, memory_obj in memory_objs_flat:
                 try:
                     logger.debug("Releasing memory object for lookup_id=%s", lookup_id)
                     memory_obj.unpin()
@@ -1544,13 +1553,15 @@ class LMCacheEngine:
         try:
             keyed_memory_objs = future.result()
             memory_obj_map: dict[CacheEngineKey, MemoryObj] = {}
+            key_to_backend: dict[CacheEngineKey, str] = {}
         except Exception as e:
             logger.error(f"Error popping event for request {kwargs['req_id']}: {e}")
             return [], 0
 
-        for backend_results in keyed_memory_objs:
+        for backend_name, backend_results in keyed_memory_objs:
             for key, memory_obj in backend_results:
                 memory_obj_map[key] = memory_obj
+                key_to_backend[key] = backend_name
 
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
         used_keys: set[CacheEngineKey] = set()
@@ -1574,6 +1585,21 @@ class LMCacheEngine:
         for key, mem_obj in memory_obj_map.items():
             if key not in used_keys:
                 mem_obj.ref_count_down()
+
+        # Propagate per-backend hit counts to retrieve stats
+        retrieve_stats = self.stats_monitor.get_current_retrieve_stats()
+        if retrieve_stats is not None:
+            per_backend_tokens: Dict[str, int] = {}
+            for key, _memory_obj, start, end in chunks:
+                backend = key_to_backend.get(key, "unknown")
+                per_backend_tokens[backend] = per_backend_tokens.get(backend, 0) + (end - start)
+            for backend, count in per_backend_tokens.items():
+                if backend == "LocalCPUBackend":
+                    retrieve_stats.cpu_hit_tokens = count
+                elif backend == "LocalDiskBackend":
+                    retrieve_stats.disk_hit_tokens = count
+                elif "Remote" in backend:
+                    retrieve_stats.remote_hit_tokens = count
 
         return chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1624,12 +1624,15 @@ class LMCacheEngine:
 
         last_failed_block_start = None
         per_backend_ranges: Dict[str, List] = {}
+        per_backend_get_time: Dict[str, float] = {}
         for location, blocks in block_mapping.items():
             keys = [key for key, _, _ in blocks]
+            t0 = time.perf_counter()
             memory_objs = self.storage_manager.batched_get(
                 keys=keys,
                 location=location,
             )
+            per_backend_get_time[location] = time.perf_counter() - t0
 
             for (key, start, end), memory_obj in zip(blocks, memory_objs, strict=False):
                 if memory_obj is None:
@@ -1669,6 +1672,7 @@ class LMCacheEngine:
                     retrieve_stats.disk_hit_tokens = count
                 elif "Remote" in loc:
                     retrieve_stats.remote_hit_tokens = count
+            retrieve_stats.detailed_metrics["per_backend_get_time"] = per_backend_get_time
 
         return reordered_chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1623,6 +1623,7 @@ class LMCacheEngine:
             block_mapping = self.storage_manager.get_block_mapping(chunk_infos)
 
         last_failed_block_start = None
+        per_backend_ranges: Dict[str, List] = {}
         for location, blocks in block_mapping.items():
             keys = [key for key, _, _ in blocks]
             memory_objs = self.storage_manager.batched_get(
@@ -1644,6 +1645,7 @@ class LMCacheEngine:
                 reordered_chunks.append((key, memory_obj, start, end))
                 tot_kv_size += memory_obj.get_size()
                 ret_mask[start:end] = True
+                per_backend_ranges.setdefault(location, []).append((start, end))
 
         if last_failed_block_start is not None:
             ret_mask[last_failed_block_start:] = False
@@ -1653,6 +1655,21 @@ class LMCacheEngine:
                 for key, memory_obj, start, end in reordered_chunks
                 if end < last_failed_block_start
             ]
+
+        # Propagate per-backend hit counts to retrieve stats
+        retrieve_stats = self.stats_monitor.get_current_retrieve_stats()
+        if retrieve_stats is not None:
+            for loc, ranges in per_backend_ranges.items():
+                if last_failed_block_start is not None:
+                    ranges = [(s, e) for s, e in ranges if e <= last_failed_block_start]
+                count = sum(e - s for s, e in ranges)
+                if loc == "LocalCPUBackend":
+                    retrieve_stats.cpu_hit_tokens = count
+                elif loc == "LocalDiskBackend":
+                    retrieve_stats.disk_hit_tokens = count
+                elif "Remote" in loc:
+                    retrieve_stats.remote_hit_tokens = count
+
         return reordered_chunks, tot_kv_size
 
     def _broadcast_or_receive_memory_objs(

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1020,7 +1020,6 @@ class LMCacheEngine:
         next(mem_obj_consumer)
 
         retrieved_tokens = torch.sum(ret_mask)
-        # Set per-tier hit tokens based on which backend served this request
         if location is not None:
             total = int(retrieved_tokens)
             if location == "LocalCPUBackend":
@@ -1291,17 +1290,15 @@ class LMCacheEngine:
 
             # Get memory objects from the future result
             memory_objs = future.result()
-            # Flatten nested lists (each backend returns (name, [(key, memobj)]))
-            memory_objs_flat = [mm for _name, m in memory_objs for mm in m]
-
             # Release each memory object
-            for _key, memory_obj in memory_objs_flat:
-                try:
-                    logger.debug("Releasing memory object for lookup_id=%s", lookup_id)
-                    memory_obj.unpin()
-                    memory_obj.ref_count_down()
-                except Exception as e:
-                    logger.error(f"Error releasing memory object: {e}")
+            for _backend_name, backend_results in memory_objs:
+                for _key, memory_obj in backend_results:
+                    try:
+                        logger.debug("Releasing memory object for lookup_id=%s", lookup_id)
+                        memory_obj.unpin()
+                        memory_obj.ref_count_down()
+                    except Exception as e:
+                        logger.error(f"Error releasing memory object: {e}")
         except Exception as e:
             logger.error(
                 f"Error during cleanup_memory_objs for lookup_id={lookup_id}: {e}"
@@ -1586,7 +1583,6 @@ class LMCacheEngine:
             if key not in used_keys:
                 mem_obj.ref_count_down()
 
-        # Propagate per-backend hit counts to retrieve stats
         retrieve_stats = self.stats_monitor.get_current_retrieve_stats()
         if retrieve_stats is not None:
             per_backend_tokens: Dict[str, int] = {}
@@ -1685,7 +1681,6 @@ class LMCacheEngine:
                 if end < last_failed_block_start
             ]
 
-        # Propagate per-backend hit counts to retrieve stats
         retrieve_stats = self.stats_monitor.get_current_retrieve_stats()
         if retrieve_stats is not None:
             for loc, ranges in per_backend_ranges.items():

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -595,6 +595,7 @@ class LocalDiskBackend(StorageBackendInterface):
             f"Disk write size: {size} bytes, "
             f"Bandwidth: {size / disk_write_time / 1e6:.2f} MB/s"
         )
+        self.stats_monitor.record_local_disk_write(size, disk_write_time)
 
     def read_file(self, key, buffer, path):
         start_time = time.time()
@@ -625,6 +626,7 @@ class LocalDiskBackend(StorageBackendInterface):
             f"Disk read size: {size} bytes, "
             f"Bandwidth: {size / disk_read_time / 1e6:.2f} MB/s"
         )
+        self.stats_monitor.record_local_disk_read(size, disk_read_time)
 
     def get_allocator_backend(self):
         return self.local_cpu_backend

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -245,6 +245,7 @@ class LocalDiskBackend(StorageBackendInterface):
         # res.result()
 
         os.remove(path)
+        self.stats_monitor.update_local_disk_evict_count()
 
         if force:
             self.cache_policy.update_on_force_evict(key)

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -607,7 +607,7 @@ class StorageManager:
         #   total_retrieved_chunks = 2 (stop at tier 0, all subsequent ignored)
         #   retrieved_length = cum_chunk_lengths_total[2] = 512
         total_retrieved_chunks = 0
-        for tier_idx, tier_result in enumerate(res):
+        for tier_idx, (_tier_name, tier_result) in enumerate(res):
             actual_chunks = len(tier_result)
             expected_chunks = tier_expected_chunks[tier_idx]
             total_retrieved_chunks += actual_chunks
@@ -616,8 +616,8 @@ class StorageManager:
             # because subsequent chunks are not contiguous
             if actual_chunks < expected_chunks:
                 # Release all chunks in subsequent tiers since they won't be used
-                for subsequent_tier in res[tier_idx + 1 :]:
-                    for mem_obj in subsequent_tier:
+                for _name, subsequent_tier in res[tier_idx + 1 :]:
+                    for _key, mem_obj in subsequent_tier:
                         mem_obj.ref_count_down()
                 break
 
@@ -682,6 +682,7 @@ class StorageManager:
         tier_expected_chunks = []
         # we also keep track of the keys for each tier and each chunk
         loading_task_keys: list[list[CacheEngineKey]] = []
+        tier_backend_names: list[str] = []
         for backend_name, backend in self.get_active_storage_backends(
             search_range=search_range
         ):
@@ -695,6 +696,7 @@ class StorageManager:
 
             backend_keys = keys[:num_hit_chunks]
             loading_task_keys.append(backend_keys)
+            tier_backend_names.append(backend_name)
 
             assert self.async_serializer is not None, (
                 "Async serializer must be initialized via post_init before using "
@@ -741,12 +743,12 @@ class StorageManager:
         # Tier 1:
         #  Tuple(loading_task_keys[1][0] : MemoryObj2)
         #  Tuple(loading_task_keys[1][1] : MemoryObj3)
-        async def gather_with_keys() -> list[list[tuple[CacheEngineKey, MemoryObj]]]:
+        async def gather_with_keys() -> list[tuple[str, list[tuple[CacheEngineKey, MemoryObj]]]]:
             loading_results = await asyncio.gather(*loading_tasks)
             return [
-                list(zip(keys, results, strict=False))
-                for keys, results in zip(
-                    loading_task_keys, loading_results, strict=False
+                (name, list(zip(keys, results, strict=False)))
+                for name, keys, results in zip(
+                    tier_backend_names, loading_task_keys, loading_results, strict=False
                 )
             ]
 

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -119,7 +119,10 @@ class TestStorageManagerPrefetchCallback:
         # Create mock memory objects for all chunks
         tier0_objs = [MockMemoryObj(i) for i in range(3)]
         tier1_objs = [MockMemoryObj(i + 3) for i in range(2)]
-        res = [tier0_objs, tier1_objs]
+        res = [
+            ("LocalCPUBackend", [(f"key_{i}", obj) for i, obj in enumerate(tier0_objs)]),
+            ("LocalDiskBackend", [(f"key_{i+3}", obj) for i, obj in enumerate(tier1_objs)]),
+        ]
 
         # Create a mock future that returns the result
         loop = asyncio.new_event_loop()
@@ -159,7 +162,11 @@ class TestStorageManagerPrefetchCallback:
         tier0_objs = [MockMemoryObj(i) for i in range(3)]
         tier1_objs = [MockMemoryObj(i + 3) for i in range(1)]  # Only 1 instead of 2
         tier2_objs = [MockMemoryObj(i + 5) for i in range(2)]  # Got all 2
-        res = [tier0_objs, tier1_objs, tier2_objs]
+        res = [
+            ("LocalCPUBackend", [(f"key_{i}", obj) for i, obj in enumerate(tier0_objs)]),
+            ("LocalDiskBackend", [(f"key_{i+3}", obj) for i, obj in enumerate(tier1_objs)]),
+            ("RemoteBackend", [(f"key_{i+5}", obj) for i, obj in enumerate(tier2_objs)]),
+        ]
 
         # Create a mock future that returns the result
         loop = asyncio.new_event_loop()
@@ -207,7 +214,11 @@ class TestStorageManagerPrefetchCallback:
         tier0_objs = [MockMemoryObj(i) for i in range(2)]  # Only 2 instead of 3
         tier1_objs = [MockMemoryObj(i + 3) for i in range(2)]  # Got all 2
         tier2_objs = [MockMemoryObj(i + 5) for i in range(2)]  # Got all 2
-        res = [tier0_objs, tier1_objs, tier2_objs]
+        res = [
+            ("LocalCPUBackend", [(f"key_{i}", obj) for i, obj in enumerate(tier0_objs)]),
+            ("LocalDiskBackend", [(f"key_{i+3}", obj) for i, obj in enumerate(tier1_objs)]),
+            ("RemoteBackend", [(f"key_{i+5}", obj) for i, obj in enumerate(tier2_objs)]),
+        ]
 
         # Create a mock future that returns the result
         loop = asyncio.new_event_loop()
@@ -251,7 +262,10 @@ class TestStorageManagerPrefetchCallback:
         # All chunks retrieved successfully
         tier0_objs = [MockMemoryObj(i) for i in range(2)]
         tier1_objs = [MockMemoryObj(i + 2) for i in range(1)]
-        res = [tier0_objs, tier1_objs]
+        res = [
+            ("LocalCPUBackend", [(f"key_{i}", obj) for i, obj in enumerate(tier0_objs)]),
+            ("LocalDiskBackend", [(f"key_{i+2}", obj) for i, obj in enumerate(tier1_objs)]),
+        ]
 
         # Create a mock future that returns the result
         loop = asyncio.new_event_loop()
@@ -288,7 +302,9 @@ class TestStorageManagerPrefetchCallback:
 
         # Only got 3 chunks instead of 5
         tier0_objs = [MockMemoryObj(i) for i in range(3)]
-        res = [tier0_objs]
+        res = [
+            ("LocalCPUBackend", [(f"key_{i}", obj) for i, obj in enumerate(tier0_objs)]),
+        ]
 
         # Create a mock future that returns the result
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the observability and telemetry subsystems to track metrics by storage tier. 

When we use multiple storage backends (CPU, disk, remote) or async retrieve operations, aggregating all hits into a single counter makes it impossible to debug performance bottlenecks. 

Main changes:
* **Tiered hit tracking**: Added `tier="cpu"`, `tier="disk"`, and `tier="remote"` labels to Prometheus hit token counters.
* **Disk I/O metrics**: Added specific metrics for local disk reads, writes, latencies, and evictions. 
* **Async propagation**: Passed backend names through the async prefetch and layerwise retrieve pipelines so we correctly attribute hits even when operations happen in the background.
* **Safer defaults**: Added default values (`0`, `0.0`, `field(default_factory=list)`) to [LMCacheStats](cci:2://file:///home/chanho/k8s_vast/kwbench/LMCache/lmcache/observability.py:35:0-125:107) fields to fix dataclass initialization errors.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests