### PR TITLE
[CLI]: `lmcache server` command

### DIFF
--- a/docs/design/cli/server-command.md
+++ b/docs/design/cli/server-command.md
@@ -1,0 +1,171 @@
+# `lmcache server` CLI Command
+
+**Status:** Proposal  |  **Date:** 2026-03-19
+
+## Goal
+
+Add `lmcache server` as a CLI subcommand that replaces the standalone
+`lmcache_server` and `python3 -m lmcache.v1.multiprocess.http_server` entry
+points. Users get one unified command to start the LMCache cache server.
+
+## Current State
+
+Today there are three separate entry points in `pyproject.toml`:
+
+| Entry point | Module | Protocol |
+|---|---|---|
+| `lmcache_v0_server` | `lmcache.server.__main__:main` | Raw TCP (legacy v0) |
+| `lmcache_server` | `lmcache.v1.server.__main__:main` | Raw TCP (v1) |
+| *(none — module path)* | `lmcache.v1.multiprocess.http_server` | ZMQ + HTTP |
+
+The multiprocess HTTP server is the primary production entry point but requires
+`python3 -m lmcache.v1.multiprocess.http_server ...` to launch.
+
+## Design
+
+### Usage
+
+```bash
+# Full HTTP + ZMQ server (default)
+lmcache server \
+    --engine-type blend --host 0.0.0.0 --port 5555 \
+    --l1-size-gb 60 --eviction-policy LRU
+
+# ZMQ-only (no HTTP frontend)
+lmcache server \
+    --no-http \
+    --host 0.0.0.0 --port 5555 \
+    --l1-size-gb 60 --eviction-policy LRU
+```
+
+### Command Behavior
+
+`lmcache server` wraps the existing `lmcache.v1.multiprocess.http_server`
+startup flow:
+
+1. Parse arguments (reusing existing `add_*_args()` helpers)
+2. Convert to config objects (`MPServerConfig`, `HTTPFrontendConfig`,
+   `StorageManagerConfig`, `PrometheusConfig`, `TelemetryConfig`)
+3. Call `run_http_server()` (or `run_cache_server()` if `--no-http`)
+4. Run in foreground; Ctrl-C to stop
+
+The command is a **thin wrapper** — it delegates entirely to the existing
+multiprocess server machinery. No server logic is duplicated.
+
+### Arguments
+
+Arguments are added by calling the existing helper functions directly on the
+subcommand's parser:
+
+| Helper | Arguments added |
+|---|---|
+| `add_mp_server_args(parser)` | `--host`, `--port`, `--chunk-size`, `--max-workers`, `--hash-algorithm`, `--engine-type` |
+| `add_storage_manager_args(parser)` | `--l1-size-gb`, `--l1-use-lazy`, `--l1-init-size-gb`, `--l1-align-bytes`, `--l1-write-ttl-seconds`, `--l1-read-ttl-seconds`, `--eviction-policy`, `--eviction-trigger-watermark`, `--eviction-ratio`, `--l2-store-policy`, `--l2-prefetch-policy`, L2 adapter args |
+| `add_http_frontend_args(parser)` | `--http-host`, `--http-port` |
+| `add_prometheus_args(parser)` | `--disable-prometheus`, `--prometheus-port`, `--prometheus-log-interval` |
+| `add_telemetry_args(parser)` | `--enable-telemetry`, `--telemetry-max-queue-size`, `--telemetry-processor` |
+
+One new argument is added by the command itself:
+
+- `--no-http` (flag, default: False) — Disable the HTTP frontend and run
+  ZMQ-only via `run_cache_server()` instead of `run_http_server()`.
+
+### Implementation
+
+#### File: `lmcache/cli/commands/server.py`
+
+```python
+class ServerCommand(BaseCommand):
+    def name(self) -> str:
+        return "server"
+
+    def help(self) -> str:
+        return "Start the LMCache cache server."
+
+    def add_arguments(self, parser):
+        add_mp_server_args(parser)
+        add_storage_manager_args(parser)
+        add_http_frontend_args(parser)
+        add_prometheus_args(parser)
+        add_telemetry_args(parser)
+        parser.add_argument(
+            "--no-http", action="store_true", default=False,
+            help="Disable HTTP frontend (ZMQ-only mode).",
+        )
+
+    def execute(self, args):
+        mp_config = parse_args_to_mp_server_config(args)
+        storage_config = parse_args_to_config(args)
+        prometheus_config = parse_args_to_prometheus_config(args)
+        telemetry_config = parse_args_to_telemetry_config(args)
+
+        if args.no_http:
+            run_cache_server(mp_config, storage_config,
+                             prometheus_config, telemetry_config)
+        else:
+            http_config = parse_args_to_http_frontend_config(args)
+            run_http_server(http_config, mp_config, storage_config,
+                            prometheus_config, telemetry_config)
+```
+
+#### Registration
+
+In `lmcache/cli/commands/__init__.py`:
+
+```python
+from lmcache.cli.commands.server import ServerCommand
+
+ALL_COMMANDS: list[BaseCommand] = [
+    MockCommand(),
+    ServerCommand(),
+]
+```
+
+### BaseCommand Considerations
+
+The `server` command is a long-running process, not a query-and-report
+command. It does **not** use the metrics system (`create_metrics` / `emit`).
+This is fine — `BaseCommand.execute()` has no requirement to use metrics.
+
+The `--format` and `--output` flags added automatically by
+`BaseCommand.register()` are harmless but unused. If this becomes confusing
+for users, we can override `register()` in `ServerCommand` to skip calling
+`_add_output_args()`. This is a minor polish item, not blocking.
+
+### Signal Handling
+
+The existing `run_http_server()` / `run_cache_server()` functions already
+handle graceful shutdown on SIGINT/SIGTERM. The CLI dispatcher in `main.py`
+also catches `KeyboardInterrupt` and exits with code 130. No additional
+signal handling is needed.
+
+### Deprecation of Old Entry Points
+
+Per the [commands.md](commands.md) design doc, `lmcache_server` is kept as
+a deprecated alias for 2 minor releases. We add a deprecation warning to
+its `main()`:
+
+```python
+import warnings
+warnings.warn(
+    "lmcache_server is deprecated. Use 'lmcache server' instead.",
+    DeprecationWarning, stacklevel=2,
+)
+```
+
+The `lmcache_v0_server` entry point is legacy (v0 protocol) and out of
+scope for this change.
+
+## Testing
+
+- **Unit test:** Verify `ServerCommand` registers correctly and parses all
+  expected arguments (mock `run_http_server` / `run_cache_server`).
+- **Integration test:** Start `lmcache server` in a subprocess, verify the
+  ZMQ and HTTP ports become reachable, send Ctrl-C and verify clean exit.
+- **`--no-http` test:** Start with `--no-http`, verify only ZMQ port is open.
+
+## Non-Goals
+
+- No changes to the server internals (ZMQ, HTTP, cache engine).
+- No configuration file support in this phase (future work).
+- No documentation changes yet (per user request).

