### PR TITLE
[Bugfix] Fix FlashInfer sparse mask on small sequences

### DIFF
--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -268,9 +268,11 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         num_block_col = seq_len // sparse_blk_col_size
         last_col_len = seq_len % sparse_blk_col_size
         block_col_sizes = torch.tensor(
-            [sparse_blk_col_size] * num_block_col, device=self.device
+            [sparse_blk_col_size] * num_block_col
+            + ([last_col_len] if last_col_len > 0 else []),
+            device=self.device
         )
-        block_col_sizes[-1] += last_col_len
+
         return LMCFlashInferSparseMetadata(
             wrapper,
             seq_len,

--- a/lmcache/v1/compute/attention/metadata.py
+++ b/lmcache/v1/compute/attention/metadata.py
@@ -54,13 +54,15 @@ class LMCFlashInferSparseMetadata(LMCAttnMetadata):
         device = top_indices.device
         top_k_num = len(top_indices)
         num_block_row = top_k_num // self.sparse_blk_row_size
+        last_row_len = top_k_num % self.sparse_blk_row_size
         block_row_sizes = torch.tensor(
-            [self.sparse_blk_row_size] * num_block_row, device=device
+            [self.sparse_blk_row_size] * num_block_row
+            + ([last_row_len] if last_row_len > 0 else []),
+            device=device
         )
-        block_row_sizes[-1] += top_k_num % self.sparse_blk_row_size
 
         block_mask_map = torch.zeros(
-            num_block_row, len(self.block_col_sizes), dtype=torch.bool, device=device
+            len(block_row_sizes), len(self.block_col_sizes), dtype=torch.bool, device=device
         )
         cols = torch.arange(block_mask_map.size(1), device=device).expand(
             block_mask_map.size(0), -1
@@ -71,7 +73,15 @@ class LMCFlashInferSparseMetadata(LMCAttnMetadata):
         top_indices_slice = top_indices[
             self.sparse_blk_row_size - 1 :: self.sparse_blk_row_size
         ]
+        if len(top_indices_slice) == 0 and len(top_indices) > 0:
+            top_indices_slice = top_indices[-1:]
         top_indices_slice //= self.sparse_blk_col_size
+        top_indices_slice = top_indices_slice.clamp_min(1) # ensure at least 1 block
+        if len(top_indices_slice) < len(block_row_sizes):
+            top_indices_slice = torch.cat([
+                top_indices_slice,
+                top_indices_slice[-1:].repeat(len(block_row_sizes) - len(top_indices_slice))
+            ])
         mask = cols < top_indices_slice.unsqueeze(1)
         block_mask_map[mask] = 1
         self.wrapper.plan(


### PR DESCRIPTION
Sequences smaller than sparse block block size would result in block_row_sizes/block_col_sizes being empty and accessing them with [-1] to append the last row/col length would result in a crash.
Fix: directly add last row/col len at tensor creation.

in update_from_top_indices() a number of top_indices smaller than a sparse block size would result in an empty mask and therefore crash the attention computation. This can happen for example on low % blending cases, because with low % the topk number of selected tokens can be smaller than a sparse block. E.g., with 0.0% 1 token is selected as a minimum.
Fix: have the mask have at least one block.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR fixes crashes that occur with FlashInfer sparse attention computation in edge cases where the sequence lengths are smaller than the sparse block mask, reason is explained above. This happens in blending when a low % of tokens are selected (or in the 0.0% case where a single token is selected by default).

**Special notes for your reviewers**:

Thank you for reviewing :)

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
