### PR TITLE
[Core] feat: add SemanticLookupProvider for approximate KV cache matching

### DIFF
--- a/lmcache/integration/vllm/tests/conftest.py
+++ b/lmcache/integration/vllm/tests/conftest.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pytest configuration for vllm integration tests.
+
+Patches torch attributes that are not available in older torch versions
+so that imports of lmcache.v1.storage_backend (which references torch.uint16)
+don't fail during test collection on development machines without GPU
+dependencies installed.
+
+Also stubs out vllm when it is not installed so that tests which only use
+LMCache-internal code (and import the adapter via __new__) can still be
+collected and executed.
+"""
+# Standard
+import enum
+import sys
+from unittest.mock import MagicMock
+
+# Third Party
+import torch
+
+# ---------------------------------------------------------------------------
+# Patch torch unsigned integer dtypes missing in older torch versions
+# ---------------------------------------------------------------------------
+for _attr, _fallback in [("uint16", "int16"), ("uint32", "int32"), ("uint64", "int64")]:
+    if not hasattr(torch, _attr):
+        setattr(torch, _attr, getattr(torch, _fallback))
+
+# ---------------------------------------------------------------------------
+# Stub out vllm if not installed
+# ---------------------------------------------------------------------------
+if "vllm" not in sys.modules:
+    # Real base classes needed so that inheritance and @dataclass work
+    class _KVConnectorMetadata:
+        pass
+
+    class _KVConnectorBase_V1:
+        pass
+
+    class _KVConnectorRole(enum.Enum):
+        SCHEDULER = "scheduler"
+        WORKER = "worker"
+
+    class _RequestStatus(enum.Enum):
+        FINISHED_STOPPED = "FINISHED_STOPPED"
+        FINISHED_ABORTED = "FINISHED_ABORTED"
+        FINISHED_IGNORED = "FINISHED_IGNORED"
+
+    class _VllmConfig:
+        pass
+
+    class _SchedulerOutput:
+        pass
+
+    class _SamplingParams:
+        pass
+
+    # Build the stub hierarchy
+    vllm_stub = MagicMock()
+
+    # config
+    config_mod = MagicMock()
+    config_mod.VllmConfig = _VllmConfig
+    sys.modules["vllm.config"] = config_mod
+
+    # distributed.kv_transfer.kv_connector.v1.base
+    base_mod = MagicMock()
+    base_mod.KVConnectorBase_V1 = _KVConnectorBase_V1
+    base_mod.KVConnectorMetadata = _KVConnectorMetadata
+    base_mod.KVConnectorRole = _KVConnectorRole
+    sys.modules["vllm.distributed"] = MagicMock()
+    sys.modules["vllm.distributed.kv_transfer"] = MagicMock()
+    sys.modules["vllm.distributed.kv_transfer.kv_connector"] = MagicMock()
+    sys.modules["vllm.distributed.kv_transfer.kv_connector.v1"] = MagicMock()
+    sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.base"] = base_mod
+
+    # distributed.parallel_state
+    parallel_mod = MagicMock()
+    sys.modules["vllm.distributed.parallel_state"] = parallel_mod
+
+    # sampling_params
+    sampling_mod = MagicMock()
+    sampling_mod.SamplingParams = _SamplingParams
+    sys.modules["vllm.sampling_params"] = sampling_mod
+
+    # v1.core.sched.output
+    sched_output_mod = MagicMock()
+    sched_output_mod.SchedulerOutput = _SchedulerOutput
+    sys.modules["vllm.v1"] = MagicMock()
+    sys.modules["vllm.v1.core"] = MagicMock()
+    sys.modules["vllm.v1.core.sched"] = MagicMock()
+    sys.modules["vllm.v1.core.sched.output"] = sched_output_mod
+
+    # v1.request
+    request_mod = MagicMock()
+    request_mod.RequestStatus = _RequestStatus
+    sys.modules["vllm.v1.request"] = request_mod
+
+    # version
+    version_mod = MagicMock()
+    version_mod.__version__ = "0.0.0"
+    sys.modules["vllm.version"] = version_mod
+
+    # Top-level vllm
+    vllm_stub.config = config_mod
+    vllm_stub.distributed = sys.modules["vllm.distributed"]
+    vllm_stub.sampling_params = sampling_mod
+    vllm_stub.v1 = sys.modules["vllm.v1"]
+    vllm_stub.version = version_mod
+    sys.modules["vllm"] = vllm_stub

--- a/lmcache/integration/vllm/tests/test_semantic_provider.py
+++ b/lmcache/integration/vllm/tests/test_semantic_provider.py
@@ -441,6 +441,42 @@ class TestSemanticHitFlow:
         assert result == 0
         assert "req-9" not in impl._semantic_substitutions
 
+    def test_semantic_hit_capped_by_request_length(self):
+        """When donor has more tokens than request, hit is capped at request length.
+
+        This prevents returning need_to_allocate > request.num_tokens, which
+        would confuse the vLLM scheduler into over-allocating KV blocks.
+        """
+        impl = _make_impl()
+        # Donor has 1024 tokens cached; request only has 512 tokens
+        donor_ids = list(range(1024))
+        sub = SemanticLookupResult(
+            alternate_token_ids=donor_ids, num_cached_tokens=1024
+        )
+        impl.lookup_client.lookup.return_value = 1024
+        impl.lookup_client.pop_pending_substitution.return_value = sub
+
+        request = _make_request("req-cap", list(range(512)))
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        # Must be capped: 512 - 0 - 1 = 511, not 1024 - 0 - 1 = 1023
+        assert result == 511
+
+    def test_semantic_hit_capped_load_spec(self):
+        """load_specs.lmcache_cached_tokens is capped at request length."""
+        impl = _make_impl()
+        donor_ids = list(range(1024))
+        sub = SemanticLookupResult(
+            alternate_token_ids=donor_ids, num_cached_tokens=1024
+        )
+        impl.lookup_client.lookup.return_value = 1024
+        impl.lookup_client.pop_pending_substitution.return_value = sub
+
+        request = _make_request("req-cap2", list(range(512)))
+        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        spec = impl.load_specs["req-cap2"]
+        # Capped at request.num_tokens (512), not raw donor count (1024)
+        assert spec.lmcache_cached_tokens == 512
+
 
 # ---------------------------------------------------------------------------
 # _apply_semantic_substitution tests

--- a/lmcache/integration/vllm/tests/test_semantic_provider.py
+++ b/lmcache/integration/vllm/tests/test_semantic_provider.py
@@ -421,6 +421,23 @@ class TestApplySemanticSubstitution:
         # token_ids unchanged
         assert req_meta.token_ids == original_ids
 
+    def test_short_donor_skipped_safely(self):
+        """If donor is shorter than needed, substitution is skipped (not applied)."""
+        impl = _make_impl()
+        # Donor has only 128 tokens but req_meta needs 256
+        impl._semantic_substitutions["req-g"] = SemanticLookupResult(
+            alternate_token_ids=list(range(128)),  # too short
+            num_cached_tokens=128,
+        )
+        original_ids = list(range(256))
+        req_meta = self._make_req_meta("req-g", original_ids)
+        impl._apply_semantic_substitution(req_meta)
+
+        # token_ids should remain unchanged (substitution skipped)
+        assert req_meta.token_ids == original_ids
+        # substitution state was consumed (popped)
+        assert "req-g" not in impl._semantic_substitutions
+
 
 # ---------------------------------------------------------------------------
 # request_finished notification tests

--- a/lmcache/integration/vllm/tests/test_semantic_provider.py
+++ b/lmcache/integration/vllm/tests/test_semantic_provider.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for SemanticLookupProvider integration.
 
-Validates PR: add SemanticLookupProvider interface for approximate KV cache
-matching.
+Validates PR: move SemanticLookupProvider logic into LMCacheLookupClient.
 """
 
 # Future
@@ -63,8 +62,12 @@ class _NeverHitProvider(SemanticLookupProvider):
         self.finish_calls.append((request_id, token_ids, num_prompt_tokens))
 
 
