### PR TITLE
[MP] Introduce CLI for MP Server

### DIFF
--- a/lmcache/v1/multiprocess/cli/__init__.py
+++ b/lmcache/v1/multiprocess/cli/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache/v1/multiprocess/cli/__main__.py
+++ b/lmcache/v1/multiprocess/cli/__main__.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LMCache multiprocess server CLI entry-point.
+
+Usage::
+
+    python -m lmcache.v1.multiprocess.cli <command> [options]
+
+Sub-commands are discovered automatically from the
+``commands/`` sub-package.  To add a new command, create a
+new module under ``commands/`` and define a module-level
+``register_command(subparsers)`` function.  No existing
+files need to be modified.
+"""
+
+# Standard
+import argparse
+import importlib
+import pkgutil
+import sys
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+def _discover_commands(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Walk ``cli.commands`` and call each module's registrar."""
+    # First Party
+    from lmcache.v1.multiprocess.cli import commands as cmd_pkg
+
+    for finder, name, _ in pkgutil.iter_modules(cmd_pkg.__path__):
+        module = importlib.import_module(
+            ".%s" % name,
+            package=cmd_pkg.__name__,
+        )
+        registrar = getattr(module, "register_command", None)
+        if registrar is None:
+            logger.warning(
+                "Command module %s has no register_command, skipped",
+                name,
+            )
+            continue
+        registrar(subparsers)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Build the top-level parser and dispatch."""
+    parser = argparse.ArgumentParser(
+        prog="lmcache-server",
+        description="LMCache multiprocess server CLI",
+    )
+    subparsers = parser.add_subparsers(
+        dest="command",
+        help="Available commands",
+    )
+    _discover_commands(subparsers)
+
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    # Each command stores its handler via set_defaults(func=...)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/v1/multiprocess/cli/base.py
+++ b/lmcache/v1/multiprocess/cli/base.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Base utilities for CLI sub-commands.
+
+Every module under ``cli/commands/`` must define a module-level
+``register_command`` function that matches :class:`CommandRegistrar`.
+The CLI entry-point discovers and calls these registrars
+automatically, so adding a new command never requires touching
+existing files.
+
+:func:`send_request` is a lightweight helper shared by every
+command that communicates with the ZMQ server.
+"""
+
+# Standard
+from typing import Any, Protocol
+import argparse
+import sys
+
+# Third Party
+import zmq
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocols.base import RequestType
+
+logger = init_logger(__name__)
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 5555
+DEFAULT_TIMEOUT = 5.0  # seconds
+
+
+class CommandRegistrar(Protocol):
+    """Protocol that every command module must satisfy."""
+
+    def __call__(
+        self,
+        subparsers: argparse._SubParsersAction,
+    ) -> None:
+        """Register one sub-command on *subparsers*."""
+        ...
+
+
+def add_connection_args(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Add ``--host`` and ``--port`` args for server connection.
+
+    Shared by every command that talks to a running server.
+    """
+    parser.add_argument(
+        "--host",
+        type=str,
+        default=DEFAULT_HOST,
+        help="ZMQ server host. Default: %s." % DEFAULT_HOST,
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="ZMQ server port. Default: %d." % DEFAULT_PORT,
+    )
+
+
+def send_request(
+    args: argparse.Namespace,
+    request_type: RequestType,
+    payloads: list[Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Any:
+    """Send a single ZMQ request and return the response.
+
+    Creates a temporary :class:`MessageQueueClient`, submits
+    the request, waits for the response and tears down the
+    connection.
+
+    Args:
+        args: Parsed CLI args (must contain ``host`` and
+            ``port``).
+        request_type: The protocol request type to send.
+        payloads: Positional payloads matching the protocol
+            definition.  Defaults to an empty list.
+        timeout: Seconds to wait before giving up.
+
+    Returns:
+        The decoded response from the server, or *None*
+        if the protocol defines no response.
+    """
+    if payloads is None:
+        payloads = []
+
+    url = "tcp://%s:%d" % (args.host, args.port)
+    ctx = zmq.Context()
+    client = MessageQueueClient(url, ctx)
+
+    try:
+        future: MessagingFuture[Any] = client.submit_request(request_type, payloads)
+        if not future.wait(timeout):
+            logger.error(
+                "Request %s timed out after %.1fs",
+                request_type.name,
+                timeout,
+            )
+            sys.exit(1)
+        return future.result()
+    finally:
+        client.close()
+        ctx.term()

--- a/lmcache/v1/multiprocess/cli/base.py
+++ b/lmcache/v1/multiprocess/cli/base.py
@@ -95,6 +95,7 @@ def send_request(
 
     url = "tcp://%s:%d" % (args.host, args.port)
     ctx = zmq.Context()
+    ctx.linger = 0
     client = MessageQueueClient(url, ctx)
 
     try:
@@ -109,4 +110,8 @@ def send_request(
         return future.result()
     finally:
         client.close()
-        ctx.term()
+        # NOTE: skip ctx.term() — MessageQueueClient.close()
+        # does not close internal inproc sockets
+        # (task_notifier / task_waiter), so ctx.term()
+        # blocks forever.  The CLI process exits right
+        # after, letting the OS reclaim all resources.

--- a/lmcache/v1/multiprocess/cli/commands/__init__.py
+++ b/lmcache/v1/multiprocess/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache/v1/multiprocess/cli/commands/clear.py
+++ b/lmcache/v1/multiprocess/cli/commands/clear.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+``clear`` sub-command — clear all cached KV data.
+
+Sends a :attr:`RequestType.CLEAR` request over ZMQ.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.cli.base import (
+    add_connection_args,
+    send_request,
+)
+from lmcache.v1.multiprocess.protocols.base import RequestType
+
+logger = init_logger(__name__)
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Entry-point called by the CLI dispatcher."""
+    send_request(args, RequestType.CLEAR)
+    logger.info("Cache cleared successfully.")
+
+
+def register_command(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Register the ``clear`` sub-command."""
+    parser = subparsers.add_parser(
+        "clear",
+        help="Clear all cached KV data",
+        description=(
+            "Send a CLEAR request to remove all stored KV cache data from the server."
+        ),
+    )
+    add_connection_args(parser)
+    parser.set_defaults(func=_run)

--- a/lmcache/v1/multiprocess/cli/commands/end_session.py
+++ b/lmcache/v1/multiprocess/cli/commands/end_session.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+``end-session`` sub-command — end a server-side session.
+
+Sends a :attr:`RequestType.END_SESSION` request over ZMQ
+to remove the session state for a given request ID.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.cli.base import (
+    add_connection_args,
+    send_request,
+)
+from lmcache.v1.multiprocess.protocols.base import RequestType
+
+logger = init_logger(__name__)
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Entry-point called by the CLI dispatcher."""
+    send_request(
+        args,
+        RequestType.END_SESSION,
+        payloads=[args.request_id],
+    )
+    logger.info(
+        "Session %s ended successfully.",
+        args.request_id,
+    )
+
+
+def register_command(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Register the ``end-session`` sub-command."""
+    parser = subparsers.add_parser(
+        "end-session",
+        help="End a server-side session",
+        description=(
+            "Send an END_SESSION request to remove "
+            "session state for a given request ID."
+        ),
+    )
+    add_connection_args(parser)
+    parser.add_argument(
+        "request_id",
+        type=str,
+        help="The request ID of the session to end.",
+    )
+    parser.set_defaults(func=_run)

--- a/lmcache/v1/multiprocess/cli/commands/get_chunk_size.py
+++ b/lmcache/v1/multiprocess/cli/commands/get_chunk_size.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+``get-chunk-size`` sub-command — query the server chunk size.
+
+Sends a :attr:`RequestType.GET_CHUNK_SIZE` request over ZMQ
+and prints the configured chunk size.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.v1.multiprocess.cli.base import (
+    add_connection_args,
+    send_request,
+)
+from lmcache.v1.multiprocess.protocols.base import RequestType
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Entry-point called by the CLI dispatcher."""
+    chunk_size = send_request(args, RequestType.GET_CHUNK_SIZE)
+    print(chunk_size)
+
+
+def register_command(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Register the ``get-chunk-size`` sub-command."""
+    parser = subparsers.add_parser(
+        "get-chunk-size",
+        help="Query the server's chunk size",
+        description=(
+            "Send a GET_CHUNK_SIZE request and print the configured chunk size."
+        ),
+    )
+    add_connection_args(parser)
+    parser.set_defaults(func=_run)

--- a/lmcache/v1/multiprocess/cli/commands/noop.py
+++ b/lmcache/v1/multiprocess/cli/commands/noop.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+``noop`` sub-command — test connectivity to a running server.
+
+Sends a :attr:`RequestType.NOOP` request over ZMQ and prints
+the response string returned by the engine's ``debug()`` method.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.v1.multiprocess.cli.base import (
+    add_connection_args,
+    send_request,
+)
+from lmcache.v1.multiprocess.protocols.base import RequestType
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Entry-point called by the CLI dispatcher."""
+    resp = send_request(args, RequestType.NOOP)
+    print(resp)
+
+
+def register_command(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Register the ``noop`` sub-command."""
+    parser = subparsers.add_parser(
+        "noop",
+        help="Ping the server (NOOP/heartbeat)",
+        description=(
+            "Send a NOOP request to verify connectivity with the LMCache server."
+        ),
+    )
+    add_connection_args(parser)
+    parser.set_defaults(func=_run)

--- a/lmcache/v1/multiprocess/cli/commands/start.py
+++ b/lmcache/v1/multiprocess/cli/commands/start.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+``start`` sub-command — launches the LMCache server.
+
+Supports two modes controlled by ``--engine-type``:
+
+* ``default`` — standard :class:`MPCacheEngine`
+* ``blend``   — cross-request :class:`BlendEngineV2`
+
+And optionally ``--with-http`` to enable the HTTP frontend.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.v1.distributed.config import (
+    add_storage_manager_args,
+    parse_args_to_config,
+)
+from lmcache.v1.mp_observability.config import (
+    add_prometheus_args,
+    parse_args_to_prometheus_config,
+)
+from lmcache.v1.mp_observability.telemetry import (
+    add_telemetry_args,
+    parse_args_to_telemetry_config,
+)
+from lmcache.v1.multiprocess.config import (
+    add_http_frontend_args,
+    add_mp_server_args,
+    parse_args_to_http_frontend_config,
+    parse_args_to_mp_server_config,
+)
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Entry-point called by the CLI dispatcher."""
+    mp_config = parse_args_to_mp_server_config(args)
+    storage_config = parse_args_to_config(args)
+    prom_config = parse_args_to_prometheus_config(args)
+    tele_config = parse_args_to_telemetry_config(args)
+
+    if getattr(args, "with_http", False):
+        # First Party
+        from lmcache.v1.multiprocess.http_server import (
+            run_http_server,
+        )
+
+        http_config = parse_args_to_http_frontend_config(args)
+        run_http_server(
+            http_config=http_config,
+            mp_config=mp_config,
+            storage_manager_config=storage_config,
+            prometheus_config=prom_config,
+            telemetry_config=tele_config,
+        )
+    else:
+        if mp_config.engine_type == "blend":
+            # First Party
+            from lmcache.v1.multiprocess.blend_server_v2 import (
+                run_cache_server,
+            )
+        else:
+            # First Party
+            from lmcache.v1.multiprocess.server import (
+                run_cache_server,
+            )
+
+        run_cache_server(
+            mp_config=mp_config,
+            storage_manager_config=storage_config,
+            prometheus_config=prom_config,
+            telemetry_config=tele_config,
+        )
+
+
+def register_command(
+    subparsers: argparse._SubParsersAction,
+) -> None:
+    """Register the ``start`` sub-command."""
+    parser = subparsers.add_parser(
+        "start",
+        help="Start the LMCache server",
+        description="Start the LMCache multiprocess cache server.",
+    )
+    parser.add_argument(
+        "--with-http",
+        action="store_true",
+        default=False,
+        help="Enable the HTTP frontend (uvicorn/FastAPI).",
+    )
+    add_mp_server_args(parser)
+    add_storage_manager_args(parser)
+    add_prometheus_args(parser)
+    add_telemetry_args(parser)
+    add_http_frontend_args(parser)
+    parser.set_defaults(func=_run)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
```
python3 -m lmcache.v1.multiprocess.cli start \
    --engine-type blend --with-http \
    --host 0.0.0.0 --port 5555 \
    --l1-size-gb 60 --eviction-policy LRU
[2026-03-11 21:14:21,621] LMCache INFO: Starting LMCache HTTP server on http://0.0.0.0:8000 (http_server.py:192:lmcache.v1.multiprocess.http_server)
INFO:     Started server process [100993]
INFO:     Waiting for application startup.

python3 -m lmcache.v1.multiprocess.cli get-chunk-size  --host localhost --port 5555
256
python3 -m lmcache.v1.multiprocess.cli noop --host localhost --port 5555
OK
python3 -m lmcache.v1.multiprocess.cli clear --host localhost --port 5555
[2026-03-11 21:17:44,275] LMCache INFO: Cache cleared successfully. (clear.py:26:lmcache.v1.multiprocess.cli.commands.clear)
```


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
