### PR TITLE
feat(gds): add multipath KV-cache offloading support

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -341,7 +341,7 @@ Settings for different storage backends and paths.
      - Description
    * - gds_path
      - LMCACHE_GDS_PATH
-     - Path for GDS backend
+     - Path for GDS backend. Supports comma-separated paths for multi-device I/O (e.g. ``/mnt/nvme0/cache,/mnt/nvme1/cache``). Each GPU selects a path via ``device_id % num_paths``.
    * - cufile_buffer_size
      - LMCACHE_CUFILE_BUFFER_SIZE
      - Buffer size for cuFile/hipFile operations

--- a/docs/source/kv_cache/storage_backends/gds.rst
+++ b/docs/source/kv_cache/storage_backends/gds.rst
@@ -48,6 +48,60 @@ Example ``config.yaml``:
     cufile_buffer_size: 8192
 
 
+Multi-Path (Multi-Device) Support
+---------------------------------
+
+When a system has multiple NVMe drives, you can distribute GDS I/O across them
+by specifying a comma-separated list of paths in ``gds_path``. Each GPU worker
+automatically selects one path based on its device index (``device_id % num_paths``),
+so traffic is spread evenly across the drives without any manual pinning.
+
+**Why this helps:** a single PCIe Gen 4 x4 NVMe tops out at ~7 GB/s. With four
+drives the aggregate bandwidth can reach ~28 GB/s, matching what multi-GPU
+systems need for KV cache eviction and prefetch.
+
+**Environment variables:**
+
+.. code-block:: bash
+
+    export LMCACHE_GDS_PATH="/mnt/nvme0/cache,/mnt/nvme1/cache,/mnt/nvme2/cache,/mnt/nvme3/cache"
+
+**YAML config:**
+
+.. code-block:: yaml
+
+    gds_path: "/mnt/nvme0/cache,/mnt/nvme1/cache,/mnt/nvme2/cache,/mnt/nvme3/cache"
+
+With the above configuration on a 4-GPU node:
+
+- ``cuda:0`` writes to ``/mnt/nvme0/cache``
+- ``cuda:1`` writes to ``/mnt/nvme1/cache``
+- ``cuda:2`` writes to ``/mnt/nvme2/cache``
+- ``cuda:3`` writes to ``/mnt/nvme3/cache``
+
+If there are more GPUs than paths, the assignment wraps around (e.g. ``cuda:4``
+maps back to ``/mnt/nvme0/cache``). A single path (no commas) works exactly as
+before.
+
+All directories are created automatically at startup. Every path in the list
+must reside on a filesystem that the rest of the GDS configuration expects
+(e.g., all paths on GDS-capable mounts when using cuFile).
+
+**Read behavior:** on startup the backend scans **all** configured paths for
+previously-stored KV cache entries, regardless of GPU affinity.  This means a
+``cuda:0`` worker whose write affinity is ``/mnt/nvme0/cache`` will still
+discover entries that were written to ``/mnt/nvme1/cache`` by ``cuda:1`` in a
+prior run.  Writes, however, always go to the single affinity-selected path.
+
+.. code-block:: text
+
+   Startup scan (read):   iterate ALL gds_paths → populate hot_cache
+   Runtime writes:        only the affinity path  (device_id % num_paths)
+   Runtime reads:         look up hot_cache first; on miss, check ALL
+                          gds_paths on disk → load from whichever path
+                          the entry lives on
+
+
 CuFile Buffer Size Explanation
 ------------------------------
 

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -192,14 +192,29 @@ class GdsBackend(AllocatorBackendInterface):
         self.loop = loop
         self.dst_device = dst_device
 
+        # Extract device index from self.dst_device (e.g. "cuda:2" -> 2)
+        device_id = (
+            int(dst_device.split(":")[1])
+            if ":" in dst_device
+            else torch.cuda.current_device()
+        )
+
         assert config.gds_path is not None, "Need to specify gds_path for GdsBackend"
