### PR TITLE
[MP][optimize] optimize evict in lru policy

### DIFF
--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -77,7 +77,10 @@ class LRUEvictionPolicy(EvictionPolicy):
             keys (list[ObjectKey]): The keys that have been created
         """
         with self._lock:
-            for key in keys:
+            # NOTE: for the request, the later keys should be evicted first.
+            # For example, the request has (key1, key2, key3), if we first
+            # evict key1, due to prefix match, key2 and key3 will not be hit.
+            for key in reversed(keys):
                 # If key already exists, move it to the end (most recently used)
                 if key in self._order:
                     self._order.move_to_end(key)
@@ -94,7 +97,9 @@ class LRUEvictionPolicy(EvictionPolicy):
             keys (list[ObjectKey]): The keys that have been accessed
         """
         with self._lock:
-            for key in keys:
+            # NOTE: for the request, the later keys should be evicted first.
+            # The example is the same as `on_keys_created`.
+            for key in reversed(keys):
                 if key in self._order:
                     # Move to end (most recently used)
                     self._order.move_to_end(key)

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -105,17 +105,17 @@ class TestLRUEvictionPolicyOrdering:
     def test_touch_moves_key_to_most_recent(self):
         """Touching a key should move it to the most recently used position."""
         policy = LRUEvictionPolicy()
-        # Create keys in order: 1, 2, 3
+        # Create keys in order: 1, 2, 3, evict order is 3, 2, 1
         policy.on_keys_created([make_key(1), make_key(2), make_key(3)])
 
-        # Touch key 1 - should move it to most recent
-        policy.on_keys_touched([make_key(1)])
+        # Touch key 3 - should move it to most recent
+        policy.on_keys_touched([make_key(3)])
 
-        # Now order should be: 2, 3, 1
+        # Now order should be: 2, 1, 3
         candidates = policy.get_eviction_candidates(3)
         assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 2
-        assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 3
-        assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 1
+        assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 1
+        assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 3
 
     def test_touch_nonexistent_key_is_safe(self):
         """Touching a nonexistent key should not raise an error."""
@@ -127,15 +127,17 @@ class TestLRUEvictionPolicyOrdering:
     def test_create_existing_key_moves_to_most_recent(self):
         """Creating an existing key should move it to most recent position."""
         policy = LRUEvictionPolicy()
+        # Create keys in order: 1, 2, 3, evict order is 3, 2, 1
         policy.on_keys_created([make_key(1), make_key(2), make_key(3)])
 
-        # Create key 1 again - should move to end
-        policy.on_keys_created([make_key(1)])
+        # Create key 3 again - should move to end
+        policy.on_keys_created([make_key(3)])
 
+        # Now order should be: 2, 1, 3
         candidates = policy.get_eviction_candidates(3)
         assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 2
-        assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 3
-        assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 1
+        assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 1
+        assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 3
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -235,10 +235,11 @@ class TestLRUEvictionPolicyCandidates:
     def test_get_candidates_returns_lru_order(self):
         """Candidates should be returned in LRU order."""
         policy = LRUEvictionPolicy()
+        # Create keys in order: 1, 2, 3, evict order is 3, 2, 1
         policy.on_keys_created([make_key(1), make_key(2), make_key(3)])
         candidates = policy.get_eviction_candidates(2)
         assert len(candidates) == 2
-        assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 1
+        assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 3
         assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 2
 
     def test_get_candidates_respects_count_limit(self):


### PR DESCRIPTION
For one request, the later keys should be evicted first, for example, the request has `(key1, key2, key3)`, if we first evict `key1`, due to prefix match, `key2` and `key3` will not be hit.

My test result is as follows:
<img width="1589" height="148" alt="Clipboard_Screenshot_1773227384" src="https://github.com/user-attachments/assets/047b0f64-774f-44af-a5c5-de796ad40f01" />
