### PR TITLE
fix: balance pin count in LocalCPUBackend.touch_cache()

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -130,6 +130,9 @@ class LocalCPUBackend(AllocatorBackendInterface):
         with self.cpu_lock:
             for key in reversed(self.keys_in_request):
                 self.cache_policy.update_on_hit(key, self.hot_cache)
+                # Unpin the key to balance the pin_count from contains()
+                if key in self.hot_cache:
+                    self.hot_cache[key].unpin()
             self.keys_in_request = []
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:


### PR DESCRIPTION
# Summary
This PR fixes a pin count balancing issue in the `LocalCPUBackend.touch_cache()` method that could cause memory objects to be pinned indefinitely.

# Problem Description
In the `LocalCPUBackend.contains()` method, when `pin=True` is passed (which happens during vLLM lookups), it calls `mem_obj.pin()` to increment the pin count. However, there was no corresponding `unpin()` call in the `touch_cache()` method to balance this increment.

# Observed Error Scenario
This issue was encountered when using LMCache with Mooncake in PD (Prefetcher-Decoder) separation mode, which utilizes `LocalCPUBackend`. The pin count imbalance led to numerous "Pin timeout detected" warnings from the pin monitor:

```
[2026-03-13 09:52:40,689] LMCache WARNING: Pin timeout detected for MemoryObj 9069133824. Pin count: 2, Elapsed time: 317.22s. Forcing unpin to 0. (pin_monitor.py:168)
[2026-03-13 09:52:40,689] LMCache WARNING: Pin timeout detected for MemoryObj 10390339584. Pin count: 2, Elapsed time: 317.22s. Forcing unpin to 0. (pin_monitor.py:168)
...
[2026-03-13 09:52:40,690] LMCache WARNING: Force unpinned 311 timeout objects in 429 pinned_objects within 300 seconds (pin_monitor.py:140)
```

These warnings indicate memory objects were remaining pinned far beyond the expected duration (300+ seconds), with pin counts that were never properly balanced. The pin monitor was forced to intervene and unpin hundreds of objects.

## Potential Impacts
- Memory objects remaining pinned indefinitely
- Reduced effectiveness of the cache eviction policy
- Increased memory pressure and potential out-of-memory situations
- Performance degradation due to suboptimal cache management

# Solution
Added `unpin()` calls in the `touch_cache()` method to balance the pin count incremented during `contains()` calls:

```python
# Unpin the key to balance the pin_count from contains()
if key in self.hot_cache:
    self.hot_cache[key].unpin()
```

# Impact Analysis
- **Scope**: This fix only affects `LocalCPUBackend` (and not other backends like `PDBackend`)
- **Safety**: The `storage_manager.touch_cache()` method explicitly only calls this on `LocalCPUBackend` and `LocalDiskBackend`, so no other backends are affected
- **Backward Compatibility**: This is a bug fix with no breaking changes

# Verification
- The fix ensures proper pin count balancing
- It maintains the existing behavior while preventing indefinite pinning
- It follows the same pattern as the rest of the codebase
- Other backends use different reference counting mechanisms and are not affected

# Related Files
- `lmcache/v1/storage_backend/local_cpu_backend.py`: Added the fix in `touch_cache()` method

This fix addresses the issue where memory objects could be pinned forever, improving the cache's memory management efficiency.