### PR TITLE
[MP][UX][L2] Support configuring L2 store/prefetch policy via command line

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -132,6 +132,29 @@ Source: ``lmcache/v1/distributed/config.py``
      - ``0.2``
      - Fraction of allocated memory to evict when triggered (0.0--1.0).
 
+L2 Policies
+-----------
+
+Source: ``lmcache/v1/distributed/config.py``
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Argument
+     - Default
+     - Description
+   * - ``--l2-store-policy``
+     - ``default``
+     - L2 store policy.  Determines which adapters receive each key
+       and whether keys are deleted from L1 after L2 store.
+       The ``default`` policy stores all keys to all adapters and keeps L1.
+   * - ``--l2-prefetch-policy``
+     - ``default``
+     - L2 prefetch policy.  Determines which adapter loads each key
+       when multiple adapters have it.
+       The ``default`` policy picks the first adapter (lowest index).
+
 L2 Adapters
 -----------
 
@@ -329,6 +352,8 @@ Full Example
         --eviction-policy LRU \
         --eviction-trigger-watermark 0.9 \
         --eviction-ratio 0.1 \
+        --l2-store-policy default \
+        --l2-prefetch-policy default \
         --l2-adapter '{"type": "nixl_store", "backend": "POSIX", "backend_params": {"file_path": "/data/lmcache/l2", "use_direct_io": "false"}, "pool_size": 64}' \
         --prometheus-port 9090 \
         --prometheus-log-interval 10 \

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -157,6 +157,43 @@ argument.  Adapters are used in the order they are specified.  The
     --l2-adapter '{"type": "nixl_store", "backend": "POSIX", "backend_params": {"file_path": "/data/ssd/l2", "use_direct_io": "false"}, "pool_size": 64}' \
     --l2-adapter '{"type": "nixl_store", "backend": "GDS", "backend_params": {"file_path": "/data/nvme/l2", "use_direct_io": "true"}, "pool_size": 128}'
 
+Store and Prefetch Policies
+----------------------------
+
+The **store policy** controls how keys flow from L1 to L2: which adapters
+receive each key and whether keys are deleted from L1 after a successful
+L2 store.  The **prefetch policy** controls how keys flow from L2 back to
+L1: when multiple adapters have the same key, the policy decides which
+adapter loads it.
+
+Select policies via CLI:
+
+.. code-block:: bash
+
+    --l2-store-policy default \
+    --l2-prefetch-policy default
+
+**Built-in policies:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 15 70
+
+   * - Flag
+     - Name
+     - Behaviour
+   * - ``--l2-store-policy``
+     - ``default``
+     - Store all keys to all adapters.  Never delete from L1.
+   * - ``--l2-prefetch-policy``
+     - ``default``
+     - For each key, pick the first (lowest-indexed) adapter that has it.
+
+Policies are extensible -- new policies can be added by creating a file
+in ``storage_controllers/`` and calling ``register_store_policy()`` or
+``register_prefetch_policy()`` at import time.  See the design doc
+``l2_adapters/design_docs/overall.md`` for details.
+
 Verifying L2 Storage
 --------------------
 

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -15,6 +15,12 @@ from lmcache.v1.distributed.l2_adapters.config import (
     add_l2_adapters_args,
     parse_args_to_l2_adapters_config,
 )
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    get_registered_prefetch_policies,
+)
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    get_registered_store_policies,
+)
 
 
 @dataclass
@@ -87,6 +93,12 @@ class StorageManagerConfig:
         default_factory=lambda: L2AdaptersConfig([])
     )
     """ The configuration for L2 adapters. """
