### PR TITLE
[MP] Update the MP docs and pass telemetry config into http_server

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -36,6 +36,12 @@ Source: ``lmcache/v1/multiprocess/config.py``
      - ``blake3``
      - Hash algorithm for token-based operations.
        Choices: ``builtin``, ``sha256_cbor``, ``blake3``.
+   * - ``--engine-type``
+     - ``default``
+     - Cache engine backend type.
+       ``default`` uses MPCacheEngine; ``blend`` uses BlendEngineV2
+       for cross-request KV reuse.
+       Choices: ``default``, ``blend``.
 
 HTTP Frontend
 -------------
@@ -283,12 +289,13 @@ Full Example
 
 .. code-block:: bash
 
-    python3 -m lmcache.v1.multiprocess.server \
+    python3 -m lmcache.v1.multiprocess.http_server \
         --host 0.0.0.0 \
         --port 6555 \
         --chunk-size 512 \
         --max-workers 4 \
         --hash-algorithm blake3 \
+        --engine-type default \
         --l1-size-gb 100 \
         --l1-use-lazy \
         --l1-init-size-gb 20 \

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -41,11 +41,13 @@ LMCache ships three server entry points:
    * - Entry Point
      - Description
    * - ``python3 -m lmcache.v1.multiprocess.server``
-     - ZMQ-only server (default, production).
-   * - ``python3 -m lmcache.v1.multiprocess.blend_server``
-     - CacheBlend-enabled server for non-prefix KV reuse.
+     - ZMQ-only server using MPCacheEngine (default, production).
    * - ``python3 -m lmcache.v1.multiprocess.http_server``
      - ZMQ + FastAPI HTTP frontend (adds ``/api/healthcheck`` for K8s probes).
+       Use ``--engine-type blend`` to enable BlendEngineV2 for cross-request
+       KV reuse (replaces the standalone ``blend_server`` entry point).
+   * - ``python3 -m lmcache.v1.multiprocess.blend_server``
+     - Legacy CacheBlend-enabled server. Prefer ``http_server --engine-type blend``.
 
 .. toctree::
    :maxdepth: 2

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -73,6 +73,7 @@ from lmcache.v1.mp_observability.telemetry import (
     TelemetryConfig,
     get_telemetry_controller,
     init_telemetry_controller,
+    parse_args_to_telemetry_config,
 )
 from lmcache.v1.mp_observability.telemetry.config import (
     DEFAULT_TELEMETRY_CONFIG,
@@ -853,8 +854,10 @@ if __name__ == "__main__":
     mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
+    telemetry_config = parse_args_to_telemetry_config(args)
     run_cache_server(
         mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
+        telemetry_config=telemetry_config,
     )

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -24,6 +24,15 @@ from lmcache.v1.mp_observability.config import (
 from lmcache.v1.mp_observability.prometheus_controller import (
     get_prometheus_controller,
 )
+from lmcache.v1.mp_observability.telemetry import (
+    TelemetryConfig,
+    add_telemetry_args,
+    get_telemetry_controller,
+    parse_args_to_telemetry_config,
+)
+from lmcache.v1.mp_observability.telemetry.config import (
+    DEFAULT_TELEMETRY_CONFIG,
+)
 from lmcache.v1.multiprocess.config import (
     HTTPFrontendConfig,
     MPServerConfig,
@@ -69,6 +78,7 @@ async def lifespan(app: FastAPI):
         mp_config=mp_config,
         storage_manager_config=_configs["storage_manager"],
         prometheus_config=_configs["prometheus"],
+        telemetry_config=_configs["telemetry"],
         return_engine=True,
     )
     app.state.zmq_server = zmq_server
@@ -79,6 +89,7 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     logger.info("Shutting down LMCache HTTP server...")
+    get_telemetry_controller().stop()
     get_prometheus_controller().stop()
     if hasattr(app.state, "zmq_server") and app.state.zmq_server is not None:
         app.state.zmq_server.close()
@@ -152,6 +163,7 @@ def run_http_server(
     mp_config: MPServerConfig,
     storage_manager_config: StorageManagerConfig,
     prometheus_config: PrometheusConfig,
+    telemetry_config: TelemetryConfig = DEFAULT_TELEMETRY_CONFIG,
 ) -> None:
     """
     Run the LMCache HTTP server with integrated MP (ZMQ) server.
@@ -161,10 +173,12 @@ def run_http_server(
         mp_config: Configuration for the ZMQ multiprocess server
         storage_manager_config: Configuration for the storage manager
         prometheus_config: Configuration for the Prometheus observability stack
+        telemetry_config: Configuration for the telemetry event system
     """
     _configs["mp"] = mp_config
     _configs["storage_manager"] = storage_manager_config
     _configs["prometheus"] = prometheus_config
+    _configs["telemetry"] = telemetry_config
 
     config = uvicorn.Config(
         app=app,
@@ -191,6 +205,7 @@ def parse_args():
     add_mp_server_args(parser)
     add_storage_manager_args(parser)
     add_prometheus_args(parser)
+    add_telemetry_args(parser)
     return parser.parse_args()
 
 
@@ -200,9 +215,11 @@ if __name__ == "__main__":
     mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     prometheus_config = parse_args_to_prometheus_config(args)
+    telemetry_config = parse_args_to_telemetry_config(args)
     run_http_server(
         http_config=http_config,
         mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         prometheus_config=prometheus_config,
+        telemetry_config=telemetry_config,
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents the `--engine-type` CLI argument introduced in the previous PR (#2722).

Adds the telemetry config parsing (introduced in #2696 ) to http server 

**Special notes for your reviewers**:

Docs-only change.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests