### PR TITLE
[MP]: Support delay start heartbeat thread to avoid unhealthy while start vllm for a huge module warmup.

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -238,6 +238,7 @@ class LMCacheMPSchedulerAdapter:
         # request, by which time vLLM is fully ready.
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None
+        self._heartbeat_lock = threading.Lock()
 
     @property
     def is_healthy(self) -> bool:
@@ -248,12 +249,15 @@ class LMCacheMPSchedulerAdapter:
         """Lazily start the heartbeat thread on first use."""
         if self._heartbeat is not None:
             return
-        self._heartbeat = HeartbeatThread(
-            mq_client=self.mq_client,
-            health_event=self._health_event,
-            interval=self._heartbeat_interval,
-        )
-        self._heartbeat.start()
+        with self._heartbeat_lock:
+            if self._heartbeat is not None:
+                return
+            self._heartbeat = HeartbeatThread(
+                mq_client=self.mq_client,
+                health_event=self._health_event,
+                interval=self._heartbeat_interval,
+            )
+            self._heartbeat.start()
 
     @_lmcache_nvtx_annotate
     def maybe_submit_lookup_request(
@@ -529,6 +533,7 @@ class LMCacheMPWorkerAdapter:
         # completes, i.e. after vLLM is fully ready.
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None
+        self._heartbeat_lock = threading.Lock()
 
         # request telemetry, used for prefill-decode disagg
         # TODO: pass down the configuration via vLLM connector config
@@ -575,7 +580,7 @@ class LMCacheMPWorkerAdapter:
             raise ConnectionError(
                 "LMCache server did not respond to "
                 "register_kv_caches within "
-                "%ss. Is the server running?" % self._mq_timeout
+                f"{self._mq_timeout}s. Is the server running?"
             ) from None
 
         # Start heartbeat only after vLLM is fully ready
@@ -586,12 +591,15 @@ class LMCacheMPWorkerAdapter:
         """Start the heartbeat thread (idempotent)."""
         if self._heartbeat is not None:
             return
-        self._heartbeat = HeartbeatThread(
-            mq_client=self.mq_client,
-            health_event=self._health_event,
-            interval=self._heartbeat_interval,
-        )
-        self._heartbeat.start()
+        with self._heartbeat_lock:
+            if self._heartbeat is not None:
+                return
+            self._heartbeat = HeartbeatThread(
+                mq_client=self.mq_client,
+                health_event=self._health_event,
+                interval=self._heartbeat_interval,
+            )
+            self._heartbeat.start()
 
     @_lmcache_nvtx_annotate
     def submit_store_request(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -133,6 +133,10 @@ class HeartbeatThread(PeriodicThread):
 
         if healthy:
             self._health_event.set()
+            if not was_healthy:
+                logger.warning(
+                    "LMCache server is healthy again — resuming normal operation"
+                )
         else:
             self._health_event.clear()
             if was_healthy:
@@ -229,18 +233,27 @@ class LMCacheMPSchedulerAdapter:
         self._health_event = threading.Event()
         self._health_event.set()
 
-        # Start heartbeat thread
-        self._heartbeat = HeartbeatThread(
-            mq_client=self.mq_client,
-            health_event=self._health_event,
-            interval=heartbeat_interval,
-        )
-        self._heartbeat.start()
+        # Heartbeat thread is created but NOT started yet.
+        # It will be lazily started on the first lookup
+        # request, by which time vLLM is fully ready.
+        self._heartbeat_interval = heartbeat_interval
+        self._heartbeat: HeartbeatThread | None = None
 
     @property
     def is_healthy(self) -> bool:
         """Whether the LMCache server is healthy."""
         return self._health_event.is_set()
+
+    def _ensure_heartbeat_started(self) -> None:
+        """Lazily start the heartbeat thread on first use."""
+        if self._heartbeat is not None:
+            return
+        self._heartbeat = HeartbeatThread(
+            mq_client=self.mq_client,
+            health_event=self._health_event,
+            interval=self._heartbeat_interval,
+        )
+        self._heartbeat.start()
 
     @_lmcache_nvtx_annotate
     def maybe_submit_lookup_request(
@@ -270,6 +283,8 @@ class LMCacheMPSchedulerAdapter:
             In the meantime, this function will record the lookup request, and the
             status of the look up request can be checked by `check_lookup_result`.
         """
+        self._ensure_heartbeat_started()
+
         if not self.is_healthy:
             return
 
@@ -509,13 +524,11 @@ class LMCacheMPWorkerAdapter:
         self._health_event = threading.Event()
         self._health_event.set()
 
-        # Start heartbeat thread
-        self._heartbeat = HeartbeatThread(
-            mq_client=self.mq_client,
-            health_event=self._health_event,
-            interval=heartbeat_interval,
-        )
-        self._heartbeat.start()
+        # Heartbeat thread is created but NOT started yet.
+        # It will be started after register_kv_caches()
+        # completes, i.e. after vLLM is fully ready.
+        self._heartbeat_interval = heartbeat_interval
+        self._heartbeat: HeartbeatThread | None = None
 
         # request telemetry, used for prefill-decode disagg
         # TODO: pass down the configuration via vLLM connector config
@@ -560,9 +573,25 @@ class LMCacheMPWorkerAdapter:
             future.result(timeout=self._mq_timeout)
         except TimeoutError:
             raise ConnectionError(
-                "LMCache server did not respond to register_kv_caches "
-                f"within {self._mq_timeout}s. Is the server running?"
+                "LMCache server did not respond to "
+                "register_kv_caches within "
+                "%ss. Is the server running?" % self._mq_timeout
             ) from None
+
+        # Start heartbeat only after vLLM is fully ready
+        # (model loaded, KV caches allocated, warmup done).
+        self._start_heartbeat()
+
+    def _start_heartbeat(self) -> None:
+        """Start the heartbeat thread (idempotent)."""
+        if self._heartbeat is not None:
+            return
+        self._heartbeat = HeartbeatThread(
+            mq_client=self.mq_client,
+            health_event=self._health_event,
+            interval=self._heartbeat_interval,
+        )
+        self._heartbeat.start()
 
     @_lmcache_nvtx_annotate
     def submit_store_request(

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -225,6 +225,9 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     adapter._health_event.set()
     adapter.tp_size = 1
     adapter._mq_timeout = 30.0
+    adapter._heartbeat = None
+    adapter._heartbeat_lock = threading.Lock()
+    adapter._heartbeat_interval = 5.0
 
     mock_client = MagicMock(spec=MessageQueueClient)
     mock_future = MagicMock()
@@ -235,8 +238,9 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
 
     token_ids = list(range(512))
 
-    # Submit lookup
-    adapter.maybe_submit_lookup_request("req-1", token_ids)
+    # Submit lookup – patch heartbeat to avoid spawning a real thread
+    with patch.object(adapter, "_ensure_heartbeat_started"):
+        adapter.maybe_submit_lookup_request("req-1", token_ids)
     lookup_call = mock_client.submit_request.call_args
     lookup_payloads = lookup_call[0][1]
     lookup_key = lookup_payloads[0]


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

```mermaid
sequenceDiagram
    participant V as vLLM Engine
    participant W as WorkerAdapter
    participant H as HeartbeatThread
    participant S as LMCache Server

    Note over V: Model loading + DeepGEMM warmup (~5min)
    V->>W: __init__()
    Note over W: Heartbeat NOT started yet.<br/>No PING, no false alarms.

    V->>W: register_kv_caches()
    W->>S: REGISTER_KV_CACHE
    S-->>W: OK
    W->>H: _start_heartbeat()
    Note over H: Heartbeat begins (double-checked locking)

    loop Every 10s
        H->>S: PING
        S-->>H: PONG → healthy ✅
    end

    Note over S: 💥 Server crashes
    H->>S: PING (timeout)
    Note over H: unhealthy → entering degraded mode

    Note over S: 🔄 Server recovers
    H->>S: PING
    S-->>H: PONG
    Note over H: healthy again → resuming normal operation ✅

```

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