+
+    store_policy: str = "default"
+    """ The L2 store policy name. """
+
+    prefetch_policy: str = "default"
+    """ The L2 prefetch policy name. """
 
 
 def add_storage_manager_args(
@@ -186,6 +198,29 @@ def add_storage_manager_args(
         "Default is 0.2.",
     )
 
+    # L2 Policies
+    policy_group = parser.add_argument_group(
+        "L2 Policies", "Store and prefetch policy selection for L2 adapters"
+    )
+    policy_group.add_argument(
+        "--l2-store-policy",
+        type=str,
+        choices=get_registered_store_policies(),
+        default="default",
+        help="L2 store policy. Determines which adapters receive each key "
+        "and whether keys are deleted from L1 after L2 store. "
+        "Default is 'default' (store all keys to all adapters, keep L1).",
+    )
+    policy_group.add_argument(
+        "--l2-prefetch-policy",
+        type=str,
+        choices=get_registered_prefetch_policies(),
+        default="default",
+        help="L2 prefetch policy. Determines which adapter loads each key "
+        "when multiple adapters have it. "
+        "Default is 'default' (pick the first adapter by index).",
+    )
+
     # Adapter config
     add_l2_adapters_args(parser)
     return parser
@@ -246,6 +281,8 @@ def parse_args_to_config(
         l1_manager_config=l1_manager_config,
         eviction_config=eviction_config,
         l2_adapter_config=l2_adapter_config,
+        store_policy=args.l2_store_policy,
+        prefetch_policy=args.l2_prefetch_policy,
     )
 
 

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -15,13 +15,6 @@ from lmcache.v1.distributed.l2_adapters.config import (
     add_l2_adapters_args,
     parse_args_to_l2_adapters_config,
 )
-from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
-    get_registered_prefetch_policies,
-)
-from lmcache.v1.distributed.storage_controllers.store_policy import (
-    get_registered_store_policies,
-)
-import lmcache.v1.distributed.storage_controllers  # noqa: F401
 
 
 @dataclass
@@ -200,6 +193,19 @@ def add_storage_manager_args(
     )
 
     # L2 Policies
+    # Import here to break circular dependency:
+    # config.py <-> storage_controllers (via eviction_controller)
+    # Safe because config.py is fully initialized by the time this
+    # function is called.
+    # First Party
+    from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+        get_registered_prefetch_policies,
+    )
+    from lmcache.v1.distributed.storage_controllers.store_policy import (
+        get_registered_store_policies,
+    )
+    import lmcache.v1.distributed.storage_controllers  # noqa: F401
+
     policy_group = parser.add_argument_group(
         "L2 Policies", "Store and prefetch policy selection for L2 adapters"
     )

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -21,6 +21,7 @@ from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     get_registered_store_policies,
 )
+import lmcache.v1.distributed.storage_controllers  # noqa: F401
 
 
 @dataclass

--- a/lmcache/v1/distributed/l2_adapters/design_docs/overall.md
+++ b/lmcache/v1/distributed/l2_adapters/design_docs/overall.md
@@ -204,6 +204,10 @@ The policy decides two things:
    Which keys to evict from L1 after successful L2 store.
    `DefaultStorePolicy`: never delete (empty list).
 
+Policies are selected by name via `--l2-store-policy` (default: `"default"`).
+New policies self-register with `register_store_policy(name, cls)` at import
+time and are auto-discovered by `storage_controllers/__init__.py`.
+
 ## PrefetchController
 
 **Purpose:** Asynchronously load KV cache data from L2 into L1 ahead of a
@@ -380,6 +384,10 @@ assignment of keys to adapters. Each key appears in at most one adapter's bitmap
 `DefaultPrefetchPolicy`: For each key, assign it to the first (lowest-indexed)
 adapter that has it. This is a simple greedy approach.
 
+Policies are selected by name via `--l2-prefetch-policy` (default: `"default"`).
+New policies self-register with `register_prefetch_policy(name, cls)` at import
+time and are auto-discovered by `storage_controllers/__init__.py`.
+
 ### Max In-Flight Limiting
 
 The controller limits concurrent prefetch requests to `max_in_flight` (default: 8).
@@ -495,3 +503,52 @@ pybind-wrapped `IStorageConnector` to the `L2AdapterInterface`:
 **Reference implementation:** The Redis (RESP) connector in
 `csrc/storage_backends/redis/` demonstrates all 5 steps of the integration
 guide.
