### PR TITLE
[MP] fix: add thread safety to Session for concurrent TP worker access

### DIFF
--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -19,7 +19,11 @@ logger = init_logger(__name__)
 
 @dataclass
 class Session:
-    """Tracks accumulated token IDs and computed chunk hashes for a request."""
+    """Tracks accumulated token IDs and computed chunk hashes for a request.
+
+    Thread-safe: all public methods are protected by an internal lock
+    to allow concurrent access from multiple TP worker threads.
+    """
 
     request_id: str
     hasher: TokenHasher
@@ -28,6 +32,7 @@ class Session:
     last_prefix_hash: Any = None
     num_chunks_processed: int = 0
     created_at: float = field(default_factory=time.time)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def set_tokens(self, full_token_ids: list[int]) -> None:
         """Update the token sequence (idempotent, replaces not extends).
@@ -35,7 +40,8 @@ class Session:
         Args:
             full_token_ids: Complete token sequence.
         """
-        self.token_ids = full_token_ids
+        with self._lock:
+            self.token_ids = full_token_ids
 
     def get_hashes(self, start: int, end: int) -> list:
         """Compute and return chunk hashes for the [start, end) token range.
@@ -60,9 +66,9 @@ class Session:
         start_chunk = start // chunk_size
         end_chunk = end // chunk_size
 
-        self._compute_hash(end_chunk)
-
-        return self.chunk_hashes[start_chunk:end_chunk]
+        with self._lock:
+            self._compute_hash(end_chunk)
+            return self.chunk_hashes[start_chunk:end_chunk]
 
     def _compute_hash(self, end_chunk: int) -> None:
         """Compute rolling hashes up to end_chunk.

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -2,6 +2,7 @@
 """Tests for Session and SessionManager."""
 
 # Standard
+import threading
 import time
 
 # Third Party
@@ -140,3 +141,77 @@ class TestSessionManager:
         session_manager.get_or_create("req-1")
         removed = session_manager.cleanup_expired()
         assert removed == 0
+
+
+class TestSessionThreadSafety:
+    """Verify Session is safe under concurrent access
+    from multiple TP worker threads."""
+
+    def test_concurrent_get_hashes(self, hasher: TokenHasher) -> None:
+        """Multiple threads calling get_hashes on the same Session
+        must produce correct hashes (no duplicates, no corruption).
+        """
+        session = Session(request_id="req-mt", hasher=hasher)
+        tokens = list(range(20))  # 5 chunks of 4
+        session.set_tokens(tokens)
+
+        # Reference hashes computed single-threaded
+        expected = hasher.compute_chunk_hashes(tokens)
+        errors: list[str] = []
+        barrier = threading.Barrier(8)
+
+        def worker(tid: int) -> None:
+            try:
+                barrier.wait(timeout=5)
+                hashes = session.get_hashes(0, 20)
+                if hashes != expected:
+                    errors.append(
+                        "Thread %d: got %r, expected %r" % (tid, hashes, expected)
+                    )
+            except Exception as exc:
+                errors.append("Thread %d: %s" % (tid, exc))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, "\n".join(errors)
+        assert session.num_chunks_processed == 5
+
+    def test_concurrent_set_and_get(self, hasher: TokenHasher) -> None:
+        """set_tokens and get_hashes called concurrently must not
+        corrupt internal state."""
+        session = Session(request_id="req-mt2", hasher=hasher)
+        tokens = list(range(8))  # 2 chunks
+        session.set_tokens(tokens)
+        expected = hasher.compute_chunk_hashes(tokens)
+        errors: list[str] = []
+        barrier = threading.Barrier(4)
+
+        def reader(tid: int) -> None:
+            try:
+                barrier.wait(timeout=5)
+                hashes = session.get_hashes(0, 8)
+                if hashes != expected:
+                    errors.append("Reader %d: mismatch" % tid)
+            except Exception as exc:
+                errors.append("Reader %d: %s" % (tid, exc))
+
+        def writer() -> None:
+            try:
+                barrier.wait(timeout=5)
+                # Re-set same tokens (idempotent)
+                session.set_tokens(tokens)
+            except Exception as exc:
+                errors.append("Writer: %s" % exc)
+
+        threads = [threading.Thread(target=reader, args=(i,)) for i in range(3)]
+        threads.append(threading.Thread(target=writer))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, "\n".join(errors)


### PR DESCRIPTION
Multiple TP worker threads concurrently call set_tokens() and get_hashes() on the same Session object (same request_id), causing race conditions in _compute_hash() that corrupt chunk_hashes (duplicates, wrong rolling state). This leads to ObjectKey mismatch between sync_lookup/store and retrieve, resulting in KEY_NOT_EXIST errors during unsafe_read.

Add threading.Lock to Session protecting set_tokens and get_hashes.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
