### PR TITLE
[CI][Hotfix][Chore] remove the repetitive definition of report_status

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -537,15 +537,6 @@ class NixlStoreL2Adapter(L2AdapterInterface):
         with self._lock:
             return self._completed_load_tasks.pop(task_id, None)
 
-    def report_status(self) -> dict:
-        """Return a status dict for the Nixl L2 adapter."""
-        with self._lock:
-            return {
-                "is_healthy": True,
-                "type": "NixlStoreL2Adapter",
-                "stored_object_count": len(self._memory_objects),
-            }
-
     def close(self):
         # Stop the event loop and wait for the thread to finish
         async def _stop_tasks():


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the duplicated `report_status` implementation introduced from #2718 

**Special notes for your reviewers**:

One-line change — just deleting the redundant method (9 lines).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [] this PR contains unit tests