### PR TITLE
[MP][Bugfix] fix vllm-side lookup logical issue and cuda stream deadlock problem

### DIFF
--- a/.buildkite/scripts/multiprocessing-test/launch-containers.sh
+++ b/.buildkite/scripts/multiprocessing-test/launch-containers.sh
@@ -11,6 +11,7 @@ export VLLM_BASELINE_CONTAINER_NAME="${VLLM_BASELINE_CONTAINER_NAME:-vllm-baseli
 
 # Configuration
 LMCACHE_PORT="${LMCACHE_PORT:-6555}"
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-6556}"
 VLLM_PORT="${VLLM_PORT:-8000}"
 VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
 
@@ -62,11 +63,12 @@ docker run -d \
     --ipc host \
     --entrypoint /opt/venv/bin/python3 \
     lmcache/vllm-openai:test \
-    -m lmcache.v1.multiprocess.server \
+    -m lmcache.v1.multiprocess.http_server \
     --l1-size-gb "$CPU_BUFFER_SIZE" \
     --eviction-policy LRU \
     --max-workers "$MAX_WORKERS" \
-    --port "$LMCACHE_PORT"
+    --port "$LMCACHE_PORT" \
+    --http-port "$LMCACHE_HTTP_PORT"
 
 echo "LMCache container started"
 

--- a/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
@@ -13,6 +13,7 @@ export VLLM_BASELINE_CONTAINER_NAME="vllm-baseline-test-$$"
 export LMCACHE_PORT="${LMCACHE_PORT:-6555}"
 export VLLM_PORT="${VLLM_PORT:-8000}"
 export VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
+export LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-6556}"
 export MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
 export BUILD_ID="${BUILD_ID:-local_$$}"
 
@@ -109,9 +110,17 @@ if ! "$SCRIPT_DIR/run-long-doc-qa.sh"; then
 fi
 echo ""
 
+
+# Step 7: Query LMCache server status
+echo "============================================"
+echo "=== Step 7: LMCache server status ==="
+echo "============================================"
+curl -s "http://localhost:${LMCACHE_HTTP_PORT}/api/status" | python3 -m json.tool || echo "⚠️ Failed to query LMCache status"
+echo ""
+
 echo "============================================"
 echo "=== ✅ All tests passed! ==="
 echo "============================================"
 
