### PR TITLE
[Bugfix]: Fix pin count balancing in PD Disaggregation mode

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1660,11 +1660,16 @@ class LMCacheConnectorV1Impl:
             self._layerwise_save_storers.pop(request.request_id, None)
 
         # Cleanup if request was aborted
-        if request.status == RequestStatus.FINISHED_ABORTED and self.async_loading:
-            # Cancel any ongoing async lookup and prefetch tasks on workers
-            lookup_id = request.request_id
-            assert self.lookup_client is not None
-            self.lookup_client.cancel_lookup(lookup_id)  # type: ignore[attr-defined]
+        if request.status == RequestStatus.FINISHED_ABORTED:
+            if self.async_loading:
+                # Cancel any ongoing async lookup and prefetch tasks on workers
+                lookup_id = request.request_id
+                assert self.lookup_client is not None
+                self.lookup_client.cancel_lookup(lookup_id)  # type: ignore[attr-defined]
+
+            # Unpin to balance pin count from lookup
+            if self.lmcache_engine is not None:
+                self.lmcache_engine.lookup_unpin(request.request_id)
 
         params = (
             request.kv_transfer_params

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1091,8 +1091,7 @@ class LMCacheConnectorV1Impl:
                 "LMCacheEngine must be initialized to unpin requests."
             )
             for request in connector_metadata.requests:
-                if request.status != RequestStatus.FINISHED_ABORTED:
-                    self.lmcache_engine.lookup_unpin(request.req_id)
+                self.lmcache_engine.lookup_unpin(request.req_id)
 
             return
 
@@ -1661,16 +1660,11 @@ class LMCacheConnectorV1Impl:
             self._layerwise_save_storers.pop(request.request_id, None)
 
         # Cleanup if request was aborted
-        if request.status == RequestStatus.FINISHED_ABORTED:
-            if self.async_loading:
-                # Cancel any ongoing async lookup and prefetch tasks on workers
-                lookup_id = request.request_id
-                assert self.lookup_client is not None
-                self.lookup_client.cancel_lookup(lookup_id)  # type: ignore[attr-defined]
-
-            # Unpin to balance pin count from lookup
-            if self.lmcache_engine is not None:
-                self.lmcache_engine.lookup_unpin(request.request_id)
+        if request.status == RequestStatus.FINISHED_ABORTED and self.async_loading:
+            # Cancel any ongoing async lookup and prefetch tasks on workers
+            lookup_id = request.request_id
+            assert self.lookup_client is not None
+            self.lookup_client.cancel_lookup(lookup_id)  # type: ignore[attr-defined]
 
         params = (
             request.kv_transfer_params

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1085,6 +1085,10 @@ class LMCacheConnectorV1Impl:
 
         if self.kv_role == "kv_consumer":
             # Don't do save if the role is kv_consumer
+            # But still need to unpin the kv caches according to req_id
+            # to balance the pin count from contains()
+            for request in connector_metadata.requests:
+                self.lmcache_engine.lookup_unpin(request.req_id)
             return
 
         if self.use_layerwise:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1087,7 +1087,9 @@ class LMCacheConnectorV1Impl:
             # Don't do save if the role is kv_consumer
             # But still need to unpin the kv caches according to req_id
             # to balance the pin count from contains()
-            assert self.lmcache_engine is not None, "LMCacheEngine must be initialized to unpin requests."
+            assert self.lmcache_engine is not None, (
+                "LMCacheEngine must be initialized to unpin requests."
+            )
             for request in connector_metadata.requests:
                 self.lmcache_engine.lookup_unpin(request.req_id)
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1091,7 +1091,8 @@ class LMCacheConnectorV1Impl:
                 "LMCacheEngine must be initialized to unpin requests."
             )
             for request in connector_metadata.requests:
-                self.lmcache_engine.lookup_unpin(request.req_id)
+                if request.status != RequestStatus.FINISHED_ABORTED:
+                    self.lmcache_engine.lookup_unpin(request.req_id)
 
             return
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1087,8 +1087,10 @@ class LMCacheConnectorV1Impl:
             # Don't do save if the role is kv_consumer
             # But still need to unpin the kv caches according to req_id
             # to balance the pin count from contains()
+            assert self.lmcache_engine is not None, "LMCacheEngine must be initialized to unpin requests."
             for request in connector_metadata.requests:
                 self.lmcache_engine.lookup_unpin(request.req_id)
+
             return
 
         if self.use_layerwise:


### PR DESCRIPTION
# Summary
This PR fixes a pin count balancing issue in PD (Prefill-Decode) Disaggregation mode. When using LMCache with vLLM's PD Disaggregation (via `kv_producer`/`kv_consumer` roles), memory objects in `LocalCPUBackend` were being pinned indefinitely on the Decoder (D) side, causing pin timeout warnings and potential memory leaks. The Prefill (P) side previously handled pin count balancing correctly, but the Decode (D) side lacked the necessary unpin operation.

# Problem Description
In PD Disaggregation mode:
- **Prefill (P) side (`kv_producer`)**: Performs lookup with `pin=True`, saves KV cache, and calls `lookup_unpin()` in `wait_for_save()` to balance the pin count.
- **Decode (D) side (`kv_consumer`)**: Performs lookup with `pin=True`, but `wait_for_save()` was returning early without calling `lookup_unpin()`, leaving the pin count unbalanced.

This caused memory objects to remain pinned indefinitely on the D-side, leading to:
- Pin timeout warnings from the pin monitor
- Reduced effectiveness of the cache eviction policy
- Increased memory pressure and potential out-of-memory situations
- Performance degradation due to suboptimal cache management

# Solution
Modified `LMCacheConnectorV1Impl.wait_for_save()` in `vllm_v1_adapter.py` to call `lookup_unpin()` for both P-side and D-side:

```python
if self.kv_role == "kv_consumer":
    # Don't do save if the role is kv_consumer
    # But still need to unpin the kv caches according to req_id
    # to balance the pin count from contains()
    for request in connector_metadata.requests:
        self.lmcache_engine.lookup_unpin(request.req_id)
    return
```

This ensures that both P-side and D-side properly balance the pin count incremented during `contains(pin=True)` calls.

# Impact Analysis
- **Scope**: This fix affects PD Disaggregation mode using vLLM's `kv_producer`/`kv_consumer` roles
- **Backward Compatibility**: No breaking changes - the fix only adds the missing `lookup_unpin()` call on D-side
- **Performance**: Minimal overhead - just an additional loop to call `lookup_unpin()` for each request