-def _make_impl(semantic_provider=None):
-    """Return a minimal LMCacheConnectorV1Impl with semantic state initialised."""
+def _make_impl(mock_lookup=None):
+    """Return a minimal LMCacheConnectorV1Impl with semantic state initialised.
+
+    The lookup_client is always a MagicMock. Call set_semantic_lookup_provider()
+    to register a provider — it will delegate to mock_lookup.set_semantic_provider.
+    """
     # First Party
     from lmcache.integration.vllm.vllm_v1_adapter import (
         LMCacheConnectorV1Impl,
@@ -72,20 +75,23 @@ def _make_impl(semantic_provider=None):
 
     impl = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
     impl.load_specs = {}
-    impl._semantic_provider = semantic_provider
     impl._semantic_substitutions = {}
     impl._lmcache_chunk_size = 256
     impl.skip_last_n_tokens = 0
     impl.kv_role = "kv_consumer"
     impl.config = MagicMock()
     impl.config.min_retrieve_tokens = 0
+    impl.config.get_extra_config_value.return_value = False
     impl._stats_monitor = MagicMock()
     impl._requests_priority = {}
+    impl._request_trackers = {}
 
     # Mock lookup client — synchronous, returns 0 by default
-    mock_lookup = MagicMock()
-    mock_lookup.lookup_cache.return_value = -1  # -1 means not cached yet
-    mock_lookup.lookup.return_value = 0
+    if mock_lookup is None:
+        mock_lookup = MagicMock()
+        mock_lookup.lookup_cache.return_value = -1  # -1 means not cached yet
+        mock_lookup.lookup.return_value = 0
+        mock_lookup.pop_pending_substitution.return_value = None
     impl._manager = MagicMock()
     impl._manager.lookup_client = mock_lookup
 
@@ -100,7 +106,38 @@ def _make_request(request_id: str, token_ids: list[int], num_computed: int = 0):
     req.num_tokens = len(token_ids)
     req.sampling_params = MagicMock()
     req.sampling_params.extra_args = None
+    # Disable multimodal features so extract_mm_features returns ([], [])
+    req.mm_features = None
+    req.mm_hashes = None
+    req.mm_positions = None
     return req
+
+
+def _make_lookup_client_for_semantic():
+    """Create a minimal LMCacheLookupClient instance (no transport, no vllm)."""
+    from lmcache.v1.lookup_client.lmcache_lookup_client import LMCacheLookupClient
+
+    client = LMCacheLookupClient.__new__(LMCacheLookupClient)
+    client.reqs_status = {}
+    client._pending_substitutions = {}
+    client.enable_blending = False
+    client._semantic_provider = None
+
+    # Mock transport: world_size=1
+    mock_transport = MagicMock()
+    mock_transport.world_size = 1
+    # Default: return 0 hit tokens
+    mock_transport.send_and_recv_all.return_value = [
+        (0).to_bytes(4, "big"),
+    ]
+    client.transport = mock_transport
+
+    # Mock token_database: process_tokens yields one chunk hash
+    mock_db = MagicMock()
+    mock_db.process_tokens.return_value = [(0, 256, b"hash1")]
+    client.token_database = mock_db
+
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -159,173 +196,250 @@ class TestSemanticLookupProviderABC:
 
 
 # ---------------------------------------------------------------------------
-# set_semantic_lookup_provider tests
+# LMCacheLookupClient semantic tests (new location for semantic logic)
+# ---------------------------------------------------------------------------
+
+
+class TestLMCacheLookupClientSemantic:
+    def test_set_semantic_provider_stores_provider(self):
+        client = _make_lookup_client_for_semantic()
+        provider = _AlwaysHitProvider([1, 2, 3])
+        client.set_semantic_provider(provider)
+        assert client._semantic_provider is provider
+
+    def test_provider_not_called_when_no_hits_and_no_provider(self):
+        """No semantic provider — zero hit is just returned as-is."""
+        client = _make_lookup_client_for_semantic()
+        # transport returns 0
+        result = client.lookup([1, 2, 3], "req-a")
+        assert result == 0
+        assert client._pending_substitutions == {}
+
+    def test_provider_called_on_zero_hit(self):
+        """on_lookup_miss called when exact lookup returns 0."""
+        provider = _NeverHitProvider()
+        client = _make_lookup_client_for_semantic()
+        client.set_semantic_provider(provider)
+
+        token_ids = list(range(256))
+        client.lookup(token_ids, "req-b")
+        assert len(provider.miss_calls) == 1
+        call_req_id, call_tokens, call_computed = provider.miss_calls[0]
+        assert call_req_id == "req-b"
+        assert call_tokens == token_ids
+        assert call_computed == 0
+
+    def test_semantic_hit_stores_pending_substitution(self):
+        """When donor lookup returns >0, pending sub is stored."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        client = _make_lookup_client_for_semantic()
+        client.set_semantic_provider(provider)
+
+        # First transport call returns 0 (miss), second returns 512 (donor hit)
+        client.transport.send_and_recv_all.side_effect = [
+            [(0).to_bytes(4, "big")],
+            [(512).to_bytes(4, "big")],
+        ]
+
+        result = client.lookup(list(range(512)), "req-c", num_computed_tokens=0)
+        assert result == 512
+        assert "req-c" in client._pending_substitutions
+        assert client._pending_substitutions["req-c"].alternate_token_ids == donor_ids
+
+    def test_semantic_miss_donor_not_in_store(self):
+        """If donor re-lookup also returns 0 — no pending substitution."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        client = _make_lookup_client_for_semantic()
+        client.set_semantic_provider(provider)
+
+        # Both calls return 0
+        client.transport.send_and_recv_all.return_value = [(0).to_bytes(4, "big")]
+
+        result = client.lookup(list(range(512)), "req-d", num_computed_tokens=0)
+        assert result == 0
+        assert "req-d" not in client._pending_substitutions
+
+    def test_clear_lookup_status_clears_pending(self):
+        """clear_lookup_status removes both reqs_status and pending sub."""
+        client = _make_lookup_client_for_semantic()
+        client.reqs_status["req-e"] = 0
+        client._pending_substitutions["req-e"] = SemanticLookupResult(
+            alternate_token_ids=[1, 2, 3], num_cached_tokens=3
+        )
+        client.clear_lookup_status("req-e")
+        assert "req-e" not in client.reqs_status
+        assert "req-e" not in client._pending_substitutions
+
+    def test_pop_pending_substitution(self):
+        """pop_pending_substitution returns and removes the result."""
+        client = _make_lookup_client_for_semantic()
+        sub = SemanticLookupResult(alternate_token_ids=[1, 2], num_cached_tokens=2)
+        client._pending_substitutions["req-f"] = sub
+        popped = client.pop_pending_substitution("req-f")
+        assert popped is sub
+        assert "req-f" not in client._pending_substitutions
+        # Second pop returns None
+        assert client.pop_pending_substitution("req-f") is None
+
+    def test_notify_request_finished_calls_provider(self):
+        """notify_request_finished delegates to provider.on_request_finished."""
+        provider = _NeverHitProvider()
+        client = _make_lookup_client_for_semantic()
+        client.set_semantic_provider(provider)
+
+        client.notify_request_finished("req-g", [1, 2, 3], 3)
+        assert len(provider.finish_calls) == 1
+        assert provider.finish_calls[0] == ("req-g", [1, 2, 3], 3)
+
+    def test_notify_request_finished_no_provider_is_noop(self):
+        """notify_request_finished with no provider does not raise."""
+        client = _make_lookup_client_for_semantic()
+        # Should not raise
+        client.notify_request_finished("req-h", [1, 2], 2)
+
+    def test_notify_request_finished_clears_pending_substitution(self):
+        """Pending substitution is cleaned up on request finish."""
+        client = _make_lookup_client_for_semantic()
+        client._pending_substitutions["req-i"] = SemanticLookupResult(
+            alternate_token_ids=[1], num_cached_tokens=1
+        )
+        client.notify_request_finished("req-i", [1], 1)
+        assert "req-i" not in client._pending_substitutions
+
+
+# ---------------------------------------------------------------------------
+# set_semantic_lookup_provider adapter tests
 # ---------------------------------------------------------------------------
 
 
 class TestSetSemanticLookupProvider:
-    def test_registers_provider(self):
+    def test_delegates_to_lookup_client(self):
+        """set_semantic_lookup_provider delegates to lookup_client."""
         impl = _make_impl()
         provider = _AlwaysHitProvider([1, 2, 3])
         impl.set_semantic_lookup_provider(provider)
-        assert impl._semantic_provider is provider
+        impl.lookup_client.set_semantic_provider.assert_called_once_with(provider)
 
-    def test_replaces_existing_provider(self):
-        provider_a = _AlwaysHitProvider([1, 2, 3])
-        provider_b = _AlwaysHitProvider([4, 5, 6])
-        impl = _make_impl(semantic_provider=provider_a)
-        impl.set_semantic_lookup_provider(provider_b)
-        assert impl._semantic_provider is provider_b
+    def test_works_when_lookup_client_is_none(self):
+        """set_semantic_lookup_provider does not crash when client is None."""
+        impl = _make_impl()
+        impl._manager.lookup_client = None
+        provider = _AlwaysHitProvider([1, 2, 3])
+        # Should not raise
+        impl.set_semantic_lookup_provider(provider)
 
 
 # ---------------------------------------------------------------------------
-# on_lookup_miss integration tests
+# get_num_new_matched_tokens adapter tests (with mock lookup_client)
 # ---------------------------------------------------------------------------
 
 
 class TestOnLookupMissNotCalled:
     def test_provider_not_called_when_standard_hit(self):
-        """Provider is never called when exact lookup finds cached tokens."""
-        provider = _AlwaysHitProvider(alternate_ids=list(range(512)))
-        impl = _make_impl(semantic_provider=provider)
+        """When lookup_client.lookup returns hits, pop_pending_sub is checked."""
+        impl = _make_impl()
+        # Lookup hits 512 tokens
+        impl.lookup_client.lookup.return_value = 512
+        impl.lookup_client.pop_pending_substitution.return_value = None
 
         request = _make_request("req-1", list(range(512)))
-        # Standard lookup returns a hit (512 tokens)
-        impl.lookup_client.lookup.return_value = 512
-
         result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
-        # Should return 511 (full prompt hit → subtract 1)
+        # Full prompt hit → 512 - 0 - 1 = 511
         assert result == 511
-        assert provider.miss_calls == []
-
-    def test_provider_not_called_when_no_provider_set(self):
-        """Default behaviour (no provider) unchanged — exact zero hit returns 0."""
-        impl = _make_impl(semantic_provider=None)
-        request = _make_request("req-2", list(range(256)))
-        impl.lookup_client.lookup.return_value = 0
-
-        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
-        assert result == 0
 
     def test_provider_not_called_for_mock_requests(self):
         """DP attention mock requests bypass all lookup logic."""
-        provider = _AlwaysHitProvider(alternate_ids=list(range(256)))
-        impl = _make_impl(semantic_provider=provider)
+        impl = _make_impl()
         request = _make_request("mock_req_dp", list(range(256)))
 
         result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
         assert result == 0
-        assert provider.miss_calls == []
 
-
-class TestOnLookupMissCalled:
-    def test_provider_called_on_zero_hit(self):
-        """Provider.on_lookup_miss called when exact lookup returns 0."""
-        donor_ids = list(range(512))
-        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
-        impl = _make_impl(semantic_provider=provider)
-
-        token_ids = list(range(512))
-        request = _make_request("req-3", token_ids)
+    def test_returns_zero_when_no_hit(self):
+        """Default: no semantic provider, zero hit → 0."""
+        impl = _make_impl()
         impl.lookup_client.lookup.return_value = 0
+        impl.lookup_client.pop_pending_substitution.return_value = None
 
-        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
-        assert len(provider.miss_calls) == 1
-        call_req_id, call_tokens, call_computed = provider.miss_calls[0]
-        assert call_req_id == "req-3"
-        assert call_tokens == token_ids
-        assert call_computed == 0
-
-    def test_provider_returns_none_falls_back_to_cold_prefill(self):
-        """When provider returns None the request proceeds as cold prefill."""
-        provider = _NeverHitProvider()
-        impl = _make_impl(semantic_provider=provider)
-        request = _make_request("req-4", list(range(256)))
-        impl.lookup_client.lookup.return_value = 0
-
+        request = _make_request("req-2", list(range(256)))
         result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
         assert result == 0
-        assert len(provider.miss_calls) == 1
-        # No semantic substitution stored
-        assert "req-4" not in impl._semantic_substitutions
 
 
 class TestSemanticHitFlow:
+    """Adapter tests for semantic hit flow via mock lookup_client."""
+
     def test_semantic_hit_returns_correct_need_to_allocate(self):
-        """When provider returns a result and re-lookup hits, correct count returned."""
+        """When lookup_client.lookup returns 512 and pending sub is set, correct count."""
+        impl = _make_impl()
         donor_ids = list(range(512))
-        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
-        impl = _make_impl(semantic_provider=provider)
+        sub = SemanticLookupResult(
+            alternate_token_ids=donor_ids, num_cached_tokens=512
+        )
+        # The lookup client already handles semantic internally and returns the
+        # donor hit count
+        impl.lookup_client.lookup.return_value = 512
+        impl.lookup_client.pop_pending_substitution.return_value = sub
 
-        token_ids = list(range(512))
-        request = _make_request("req-5", token_ids)
-
-        # First call: standard lookup misses
-        impl.lookup_client.lookup.side_effect = [
-            0,  # standard lookup → 0
-            512,  # re-lookup with alternate_ids → full hit
-        ]
-
+        request = _make_request("req-5", list(range(512)))
         result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
         # Full prompt hit → 512 - 0 - 1 = 511
         assert result == 511
 
     def test_semantic_hit_stores_substitution(self):
-        """Pending substitution stored in _semantic_substitutions."""
+        """When lookup returns >0 and pop_pending returns a sub, it's stored."""
+        impl = _make_impl()
         donor_ids = list(range(512))
-        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
-        impl = _make_impl(semantic_provider=provider)
+        sub = SemanticLookupResult(
+            alternate_token_ids=donor_ids, num_cached_tokens=512
+        )
+        impl.lookup_client.lookup.return_value = 512
+        impl.lookup_client.pop_pending_substitution.return_value = sub
 
         request = _make_request("req-6", list(range(512)))
-        impl.lookup_client.lookup.side_effect = [0, 512]
-
         impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
         assert "req-6" in impl._semantic_substitutions
-        sub = impl._semantic_substitutions["req-6"]
-        assert sub.alternate_token_ids == donor_ids
+        assert impl._semantic_substitutions["req-6"] is sub
 
     def test_semantic_hit_updates_load_spec(self):
         """load_specs updated with semantic hit count."""
-
+        impl = _make_impl()
         donor_ids = list(range(512))
-        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
-        impl = _make_impl(semantic_provider=provider)
+        sub = SemanticLookupResult(
+            alternate_token_ids=donor_ids, num_cached_tokens=256
+        )
+        impl.lookup_client.lookup.return_value = 256
+        impl.lookup_client.pop_pending_substitution.return_value = sub
 
         request = _make_request("req-7", list(range(512)))
-        impl.lookup_client.lookup.side_effect = [0, 256]
-
         impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
         assert "req-7" in impl.load_specs
         spec = impl.load_specs["req-7"]
         assert spec.lmcache_cached_tokens == 256
         assert spec.can_load is False
 
-    def test_semantic_miss_donor_not_in_store(self):
-        """If re-lookup with donor tokens returns 0 — fall through to cold prefill."""
-        donor_ids = list(range(512))
-        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
-        impl = _make_impl(semantic_provider=provider)
+    def test_no_substitution_when_pop_returns_none(self):
+        """When pop_pending returns None — no substitution stored."""
+        impl = _make_impl()
+        impl.lookup_client.lookup.return_value = 512
+        impl.lookup_client.pop_pending_substitution.return_value = None
 
         request = _make_request("req-8", list(range(512)))
-        # Both standard and semantic re-lookup miss
-        impl.lookup_client.lookup.return_value = 0
-
-        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
-        assert result == 0
+        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
         assert "req-8" not in impl._semantic_substitutions
 
-    def test_semantic_lookup_clears_status_on_miss(self):
-        """lookup_client.clear_lookup_status called when semantic lookup returns 0."""
-        donor_ids = list(range(512))
-        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
-        impl = _make_impl(semantic_provider=provider)
+    def test_zero_hit_no_substitution(self):
+        """When lookup returns 0, no substitution is stored."""
+        impl = _make_impl()
+        impl.lookup_client.lookup.return_value = 0
+        impl.lookup_client.pop_pending_substitution.return_value = None
 
         request = _make_request("req-9", list(range(512)))
-        impl.lookup_client.lookup.return_value = 0
-
-        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
-        # clear_lookup_status should be called for cleanup
-        impl.lookup_client.clear_lookup_status.assert_called()
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert result == 0
+        assert "req-9" not in impl._semantic_substitutions
 
 
 # ---------------------------------------------------------------------------
@@ -457,10 +571,9 @@ class TestOnRequestFinished:
         req.kv_transfer_params = None
         return req
 
-    def test_provider_notified_on_finish(self):
-        provider = _NeverHitProvider()
-        impl = _make_impl(semantic_provider=provider)
-        impl.lookup_client = MagicMock()
+    def test_lookup_client_notified_on_finish(self):
+        """lookup_client.notify_request_finished is called on request finish."""
+        impl = _make_impl()
         impl.async_loading = False
         impl.use_layerwise = False
 
@@ -468,9 +581,9 @@ class TestOnRequestFinished:
         request = self._make_request_finished("req-fin-1", token_ids)
         impl.request_finished(request, block_ids=[])
 
-        assert len(provider.finish_calls) == 1
-        assert provider.finish_calls[0][0] == "req-fin-1"
-        assert provider.finish_calls[0][1] == token_ids
+        impl.lookup_client.notify_request_finished.assert_called_once_with(
+            "req-fin-1", token_ids, 256
+        )
 
     def test_pending_substitution_cleared_on_finish(self):
         """Any leftover semantic substitution state is cleaned up on finish."""
@@ -479,7 +592,6 @@ class TestOnRequestFinished:
             alternate_token_ids=[1, 2, 3],
             num_cached_tokens=3,
         )