-        self.gds_path = config.gds_path
-        self.fstype = get_fstype(config.gds_path)
+
+        # Multi-path support: parse comma-separated paths and select one
+        # based on GPU device ID (by_gpu sharding, like NIXL PR #2418).
+        self.gds_paths = [p.strip() for p in config.gds_path.split(",") if p.strip()]
+        assert len(self.gds_paths) > 0, "gds_path cannot be empty"
+
+        # TODO: next patch we can add additional sharding strategies
+        self.gds_path = self.gds_paths[device_id % len(self.gds_paths)]
+        self.fstype = get_fstype(self.gds_path)
 
         # Log the fstype - this is useful in reports and varying optimizations
         # based on the kind of fstype used.
         logger.info(
             f"GDS backend using fstype '{self.fstype}' on path '{self.gds_path}'"
+            f" (device {device_id}, {len(self.gds_paths)} path(s) configured)"
         )
 
         # Initialize use_cufile and use_hipfile before creating the memory allocator
@@ -297,8 +312,8 @@ class GdsBackend(AllocatorBackendInterface):
             if use_direct_io is not None:
                 self.use_direct_io = use_direct_io
 
-        if not os.path.exists(self.gds_path):
-            os.makedirs(self.gds_path, exist_ok=True)
+        for p in self.gds_paths:
+            os.makedirs(p, exist_ok=True)
 
         self.stats = None  # TODO: plug into LMCache Statistics
 
@@ -331,20 +346,21 @@ class GdsBackend(AllocatorBackendInterface):
         # whether we can serialize meta-data in groups for faster loading.
         tasks = []
         start = time.perf_counter()
-        with os.scandir(self.gds_path) as it:
-            for entry in it:
-                if not entry.is_dir():
-                    continue
-                l1_dir = os.path.basename(entry.name)
-                if len(l1_dir) != 2:
-                    continue
-                tasks.append(
-                    asyncio.to_thread(
-                        self._scan_metadata_subdir,
-                        os.path.join(self.gds_path, l1_dir),
-                        l1_dir,
+        for p in self.gds_paths:
+            with os.scandir(p) as it:
+                for entry in it:
+                    if not entry.is_dir():
+                        continue
+                    l1_dir = os.path.basename(entry.name)
+                    if len(l1_dir) != 2:
+                        continue
+                    tasks.append(
+                        asyncio.to_thread(
+                            self._scan_metadata_subdir,
+                            os.path.join(p, l1_dir),
+                            l1_dir,
+                        )
                     )
-                )
         # TODO: If Python 3.11+, can we use TaskGroup instead?
         await asyncio.gather(*tasks)
         end = time.perf_counter()
@@ -461,49 +477,53 @@ class GdsBackend(AllocatorBackendInterface):
         return False
 
     def _try_to_read_metadata(self, key: CacheEngineKey) -> Optional[DiskCacheMetadata]:
-        path, subdir_key, _, _ = self._key_to_path(key)
-        path += _METADATA_FILE_SUFFIX
-        if os.path.exists(path):
-            try:
-                return self._read_metadata(key, path, subdir_key)
-            except FileNotFoundError:
-                logger.warning(
-                    f"[GDS] File not found for key {key.to_string()} at expected path "
-                    f"{path}, returning None"
-                )
-            except PermissionError:
-                logger.warning(
-                    f"[GDS]: Permission Denied for PID {os.getpid()} on {path},"
-                    f" returning None"
-                )
-            except UnsupportedMetadataVersion:
-                logger.error(f"Unsupported metadata version for {path}, ignoring")
-            except (OSError, IOError) as e:
-                logger.error(
-                    f"Failed to read metadata file {path}: {type(e).__name__}: {e}. "
-                    f"File may be corrupted or inaccessible. "
-                    f"Ignoring cache entry for key {key.to_string()}."
-                )
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error reading metadata file {path}: "
-                    f"{type(e).__name__}: {e}. Ignoring cache entry for key "
-                    f"{key.to_string()}."
-                )
+        for p in self.gds_paths:
+            path, subdir_key, _, _ = self._key_to_path(key, base_path=p)
+            path += _METADATA_FILE_SUFFIX
+            if os.path.exists(path):
+                try:
+                    return self._read_metadata(key, path, subdir_key)
+                except FileNotFoundError:
+                    logger.warning(
+                        f"[GDS] File not found for key {key.to_string()} "
+                        f"at expected path {path}, returning None"
+                    )
+                except PermissionError:
+                    logger.warning(
+                        f"[GDS]: Permission Denied for PID {os.getpid()} on {path},"
+                        f" returning None"
+                    )
+                except UnsupportedMetadataVersion:
+                    logger.error(f"Unsupported metadata version for {path}, ignoring")
+                except (OSError, IOError) as e:
+                    logger.error(
+                        f"Failed to read metadata file {path}: {type(e).__name__}: "
+                        f"{e}. File may be corrupted or inaccessible. "
+                        f"Ignoring cache entry for key {key.to_string()}."
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Unexpected error reading metadata file {path}: "
+                        f"{type(e).__name__}: {e}. Ignoring cache entry for key "
+                        f"{key.to_string()}."
+                    )
 
         return None
 
     def _key_to_path(
         self,
         key: CacheEngineKey,
+        base_path: Optional[str] = None,
     ) -> Tuple[str, str, str, str]:
         hash = str(key.chunk_hash)
         l1_dir = hash[:2]
         l2_dir = hash[2:4]
         key_str = key.to_string()
