### PR TITLE
Fix[config]: replace store_true with BooleanOptionalAction for --l1-use-lazy

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -79,9 +79,11 @@ Source: ``lmcache/v1/distributed/config.py``
    * - ``--l1-size-gb``
      - *required*
      - Size of L1 memory in GB.
-   * - ``--l1-use-lazy``
+   * - ``--l1-use-lazy`` / ``--no-l1-use-lazy``
      - ``True``
-     - Use lazy allocation for L1 memory.
+     - Enable or disable lazy allocation for L1 memory.
+       Pass ``--l1-use-lazy`` to enable (default) or
+       ``--no-l1-use-lazy`` to explicitly disable.
    * - ``--l1-init-size-gb``
      - ``20``
      - Initial allocation size (GB) when using lazy allocation.

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -126,7 +126,7 @@ def add_storage_manager_args(
     )
     memory_group.add_argument(
         "--l1-use-lazy",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Whether to use lazy loading for L1 memory. (Default is True)",
     )


### PR DESCRIPTION
fix(config): replace store_true with BooleanOptionalAction for --l1-use-lazy

Use argparse.BooleanOptionalAction instead of action='store_true' so that --no-l1-use-lazy can be passed on the command line to explicitly disable lazy loading for L1 memory.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