+
+## Implementing a New Store or Prefetch Policy
+
+Both store and prefetch policies use a name-based registry with automatic
+module discovery. **To add a new policy, create a single file in
+`storage_controllers/` — no changes to any existing file are needed.**
+
+### Store Policy
+
+1. Create a new file (e.g., `storage_controllers/store_policy_tiered.py`).
+2. Subclass `StorePolicy` and implement `select_store_targets()` and
+   `select_l1_deletions()`.
+3. Call `register_store_policy("tiered", TieredStorePolicy)` at module level.
+
+```python
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    StorePolicy,
+    AdapterDescriptor,
+    register_store_policy,
+)
+from lmcache.v1.distributed.api import ObjectKey
+
+
+class TieredStorePolicy(StorePolicy):
+    def select_store_targets(self, keys, adapters):
+        # custom logic ...
+        ...
+
+    def select_l1_deletions(self, keys):
+        return []
+
+
+register_store_policy("tiered", TieredStorePolicy)
+```
+
+The policy is now available via `--l2-store-policy tiered`.
+
+### Prefetch Policy
+
+Same pattern: subclass `PrefetchPolicy`, implement `select_load_plan()`,
+and call `register_prefetch_policy("name", cls)`.
+
+### How Discovery Works
+
+`storage_controllers/__init__.py` uses `pkgutil.iter_modules()` to import
+every module in the package at import time. When your module is imported,
+the `register_*_policy()` call at module level adds it to the registry.
+The `--l2-store-policy` and `--l2-prefetch-policy` CLI arguments use the
+registry to populate their `choices` list.

--- a/lmcache/v1/distributed/storage_controllers/__init__.py
+++ b/lmcache/v1/distributed/storage_controllers/__init__.py
@@ -1,15 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
+"""
+Storage controllers with automatic module discovery.
+
+All modules under this package that call ``register_store_policy`` or
+``register_prefetch_policy`` at import time are discovered automatically.
+To add a new policy, simply create a new module in this directory -- **no
+changes to any existing file are needed**.
+"""
+
+# Standard
+import importlib
+import pkgutil
 
 # First Party
