### PR TITLE
[MP] Add a new argument to specify whether retain_in_l1

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -170,6 +170,10 @@ Source: ``lmcache/v1/distributed/config.py``
      - L2 prefetch policy.  Determines which adapter loads each key
        when multiple adapters have it.
        The ``default`` policy picks the first adapter (lowest index).
+       Prefetched keys are temporary (deleted after the reader finishes).
+       The ``retain`` policy uses the same load plan but keeps
+       prefetched keys permanently in L1.
+       Choices: ``default``, ``retain``.
    * - ``--l2-prefetch-max-in-flight``
      - ``8``
      - Maximum number of concurrent prefetch (L2 load) requests.

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -261,6 +261,12 @@ Select policies via CLI:
    * - ``--l2-prefetch-policy``
      - ``default``
      - For each key, pick the first (lowest-indexed) adapter that has it.
+       Prefetched keys are **temporary** (deleted after the reader finishes).
+   * - ``--l2-prefetch-policy``
+     - ``retain``
+     - Same load plan as ``default``, but prefetched keys are **retained**
+       permanently in L1.  Useful when prefetched data is likely reused
+       by subsequent requests (e.g. shared system-prompt chunks).
 
 Prefetch Concurrency
 ~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -565,9 +565,12 @@ class PrefetchController(StorageControllerInterface):
         keys_to_reserve = merged_bitmap.gather(request.keys)
         l1_mgr = self._l1_manager
 
+        retentions = self._policy.select_l1_retentions(
+            keys_to_reserve,
+        )
         write_results = l1_mgr.reserve_write(
             keys=keys_to_reserve,
-            is_temporary=[True] * len(keys_to_reserve),
+            is_temporary=[not r for r in retentions],
             layout_desc=request.layout_desc,
             mode="new",
         )

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -169,13 +169,6 @@ class DefaultPrefetchPolicy(PrefetchPolicy):
 
         return plan
 
-    def select_l1_retentions(
-        self,
-        keys: list[ObjectKey],
-    ) -> list[bool]:
-        """All prefetched keys are temporary (not retained)."""
-        return [False] * len(keys)
-
 
 class RetainPrefetchPolicy(DefaultPrefetchPolicy):
     """Prefetch policy that retains all prefetched keys in L1.

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -50,6 +50,32 @@ class PrefetchPolicy(ABC):
             of the union of the input bitmaps.
         """
 
+    def select_l1_retentions(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[bool]:
+        """Determine which keys to retain in L1 after prefetched
+        objects are consumed.
+
+        Called by PrefetchController just before
+        ``l1_mgr.reserve_write`` to build the ``is_temporary``
+        flags.  A ``True`` value means the key is retained
+        (permanent); ``False`` means it is temporary and will be
+        deleted after the reader finishes.
+
+        The default implementation marks all keys as temporary
+        (not retained).  Override in subclasses to implement
+        hot-cache or selective-retention strategies.
+
+        Args:
+            keys: Keys about to be written into L1.
+
+        Returns:
+            A list of bools with the same length as *keys*.
+            ``True`` = retain (permanent), ``False`` = temporary.
+        """
+        return [False] * len(keys)
+
 
 # -----------------------------------------------------------------------------
 # Registry: prefetch policy name -> policy class
@@ -143,5 +169,32 @@ class DefaultPrefetchPolicy(PrefetchPolicy):
 
         return plan
 
+    def select_l1_retentions(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[bool]:
+        """All prefetched keys are temporary (not retained)."""
+        return [False] * len(keys)
+
+
+class RetainPrefetchPolicy(DefaultPrefetchPolicy):
+    """Prefetch policy that retains all prefetched keys in L1.
+
+    Inherits ``select_load_plan`` from ``DefaultPrefetchPolicy``
+    (first-adapter-wins) and only overrides the L1 retention
+    decision: all prefetched keys become permanent.
+
+    Use this when prefetched data is likely to be reused by
+    subsequent requests (e.g. shared system-prompt chunks).
+    """
+
+    def select_l1_retentions(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[bool]:
+        """Retain all prefetched keys permanently in L1."""
+        return [True] * len(keys)
+
 
 register_prefetch_policy("default", DefaultPrefetchPolicy)
+register_prefetch_policy("retain", RetainPrefetchPolicy)

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -12,6 +12,7 @@ from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
+    RetainPrefetchPolicy,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
@@ -213,3 +214,95 @@ class TestDefaultPrefetchPolicy:
         assert plan_to_indices(result) == {0: [0, 1, 2]}
         assert 1 not in result
         assert 2 not in result
+
+
+# =============================================================================
+# DefaultPrefetchPolicy.select_l1_retentions Tests
+# =============================================================================
+
+
+class TestDefaultPrefetchPolicyRetentions:
+    """Test DefaultPrefetchPolicy.select_l1_retentions."""
+
+    def test_returns_all_false(self):
+        """Default policy marks all keys as temporary."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(5)]
+        result = policy.select_l1_retentions(keys)
+        assert result == [False] * 5
+
+    def test_empty_keys(self):
+        """Empty keys list returns empty list."""
+        policy = DefaultPrefetchPolicy()
+        result = policy.select_l1_retentions([])
+        assert result == []
+
+    def test_single_key(self):
+        """Single key returns single False."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(0)]
+        result = policy.select_l1_retentions(keys)
+        assert result == [False]
+
+    def test_length_matches_input(self):
+        """Output length always matches input length."""
+        policy = DefaultPrefetchPolicy()
+        for n in [0, 1, 10, 100]:
+            keys = [make_object_key(i) for i in range(n)]
+            result = policy.select_l1_retentions(keys)
+            assert len(result) == n
+
+
+# =============================================================================
+# RetainPrefetchPolicy Tests
+# =============================================================================
+
+
+class TestRetainPrefetchPolicyRetentions:
+    """Test RetainPrefetchPolicy.select_l1_retentions."""
+
+    def test_returns_all_true(self):
+        """Retain policy marks all keys as permanent."""
+        policy = RetainPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(5)]
+        result = policy.select_l1_retentions(keys)
+        assert result == [True] * 5
+
+    def test_empty_keys(self):
+        """Empty keys list returns empty list."""
+        policy = RetainPrefetchPolicy()
+        result = policy.select_l1_retentions([])
+        assert result == []
+
+    def test_single_key(self):
+        """Single key returns single True."""
+        policy = RetainPrefetchPolicy()
+        keys = [make_object_key(0)]
+        result = policy.select_l1_retentions(keys)
+        assert result == [True]
+
+    def test_length_matches_input(self):
+        """Output length always matches input length."""
+        policy = RetainPrefetchPolicy()
+        for n in [0, 1, 10, 100]:
+            keys = [make_object_key(i) for i in range(n)]
+            result = policy.select_l1_retentions(keys)
+            assert len(result) == n
+
+
+class TestRetainPrefetchPolicyLoadPlan:
+    """RetainPrefetchPolicy inherits load plan from Default."""
+
+    def test_inherits_load_plan(self):
+        """Load plan should behave identically to Default."""
+        policy = RetainPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        lookup_results = {
+            0: make_bitmap(3, [0, 1]),
+            1: make_bitmap(3, [1, 2]),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert plan_to_indices(result) == {0: [0, 1], 1: [2]}


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new prefetch policy that changes L1 lifetime semantics for prefetched data and can increase memory usage if enabled. The default behavior remains temporary prefetch, so impact is limited to users selecting the new policy.
> 
> **Overview**
> Adds an L2 prefetch retention mechanism by extending `PrefetchPolicy` with `select_l1_retentions()` and wiring it into `PrefetchController` so `reserve_write()` can mark prefetched entries as temporary vs permanent.
> 
> Introduces a new `retain` prefetch policy (`RetainPrefetchPolicy`) that keeps all prefetched keys permanently in L1, updates MP docs for the new `--l2-prefetch-policy retain` option, and adds unit tests covering both default (temporary) and retain behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 529032ca4a1b1ea41624d043ff329e4ff6b5a83d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->