### PR TITLE
feat(disk): support multi-path local disk backend for multi-device I/O

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -36,7 +36,10 @@ Basic cache settings that control the core functionality of LMCache.
      - Maximum CPU cache size in GB. Default: 5.0
    * - local_disk
      - LMCACHE_LOCAL_DISK
-     - Path to local disk cache. Format: "file:///path/to/cache".
+     - Path (or comma-separated paths) to local disk cache directories. Format: ``"file:///path/to/cache"`` or ``"/path/a,/path/b"`` for multi-device I/O. See ``local_disk_path_sharding`` for how paths are assigned to GPUs.
+   * - local_disk_path_sharding
+     - LMCACHE_LOCAL_DISK_PATH_SHARDING
+     - Strategy for selecting a path when multiple paths are provided. Currently only ``"by_gpu"`` is supported, which selects paths based on GPU device ID (default: "by_gpu").
    * - max_local_disk_size
      - LMCACHE_MAX_LOCAL_DISK_SIZE
      - Maximum disk cache size in GB. Default: 0.0

--- a/docs/source/kv_cache/storage_backends/local_storage.rst
+++ b/docs/source/kv_cache/storage_backends/local_storage.rst
@@ -49,6 +49,58 @@ Passed in through ``LMCACHE_CONFIG_FILE=your-lmcache-config.yaml``
     # This should be turned on for better performance if most local CPU memory is used
     extra_config: {'use_odirect': True}
 
+
+Multi-Path (Multi-Device) Disk Offloading
+-----------------------------------------
+
+If you have **multiple NVMe devices** (or any independent mount points), you can
+assign each GPU its own disk path so that each device writes to a dedicated drive.
+
+Specify a **comma-separated list** of paths in ``local_disk``.
+Each path can optionally use the ``file://`` prefix.  The
+``local_disk_path_sharding`` option controls how each GPU worker selects its
+path.  Currently only ``"by_gpu"`` is supported (the default), which selects a
+path based on the device index (``device_id % num_paths``), so all KV cache
+files from a given GPU land on the same NVMe.  This is especially useful when
+GPUs and NVMe devices share a PCIe switch or NUMA node.
+
+For example, with two GPUs and two paths:
+
+- ``cuda:0`` → ``/mnt/nvme0/kvcache/``
+- ``cuda:1`` → ``/mnt/nvme1/kvcache/``
+
+``max_local_disk_size`` is the **total budget** shared across all paths.
+
+**Environment variable example:**
+
+.. code-block:: bash
+
+    export LMCACHE_LOCAL_DISK="file:///mnt/nvme0/kvcache/,file:///mnt/nvme1/kvcache/"
+    export LMCACHE_LOCAL_DISK_PATH_SHARDING="by_gpu"
+    export LMCACHE_MAX_LOCAL_DISK_SIZE=20.0   # combined budget (GB)
+
+**YAML example:**
+
+.. code-block:: yaml
+
+    local_disk: "/mnt/nvme0/kvcache/,/mnt/nvme1/kvcache/"
+    local_disk_path_sharding: "by_gpu"
+    max_local_disk_size: 20.0
+
+.. note::
+
+    Each GPU worker uses only its assigned path, so O_DIRECT alignment
+    is determined by that path's filesystem block size.  Different
+    devices may have different block sizes without issue.
+
+.. tip::
+
+    If you are able to use kernel-level RAID 0 (e.g. ``mdadm --level=0``)
+    you will get true block-level striping (even a single large file can
+    use bandwidth from both devices simultaneously).  The multi-path
+    feature is most useful when you cannot or do not want to reconfigure
+    the block devices — for example, when they already have other data.
+
 Local Storage Explanation:
 --------------------------
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -74,6 +74,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": None,
         "env_converter": _parse_local_disk,
     },
+    "local_disk_path_sharding": {
+        "type": str,
+        "default": "by_gpu",
+        "env_converter": str,
+    },
     "max_local_disk_size": {"type": float, "default": 0.0, "env_converter": float},
     "remote_url": {
         "type": Optional[str],

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, Dict, Optional, Protocol, Union
 import ast
 import json
 import os
-import re
 import threading
 import uuid
 
@@ -49,15 +48,41 @@ def _apply_env_converter_safely(config_definitions, name, value):
 
 # Common configuration parsing utilities
 def _parse_local_disk(local_disk) -> Optional[str]:
-    """Parse local disk path configuration"""
-    match local_disk:
-        case None:
-            local_disk_path = None
-        case path if re.match(r"file://(.*)/", path):
-            local_disk_path = path[7:]
-        case _:
-            local_disk_path = local_disk
-    return local_disk_path
+    """Parse local disk path configuration.
+
+    Accepts a single path or comma-separated paths, each optionally
+    prefixed with ``file://``.  Returns a comma-joined string of bare
+    directory paths suitable for ``LocalDiskBackend``.
+
+    Examples::
+
+        "file:///mnt/nvme0/"              -> "/mnt/nvme0/"
+        "/mnt/nvme0/,/mnt/nvme1/"         -> "/mnt/nvme0/,/mnt/nvme1/"
+        "file:///mnt/nvme0/,file:///mnt/nvme1/"
+                                           -> "/mnt/nvme0/,/mnt/nvme1/"
+
+    Args:
+        local_disk: Raw config value — ``None``, a single path, or
+            comma-separated paths.
+
+    Returns:
+        Comma-joined bare directory paths, or ``None`` if disabled.
+    """
+    if local_disk is None:
+        return None
+
+    raw_parts = [p.strip() for p in str(local_disk).split(",") if p.strip()]
+    if not raw_parts:
+        return None
+
+    parsed: list[str] = []
+    for part in raw_parts:
+        if part.startswith("file://"):
+            parsed.append(part[7:])
+        else:
+            parsed.append(part)
+
+    return ",".join(parsed)
 
 
 def _to_int_list(

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -119,10 +119,36 @@ class LocalDiskBackend(StorageBackendInterface):
         self.disk_lock = threading.Lock()
 
         assert config.local_disk is not None
-        self.path: str = config.local_disk
-        if not os.path.exists(self.path):
-            os.makedirs(self.path)
-            logger.info(f"Created local disk cache directory: {self.path}")
+
+        # Multi-path support: parse comma-separated paths and select one
+        # based on the configured sharding strategy.
+        paths = [p.strip() for p in config.local_disk.split(",") if p.strip()]
+        assert len(paths) > 0, "At least one disk path must be provided"
+
+        self.local_disk_path_sharding = config.local_disk_path_sharding
+        assert self.local_disk_path_sharding == "by_gpu", (
+            f"Unsupported local_disk_path_sharding "
+            f"'{self.local_disk_path_sharding}'. "
+            "Only 'by_gpu' is supported currently."
+        )
+
+        # Extract device index from dst_device (e.g. "cuda:2" -> 2)
+        device_id = (
+            int(dst_device.split(":")[1])
+            if ":" in dst_device
+            else (torch.cuda.current_device() if torch.cuda.is_available() else 0)
+        )
+        self.path: str = paths[device_id % len(paths)]
+
+        # Create all directories (not just the selected one)
+        for p in paths:
+            os.makedirs(p, exist_ok=True)
+        logger.info(
+            "Local disk cache path: %s (device %s, %d path(s) configured)",
+            self.path,
+            dst_device,
+            len(paths),
+        )
 
         self.loop = loop
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -12,6 +12,7 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config_base import _parse_local_disk
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -37,11 +38,16 @@ class MockLMCacheWorker:
         self.messages.append(msg)
 
 
-def create_test_config(disk_path: str, max_disk_size: float = 1.0):
+def create_test_config(
+    disk_path: str,
+    max_disk_size: float = 1.0,
+    local_disk_path_sharding: str = "by_gpu",
+):
     """Create a test configuration for LocalDiskBackend."""
     config = LMCacheEngineConfig.from_defaults(
         chunk_size=256,
         local_disk=disk_path,
+        local_disk_path_sharding=local_disk_path_sharding,
         max_local_disk_size=max_disk_size,
         lmcache_instance_id="test_instance",
     )
@@ -109,7 +115,7 @@ def local_disk_backend(temp_disk_path, async_loop, local_cpu_backend):
         config=config,
         loop=async_loop,
         local_cpu_backend=local_cpu_backend,
-        dst_device="cuda",
+        dst_device="cuda:0",
     )
 
 
@@ -123,10 +129,10 @@ class TestLocalDiskBackend:
             config=config,
             loop=async_loop,
             local_cpu_backend=local_cpu_backend,
-            dst_device="cuda",
+            dst_device="cuda:0",
         )
 
-        assert backend.dst_device == "cuda"
+        assert backend.dst_device == "cuda:0"
         assert backend.local_cpu_backend == local_cpu_backend
         assert backend.path == temp_disk_path
         assert os.path.exists(temp_disk_path)
@@ -148,7 +154,7 @@ class TestLocalDiskBackend:
             config=config,
             loop=async_loop,
             local_cpu_backend=local_cpu_backend,
-            dst_device="cuda",
+            dst_device="cuda:0",
             lmcache_worker=lmcache_worker,
         )
 
@@ -187,3 +193,189 @@ class TestLocalDiskBackend:
         assert result is None
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestMultiPathDiskBackend:
+    """Test cases for multi-path (multi-device) LocalDiskBackend."""
+
+    def test_init_multi_path(self, async_loop, local_cpu_backend):
+        """Test initialisation with comma-separated paths."""
+        dir_a = tempfile.mkdtemp()
+        dir_b = tempfile.mkdtemp()
+        try:
+            combined = f"{dir_a},{dir_b}"
+            config = create_test_config(combined)
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:0",
+            )
+
+            # Path selected by device_id (0 % 2 = 0 -> dir_a)
+            assert backend.path == dir_a
+            # Both directories should exist
+            assert os.path.isdir(dir_a)
+            assert os.path.isdir(dir_b)
+            # Block size is a plain int for the selected path
+            assert isinstance(backend.os_disk_bs, int)
+        finally:
+            shutil.rmtree(dir_a, ignore_errors=True)
+            shutil.rmtree(dir_b, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_gpu_affinity_selects_path(self, async_loop, local_cpu_backend):
+        """Different cuda devices select different paths via modulo."""
+        dir_a = tempfile.mkdtemp()
+        dir_b = tempfile.mkdtemp()
+        try:
+            combined = f"{dir_a},{dir_b}"
+            config = create_test_config(combined)
+
+            dirs_by_gpu = {}
+            for device in ("cuda:0", "cuda:1"):
+                backend = LocalDiskBackend(
+                    config=config,
+                    loop=async_loop,
+                    local_cpu_backend=local_cpu_backend,
+                    dst_device=device,
+                )
+                dirs_by_gpu[device] = backend.path
+
+            assert dirs_by_gpu["cuda:0"] == dir_a
+            assert dirs_by_gpu["cuda:1"] == dir_b
+        finally:
+            shutil.rmtree(dir_a, ignore_errors=True)
+            shutil.rmtree(dir_b, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_all_directories_created(self, async_loop, local_cpu_backend):
+        """All paths in the list get their directories created."""
+        base = tempfile.mkdtemp()
+        try:
+            paths = [os.path.join(base, f"nvme{i}") for i in range(3)]
+            combined = ",".join(paths)
+            config = create_test_config(combined)
+            LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:0",
+            )
+            for p in paths:
+                assert os.path.isdir(p), f"{p} should exist"
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_single_path_backward_compat(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """A single path (no commas) works exactly as before."""
+        config = create_test_config(temp_disk_path)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cuda:0",
+        )
+        assert backend.path == temp_disk_path
+        local_cpu_backend.memory_allocator.close()
+
+    def test_path_sharding_default(self, temp_disk_path, async_loop, local_cpu_backend):
+        """Default local_disk_path_sharding is 'by_gpu'."""
+        config = create_test_config(temp_disk_path)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cuda:0",
+        )
+        assert backend.local_disk_path_sharding == "by_gpu"
+        local_cpu_backend.memory_allocator.close()
+
+    def test_path_sharding_explicit_by_gpu(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """Explicitly setting local_disk_path_sharding='by_gpu' works."""
+        config = create_test_config(temp_disk_path, local_disk_path_sharding="by_gpu")
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cuda:0",
+        )
+        assert backend.local_disk_path_sharding == "by_gpu"
+        local_cpu_backend.memory_allocator.close()
+
+    def test_path_sharding_unsupported_raises(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """Unsupported local_disk_path_sharding raises AssertionError."""
+        config = create_test_config(
+            temp_disk_path, local_disk_path_sharding="round_robin"
+        )
+        with pytest.raises(
+            AssertionError, match="Unsupported local_disk_path_sharding"
+        ):
+            LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:0",
+            )
+
+    def test_cpu_dst_device_defaults_to_first_path(self, async_loop, local_cpu_backend):
+        """dst_device='cpu' should fall back to device_id=0."""
+        dir_a = tempfile.mkdtemp()
+        dir_b = tempfile.mkdtemp()
+        try:
+            combined = f"{dir_a},{dir_b}"
+            config = create_test_config(combined)
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cpu",
+            )
+            # device_id=0 -> 0 % 2 = 0 -> dir_a
+            assert backend.path == dir_a
+        finally:
+            shutil.rmtree(dir_a, ignore_errors=True)
+            shutil.rmtree(dir_b, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+
+class TestParseLocalDisk:
+    """Unit tests for the _parse_local_disk config parser."""
+
+    def test_none(self):
+        assert _parse_local_disk(None) is None
+
+    def test_single_raw_path(self):
+        assert _parse_local_disk("/mnt/nvme0/cache/") == "/mnt/nvme0/cache/"
+
+    def test_single_file_uri(self):
+        assert _parse_local_disk("file:///mnt/nvme0/cache/") == "/mnt/nvme0/cache/"
+
+    def test_single_file_uri_no_trailing_slash(self):
+        assert _parse_local_disk("file:///mnt/nvme0/cache") == "/mnt/nvme0/cache"
+
+    def test_comma_separated_raw(self):
+        result = _parse_local_disk("/mnt/nvme0/,/mnt/nvme1/")
+        assert result == "/mnt/nvme0/,/mnt/nvme1/"
+
+    def test_comma_separated_file_uris(self):
+        result = _parse_local_disk("file:///mnt/nvme0/,file:///mnt/nvme1/")
+        assert result == "/mnt/nvme0/,/mnt/nvme1/"
+
+    def test_mixed_uri_and_raw(self):
+        result = _parse_local_disk("file:///mnt/nvme0/,/mnt/nvme1/")
+        assert result == "/mnt/nvme0/,/mnt/nvme1/"
+
+    def test_whitespace_around_paths(self):
+        result = _parse_local_disk("  /mnt/nvme0/ , /mnt/nvme1/  ")
+        assert result == "/mnt/nvme0/,/mnt/nvme1/"
+
+    def test_empty_string(self):
+        assert _parse_local_disk("") is None


### PR DESCRIPTION
Allow `local_disk` to accept comma-separated paths (e.g. "/mnt/nvme0/,/mnt/nvme1/") so KV cache files are hash-distributed across multiple devices, increasing aggregate disk bandwidth.

- _parse_local_disk now handles comma-separated paths with per-entry file:// prefix stripping
- LocalDiskBackend tracks per-path filesystem block sizes for correct O_DIRECT alignment on heterogeneous devices
- Backward-compatible .path property returns the first path
- Added tests for multi-path init, key distribution, determinism, block size lookup, and config parser
- Updated local_storage.rst and configurations.rst docs

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disk cache initialization and path selection logic, which can affect where KV files are written/read and O_DIRECT alignment behavior. Risk is moderate due to new config surface (`local_disk_path_sharding`) and device-id parsing, but behavior is backward-compatible for single-path setups and covered by added tests.
> 
> **Overview**
> Enables **multi-device local disk offloading** by allowing `local_disk` to be a comma-separated list of cache directories and adding `local_disk_path_sharding` (default `by_gpu`) to deterministically choose a per-worker path based on GPU device index.
> 
> Updates `_parse_local_disk` to strip optional `file://` prefixes per entry and normalize multi-path values, adjusts `LocalDiskBackend` to create all configured directories and select the active path for I/O, and adds unit tests plus docs describing multi-path configuration and sharding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3101789cc4d3a24361e1bd4e100197a5db067452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->