### PR TITLE
fix: replace global lock with per-device transfer_lock to prevent deadlock

### DIFF
--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -9,6 +9,7 @@ This module provides GPU-side KV cache management functionality, including:
 
 # Standard
 import array
+import threading
 
 # Third Party
 import cupy
@@ -101,6 +102,12 @@ class GPUCacheContext:
         self.high_priority_cupy_stream_ = cupy.cuda.ExternalStream(
             self.high_priority_cuda_stream_.cuda_stream, self.device_.index
         )
+
+        # Per-device lock to serialise GPU↔CPU data transfers
+        # on the same device without blocking transfers on other
+        # devices.  Replaces the old global ``MPCacheEngine.lock``
+        # to avoid deadlocks with the implicit CUDA driver lock.
+        self.transfer_lock = threading.Lock()
 
         # Extra initialization
         self.cupy_stream_.launch_host_func(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -300,7 +300,7 @@ class MPCacheEngine:
 
                 # Copy from GPU to CPU
                 tmp_buffer = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
-                with self.lock:
+                with gpu_context.transfer_lock:
                     lmc_ops.multi_layer_kv_transfer(
                         tmp_buffer,
                         gpu_context.kv_pointers,
@@ -419,7 +419,7 @@ class MPCacheEngine:
 
                 # Copy from CPU to GPU
                 tmp_gpu_buffer_ = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
-                with self.lock:
+                with gpu_context.transfer_lock:
                     lmcache_memcpy_async_h2d(memory_obj, tmp_gpu_buffer_)
                     lmc_ops.multi_layer_kv_transfer(
                         tmp_gpu_buffer_,


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The global `self.lock` in MPCacheEngine was acquired inside
`torch.cuda.device()` context, creating a circular dependency
with the implicit CUDA driver lock (ABBA deadlock).

Replace it with a per-device `transfer_lock` on GPUCacheContext
 so that GPU↔CPU transfers on the same
device are serialised without cross-lock contention. 

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