-        impl.lookup_client = MagicMock()
         impl.async_loading = False
         impl.use_layerwise = False
 
@@ -496,18 +608,10 @@ class TestOnRequestFinished:
         impl.request_finished(request, block_ids=[])
         assert "req-fin-2" not in impl._semantic_substitutions
 
-    def test_provider_exception_does_not_propagate(self):
-        """Exception in on_request_finished is logged, not raised."""
-
-        class _BrokenProvider(SemanticLookupProvider):
-            def on_lookup_miss(self, *args):
-                return None
-
-            def on_request_finished(self, *args):
-                raise RuntimeError("provider broken")
-
-        impl = _make_impl(semantic_provider=_BrokenProvider())
-        impl.lookup_client = MagicMock()
+    def test_no_lookup_client_does_not_crash(self):
+        """request_finished with no lookup_client is safe."""
+        impl = _make_impl()
+        impl._manager.lookup_client = None
         impl.async_loading = False
         impl.use_layerwise = False
 
@@ -522,23 +626,4 @@ class TestOnRequestFinished:
         request.kv_transfer_params = None
 
         # Should not raise
-        impl.request_finished(request, block_ids=[])
-
-    def test_no_provider_set_does_not_crash(self):
-        """request_finished with no provider is a no-op for semantic path."""
-        impl = _make_impl(semantic_provider=None)
-        impl.lookup_client = MagicMock()
-        impl.async_loading = False
-        impl.use_layerwise = False
-
-        # Third Party
-        from vllm.v1.request import RequestStatus
-
-        request = MagicMock()
-        request.request_id = "req-fin-4"
-        request.all_token_ids = [1, 2]
-        request.num_prompt_tokens = 2
-        request.status = RequestStatus.FINISHED_STOPPED
-        request.kv_transfer_params = None
-
         impl.request_finished(request, block_ids=[])

--- a/lmcache/integration/vllm/tests/test_semantic_provider.py
+++ b/lmcache/integration/vllm/tests/test_semantic_provider.py
@@ -308,6 +308,59 @@ class TestLMCacheLookupClientSemantic:
         client.notify_request_finished("req-i", [1], 1)
         assert "req-i" not in client._pending_substitutions
 
+    def test_on_lookup_miss_exception_is_caught_and_returns_zero(self):
+        """If on_lookup_miss raises, lookup returns 0 and reqs_status stays 0.
+
+        The exception must be swallowed so a broken provider can never block
+        inference. reqs_status must remain consistent (set to 0) so the engine
+        does not confuse the request as an ongoing lookup.
+        """
+
+        class _RaisingProvider(SemanticLookupProvider):
+            def on_lookup_miss(self, request_id, token_ids, num_computed_tokens):
+                raise RuntimeError("provider failure")
+
+            def on_request_finished(self, request_id, token_ids, num_prompt_tokens):
+                pass
+
+        client = _make_lookup_client_for_semantic()
+        client.set_semantic_provider(_RaisingProvider())
+
+        # transport returns 0 (miss) so on_lookup_miss is called
+        client.transport.send_and_recv_all.return_value = [(0).to_bytes(4, "big")]
+
+        # Must not raise
+        result = client.lookup(list(range(256)), "req-exc")
+
+        assert result == 0
+        assert "req-exc" not in client._pending_substitutions
+        # reqs_status[lookup_id] = 0 was set before the provider call
+        assert client.reqs_status.get("req-exc") == 0
+
+    def test_set_semantic_provider_calls_shutdown_on_replaced_provider(self):
+        """Replacing a provider calls on_shutdown() on the old one."""
+        shutdown_called = []
+
+        class _ShutdownProvider(SemanticLookupProvider):
+            def on_lookup_miss(self, request_id, token_ids, num_computed_tokens):
+                return None
+
+            def on_request_finished(self, request_id, token_ids, num_prompt_tokens):
+                pass
+
+            def on_shutdown(self):
+                shutdown_called.append(True)
+
+        client = _make_lookup_client_for_semantic()
+        old_provider = _ShutdownProvider()
+        client.set_semantic_provider(old_provider)
+
+        new_provider = _NeverHitProvider()
+        client.set_semantic_provider(new_provider)
+
+        assert len(shutdown_called) == 1
+        assert client._semantic_provider is new_provider
+
 
 # ---------------------------------------------------------------------------
 # set_semantic_lookup_provider adapter tests

