### PR TITLE
[BugFix] Remove unused memory cleanup logic to prevent premature free

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1553,7 +1553,6 @@ class LMCacheEngine:
                 memory_obj_map[key] = memory_obj
 
         # TODO(Jiayi): hashing inside `process_tokens` can be skipped.
-        used_keys: set[CacheEngineKey] = set()
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
             mask=mask,
@@ -1568,7 +1567,6 @@ class LMCacheEngine:
             chunks.append((key, memory_obj, start, end))
             tot_kv_size += memory_obj.get_size()
             ret_mask[start:end] = True
-            used_keys.add(key)
 
         return chunks, tot_kv_size
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1570,11 +1570,6 @@ class LMCacheEngine:
             ret_mask[start:end] = True
             used_keys.add(key)
 
-        # NOTE: free the memory objects that are not hit.
-        for key, mem_obj in memory_obj_map.items():
-            if key not in used_keys:
-                mem_obj.ref_count_down()
-
         return chunks, tot_kv_size
 
     def _process_tokens_internal(


### PR DESCRIPTION
**What this PR does / why we need it**:
- Currently, the async lookup path will call ref_count_down() during process_tokens_internal for the unused mem obj, then lookup_unpin() will call ref_count_down() during the cleanup.
- This lead to the mem_obj in the local_cpu_backend being invalidated but still remain in hotcache.
- The **next request** that hits the hot cache will obtain this invalidated mem_obj and hit the assertion error in the gpu_connector.
- Removing the unused only should be fine, as the clean_up will bulk remove the unused anyway.

**Special notes for your reviewers**:
- I can consistently reproduce this after running the vllm benchmark, and this only manifest after the benchmark has progressed for a while.


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
