### PR TITLE
[MP] feat: add LMCacheMPPollingSchedulerAdapter for synchronous lookup and prefetch  in MP mode

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 import os
 import threading
+import time
 
 # Third Party
 import torch
@@ -467,6 +468,154 @@ class LMCacheMPSchedulerAdapter:
             end=end,
             request_id=request_id,
         )
+
+
+class LMCacheMPPollingSchedulerAdapter(LMCacheMPSchedulerAdapter):
+    """LMCacheMPSchedulerAdapter subclass that overrides check_lookup_result
+    to block until the prefetch job is complete.
+
+    Unlike the base class which returns None immediately when the result is
+    not yet available, this class polls the server in a loop and only returns
+    once the prefetch job has finished.  This avoids the need for the caller
+    to repeatedly invoke check_lookup_result across multiple scheduling steps.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        context: zmq.Context,
+        model_name: str,
+        world_size: int,
+        kv_rank: int,
+        vllm_block_size: int,
+        tp_size: int = 1,
+        poll_interval: float = 0.005,
+        lookup_timeout: float = 5.0,
+        mq_timeout: float = DEFAULT_MQ_TIMEOUT,
+        heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+    ):
+        """
+        Args:
+            server_url: The server URL for the LMCache message queue.
+            context: The ZMQ context.
+            model_name: The model name used for LMCache keys.
+            world_size: The world size used for LMCache keys.
+            kv_rank: The kv rank used for LMCache keys.
+            vllm_block_size: The block size used in vLLM.
+            tp_size: Tensor-parallel size for MLA multi-reader locking.
+            poll_interval: Interval in seconds between polling attempts
+                (default 5ms).
+            lookup_timeout: Maximum time in seconds to wait for a prefetch
+                job to complete before giving up (default 5s). When the
+                timeout is exceeded, 0 is returned so the request proceeds
+                with normal inference without any KV cache hit.
+            mq_timeout: Timeout in seconds for message queue requests.
+            heartbeat_interval: Interval in seconds between heartbeat pings.
+        """
+        super().__init__(
+            server_url=server_url,
+            context=context,
+            model_name=model_name,
+            world_size=world_size,
+            kv_rank=kv_rank,
+            vllm_block_size=vllm_block_size,
+            tp_size=tp_size,
+            mq_timeout=mq_timeout,
+            heartbeat_interval=heartbeat_interval,
+        )
+        self._poll_interval = poll_interval
+        self._lookup_timeout = lookup_timeout
+
+    @_lmcache_nvtx_annotate
+    def check_lookup_result(self, request_id: str) -> int:
+        """Block until the prefetch job for request_id is complete and return
+        the matched token count.
+
+        Overrides the base class non-blocking implementation: instead of
+        returning None when the result is not yet available, this method
+        polls the server repeatedly until the prefetch job finishes.
+
+        Args:
+            request_id: The ID of the lookup request submitted in
+                ``maybe_submit_lookup_request``.
+
+        Returns:
+            An integer representing the total number of tokens matched
+            in LMCache (prefix matching).
+        """
+        if request_id not in self._lookup_job_ids:
+            # No job — either unhealthy at submit time or already cleaned up
+            return 0
+
+        job_id = self._lookup_job_ids[request_id]
+
+        if job_id in self._finished_lookup_jobs:
+            return self._finished_lookup_jobs[job_id] * self.chunk_size
+
+        deadline = time.monotonic() + self._lookup_timeout
+        # Keep a single in-flight future and reuse it across poll iterations.
+        # Sending a new request every iteration is unsafe: the server uses
+        # exactly-once semantics and pops the job after returning a non-None
+        # result.  If an earlier request's response arrives *after* we already
+        # timed out on its future and sent a new one, the job is gone and all
+        # subsequent requests return None — silently losing the result.
+        #
+        # Strategy:
+        #   1. Send one request and wait up to _poll_interval for a response.
+        #   2. On TimeoutError the request is still in-flight; keep waiting on
+        #      the *same* future (don't send a new one).
+        #   3. Only send a new request when the server explicitly returned None
+        #      (prefetch still in progress) — meaning the previous request was
+        #      fully processed and the job still exists.
+        inflight_future = send_lmcache_request(
+            self.mq_client,
+            RequestType.QUERY_PREFETCH_STATUS,
+            [job_id],
+        )
+        while True:
+            if not self.is_healthy:
+                self._lookup_job_ids.pop(request_id, None)
+                self._finished_lookup_jobs.pop(job_id, None)
+                return 0
+            try:
+                result = inflight_future.result(timeout=self._poll_interval)
+            except TimeoutError:
+                # The request is still in-flight — do NOT send a new one.
+                # Just check the deadline and keep waiting on the same future.
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "Lookup timeout (%.1fs) exceeded for request_id=%s, "
+                        "job_id=%s. Returning 0 matched tokens.",
+                        self._lookup_timeout,
+                        request_id,
+                        job_id,
+                    )
+                    self._lookup_job_ids.pop(request_id, None)
+                    self._finished_lookup_jobs.pop(job_id, None)
+                    return 0
+                continue
+            if result is not None:
+                self._finished_lookup_jobs[job_id] = result
+                return result * self.chunk_size
+            # result is None: server confirmed prefetch is still in progress.
+            # It is now safe to send a new request.
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Lookup timeout (%.1fs) exceeded for request_id=%s, "
+                    "job_id=%s. Returning 0 matched tokens.",
+                    self._lookup_timeout,
+                    request_id,
+                    job_id,
+                )
+                self._lookup_job_ids.pop(request_id, None)
+                self._finished_lookup_jobs.pop(job_id, None)
+                return 0
+            time.sleep(self._poll_interval)
+            inflight_future = send_lmcache_request(
+                self.mq_client,
+                RequestType.QUERY_PREFETCH_STATUS,
+                [job_id],
+            )
 
 
 class LMCacheMPWorkerAdapter:


### PR DESCRIPTION

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Currently, the MP-mode prefetch lookup is asynchronous and two-step: the vllm scheduler first calls maybe_submit_lookup_request() to submit a prefetch job, then polls check_lookup_result() in subsequent scheduling rounds to retrieve the result. This introduces scheduling latency when the prefetch result is needed immediately (e.g., for short requests or when the cache hit rate is high).

This PR adds LMCacheMPPollingSchedulerAdapter, a subclass of LMCacheMPSchedulerAdapter that provides a synchronous (blocking) prefetch lookup in MP mode.

The base class check_lookup_result returns None immediately when the prefetch job is not yet complete, requiring the caller to retry across multiple scheduling steps. This new subclass overrides check_lookup_result to poll the server in a loop until the prefetch job finishes, so the caller always gets a definitive matched-token count in a single call.

Key behaviors:

- Polls QUERY_PREFETCH_STATUS at a configurable interval (poll_interval, default 5ms) until the job is done.

- Enforces a configurable timeout (lookup_timeout, default 5s); if exceeded, logs a warning and returns 0 matched tokens so the request falls back to normal inference without KV cache hit.

- Fully backward-compatible: the base class behavior is unchanged; callers opt in by using LMCacheMPPollingSchedulerAdapter instead.

**Special notes for your reviewers**:

- The polling loop uses time.monotonic() for timeout tracking to avoid wall-clock drift issues.

- poll_interval=0.005 (5ms) and lookup_timeout=5.0 (5s) are chosen as sensible defaults but are fully configurable via constructor arguments.

- On timeout, _lookup_job_ids entry is cleaned up to avoid memory leaks.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a blocking polling loop around `QUERY_PREFETCH_STATUS`, which can affect scheduler latency and load on the MQ server if misconfigured. Timeout/health handling reduces worst-case impact but correctness depends on exactly-once response semantics and proper timeout tuning.
> 
> **Overview**
> Adds `LMCacheMPPollingSchedulerAdapter`, an opt-in subclass of `LMCacheMPSchedulerAdapter` that makes MP-mode lookup *synchronous*: `check_lookup_result` now blocks and polls until the LMCache prefetch job completes, instead of returning `None` and requiring callers to re-check across scheduling rounds.
> 
> The polling implementation uses a configurable `poll_interval` and overall `lookup_timeout`, cleans up per-request lookup state on timeout/unhealthy server, and carefully reuses a single in-flight MQ future to avoid losing results under the server’s exactly-once semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a226d9846a283a1d90cfc6a74fd73ab38ac5ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->