--- a/lmcache/integration/vllm/tests/test_semantic_provider.py
+++ b/lmcache/integration/vllm/tests/test_semantic_provider.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SemanticLookupProvider integration.
+
+Validates PR: add SemanticLookupProvider interface for approximate KV cache
+matching.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.lookup_client.semantic_provider import (
+    SemanticLookupProvider,
+    SemanticLookupResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysHitProvider(SemanticLookupProvider):
+    """Provider that always returns a fixed donor result."""
+
+    def __init__(self, alternate_ids: list[int], source_id: str = "test") -> None:
+        self.alternate_ids = alternate_ids
+        self.source_id = source_id
+        self.miss_calls: list[tuple] = []
+        self.finish_calls: list[tuple] = []
+
+    def on_lookup_miss(self, request_id, token_ids, num_computed_tokens):
+        self.miss_calls.append((request_id, token_ids, num_computed_tokens))
+        return SemanticLookupResult(
+            alternate_token_ids=self.alternate_ids,
+            num_cached_tokens=len(self.alternate_ids),
+            skip_save=True,
+            provider_metadata={"src": self.source_id},
+            source_id=self.source_id,
+        )
+
+    def on_request_finished(self, request_id, token_ids, num_prompt_tokens):
+        self.finish_calls.append((request_id, token_ids, num_prompt_tokens))
+
+
+class _NeverHitProvider(SemanticLookupProvider):
+    """Provider that always returns None (no semantic hit)."""
+
+    def __init__(self) -> None:
+        self.miss_calls: list[tuple] = []
+        self.finish_calls: list[tuple] = []
+
+    def on_lookup_miss(self, request_id, token_ids, num_computed_tokens):
+        self.miss_calls.append((request_id, token_ids, num_computed_tokens))
+        return None
+
+    def on_request_finished(self, request_id, token_ids, num_prompt_tokens):
+        self.finish_calls.append((request_id, token_ids, num_prompt_tokens))
+
+
+def _make_impl(semantic_provider=None):
+    """Return a minimal LMCacheConnectorV1Impl with semantic state initialised."""
+    # First Party
+    from lmcache.integration.vllm.vllm_v1_adapter import (
+        LMCacheConnectorV1Impl,
+    )
+
+    impl = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    impl.load_specs = {}
+    impl._semantic_provider = semantic_provider
+    impl._semantic_substitutions = {}
+    impl._lmcache_chunk_size = 256
+    impl.skip_last_n_tokens = 0
+    impl.kv_role = "kv_consumer"
+    impl.config = MagicMock()
+    impl.config.min_retrieve_tokens = 0
+    impl._stats_monitor = MagicMock()
+    impl._requests_priority = {}
+
+    # Mock lookup client — synchronous, returns 0 by default
+    mock_lookup = MagicMock()
+    mock_lookup.lookup_cache.return_value = -1  # -1 means not cached yet
+    mock_lookup.lookup.return_value = 0
+    impl._manager = MagicMock()
+    impl._manager.lookup_client = mock_lookup
+
+    return impl
+
+
+def _make_request(request_id: str, token_ids: list[int], num_computed: int = 0):
+    req = MagicMock()
+    req.request_id = request_id
+    req.all_token_ids = token_ids
+    req.prompt_token_ids = token_ids
+    req.num_tokens = len(token_ids)
+    req.sampling_params = MagicMock()
+    req.sampling_params.extra_args = None
+    return req
+
+
+# ---------------------------------------------------------------------------
+# SemanticLookupResult dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticLookupResult:
+    def test_required_fields(self):
+        result = SemanticLookupResult(
+            alternate_token_ids=[1, 2, 3],
+            num_cached_tokens=3,
+        )
+        assert result.alternate_token_ids == [1, 2, 3]
+        assert result.num_cached_tokens == 3
+        assert result.skip_save is True
+        assert result.provider_metadata is None
+        assert result.source_id == ""
+
+    def test_all_fields(self):
+        meta = {"position": 42}
+        result = SemanticLookupResult(
+            alternate_token_ids=[10, 20],
+            num_cached_tokens=2,
+            skip_save=False,
+            provider_metadata=meta,
+            source_id="my-donor",
+        )
+        assert result.skip_save is False
+        assert result.provider_metadata is meta
+        assert result.source_id == "my-donor"
+
+
+# ---------------------------------------------------------------------------
+# SemanticLookupProvider ABC tests
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticLookupProviderABC:
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError):
+            SemanticLookupProvider()  # type: ignore[abstract]
+
+    def test_concrete_subclass_can_instantiate(self):
+        p = _AlwaysHitProvider([1, 2, 3])
+        assert isinstance(p, SemanticLookupProvider)
+
+    def test_on_init_default_is_noop(self):
+        p = _AlwaysHitProvider([1, 2, 3])
+        # Should not raise
+        p.on_init(config=MagicMock(), vllm_config=MagicMock())
+
+    def test_on_shutdown_default_is_noop(self):
+        p = _AlwaysHitProvider([1, 2, 3])
+        p.on_shutdown()
+
+
+# ---------------------------------------------------------------------------
+# set_semantic_lookup_provider tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetSemanticLookupProvider:
+    def test_registers_provider(self):
+        impl = _make_impl()
+        provider = _AlwaysHitProvider([1, 2, 3])
+        impl.set_semantic_lookup_provider(provider)
+        assert impl._semantic_provider is provider
+
+    def test_replaces_existing_provider(self):
+        provider_a = _AlwaysHitProvider([1, 2, 3])
+        provider_b = _AlwaysHitProvider([4, 5, 6])
+        impl = _make_impl(semantic_provider=provider_a)
+        impl.set_semantic_lookup_provider(provider_b)
+        assert impl._semantic_provider is provider_b
+
+
+# ---------------------------------------------------------------------------
+# on_lookup_miss integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnLookupMissNotCalled:
+    def test_provider_not_called_when_standard_hit(self):
+        """Provider is never called when exact lookup finds cached tokens."""
+        provider = _AlwaysHitProvider(alternate_ids=list(range(512)))
+        impl = _make_impl(semantic_provider=provider)
+
+        request = _make_request("req-1", list(range(512)))
+        # Standard lookup returns a hit (512 tokens)
+        impl.lookup_client.lookup.return_value = 512
+
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        # Should return 511 (full prompt hit → subtract 1)
+        assert result == 511
+        assert provider.miss_calls == []
+
+    def test_provider_not_called_when_no_provider_set(self):
+        """Default behaviour (no provider) unchanged — exact zero hit returns 0."""
+        impl = _make_impl(semantic_provider=None)
+        request = _make_request("req-2", list(range(256)))
+        impl.lookup_client.lookup.return_value = 0
+
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert result == 0
+
+    def test_provider_not_called_for_mock_requests(self):
+        """DP attention mock requests bypass all lookup logic."""
+        provider = _AlwaysHitProvider(alternate_ids=list(range(256)))
+        impl = _make_impl(semantic_provider=provider)
+        request = _make_request("mock_req_dp", list(range(256)))
+
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert result == 0
+        assert provider.miss_calls == []
+
+
+class TestOnLookupMissCalled:
+    def test_provider_called_on_zero_hit(self):
+        """Provider.on_lookup_miss called when exact lookup returns 0."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        impl = _make_impl(semantic_provider=provider)
+
+        token_ids = list(range(512))
+        request = _make_request("req-3", token_ids)
+        impl.lookup_client.lookup.return_value = 0
+
+        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert len(provider.miss_calls) == 1
+        call_req_id, call_tokens, call_computed = provider.miss_calls[0]
+        assert call_req_id == "req-3"
+        assert call_tokens == token_ids
+        assert call_computed == 0
+
+    def test_provider_returns_none_falls_back_to_cold_prefill(self):
+        """When provider returns None the request proceeds as cold prefill."""
+        provider = _NeverHitProvider()
+        impl = _make_impl(semantic_provider=provider)
+        request = _make_request("req-4", list(range(256)))
+        impl.lookup_client.lookup.return_value = 0
+
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert result == 0
+        assert len(provider.miss_calls) == 1
+        # No semantic substitution stored
+        assert "req-4" not in impl._semantic_substitutions
+
+
+class TestSemanticHitFlow:
+    def test_semantic_hit_returns_correct_need_to_allocate(self):
+        """When provider returns a result and re-lookup hits, correct count returned."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        impl = _make_impl(semantic_provider=provider)
+
+        token_ids = list(range(512))
+        request = _make_request("req-5", token_ids)
+
+        # First call: standard lookup misses
+        impl.lookup_client.lookup.side_effect = [
+            0,  # standard lookup → 0
+            512,  # re-lookup with alternate_ids → full hit
+        ]
+
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        # Full prompt hit → 512 - 0 - 1 = 511
+        assert result == 511
+
+    def test_semantic_hit_stores_substitution(self):
+        """Pending substitution stored in _semantic_substitutions."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        impl = _make_impl(semantic_provider=provider)
+
+        request = _make_request("req-6", list(range(512)))
+        impl.lookup_client.lookup.side_effect = [0, 512]
+
+        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert "req-6" in impl._semantic_substitutions
+        sub = impl._semantic_substitutions["req-6"]
+        assert sub.alternate_token_ids == donor_ids
+
+    def test_semantic_hit_updates_load_spec(self):
+        """load_specs updated with semantic hit count."""
+
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        impl = _make_impl(semantic_provider=provider)
+
+        request = _make_request("req-7", list(range(512)))
+        impl.lookup_client.lookup.side_effect = [0, 256]
+
+        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert "req-7" in impl.load_specs
+        spec = impl.load_specs["req-7"]
+        assert spec.lmcache_cached_tokens == 256
+        assert spec.can_load is False
+
+    def test_semantic_miss_donor_not_in_store(self):
+        """If re-lookup with donor tokens returns 0 — fall through to cold prefill."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        impl = _make_impl(semantic_provider=provider)
+
+        request = _make_request("req-8", list(range(512)))
+        # Both standard and semantic re-lookup miss
+        impl.lookup_client.lookup.return_value = 0
+
+        result = impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        assert result == 0
+        assert "req-8" not in impl._semantic_substitutions
+
+    def test_semantic_lookup_clears_status_on_miss(self):
+        """lookup_client.clear_lookup_status called when semantic lookup returns 0."""
+        donor_ids = list(range(512))
+        provider = _AlwaysHitProvider(alternate_ids=donor_ids)
+        impl = _make_impl(semantic_provider=provider)
+
+        request = _make_request("req-9", list(range(512)))
+        impl.lookup_client.lookup.return_value = 0
+
+        impl.get_num_new_matched_tokens(request, num_computed_tokens=0)
+        # clear_lookup_status should be called for cleanup
+        impl.lookup_client.clear_lookup_status.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _apply_semantic_substitution tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplySemanticSubstitution:
+    def _make_req_meta(self, req_id: str, token_ids: list[int]):
+        # Third Party
+        import torch
+
+        # First Party
+        from lmcache.integration.vllm.vllm_v1_adapter import ReqMeta, SaveSpec
+
+        return ReqMeta(
+            req_id=req_id,
+            token_ids=token_ids[:],
+            slot_mapping=torch.zeros(len(token_ids), dtype=torch.long),
+            save_spec=SaveSpec(skip_leading_tokens=0, can_save=True),
+        )
+
+    def test_swaps_token_ids(self):
+        impl = _make_impl()
+        donor_ids = list(range(100, 612))
+        impl._semantic_substitutions["req-a"] = SemanticLookupResult(
+            alternate_token_ids=donor_ids,
+            num_cached_tokens=512,
+        )
+        req_meta = self._make_req_meta("req-a", list(range(512)))
+        impl._apply_semantic_substitution(req_meta)
+
+        assert req_meta.token_ids == donor_ids[:512]
+
+    def test_disables_save_when_skip_save_true(self):
+        impl = _make_impl()
+        impl._semantic_substitutions["req-b"] = SemanticLookupResult(
+            alternate_token_ids=list(range(512)),
+            num_cached_tokens=512,
+            skip_save=True,
+        )
+        req_meta = self._make_req_meta("req-b", list(range(512)))
+        impl._apply_semantic_substitution(req_meta)
+
+        assert req_meta.save_spec is not None
+        assert req_meta.save_spec.can_save is False
+
+    def test_preserves_save_when_skip_save_false(self):
+        impl = _make_impl()
+        impl._semantic_substitutions["req-c"] = SemanticLookupResult(
+            alternate_token_ids=list(range(512)),
+            num_cached_tokens=512,
+            skip_save=False,
+        )
+        req_meta = self._make_req_meta("req-c", list(range(512)))
+        impl._apply_semantic_substitution(req_meta)
+
+        assert req_meta.save_spec is not None
+        assert req_meta.save_spec.can_save is True
+
+    def test_sets_provider_metadata(self):
+        impl = _make_impl()
+        meta = {"offset": 512}
+        impl._semantic_substitutions["req-d"] = SemanticLookupResult(
+            alternate_token_ids=list(range(512)),
+            num_cached_tokens=512,
+            provider_metadata=meta,
+        )
+        req_meta = self._make_req_meta("req-d", list(range(512)))
+        impl._apply_semantic_substitution(req_meta)
+
+        assert req_meta.provider_metadata is meta
+
+    def test_pops_substitution(self):
+        """Substitution is consumed exactly once."""
+        impl = _make_impl()
+        impl._semantic_substitutions["req-e"] = SemanticLookupResult(
+            alternate_token_ids=list(range(256)),
+            num_cached_tokens=256,
+        )
+        req_meta = self._make_req_meta("req-e", list(range(256)))
+        impl._apply_semantic_substitution(req_meta)
+
+        assert "req-e" not in impl._semantic_substitutions
+
+    def test_noop_when_no_substitution(self):
+        """No-op for requests without a pending substitution."""
+        impl = _make_impl()
+        original_ids = list(range(256))
+        req_meta = self._make_req_meta("req-f", original_ids)
+        impl._apply_semantic_substitution(req_meta)
+
+        # token_ids unchanged
+        assert req_meta.token_ids == original_ids
+
+
+# ---------------------------------------------------------------------------
+# request_finished notification tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnRequestFinished:
+    def _make_request_finished(self, req_id: str, token_ids: list[int]):
+        # Third Party
+        from vllm.v1.request import RequestStatus
+
+        req = MagicMock()
+        req.request_id = req_id
+        req.all_token_ids = token_ids
+        req.num_prompt_tokens = len(token_ids)
+        req.status = RequestStatus.FINISHED_STOPPED
+        req.kv_transfer_params = None
+        return req
+
+    def test_provider_notified_on_finish(self):
+        provider = _NeverHitProvider()
+        impl = _make_impl(semantic_provider=provider)
+        impl.lookup_client = MagicMock()
+        impl.async_loading = False
+        impl.use_layerwise = False
+
+        token_ids = list(range(256))
+        request = self._make_request_finished("req-fin-1", token_ids)
+        impl.request_finished(request, block_ids=[])
+
+        assert len(provider.finish_calls) == 1
+        assert provider.finish_calls[0][0] == "req-fin-1"
+        assert provider.finish_calls[0][1] == token_ids
+
+    def test_pending_substitution_cleared_on_finish(self):
+        """Any leftover semantic substitution state is cleaned up on finish."""
+        impl = _make_impl()
+        impl._semantic_substitutions["req-fin-2"] = SemanticLookupResult(
+            alternate_token_ids=[1, 2, 3],
+            num_cached_tokens=3,
+        )
+        impl.lookup_client = MagicMock()
+        impl.async_loading = False
+        impl.use_layerwise = False
+
+        # Third Party
+        from vllm.v1.request import RequestStatus
+
+        request = MagicMock()
+        request.request_id = "req-fin-2"
+        request.all_token_ids = [1, 2, 3]
+        request.num_prompt_tokens = 3
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.kv_transfer_params = None
+
+        impl.request_finished(request, block_ids=[])
+        assert "req-fin-2" not in impl._semantic_substitutions
+
+    def test_provider_exception_does_not_propagate(self):
+        """Exception in on_request_finished is logged, not raised."""
+
+        class _BrokenProvider(SemanticLookupProvider):
+            def on_lookup_miss(self, *args):
+                return None
+
+            def on_request_finished(self, *args):
+                raise RuntimeError("provider broken")
+
+        impl = _make_impl(semantic_provider=_BrokenProvider())
+        impl.lookup_client = MagicMock()
+        impl.async_loading = False
+        impl.use_layerwise = False
+
+        # Third Party
+        from vllm.v1.request import RequestStatus
+
+        request = MagicMock()
+        request.request_id = "req-fin-3"
+        request.all_token_ids = [1, 2]
+        request.num_prompt_tokens = 2
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.kv_transfer_params = None
+
+        # Should not raise
+        impl.request_finished(request, block_ids=[])
+
+    def test_no_provider_set_does_not_crash(self):
+        """request_finished with no provider is a no-op for semantic path."""
+        impl = _make_impl(semantic_provider=None)
+        impl.lookup_client = MagicMock()
+        impl.async_loading = False
+        impl.use_layerwise = False
+
+        # Third Party
+        from vllm.v1.request import RequestStatus
+
+        request = MagicMock()
+        request.request_id = "req-fin-4"
+        request.all_token_ids = [1, 2]
+        request.num_prompt_tokens = 2
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.kv_transfer_params = None
+
+        impl.request_finished(request, block_ids=[])

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -27,6 +27,10 @@ import torch
 # Use LMCache's own math utilities instead of vllm's
 # (avoids dependency on vllm internal changes like https://github.com/vllm-project/vllm/pull/27188)
 from lmcache import utils
