### PR TITLE
fix(l1_manager): propagate extra_count through prefetch path to prevent premature eviction

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -512,6 +512,7 @@ class L1Manager:
     def finish_write_and_reserve_read(
         self,
         keys: list[ObjectKey],
+        extra_count: int = 0,
     ) -> dict[ObjectKey, L1OperationResult]:
         """Atomically finish write and acquire read lock for the given keys.
 
@@ -522,6 +523,10 @@ class L1Manager:
 
         Args:
             keys: Keys to transition from write-locked to read-locked.
+            extra_count: Extra read locks on top of the default 1 lock.
+                Total locks acquired per key = 1 + extra_count.  Useful
+                when multiple TP workers each consume one read lock for
+                the same key (e.g. MLA models with TP > 1).
 
         Returns:
             A dictionary mapping each object key to a tuple of
@@ -532,6 +537,8 @@ class L1Manager:
             KEY_IN_WRONG_STATE: The key is not write-locked, or it already
                 has read locks.
         """
+        extra_count = _validate_extra_count(extra_count)
+        total = 1 + extra_count
         ret: dict[ObjectKey, L1OperationResult] = {}
         successful_keys: list[ObjectKey] = []
 
@@ -559,7 +566,8 @@ class L1Manager:
                 continue
 
             entry.write_lock.unlock()
-            entry.read_lock.lock()
+            for _ in range(total):
+                entry.read_lock.lock()
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
             successful_keys.append(key)
 

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -138,6 +138,10 @@ class InFlightPrefetchRequest:
     keys: list[ObjectKey]
     layout_desc: MemoryLayoutDesc
     phase: PrefetchPhase
+    extra_count: int = 0
+    """Extra read locks per key (on top of the default 1) to acquire when
+    transitioning from write-locked to read-locked.  Must match the
+    ``extra_count`` used in the corresponding ``submit_prefetch_task`` call."""
 
     # Lookup phase: adapter_idx -> task_id (removed as results arrive)
     pending_lookup_tasks: dict[int, L2TaskId] = field(default_factory=dict)
@@ -202,7 +206,7 @@ class PrefetchController(StorageControllerInterface):
         # In-flight request tracking (background thread only)
         self._in_flight_requests: dict[PrefetchRequestId, InFlightPrefetchRequest] = {}
         self._pending_queue: list[
-            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc]
+            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int]
         ] = []
 
         # Shadow counters for status reporting (updated in background loop)
@@ -214,7 +218,7 @@ class PrefetchController(StorageControllerInterface):
         # Thread-safe submission queue (external -> background)
         self._submission_lock = threading.Lock()
         self._submission_queue: list[
-            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc]
+            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int]
         ] = []
         self._next_request_id: PrefetchRequestId = 0
         self._submission_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
@@ -247,6 +251,7 @@ class PrefetchController(StorageControllerInterface):
         self,
         keys: list[ObjectKey],
         layout_desc: MemoryLayoutDesc,