--- a/docs/source/developer_guide/cli.rst
+++ b/docs/source/developer_guide/cli.rst
@@ -35,7 +35,8 @@ File Layout
    └── commands/
        ├── __init__.py      # ALL_COMMANDS registry
        ├── base.py          # BaseCommand ABC
-       └── mock.py          # Example command
+       ├── mock.py          # Example command
+       └── server.py        # lmcache server
 
 
 Step-by-Step: Adding a New Command

--- a/docs/source/getting_started/cli.rst
+++ b/docs/source/getting_started/cli.rst
@@ -18,6 +18,9 @@ After installing LMCache, the ``lmcache`` command is available:
    # Show available commands
    lmcache -h
 
+   # Start the LMCache server
+   lmcache server --l1-size-gb 60 --eviction-policy LRU
+
    # Run the example mock command
    lmcache mock --name my-run --num-items 5
 
@@ -37,9 +40,81 @@ Available Commands
 
    * - Command
      - Description
+   * - ``server``
+     - Start the LMCache cache server (ZMQ + HTTP). See :ref:`cli-server`
+       below for details.
    * - ``mock``
      - Example command that outputs fake metrics. Useful for testing the CLI
        framework and as a reference for new commands.
+
+
+.. _cli-server:
+
+``lmcache server``
+------------------
+
+Start the LMCache cache server. This replaces the standalone
+``lmcache_server`` and ``python3 -m lmcache.v1.multiprocess.http_server``
+entry points.
+
+By default the server starts both the ZMQ backend and an HTTP frontend.
+Use ``--no-http`` for ZMQ-only mode.
+
+.. code-block:: bash
+
+   # HTTP + ZMQ (default)
+   lmcache server \
+       --engine-type blend --host 0.0.0.0 --port 5555 \
+       --l1-size-gb 60 --eviction-policy LRU
+
+   # ZMQ-only (no HTTP frontend)
+   lmcache server --no-http \
+       --host 0.0.0.0 --port 5555 \
+       --l1-size-gb 60 --eviction-policy LRU
+
+Server Arguments
+~~~~~~~~~~~~~~~~
+
+The server command accepts arguments from several groups:
+
+**Core server (ZMQ)**
+
+- ``--host`` — ZMQ server host (default: ``localhost``)
+- ``--port`` — ZMQ server port (default: ``5555``)
+- ``--chunk-size`` — Chunk size for KV cache operations (default: ``256``)
+- ``--max-workers`` — Maximum worker threads (default: ``1``)
+- ``--hash-algorithm`` — Hash algorithm: ``builtin``, ``sha256_cbor``, ``blake3`` (default: ``blake3``)
+- ``--engine-type`` — Cache engine type: ``default``, ``blend`` (default: ``default``)
+
+**HTTP frontend**
+
+- ``--http-host`` — HTTP server host (default: ``0.0.0.0``)
+- ``--http-port`` — HTTP server port (default: ``8000``)
+- ``--no-http`` — Disable the HTTP frontend entirely
+
+**L1 memory**
+
+- ``--l1-size-gb`` — Size of L1 memory in GB (**required**)
+- ``--l1-use-lazy`` — Use lazy allocation (default: ``True``)
+- ``--l1-init-size-gb`` — Initial allocation size in GB when lazy (default: ``20``)
+- ``--l1-align-bytes`` — Alignment in bytes (default: ``4096``)
+
+**Eviction**
+
+- ``--eviction-policy`` — Eviction policy: ``LRU``, ``noop`` (**required**)
+- ``--eviction-trigger-watermark`` — Memory usage fraction to trigger eviction (default: ``0.8``)
+- ``--eviction-ratio`` — Fraction of memory to evict (default: ``0.2``)
+
+**Observability**
+
+- ``--disable-prometheus`` — Disable Prometheus metrics
+- ``--prometheus-port`` — Prometheus metrics port (default: ``9090``)
+- ``--enable-telemetry`` — Enable the telemetry event system
+
+.. note::
+
+   The standalone ``lmcache_server`` entry point is deprecated.
+   Use ``lmcache server`` instead.
 
 
 Metrics Output

--- a/lmcache/cli/commands/__init__.py
+++ b/lmcache/cli/commands/__init__.py
@@ -10,9 +10,11 @@ To add a new command:
 # First Party
 from lmcache.cli.commands.base import BaseCommand
 from lmcache.cli.commands.mock import MockCommand
+from lmcache.cli.commands.server import ServerCommand
 
 ALL_COMMANDS: list[BaseCommand] = [
     MockCommand(),
+    ServerCommand(),
 ]
 
 __all__ = ["ALL_COMMANDS", "BaseCommand"]

--- a/lmcache/cli/commands/server.py
+++ b/lmcache/cli/commands/server.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache server`` — start the LMCache cache server.
+
+Wraps the existing multiprocess server startup, exposing it as a CLI
+subcommand instead of requiring ``python3 -m lmcache.v1.multiprocess.http_server``.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import BaseCommand
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+class ServerCommand(BaseCommand):
+    """Start the LMCache cache server (ZMQ + optional HTTP frontend)."""
+
+    def name(self) -> str:
+        return "server"
+
+    def help(self) -> str:
+        return "Start the LMCache cache server."
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        # Reuse the existing argument helpers so that every flag accepted
+        # by the standalone entry points is also available here.
+        # First Party
+        from lmcache.v1.distributed.config import add_storage_manager_args
+        from lmcache.v1.mp_observability.config import add_prometheus_args
+        from lmcache.v1.mp_observability.telemetry import add_telemetry_args
+        from lmcache.v1.multiprocess.config import (
+            add_http_frontend_args,
+            add_mp_server_args,
+        )
+
+        add_mp_server_args(parser)
+        add_storage_manager_args(parser)
+        add_http_frontend_args(parser)
+        add_prometheus_args(parser)
+        add_telemetry_args(parser)
+
+        parser.add_argument(
+            "--no-http",
+            action="store_true",
+            default=False,
+            help="Disable the HTTP frontend (ZMQ-only mode).",
+        )
+
+    def register(self, subparsers: argparse._SubParsersAction) -> None:
+        """Register with deferred argument setup.
+
+        The server's ``add_arguments`` imports heavyweight modules
+        (torch, etc.) via the existing ``add_*_args`` helpers.  We
+        catch ``ImportError`` so that ``lmcache -h`` and other
+        subcommands still work in minimal environments where the
+        server dependencies are not installed.
+        """
+        parser = subparsers.add_parser(self.name(), help=self.help())
+        try:
+            self.add_arguments(parser)
+        except ImportError as exc:
+            msg = str(exc)
+            logger.debug("Server dependencies not available: %s", msg)
+            parser.set_defaults(
+                func=lambda _args, _msg=msg: logger.error(
+                    "Cannot start server — missing dependency: %s. "
+                    "Install the full LMCache package to use 'lmcache server'.",
+                    _msg,
+                )
+            )
+            return
+        parser.set_defaults(func=self.execute)
+
+    def execute(self, args: argparse.Namespace) -> None:
+        # First Party
+        from lmcache.v1.distributed.config import parse_args_to_config
+        from lmcache.v1.mp_observability.config import (
+            parse_args_to_prometheus_config,
+        )
+        from lmcache.v1.mp_observability.telemetry import (
+            parse_args_to_telemetry_config,
+        )
+        from lmcache.v1.multiprocess.config import (
+            parse_args_to_http_frontend_config,
+            parse_args_to_mp_server_config,
+        )
+
+        mp_config = parse_args_to_mp_server_config(args)
+        storage_config = parse_args_to_config(args)
+        prometheus_config = parse_args_to_prometheus_config(args)
+        telemetry_config = parse_args_to_telemetry_config(args)
+
+        if args.no_http:
+            # First Party
+            from lmcache.v1.multiprocess.server import run_cache_server
+
+            logger.info(
+                "Starting LMCache server (ZMQ-only) at "
+                f"{mp_config.host}:{mp_config.port}"
+            )
+            run_cache_server(
+                mp_config,
+                storage_config,
+                prometheus_config,
+                telemetry_config,
+            )
+        else:
+            # First Party
+            from lmcache.v1.multiprocess.http_server import run_http_server
+
+            http_config = parse_args_to_http_frontend_config(args)
+            logger.info(
+                "Starting LMCache server at "
+                f"{mp_config.host}:{mp_config.port} "
+                f"(HTTP at {http_config.http_host}:{http_config.http_port})"
+            )
+            run_http_server(
+                http_config,
+                mp_config,
+                storage_config,
+                prometheus_config,
+                telemetry_config,
+            )

--- a/lmcache/v1/server/__main__.py
+++ b/lmcache/v1/server/__main__.py
@@ -150,6 +150,13 @@ class LMCacheServer:
 def main():
     # Standard
     import sys
+    import warnings
+
+    warnings.warn(
+        "lmcache_server is deprecated. Use 'lmcache server' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if len(sys.argv) not in [3, 4]:
         logger.error(f"Usage: {sys.argv[0]} <host> <port> <storage>(default:cpu)")


### PR DESCRIPTION
WIP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new long-running CLI entry point that wires into the existing multiprocess server startup; while it doesn’t change server internals, it affects how users launch production servers and adds import-time dependency handling.
> 
> **Overview**
> Adds a new `lmcache server` CLI subcommand that starts the existing multiprocess cache server, with a `--no-http` mode to run ZMQ-only via `run_cache_server` instead of `run_http_server`.
> 
> Registers the new command in the CLI command registry and updates CLI docs to include usage and argument reference. The legacy `lmcache_server` entry point now emits a `DeprecationWarning` directing users to `lmcache server`, and the new command’s `register()` defers heavy imports so `lmcache -h` still works without full server dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 972f676278e429a2db29aca12774eb82638d1f14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->