### PR TITLE
Use free ports for LM server test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,6 +374,13 @@ def mock_redis_cluster():
 
 @pytest.fixture(scope="module")
 def lmserver_v1_process(request):
+    def get_free_port() -> int:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("localhost", 0))
+        _, port = sock.getsockname()
+        sock.close()
+        return port
+
     def ensure_connection(host, port):
         retries = 10
         client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -403,7 +410,7 @@ def lmserver_v1_process(request):
     max_retries = 5
     while max_retries > 0:
         max_retries -= 1
-        port_number = random.randint(10000, 65500)
+        port_number = get_free_port()
         print("Starting the lmcache v1 server process on port")
         proc = subprocess.Popen(
             shlex.split(
@@ -416,7 +423,7 @@ def lmserver_v1_process(request):
 
         successful = False
         if proc.poll() is not None:
-            successful = True
+            successful = False
         else:
             successful = ensure_connection("localhost", port_number)
 
@@ -441,6 +448,13 @@ def lmserver_v1_process(request):
 
 @pytest.fixture(scope="module")
 def lmserver_process(request):
+    def get_free_port() -> int:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("localhost", 0))
+        _, port = sock.getsockname()
+        sock.close()
+        return port
+
     def ensure_connection(host, port):
         retries = 10
         client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -470,7 +484,7 @@ def lmserver_process(request):
     max_retries = 5
     while max_retries > 0:
         max_retries -= 1
-        port_number = random.randint(10000, 65500)
+        port_number = get_free_port()
         print("Starting the lmcache server process on port")
         proc = subprocess.Popen(
             shlex.split(f"python3 -m lmcache.server localhost {port_number} {device}")
@@ -481,7 +495,7 @@ def lmserver_process(request):
 
         successful = False
         if proc.poll() is not None:
-            successful = True
+            successful = False
         else:
             successful = ensure_connection("localhost", port_number)
 


### PR DESCRIPTION
## Summary
- pick an OS-assigned free port for lmcache server test fixtures
- treat early process exit as failure instead of success

## Testing
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /Users/darshankadu/Documents/GitHub/LMCache/.venv/bin/python
cachedir: .pytest_cache
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
metadata: {'Python': '3.12.12', 'Platform': 'macOS-15.6-arm64-arm-64bit', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'anyio': '4.12.1', 'benchmark': '5.2.3', 'metadata': '3.1.1', 'html': '4.2.0', 'asyncio': '1.3.0', 'buildkite-test-collector': '1.3.1', 'cov': '7.0.0'}}
rootdir: /Users/darshankadu/Documents/GitHub/LMCache/tests
configfile: pytest.ini
plugins: anyio-4.12.1, benchmark-5.2.3, metadata-3.1.1, html-4.2.0, asyncio-1.3.0, buildkite-test-collector-1.3.1, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 1 item

tests/v1/test_connector.py::test_lm_connector[lm://localhost:65000-cpu] Starting the lmcache v1 server process on port
Probing connection, remaining retries:  9
PASSED

=============================== warnings summary ===============================
v1/test_connector.py::test_lm_connector[lm://localhost:65000-cpu]
  /Users/darshankadu/Documents/GitHub/LMCache/tests/conftest.py:560: RuntimeWarning: coroutine 'InstrumentedRemoteConnector.close' was never awaited
    obj.close()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 1 passed, 1 warning in 6.64s =========================