### PR TITLE
fix(server): guard finish_read_prefetched behind retrieve_succeeded flag

### DIFF
--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -218,11 +218,11 @@ class StorageManager:
         try:
             yield good_objs if all_good else None
             successfully_yielded = True
-        except Exception as e:
-            logger.warning(
-                "Exception occurred while processing read prefetched results: %s",
-                str(e),
+        except Exception:
+            logger.exception(
+                "Exception occurred while processing read prefetched results",
             )
+            raise
         finally:
             # Decrease the read lock for all successfully read memory objects
             # if None is yielded or exception occurs during caller's processing

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -492,6 +492,7 @@ class MPCacheEngine:
             event = torch.cuda.Event(interprocess=True)
 
             prefetched_keys: list[ObjectKey] = []
+            retrieve_succeeded = False
             try:
                 with self.storage_manager.read_prefetched_results(
                     obj_keys
@@ -502,15 +503,18 @@ class MPCacheEngine:
 
                     prefetched_keys = obj_keys[: len(memory_objs)]
                     _retrieve_loop(obj_keys, memory_objs)
+                # Only set True when with-block exits normally
+                retrieve_succeeded = True
             except Exception as e:
                 logger.warning("Cannot retrieve keys due to exception: %s", str(e))
                 return event.ipc_handle(), False
             finally:
                 event.record()
-                gpu_context.cupy_stream.launch_host_func(
-                    self.storage_manager.finish_read_prefetched,
-                    prefetched_keys,
-                )
+                if retrieve_succeeded:
+                    gpu_context.cupy_stream.launch_host_func(
+                        self.storage_manager.finish_read_prefetched,
+                        prefetched_keys,
+                    )
                 if get_telemetry_controller().is_enabled():
                     gpu_context.cupy_stream.launch_host_func(
                         log_telemetry,


### PR DESCRIPTION
When _retrieve_loop raises an exception inside the with-block, the read_prefetched_results context manager already releases the read locks in its finally clause. The retrieve() finally block was unconditionally scheduling a GPU callback to call
finish_read_prefetched, causing a double-free of read locks.

Introduce retrieve_succeeded flag that is only set to True when the with-block exits normally. The GPU callback is now conditional on this flag, forming a defense-in-depth pair with the context manager re-raise fix.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

In MPCacheEngine.retrieve(), the finally block unconditionally schedules a GPU callback to call finish_read_prefetched, which releases the read lock. When _retrieve_loop raises an exception, the read_prefetched_results context manager already releases the lock in its own finally clause. However, Python's finally block executes even after a return in an except block, so the GPU callback is still scheduled, causing a read lock double-free.
Fix: Introduce a retrieve_succeeded flag initialized to False, set to True only after the with block exits normally. The GPU callback in finally is now conditional on this flag. This forms a defense-in-depth pair with the context manager re-raise fix (PR #2737) — either fix alone prevents the double-free, but together they provide two independent safety layers.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