-from lmcache.v1.distributed.storage_controllers.eviction_controller import (  # noqa: E501
+from lmcache.v1.distributed.storage_controllers.eviction_controller import (
     EvictionController,
 )
-from lmcache.v1.distributed.storage_controllers.prefetch_controller import (  # noqa: E501
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
     PrefetchController,
 )
 from lmcache.v1.distributed.storage_controllers.store_controller import (
     StoreController,
 )
+
+# Auto-discover and import every module in this package so
+# that each policy's self-registration code runs.
+_PACKAGE_PATH = __path__  # type: ignore[name-defined]
+_PACKAGE_NAME = __name__
+for _finder, _mod_name, _is_pkg in pkgutil.iter_modules(_PACKAGE_PATH):
+    importlib.import_module(f".{_mod_name}", _PACKAGE_NAME)
 
 __all__ = [
     "EvictionController",

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -51,6 +51,55 @@ class PrefetchPolicy(ABC):
         """
 
 
+# -----------------------------------------------------------------------------
+# Registry: prefetch policy name -> policy class
+# -----------------------------------------------------------------------------
+
+_PREFETCH_POLICY_REGISTRY: dict[str, type[PrefetchPolicy]] = {}
+
+
+def register_prefetch_policy(
+    name: str,
+    policy_cls: type[PrefetchPolicy],
+) -> None:
+    """
+    Register a prefetch policy class under a name.
+
+    Each policy module should call this at import time.
+
+    Args:
+        name: Policy name (e.g. "default").
+        policy_cls: A concrete PrefetchPolicy subclass.
+    """
+    if name in _PREFETCH_POLICY_REGISTRY:
+        raise ValueError(f"Prefetch policy already registered: {name!r}")
+    _PREFETCH_POLICY_REGISTRY[name] = policy_cls
+
+
+def get_registered_prefetch_policies() -> list[str]:
+    """Return the list of registered prefetch policy names."""
+    return list(_PREFETCH_POLICY_REGISTRY)
+
+
+def create_prefetch_policy(name: str) -> PrefetchPolicy:
+    """
+    Create a prefetch policy instance by name.
+
+    Args:
+        name: Registered policy name.
+
+    Returns:
+        A new PrefetchPolicy instance.
+
+    Raises:
+        ValueError: If no policy is registered under the given name.
+    """
+    if name not in _PREFETCH_POLICY_REGISTRY:
+        known = ", ".join(sorted(_PREFETCH_POLICY_REGISTRY)) or "(none)"
+        raise ValueError(f"Unknown prefetch policy {name!r}. Known: {known}")
+    return _PREFETCH_POLICY_REGISTRY[name]()
+
+
 class DefaultPrefetchPolicy(PrefetchPolicy):
     """
     Default prefetch policy: for each key, pick the first adapter
@@ -93,3 +142,6 @@ class DefaultPrefetchPolicy(PrefetchPolicy):
             plan[ad.index] = local_bitmap
 
         return plan
+
+
+register_prefetch_policy("default", DefaultPrefetchPolicy)

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -92,6 +92,55 @@ class StorePolicy(ABC):
         """
 
 
+# -----------------------------------------------------------------------------
+# Registry: store policy name -> policy class
+# -----------------------------------------------------------------------------
+
+_STORE_POLICY_REGISTRY: dict[str, type[StorePolicy]] = {}
+
+
+def register_store_policy(
+    name: str,
+    policy_cls: type[StorePolicy],
+) -> None:
+    """
+    Register a store policy class under a name.
+
+    Each policy module should call this at import time.
+
+    Args:
+        name: Policy name (e.g. "default").
+        policy_cls: A concrete StorePolicy subclass.
+    """
+    if name in _STORE_POLICY_REGISTRY:
+        raise ValueError(f"Store policy already registered: {name!r}")
+    _STORE_POLICY_REGISTRY[name] = policy_cls
+
+
+def get_registered_store_policies() -> list[str]:
+    """Return the list of registered store policy names."""
+    return list(_STORE_POLICY_REGISTRY)
+
+
+def create_store_policy(name: str) -> StorePolicy:
+    """
+    Create a store policy instance by name.
+
+    Args:
+        name: Registered policy name.
+
+    Returns:
+        A new StorePolicy instance.
+
+    Raises:
+        ValueError: If no policy is registered under the given name.
+    """
+    if name not in _STORE_POLICY_REGISTRY:
+        known = ", ".join(sorted(_STORE_POLICY_REGISTRY)) or "(none)"
+        raise ValueError(f"Unknown store policy {name!r}. Known: {known}")
+    return _STORE_POLICY_REGISTRY[name]()
+
+
 class DefaultStorePolicy(StorePolicy):
     """
     Default store policy: store all keys to all adapters,
@@ -129,3 +178,6 @@ class DefaultStorePolicy(StorePolicy):
             Empty list (keep all keys in L1).
         """
         return []
+
+
+register_store_policy("default", DefaultStorePolicy)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -27,11 +27,11 @@ from lmcache.v1.distributed.storage_controllers import (
     StoreController,
 )
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
-    DefaultPrefetchPolicy,
+    create_prefetch_policy,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
-    DefaultStorePolicy,
+    create_store_policy,
 )
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.logger.storage_manager_stats_logger import (
@@ -87,7 +87,7 @@ class StorageManager:
             l1_manager=self._l1_manager,
             l2_adapters=self._l2_adapters,
             adapter_descriptors=adapter_descriptors,
-            policy=DefaultStorePolicy(),
+            policy=create_store_policy(config.store_policy),
         )
         self._store_controller.start()
 
@@ -96,7 +96,7 @@ class StorageManager:
             l1_manager=self._l1_manager,
             l2_adapters=self._l2_adapters,
             adapter_descriptors=adapter_descriptors,
-            policy=DefaultPrefetchPolicy(),
+            policy=create_prefetch_policy(config.prefetch_policy),
         )
         self._prefetch_controller.start()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `--l2-store-policy` and `--l2-prefetch-policy` CLI flags so users can select L2 store and prefetch policies by name. This prepares for upcoming new policy implementations — adding a new policy only requires creating a single file in `storage_controllers/` with a `register_store_policy()` or `register_prefetch_policy()` call; auto-discovery handles the rest.

Changes:
- Add name-based policy registries to `store_policy.py` and `prefetch_policy.py` (`register_*_policy`, `create_*_policy`)
- Add `pkgutil.iter_modules()` auto-discovery to `storage_controllers/__init__.py`
- Add `store_policy` / `prefetch_policy` fields to `StorageManagerConfig` and corresponding CLI args
- Replace hardcoded `DefaultStorePolicy()` / `DefaultPrefetchPolicy()` in `StorageManager` with registry-based creation

**Special notes for your reviewers**:

Default behavior is unchanged — both flags default to `"default"`, matching the existing `DefaultStorePolicy` and `DefaultPrefetchPolicy`.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests