### PR TITLE
Fix crash in disk backend read_file on FileNotFoundError

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -536,13 +536,20 @@ class LocalDiskBackend(StorageBackendInterface):
     ) -> list[MemoryObj]:
         """
         Async load bytearray from disk.
+
+        Returns only the successfully loaded MemoryObj instances.
+        If a file is missing on disk, the corresponding MemoryObj is
+        unpinned and freed, and excluded from the returned list.
         """
 
         logger.debug("Executing `async_load_bytes` from disk.")
-        # TODO (Jiayi): handle the case where loading fails.
+        loaded_objs: list[MemoryObj] = []
         for path, key, mem_obj in zip(paths, keys, memory_objs, strict=False):
             buffer = mem_obj.byte_array
-            self.read_file(key, buffer, path)
+            if not self.read_file(key, buffer, path):
+                mem_obj.unpin()
+                mem_obj.ref_count_down()
+                continue
 
             # TODO(Jiayi): Please recover the metadata in a more
             # elegant way in the future.
@@ -553,7 +560,9 @@ class LocalDiskBackend(StorageBackendInterface):
             self.dict[key].unpin()
             self.disk_lock.release()
 
-        return memory_objs
+            loaded_objs.append(mem_obj)
+
+        return loaded_objs
 
     def load_bytes_from_disk(
         self,
@@ -565,13 +574,17 @@ class LocalDiskBackend(StorageBackendInterface):
     ) -> Optional[MemoryObj]:
         """
         Load bytearray from disk.
+
+        Returns None if the file is missing on disk.
         """
 
         memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
         assert memory_obj is not None, "Memory allocation failed during disk load."
 
         buffer = memory_obj.byte_array
-        self.read_file(key, buffer, path)
+        if not self.read_file(key, buffer, path):
+            memory_obj.ref_count_down()
+            return None
 
         # TODO(Jiayi): Please recover the metadata in a more
         # elegant way in the future.
@@ -596,7 +609,12 @@ class LocalDiskBackend(StorageBackendInterface):
             f"Bandwidth: {size / disk_write_time / 1e6:.2f} MB/s"
         )
 
-    def read_file(self, key, buffer, path):
+    def read_file(self, key, buffer, path) -> bool:
+        """Read file contents into buffer.
+
+        Returns True on success, False if the file was not found
+        (in which case the key is removed from self.dict).
+        """
         start_time = time.time()
         size = len(buffer)
         fblock_aligned = size % self.os_disk_bs == 0
@@ -616,15 +634,16 @@ class LocalDiskBackend(StorageBackendInterface):
                     fdo.readinto(buffer)
         except FileNotFoundError:
             logger.warning(f"File not found on disk: {path}")
-            if self.dict.get(key, None):
-                self.dict.pop(key)
-            return
+            with self.disk_lock:
+                self.dict.pop(key, None)
+            return False
 
         disk_read_time = time.time() - start_time
         logger.debug(
             f"Disk read size: {size} bytes, "
             f"Bandwidth: {size / disk_read_time / 1e6:.2f} MB/s"
         )
+        return True
 
     def get_allocator_backend(self):
         return self.local_cpu_backend

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -187,3 +187,52 @@ class TestLocalDiskBackend:
         assert result is None
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_read_file_missing_file_no_crash(self, local_disk_backend):
+        """Test that read_file handles FileNotFoundError gracefully.
+
+        Regression test: previously, read_file would pop the key from
+        self.dict on FileNotFoundError, and callers would then crash
+        with a KeyError when accessing self.dict[key].
+        """
+        from lmcache.v1.memory_management import MemoryFormat
+
+        key = create_test_key(99)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        dtype = torch.bfloat16
+        fmt = MemoryFormat.KV_2LTD
+
+        # Register the key in the dict so it looks like a valid cache entry
+        local_disk_backend.insert_key(key, 1024, shape, dtype, fmt)
+        assert local_disk_backend.contains(key)
+
+        # The file doesn't exist on disk — read_file should return False
+        path = local_disk_backend._key_to_path(key)
+        buffer = bytearray(1024)
+        result = local_disk_backend.read_file(key, buffer, path)
+
+        assert result is False
+        assert not local_disk_backend.contains(key)
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_load_bytes_from_disk_missing_file(self, local_disk_backend):
+        """Test that load_bytes_from_disk returns None for missing files."""
+        from lmcache.v1.memory_management import MemoryFormat
+
+        key = create_test_key(100)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        dtype = torch.bfloat16
+        fmt = MemoryFormat.KV_2LTD
+
+        local_disk_backend.insert_key(key, 1024, shape, dtype, fmt)
+        path = local_disk_backend._key_to_path(key)
+
+        result = local_disk_backend.load_bytes_from_disk(
+            key, path, dtype, shape, fmt
+        )
+
+        assert result is None
+        assert not local_disk_backend.contains(key)
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

When `read_file()` encounters a `FileNotFoundError`, it pops the key from `self.dict` and returns. Both callers (`load_bytes_from_disk` and `batched_async_load_bytes_from_disk`) then access `self.dict[key].cached_positions`, causing a `KeyError` that crashes the vLLM engine.

Fix: `read_file()` now returns a `bool` indicating success. Both callers check the return value and gracefully handle failure (return `None` or skip the failed key, free allocated memory). The `dict.pop()` in the error handler is also protected by `disk_lock` for thread safety.

Fixes the following crash path:
`get_blocking()` → `load_bytes_from_disk()` → `read_file()` → `FileNotFoundError` → `dict.pop(key)` → caller accesses `self.dict[key]` → `KeyError`

**Special notes for your reviewers**:

Changes are limited to `local_disk_backend.py`. Two regression tests added in `test_local_disk_backend.py`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests