### PR TITLE
[MP][Bugfix] introducing new l1 listener to prevent re-storing prefetched object

### DIFF
--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -108,3 +108,6 @@ class EvictionPolicy(L1ManagerListener):
 
     def on_l1_keys_deleted_by_manager(self, keys: list[ObjectKey]):
         self.on_keys_removed(keys)
+
+    def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]):
+        self.on_keys_created(keys)

--- a/lmcache/v1/distributed/internal_api.py
+++ b/lmcache/v1/distributed/internal_api.py
@@ -141,6 +141,22 @@ class L1ManagerListener(EventListener):
         pass
 
     @abstractmethod
+    def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]):
+        """
+        Notify the listener that keys have been finished for writing
+        and reserved for read on L1.
+
+        This will only be trigger by the prefetch operation now.
+
+        Args:
+            keys (list[ObjectKey]): The keys that have been successfully
+                finished for writing and reserved for read
+        """
+        # NOTE (ApostaC): may consider renaming this to `on_l1_keys_finish_prefetch`
+        # for better clarity
+        pass
+
+    @abstractmethod
     def on_l1_keys_deleted_by_manager(self, keys: list[ObjectKey]):
         """
         Notify the listener that keys have been deleted from L1.

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -572,8 +572,7 @@ class L1Manager:
             successful_keys.append(key)
 
         for listener in self._registered_listeners:
-            listener.on_l1_keys_write_finished(successful_keys)
-            listener.on_l1_keys_reserved_read(successful_keys)
+            listener.on_l1_keys_finish_write_and_reserve_read(successful_keys)
         return ret
 
     @l1_mgr_synchronized

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -109,6 +109,11 @@ class StoreListener(L1ManagerListener):
     def on_l1_keys_deleted_by_manager(self, keys: list[ObjectKey]) -> None:
         pass
 
+    def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]) -> None:
+        # No op here because we don't want to trigger store when the
+        # objects are prefetched to L1.
+        pass
+
     def close(self) -> None:
         """Close the eventfd."""
         os.close(self._event_fd)

--- a/lmcache/v1/mp_observability/logger/l1_stats_logger.py
+++ b/lmcache/v1/mp_observability/logger/l1_stats_logger.py
@@ -95,6 +95,10 @@ class L1ManagerStatsLogger(L1ManagerListener, PrometheusLogger):
     def on_l1_keys_deleted_by_manager(self, keys: list[ObjectKey]):
         self.stats.interval_l1_evicted_keys += len(keys)
 
+    @stats_safe
+    def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]):
+        self.stats.interval_l1_write_keys += len(keys)
+
     def log_prometheus(self) -> None:
         """Log accumulated stats to Prometheus and reset internal counters."""
         with _stats_lock:

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -213,6 +213,17 @@ class TestStoreListener:
         assert len(popped) == 3
         listener.close()
 
+    def test_finish_write_and_reserve_read_does_not_enqueue(self):
+        """on_l1_keys_finish_write_and_reserve_read should not enqueue keys."""
+        listener = StoreListener()
+        keys = [make_object_key(i) for i in range(3)]
+
+        listener.on_l1_keys_finish_write_and_reserve_read(keys)
+
+        assert listener.pop_pending_keys() == []
+        assert listener.pending_count() == 0
+        listener.close()
+
 
 # =============================================================================
 # StoreController Integration Tests

--- a/tests/v1/mp_observability/test_l1_stats_logger.py
+++ b/tests/v1/mp_observability/test_l1_stats_logger.py
@@ -97,6 +97,17 @@ class TestL1CounterCallbacks:
         logger.on_l1_keys_deleted_by_manager(make_keys(4, offset=10))
         assert logger.stats.interval_l1_evicted_keys == 7
 
+    def test_finish_write_and_reserve_read_increments_write_counter(self, logger):
+        logger.on_l1_keys_finish_write_and_reserve_read(make_keys(4))
+        assert logger.stats.interval_l1_write_keys == 4
+
+    def test_finish_write_and_reserve_read_accumulates_with_write_finished(
+        self, logger
+    ):
+        logger.on_l1_keys_write_finished(make_keys(3))
+        logger.on_l1_keys_finish_write_and_reserve_read(make_keys(5, offset=10))
+        assert logger.stats.interval_l1_write_keys == 8
+
 
 # ---------------------------------------------------------------------------
 # log_prometheus(): stats swap and Prometheus metric forwarding


### PR DESCRIPTION
Inspired by PR: #2738

**What this PR does / why we need it**:

Previously, `L1Manager.finish_write_and_reserve_read()` (used by prefetch) fired two separate listener callbacks: `on_l1_keys_write_finished` + `on_l1_keys_reserved_read`. The `on_l1_keys_write_finished` callback caused `StoreListener` to enqueue prefetched keys for L2 store — re-storing objects that were just fetched *from* L2.

This PR introduces a dedicated `on_l1_keys_finish_write_and_reserve_read` callback in `L1ManagerListener` so that each subclass can handle the prefetch transition appropriately:

- **StoreListener**: no-op (don't re-store prefetched data back to L2)
- **EvictionPolicy**: registers keys as created (tracks them for eviction)
- **L1ManagerStatsLogger**: counts as write completion (for Prometheus metrics)

**Special notes for your reviewers**:

The L1Manager now fires a single `on_l1_keys_finish_write_and_reserve_read` callback instead of separate `on_l1_keys_write_finished` + `on_l1_keys_reserved_read` in `finish_write_and_reserve_read()`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests