### PR TITLE
[MP][Feat] Support dedicated thread pool for MP callbacks

### DIFF
--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -641,6 +641,9 @@ class MessageQueueServer:
                 )
 
         # Pass 2: create pool and assign
+        if not request_types:
+            return
+
         pool = ThreadPoolExecutor(
             max_workers=max_workers,
             thread_name_prefix=f"dedicated-pool-{len(self.dedicated_pools)}",

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -360,6 +360,9 @@ class MessageQueueServer:
         # Registered handlers: request_type -> (payload_cls, handler)
         self.handlers: dict[RequestType, RequestHandlerBase[Any]] = {}
 
+        # Dedicated thread pools for specific request types
+        self.dedicated_pools: list[ThreadPoolExecutor] = []
+
     def _call_sync_handler(
         self,
         handler_entry: SyncRequestHandler[Any],
@@ -606,10 +609,62 @@ class MessageQueueServer:
     ) -> None:
         raise NotImplementedError
 
+    def add_dedicated_thread_pool(
+        self,
+        request_types: list[RequestType],
+        max_workers: int,
+    ) -> None:
+        """Assign a dedicated ThreadPoolExecutor to specific request types.
+
+        Must be called after the handlers are registered (via add_handler /
+        add_blocking_handler) and before start().  Each request_type must
+        already be registered as a BlockingRequestHandler; otherwise a
+        ValueError or TypeError is raised.
+
+        Args:
+            request_types: The request types that should use this pool.
+            max_workers: Number of worker threads in the dedicated pool.
+        """
+        # Pass 1: validate all request types
+        for request_type in request_types:
+            handler = self.handlers.get(request_type)
+            if handler is None:
+                raise ValueError(
+                    f"No handler registered for request type: {request_type}. "
+                    f"Register handlers before calling add_dedicated_thread_pool."
+                )
+            if not isinstance(handler, BlockingRequestHandler):
+                raise TypeError(
+                    f"Handler for {request_type} is "
+                    f"{type(handler).__name__}, not BlockingRequestHandler. "
+                    f"Only blocking handlers can use dedicated thread pools."
+                )
+
+        # Pass 2: create pool and assign
+        pool = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix=f"dedicated-pool-{len(self.dedicated_pools)}",
+        )
+        self.dedicated_pools.append(pool)
+        for request_type in request_types:
+            handler = self.handlers[request_type]
+            assert isinstance(handler, BlockingRequestHandler)
+            handler.executor = pool
+
+        logger.debug(
+            "Created dedicated thread pool (max_workers=%d) for request types: %s",
+            max_workers,
+            [rt.name for rt in request_types],
+        )
+
     def start(self):
         self.worker_thread.start()
 
     def close(self) -> None:
         self.is_finished.set()
-        self.worker_thread.join()
+        if self.worker_thread.is_alive():
+            self.worker_thread.join()
         self.socket.close()
+        self.thread_pool.shutdown(wait=False)
+        for pool in self.dedicated_pools:
+            pool.shutdown(wait=False)

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -14,6 +14,7 @@ import zmq
 # First Party
 from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper, IPCCacheEngineKey
 from lmcache.v1.multiprocess.mq import (
+    BlockingRequestHandler,
     MessageQueueClient,
     MessageQueueServer,
 )
@@ -22,6 +23,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_handler_type,
     get_payload_classes,
 )
+from lmcache.v1.multiprocess.server import add_handler_helper
 
 # Test helpers
 from tests.v1.multiprocess import test_mq_handler_helpers
@@ -519,3 +521,118 @@ def test_mq_lookup_with_different_key():
         expected_response=expected_response,
         num_requests=1,
     )