+from lmcache.v1.lookup_client.semantic_provider import (
+    SemanticLookupProvider,
+    SemanticLookupResult,
+)
 from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
@@ -288,6 +292,9 @@ class ReqMeta:
     disagg_spec: Optional[DisaggSpec] = None
     # the configs of the request
     request_configs: Optional[dict] = None
+    # Opaque, picklable metadata from a SemanticLookupProvider.
+    # Passed through to PostLoadHook.after_kv_load() via PostLoadContext.
+    provider_metadata: Any = None
 
     @staticmethod
     def from_request_tracker(
@@ -569,6 +576,12 @@ class LMCacheConnectorV1Impl:
         self._requests_priority: dict[str, int] = {}
         self._invalid_block_ids: set[int] = set()
 
+        # SemanticLookupProvider — optional approximate KV matching
+        self._semantic_provider: Optional[SemanticLookupProvider] = None
+        # req_id -> SemanticLookupResult pending token-id substitution in
+        # build_connector_meta; cleared when the request is handled or finished
+        self._semantic_substitutions: dict[str, SemanticLookupResult] = {}
+
     def _check_legacy_register_kv_caches(self) -> None:
         """Check for legacy connector without register_kv_caches implementation."""
         if self.lmcache_engine is None:
@@ -590,6 +603,27 @@ class LMCacheConnectorV1Impl:
                 "features may not work, such as DSA"
             )
             self._manager.post_init()
+
+    # ==================== Semantic Lookup Provider ====================
+
+    def set_semantic_lookup_provider(self, provider: SemanticLookupProvider) -> None:
+        """Register a :class:`SemanticLookupProvider`.
+
+        The provider is consulted when the standard chunk-hash lookup returns
+        zero hit tokens.  It can supply an alternate token sequence whose KV
+        cache is already in the store, enabling approximate / semantic cache
+        reuse without storing duplicate KV data.
+
+        Only one provider can be active at a time; calling this method
+        again replaces the previous provider.
+
+        Parameters
+        ----------
+        provider:
+            An instance of a :class:`SemanticLookupProvider` subclass.
+        """
+        self._semantic_provider = provider
+        logger.info("SemanticLookupProvider registered: %s", type(provider).__name__)
 
     # ==================== Property Accessors ====================
 
@@ -1337,6 +1371,31 @@ class LMCacheConnectorV1Impl:
         )
 
         if below_min_retrieve or need_to_allocate <= 0:
+            # Standard lookup found no usable cached tokens.
+            # Consult the semantic provider (if any) for an approximate match.
+            # Only do this when there are truly zero hit tokens (not when
+            # below_min_retrieve: that means there IS a hit, just too small).
+            if (
+                num_external_hit_tokens == 0
+                and not below_min_retrieve
+                and self._semantic_provider is not None
+                and not request.request_id.startswith("mock_req")
+            ):
+                # Always derive token_ids fresh from the request so this branch
+                # is correct whether we are in a first lookup (else) or an
+                # idempotent re-call (if / cached branch).
+                sem_token_ids: list[int] = list(request.all_token_ids)
+                if self.skip_last_n_tokens > 0:
+                    sem_token_ids = sem_token_ids[: -self.skip_last_n_tokens]
+                sem_request_configs = extract_request_configs(request.sampling_params)
+                sem_result = self._try_semantic_lookup(
+                    req_id,
+                    sem_token_ids,
+                    num_computed_tokens,
+                    sem_request_configs,
+                )
+                if sem_result is not None:
+                    return sem_result
             return 0
 
         # TODO: Align to vLLM block size. Should test whether it can be removed
@@ -1344,6 +1403,95 @@ class LMCacheConnectorV1Impl:
         #        self._block_size
 
         return need_to_allocate
+
+    def _try_semantic_lookup(
+        self,
+        req_id: str,
+        token_ids: list[int],
+        num_computed_tokens: int,
+        request_configs: Optional[dict],
+    ) -> Optional[int]:
+        """Consult the semantic provider and set up a donor substitution.
+
+        Called from :meth:`get_num_new_matched_tokens` when the standard
+        chunk-hash lookup returns zero hit tokens.
+
+        Returns the tokens-to-allocate count (>0) when a semantic hit is
+        found, or ``None`` when the provider returns no match.
+        """
+        assert self._semantic_provider is not None
+        assert self.lookup_client is not None
+
+        result = self._semantic_provider.on_lookup_miss(
+            req_id, token_ids, num_computed_tokens
+        )
+        if result is None:
+            return None
+
+        # Re-lookup the chunk store using the donor's token IDs.
+        # Clear the previously cached zero-hit result first so that
+        # the lookup client accepts the new query.
+        self.lookup_client.clear_lookup_status(req_id)
+        num_semantic_hit = self.lookup_client.lookup(
+            result.alternate_token_ids,
+            lookup_id=req_id,
+            request_configs=request_configs,
+        )
+
+        if not num_semantic_hit or num_semantic_hit <= num_computed_tokens:
+            # Donor KV not in the store (or too few tokens) — fall through
+            # to normal cold prefill. Restore clean lookup state.
+            self.lookup_client.clear_lookup_status(req_id)
+            return None
+
+        # Store the substitution so build_connector_meta can swap token IDs.
+        self._semantic_substitutions[req_id] = result
+
+        need_to_allocate = num_semantic_hit - num_computed_tokens
+        # Full-prompt hit: recompute the last token (same as standard path)
+        if num_semantic_hit == len(token_ids):
+            need_to_allocate -= 1
+
+        if need_to_allocate <= 0:
+            self.lookup_client.clear_lookup_status(req_id)
+            self._semantic_substitutions.pop(req_id, None)
+            return None
+
+        self.load_specs[req_id] = LoadSpec(
+            vllm_cached_tokens=num_computed_tokens,
+            lmcache_cached_tokens=num_semantic_hit,
+            can_load=False,
+        )
+        logger.info(
+            "Semantic hit for req %s: donor=%s hit=%d need_to_alloc=%d",
+            req_id,
+            result.source_id or "unknown",
+            num_semantic_hit,
+            need_to_allocate,
+        )
+        return need_to_allocate
+
+    def _apply_semantic_substitution(self, req_meta: "ReqMeta") -> None:
+        """Swap ``req_meta.token_ids`` with the donor tokens for a semantic hit.
+
+        Called from :meth:`build_connector_meta` for each newly created
+        :class:`ReqMeta`.  Pops the pending substitution so it is applied
+        exactly once.
+        """
+        sub = self._semantic_substitutions.pop(req_meta.req_id, None)
+        if sub is None:
+            return
+        # Align the donor token IDs to the same length that
+        # from_request_tracker() selected for this request.
+        req_meta.token_ids = sub.alternate_token_ids[: len(req_meta.token_ids)]
+        if sub.skip_save and req_meta.save_spec is not None:
+            req_meta.save_spec.can_save = False
+        req_meta.provider_metadata = sub.provider_metadata
+        logger.debug(
+            "Applied semantic substitution for req %s (donor src=%s)",
+            req_meta.req_id,
+            sub.source_id or "unknown",
+        )
 
     @_lmcache_nvtx_annotate
     def update_state_after_alloc(self, request: "Request", num_external_tokens: int):
@@ -1482,6 +1630,7 @@ class LMCacheConnectorV1Impl:
                 save_decode_cache=self.config.save_decode_cache,
             )
             if req_meta is not None:
+                self._apply_semantic_substitution(req_meta)
                 meta.add_request(req_meta)
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
@@ -1528,6 +1677,7 @@ class LMCacheConnectorV1Impl:
                     save_decode_cache=self.config.save_decode_cache,
                 )
                 if req_meta is not None:
+                    self._apply_semantic_substitution(req_meta)
                     meta.add_request(req_meta)
             return meta
 
@@ -1637,6 +1787,7 @@ class LMCacheConnectorV1Impl:
                 save_decode_cache=self.config.save_decode_cache,
             )
             if req_meta is not None:
+                self._apply_semantic_substitution(req_meta)
                 meta.add_request(req_meta)
 
         return meta