-# Step 7: Cleanup runs automatically via trap
+# Step 8: Cleanup runs automatically via trap
 

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -29,7 +29,8 @@ PYBIND11_MODULE(c_ops, m) {
         py::arg("slot_mapping"), py::arg("paged_memory_device"),
         py::arg("page_buffer_size"), py::arg("direction"),
         py::arg("gpu_kv_format"), py::arg("block_size") = 0,
-        py::arg("skip_prefix_n_tokens") = 0);
+        py::arg("skip_prefix_n_tokens") = 0,
+        py::call_guard<py::gil_scoped_release>());
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);
   m.def("single_layer_kv_transfer", &single_layer_kv_transfer,
@@ -42,7 +43,8 @@ PYBIND11_MODULE(c_ops, m) {
         py::arg("direction"), py::arg("token_major") = false);
   m.def("load_and_reshape_flash", &load_and_reshape_flash);
   m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
-  m.def("lmcache_memcpy_async", &lmcache_memcpy_async);
+  m.def("lmcache_memcpy_async", &lmcache_memcpy_async,
+        py::call_guard<py::gil_scoped_release>());
   m.def("encode_fast_new", &encode_cuda_new);
   m.def("decode_fast_new", &decode_cuda_new);
   m.def("decode_fast_prefsum", &decode_cuda_prefsum);

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -120,8 +120,12 @@ class LMCacheMPSchedulerAdapter:
         """
         self.mq_client = MessageQueueClient(server_url, context)
 
-        # Two-phase lookup state: request_id -> server prefetch job ID
+        # Two-phase lookup state:
+        # - phase 1: request_id -> server prefetch job ID
+        # - phase 2: job_id -> matched chunk count (will be cached)
+        # The cached lookup result will be cleared by `cleanup_lookup_result`
         self._lookup_job_ids: dict[str, int] = {}
+        self._finished_lookup_jobs: dict[int, int] = {}
 
         self.model_name = model_name
         self.world_size = world_size
@@ -206,6 +210,11 @@ class LMCacheMPSchedulerAdapter:
         )
 
         job_id = self._lookup_job_ids[request_id]
+
+        if job_id in self._finished_lookup_jobs:
+            # Return cached result if the job is already finished
+            return self._finished_lookup_jobs[job_id] * self.chunk_size
+
         result = send_lmcache_request(
             self.mq_client,
             RequestType.QUERY_PREFETCH_STATUS,
@@ -214,6 +223,8 @@ class LMCacheMPSchedulerAdapter:
 
         if result is None:
             return None
+
+        self._finished_lookup_jobs[job_id] = result
 
         return result * self.chunk_size
 
@@ -230,7 +241,9 @@ class LMCacheMPSchedulerAdapter:
         Args:
             request_id: The ID of the finished request.
         """
-        self._lookup_job_ids.pop(request_id, None)
+        job_id = self._lookup_job_ids.pop(request_id, None)
+        if job_id is not None:
+            self._finished_lookup_jobs.pop(job_id, None)
 
     def free_lookup_locks(
         self,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -233,11 +233,6 @@ class MPCacheEngine:
         self._next_prefetch_job_id: int = 0
         self._prefetch_job_lock = threading.Lock()
 
-        # FIX: fix the problem of telemetry logging in cupy stream
-        # Need to log a retrieve operation before logging any store
-        # operation in the cupy stream
-        self._can_log_store = False
-
     def register_kv_cache(
         self,
         instance_id: int,
@@ -329,7 +324,7 @@ class MPCacheEngine:
             )
             vllm_event.wait(stream=gpu_context.stream)
 
-            if get_telemetry_controller().is_enabled() and self._can_log_store:
+            if get_telemetry_controller().is_enabled():
                 gpu_context.cupy_stream.launch_host_func(
                     log_telemetry,
                     make_start_event(
@@ -378,7 +373,7 @@ class MPCacheEngine:
             list(reserved_dict.keys()),
         )
 
-        if get_telemetry_controller().is_enabled() and self._can_log_store:
+        if get_telemetry_controller().is_enabled():
             self.gpu_contexts[instance_id].cupy_stream.launch_host_func(
                 log_telemetry,
                 make_end_event(
@@ -535,7 +530,6 @@ class MPCacheEngine:
             ed - st,
         )
 
-        self._can_log_store = True
         return event.ipc_handle(), True
 
     def _find_layout_desc(
@@ -650,8 +644,8 @@ class MPCacheEngine:
             prefetch_job_id: Job ID returned by lookup().
 
         Returns:
-            Chunk count (int) when done, None if still in progress,
-            or 0 if the job ID is unknown.
+            Chunk count (int) when done, None if still in progress
+            or the job ID is unknown.
         """
         with self._prefetch_job_lock:
             job = self._prefetch_jobs.get(prefetch_job_id)
@@ -660,7 +654,7 @@ class MPCacheEngine:
                 "Prefetch job %d not found (already completed or invalid)",
                 prefetch_job_id,
             )
-            return 0
+            return None
 
         found_count = self.storage_manager.query_prefetch_status(job.handle)
         if found_count is None:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two bugs in the multi-process (MP) mode that together cause hangs:

1. **vLLM-side lookup result caching**: After a prefetch job completes, the server removes it from its job map. Subsequent `QUERY_PREFETCH_STATUS` calls for that job ID return `None` (previously `0`), causing the scheduler to think the lookup is still in progress and poll forever. This PR:
   - Caches finished lookup results on the vLLM side (`_finished_lookup_jobs`) so repeated queries return the cached count instead of re-querying the server.
   - Changes the server to return `None` (instead of `0`) for unknown job IDs, making the semantics consistent: `None` = not ready / unknown, `int` = done.
   - Cleans up cached results in `cleanup_lookup_result`.

2. **CUDA stream deadlock from `launch_host_func`**: Telemetry logging callbacks scheduled via `cupy_stream.launch_host_func` need the GIL, but `paged_kv_transfer` and `lmcache_memcpy_async` hold the GIL while waiting on the CUDA stream — creating a deadlock. This PR adds `py::call_guard<py::gil_scoped_release>()` to both C++ bindings so the GIL is released during execution, allowing host callbacks to acquire it. This also removes the `_can_log_store` workaround that was masking the issue.

**Special notes for your reviewers**:

- The GIL release guard is safe for these two functions because they operate on GPU memory via CUDA streams and do not touch Python objects.
- The `_can_log_store` flag was a partial workaround that prevented store telemetry until after the first retrieve; it is no longer needed with the proper GIL fix.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests