### PR TITLE
[MP] Support buffer only mode for MP mode

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -124,7 +124,10 @@ Source: ``lmcache/v1/distributed/config.py``
      - Description
    * - ``--eviction-policy``
      - *required*
-     - Eviction policy.  Currently only ``LRU`` is supported.
+     - Eviction policy.
+       Choices: ``LRU``, ``noop``.
+       Use ``noop`` for buffer-only mode where L1 acts as a pure
+       write buffer (data is deleted from L1 after L2 store).
    * - ``--eviction-trigger-watermark``
      - ``0.8``
      - Memory usage ratio (0.0--1.0) that triggers eviction.
@@ -149,6 +152,9 @@ Source: ``lmcache/v1/distributed/config.py``
      - L2 store policy.  Determines which adapters receive each key
        and whether keys are deleted from L1 after L2 store.
        The ``default`` policy stores all keys to all adapters and keeps L1.
+       The ``noop`` policy stores all keys to all adapters and then
+       deletes them from L1 (buffer-only mode).
+       Choices: ``default``, ``noop``.
    * - ``--l2-prefetch-policy``
      - ``default``
      - L2 prefetch policy.  Determines which adapter loads each key
@@ -349,10 +355,10 @@ Full Example
         --l1-align-bytes 4096 \
         --l1-write-ttl-seconds 600 \
         --l1-read-ttl-seconds 300 \
-        --eviction-policy LRU \
+        --eviction-policy noop \
+        --l2-store-policy noop \
         --eviction-trigger-watermark 0.9 \
         --eviction-ratio 0.1 \
-        --l2-store-policy default \
         --l2-prefetch-policy default \
         --l2-adapter '{"type": "nixl_store", "backend": "POSIX", "backend_params": {"file_path": "/data/lmcache/l2", "use_direct_io": "false"}, "pool_size": 64}' \
         --prometheus-port 9090 \

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -185,9 +185,29 @@ Select policies via CLI:
    * - ``--l2-store-policy``
      - ``default``
      - Store all keys to all adapters.  Never delete from L1.
+   * - ``--l2-store-policy``
+     - ``noop``
+     - Buffer-only mode.  Store all keys to all adapters, then
+       **delete them from L1** immediately.  Pair with
+       ``--eviction-policy noop`` to avoid useless LRU overhead.
    * - ``--l2-prefetch-policy``
      - ``default``
      - For each key, pick the first (lowest-indexed) adapter that has it.
+
+Buffer-Only Mode
+~~~~~~~~~~~~~~~~~
+
+When L1 is used purely as a write buffer (all data lives in L2), use
+``--l2-store-policy noop`` together with ``--eviction-policy noop``.
+This combination deletes keys from L1 as soon as they are stored to L2
+and disables the LRU eviction tracker entirely, reducing memory and CPU
+overhead.
+
+.. code-block:: bash
+
+    --eviction-policy noop \
+    --l2-store-policy noop \
+    --l2-prefetch-policy default
 
 Policies are extensible -- new policies can be added by creating a file
 in ``storage_controllers/`` and calling ``register_store_policy()`` or

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -61,8 +61,8 @@ class EvictionConfig:
     The configuration for eviction policies.
     """
 
-    eviction_policy: Literal["LRU"]
-    """ The eviction policy to use. Currently only 'LRU' is supported. """
+    eviction_policy: Literal["LRU", "noop"]
+    """ The eviction policy to use. """
 
     trigger_watermark: float = field(default=0.8)
     """ The memory usage watermark to trigger eviction (0.0 to 1.0). """
@@ -173,9 +173,9 @@ def add_storage_manager_args(
     eviction_group.add_argument(
         "--eviction-policy",
         type=str,
-        choices=["LRU"],
+        choices=["LRU", "noop"],
         required=True,
-        help="The eviction policy to use. Currently only 'LRU' is supported.",
+        help="The eviction policy to use ('LRU' or 'noop').",
     )
     eviction_group.add_argument(
         "--eviction-trigger-watermark",

--- a/lmcache/v1/distributed/eviction_policy/__init__.py
+++ b/lmcache/v1/distributed/eviction_policy/__init__.py
@@ -10,8 +10,12 @@ from lmcache.v1.distributed.eviction_policy.factory import (
 from lmcache.v1.distributed.eviction_policy.lru import (
     LRUEvictionPolicy,
 )
+from lmcache.v1.distributed.eviction_policy.noop import (
+    NoOpEvictionPolicy,
+)
 
 __all__ = [
     "LRUEvictionPolicy",
+    "NoOpEvictionPolicy",
     "CreateEvictionPolicy",
 ]

--- a/lmcache/v1/distributed/eviction_policy/factory.py
+++ b/lmcache/v1/distributed/eviction_policy/factory.py
@@ -4,6 +4,7 @@
 from lmcache.v1.distributed.config import EvictionConfig
 from lmcache.v1.distributed.eviction import EvictionPolicy
 from lmcache.v1.distributed.eviction_policy.lru import LRUEvictionPolicy
+from lmcache.v1.distributed.eviction_policy.noop import NoOpEvictionPolicy
 
 
 def CreateEvictionPolicy(eviction_config: EvictionConfig) -> EvictionPolicy:
@@ -18,6 +19,8 @@ def CreateEvictionPolicy(eviction_config: EvictionConfig) -> EvictionPolicy:
     """
     if eviction_config.eviction_policy == "LRU":
         return LRUEvictionPolicy()
+    elif eviction_config.eviction_policy == "noop":
+        return NoOpEvictionPolicy()
     else:
         raise ValueError(
             f"Unsupported eviction policy: {eviction_config.eviction_policy}"

--- a/lmcache/v1/distributed/eviction_policy/noop.py
+++ b/lmcache/v1/distributed/eviction_policy/noop.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+No-op eviction policy for buffer-only mode.
+
+When L1 is used purely as a write buffer (data is deleted from L1
+immediately after being stored to L2 by the StoreController), there
+is no need for the eviction policy to track keys at all.
+"""
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction import EvictionPolicy
+from lmcache.v1.distributed.internal_api import (
+    EvictionAction,
+    EvictionDestination,
+)
+
+
+class NoOpEvictionPolicy(EvictionPolicy):
+    """
+    Eviction policy that performs no tracking and never evicts.
+
+    Designed for buffer-only mode where the StoreController is
+    responsible for cleaning up L1 after successful L2 writes.
+    This avoids the overhead of maintaining an LRU OrderedDict
+    that would otherwise do pointless insert-then-remove cycles.
+    """
+
+    def register_eviction_destination(self, destination: EvictionDestination):
+        pass
+
+    def on_keys_created(self, keys: list[ObjectKey]):
+        pass
+
+    def on_keys_touched(self, keys: list[ObjectKey]):
+        pass
+
+    def on_keys_removed(self, keys: list[ObjectKey]):
+        pass
+
+    def get_eviction_actions(self, expected_ratio: float) -> list[EvictionAction]:
+        return []

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -180,4 +180,49 @@ class DefaultStorePolicy(StorePolicy):
         return []
 
 
+class BufferOnlyStorePolicy(StorePolicy):
+    """
+    Buffer-only store policy: store all keys to all adapters,
+    then delete them from L1 immediately.
+
+    Use this with NoOpEvictionPolicy to avoid useless LRU
+    tracking overhead when L1 is a pure write buffer.
+    """
+
+    def select_store_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[ObjectKey]]:
+        """
+        Store all keys to all adapters.
+
+        Args:
+            keys: Keys that were just written to L1.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from every adapter index to the full
+            list of keys.
+        """
+        return {ad.index: list(keys) for ad in adapters}
+
+    def select_l1_deletions(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[ObjectKey]:
+        """
+        Delete all keys from L1 after successful L2 store.
+
+        Args:
+            keys: Keys that were successfully stored to L2.
+
+        Returns:
+            All keys (remove everything from L1).
+        """
+        return list(keys)
+
+
 register_store_policy("default", DefaultStorePolicy)
+register_store_policy("noop", BufferOnlyStorePolicy)
+

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -210,4 +210,4 @@ class BufferOnlyStorePolicy(DefaultStorePolicy):
 
 
 register_store_policy("default", DefaultStorePolicy)
-register_store_policy("noop", BufferOnlyStorePolicy)
+register_store_policy("skip_l1", BufferOnlyStorePolicy)

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -180,32 +180,18 @@ class DefaultStorePolicy(StorePolicy):
         return []
 
 
-class BufferOnlyStorePolicy(StorePolicy):
+class BufferOnlyStorePolicy(DefaultStorePolicy):
     """
     Buffer-only store policy: store all keys to all adapters,
     then delete them from L1 immediately.
 
     Use this with NoOpEvictionPolicy to avoid useless LRU
     tracking overhead when L1 is a pure write buffer.
+
+    Inherits ``select_store_targets`` from ``DefaultStorePolicy``
+    (store all keys to all adapters) and only overrides the L1
+    deletion decision.
     """
-
-    def select_store_targets(
-        self,
-        keys: list[ObjectKey],
-        adapters: list[AdapterDescriptor],
-    ) -> dict[int, list[ObjectKey]]:
-        """
-        Store all keys to all adapters.
-
-        Args:
-            keys: Keys that were just written to L1.
-            adapters: Descriptors of available L2 adapters.
-
-        Returns:
-            Mapping from every adapter index to the full
-            list of keys.
-        """
-        return {ad.index: list(keys) for ad in adapters}
 
     def select_l1_deletions(
         self,

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -211,4 +211,3 @@ class BufferOnlyStorePolicy(DefaultStorePolicy):
 
 register_store_policy("default", DefaultStorePolicy)
 register_store_policy("noop", BufferOnlyStorePolicy)
-

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -20,6 +20,9 @@ import torch
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.eviction_policy.noop import (
+    NoOpEvictionPolicy,
+)
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
     MockL2Adapter,
@@ -31,6 +34,7 @@ from lmcache.v1.distributed.storage_controllers.store_controller import (
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    BufferOnlyStorePolicy,
     DefaultStorePolicy,
     StorePolicy,
 )
@@ -589,3 +593,98 @@ class TestStoreControllerCustomPolicy:
         ctrl.stop()
         for a in adapters:
             a.close()
+
+
+class TestBufferOnlyMode:
+    """Test buffer-only mode: BufferOnlyStorePolicy + NoOpEvictionPolicy."""
+
+    def test_l1_cleaned_after_l2_store(self, l1_manager):
+        """L1 data should be deleted after successful L2 store."""
+        adapter = make_adapter()
+        noop_policy = NoOpEvictionPolicy()
+        l1_manager.register_listener(noop_policy)
+
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=BufferOnlyStorePolicy(),
+        )
+        ctrl.start()
+
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        # Wait for L2 store
+        ok = wait_for_condition(
+            lambda: adapter.debug_has_key(keys[0]),
+            timeout=5.0,
+        )
+        assert ok, "Object should be stored in L2"
+
+        # L1 should be cleaned: re-create with mode='new' succeeds
+        ok = wait_for_condition(
+            lambda: l1_manager.reserve_write(
+                keys=keys,
+                is_temporary=[False],
+                layout_desc=layout,
+                mode="new",
+            )[keys[0]][1]
+            is not None,
+            timeout=5.0,
+        )
+        assert ok, "Key should be re-creatable after L1 deletion in buffer-only mode"
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_noop_eviction_never_evicts(self):
+        """NoOpEvictionPolicy should never return eviction actions."""
+        noop = NoOpEvictionPolicy()
+        noop.on_keys_created([make_object_key(i) for i in range(10)])
+        assert noop.get_eviction_actions(1.0) == []
+
+    def test_buffer_only_multiple_keys(self, l1_manager):
+        """Multiple keys should all flow to L2 and be removed
+        from L1."""
+        adapter = make_adapter()
+        noop_policy = NoOpEvictionPolicy()
+        l1_manager.register_listener(noop_policy)
+
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=BufferOnlyStorePolicy(),
+        )
+        ctrl.start()
+
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(5)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        ok = wait_for_condition(
+            lambda: adapter.debug_get_stored_object_count() == 5,
+            timeout=5.0,
+        )
+        assert ok, "All 5 objects should be stored in L2"
+
+        # All keys should be removable from L1 (re-create)
+        ok = wait_for_condition(
+            lambda: all(
+                l1_manager.reserve_write(
+                    keys=[k],
+                    is_temporary=[False],
+                    layout_desc=layout,
+                    mode="new",
+                )[k][1]
+                is not None
+                for k in keys
+            ),
+            timeout=5.0,
+        )
+        assert ok, "All keys should be re-creatable after buffer-only L1 cleanup"
+
+        ctrl.stop()
+        adapter.close()

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -623,18 +623,12 @@ class TestBufferOnlyMode:
         )
         assert ok, "Object should be stored in L2"
 
-        # L1 should be cleaned: re-create with mode='new' succeeds
+        # L1 should be cleaned: check key is gone
         ok = wait_for_condition(
-            lambda: l1_manager.reserve_write(
-                keys=keys,
-                is_temporary=[False],
-                layout_desc=layout,
-                mode="new",
-            )[keys[0]][1]
-            is not None,
+            lambda: l1_manager.get_object_state(keys[0]) is None,
             timeout=5.0,
         )
-        assert ok, "Key should be re-creatable after L1 deletion in buffer-only mode"
+        assert ok, "Key should be deleted from L1 in buffer-only mode"
 
         ctrl.stop()
         adapter.close()
@@ -670,21 +664,12 @@ class TestBufferOnlyMode:
         )
         assert ok, "All 5 objects should be stored in L2"
 
-        # All keys should be removable from L1 (re-create)
+        # All keys should be gone from L1
         ok = wait_for_condition(
-            lambda: all(
-                l1_manager.reserve_write(
-                    keys=[k],
-                    is_temporary=[False],
-                    layout_desc=layout,
-                    mode="new",
-                )[k][1]
-                is not None
-                for k in keys
-            ),
+            lambda: all(l1_manager.get_object_state(k) is None for k in keys),
             timeout=5.0,
         )
-        assert ok, "All keys should be re-creatable after buffer-only L1 cleanup"
+        assert ok, "All keys should be deleted from L1 after buffer-only cleanup"
 
         ctrl.stop()
         adapter.close()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

```
L1_SIZE_GB=0.03
L2_JSON='{"type": "mock", "max_size_gb": 1.0, "mock_bandwidth_gb": 20.0}'
python3 -m lmcache.v1.multiprocess.server \
    --host localhost --port 15556 \
    --chunk-size 256 --l1-size-gb $L1_SIZE_GB \
    --eviction-policy noop --max-workers 1 \
    --l2-adapter "$L2_JSON"
```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