+        extra_count: int = 0,
     ) -> PrefetchRequestId:
         """
         Submit a prefetch request for the given keys.
@@ -264,6 +269,11 @@ class PrefetchController(StorageControllerInterface):
             keys: List of object keys to prefetch from L2 into L1.
                 The ordering defines the prefix: index 0 is the first key.
             layout_desc: Memory layout for L1 write buffer allocation.
+            extra_count: Extra read locks per key (on top of the default 1)
+                to acquire when transitioning loaded keys from write-locked
+                to read-locked.  Must match the ``extra_count`` used in the
+                corresponding ``submit_prefetch_task`` call so that all TP
+                workers can each consume one read lock.
 
         Returns:
             A request ID for tracking via query_prefetch_result.
@@ -271,7 +281,7 @@ class PrefetchController(StorageControllerInterface):
         with self._submission_lock:
             request_id = self._next_request_id
             self._next_request_id += 1
-            self._submission_queue.append((request_id, keys, layout_desc))
+            self._submission_queue.append((request_id, keys, layout_desc, extra_count))
         os.eventfd_write(self._submission_efd, 1)
         return request_id
 
@@ -389,9 +399,9 @@ class PrefetchController(StorageControllerInterface):
         while (
             self._pending_queue and len(self._in_flight_requests) < self._max_in_flight
         ):
-            request_id, keys, layout_desc = self._pending_queue.pop(0)
+            request_id, keys, layout_desc, extra_count = self._pending_queue.pop(0)
             self._status_pending_count -= 1
-            self._start_lookup_phase(request_id, keys, layout_desc)
+            self._start_lookup_phase(request_id, keys, layout_desc, extra_count)
 
     # =========================================================================
     # Lookup phase
@@ -402,6 +412,7 @@ class PrefetchController(StorageControllerInterface):
         request_id: PrefetchRequestId,
         keys: list[ObjectKey],
         layout_desc: MemoryLayoutDesc,
+        extra_count: int = 0,
     ) -> None:
         """Submit lookup_and_lock to all adapters for a new request."""
         if not self._l2_adapters:
@@ -418,6 +429,7 @@ class PrefetchController(StorageControllerInterface):
             keys=keys,
             layout_desc=layout_desc,
             phase=PrefetchPhase.LOOKUP,
+            extra_count=extra_count,
             pending_lookup_tasks=pending_lookup_tasks,
         )
         self._in_flight_requests[request_id] = request
@@ -603,8 +615,11 @@ class PrefetchController(StorageControllerInterface):
         l1_mgr = self.get_l1_manager()
 
         # Transition loaded keys: write-locked -> read-locked
+        # Use extra_count so that all TP workers each get their own read lock.
         if loaded_keys:
-            l1_mgr.finish_write_and_reserve_read(loaded_keys)
+            l1_mgr.finish_write_and_reserve_read(
+                loaded_keys, extra_count=request.extra_count
+            )
 
         # Clean up failed keys
         if failed_keys:
@@ -618,7 +633,7 @@ class PrefetchController(StorageControllerInterface):
         non_prefix_loaded_bitmap = result_bitmap & (~prefix_mask)
         non_prefix_loaded = non_prefix_loaded_bitmap.gather(request.keys)
         if non_prefix_loaded:
-            l1_mgr.finish_read(non_prefix_loaded)
+            l1_mgr.finish_read(non_prefix_loaded, extra_count=request.extra_count)
 
         self._complete_request(request.request_id, prefix_hits)
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -305,6 +305,7 @@ class StorageManager:
             request_id = self._prefetch_controller.submit_prefetch_request(
                 remaining_keys,
                 layout_desc,
+                extra_count=extra_count,
             )
 
         submit_time = time.monotonic()

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -699,3 +699,260 @@ class TestMultipleRequests:
         l1_manager.finish_read(keys2)
         ctrl.stop()
         adapter.close()
+
+
+# =============================================================================
+# extra_count Path
+# =============================================================================
+
+
+class TestExtraCountPrefetch:
+    """Test that extra_count is correctly propagated through the prefetch path.
+
+    When extra_count=N is passed to submit_prefetch_request, the controller
+    must acquire 1 + N read locks per key (one for the prefetch controller
+    itself, plus N for additional TP workers).  Each consumer must call
+    finish_read (or finish_read_prefetched) once to release its lock.
+
+    These tests verify:
+    1. Keys remain accessible after the first finish_read when extra_count > 0.
+    2. Keys are evictable only after ALL 1 + N locks are released.
+    3. extra_count=0 (default) behaves identically to the original single-lock
+       path.
+    4. Prefix trimming still works correctly with extra_count > 0.
+    5. Non-prefix loaded keys have all extra locks released by _finalize_load.
+    """
+
+    def test_extra_count_zero_default_behavior(self, l1_manager):
+        """extra_count=0 (default): single read lock, key freed after one
+        finish_read."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout, extra_count=0)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 3
+
+        # Keys should be readable immediately after prefetch
+        read_results = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        # Release the single read lock — keys should become unlocked
+        finish_results = l1_manager.finish_read(keys, extra_count=0)
+        for key in keys:
+            assert finish_results[key] == L1Error.SUCCESS
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_extra_count_one_requires_two_finish_reads(self, l1_manager):
+        """extra_count=1: two read locks acquired; key stays locked after
+        first finish_read and is released after second."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        # extra_count=1 → 2 read locks per key
+        req_id = ctrl.submit_prefetch_request(keys, layout, extra_count=1)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 3
+
+        # Keys must be readable right after prefetch
+        read_results = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        # Release lock #1 (the "prefetch controller" lock, extra_count=0)
+        finish_results = l1_manager.finish_read(keys, extra_count=0)
+        for key in keys:
+            assert finish_results[key] == L1Error.SUCCESS
+
+        # Keys must STILL be readable — lock #2 (the TP worker lock) is held
+        read_results2 = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert read_results2[key][0] == L1Error.SUCCESS, (
+                f"Key {key} should still be read-locked after first finish_read"
+            )
+
+        # Release lock #2 (the TP worker lock, extra_count=0)
+        finish_results2 = l1_manager.finish_read(keys, extra_count=0)
+        for key in keys:
+            assert finish_results2[key] == L1Error.SUCCESS
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_extra_count_three_requires_four_finish_reads(self, l1_manager):
+        """extra_count=3 (TP=4): four read locks; key stays locked until all
+        four are released."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(2)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        # extra_count=3 → 4 read locks per key
+        req_id = ctrl.submit_prefetch_request(keys, layout, extra_count=3)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 2
+
+        # Release locks one by one; key must remain readable until the last
+        for release_idx in range(3):
+            finish_results = l1_manager.finish_read(keys, extra_count=0)
+            for key in keys:
+                assert finish_results[key] == L1Error.SUCCESS
+
+            # Still readable — remaining locks are held
+            read_results = l1_manager.unsafe_read(keys)
+            for key in keys:
+                assert read_results[key][0] == L1Error.SUCCESS, (
+                    f"Key {key} should still be locked after {release_idx + 1} "
+                    f"finish_read calls"
+                )
+
+        # Release the final lock
+        finish_results = l1_manager.finish_read(keys, extra_count=0)
+        for key in keys:
+            assert finish_results[key] == L1Error.SUCCESS
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_extra_count_with_prefix_trim(self, l1_manager):
+        """extra_count=1 with a gap in L2: only prefix keys get 2 locks;
+        non-prefix keys are never loaded."""
+        adapter = make_adapter()
+        layout = make_layout()
+        all_keys = [make_object_key(i) for i in range(5)]
+        # Store keys 0, 1, 3, 4 — gap at index 2
+        stored_keys = [all_keys[i] for i in [0, 1, 3, 4]]
+        store_keys_in_l2(adapter, stored_keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(all_keys, layout, extra_count=1)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 2, f"Expected 2 prefix hits (gap at index 2), got {result}"
+
+        prefix_keys = all_keys[:2]
+
+        # Prefix keys must be readable
+        read_results = l1_manager.unsafe_read(prefix_keys)
+        for key in prefix_keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        # Release lock #1 — prefix keys still held by lock #2
+        l1_manager.finish_read(prefix_keys, extra_count=0)
+
+        read_results2 = l1_manager.unsafe_read(prefix_keys)
+        for key in prefix_keys:
+            assert read_results2[key][0] == L1Error.SUCCESS, (
+                f"Prefix key {key} should still be locked after first finish_read"
+            )
+
+        # Release lock #2
+        l1_manager.finish_read(prefix_keys, extra_count=0)
+
+        # Non-prefix keys must NOT be in L1
+        non_prefix_keys = all_keys[2:]
+        reserve_results = l1_manager.reserve_read(non_prefix_keys)
+        for key in non_prefix_keys:
+            assert reserve_results[key][0] == L1Error.KEY_NOT_EXIST, (
+                f"Non-prefix key {key} should not be in L1"
+            )
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_extra_count_non_prefix_loaded_keys_fully_released(self, l1_manager):
+        """Keys loaded beyond the prefix (due to partial load failure) must
+        have ALL extra locks released by _finalize_load so they can be evicted.
+
+        We simulate this by storing keys {0, 1, 2} in L2 but making key 1
+        fail to reserve in L1 (by pre-occupying it), creating a gap so that
+        key 2 is loaded but lies beyond the prefix.  _finalize_load must
+        release 1 + extra_count locks for key 2.
+        """
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        # Pre-occupy key[1] in L1 with a write lock so reserve_write fails for it.
+        # This forces a gap: key 0 is prefix (hit), key 1 fails reservation
+        # (gap), key 2 is loaded but beyond the prefix.
+        pre_write_results = l1_manager.reserve_write(
+            keys=[keys[1]],
+            is_temporary=[False],
+            layout_desc=layout,
+            mode="new",
+        )
+        assert pre_write_results[keys[1]][0] == L1Error.SUCCESS
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout, extra_count=1)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        # Only key 0 is in the prefix (key 1 reservation failed → gap)
+        assert result == 1, f"Expected 1 prefix hit, got {result}"
+
+        # key[0] should be in L1 with 2 read locks (1 + extra_count=1)
+        read_results = l1_manager.unsafe_read([keys[0]])
+        assert read_results[keys[0]][0] == L1Error.SUCCESS
+
+        # key[2] was loaded but is beyond the prefix; _finalize_load must have
+        # released all 1 + extra_count=2 locks, so it should be gone from L1
+        # (it's a temporary object and its lock count should be 0).
+        reserve_results = l1_manager.reserve_read([keys[2]])
+        assert reserve_results[keys[2]][0] == L1Error.KEY_NOT_EXIST, (
+            "Non-prefix loaded key[2] should have all locks released and be "
+            "evicted from L1"
+        )
+
+        # Clean up: release key[0]'s 2 locks and key[1]'s write lock
+        l1_manager.finish_read([keys[0]], extra_count=0)
+        l1_manager.finish_read([keys[0]], extra_count=0)
+        l1_manager.finish_write([keys[1]])
+        l1_manager.delete([keys[1]])
+
+        ctrl.stop()
+        adapter.close()