+
+
+# ==============================================================================
+# Dedicated Thread Pool Tests
+# ==============================================================================
+
+
+def test_add_dedicated_thread_pool():
+    """
+    Test that add_dedicated_thread_pool reassigns handler executors
+    to a new dedicated pool.
+    """
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:15700", context, max_workers=2)
+
+    # Register blocking handlers
+    add_handler_helper(server, RequestType.STORE, test_mq_handler_helpers.store_handler)
+    add_handler_helper(
+        server, RequestType.RETRIEVE, test_mq_handler_helpers.retrieve_handler
+    )
+    # Register a sync handler
+    add_handler_helper(server, RequestType.NOOP, test_mq_handler_helpers.noop_handler)
+
+    default_pool = server.thread_pool
+
+    # STORE and RETRIEVE should currently use default pool
+    store_handler = server.handlers[RequestType.STORE]
+    retrieve_handler = server.handlers[RequestType.RETRIEVE]
+    assert isinstance(store_handler, BlockingRequestHandler)
+    assert isinstance(retrieve_handler, BlockingRequestHandler)
+    assert store_handler.executor is default_pool
+    assert retrieve_handler.executor is default_pool
+
+    # Create dedicated pool for STORE and RETRIEVE
+    server.add_dedicated_thread_pool(
+        [RequestType.STORE, RequestType.RETRIEVE], max_workers=4
+    )
+
+    # Verify reassignment
+    assert store_handler.executor is not default_pool
+    assert retrieve_handler.executor is not default_pool
+    # Both should share the same dedicated pool
+    assert store_handler.executor is retrieve_handler.executor
+    assert len(server.dedicated_pools) == 1
+
+    server.close()
+
+
+def test_dedicated_thread_pool_error_on_sync_handler():
+    """
+    Test that add_dedicated_thread_pool raises TypeError for SYNC handlers.
+    """
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:15701", context, max_workers=1)
+
+    add_handler_helper(server, RequestType.NOOP, test_mq_handler_helpers.noop_handler)
+
+    with pytest.raises(TypeError, match="not BlockingRequestHandler"):
+        server.add_dedicated_thread_pool([RequestType.NOOP], max_workers=1)
+
+    server.close()
+
+
+def test_dedicated_thread_pool_error_on_unregistered():
+    """
+    Test that add_dedicated_thread_pool raises ValueError for
+    unregistered request types.
+    """
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:15702", context, max_workers=1)
+
+    with pytest.raises(ValueError, match="No handler registered"):
+        server.add_dedicated_thread_pool([RequestType.STORE], max_workers=1)
+
+    server.close()
+
+
+def test_multiple_dedicated_thread_pools():
+    """
+    Test that multiple dedicated pools can coexist, each serving
+    different request types.
+    """
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:15703", context, max_workers=1)
+
+    add_handler_helper(server, RequestType.STORE, test_mq_handler_helpers.store_handler)
+    add_handler_helper(
+        server, RequestType.RETRIEVE, test_mq_handler_helpers.retrieve_handler
+    )
+    add_handler_helper(
+        server, RequestType.LOOKUP, test_mq_handler_helpers.lookup_handler
+    )
+
+    # Create two separate dedicated pools
+    server.add_dedicated_thread_pool([RequestType.STORE], max_workers=2)
+    server.add_dedicated_thread_pool(
+        [RequestType.RETRIEVE, RequestType.LOOKUP], max_workers=3
+    )
+
+    store_handler = server.handlers[RequestType.STORE]
+    retrieve_handler = server.handlers[RequestType.RETRIEVE]
+    lookup_handler = server.handlers[RequestType.LOOKUP]
+    assert isinstance(store_handler, BlockingRequestHandler)
+    assert isinstance(retrieve_handler, BlockingRequestHandler)
+    assert isinstance(lookup_handler, BlockingRequestHandler)
+
+    # Each group should have its own pool
+    assert store_handler.executor is not retrieve_handler.executor
+    assert retrieve_handler.executor is lookup_handler.executor
+    # Neither should be the default pool
+    assert store_handler.executor is not server.thread_pool
+    assert retrieve_handler.executor is not server.thread_pool
+    assert len(server.dedicated_pools) == 2
+
+    server.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `MessageQueueServer.add_dedicated_thread_pool(request_types, max_workers)` so that specific blocking request types can run on their own `ThreadPoolExecutor` instead of sharing the single default pool. This prevents slow/blocking handlers (e.g., STORE, RETRIEVE) from starving other request types when the default pool is exhausted.

Usage (after handler registration, before `server.start()`):
```python
server.add_dedicated_thread_pool([RequestType.STORE, RequestType.RETRIEVE], max_workers=4)
```

Multiple dedicated pools are supported. The method validates that all specified request types are registered `BlockingRequestHandler`s before creating the pool (two-pass for atomicity).

**Special notes for your reviewers**:

Minimal changes to existing code — only added one field to `__init__`, one guard in `close()`, and pool shutdown logic. The new method reassigns the `executor` attribute on already-registered `BlockingRequestHandler` instances. No existing methods were modified.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests