### PR TITLE
[MP][Bugfix] fixing race condition for zmq output notifier

### DIFF
--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -337,8 +337,9 @@ class MessageQueueServer:
         self.ctx = context
         self.socket = self.ctx.socket(zmq.ROUTER)
         self.socket.bind(bind_url)
-        # Output task notifier socket and output queue
-
+        # Use eventfd instead of zmq PUSH/PULL sockets because blocking
+        # handler callbacks run on ThreadPoolExecutor threads, and zmq
+        # sockets are not thread-safe. eventfd_write() is atomic.
         self._output_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
         self.output_queue: queue.Queue = queue.Queue()
 

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -660,7 +660,7 @@ class MessageQueueServer:
         if self.worker_thread.is_alive():
             self.worker_thread.join()
         self.socket.close()
-        os.close(self._output_efd)
         self.thread_pool.shutdown(wait=False)
         for pool in self.dedicated_pools:
             pool.shutdown(wait=False)
+        os.close(self._output_efd)

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -4,6 +4,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, Optional, TypeVar, get_type_hints
 import inspect
+import os
 import queue
 import threading
 import uuid
@@ -338,15 +339,13 @@ class MessageQueueServer:
         self.socket.bind(bind_url)
         # Output task notifier socket and output queue
 
-        self.output_notifier, self.output_waiter = prepare_internal_push_pull_sockets(
-            self.ctx
-        )
+        self._output_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
         self.output_queue: queue.Queue = queue.Queue()
 
         # Poller
         self.poller = zmq.Poller()
         self.poller.register(self.socket, zmq.POLLIN)
-        self.poller.register(self.output_waiter, zmq.POLLIN)
+        self.poller.register(self._output_efd, zmq.POLLIN)
 
         # Main loop thread
         self.is_finished = threading.Event()
@@ -414,15 +413,11 @@ class MessageQueueServer:
                 )
 
                 self.output_queue.put(frames_to_send)
-                self.output_notifier.send(b"1")
+                os.eventfd_write(self._output_efd, 1)
 
             except Exception as e:
                 logger.error("Error in blocking handler: %s", e)
 
-        # TODO: HERE'S A BUG: WE CANNOT SEND RESPONSE IN THE FUTURE THREAD
-        # BECAUSE THE OUTPUT ZMQ SOCKET IS NOT THREAD-SAFE.
-        # WE SHOULD USE A ZMQ SOCKET TO NOTIFY THE MAIN THREAD TO SEND THE
-        # RESPONSE AND USE THE THREAD-QUEUE TO PASS THE RESPONSE DATA
         future.add_done_callback(_notify_response)
 
     def _call_handler(
@@ -447,7 +442,7 @@ class MessageQueueServer:
         while not self.is_finished.is_set():
             socks = dict(self.poller.poll(1000))
             inbound_state = socks.get(self.socket, None)
-            outbound_state = socks.get(self.output_waiter, None)
+            outbound_state = socks.get(self._output_efd, None)
 
             # Process the incoming requests
             if inbound_state and inbound_state & zmq.POLLIN:
@@ -477,12 +472,8 @@ class MessageQueueServer:
 
             # Send the responses
             if outbound_state and outbound_state & zmq.POLLIN:
-                # Drain the notifier
-                while True:
-                    try:
-                        self.output_waiter.recv(zmq.DONTWAIT)
-                    except zmq.Again:
-                        break
+                # Consume the eventfd counter (resets atomically)
+                os.eventfd_read(self._output_efd)
 
                 # Process the output tasks
                 try:
@@ -668,6 +659,7 @@ class MessageQueueServer:
         if self.worker_thread.is_alive():
             self.worker_thread.join()
         self.socket.close()
+        os.close(self._output_efd)
         self.thread_pool.shutdown(wait=False)
         for pool in self.dedicated_pools:
             pool.shutdown(wait=False)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a race condition in `MessageQueueServer._call_blocking_handler` where the `output_notifier` zmq PUSH socket was called from `ThreadPoolExecutor` callback threads. ZMQ sockets are not thread-safe, so concurrent `send()` calls from multiple worker threads could corrupt state.

Replaces the zmq PUSH/PULL inproc socket pair with a single `os.eventfd`. `eventfd_write()` is an atomic kernel syscall, making it inherently thread-safe for cross-thread notification. This also simplifies the drain logic — `eventfd_read()` atomically resets the counter in one call vs. a recv loop.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests