### PR TITLE
[Bugfix] large-offset CUDA KV transfers

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -26,6 +26,8 @@
     } while (0)
 #endif
 
+namespace {
+
 unsigned int checked_cuda_dim_component(const int64_t value,
                                         const int64_t limit,
                                         const char* const name) {
@@ -53,6 +55,8 @@ dim3 make_block_dim3(const int64_t x, const int64_t y = 1,
       checked_cuda_dim_component(y, props->maxThreadsDim[1], "block.y"),
       checked_cuda_dim_component(z, props->maxThreadsDim[2], "block.z"));
 }
+
+}  // namespace
 
 namespace lmc {
 

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -5,6 +5,7 @@
 #include "mem_kernels.cuh"
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <limits>
 #ifdef USE_ROCM
   #include <hip/hip_fp8.h>
 #else
@@ -24,6 +25,34 @@
       }                                                                     \
     } while (0)
 #endif
+
+unsigned int checked_cuda_dim_component(const int64_t value,
+                                        const int64_t limit,
+                                        const char* const name) {
+  TORCH_CHECK(value >= 0, name, " must be non-negative, got ", value);
+  TORCH_CHECK(value <= limit, name, " exceeds the active CUDA device limit (",
+              limit, "), got ", value);
+  TORCH_CHECK(
+      value <= static_cast<int64_t>(std::numeric_limits<unsigned int>::max()),
+      name, " exceeds the dim3 component range, got ", value);
+  return static_cast<unsigned int>(value);
+}
+
+dim3 make_grid_dim3(const int64_t x, const int64_t y = 1, const int64_t z = 1) {
+  const auto* const props = at::cuda::getCurrentDeviceProperties();
+  return dim3(checked_cuda_dim_component(x, props->maxGridSize[0], "grid.x"),
+              checked_cuda_dim_component(y, props->maxGridSize[1], "grid.y"),
+              checked_cuda_dim_component(z, props->maxGridSize[2], "grid.z"));
+}
+
+dim3 make_block_dim3(const int64_t x, const int64_t y = 1,
+                     const int64_t z = 1) {
+  const auto* const props = at::cuda::getCurrentDeviceProperties();
+  return dim3(
+      checked_cuda_dim_component(x, props->maxThreadsDim[0], "block.x"),
+      checked_cuda_dim_component(y, props->maxThreadsDim[1], "block.y"),
+      checked_cuda_dim_component(z, props->maxThreadsDim[2], "block.z"));
+}
 
 namespace lmc {
 
@@ -475,10 +504,9 @@ void multi_layer_kv_transfer_templated(
 
   int64_t k_or_v_size = lmc::is_mla(gpu_kv_format) ? 1 : 2;
 
-  dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
-  dim3 block(std::min<int64_t>(num_xwords, 128));
-
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
+  dim3 grid = make_grid_dim3(num_transfer_tokens, num_layers, k_or_v_size);
+  dim3 block = make_block_dim3(std::min<int64_t>(num_xwords, 128));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (direction == TransferDirection::H2D) {
@@ -616,10 +644,9 @@ void multi_layer_kv_transfer_unilateral(
 
   int64_t k_or_v_size = 2;
 
-  dim3 grid(key_value.size(2), key_value.size(1), k_or_v_size);
-  dim3 block(std::min<int64_t>(num_qwords, 128));
-
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
+  dim3 grid = make_grid_dim3(key_value.size(2), key_value.size(1), k_or_v_size);
+  dim3 block = make_block_dim3(std::min<int64_t>(num_qwords, 128));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (direction == TransferDirection::H2D) {
@@ -734,10 +761,11 @@ void single_layer_kv_transfer(
   // int block_stride_in_64bit = vllm_key_cache.stride(0) / elements_per_entry;
   // TORCH_CHECK(vllm_key_cache.stride(0) == vllm_value_cache.stride(0));
 
-  dim3 grid(num_tokens);
-  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(
       device_of(vllm_key_value_cache));
+  dim3 grid = make_grid_dim3(num_tokens);
+  dim3 block =
+      make_block_dim3(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   // Dispatch to the appropriate template specialization based on use_mla
@@ -797,9 +825,10 @@ void load_and_reshape_flash(
   int64_t block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
   TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
 
-  dim3 grid(num_tokens);
-  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(key_cache));
+  dim3 grid = make_grid_dim3(num_tokens);
+  dim3 block =
+      make_block_dim3(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   lmc::load_and_reshape_flash_kernel<int64_t><<<grid, block, 0, stream>>>(
@@ -847,9 +876,10 @@ void reshape_and_cache_back_flash(
   int64_t block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
   TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
 
-  dim3 grid(num_tokens);
-  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(key_cache));
+  dim3 grid = make_grid_dim3(num_tokens);
+  dim3 block =
+      make_block_dim3(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   lmc::reshape_and_cache_back_flash_kernel<int64_t><<<grid, block, 0, stream>>>(
@@ -914,9 +944,10 @@ void single_layer_kv_transfer_sgl(
   int64_t block_stride_in_64bit = sgl_key_cache.stride(0) / elements_per_entry;
   TORCH_CHECK(sgl_key_cache.stride(0) == sgl_value_cache.stride(0));
 
-  dim3 grid(num_tokens);
-  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(sgl_key_cache));
+  dim3 grid = make_grid_dim3(num_tokens);
+  dim3 block =
+      make_block_dim3(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   lmc::single_layer_kv_transfer_sgl_kernel<int64_t><<<grid, block, 0, stream>>>(

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -42,9 +42,10 @@ __global__ void load_and_reshape_flash_kernel(
     const scalar_t* __restrict__ value_cache,  // [num_blocks, block_size,
                                                // num_heads, head_size]
     const int64_t* __restrict__ slot_mapping,  // [num_tokens]
-    const int block_stride_in_64bit, const int key_value_stride,
-    const int num_heads, const int head_size_in_64bit, const int block_size,
-    const int key_layer_offset, const int value_layer_offset) {
+    const int64_t block_stride_in_64bit, const int64_t key_value_stride,
+    const int64_t num_heads, const int64_t head_size_in_64bit,
+    const int64_t block_size, const int64_t key_layer_offset,
+    const int64_t value_layer_offset) {
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
 
@@ -54,16 +55,16 @@ __global__ void load_and_reshape_flash_kernel(
 
   const int64_t block_idx = slot_idx / block_size;
   const int64_t block_offset = slot_idx % block_size;
-  const int n = num_heads * head_size_in_64bit;
+  const int64_t n = num_heads * head_size_in_64bit;
 
-  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+  for (int64_t i = threadIdx.x; i < n; i += blockDim.x) {
     const int64_t tgt_key_idx =
         key_layer_offset + token_idx * key_value_stride + i;
     const int64_t tgt_value_idx =
         value_layer_offset + token_idx * key_value_stride + i;
 
-    const int head_idx = i / head_size_in_64bit;
-    const int head_offset = i % head_size_in_64bit;
+    const int64_t head_idx = i / head_size_in_64bit;
+    const int64_t head_offset = i % head_size_in_64bit;
     const int64_t src_key_value_idx =
         block_idx * block_stride_in_64bit +
         block_offset * num_heads * head_size_in_64bit +
@@ -86,9 +87,10 @@ __global__ void reshape_and_cache_back_flash_kernel(
     scalar_t* __restrict__ value_cache,  // [num_blocks, block_size, num_heads,
                                          // head_size]
     const int64_t* __restrict__ slot_mapping,  // [num_tokens]
-    const int block_stride_in_64bit, const int key_value_stride,
-    const int num_heads, const int head_size_in_64bit, const int block_size,
-    const int key_layer_offset, const int value_layer_offset) {
+    const int64_t block_stride_in_64bit, const int64_t key_value_stride,
+    const int64_t num_heads, const int64_t head_size_in_64bit,
+    const int64_t block_size, const int64_t key_layer_offset,
+    const int64_t value_layer_offset) {
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
 
@@ -98,16 +100,16 @@ __global__ void reshape_and_cache_back_flash_kernel(
 
   const int64_t block_idx = slot_idx / block_size;
   const int64_t block_offset = slot_idx % block_size;
-  const int n = num_heads * head_size_in_64bit;
+  const int64_t n = num_heads * head_size_in_64bit;
 
-  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+  for (int64_t i = threadIdx.x; i < n; i += blockDim.x) {
     const int64_t tgt_key_idx =
         key_layer_offset + token_idx * key_value_stride + i;
     const int64_t tgt_value_idx =
         value_layer_offset + token_idx * key_value_stride + i;
 
-    const int head_idx = i / head_size_in_64bit;
-    const int head_offset = i % head_size_in_64bit;
+    const int64_t head_idx = i / head_size_in_64bit;
+    const int64_t head_offset = i % head_size_in_64bit;
     const int64_t src_key_value_idx =
         block_idx * block_stride_in_64bit +
         block_offset * num_heads * head_size_in_64bit +
@@ -143,9 +145,10 @@ __global__ void single_layer_kv_transfer_kernel(
                                                   // head_size]
 
     const int64_t* __restrict__ slot_mapping,  // [num_tokens]
-    const int vllm_block_key_stride_in_64bit, const int vllm_value_offset,
-    const int lmc_stride, const int lmc_value_offset, const int num_heads,
-    const int head_size_in_64bit, const int block_size,
+    const int64_t vllm_block_key_stride_in_64bit,
+    const int64_t vllm_value_offset, const int64_t lmc_stride,
+    const int64_t lmc_value_offset, const int64_t num_heads,
+    const int64_t head_size_in_64bit, const int64_t block_size,
     const TransferDirection direction) {
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
@@ -156,13 +159,13 @@ __global__ void single_layer_kv_transfer_kernel(
 
   const int64_t block_idx = slot_idx / block_size;
   const int64_t block_offset = slot_idx % block_size;
-  const int n = num_heads * head_size_in_64bit;
+  const int64_t n = num_heads * head_size_in_64bit;
 
-  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+  for (int64_t i = threadIdx.x; i < n; i += blockDim.x) {
     const int64_t lmc_key_idx = token_idx * lmc_stride + i;
 
-    const int head_idx = i / head_size_in_64bit;
-    const int head_offset = i % head_size_in_64bit;
+    const int64_t head_idx = i / head_size_in_64bit;
+    const int64_t head_offset = i % head_size_in_64bit;
     const int64_t vllm_key_idx = block_idx * vllm_block_key_stride_in_64bit +
                                  block_offset * num_heads * head_size_in_64bit +
                                  head_idx * head_size_in_64bit + head_offset;
@@ -193,9 +196,10 @@ __global__ void single_layer_kv_transfer_kernel(
 
 template <GPUKVFormat format>
 __device__ __forceinline__ int64_t
-page_buffer_offset(const int k_or_v, const int token_idx,
-                   const int scalar_offset, const int scalars_per_token,
-                   const int page_buffer_size, const int block_size) {
+page_buffer_offset(const int64_t k_or_v, const int64_t token_idx,
+                   const int64_t scalar_offset,
+                   const int64_t scalars_per_token,
+                   const int64_t page_buffer_size, const int64_t block_size) {
   // vllm cross layer
   if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
@@ -208,8 +212,8 @@ page_buffer_offset(const int k_or_v, const int token_idx,
   }
   // vllm flash infer
   else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
-    const int block_idx = token_idx / block_size;
-    const int block_offset = token_idx % block_size;
+    const int64_t block_idx = token_idx / block_size;
+    const int64_t block_offset = token_idx % block_size;
     return block_idx * 2 * block_size * scalars_per_token +
            k_or_v * block_size * scalars_per_token +
            block_offset * scalars_per_token + scalar_offset;
@@ -222,14 +226,16 @@ page_buffer_offset(const int k_or_v, const int token_idx,
 }
 
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
-    const int token_idx, const int scalar_offset, const int scalars_per_token) {
+    const int64_t token_idx, const int64_t scalar_offset,
+    const int64_t scalars_per_token) {
   return token_idx * scalars_per_token + scalar_offset;
 }
 
 __device__ __forceinline__ int64_t
-key_value_offset(const int k_or_v, const int layer_idx, const int token_idx,
-                 const int scalar_offset, const int scalars_per_token,
-                 const int num_tokens, const int num_layers) {
+key_value_offset(const int64_t k_or_v, const int64_t layer_idx,
+                 const int64_t token_idx, const int64_t scalar_offset,
+                 const int64_t scalars_per_token, const int64_t num_tokens,
+                 const int64_t num_layers) {
   return k_or_v * num_layers * num_tokens * scalars_per_token +
          layer_idx * num_tokens * scalars_per_token +
          token_idx * scalars_per_token + scalar_offset;
@@ -250,9 +256,9 @@ __global__ void single_layer_kv_transfer_sgl_kernel(
     scalar_t* __restrict__ sgl_value_cache,      // [num_blocks, block_size,
                                                  // num_heads, head_size]
     const int64_t* __restrict__ slot_mapping,    // [num_tokens]
-    const int block_stride_in_64bit, const int lmc_stride,
-    const int lmc_value_offset, const int num_heads,
-    const int head_size_in_64bit, const int block_size,
+    const int64_t block_stride_in_64bit, const int64_t lmc_stride,
+    const int64_t lmc_value_offset, const int64_t num_heads,
+    const int64_t head_size_in_64bit, const int64_t block_size,
     const TransferDirection direction) {
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
@@ -263,14 +269,14 @@ __global__ void single_layer_kv_transfer_sgl_kernel(
 
   const int64_t block_idx = slot_idx / block_size;
   const int64_t block_offset = slot_idx % block_size;
-  const int n = num_heads * head_size_in_64bit;
+  const int64_t n = num_heads * head_size_in_64bit;
 
-  for (int i = threadIdx.x; i < n; i += blockDim.x) {
+  for (int64_t i = threadIdx.x; i < n; i += blockDim.x) {
     const int64_t lmc_key_idx = token_idx * lmc_stride + i;
     const int64_t lmc_value_idx = lmc_key_idx + lmc_value_offset;
 
-    const int head_idx = i / head_size_in_64bit;
-    const int head_offset = i % head_size_in_64bit;
+    const int64_t head_idx = i / head_size_in_64bit;
+    const int64_t head_offset = i % head_size_in_64bit;
     const int64_t sgl_key_value_idx =
         block_idx * block_stride_in_64bit +
         block_offset * num_heads * head_size_in_64bit +
@@ -304,16 +310,16 @@ __global__ void load_and_reshape_multi_layer_kernel(
                                                 // 2, block_size,
                                                 // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
-    const int scalars_per_token, const int num_tokens, const int num_layers,
-    const int page_buffer_size, const int block_size,
-    const int skip_prefix_n_tokens) {
-  const int token_id = blockIdx.x;
-  const int layer_id = blockIdx.y;
-  const int k_or_v = blockIdx.z;
-  const int tid = threadIdx.x;
-  const int num_threads = blockDim.x;
+    const int64_t scalars_per_token, const int64_t num_tokens,
+    const int64_t num_layers, const int64_t page_buffer_size,
+    const int64_t block_size, const int64_t skip_prefix_n_tokens) {
+  const int64_t token_id = blockIdx.x;
+  const int64_t layer_id = blockIdx.y;
+  const int64_t k_or_v = blockIdx.z;
+  const int64_t tid = threadIdx.x;
+  const int64_t num_threads = blockDim.x;
 
-  const int kv_token_id = token_id + skip_prefix_n_tokens;
+  const int64_t kv_token_id = token_id + skip_prefix_n_tokens;
   const int64_t slot_idx = slot_mapping[kv_token_id];
   scalar_t* paged_buffer_ptr = paged_buffer_ptrs[layer_id];
 
@@ -322,7 +328,7 @@ __global__ void load_and_reshape_multi_layer_kernel(
   }
 
   /** Copy the data from page buffer to key_value **/
-  for (int i = tid; i < scalars_per_token; i += num_threads) {
+  for (int64_t i = tid; i < scalars_per_token; i += num_threads) {
     const int64_t lmcache_offset =
         key_value_offset(k_or_v, layer_id, kv_token_id, i, scalars_per_token,
                          num_tokens, num_layers);
@@ -350,13 +356,13 @@ __global__ void load_and_reshape_multi_layer_kernel_unilateral(
                                                 // [PAGE_BUFFER_SIZE,
                                                 // scalars_per_token]
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
-    const int scalars_per_token, const int num_tokens, const int num_layers,
-    const int page_buffer_size) {
-  const int token_id = blockIdx.x;
-  const int layer_id = blockIdx.y;
-  const int k_or_v = blockIdx.z;
-  const int tid = threadIdx.x;
-  const int num_threads = blockDim.x;
+    const int64_t scalars_per_token, const int64_t num_tokens,
+    const int64_t num_layers, const int64_t page_buffer_size) {
+  const int64_t token_id = blockIdx.x;
+  const int64_t layer_id = blockIdx.y;
+  const int64_t k_or_v = blockIdx.z;
+  const int64_t tid = threadIdx.x;
+  const int64_t num_threads = blockDim.x;
 
   const int64_t slot_idx = slot_mapping[token_id];
   scalar_t* key_ptr = paged_buffer_ptrs[layer_id];
@@ -367,7 +373,7 @@ __global__ void load_and_reshape_multi_layer_kernel_unilateral(
   }
 
   /** Copy the data from page buffer to key_value **/
-  for (int i = tid; i < scalars_per_token; i += num_threads) {
+  for (int64_t i = tid; i < scalars_per_token; i += num_threads) {
     const int64_t lmcache_offset =
         key_value_offset(k_or_v, layer_id, token_id, i, scalars_per_token,
                          num_tokens, num_layers);
@@ -453,26 +459,27 @@ void multi_layer_kv_transfer_templated(
                     // for MLA.
     const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
-    const torch::Device& paged_memory_device, const int page_buffer_size,
+    const torch::Device& paged_memory_device,
+    const int64_t page_buffer_size,
     const TransferDirection direction, const GPUKVFormat gpu_kv_format,
-    const int block_size, const int skip_prefix_n_tokens) {
+    const int64_t block_size, const int64_t skip_prefix_n_tokens) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
       get_kernel_ptr<T*, const torch::Tensor>(key_value_ptrs);
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
-  int num_layers = key_value.size(1);
-  int num_tokens = key_value.size(2);
-  int num_transfer_tokens = num_tokens - skip_prefix_n_tokens;
-  int num_origin_elements = key_value.size(3);
-  int elements_per_xword = sizeof(T) / key_value.element_size();
-  int num_xwords = num_origin_elements / elements_per_xword;
+  int64_t num_layers = key_value.size(1);
+  int64_t num_tokens = key_value.size(2);
+  int64_t num_transfer_tokens = num_tokens - skip_prefix_n_tokens;
+  int64_t num_origin_elements = key_value.size(3);
+  int64_t elements_per_xword = sizeof(T) / key_value.element_size();
+  int64_t num_xwords = num_origin_elements / elements_per_xword;
 
-  int k_or_v_size = lmc::is_mla(gpu_kv_format) ? 1 : 2;
+  int64_t k_or_v_size = lmc::is_mla(gpu_kv_format) ? 1 : 2;
 
   dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
-  dim3 block(std::min(num_xwords, 128));
+  dim3 block(std::min<int64_t>(num_xwords, 128));
 
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -528,11 +535,11 @@ void multi_layer_kv_transfer_templated(
 void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
-    const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size,
-    const int skip_prefix_n_tokens) {
-  int num_origin_elements = key_value.size(3);
-  int copy_size = num_origin_elements * key_value.element_size();
+    const int64_t page_buffer_size, const TransferDirection direction,
+    const GPUKVFormat gpu_kv_format, const int64_t block_size,
+    const int64_t skip_prefix_n_tokens) {
+  int64_t num_origin_elements = key_value.size(3);
+  int64_t copy_size = num_origin_elements * key_value.element_size();
 #ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
   #define LAUNCH_MULTI_LAYER_KV_TRANSFER(type)                          \
     do {                                                                \
@@ -587,7 +594,8 @@ void multi_layer_kv_transfer_unilateral(
 
     const torch::Tensor& key_value_ptrs,  // [num_layers*2]
     const torch::Tensor& slot_mapping,    // [num_tokens],
-    const torch::Device& paged_memory_device, const int page_buffer_size,
+    const torch::Device& paged_memory_device,
+    const int64_t page_buffer_size,
     const TransferDirection direction, const GPUKVFormat gpu_kv_format) {
   const bool use_mla = lmc::is_mla(gpu_kv_format);
   // MLA case collapses back to multi_layer_kv_transfer
@@ -604,16 +612,16 @@ void multi_layer_kv_transfer_unilateral(
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
-  int num_layers = key_value.size(1);
-  int num_tokens = slot_mapping.size(0);
-  int num_origin_elements = key_value.size(3);
-  int elements_per_qword = 8 / key_value.element_size();
-  int num_qwords = num_origin_elements / elements_per_qword;
+  int64_t num_layers = key_value.size(1);
+  int64_t num_tokens = slot_mapping.size(0);
+  int64_t num_origin_elements = key_value.size(3);
+  int64_t elements_per_qword = 8 / key_value.element_size();
+  int64_t num_qwords = num_origin_elements / elements_per_qword;
 
-  int k_or_v_size = 2;
+  int64_t k_or_v_size = 2;
 
   dim3 grid(key_value.size(2), key_value.size(1), k_or_v_size);
-  dim3 block(std::min(num_qwords, 128));
+  dim3 block(std::min<int64_t>(num_qwords, 128));
 
   const at::cuda::OptionalCUDAGuard device_guard(paged_memory_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -676,12 +684,12 @@ void single_layer_kv_transfer(
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
-  int elements_per_entry = 8 / vllm_key_value_cache.element_size();
+  int64_t elements_per_entry = 8 / vllm_key_value_cache.element_size();
 
-  int num_tokens = slot_mapping.size(0);
-  int num_heads;
-  int head_size_in_64bit;
-  int block_size;
+  int64_t num_tokens = slot_mapping.size(0);
+  int64_t num_heads;
+  int64_t head_size_in_64bit;
+  int64_t block_size;
 
   const bool use_mla = lmc::is_mla(gpu_kv_format);
 
@@ -696,8 +704,8 @@ void single_layer_kv_transfer(
     block_size = vllm_key_value_cache.size(2);
   }
 
-  int lmc_stride;
-  int lmc_value_offset;
+  int64_t lmc_stride;
+  int64_t lmc_value_offset;
   if (use_mla) {
     // MLA format: [num_tokens, aligned_head_size]
     lmc_stride = lmc_key_value_cache.stride(0) / elements_per_entry;
@@ -710,8 +718,8 @@ void single_layer_kv_transfer(
     lmc_value_offset = lmc_key_value_cache.stride(0) / elements_per_entry;
   }
 
-  int vllm_block_key_stride_in_64bit;
-  int vllm_value_offset;
+  int64_t vllm_block_key_stride_in_64bit;
+  int64_t vllm_value_offset;
   if (use_mla) {
     // MLA format: [num_blocks, block_size, head_size]
     vllm_block_key_stride_in_64bit =
@@ -731,7 +739,7 @@ void single_layer_kv_transfer(
   // TORCH_CHECK(vllm_key_cache.stride(0) == vllm_value_cache.stride(0));
 
   dim3 grid(num_tokens);
-  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(
       device_of(vllm_key_value_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -774,26 +782,27 @@ void load_and_reshape_flash(
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
-  int elements_per_entry = 8 / key_cache.element_size();
+  int64_t elements_per_entry = 8 / key_cache.element_size();
 
-  int num_tokens = slot_mapping.size(0);
-  int num_heads = key_cache.size(2);
-  int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
+  int64_t num_tokens = slot_mapping.size(0);
+  int64_t num_heads = key_cache.size(2);
+  int64_t head_size_in_64bit = key_cache.size(3) / elements_per_entry;
 
-  int block_size = key_cache.size(1);
+  int64_t block_size = key_cache.size(1);
 
-  int key_value_stride = key_value.stride(2) / elements_per_entry;
+  int64_t key_value_stride = key_value.stride(2) / elements_per_entry;
 
-  int num_layers = key_value.size(1);
-  int key_layer_offset = layer_idx * key_value.stride(1) / elements_per_entry;
-  int value_layer_offset =
+  int64_t num_layers = key_value.size(1);
+  int64_t key_layer_offset =
+      layer_idx * key_value.stride(1) / elements_per_entry;
+  int64_t value_layer_offset =
       (layer_idx + num_layers) * key_value.stride(1) / elements_per_entry;
 
-  int block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
+  int64_t block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
   TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
 
   dim3 grid(num_tokens);
-  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(key_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
@@ -823,26 +832,27 @@ void reshape_and_cache_back_flash(
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
-  int elements_per_entry = 8 / key_cache.element_size();
+  int64_t elements_per_entry = 8 / key_cache.element_size();
 
-  int num_tokens = slot_mapping.size(0);
-  int num_heads = key_cache.size(2);
-  int head_size_in_64bit = key_cache.size(3) / elements_per_entry;
+  int64_t num_tokens = slot_mapping.size(0);
+  int64_t num_heads = key_cache.size(2);
+  int64_t head_size_in_64bit = key_cache.size(3) / elements_per_entry;
 
-  int block_size = key_cache.size(1);
+  int64_t block_size = key_cache.size(1);
 
-  int key_value_stride = key_value.stride(2) / elements_per_entry;
+  int64_t key_value_stride = key_value.stride(2) / elements_per_entry;
 
-  int num_layers = key_value.size(1);
-  int key_layer_offset = layer_idx * key_value.stride(1) / elements_per_entry;
-  int value_layer_offset =
+  int64_t num_layers = key_value.size(1);
+  int64_t key_layer_offset =
+      layer_idx * key_value.stride(1) / elements_per_entry;
+  int64_t value_layer_offset =
       (layer_idx + num_layers) * key_value.stride(1) / elements_per_entry;
 
-  int block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
+  int64_t block_stride_in_64bit = key_cache.stride(0) / elements_per_entry;
   TORCH_CHECK(key_cache.stride(0) == value_cache.stride(0));
 
   dim3 grid(num_tokens);
-  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(key_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
@@ -887,16 +897,16 @@ void single_layer_kv_transfer_sgl(
   const int64_t* slot_mapping_ptr =
       get_kernel_ptr<const int64_t, const torch::Tensor>(slot_mapping);
 
-  int elements_per_entry = 8 / sgl_key_cache.element_size();
+  int64_t elements_per_entry = 8 / sgl_key_cache.element_size();
 
-  int num_tokens = slot_mapping.size(0);
-  int num_heads = sgl_key_cache.size(2);
-  int head_size_in_64bit = sgl_key_cache.size(3) / elements_per_entry;
+  int64_t num_tokens = slot_mapping.size(0);
+  int64_t num_heads = sgl_key_cache.size(2);
+  int64_t head_size_in_64bit = sgl_key_cache.size(3) / elements_per_entry;
 
-  int block_size = sgl_key_cache.size(1);
+  int64_t block_size = sgl_key_cache.size(1);
 
-  int lmc_stride;
-  int lmc_value_offset;
+  int64_t lmc_stride;
+  int64_t lmc_value_offset;
   if (token_major) {
     lmc_stride = lmc_key_value_cache.stride(0) / elements_per_entry;
     lmc_value_offset = lmc_key_value_cache.stride(1) / elements_per_entry;
@@ -905,11 +915,11 @@ void single_layer_kv_transfer_sgl(
     lmc_value_offset = lmc_key_value_cache.stride(0) / elements_per_entry;
   }
 
-  int block_stride_in_64bit = sgl_key_cache.stride(0) / elements_per_entry;
+  int64_t block_stride_in_64bit = sgl_key_cache.stride(0) / elements_per_entry;
   TORCH_CHECK(sgl_key_cache.stride(0) == sgl_value_cache.stride(0));
 
   dim3 grid(num_tokens);
-  dim3 block(std::min(num_heads * head_size_in_64bit, 128));
+  dim3 block(std::min<int64_t>(num_heads * head_size_in_64bit, 128));
   const at::cuda::OptionalCUDAGuard device_guard(device_of(sgl_key_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -197,8 +197,7 @@ __global__ void single_layer_kv_transfer_kernel(
 template <GPUKVFormat format>
 __device__ __forceinline__ int64_t
 page_buffer_offset(const int64_t k_or_v, const int64_t token_idx,
-                   const int64_t scalar_offset,
-                   const int64_t scalars_per_token,
+                   const int64_t scalar_offset, const int64_t scalars_per_token,
                    const int64_t page_buffer_size, const int64_t block_size) {
   // vllm cross layer
   if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
@@ -231,11 +230,10 @@ __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
   return token_idx * scalars_per_token + scalar_offset;
 }
 
-__device__ __forceinline__ int64_t
-key_value_offset(const int64_t k_or_v, const int64_t layer_idx,
-                 const int64_t token_idx, const int64_t scalar_offset,
-                 const int64_t scalars_per_token, const int64_t num_tokens,
-                 const int64_t num_layers) {
+__device__ __forceinline__ int64_t key_value_offset(
+    const int64_t k_or_v, const int64_t layer_idx, const int64_t token_idx,
+    const int64_t scalar_offset, const int64_t scalars_per_token,
+    const int64_t num_tokens, const int64_t num_layers) {
   return k_or_v * num_layers * num_tokens * scalars_per_token +
          layer_idx * num_tokens * scalars_per_token +
          token_idx * scalars_per_token + scalar_offset;
@@ -459,8 +457,7 @@ void multi_layer_kv_transfer_templated(
                     // for MLA.
     const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
-    const torch::Device& paged_memory_device,
-    const int64_t page_buffer_size,
+    const torch::Device& paged_memory_device, const int64_t page_buffer_size,
     const TransferDirection direction, const GPUKVFormat gpu_kv_format,
     const int64_t block_size, const int64_t skip_prefix_n_tokens) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
@@ -594,8 +591,7 @@ void multi_layer_kv_transfer_unilateral(
 
     const torch::Tensor& key_value_ptrs,  // [num_layers*2]
     const torch::Tensor& slot_mapping,    // [num_tokens],
-    const torch::Device& paged_memory_device,
-    const int64_t page_buffer_size,
+    const torch::Device& paged_memory_device, const int64_t page_buffer_size,
     const TransferDirection direction, const GPUKVFormat gpu_kv_format) {
   const bool use_mla = lmc::is_mla(gpu_kv_format);
   // MLA case collapses back to multi_layer_kv_transfer

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -77,15 +77,15 @@ enum class GPUKVFormat : int {
 void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
-    const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size = 0,
-    const int skip_prefix_n_tokens = 0);
+    const int64_t page_buffer_size, const TransferDirection direction,
+    const GPUKVFormat gpu_kv_format, const int64_t block_size = 0,
+    const int64_t skip_prefix_n_tokens = 0);
 
 // collapses to multi_layer_kv_transfer for MLA
 void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
-    const int page_buffer_size, const TransferDirection direction,
+    const int64_t page_buffer_size, const TransferDirection direction,
     const GPUKVFormat gpu_kv_format);
 
 void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -599,58 +599,77 @@ def test_lmcache_memcpy_async():
         (13 * chunk_size) // 4,
         chunk_size * num_chunks,
     ]
+    host_offset_biases = [0, 1 << 40]
 
     # H2D copy
-    for start, end in zip(starts, ends, strict=False):
-        # should not be equal before copy
-        with pytest.raises(AssertionError):
+    for host_offset_bias in host_offset_biases:
+        for start, end in zip(starts, ends, strict=False):
+            # should not be equal before copy
+            with pytest.raises(AssertionError):
+                check_gpu_and_cpu_equal(
+                    big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
+                    big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
+                )
+
+            lmc_ops.lmcache_memcpy_async(
+                big_gpu_tensor.data_ptr() + start,
+                big_cpu_tensor.data_ptr() + start,
+                end - start,
+                lmc_ops.TransferDirection.H2D,
+                host_offset_bias + start,
+                chunk_size,
+            )
+            torch.cuda.synchronize()
+
             check_gpu_and_cpu_equal(
                 big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
                 big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
             )
 
-        lmc_ops.lmcache_memcpy_async(
-            big_gpu_tensor.data_ptr() + start,
-            big_cpu_tensor.data_ptr() + start,
-            end - start,
-            lmc_ops.TransferDirection.H2D,
-            start,
-            chunk_size,
-        )
-        torch.cuda.synchronize()
-
-        check_gpu_and_cpu_equal(
-            big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
-            big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
-        )
+            big_gpu_tensor[
+                start // dtype.itemsize : end // dtype.itemsize
+            ] = torch.rand(
+                end // dtype.itemsize - start // dtype.itemsize,
+                dtype=dtype,
+                device="cuda",
+            )
 
     # Reset the data in gpu
     big_gpu_tensor = torch.rand(
         elements_per_chunk * num_chunks, dtype=dtype, device="cuda"
     )
     # D2H copy
-    for start, end in zip(starts, ends, strict=False):
-        # copy from gpu to cpu
-        with pytest.raises(AssertionError):
+    for host_offset_bias in host_offset_biases:
+        for start, end in zip(starts, ends, strict=False):
+            # copy from gpu to cpu
+            with pytest.raises(AssertionError):
+                check_gpu_and_cpu_equal(
+                    big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
+                    big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
+                )
+
+            lmc_ops.lmcache_memcpy_async(
+                big_cpu_tensor.data_ptr() + start,
+                big_gpu_tensor.data_ptr() + start,
+                end - start,
+                lmc_ops.TransferDirection.D2H,
+                host_offset_bias + start,
+                chunk_size,
+            )
+            torch.cuda.synchronize()
+
             check_gpu_and_cpu_equal(
                 big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
                 big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
             )
 
-        lmc_ops.lmcache_memcpy_async(
-            big_cpu_tensor.data_ptr() + start,
-            big_gpu_tensor.data_ptr() + start,
-            end - start,
-            lmc_ops.TransferDirection.D2H,
-            start,
-            chunk_size,
-        )
-        torch.cuda.synchronize()
-
-        check_gpu_and_cpu_equal(
-            big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
-            big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
-        )
+            big_cpu_tensor[
+                start // dtype.itemsize : end // dtype.itemsize
+            ] = torch.rand(
+                end // dtype.itemsize - start // dtype.itemsize,
+                dtype=dtype,
+                device="cpu",
+            )
 
     # Unregister the cpu memory
     ptr = big_cpu_tensor.data_ptr()

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -626,12 +626,12 @@ def test_lmcache_memcpy_async():
                 big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
             )
 
-            big_gpu_tensor[
-                start // dtype.itemsize : end // dtype.itemsize
-            ] = torch.rand(
-                end // dtype.itemsize - start // dtype.itemsize,
-                dtype=dtype,
-                device="cuda",
+            big_gpu_tensor[start // dtype.itemsize : end // dtype.itemsize] = (
+                torch.rand(
+                    end // dtype.itemsize - start // dtype.itemsize,
+                    dtype=dtype,
+                    device="cuda",
+                )
             )
 
     # Reset the data in gpu
@@ -663,12 +663,12 @@ def test_lmcache_memcpy_async():
                 big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize],
             )
 
-            big_cpu_tensor[
-                start // dtype.itemsize : end // dtype.itemsize
-            ] = torch.rand(
-                end // dtype.itemsize - start // dtype.itemsize,
-                dtype=dtype,
-                device="cpu",
+            big_cpu_tensor[start // dtype.itemsize : end // dtype.itemsize] = (
+                torch.rand(
+                    end // dtype.itemsize - start // dtype.itemsize,
+                    dtype=dtype,
+                    device="cpu",
+                )
             )
 
     # Unregister the cpu memory


### PR DESCRIPTION
Issue reported by @jymoon323

**What this PR does / why we need it**:

  This PR fixes large allocator-relative CUDA KV transfer offsets by widening offset/stride/page-buffer arithmetic in the CUDA transfer path from `int` to `int64_t`.

  The bug was in the CUDA-side indexing path used by LMCache GPU connectors with `LocalCPUBackend`: several helpers and launch wrappers still accepted or downcasted values to `int`, so very large offsets could overflow before the final address calculation. 
This is especially relevant for large backing buffers and >1TB offset scenarios.

  This PR:
  - updates the CUDA kernel helpers and launch wrappers in `csrc/mem_kernels.cu` / `csrc/mem_kernels.cuh` to use `int64_t` end-to-end for offset-related math
  - keeps launch dimensions and execution structure unchanged
  - adds a regression test in `tests/v1/test_mem_kernels.py` covering allocator-relative offsets above `1 << 40`

  **Special notes for your reviewers**:

This is intended to be a correctness-only fix for large offsets. 
It does not add new branches, synchronizations, or copies in the hot path. 
In validation, the connector microbenchmark and LocalCPU store/retrieve benchmarks stayed within the expected noise range, with no meaningful regression observed.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests

  **Test results**:

  Correctness:
  - `pytest -xvs tests/v1/test_mem_kernels.py`
    - `37 passed`
  - `pytest -xvs tests/v1/test_gpu_connector.py -k "not bench"`
    - `31 passed, 1 skipped, 1 deselected`

  Performance:
  - `tests/v1/test_gpu_connector.py::test_vllm_paged_connector_v2_to_gpu_bench`
    - `44.7575 us -> 42.8190 us` (I dont know why it decreased prob just noise by acc or cpu frequency changes)
  - `tests/benchmarks/test_benchmark.py::test_store_1GB[cpu-False]`
    - `21.3975 ms -> 21.2269 ms` 
  - `tests/benchmarks/test_benchmark.py::test_retrieve_1GB_allhit[cpu-False]`
    - `19.9299 ms -> 20.1026 ms` 

  End-to-end:
  - `vllm` + LMCache `LocalCPUBackend`
    - first request stored `784` tokens
    - second request retrieved `784` tokens from LMCache

  - `sglang` + LMCache `LocalCPUBackend`
    - first request stored `712` tokens
    - after `/flush_cache`, second overlapping request retrieved `680` tokens from LMCache
    - prefill log showed `#new-token: 18, #cached-token: 680`
  - I didnt test with mp mode since its not fixed yet.