### PR TITLE
refactor: move busy loop from LocalCPUBackend to MixedMemoryAllocator

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -10,6 +10,7 @@ import abc
 import ctypes
 import os
 import threading
+import time
 
 # Third Party
 from sortedcontainers import SortedList
@@ -2045,6 +2046,83 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
                 )
         else:
             raise ValueError(f"Unsupported memory format: {fmt}")
+
+    @_lmcache_nvtx_annotate
+    def allocate_with_retry(
+        self,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        allocator_type: Optional[str] = None,
+        busy_loop: bool = True,
+        time_to_wait: float = 0.1,
+    ) -> Optional[MemoryObj]:
+        """
+        Allocate memory; if allocation fails and busy_loop is True, wait and
+        retry once. This moves the wait/retry policy into the allocator so
+        the backend does not need to busy-loop or sleep.
+
+        :param shapes: Shape(s) of the tensor to allocate.
+        :param dtypes: Dtype(s) of the tensor to allocate.
+        :param fmt: Memory format.
+        :param allocator_type: Optional allocator type hint.
+        :param busy_loop: If True and allocation fails, sleep time_to_wait
+            and try again before returning.
+        :param time_to_wait: Seconds to sleep before retry when busy_loop is True.
+        :return: MemoryObj if allocation succeeded, None otherwise.
+        """
+        memory_obj = self.allocate(shapes, dtypes, fmt, allocator_type)
+        if memory_obj is not None:
+            return memory_obj
+        if not busy_loop:
+            return None
+        logger.warning(
+            "No free blocks in allocator; waiting %.2f s before retry.",
+            time_to_wait,
+        )
+        time.sleep(time_to_wait)
+        return self.allocate(shapes, dtypes, fmt, allocator_type)
+
+    @_lmcache_nvtx_annotate
+    def batched_allocate_with_retry(
+        self,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+        batch_size: int,
+        fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+        allocator_type: Optional[str] = None,
+        busy_loop: bool = True,
+        time_to_wait: float = 0.1,
+    ) -> Optional[List[MemoryObj]]:
+        """
+        Batched allocate; if allocation fails and busy_loop is True, wait and
+        retry once. Same policy as allocate_with_retry for the allocator layer.
+
+        :param shapes: Shape(s) of the tensor to allocate.
+        :param dtypes: Dtype(s) of the tensor to allocate.
+        :param batch_size: Number of blocks to allocate.
+        :param fmt: Memory format.
+        :param allocator_type: Optional allocator type hint.
+        :param busy_loop: If True and allocation fails, sleep time_to_wait
+            and try again before returning.
+        :param time_to_wait: Seconds to sleep before retry when busy_loop is True.
+        :return: List of MemoryObjs if allocation succeeded, None otherwise.
+        """
+        memory_objs = self.batched_allocate(
+            shapes, dtypes, batch_size, fmt, allocator_type
+        )
+        if memory_objs is not None:
+            return memory_objs
+        if not busy_loop:
+            return None
+        logger.warning(
+            "No free blocks in allocator; waiting %.2f s before retry.",
+            time_to_wait,
+        )
+        time.sleep(time_to_wait)
+        return self.batched_allocate(
+            shapes, dtypes, batch_size, fmt, allocator_type
+        )
 
     @_lmcache_nvtx_annotate
     def free(self, memory_obj: MemoryObj, allocator_type: Optional[str] = None):

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -3,7 +3,6 @@
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 import threading
-import time
 
 # Third Party
 import torch
@@ -564,18 +563,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     )
                     break
 
-                # TODO: make time_to_wait a config
-                time_to_wait = 0.1
-                logger.warning(
-                    "No eviction candidates found in local cpu backend. "
-                    "Local cpu memory is under pressure. "
-                    f"Waiting for {time_to_wait} seconds before retrying."
-                )
-                # self.memory_allocator.memcheck()
-                # do not hold the lock during sleep
-                time.sleep(time_to_wait)
-
-            memory_obj = self.memory_allocator.allocate(shapes, dtypes, fmt)
+            memory_obj = self._allocate_once(shapes, dtypes, fmt, busy_loop)
             if memory_obj is not None:
                 break
 
@@ -688,19 +676,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     )
                     break
 
-                # TODO: make time_to_wait a config
-                time_to_wait = 0.1
-                logger.warning(
-                    "No eviction candidates found in local cpu backend. "
-                    "Local cpu memory is under pressure. "
-                    f"Waiting for {time_to_wait} seconds before retrying."
-                )
-                # self.memory_allocator.memcheck()
-                # do not hold the lock during sleep
-                time.sleep(time_to_wait)
-
-            memory_objs = self.memory_allocator.batched_allocate(
-                shapes, dtypes, batch_size, fmt
+            memory_objs = self._batched_allocate_once(
+                shapes, dtypes, batch_size, fmt, busy_loop
             )
             if memory_objs:
                 break
@@ -802,6 +779,52 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
     def get_memory_allocator(self):
         return self.memory_allocator
+
+    def _allocate_once(
+        self,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+        fmt: MemoryFormat,
+        busy_loop: bool,
+    ) -> Optional[MemoryObj]:
+        """
+        One allocation attempt; uses allocator's allocate_with_retry when
+        available so that wait/retry (busy loop) lives in the allocator.
+        """
+        allocator = self.memory_allocator
+        if isinstance(allocator, MixedMemoryAllocator):
+            return allocator.allocate_with_retry(
+                shapes,
+                dtypes,
+                fmt=fmt,
+                busy_loop=busy_loop,
+                time_to_wait=0.1,
+            )
+        return allocator.allocate(shapes, dtypes, fmt)
+
+    def _batched_allocate_once(
+        self,
+        shapes: Union[torch.Size, list[torch.Size]],
+        dtypes: Union[torch.dtype, list[torch.dtype]],
+        batch_size: int,
+        fmt: MemoryFormat,
+        busy_loop: bool,
+    ) -> Optional[List[MemoryObj]]:
+        """
+        One batched allocation attempt; uses allocator's
+        batched_allocate_with_retry when available.
+        """
+        allocator = self.memory_allocator
+        if isinstance(allocator, MixedMemoryAllocator):
+            return allocator.batched_allocate_with_retry(
+                shapes,
+                dtypes,
+                batch_size,
+                fmt=fmt,
+                busy_loop=busy_loop,
+                time_to_wait=0.1,
+            )
+        return allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
 
     def close(self) -> None:
         if self.batched_msg_sender is not None:


### PR DESCRIPTION
## What this PR does / why we need it

- Move the busy loop (wait + retry on allocation failure) from `LocalCPUBackend` into `MixedMemoryAllocator`: add `allocate_with_retry` and `batched_allocate_with_retry` so the allocator owns the wait/retry policy when `busy_loop=True`.
- `LocalCPUBackend.allocate` / `batched_allocate` now call the allocator retry API and no longer use `time.sleep`; the eviction loop (get evict candidates, evict, then allocate) stays in the backend.

Refs #1882 (Good First Issue: move busy loop from backend to allocator).

## Special notes for your reviewers

- Behaviour unchanged: one failed allocate → sleep(0.1) → one retry is now inside the allocator; backend still does eviction then one “allocate attempt” (which may include that retry).

## If applicable

- [ ] This PR contains user facing changes - docs added
- [x] This PR contains unit tests (existing `tests/v1/storage_backend/test_local_cpu_backend.py` covers the refactor; no new tests added)