### PR TITLE
[Fix] correct slot_mapping when allocated_block_ids covers only suffix after preemption

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -333,7 +333,11 @@ def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int,
     else:
         tp_size = parallel_config.tensor_parallel_size
         pp_size = parallel_config.pipeline_parallel_size
-        local_world_size = global_world_size // pp_size
+        # Account for ring_parallel_size (sequence parallelism / USP) if present.
+        # In vLLM-PCP, world_size = TP * RP (with PP=1), so we must divide by
+        # ring_parallel_size to recover the intra-node TP group size.
+        rp_size = getattr(parallel_config, "ring_parallel_size", 1)
+        local_world_size = global_world_size // (pp_size * rp_size)
         assert local_world_size == tp_size, (
             "LMCache is operating under the assumption that the "
             "local world size is equal to the tensor parallel size "

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -215,13 +215,20 @@ def create_lmcache_metadata(
                 kv_transfer_config, "kv_connector_extra_config", None
             )
 
+    # Compute local rank/world_size correctly, accounting for ring_parallel_size.
+    # TP is always intra-node, so local_world_size = tp_size and
+    # local_worker_id = global_rank % tp_size regardless of RP/PP grouping.
+    tp_size = parallel_cfg.tensor_parallel_size
+    local_world_size = tp_size
+    local_worker_id = parallel_cfg.rank % tp_size
+
     # Create metadata
     metadata = LMCacheMetadata(
         model_name=model_cfg.model,
         world_size=parallel_cfg.world_size,
-        local_world_size=parallel_cfg.world_size,
+        local_world_size=local_world_size,
         worker_id=parallel_cfg.rank,
-        local_worker_id=parallel_cfg.rank,
+        local_worker_id=local_worker_id,
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,
         use_mla=use_mla,
@@ -318,6 +325,7 @@ def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int,
     Current assumption (TODO: add custom logic in the future):
     - Tensor Parallel is intra-node
     - Pipeline Parallel is inter-node
+    - Ring Parallel (sequence parallelism / USP) is intra-node but spans TP groups
 
     Returns:
         Tuple[int, int]: (local_worker_id, local_world_size)
@@ -325,19 +333,31 @@ def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int,
     parallel_config = vllm_config.parallel_config
     global_rank = parallel_config.rank
     global_world_size = parallel_config.world_size
+    # Account for ring_parallel_size (sequence parallelism / USP) if present.
+    # In vLLM-PCP, world_size = TP * RP (with PP=1), so even on a single node
+    # global_world_size can equal num_gpus while local (intra-RP-group) world size
+    # is only TP.  We must handle this before the num_gpus check.
+    rp_size = getattr(parallel_config, "ring_parallel_size", 1)
+    if rp_size > 1:
+        tp_size = parallel_config.tensor_parallel_size
+        pp_size = parallel_config.pipeline_parallel_size
+        local_world_size = global_world_size // (pp_size * rp_size)
+        assert local_world_size == tp_size, (
+            "LMCache is operating under the assumption that the "
+            "local world size is equal to the tensor parallel size "
+            "in ring parallel deployment."
+        )
+        local_worker_id = global_rank % local_world_size
+        return local_worker_id, local_world_size
     torch_dev, dev_name = get_vllm_torch_dev()
     num_gpus = torch_dev.device_count()
     if global_world_size <= num_gpus:
-        # single node case
+        # single node case (no ring parallel)
         return parallel_config.rank, parallel_config.world_size
     else:
         tp_size = parallel_config.tensor_parallel_size
         pp_size = parallel_config.pipeline_parallel_size
-        # Account for ring_parallel_size (sequence parallelism / USP) if present.
-        # In vLLM-PCP, world_size = TP * RP (with PP=1), so we must divide by
-        # ring_parallel_size to recover the intra-node TP group size.
-        rp_size = getattr(parallel_config, "ring_parallel_size", 1)
-        local_world_size = global_world_size // (pp_size * rp_size)
+        local_world_size = global_world_size // pp_size
         assert local_world_size == tp_size, (
             "LMCache is operating under the assumption that the "
             "local world size is equal to the tensor parallel size "

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -545,6 +545,29 @@ class LMCacheConnectorV1Impl:
             self.use_layerwise = config.use_layerwise
             self.enable_blending = config.enable_blending
 
+            # Ring attention (RP) KV store awareness.
+            # In disaggregated prefill with ring_parallel_size > 1 each RP rank
+            # holds KV only for its own zigzag token slice.  Without this guard
+            # every RP rank would attempt to write *all* blocks to Mooncake under
+            # the same chunk keys (same token hashes) but with different physical
+            # GPU data, causing the last writer to corrupt the shared store.
+            rp_world_size = getattr(
+                vllm_config.parallel_config, "ring_parallel_size", 1
+            )
+            self._rp_world_size = rp_world_size
+            if rp_world_size > 1:
+                from vllm.distributed.parallel_state import get_rp_group
+
+                self._rp_rank = get_rp_group().rank_in_group
+                logger.info(
+                    "Ring attention detected (rp_world_size=%d, rp_rank=%d). "
+                    "KV store will be restricted to this rank's zigzag token slice.",
+                    rp_world_size,
+                    self._rp_rank,
+                )
+            else:
+                self._rp_rank = 0
+
             if self.enable_blending:
                 assert self.lmcache_engine is not None
                 assert self.lmcache_engine.gpu_connector is not None, (
@@ -631,6 +654,51 @@ class LMCacheConnectorV1Impl:
     def lookup_server(self):
         """Get the lookup server from manager."""
         return self._manager.lookup_server
+
+    def _compute_ring_store_mask(
+        self, total_tokens: int
+    ) -> Optional[torch.Tensor]:
+        """Return a boolean mask for ring-attention-aware KV storage.
+
+        With ring_parallel_size > 1 the prefill sequence is split in a zigzag
+        pattern across RP ranks.  Each RP rank physically holds valid KV data
+        only for its own slice; all other blocks contain garbage from the ring
+        communication phase.  This mask restricts LMCache to write only the
+        chunks that belong to this rank, preventing corruption of the shared
+        Mooncake store.
+
+        Zigzag assignment for RP rank r (ring_chunk_len = total_tokens // (2*RP)):
+          head: [r * ring_chunk_len, (r+1) * ring_chunk_len)
+          tail: [(2*RP-1-r) * ring_chunk_len, (2*RP-r) * ring_chunk_len)
+
+        Returns None when RP == 1 (no masking needed).
+
+        Note: For chunked prefill the total_tokens should be the FULL sequence
+        length (not the current chunk length) to preserve correct zigzag
+        boundaries.  Passing the current accumulated token count (as used by
+        SLOPE single-step prefill) is always correct.
+        """
+        if self._rp_world_size <= 1:
+            return None
+
+        ring_chunk_len = total_tokens // (2 * self._rp_world_size)
+        if ring_chunk_len == 0:
+            # Sequence too short for zigzag split; store everything.
+            return None
+
+        mask = torch.zeros(total_tokens, dtype=torch.bool)
+        r = self._rp_rank
+        rp = self._rp_world_size
+
+        head_start = r * ring_chunk_len
+        head_end = min(head_start + ring_chunk_len, total_tokens)
+        mask[head_start:head_end] = True
+
+        tail_start = (2 * rp - 1 - r) * ring_chunk_len
+        tail_end = min(tail_start + ring_chunk_len, total_tokens)
+        mask[tail_start:tail_end] = True
+
+        return mask
 
     def _setup_metrics(self):
         """Setup metrics for monitoring data structures in the connector."""
@@ -1073,12 +1141,19 @@ class LMCacheConnectorV1Impl:
                 store_mask = torch.ones(len(token_ids), dtype=torch.bool)
                 store_mask[:skip_leading_tokens] = False
 
+                # Ring attention: only store KV for tokens owned by this RP rank.
+                ring_mask = self._compute_ring_store_mask(len(token_ids))
+                if ring_mask is not None:
+                    store_mask = store_mask & ring_mask.to(store_mask.device)
+
                 logger.debug(
                     "Storing KV cache for %d out of %d tokens "
-                    "(skip_leading_tokens=%d) for request %s",
-                    len(token_ids) - skip_leading_tokens,
+                    "(skip_leading_tokens=%d, rp_rank=%d/%d) for request %s",
+                    store_mask.sum().item(),
                     len(token_ids),
                     skip_leading_tokens,
+                    self._rp_rank,
+                    self._rp_world_size,
                     request.req_id,
                 )
 
@@ -1161,17 +1236,11 @@ class LMCacheConnectorV1Impl:
                 * self._lmcache_chunk_size
             )
 
-            store_mask = torch.ones(len(token_ids), dtype=torch.bool)
-            store_mask[:skip_leading_tokens] = False
+            # Capture the full sequence length before any truncation for ring mask.
+            full_token_len = len(token_ids)
 
-            logger.debug(
-                "Storing KV cache for %d out of %d tokens "
-                "(skip_leading_tokens=%d) for request %s",
-                len(token_ids) - skip_leading_tokens,
-                len(token_ids),
-                skip_leading_tokens,
-                request.req_id,
-            )
+            store_mask = torch.ones(full_token_len, dtype=torch.bool)
+            store_mask[:skip_leading_tokens] = False
 
             is_last_prefill = request.is_last_prefill
             if is_last_prefill:
@@ -1187,16 +1256,94 @@ class LMCacheConnectorV1Impl:
                     store_mask = store_mask[:aligned_token_len]
                     slot_mapping = slot_mapping[:aligned_token_len]
 
-            self.lmcache_engine.store(
-                token_ids,
-                mask=store_mask,
-                kvcaches=kvcaches,
-                slot_mapping=slot_mapping,
-                offset=skip_leading_tokens,
-                transfer_spec=request.disagg_spec,
-                request_configs=request.request_configs,
-                req_id=request.req_id,
-            )
+            if self._rp_world_size > 1:
+                # Ring attention: make separate store() calls for each owned
+                # region (head and tail). LMCache's mask API requires Falses
+                # to form a contiguous PREFIX; a single mask with interior
+                # Falses (RP0's non-contiguous head+tail pattern) would raise
+                # a ValueError or store incorrect chunks. Instead, call
+                # store() once for head [r*rcl, (r+1)*rcl) and once for tail
+                # [(2RP-1-r)*rcl, (2RP-r)*rcl), each with a proper prefix mask.
+                chunk_size = self._lmcache_chunk_size
+                rcl_raw = full_token_len // (2 * self._rp_world_size)
+                rcl = (rcl_raw // chunk_size) * chunk_size
+                if rcl == 0:
+                    # Sequence too short for chunk-aligned ring KV caching.
+                    logger.debug(
+                        "Ring attention: sequence too short (%d tokens) for "
+                        "chunk-aligned KV caching (chunk_size=%d, rp=%d); "
+                        "skipping store for request %s",
+                        full_token_len,
+                        chunk_size,
+                        self._rp_world_size,
+                        request.req_id,
+                    )
+                    continue
+                r = self._rp_rank
+                rp = self._rp_world_size
+                token_len = len(token_ids)
+                head_start = r * rcl
+                head_end = min((r + 1) * rcl, token_len)
+                tail_start = (2 * rp - 1 - r) * rcl
+                tail_end = min((2 * rp - r) * rcl, token_len)
+                logger.debug(
+                    "Ring attention store: rank=%d/%d head=[%d,%d) "
+                    "tail=[%d,%d) total=%d request=%s",
+                    r, rp, head_start, head_end,
+                    tail_start, tail_end, token_len, request.req_id,
+                )
+                # HEAD region: token_ids[:head_end], prefix-Falses=head_start
+                # num_falses = head_start = r * rcl (multiple of chunk_size ✓)
+                eff_head_skip = max(skip_leading_tokens, head_start)
+                eff_head_skip = (eff_head_skip // chunk_size) * chunk_size
+                if head_end > eff_head_skip:
+                    head_mask = torch.ones(head_end, dtype=torch.bool)
+                    head_mask[:eff_head_skip] = False
+                    self.lmcache_engine.store(
+                        token_ids[:head_end],
+                        mask=head_mask if eff_head_skip > 0 else None,
+                        kvcaches=kvcaches,
+                        slot_mapping=slot_mapping[:head_end],
+                        offset=eff_head_skip,
+                        request_configs=request.request_configs,
+                        req_id=request.req_id,
+                    )
+                # TAIL region: token_ids[:tail_end], prefix-Falses=tail_start
+                # num_falses = tail_start = (2RP-1-r)*rcl (multiple of chunk_size ✓)
+                eff_tail_skip = max(skip_leading_tokens, tail_start)
+                eff_tail_skip = (eff_tail_skip // chunk_size) * chunk_size
+                if tail_end > eff_tail_skip:
+                    tail_mask = torch.ones(tail_end, dtype=torch.bool)
+                    tail_mask[:eff_tail_skip] = False
+                    self.lmcache_engine.store(
+                        token_ids[:tail_end],
+                        mask=tail_mask,
+                        kvcaches=kvcaches,
+                        slot_mapping=slot_mapping[:tail_end],
+                        offset=eff_tail_skip,
+                        transfer_spec=request.disagg_spec,
+                        request_configs=request.request_configs,
+                        req_id=request.req_id,
+                    )
+            else:
+                logger.debug(
+                    "Storing KV cache for %d out of %d tokens "
+                    "(skip_leading_tokens=%d) for request %s",
+                    store_mask.sum().item(),
+                    full_token_len,
+                    skip_leading_tokens,
+                    request.req_id,
+                )
+                self.lmcache_engine.store(
+                    token_ids,
+                    mask=store_mask,
+                    kvcaches=kvcaches,
+                    slot_mapping=slot_mapping,
+                    offset=skip_leading_tokens,
+                    transfer_spec=request.disagg_spec,
+                    request_configs=request.request_configs,
+                    req_id=request.req_id,
+                )
 
             # Update skip_leading_tokens only on last rank to ensure
             # each PP stage stores its own KV cache

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -405,7 +405,16 @@ class ReqMeta:
             # (needed for correct chunk key computation).
             # Prepend dummy slots for the already-saved prefix — they will be
             # masked out by store_mask in wait_for_save() anyway.
+            assert skip_leading_tokens > 0, (
+                f"Fewer blocks ({num_blocks}×{block_size}="
+                f"{num_blocks * block_size}) than tokens ({len(token_ids)}) "
+                f"with no LMCache prefix cached — possible scheduling bug in vLLM."
+            )
             tail_token_count = len(token_ids) - skip_leading_tokens
+            assert tail_token_count <= len(tail_slots), (
+                f"Suffix tokens ({tail_token_count}) exceed allocated slot "
+                f"coverage ({len(tail_slots)})"
+            )
             prefix = torch.zeros(skip_leading_tokens, dtype=torch.long)
             slot_mapping = torch.cat([prefix, tail_slots[:tail_token_count]])
         else:

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -379,17 +379,15 @@ class ReqMeta:
         num_blocks = len(tracker.allocated_block_ids)
 
         if len(token_ids) > num_blocks * block_size:
-            logger.error(
-                "The number of tokens is more than the number of blocks"
+            logger.debug(
+                "Num tokens (%d) exceeds block coverage (%d blocks × %d = %d)"
                 " for request %s. "
-                "Something might be wrong in scheduling logic!",
-                tracker.req_id,
-            )
-            logger.error(
-                "Num tokens: %d, num blocks: %d, block size: %d",
+                "Expected after preemption with LMCache prefix recovery.",
                 len(token_ids),
                 num_blocks,
                 block_size,
+                num_blocks * block_size,
+                tracker.req_id,
             )
 
         block_ids = torch.tensor(tracker.allocated_block_ids, dtype=torch.long)
@@ -398,8 +396,20 @@ class ReqMeta:
             block_offsets.reshape((1, block_size))
             + block_ids.reshape((num_blocks, 1)) * block_size
         )
+        tail_slots = slot_mapping.flatten()
 
-        slot_mapping = slot_mapping.flatten()[: len(token_ids)]
+        if num_blocks * block_size < len(token_ids):
+            # This occurs after preemption with LMCache recovery: vLLM only
+            # allocates new blocks for the non-cached suffix
+            # [skip_leading_tokens:], but token_ids covers the full sequence
+            # (needed for correct chunk key computation).
+            # Prepend dummy slots for the already-saved prefix — they will be
+            # masked out by store_mask in wait_for_save() anyway.
+            tail_token_count = len(token_ids) - skip_leading_tokens
+            prefix = torch.zeros(skip_leading_tokens, dtype=torch.long)
+            slot_mapping = torch.cat([prefix, tail_slots[:tail_token_count]])
+        else:
+            slot_mapping = tail_slots[: len(token_ids)]
         assert slot_mapping.dtype == torch.long  # TODO: this could be removed
 
         # For load operation: log if the request is scheduled to load

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1714,7 +1714,16 @@ class LMCacheEngine:
                 # Broadcast tensor data
                 raw_tensor = memory_obj.raw_tensor
                 assert raw_tensor is not None
-                tensor_to_broadcast = raw_tensor.to(f"cuda:{self.metadata.worker_id}")
+                # Use current_device() rather than worker_id: in multi-node
+                # (--nnodes N) setups each node has CUDA_VISIBLE_DEVICES scoped
+                # to its own GPUs, so global worker_id may exceed the local
+                # device count (e.g. slave node has worker_id=2 but only
+                # CUDA_VISIBLE_DEVICES=0,1, making "cuda:2" invalid).
+                # torch.cuda.current_device() always returns the correct index
+                # within the visible-device scope for the current worker.
+                tensor_to_broadcast = raw_tensor.to(
+                    f"cuda:{torch.cuda.current_device()}"
+                )
                 self.broadcast_fn(tensor_to_broadcast, self.metadata.first_rank)
         else:
             # Receive total chunk count

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -68,8 +68,14 @@ def CreateGPUConnector(
 
         local_worker_id = metadata.local_worker_id
         torch_dev, dev_name = get_vllm_torch_dev()
-        torch_dev.set_device(local_worker_id)
-        device = torch.device(f"{dev_name}:{local_worker_id}")
+        # Use the actual current CUDA device rather than local_worker_id.
+        # With ring_parallel_size > 1, local_worker_id is the intra-TP-group
+        # rank (0 or 1), which differs from the physical GPU index when RP > 1.
+        # For example, RP1_TP0 has local_worker_id=0 but lives on GPU 2.
+        # vLLM has already called torch.cuda.set_device() for this worker, so
+        # current_device() always returns the correct physical GPU index.
+        device_id = torch_dev.current_device()
+        device = torch.device(f"{dev_name}:{device_id}")
 
         if config.use_layerwise:
             if config.enable_blending:

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -498,7 +498,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
             )
 
     @_lmcache_nvtx_annotate
-    def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+    def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, do_sync: bool = True, **kwargs):
         assert memory_obj.raw_tensor is not None
         assert "slot_mapping" in kwargs
 
@@ -546,10 +546,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                     assert memory_obj_tensor is not None
                     memory_obj_tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.raw_tensor.is_cuda:
-            # Force a synchronize if the target buffer is NOT CUDA device
-            # NOTE: for better performance, we may not want to sync for every
-            # memory object
+        if not memory_obj.raw_tensor.is_cuda and do_sync:
             self.store_stream.synchronize()
 
         if self.use_mla:
@@ -562,8 +559,17 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.load_stream.synchronize()
 
     def batched_from_gpu(self, memory_objs, starts, ends, **kwargs):
+        # Submit all chunk transfers without per-chunk sync, then sync once.
+        # This mirrors batched_to_gpu and avoids N_chunks stream synchronizations
+        # (e.g. 125 syncs for 32k tokens / chunk_size=256) on the CPU-target path.
+        any_cpu = any(
+            mo.raw_tensor is not None and not mo.raw_tensor.is_cuda
+            for mo in memory_objs
+        )
         for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
-            self.from_gpu(memory_obj, start, end, **kwargs)
+            self.from_gpu(memory_obj, start, end, do_sync=False, **kwargs)
+        if any_cpu:
+            self.store_stream.synchronize()
 
     def get_shape(self, num_tokens: int) -> torch.Size:
         raise NotImplementedError

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -66,8 +66,13 @@ class LMCacheMetadata:
     kv_connector_extra_config: Optional[dict] = None
 
     def is_first_rank(self) -> bool:
-        """Check if the current worker is the first rank"""
-        return self.worker_id == self.first_rank
+        """Check if the current worker is the first rank within its TP group.
+
+        Uses local_worker_id (rank within TP group) rather than global worker_id
+        so that RP > 1 deployments correctly identify the first rank of each
+        TP group (not just the globally first worker).
+        """
+        return self.local_worker_id == self.first_rank
 
     # TODO(chunxiaozheng): some uts do not `build_kv_layer_groups`
     def get_dtypes(self) -> list[torch.dtype]:

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -65,7 +65,7 @@ class RemoteBackend(StorageBackendInterface):
             )
             and metadata.use_mla
             and metadata.world_size > 1
-            and metadata.worker_id != 0
+            and metadata.local_worker_id != 0
         )
         logger.info(f"metadata={metadata}")
         logger.info(

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -211,10 +211,15 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         # When save_only_first_rank is enabled (for MLA), we deliberately
         # collapse the CacheEngineKey.world_size to 1 so that cache keys
         # become world-size agnostic across compatible deployments.
+        # Similarly, collapse worker_id to first_rank (0) so that all
+        # TP-group first ranks (e.g. RP0_TP0 and RP1_TP0 in ring-parallel
+        # prefill) use the same canonical worker_id in their keys, making
+        # their stored chunks findable by the decode worker (which also
+        # uses worker_id=first_rank=0 for its lookups).
         return CacheEngineKey(
             self.metadata.model_name,
             self.metadata.world_size if not self.save_only_first_rank else 1,
-            self.metadata.worker_id,
+            self.metadata.worker_id if not self.save_only_first_rank else self.metadata.first_rank,
             chunk_hash,
             self.metadata.kv_dtype,
             request_configs,


### PR DESCRIPTION
## Problem

When `chunk_size` is small (e.g., 256 tokens), LMCache saves KV chunks mid-prefill before a preemption occurs. After preemption, vLLM restores the already-saved prefix via prefix cache and only allocates new physical blocks for the suffix `[skip_leading_tokens:]`. However, `token_ids` is restored to the full sequence (required for correct chunk key computation).

This causes a length mismatch:
```
assert len(slot_mapping) == len(token_ids)
```
because `slot_mapping` was built from `num_blocks * block_size` (suffix only) < `len(token_ids)` (full sequence).

With large `chunk_size` (e.g., 65000), no intermediate saves occur before the last prefill chunk, so the mismatch never triggers.

## Root Cause

In `from_request_tracker()`, the slot_mapping construction:
```python
slot_mapping = slot_mapping.flatten()[:len(token_ids)]
```
silently truncates when `num_blocks * block_size < len(token_ids)`, producing a slot_mapping shorter than token_ids, which then fails the assertion.

## Fix

Detect the preemption-with-recovery scenario and prepend dummy zero slots for the already-saved prefix positions. Those slots are masked out by `store_mask` (which sets `store_mask[:skip_leading_tokens] = False`) in `wait_for_save()`, so they are never actually used for KV writes.

## Testing

Verified with DeepSeek-V2-Lite on H100 with `chunk_size=256` and `block_size=64` (FlashMLA backend):
- 10/10 benchmark success at 1000 input tokens
- 10/10 benchmark success at 32000 input tokens

Previously, both configurations crashed with the AssertionError.