### PR TITLE
fix(l1_manager): prevent StoreController from re-storing L2-loaded objects

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -571,8 +571,16 @@ class L1Manager:
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
             successful_keys.append(key)
 
+        # NOTE: We intentionally do NOT fire
+        # on_l1_keys_write_finished here.  This method is used
+        # by the prefetch controller to transition L2-loaded
+        # (temporary) objects from write-locked to read-locked.
+        # Firing the write-finished event would cause the
+        # StoreController to re-store these objects back to L2,
+        # which is both wasteful and introduces a race where
+        # the store controller's later finish_read can release
+        # a read lock that belongs to a TP worker.
         for listener in self._registered_listeners:
-            listener.on_l1_keys_write_finished(successful_keys)
             listener.on_l1_keys_reserved_read(successful_keys)
         return ret
 


### PR DESCRIPTION
Remove on_l1_keys_write_finished from finish_write_and_reserve_read to prevent StoreController from mistakenly re-storing temporary objects loaded by PrefetchController from L2. The extra store task introduces a race where StoreController's later finish_read releases a read lock that belongs to a TP worker, causing premature deletion of temporary objects.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

finish_write_and_reserve_read() is used by PrefetchController to atomically transition L2-loaded temporary objects from write-locked to read-locked state. However, it was incorrectly firing on_l1_keys_write_finished, which caused StoreController to treat these objects as newly written data and submit redundant L2 store tasks.
The redundant store task itself is harmless, but StoreController's reserve_read + finish_read cycle introduces an extra read lock increment/decrement that races with the TP worker's own finish_read_prefetched. Under certain timing, this causes the read lock count to drop to zero prematurely, deleting the temporary object before all workers have consumed it, resulting in KEY_NOT_EXIST errors.
Fix: Remove on_l1_keys_write_finished from finish_write_and_reserve_read(). This method represents a state transition (write→read), not a new-data-written event. The data already exists in L2 and does not need to be stored again.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