### PR DESCRIPTION
fix(l1_manager): propagate extra_count through prefetch path to prevent premature eviction

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
When a prefetch request completes and loaded keys transition from write-locked to read-locked, finish_write_and_reserve_read was always acquiring exactly 1 read lock per key, regardless of the extra_count passed by the caller. This caused premature eviction in Tensor Parallelism (TP > 1) scenarios (e.g. MLA models), where each TP worker needs to consume its own read lock — but only 1 lock was held, so the first worker's finish_read would drop the ref-count to 0 and trigger eviction before the remaining workers could access the data.

This PR propagates extra_count through the entire prefetch path:

StorageManager.submit_prefetch_request → PrefetchController.submit_prefetch_request → _submission_queue / _pending_queue → _start_lookup_phase → InFlightPrefetchRequest.extra_count

On prefetch completion: finish_write_and_reserve_read(loaded_keys, extra_count=request.extra_count) acquires 1 + extra_count read locks per key

Non-prefix loaded keys that are immediately released also pass extra_count to finish_read

L1Manager.finish_write_and_reserve_read now accepts extra_count and calls entry.read_lock.lock() a total of 1 + extra_count times per key

**Special notes for your reviewers**:
The extra_count semantics are unchanged from the existing submit_prefetch_task / finish_read contract — this PR only ensures the value is correctly threaded through the prefetch pipeline rather than silently dropped.

_pending_queue and _submission_queue tuple types are widened from (..., MemoryLayoutDesc) to (..., MemoryLayoutDesc, int)

No behavior change when extra_count=0 (the default), so existing single-TP deployments are unaffected.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
