### PR TITLE
Add argument --prefetch-max-in-flight to fix hardcode

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -170,6 +170,11 @@ Source: ``lmcache/v1/distributed/config.py``
      - L2 prefetch policy.  Determines which adapter loads each key
        when multiple adapters have it.
        The ``default`` policy picks the first adapter (lowest index).
+   * - ``--l2-prefetch-max-in-flight``
+     - ``8``
+     - Maximum number of concurrent prefetch (L2 load) requests.
+       Limits how many in-flight loads the PrefetchController may
+       issue at once, preventing excessive L1 memory pressure.
 
 L2 Adapters
 -----------
@@ -347,6 +352,7 @@ Full Example
         --eviction-trigger-watermark 0.9 \
         --eviction-ratio 0.1 \
         --l2-prefetch-policy default \
+        --l2-prefetch-max-in-flight 8 \
         --l2-adapter '{"type": "nixl_store", "backend": "POSIX", "backend_params": {"file_path": "/data/lmcache/l2", "use_direct_io": "false"}, "pool_size": 64}' \
         --prometheus-port 9090 \
         --prometheus-log-interval 10 \

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -194,6 +194,25 @@ Select policies via CLI:
      - ``default``
      - For each key, pick the first (lowest-indexed) adapter that has it.
 
+Prefetch Concurrency
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``--l2-prefetch-max-in-flight`` flag limits the number of concurrent
+prefetch requests that the ``PrefetchController`` can have in flight at
+any time.  A higher value increases L2-to-L1 throughput but also
+increases L1 memory pressure from in-flight data.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Flag
+     - Default
+     - Description
+   * - ``--l2-prefetch-max-in-flight``
+     - ``8``
+     - Maximum number of concurrent prefetch requests.
+
 Buffer-Only Mode
 ~~~~~~~~~~~~~~~~~
 

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -94,6 +94,9 @@ class StorageManagerConfig:
     prefetch_policy: str = "default"
     """ The L2 prefetch policy name. """
 
+    prefetch_max_in_flight: int = 8
+    """ Maximum number of concurrent prefetch requests. """
+
 
 def add_storage_manager_args(
     parser: argparse.ArgumentParser,
@@ -227,6 +230,12 @@ def add_storage_manager_args(
         "when multiple adapters have it. "
         "Default is 'default' (pick the first adapter by index).",
     )
+    policy_group.add_argument(
+        "--prefetch-max-in-flight",
+        type=int,
+        default=8,
+        help="Maximum number of concurrent prefetch requests. Default is 8.",
+    )
 
     # Adapter config
     add_l2_adapters_args(parser)
@@ -290,6 +299,7 @@ def parse_args_to_config(
         l2_adapter_config=l2_adapter_config,
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
+        prefetch_max_in_flight=args.prefetch_max_in_flight,
     )
 
 

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -231,7 +231,7 @@ def add_storage_manager_args(
         "Default is 'default' (pick the first adapter by index).",
     )
     policy_group.add_argument(
-        "--prefetch-max-in-flight",
+        "--l2-prefetch-max-in-flight",
         type=int,
         default=8,
         help="Maximum number of concurrent prefetch requests. Default is 8.",
@@ -299,7 +299,7 @@ def parse_args_to_config(
         l2_adapter_config=l2_adapter_config,
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
-        prefetch_max_in_flight=args.prefetch_max_in_flight,
+        prefetch_max_in_flight=args.l2_prefetch_max_in_flight,
     )
 
 

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -199,10 +199,6 @@ class PrefetchController(StorageControllerInterface):
         self._l2_adapters = l2_adapters
         self._adapter_descriptors = adapter_descriptors
         self._policy = policy
-        # TODO(ApostaC): max_in_flight should not be a static constant.
-        # Replace with a dynamic admission controller that monitors L1 memory
-        # usage of in-flight prefetch requests. A fixed limit can still blow
-        # up L1 memory when individual requests are large.
         self._max_in_flight = max_in_flight
 
         # In-flight request tracking (background thread only)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -112,6 +112,7 @@ class StorageManager:
             l2_adapters=self._l2_adapters,
             adapter_descriptors=adapter_descriptors,
             policy=create_prefetch_policy(config.prefetch_policy),
+            max_in_flight=config.prefetch_max_in_flight,
         )
         self._prefetch_controller.start()
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: exposes an existing prefetch concurrency limit as a CLI/config option and wires it through to `PrefetchController`, with default behavior unchanged. Main risk is operational misconfiguration (setting the limit too high could increase L1 memory pressure).
> 
> **Overview**
> Adds a new `--l2-prefetch-max-in-flight` CLI flag (default `8`) to control how many concurrent L2 prefetch/load requests the `PrefetchController` can issue, replacing the previously fixed limit.
> 
> Wires the new setting through `StorageManagerConfig` into `StorageManager` when constructing `PrefetchController`, and updates multiprocess docs/examples to document the flag and its memory/throughput tradeoff.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88039a4af401b2cdd6e5f4ece5cba87eaf204269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->