### PR TITLE
Make eviction retry interval configurable in local_cpu_backend

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -277,6 +277,16 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": "LRU",
         "env_converter": str,
     },
+    "eviction_retry_interval_sec": {
+        "type": float,
+        "default": 0.1,
+        "env_converter": float,
+        "description": (
+            "Time in seconds to wait before retrying memory allocation "
+            "when local CPU memory is under pressure and no eviction "
+            "candidates are available. Default is 0.1 seconds."
+        ),
+    },
     "numa_mode": {
         "type": Optional[str],
         "default": None,
@@ -517,6 +527,12 @@ def _validate_config(self):
     if self.min_retrieve_tokens < 0:
         raise ValueError(
             "min_retrieve_tokens must be >= 0, got %d" % self.min_retrieve_tokens
+        )
+
+    if self.eviction_retry_interval_sec <= 0:
+        raise ValueError(
+            "eviction_retry_interval_sec must be non-negative, got %s"
+            % self.eviction_retry_interval_sec
         )
 
     if self.enable_blending:

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -564,8 +564,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     )
                     break
 
-                # TODO: make time_to_wait a config
-                time_to_wait = 0.1
+                time_to_wait = self.config.eviction_retry_interval_sec
                 logger.warning(
                     "No eviction candidates found in local cpu backend. "
                     "Local cpu memory is under pressure. "
@@ -688,8 +687,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     )
                     break
 
-                # TODO: make time_to_wait a config
-                time_to_wait = 0.1
+                time_to_wait = self.config.eviction_retry_interval_sec
                 logger.warning(
                     "No eviction candidates found in local cpu backend. "
                     "Local cpu memory is under pressure. "

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -542,6 +542,29 @@ class TestLocalCPUBackend:
         assert memory_obj.get_ref_count() == initial_ref_count + 1
         local_cpu_backend.memory_allocator.close()
 
+    def test_eviction_retry_interval_default(self, memory_allocator):
+        """Test that eviction_retry_interval_sec defaults to 0.1."""
+        config = create_test_config()
+        assert config.eviction_retry_interval_sec == 0.1
+        memory_allocator.close()
+
+    def test_eviction_retry_interval_custom(self, memory_allocator):
+        """Test that eviction_retry_interval_sec accepts a custom value."""
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            lmcache_instance_id="test_instance",
+            eviction_retry_interval_sec=0.05,
+        )
+        assert config.eviction_retry_interval_sec == 0.05
+
+        PinMonitor.GetOrCreate(config)
+        backend = LocalCPUBackend(config=config, memory_allocator=memory_allocator)
+        assert backend.config.eviction_retry_interval_sec == 0.05
+
+        PinMonitor.DestroyInstance()
+        memory_allocator.close()
+
 
 class TestLocalCPUBackendAllocatorAlignment:
     def test_rust_odirect_auto_alignment_for_mixed_allocator(self, monkeypatch):

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -681,3 +681,9 @@ class TestValidateAndSetConfigValueTypeConversion:
         config = LMCacheEngineConfig.from_defaults()
         result = validate_and_set_config_value(config, "extra_config", "{invalid_json")
         assert result is False
+
+    def test_eviction_retry_interval_sec_validation_rejects_negative(self):
+        """Test that eviction_retry_interval_sec rejects negative values."""
+        config = LMCacheEngineConfig.from_defaults(eviction_retry_interval_sec=-0.1)
+        with pytest.raises(ValueError, match="eviction_retry_interval_sec"):
+            config.validate()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR addresses the todo item in [local_cpu_backend.py](https://github.com/LMCache/LMCache/compare/dev...Kota-SH:LMCache:dev?expand=1#diff-20cd22164d517e4370f59fad0d9e69584d4b14e134259db36edb15dadbf29096) :   `# TODO: make time_to_wait a config`

Adds an eviction_retry_interval_sec config option (default 0.1) and uses it instead of the hardcoded value in LocalCPUBackend’s allocate and batched_allocate retry loops.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