@@ -1684,6 +1835,24 @@ class LMCacheConnectorV1Impl:
                 return_params = return_params or {}
                 return_params["num_lmcache_cached_tokens"] = (
                     request_tracker.num_lmcache_cached_tokens
+                )
+
+        # Notify semantic provider and clean up any leftover substitution state
+        if self._semantic_provider is not None:
+            self._semantic_substitutions.pop(request.request_id, None)
+            try:
+                token_ids = list(request.all_token_ids)
+                num_prompt_tokens = getattr(
+                    request, "num_prompt_tokens", len(token_ids)
+                )
+                self._semantic_provider.on_request_finished(
+                    request.request_id, token_ids, num_prompt_tokens
+                )
+            except Exception:
+                logger.warning(
+                    "SemanticLookupProvider.on_request_finished raised for req %s",
+                    request.request_id,
+                    exc_info=True,
                 )
 
         return False, return_params

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1384,17 +1384,31 @@ LMCacheLookupClient`).  This method delegates the provider to the client
         if num_external_hit_tokens > 0:
             pending_sub = self.lookup_client.pop_pending_substitution(req_id)
             if pending_sub is not None:
+                # Cap semantic hit count by the request's own prompt length.
+                # The donor may have more tokens cached than this request has —
+                # returning more matched tokens than the prompt length would
+                # cause the vLLM scheduler to over-allocate KV blocks.
+                num_usable = min(num_external_hit_tokens, request.num_tokens)
+                need_to_allocate = num_usable - num_computed_tokens
+                if num_usable == request.num_tokens:
+                    need_to_allocate -= 1
+                # Re-evaluate below_min_retrieve with the capped need_to_allocate
+                below_min_retrieve = (
+                    min_retrieve > 0 and need_to_allocate < min_retrieve
+                )
                 self._semantic_substitutions[req_id] = pending_sub
                 self.load_specs[req_id] = LoadSpec(
                     vllm_cached_tokens=num_computed_tokens,
-                    lmcache_cached_tokens=num_external_hit_tokens,
+                    lmcache_cached_tokens=num_usable,
                     can_load=False,
                 )
                 logger.info(
-                    "Semantic hit for req %s: donor=%s hit=%d need_to_alloc=%d",
+                    "Semantic hit for req %s: donor=%s hit=%d usable=%d "
+                    "need_to_alloc=%d",
                     req_id,
                     pending_sub.source_id or "unknown",
                     num_external_hit_tokens,
+                    num_usable,
                     need_to_allocate,
                 )
 
@@ -1429,6 +1443,12 @@ LMCacheLookupClient`).  This method delegates the provider to the client
                 len(sub.alternate_token_ids),
                 len(req_meta.token_ids),
             )
