### PR TITLE
fix: add None check before stream synchronization

### DIFF
--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -111,7 +111,8 @@ def allocate_and_copy_objects(
             memory_obj.tensor.copy_(src_memory_obj.tensor, non_blocking=True)
         allocated_objects.append(memory_obj)
 
-    stream.synchronize()
+    if stream is not None:
+        stream.synchronize()
     return keys[: len(allocated_objects)], allocated_objects
 
 


### PR DESCRIPTION
Prevent AttributeError by ensuring the stream object is not None before calling stream.synchronize().

otherwise, crash will happen on non-cuda devices.