### PR TITLE
[CI]: add full tag selectively

### DIFF
--- a/.github/workflows/automerge-labeler.yml
+++ b/.github/workflows/automerge-labeler.yml
@@ -11,7 +11,37 @@ jobs:
   add_remove_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: ubuntudroid/automerge-labeler@v1
+      - name: Check changed files
+        if: github.event.action == 'auto_merge_enabled'
+        id: changed-files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            // Patterns that are considered docs-or-CI-only (skip full label)
+            const docsOrCiPattern = /^(docs\/|\.github\/|\.buildkite\/(?!k3_tests\/))|.*\.md$/;
+
+            const hasCodeChanges = files.some(f => !docsOrCiPattern.test(f.filename));
+            core.setOutput('has_code_changes', hasCodeChanges.toString());
+
+      - name: Add full label
+        if: >-
+          github.event.action == 'auto_merge_enabled'
+          && steps.changed-files.outputs.has_code_changes == 'true'
+        uses: ubuntudroid/automerge-labeler@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          label: 'full'
+
+      - name: Remove full label
+        if: github.event.action == 'auto_merge_disabled'
+        uses: ubuntudroid/automerge-labeler@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           label: 'full'


### PR DESCRIPTION
Full tag triggers comprehensive and multiprocess tests which we don't always want to run on more non-critical PRs merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI labeling logic that controls when comprehensive test suites run; a bad filename pattern match could unintentionally skip or trigger the `full` test path. Uses `pull_request_target` with `github-script`, so correctness of the script/permissions matters for CI behavior.
> 
> **Overview**
> Updates the auto-merge labeling workflow to **only add the `full` label when auto-merge is enabled and the PR includes non-docs/CI changes**.
> 
> This adds a `github-script` step that lists PR files and skips labeling when changes are limited to `docs/`, `.github/`, most `.buildkite/` paths (excluding `k3_tests/`), or `*.md`. The `full` label is still removed when auto-merge is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42cba24b5d514abdcbfb1ecd2278ed3c4c95280f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->