+            # Cancel the semantic load so start_load_kv does not attempt to
+            # retrieve KV for the original tokens (which had zero exact hits).
+            # can_load=False is the existing mechanism to skip loading while
+            # still forwarding the spec to the worker for metrics.
+            if req_meta.load_spec is not None:
+                req_meta.load_spec.can_load = False
             return
         # Align the donor token IDs to the same length that
         # from_request_tracker() selected for this request (chunk-boundary

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -629,6 +629,14 @@ LMCacheLookupClient`).  This method delegates the provider to the client
         """
         if self.lookup_client is not None:
             self.lookup_client.set_semantic_provider(provider)
+        try:
+            provider.on_init(config=self.config, vllm_config=self._vllm_config)
+        except Exception:
+            logger.warning(
+                "SemanticLookupProvider.on_init raised for %s",
+                type(provider).__name__,
+                exc_info=True,
+            )
         logger.info("SemanticLookupProvider registered: %s", type(provider).__name__)
 
     # ==================== Property Accessors ====================

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -576,10 +576,10 @@ class LMCacheConnectorV1Impl:
         self._requests_priority: dict[str, int] = {}
         self._invalid_block_ids: set[int] = set()
 
-        # SemanticLookupProvider — optional approximate KV matching
-        self._semantic_provider: Optional[SemanticLookupProvider] = None
         # req_id -> SemanticLookupResult pending token-id substitution in
-        # build_connector_meta; cleared when the request is handled or finished
+        # build_connector_meta; cleared when the request is handled or finished.
+        # Populated via lookup_client.pop_pending_substitution() after a
+        # successful semantic lookup.
         self._semantic_substitutions: dict[str, SemanticLookupResult] = {}
 
     def _check_legacy_register_kv_caches(self) -> None:
@@ -617,12 +617,18 @@ class LMCacheConnectorV1Impl:
         Only one provider can be active at a time; calling this method
         again replaces the previous provider.
 
+        The semantic lookup logic now lives inside the lookup client
+        (:class:`~lmcache.v1.lookup_client.lmcache_lookup_client.\
+LMCacheLookupClient`).  This method delegates the provider to the client
+        and also calls the provider's :meth:`on_init` lifecycle hook.
+
         Parameters
         ----------
         provider:
             An instance of a :class:`SemanticLookupProvider` subclass.
         """
-        self._semantic_provider = provider
+        if self.lookup_client is not None:
+            self.lookup_client.set_semantic_provider(provider)
         logger.info("SemanticLookupProvider registered: %s", type(provider).__name__)
 
     # ==================== Property Accessors ====================
@@ -1313,6 +1319,7 @@ class LMCacheConnectorV1Impl:
                 token_ids,
                 lookup_id=req_id,
                 request_configs=request_configs,
+                num_computed_tokens=num_computed_tokens,
             )
 
         if num_external_hit_tokens is None:
@@ -1370,112 +1377,34 @@ class LMCacheConnectorV1Impl:
             can_load=False,
         )
 
-        if below_min_retrieve or need_to_allocate <= 0:
-            # Standard lookup found no usable cached tokens.
-            # Consult the semantic provider (if any) for an approximate match.
-            # Only do this when there are truly zero hit tokens (not when
-            # below_min_retrieve: that means there IS a hit, just too small).
-            if (
-                num_external_hit_tokens == 0
-                and not below_min_retrieve
-                and self._semantic_provider is not None
-                and not request.request_id.startswith("mock_req")
-            ):
-                # Always derive token_ids fresh from the request so this branch
-                # is correct whether we are in a first lookup (else) or an
-                # idempotent re-call (if / cached branch).
-                sem_token_ids: list[int] = list(request.all_token_ids)
-                if self.skip_last_n_tokens > 0:
-                    sem_token_ids = sem_token_ids[: -self.skip_last_n_tokens]
-                sem_request_configs = extract_request_configs(request.sampling_params)
-                sem_result = self._try_semantic_lookup(
-                    req_id,
-                    sem_token_ids,
-                    num_computed_tokens,
-                    sem_request_configs,
+        # Transfer any pending semantic substitution from lookup client.
+        # The semantic fallback (if any) already ran inside lookup_client.lookup();
+        # we just need to move the result into _semantic_substitutions so
+        # build_connector_meta can apply the token-ID swap.
+        if num_external_hit_tokens > 0:
+            pending_sub = self.lookup_client.pop_pending_substitution(req_id)
+            if pending_sub is not None:
+                self._semantic_substitutions[req_id] = pending_sub
+                self.load_specs[req_id] = LoadSpec(
+                    vllm_cached_tokens=num_computed_tokens,
+                    lmcache_cached_tokens=num_external_hit_tokens,
+                    can_load=False,
                 )
-                if sem_result is not None:
-                    return sem_result
+                logger.info(
+                    "Semantic hit for req %s: donor=%s hit=%d need_to_alloc=%d",
+                    req_id,
+                    pending_sub.source_id or "unknown",
+                    num_external_hit_tokens,
+                    need_to_allocate,
+                )
+
+        if below_min_retrieve or need_to_allocate <= 0:
             return 0
 
         # TODO: Align to vLLM block size. Should test whether it can be removed
         # need_to_allocate = need_to_allocate // self._block_size * \
         #        self._block_size
 
-        return need_to_allocate
-
-    def _try_semantic_lookup(
-        self,
-        req_id: str,
-        token_ids: list[int],
-        num_computed_tokens: int,
-        request_configs: Optional[dict],
-    ) -> Optional[int]:
-        """Consult the semantic provider and set up a donor substitution.
-
-        Called from :meth:`get_num_new_matched_tokens` when the standard
-        chunk-hash lookup returns zero hit tokens.
-
-        Returns the tokens-to-allocate count (>0) when a semantic hit is
-        found, or ``None`` when the provider returns no match.
-
-        Note on idempotency: if this method returns ``None`` (provider finds
-        no semantic hit), the standard lookup result (0) remains cached in
-        the lookup client.  On a subsequent idempotent re-call (preemption
-        recovery without ``update_state_after_alloc``), the provider's
-        ``on_lookup_miss`` will be invoked again.  Providers should be
-        prepared for this and treat duplicate calls as idempotent.
-        """
-        assert self._semantic_provider is not None
-        assert self.lookup_client is not None
-
-        result = self._semantic_provider.on_lookup_miss(
-            req_id, token_ids, num_computed_tokens
-        )
-        if result is None:
-            return None
-
-        # Re-lookup the chunk store using the donor's token IDs.
-        # Clear the previously cached zero-hit result first so that
-        # the lookup client accepts the new query.
-        self.lookup_client.clear_lookup_status(req_id)
-        num_semantic_hit = self.lookup_client.lookup(
-            result.alternate_token_ids,
-            lookup_id=req_id,
-            request_configs=request_configs,
-        )
-
-        if not num_semantic_hit or num_semantic_hit <= num_computed_tokens:
-            # Donor KV not in the store (or too few tokens) — fall through
-            # to normal cold prefill. Restore clean lookup state.
-            self.lookup_client.clear_lookup_status(req_id)
-            return None
-
-        # Store the substitution so build_connector_meta can swap token IDs.
-        self._semantic_substitutions[req_id] = result
-
-        need_to_allocate = num_semantic_hit - num_computed_tokens
-        # Full-prompt hit: recompute the last token (same as standard path)
-        if num_semantic_hit == len(token_ids):
-            need_to_allocate -= 1
-
-        if need_to_allocate <= 0:
-            self.lookup_client.clear_lookup_status(req_id)
-            self._semantic_substitutions.pop(req_id, None)
-            return None
-
-        self.load_specs[req_id] = LoadSpec(
-            vllm_cached_tokens=num_computed_tokens,
-            lmcache_cached_tokens=num_semantic_hit,
-            can_load=False,
-        )
-        logger.info(
-            "Semantic hit for req %s: donor=%s hit=%d need_to_alloc=%d",
-            req_id,
-            result.source_id or "unknown",
-            num_semantic_hit,
-            need_to_allocate,
-        )
         return need_to_allocate
 
     def _apply_semantic_substitution(self, req_meta: "ReqMeta") -> None:
@@ -1858,23 +1787,17 @@ class LMCacheConnectorV1Impl:
                     request_tracker.num_lmcache_cached_tokens
                 )
 
-        # Notify semantic provider and clean up any leftover substitution state
-        if self._semantic_provider is not None:
-            self._semantic_substitutions.pop(request.request_id, None)
-            try:
-                token_ids = list(request.all_token_ids)
-                num_prompt_tokens = getattr(
-                    request, "num_prompt_tokens", len(token_ids)
-                )
-                self._semantic_provider.on_request_finished(
-                    request.request_id, token_ids, num_prompt_tokens
-                )
-            except Exception:
-                logger.warning(
-                    "SemanticLookupProvider.on_request_finished raised for req %s",
-                    request.request_id,
-                    exc_info=True,
-                )
+        # Clean up any leftover semantic substitution state and notify the
+        # lookup client (which will forward to the provider if one is set).
+        self._semantic_substitutions.pop(request.request_id, None)
+        if self.lookup_client is not None:
+            token_ids = list(request.all_token_ids)
+            num_prompt_tokens = getattr(
+                request, "num_prompt_tokens", len(token_ids)
+            )
+            self.lookup_client.notify_request_finished(
+                request.request_id, token_ids, num_prompt_tokens
+            )
 
         return False, return_params
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -27,10 +27,6 @@ import torch
 # Use LMCache's own math utilities instead of vllm's
 # (avoids dependency on vllm internal changes like https://github.com/vllm-project/vllm/pull/27188)
 from lmcache import utils
-from lmcache.v1.lookup_client.semantic_provider import (
-    SemanticLookupProvider,
-    SemanticLookupResult,
-)
 from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
@@ -44,6 +40,10 @@ from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import validate_and_set_config_value
+from lmcache.v1.lookup_client.semantic_provider import (
+    SemanticLookupProvider,
+    SemanticLookupResult,
+)
 from lmcache.v1.manager import LMCacheManager
 
 if TYPE_CHECKING:
@@ -1418,6 +1418,13 @@ class LMCacheConnectorV1Impl:
 
         Returns the tokens-to-allocate count (>0) when a semantic hit is
         found, or ``None`` when the provider returns no match.
+
+        Note on idempotency: if this method returns ``None`` (provider finds
+        no semantic hit), the standard lookup result (0) remains cached in
+        the lookup client.  On a subsequent idempotent re-call (preemption
+        recovery without ``update_state_after_alloc``), the provider's
+        ``on_lookup_miss`` will be invoked again.  Providers should be
+        prepared for this and treat duplicate calls as idempotent.
         """
         assert self._semantic_provider is not None
         assert self.lookup_client is not None
@@ -1481,8 +1488,22 @@ class LMCacheConnectorV1Impl:
         sub = self._semantic_substitutions.pop(req_meta.req_id, None)
         if sub is None:
             return
+        # Guard: the donor must cover at least as many tokens as
+        # from_request_tracker() allocated for this request.  A shorter
+        # donor would leave req_meta.token_ids shorter than slot_mapping,
+        # causing an assertion failure in start_load_kv.
+        if len(sub.alternate_token_ids) < len(req_meta.token_ids):
+            logger.warning(
+                "Semantic donor for req %s has %d tokens but %d are needed; "
+                "skipping substitution and falling back to cold prefill.",
+                req_meta.req_id,
+                len(sub.alternate_token_ids),
+                len(req_meta.token_ids),
+            )
+            return
         # Align the donor token IDs to the same length that
-        # from_request_tracker() selected for this request.
+        # from_request_tracker() selected for this request (chunk-boundary
+        # aligned, may be shorter than the full prompt).
         req_meta.token_ids = sub.alternate_token_ids[: len(req_meta.token_ids)]
         if sub.skip_save and req_meta.save_spec is not None:
             req_meta.save_spec.can_save = False

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Optional, Union
+from typing import Any, Optional, Union
 import abc
 
 # Third Party
@@ -30,6 +30,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         """
         Perform lookup for the given token IDs.
@@ -46,6 +47,9 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
 
             request_configs: The configs of the request,
             includes tags and the other configs
+
+            num_computed_tokens: Number of tokens already computed locally
+            (vLLM prefix cache hit). Used by semantic lookup fallback.
 
         Returns:
             The number of tokens that exist inside LMCache.
@@ -73,5 +77,44 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
 
         Args:
             lookup_id: The lookup ID whose status needs to be cleared.
+        """
+        return
+
+    def set_semantic_provider(self, provider: Any) -> None:
+        """Register a SemanticLookupProvider (default no-op for most clients).
+
+        Args:
+            provider: An instance of a SemanticLookupProvider subclass.
+        """
+        return
+
+    def pop_pending_substitution(self, lookup_id: str) -> Optional[Any]:
+        """Pop and return a pending semantic substitution result, if any.
+
+        Returns None by default (no semantic fallback implemented).
+
+        Args:
+            lookup_id: The lookup ID (request ID) to check.
+
+        Returns:
+            SemanticLookupResult if a substitution is pending, else None.
+        """
+        return None
+
+    def notify_request_finished(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        num_prompt_tokens: int,
+    ) -> None:
+        """Notify the client that a request has finished (default no-op).
+
+        Called by the adapter so that clients that hold a SemanticLookupProvider
+        can forward the on_request_finished lifecycle event.
+
+        Args:
+            request_id: vLLM request ID of the finished request.
+            token_ids: Full prompt token IDs of the finished request.
+            num_prompt_tokens: Number of prompt tokens in the request.
         """
         return

--- a/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
+++ b/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
@@ -119,6 +119,7 @@ class ChunkStatisticsLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         start_time = time.time()
         result = self.actual_lookup_client.lookup(

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -42,6 +42,7 @@ class HitLimitLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         # get real hit tokens
         result = self.actual_lookup_client.lookup(

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -195,6 +195,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         hashes: list[int] = []
         offsets = []

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -12,6 +12,10 @@ from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.lookup_client.abstract_client import LookupClientInterface
+from lmcache.v1.lookup_client.semantic_provider import (
+    SemanticLookupProvider,
+    SemanticLookupResult,
+)
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.rpc.transport import (
     RpcClientTransport,
@@ -75,6 +79,11 @@ class LMCacheLookupClient(LookupClientInterface):
         else:
             self.token_database = ChunkedTokenDatabase(config, metadata)
 
+        # Semantic fallback provider (optional)
+        self._semantic_provider: Optional[SemanticLookupProvider] = None
+        # Pending donor substitutions keyed by lookup_id
+        self._pending_substitutions: dict[str, SemanticLookupResult] = {}
+
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
         """
         "-1 means not found;
@@ -83,19 +92,71 @@ class LMCacheLookupClient(LookupClientInterface):
         """
         return self.reqs_status.get(lookup_id, -1)
 
-    def lookup(
+    def set_semantic_provider(self, provider: SemanticLookupProvider) -> None:
+        """Register a SemanticLookupProvider for approximate KV cache matching.
+
+        Args:
+            provider: An instance of a SemanticLookupProvider subclass.
+        """
+        self._semantic_provider = provider
+        logger.info(
+            "SemanticLookupProvider registered in LMCacheLookupClient: %s",
+            type(provider).__name__,
+        )
+
+    def pop_pending_substitution(
+        self, lookup_id: str
+    ) -> Optional[SemanticLookupResult]:
+        """Pop and return a pending semantic substitution result, if any.
+
+        Args:
+            lookup_id: The request ID to check.
+
+        Returns:
+            SemanticLookupResult if a substitution is pending, else None.
+        """
+        return self._pending_substitutions.pop(lookup_id, None)
+
+    def notify_request_finished(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        num_prompt_tokens: int,
+    ) -> None:
+        """Notify the semantic provider that a request has finished.
+
+        Also cleans up any leftover pending substitution state for the request.
+
+        Args:
+            request_id: vLLM request ID of the finished request.
+            token_ids: Full prompt token IDs of the finished request.
+            num_prompt_tokens: Number of prompt tokens in the request.
+        """
+        # Clean up any leftover substitution state
+        self._pending_substitutions.pop(request_id, None)
+
+        if self._semantic_provider is not None:
+            try:
+                self._semantic_provider.on_request_finished(
+                    request_id, token_ids, num_prompt_tokens
+                )
+            except Exception:
+                logger.warning(
+                    "SemanticLookupProvider.on_request_finished raised for req %s",
+                    request_id,
+                    exc_info=True,
+                )
+
+    def _do_transport_lookup(
         self,
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
-        request_configs: Optional[dict] = None,
-    ) -> Optional[int]:
-        request_configs_str = ""
-        if request_configs is not None and len(request_configs) != 0:
-            request_configs_str = json.dumps(request_configs)
+        request_configs_str: str,
+    ) -> int:
+        """Send a lookup request via transport and return the hit token count.
 
-        # NOTE(Jiayi): We cannot only send hashes when
-        # blending enabled because the blender need the
-        # input embedding.
+        Returns 0 on transport failure or empty response.
+        """
         if not self.enable_blending:
             hashes = []
             offsets = []
@@ -108,8 +169,7 @@ class LMCacheLookupClient(LookupClientInterface):
                 hashes.append(key)
                 offsets.append(end - start)
 
-            # if the token database returns no hashes,
-            # return 0
+            # if the token database returns no hashes, return 0
             if not hashes:
                 return 0
 
@@ -144,13 +204,62 @@ class LMCacheLookupClient(LookupClientInterface):
         # NOTE: it is possible that the number of hit
         # tokens is different across (TP and PP) ranks,
         # so we can use the minimum value.
-        num_hit_toks = min(results)
+        return min(results)
+
+    def lookup(
+        self,
+        token_ids: Union[torch.Tensor, list[int]],
+        lookup_id: str,
+        request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
+    ) -> Optional[int]:
+        request_configs_str = ""
+        if request_configs is not None and len(request_configs) != 0:
+            request_configs_str = json.dumps(request_configs)
+
+        num_hit_toks = self._do_transport_lookup(
+            token_ids, lookup_id, request_configs_str
+        )
         self.reqs_status[lookup_id] = num_hit_toks
+
+        # Semantic fallback: only in non-blending path, only on zero hit
+        if (
+            num_hit_toks == 0
+            and not self.enable_blending
+            and self._semantic_provider is not None
+        ):
+            result = None
+            try:
+                result = self._semantic_provider.on_lookup_miss(
+                    lookup_id, list(token_ids), num_computed_tokens
+                )
+            except Exception:
+                logger.warning(
+                    "SemanticLookupProvider.on_lookup_miss raised for req %s",
+                    lookup_id,
+                    exc_info=True,
+                )
+
+            if result is not None:
+                # Clear the cached zero-hit so the re-lookup is accepted
+                self.reqs_status.pop(lookup_id, None)
+                donor_hit = self._do_transport_lookup(
+                    result.alternate_token_ids, lookup_id, request_configs_str
+                )
+                if donor_hit > num_computed_tokens:
+                    self.reqs_status[lookup_id] = donor_hit
+                    self._pending_substitutions[lookup_id] = result
+                    return donor_hit
+                else:
+                    # Donor not in store or too few tokens — cold prefill
+                    self.reqs_status[lookup_id] = 0
+                    return 0
 
         return num_hit_toks
 
     def clear_lookup_status(self, lookup_id: str) -> None:
         self.reqs_status.pop(lookup_id, None)
+        self._pending_substitutions.pop(lookup_id, None)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports
@@ -165,6 +274,14 @@ class LMCacheLookupClient(LookupClientInterface):
         return False
 
     def close(self):
+        if self._semantic_provider is not None:
+            try:
+                self._semantic_provider.on_shutdown()
+            except Exception:
+                logger.warning(
+                    "SemanticLookupProvider.on_shutdown raised",
+                    exc_info=True,
+                )
         self.transport.close()
 
 

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -95,9 +95,22 @@ class LMCacheLookupClient(LookupClientInterface):
     def set_semantic_provider(self, provider: SemanticLookupProvider) -> None:
         """Register a SemanticLookupProvider for approximate KV cache matching.
 
+        If a provider is already registered, its ``on_shutdown`` lifecycle
+        hook is called before the replacement takes effect.
+
         Args:
             provider: An instance of a SemanticLookupProvider subclass.
         """
+        if self._semantic_provider is not None:
+            try:
+                self._semantic_provider.on_shutdown()
+            except Exception:
+                logger.warning(
+                    "SemanticLookupProvider.on_shutdown raised for %s during "
+                    "replacement; continuing with new provider",
+                    type(self._semantic_provider).__name__,
+                    exc_info=True,
+                )
         self._semantic_provider = provider
         logger.info(
             "SemanticLookupProvider registered in LMCacheLookupClient: %s",

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -54,6 +54,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         try:
             if not self.enable_blending:

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -54,6 +54,7 @@ class MooncakeLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: Optional[str] = None,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         # process token_ids to cacheengine keys
         keys = []

--- a/lmcache/v1/lookup_client/semantic_provider.py
+++ b/lmcache/v1/lookup_client/semantic_provider.py
@@ -35,7 +35,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
-    pass
+    # First Party
+    from lmcache.v1.config import LMCacheEngineConfig
+
+    # Third Party
+    from vllm.config import VllmConfig
 
 
 @dataclass
@@ -145,7 +149,11 @@ class SemanticLookupProvider(ABC):
         """
         ...
 
-    def on_init(self, config: Any, vllm_config: Any) -> None:  # noqa: B027
+    def on_init(  # noqa: B027
+        self,
+        config: "LMCacheEngineConfig",
+        vllm_config: "VllmConfig",
+    ) -> None:
         """Called once when the :class:`LMCacheConnectorV1Impl` initialises.
 
         Parameters

--- a/lmcache/v1/lookup_client/semantic_provider.py
+++ b/lmcache/v1/lookup_client/semantic_provider.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SemanticLookupProvider — interface for approximate KV cache matching.
+
+When an exact chunk-hash lookup misses, the provider can supply an alternate
+set of token IDs whose KV cache is already stored.  The engine will then
+retrieve the donor KV and use it for the query request, skipping full
+prefill recomputation.
+
+Typical use-cases
+-----------------
+* Semantic KV sharing (e.g. SemBlend): look up semantically similar
+  documents already in the cache.
+* Fuzzy prefix matching: tolerate small edits at prefix boundaries.
+* RAG-aware caching: reuse cached KV for retrieved contexts.
+* Topic-based KV sharing: share computation across requests with the
+  same subject matter.
+
+Usage
+-----
+Implement :class:`SemanticLookupProvider` and register it::
+
+    engine_impl.set_semantic_lookup_provider(my_provider)
+
+``on_lookup_miss`` is called during the scheduler step (before blocks are
+allocated), so it must be fast.  Heavy embedding / similarity search should
+be done asynchronously and the result staged before the call.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class SemanticLookupResult:
+    """Result returned by :meth:`SemanticLookupProvider.on_lookup_miss`.
+
+    Attributes
+    ----------
+    alternate_token_ids:
+        Token IDs of the donor request whose KV cache should be retrieved
+        instead of performing a full prefill.  Must already be stored in the
+        LMCache chunk store.
+    num_cached_tokens:
+        Hint for how many tokens the caller expects to be cached (used only
+        for logging; the actual count is determined by the chunk-level
+        lookup).
+    skip_save:
+        When ``True`` (the default) the donor's KV is *not* re-saved under
+        the query's chunk hashes, preventing cache pollution.
+    provider_metadata:
+        Arbitrary, **picklable** data passed through to
+        :class:`~lmcache.v1.hooks.PostLoadHook` via
+        :attr:`~lmcache.v1.hooks.PostLoadContext.provider_metadata`.
+        Must be picklable because it may be serialised across processes in
+        tensor-parallel deployments.
+    source_id:
+        Optional string identifier used in log messages and metrics.
+    """
+
+    alternate_token_ids: list[int]
+    num_cached_tokens: int
+    skip_save: bool = True
+    provider_metadata: Any = None
+    source_id: str = ""
+
+
+class SemanticLookupProvider(ABC):
+    """Abstract base class for approximate / semantic KV cache matching.
+
+    Subclasses implement :meth:`on_lookup_miss` to supply a donor request
+    whenever the standard exact-match lookup returns zero hit tokens, and
+    :meth:`on_request_finished` to update internal state after each request
+    completes.
+
+    The two optional lifecycle hooks (:meth:`on_init` and
+    :meth:`on_shutdown`) allow the provider to integrate with LMCache's
+    startup / teardown sequence.
+
+    Thread-safety
+    -------------
+    :meth:`on_lookup_miss` and :meth:`on_request_finished` may be called
+    from the scheduler thread while :meth:`on_init` / :meth:`on_shutdown`
+    are called from the engine initialisation thread.  Implementations are
+    responsible for their own locking where necessary.
+    """
+
+    @abstractmethod
+    def on_lookup_miss(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        num_computed_tokens: int,
+    ) -> Optional[SemanticLookupResult]:
+        """Called when the exact chunk-hash lookup returns zero hit tokens.
+
+        The implementation should return a :class:`SemanticLookupResult`
+        whose ``alternate_token_ids`` are already present in the LMCache
+        chunk store, or ``None`` to fall back to a normal (cold) prefill.
+
+        Parameters
+        ----------
+        request_id:
+            vLLM request ID (unique per request).
+        token_ids:
+            Full prompt token IDs for the incoming request.
+        num_computed_tokens:
+            Number of tokens already computed locally (vLLM prefix cache
+            hit).  Positive when the request was partially preempted and
+            re-scheduled.
+
+        Returns
+        -------
+        :class:`SemanticLookupResult` or ``None``
+        """
+        ...
+
+    @abstractmethod
+    def on_request_finished(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        num_prompt_tokens: int,
+    ) -> None:
+        """Called after a request finishes (successfully or aborted).
+
+        Implementations should use this to update donor registries or
+        any per-request state keyed by ``request_id``.
+
+        Parameters
+        ----------
+        request_id:
+            vLLM request ID of the finished request.
+        token_ids:
+            Full prompt token IDs of the finished request.
+        num_prompt_tokens:
+            Number of prompt tokens in the request.
+        """
+        ...
+
+    def on_init(self, config: Any, vllm_config: Any) -> None:  # noqa: B027
+        """Called once when the :class:`LMCacheConnectorV1Impl` initialises.
+
+        Parameters
+        ----------
+        config:
+            :class:`~lmcache.v1.config.LMCacheEngineConfig` instance.
+        vllm_config:
+            vLLM ``VllmConfig`` instance.
+        """
+
+    def on_shutdown(self) -> None:  # noqa: B027
+        """Called once when the :class:`LMCacheConnectorV1Impl` shuts down."""


### PR DESCRIPTION
## Motivation

When the standard exact chunk-hash lookup returns zero hit tokens, there is currently no way for an external system to supply an alternate token sequence whose KV cache *is* already stored.  This blocks several important use-cases:

* **Semantic KV sharing** — reuse cached KV for semantically similar but lexically distinct contexts (e.g. different phrasings of the same document).
* **Fuzzy prefix matching** — tolerate small edits at prefix boundaries without a full cold prefill.
* **RAG-aware caching** — reuse cached KV for the same retrieved context served to different queries.
* **Topic-based KV sharing** — share prefill computation across requests with the same subject matter.

This PR adds a minimal, opt-in `SemanticLookupProvider` interface that covers all of these.

---

## What this PR adds

### New file: `lmcache/v1/lookup_client/semantic_provider.py`

```
SemanticLookupResult   — dataclass returned by the provider
SemanticLookupProvider — ABC with two required hooks:
    on_lookup_miss(request_id, token_ids, num_computed_tokens)
        -> SemanticLookupResult | None
    on_request_finished(request_id, token_ids, num_prompt_tokens) -> None
  and two optional lifecycle hooks (on_init / on_shutdown).
