### PR TITLE
fix(storage_manager): re-raise exception in read_prefetched_results

### DIFF
--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -218,11 +218,12 @@ class StorageManager:
         try:
             yield good_objs if all_good else None
             successfully_yielded = True
-        except Exception as e:
+        except Exception:
             logger.warning(
-                "Exception occurred while processing read prefetched results: %s",
-                str(e),
+                "Exception occurred while processing read prefetched results",
+                exc_info=True,
             )
+            raise
         finally:
             # Decrease the read lock for all successfully read memory objects
             # if None is yielded or exception occurs during caller's processing


### PR DESCRIPTION
The context manager was swallowing exceptions raised inside the with-block (e.g. TypeError from _retrieve_loop). This caused the caller to continue as if the retrieve succeeded, leading to a double-free of read locks: once by the context manager's finally clause, and again by the caller's GPU callback.

Add 'raise' to propagate the exception so callers correctly enter their except branch and skip the redundant finish_read_prefetched.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The read_prefetched_results context manager catches exceptions raised inside the with block (e.g., TypeError from _retrieve_loop) but does not re-raise them. Per Python's @contextmanager protocol, this causes the exception to be silently swallowed — the caller continues execution as if the with block succeeded normally.
This leads to a read lock double-free: the context manager's finally clause releases the read lock (correctly), but since the caller doesn't know an exception occurred, it proceeds to schedule a GPU callback that calls finish_read_prefetched again, releasing the same lock a second time. For temporary objects, this drives the lock count to zero and triggers premature deletion.
Fix: Add raise after the warning log in the except block so the exception propagates correctly. The caller then enters its own except branch and skips the redundant finish_read_prefetched call.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
