### PR TITLE
Fix LocalDiskBackend remove() crash on FileNotFoundError

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -244,7 +244,10 @@ class LocalDiskBackend(StorageBackendInterface):
         # )
         # res.result()
 
-        os.remove(path)
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            logger.warning(f"File not found on disk: {path}")
 
         if force:
             self.cache_policy.update_on_force_evict(key)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR makes `LocalDiskBackend.remove()` resilient to `FileNotFoundError` when deleting local disk cache files.

In stress tests with vLLM + LMCache (CPU + Local Disk), we observed crashes in the eviction/save path when `os.remove(path)` failed because the file was already gone.  
The likely cause is a race/timing issue where metadata still exists but the backing file has already been removed.

To avoid engine failure on this non-critical condition, this PR wraps `os.remove(path)` with `try/except FileNotFoundError` and treats the delete as idempotent.

**Special notes for your reviewers**:
The error msg: 

```sh
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py", line 187, in wait_for_save
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     self._lmcache_engine.wait_for_save()
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/integration/vllm/vllm_v1_adapter.py", line 1397, in wait_for_save
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     self.lmcache_engine.store(
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     return func(*args, **kwargs)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/v1/cache_engine.py", line 441, in store
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     self.storage_manager.batched_put(keys, memory_objs, transfer_spec=transfer_spec)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/v1/storage_backend/storage_manager.py", line 415, in batched_put
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     backend.batched_submit_put_task(ks, objs, transfer_spec=transfer_spec)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/v1/storage_backend/local_disk_backend.py", line 354, in batched_submit_put_task
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     self.submit_put_task(key, memory_obj)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/v1/storage_backend/local_disk_backend.py", line 324, in submit_put_task
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     self.batched_remove(evict_keys, force=False)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/v1/storage_backend/abstract_backend.py", line 237, in batched_remove
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     num_removed += self.remove(key, force=force)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/lmcache/v1/storage_backend/local_disk_backend.py", line 247, in remove
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938]     os.remove(path)
(EngineCore_DP0 pid=97) ERROR 03-17 20:17:32 [core.py:938] FileNotFoundError: [Errno 2] No such file or directory: '/data/kvcache/vllm@-root-.cache-modelscope-hub-models-Qwen-Qwen3-32B-@1@0@6b4b298ad45a4a58@bfloat16.pt'
(EngineCore_DP0 pid=97) Process EngineCore_DP0:
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546] AsyncLLM output_handler failed.
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546] Traceback (most recent call last):
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/async_llm.py", line 502, in output_handler
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546]     outputs = await engine_core.get_output_async()
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 899, in get_output_async
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546]     raise self._format_exception(outputs) from None
(APIServer pid=1) ERROR 03-17 20:17:32 [async_llm.py:546] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue. See stack trace (above) for the root cause. 
```


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