```

`SemanticLookupResult` carries:
| Field | Purpose |
|---|---|
| `alternate_token_ids` | Donor tokens whose KV is already in the store |
| `num_cached_tokens` | Expected hit count (for logging) |
| `skip_save` | Prevent cache pollution (default `True`) |
| `provider_metadata` | Picklable opaque data forwarded to `PostLoadHook` (PR 2) |
| `source_id` | Optional label for logs/metrics |

### Modified: `lmcache/integration/vllm/vllm_v1_adapter.py`

Integration in `LMCacheConnectorV1Impl`:

| Addition | Description |
|---|---|
| `set_semantic_lookup_provider(provider)` | Public registration method |
| `_try_semantic_lookup(...)` | Called when standard lookup returns 0; re-looks up donor tokens |
| `_apply_semantic_substitution(req_meta)` | Swaps `token_ids` in `ReqMeta`; called from all 3 `build_connector_meta` paths |
| `provider_metadata` field on `ReqMeta` | Carries opaque data to `start_load_kv` / `PostLoadHook` |

**Zero overhead when no provider is registered** — all new code paths are guarded by `if self._semantic_provider is not None`.

---

## Behaviour

1. Standard chunk-hash lookup runs as normal.
2. **Only if** the result is zero hit tokens **and** a provider is registered, `on_lookup_miss` is called.
3. If the provider returns `None`, the request proceeds as a normal cold prefill (no change).
4. If the provider returns a `SemanticLookupResult`, the donor tokens are looked up in the chunk store.
5. On a donor hit: a `LoadSpec` is created, the substitution is staged, and the token-to-allocate count is returned.
6. `build_connector_meta` applies the substitution (swaps `token_ids`, sets `can_save=False` when `skip_save=True`).
7. `request_finished` notifies the provider via `on_request_finished` for bookkeeping.

---

## Test coverage

New file: `lmcache/integration/vllm/tests/test_semantic_provider.py` — 26 tests:

* `SemanticLookupResult` defaults and fields
* `SemanticLookupProvider` ABC contract (cannot instantiate without implementing abstract methods)
* `set_semantic_lookup_provider` registration
* `on_lookup_miss` not called when standard lookup returns hits
* `on_lookup_miss` not called for mock/metadata-only requests
* `on_lookup_miss` called when standard lookup returns zero hits
* Semantic hit flow: correct token count, substitution stored, `LoadSpec` created, falls back gracefully when donor not in store
* `_apply_semantic_substitution`: swaps tokens, disables save on `skip_save=True`, sets `provider_metadata`, consumes substitution exactly once, no-op when no substitution, **short donor skipped safely** (guard against `slot_mapping` length mismatch)
* `on_request_finished` notification

---

## Backward compatibility

`_semantic_provider` defaults to `None`.  All existing behaviour is completely unchanged when no provider is registered.  The new `provider_metadata` field on `ReqMeta` defaults to `None`.

---

## Note on PR ordering

**https://github.com/LMCache/LMCache/pull/2804** ([Core] feat: add PostLoadHook for KV cache transformations after retrieval) builds on top of this PR.  Specifically, the `provider_metadata` field added to `ReqMeta` here flows through to `PostLoadContext`.  Please review and merge this PR before [PR-2804](https://github.com/LMCache/LMCache/pull/2804).