+        if base_path is None:
+            base_path = self.gds_path
         return (
             os.path.join(
-                self.gds_path,
+                base_path,
                 l1_dir,
                 l2_dir,
                 urllib.parse.quote(key_str, safe="") + self.data_suffix,

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -7,6 +7,8 @@ import shutil
 import sys
 import tempfile
 import threading
+import time
+import urllib.parse
 
 # Third Party
 import pytest
@@ -15,9 +17,10 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.gds_backend import (
+    _DATA_FILE_SUFFIX,
     _METADATA_FILE_SUFFIX,
     _METADATA_VERSION,
     GdsBackend,
@@ -473,3 +476,282 @@ class TestGdsBackend:
                     metadata=metadata,
                     dst_device="cuda:0",
                 )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Requires CUDA for TestGdsMultiPath",
+)
+@pytest.mark.skipif(sys.platform != "linux", reason="Runs only on Linux")
+class TestGdsMultiPath:
+    """Tests for multi-path GDS backend support.
+
+    Verifies comma-separated gds_path parsing, GPU-to-NVMe affinity
+    (by_gpu sharding), directory creation for all paths, and backward
+    compatibility with single-path configs.
+    """
+
+    @staticmethod
+    def _make_backend(gds_path: str, dst_device: str, async_loop):
+        """Create a GdsBackend with mocked allocator and fstype.
+
+        Mocks are used so the tests run without cuFile / real NVMe.
+        """
+
+        class DummyAllocator:
+            def __init__(self):
+                self.base_pointer = 0
+
+            def close(self):
+                pass
+
+        config = create_test_config(gds_path)
+        metadata = create_test_metadata()
+        with (
+            mock.patch(
+                "lmcache.v1.storage_backend.gds_backend.get_fstype",
+                return_value="tmpfs",
+            ),
+            mock.patch.object(
+                GdsBackend,
+                "initialize_allocator",
+                return_value=DummyAllocator(),
+            ),
+            mock.patch(
+                "lmcache.v1.storage_backend.gds_backend.ctypes.CDLL",
+                return_value=mock.MagicMock(),
+            ),
+        ):
+            backend = GdsBackend(
+                config=config,
+                loop=async_loop,
+                metadata=metadata,
+                dst_device=dst_device,
+            )
+        return backend
+
+    def test_single_path_backward_compat(self, temp_gds_path, async_loop):
+        """A single gds_path (no commas) behaves like before."""
+        backend = self._make_backend(temp_gds_path, "cuda:0", async_loop)
+        try:
+            assert backend.gds_paths == [temp_gds_path]
+            assert backend.gds_path == temp_gds_path
+        finally:
+            backend.close()
+
+    def test_multi_path_parsing(self, async_loop):
+        """Comma-separated paths are split into gds_paths list."""
+        paths = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            gds_path = ",".join(paths)
+            backend = self._make_backend(gds_path, "cuda:0", async_loop)
+            try:
+                assert backend.gds_paths == paths
+                assert len(backend.gds_paths) == 3
+            finally:
+                backend.close()
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)
+
+    def test_multi_path_parsing_with_spaces(self, async_loop):
+        """Spaces around commas are stripped."""
+        paths = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            gds_path = f"  {paths[0]}  ,  {paths[1]}  "
+            backend = self._make_backend(gds_path, "cuda:0", async_loop)
+            try:
+                assert backend.gds_paths == paths
+            finally:
+                backend.close()
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)
+
+    def test_gpu_affinity_selects_path(self, async_loop):
+        """Different cuda devices select different paths via modulo."""
+        paths = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            gds_path = ",".join(paths)
+            for device_id in range(8):
+                dst = f"cuda:{device_id}"
+                backend = self._make_backend(gds_path, dst, async_loop)
+                try:
+                    expected = paths[device_id % 4]
+                    assert backend.gds_path == expected, (
+                        f"cuda:{device_id} should map to {expected}, "
+                        f"got {backend.gds_path}"
+                    )
+                finally:
+                    backend.close()
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)
+
+    def test_all_directories_created(self, async_loop):
+        """All paths in gds_paths get their directories created."""
+        base = tempfile.mkdtemp()
+        try:
+            paths = [os.path.join(base, f"nvme{i}") for i in range(3)]
+            gds_path = ",".join(paths)
+            backend = self._make_backend(gds_path, "cuda:0", async_loop)
+            try:
+                for p in paths:
+                    assert os.path.isdir(p), f"{p} should exist"
+            finally:
+                backend.close()
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+
+    def test_key_to_path_uses_selected_path(self, async_loop):
+        """_key_to_path builds file paths under the selected gds_path."""
+        paths = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            gds_path = ",".join(paths)
+            backend = self._make_backend(gds_path, "cuda:0", async_loop)
+            try:
+                key = create_test_key(0)
+                file_path, _, _, _ = backend._key_to_path(key)
+                assert file_path.startswith(backend.gds_path)
+            finally:
+                backend.close()
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)
+
+    def test_deterministic_path_selection(self, async_loop):
+        """Same device always selects the same path."""
+        paths = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            gds_path = ",".join(paths)
+            selected = set()
+            for _ in range(5):
+                backend = self._make_backend(gds_path, "cuda:1", async_loop)
+                try:
+                    selected.add(backend.gds_path)
+                finally:
+                    backend.close()
+            assert len(selected) == 1, "Path selection should be deterministic"
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)
+
+    def test_scan_discovers_entries_across_all_paths(self, async_loop):
+        """Startup scan finds metadata written under a non-affinity path.
+
+        cuda:0 has affinity to paths[0], but a metadata file is placed
+        under paths[1].  The scan should still discover it because
+        ``_scan_metadata`` iterates all ``gds_paths``.
+        """
+        paths = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            # chunk_hash must have >=4 decimal digits so l1/l2 dirs
+            # are each 2 chars (the scanner filters on len == 2).
+            key = CacheEngineKey(
+                model_name="testmodel",
+                world_size=3,
+                worker_id=1,
+                chunk_hash=1234,
+                dtype=torch.bfloat16,
+            )
+            hash_str = str(key.chunk_hash)
+            l1_dir = hash_str[:2]
+            l2_dir = hash_str[2:4]
+            key_str = urllib.parse.quote(key.to_string(), safe="")
+
+            # Build directory structure under paths[1] (non-affinity path)
+            subdir = os.path.join(paths[1], l1_dir, l2_dir)
+            os.makedirs(subdir, exist_ok=True)
+
+            # Write a valid metadata file
+            dummy_tensor = torch.zeros(2, 256, 8, 128, dtype=torch.bfloat16)
+            metadata_bytes = pack_metadata(
+                dummy_tensor,
+                fmt=MemoryFormat.KV_2LTD,
+                lmcache_version="1",
+            )
+            meta_path = os.path.join(
+                subdir,
+                key_str + _DATA_FILE_SUFFIX + _METADATA_FILE_SUFFIX,
+            )
+            with open(meta_path, "wb") as f:
+                f.write(metadata_bytes)
+
+            # Create backend — cuda:0 affinity selects paths[0]
+            gds_path = ",".join(paths)
+            backend = self._make_backend(gds_path, "cuda:0", async_loop)
+            try:
+                assert backend.gds_path == paths[0]
+
+                # Wait for the async _scan_metadata to finish
+                time.sleep(1)
+
+                # contains() would NOT find this via _try_to_read_metadata
+                # (which only checks the affinity path).  If it returns
+                # True, the cross-path scan populated hot_cache.
+                assert backend.contains(key), (
+                    "Scan should discover metadata across all gds_paths"
+                )
+            finally:
+                backend.close()
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)
+
+    def test_try_to_read_metadata_finds_across_all_paths(self, async_loop):
+        """contains() fallback finds metadata on a non-affinity path.
+
+        After clearing hot_cache (so the startup scan results are gone),
+        ``contains()`` falls back to ``_try_to_read_metadata`` which
+        should search all ``gds_paths``, not just the affinity path.
+        """
+        paths = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            key = CacheEngineKey(
+                model_name="testmodel",
+                world_size=3,
+                worker_id=1,
+                chunk_hash=1234,
+                dtype=torch.bfloat16,
+            )
+            hash_str = str(key.chunk_hash)
+            l1_dir = hash_str[:2]
+            l2_dir = hash_str[2:4]
+            key_str = urllib.parse.quote(key.to_string(), safe="")
+
+            # Place metadata under paths[1] (non-affinity path)
+            subdir = os.path.join(paths[1], l1_dir, l2_dir)
+            os.makedirs(subdir, exist_ok=True)
+
+            dummy_tensor = torch.zeros(2, 256, 8, 128, dtype=torch.bfloat16)
+            metadata_bytes = pack_metadata(
+                dummy_tensor,
+                fmt=MemoryFormat.KV_2LTD,
+                lmcache_version="1",
+            )
+            meta_path = os.path.join(
+                subdir,
+                key_str + _DATA_FILE_SUFFIX + _METADATA_FILE_SUFFIX,
+            )
+            with open(meta_path, "wb") as f:
+                f.write(metadata_bytes)
+
+            gds_path = ",".join(paths)
+            backend = self._make_backend(gds_path, "cuda:0", async_loop)
+            try:
+                assert backend.gds_path == paths[0]
+
+                # Wait for async scan, then clear its results
+                time.sleep(1)
+                with backend.hot_lock:
+                    backend.hot_cache.clear()
+
+                # contains() now relies solely on _try_to_read_metadata
+                assert backend.contains(key), (
+                    "_try_to_read_metadata should search all gds_paths"
+                )
+            finally:
+                backend.close()
+        finally:
+            for p in paths:
+                shutil.rmtree(p, ignore_errors=True)


### PR DESCRIPTION
Parse comma-separated gds_path and select path per GPU worker using by_gpu sharding (device_id % num_paths), matching the approach in NIXL PR #2418. This distributes KV cache I/O across multiple NVMe drives to increase aggregate bandwidth.

Single-path configs work unchanged.

Includes tests (TestGdsMultiPath) and documentation updates.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
