### PR TITLE
[Misc] Improve LRU handling in RustRawBlockBackend

### DIFF
--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -338,18 +338,34 @@ class RustRawBlockBackend(StoragePluginInterface):
 
     def _evict_one(self) -> bool:
         """Evict least recently used chunk that is not pinned or in-flight."""
-        for victim in list(self._lru.keys()):
+        stale_victims = []
+        victim_to_evict = None
+        entry_to_evict = None
+
+        for victim in self._lru:
             if victim in self._pinned or victim in self._inflight:
                 continue
-            entry = self._index.pop(victim, None)
+
+            entry = self._index.get(victim)
             if entry is None:
-                self._lru.pop(victim, None)
+                stale_victims.append(victim)
                 continue
+
+            victim_to_evict = victim
+            entry_to_evict = entry
+            break
+
+        for victim in stale_victims:
             self._lru.pop(victim, None)
-            self._pinned.discard(victim)
-            self._free_slots.append(int(entry.offset // self.slot_bytes))
-            return True
-        return False
+
+        if victim_to_evict is None:
+            return False
+
+        self._index.pop(victim_to_evict, None)
+        self._lru.pop(victim_to_evict, None)
+        self._pinned.discard(victim_to_evict)
+        self._free_slots.append(int(entry_to_evict.offset // self.slot_bytes))
+        return True
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self._lock:

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -331,8 +331,10 @@ class RustRawBlockBackend(StoragePluginInterface):
 
     def _touch(self, key: CacheEngineKey) -> None:
         """Update LRU: move key to most-recently-used position."""
-        self._lru.pop(key, None)
-        self._lru[key] = None
+        if key in self._lru:
+            self._lru.move_to_end(key)
+        else:
+            self._lru[key] = None
 
     def _evict_one(self) -> bool:
         """Evict least recently used chunk that is not pinned or in-flight."""


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

1. Fix LRU touch path

- When touching the LRU cache, `move_to_end()` is used if the key already exists, 
replacing the previous `pop + insert` pattern. If the key does not exist, it is inserted into the LRU cache.
- This clarifies the LRU touch logic and makes the intended behavior more explicit.

2. Optimize `evict_one()`
- Refactor `evict_one()` to iterate directly over `OrderedDict` instead of materializing `list(self._lru.keys())`.
- This avoids per-call key list allocation on the eviction path, while preserving existing eviction semantics (skip pinned/in-flight entries and evict the least recently used victim).
  
**Special notes for your reviewers**:

**Testing**
pytest tests/v1/storage_backend/test_rust_raw_block_backend.py - 3 passed
