### PR TITLE
[CI] Add GHA to periodically sync torch version from latest vLLM

### DIFF
--- a/.github/workflows/sync_torch_version.yml
+++ b/.github/workflows/sync_torch_version.yml
@@ -1,0 +1,49 @@
+name: Sync Torch Version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          token: ${{ github.token }}
+
+      - name: Sync torch version with vLLM
+        id: sync
+        run: |
+          set -euo pipefail
+          url="https://raw.githubusercontent.com/vllm-project/vllm/main/pyproject.toml"
+          upstream=$(curl -fsSL "$url" | sed -nE 's/.*torch\s*==\s*"?([0-9.]+)"?.*/\1/p' | head -1)
+          [[ -z "$upstream" ]] && { echo "Failed to get torch version from vLLM"; exit 1; }
+          current=$(sed -nE 's/.*torch\s*==\s*"?([0-9.]+)"?.*/\1/p' pyproject.toml | head -1)
+          if [[ "$upstream" != "$current" ]]; then
+            sed -i -E "s/(torch\s*==\s*)[0-9.]+/\1$upstream/" pyproject.toml
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+          echo "upstream=$upstream" >> $GITHUB_OUTPUT
+          echo "current=$current" >> $GITHUB_OUTPUT
+
+      - if: steps.sync.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: automation/sync-torch-version
+          base: dev
+          add-paths: pyproject.toml
+          commit-message: "build: sync torch version with vllm (${{ steps.sync.outputs.upstream }})"
+          title: "build: sync torch version with vllm (${{ steps.sync.outputs.upstream }})"
+          body: "Sync torch with vLLM. ${{ steps.sync.outputs.current }} → ${{ steps.sync.outputs.upstream }}"
+          labels: dependencies, automation

--- a/.github/workflows/sync_torch_version.yml
+++ b/.github/workflows/sync_torch_version.yml
@@ -40,6 +40,7 @@ jobs:
       - if: steps.sync.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ github.token }}
           branch: automation/sync-torch-version
           base: dev
           add-paths: pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch==2.8.0",
+    "torch==2.10.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "torch==2.10.0",
+    "torch==2.8.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -84,8 +84,6 @@ select = [
     # "I",
     # flake8-logging-format
     #"G",
-    # flake8-self (private member access)
-    "SLF",
 ]
 ignore = [
     # star imports
@@ -97,11 +95,6 @@ ignore = [
     # f-string format
     "UP032",
 ]
-
-[tool.ruff.lint.per-file-ignores]
-# Ignore SLF everywhere except lmcache/v1/multiprocess/
-"!lmcache/v1/multiprocess/**" = ["SLF"]
-"!lmcache/v1/distributed/**" = ["SLF"]
 
 [tool.ruff.lint.isort]
 # same as .isort.cfg
@@ -115,7 +108,6 @@ from-first = true
 
 [tool.mypy]
 
-platform = "linux"
 modules = ["lmcache", "tests", "benchmarks"]
 
 disable_error_code = [
@@ -143,10 +135,6 @@ disallow_untyped_calls = false
 warn_return_any = false
 
 follow_imports = "silent"
-
-[tool.codespell]
-ignore-words-list = "afterall,allready,notin"
-skip = "operator/config/crd/bases/*"
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64"


### PR DESCRIPTION
 
**What this PR does / why we need it**:
Adds a GitHub Actions workflow to periodically check the pinned torch version in the latest vLLM and automatically open a PR to update LMCache’s pyproject.toml accordingly. This helps keep LMCache’s build torch version aligned with vLLM and avoids ABI mismatches.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
