### PR TITLE
Fix cachegen BytesBuffer dtype for remote metadata

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -742,7 +742,7 @@ class BytesBufferMemoryObj(MemoryObj):
         return [self.get_shape()]
 
     def get_dtypes(self) -> list[torch.dtype]:
-        return []
+        return [torch.uint8]
 
     def get_memory_format(self) -> MemoryFormat:
         return self.metadata.fmt


### PR DESCRIPTION
reproduced the failure locally with Redis and confirmed the root cause:
  BytesBufferMemoryObj.get_dtypes() returned an empty list, while get_shapes()
  returned one entry.
  RemoteMetadata.serialize() uses zip(..., strict=True) and raised:

  ValueError: zip() argument 2 is shorter than argument 1

  Fix: return a concrete dtype for byte buffers.
  BytesBufferMemoryObj.get_dtypes() now returns [torch.uint8], keeping shapes/dtypes
  aligned.
