### PR TITLE
Fix vLLM DP integration for MLA cache identity and lookup RPC

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -36,6 +36,8 @@ class VLLMWorkerIdentity:
     local_world_size: int
     worker_id: int
     local_worker_id: int
+    rpc_world_size: int
+    rpc_worker_id: int
 
 
 def is_false(value: str) -> bool:
@@ -291,6 +293,8 @@ def resolve_vllm_worker_identity(vllm_config: "VllmConfig") -> VLLMWorkerIdentit
         local_world_size=local_world_size,
         worker_id=worker_id,
         local_worker_id=local_worker_id,
+        rpc_world_size=tp_pp_world_size,
+        rpc_worker_id=tp_pp_rank,
     )
 
 
@@ -345,6 +349,8 @@ def create_lmcache_metadata(
             local_world_size=parallel_cfg.world_size,
             worker_id=parallel_cfg.rank,
             local_worker_id=parallel_cfg.rank,
+            rpc_world_size=parallel_cfg.world_size,
+            rpc_worker_id=parallel_cfg.rank,
         )
 
     # Get KV cache dtype
@@ -385,6 +391,8 @@ def create_lmcache_metadata(
         served_model_name=model_cfg.served_model_name,
         engine_id=engine_id,
         kv_connector_extra_config=kv_connector_extra_config,
+        rpc_world_size=worker_identity.rpc_world_size,
+        rpc_worker_id=worker_identity.rpc_worker_id,
     )
 
     return metadata, config

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Optional, Tuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 import hashlib
 import os
 import string
@@ -25,6 +26,16 @@ ENGINE_NAME = "vllm-instance"
 # Thread-safe singleton storage
 _config_instance: Optional[LMCacheEngineConfig] = None
 _config_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class VLLMWorkerIdentity:
+    """DP-aware LMCache worker identity resolved from a vLLM worker config."""
+
+    world_size: int
+    local_world_size: int
+    worker_id: int
+    local_worker_id: int
 
 
 def is_false(value: str) -> bool:
@@ -146,6 +157,143 @@ def mla_enabled(model_config: "ModelConfig") -> bool:
     )
 
 
+def _get_env_int(name: str) -> Optional[int]:
+    value = os.getenv(name)
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid integer environment variable %s=%s",
+            name,
+            value,
+        )
+        return None
+
+
+def _get_vllm_visible_device_state() -> tuple[Optional[int], Optional[int]]:
+    try:
+        torch_dev, _ = get_vllm_torch_dev()
+    except RuntimeError:
+        return None, None
+
+    try:
+        visible_device_count = torch_dev.device_count()
+    except (AttributeError, RuntimeError):
+        return None, None
+
+    if visible_device_count <= 0:
+        return None, None
+
+    try:
+        current_device = torch_dev.current_device()
+    except (AttributeError, RuntimeError):
+        current_device = None
+
+    return current_device, visible_device_count
+
+
+def _get_vllm_data_parallel_rank(parallel_config: Any) -> int:
+    return getattr(
+        parallel_config,
+        "data_parallel_index",
+        getattr(parallel_config, "data_parallel_rank", 0),
+    )
+
+
+def _get_vllm_data_parallel_rank_local(parallel_config: Any, dp_rank: int) -> int:
+    dp_local_rank = getattr(parallel_config, "data_parallel_rank_local", None)
+    if dp_local_rank is not None and dp_local_rank >= 0:
+        return dp_local_rank
+
+    env_dp_local_rank = _get_env_int("VLLM_DP_RANK_LOCAL")
+    if env_dp_local_rank is not None and env_dp_local_rank >= 0:
+        return env_dp_local_rank
+
+    # Dense-model DP deployments that do not expose a separate local rank are
+    # typically single-node, so the global DP rank still matches the process's
+    # local GPU ordinal. We only reach this fallback when neither vLLM nor the
+    # launcher provided a node-local rank explicitly.
+    return dp_rank
+
+
+def _get_vllm_data_parallel_size(parallel_config: Any) -> int:
+    env_dp_size = _get_env_int("VLLM_DP_SIZE")
+    candidates = [
+        1,
+        # Preserved when vLLM keeps the original DP size in the worker config.
+        getattr(parallel_config, "data_parallel_size", 1),
+        # Dense-model DP workers may rewrite data_parallel_size=1 but keep the
+        # API process count at the original DP width.
+        getattr(parallel_config, "_api_process_count", 1),
+        # data_parallel_index may survive even when size is rewritten, so
+        # rank+1 gives a lower bound on the original DP world size.
+        _get_vllm_data_parallel_rank(parallel_config) + 1,
+    ]
+    if env_dp_size is not None:
+        # External launchers can provide the authoritative DP size explicitly.
+        candidates.append(env_dp_size)
+    return max(candidates)
+
+
+def resolve_vllm_worker_identity(vllm_config: "VllmConfig") -> VLLMWorkerIdentity:
+    """Resolve LMCache worker identity from vLLM in a DP-aware way.
+
+    vLLM rewrites non-MoE DP worker configs to `data_parallel_size=1` and
+    `data_parallel_rank=0`, while preserving `data_parallel_index`,
+    `data_parallel_rank_local`, and the current CUDA/XPU device. LMCache must
+    use those preserved fields to avoid collapsing all DP workers onto rank 0
+    and rebinding the process to the wrong device.
+    """
+
+    parallel_config = vllm_config.parallel_config
+    tp_pp_rank = getattr(parallel_config, "rank", 0)
+    tp_pp_world_size = getattr(parallel_config, "world_size", 1)
+    tp_pp_local_world_size = getattr(
+        parallel_config, "local_world_size", tp_pp_world_size
+    )
+
+    if (
+        getattr(parallel_config, "distributed_executor_backend", None)
+        == "external_launcher"
+    ):
+        worker_id = tp_pp_rank
+        world_size = tp_pp_world_size
+    else:
+        dp_rank = _get_vllm_data_parallel_rank(parallel_config)
+        dp_world_size = _get_vllm_data_parallel_size(parallel_config)
+        worker_id = dp_rank * tp_pp_world_size + tp_pp_rank
+        world_size = dp_world_size * tp_pp_world_size
+
+    current_device, visible_device_count = _get_vllm_visible_device_state()
+    if current_device is not None:
+        local_worker_id = current_device
+        local_world_size = visible_device_count or 1
+    else:
+        dp_rank = _get_vllm_data_parallel_rank(parallel_config)
+        dp_local_rank = _get_vllm_data_parallel_rank_local(parallel_config, dp_rank)
+        local_tp_pp_rank = tp_pp_rank % max(tp_pp_local_world_size, 1)
+        local_worker_id = dp_local_rank * tp_pp_local_world_size + local_tp_pp_rank
+        if visible_device_count is not None:
+            local_world_size = visible_device_count
+        elif getattr(parallel_config, "nnodes", 1) == 1:
+            local_world_size = world_size
+        else:
+            local_world_size = max(
+                getattr(parallel_config, "data_parallel_size_local", 1),
+                1,
+            ) * tp_pp_local_world_size
+
+    return VLLMWorkerIdentity(
+        world_size=world_size,
+        local_world_size=local_world_size,
+        worker_id=worker_id,
+        local_worker_id=local_worker_id,
+    )
+
+
 def create_lmcache_metadata(
     vllm_config=None,
     model_config=None,
@@ -170,7 +318,8 @@ def create_lmcache_metadata(
         tuple: (LMCacheMetadata, LMCacheEngineConfig)
     """
     # Third Party
-    # Try to import from old location before merged https://github.com/vllm-project/vllm/pull/26908
+    # Try to import from the old location before
+    # https://github.com/vllm-project/vllm/pull/26908 landed.
     try:
         # Third Party
         from vllm.utils.torch_utils import get_kv_cache_torch_dtype
@@ -186,10 +335,17 @@ def create_lmcache_metadata(
         model_cfg = vllm_config.model_config
         parallel_cfg = vllm_config.parallel_config
         cache_cfg = vllm_config.cache_config
+        worker_identity = resolve_vllm_worker_identity(vllm_config)
     else:
         model_cfg = model_config
         parallel_cfg = parallel_config
         cache_cfg = cache_config
+        worker_identity = VLLMWorkerIdentity(
+            world_size=parallel_cfg.world_size,
+            local_world_size=parallel_cfg.world_size,
+            worker_id=parallel_cfg.rank,
+            local_worker_id=parallel_cfg.rank,
+        )
 
     # Get KV cache dtype
     kv_dtype = get_kv_cache_torch_dtype(cache_cfg.cache_dtype, model_cfg.dtype)
@@ -218,10 +374,10 @@ def create_lmcache_metadata(
     # Create metadata
     metadata = LMCacheMetadata(
         model_name=model_cfg.model,
-        world_size=parallel_cfg.world_size,
-        local_world_size=parallel_cfg.world_size,
-        worker_id=parallel_cfg.rank,
-        local_worker_id=parallel_cfg.rank,
+        world_size=worker_identity.world_size,
+        local_world_size=worker_identity.local_world_size,
+        worker_id=worker_identity.worker_id,
+        local_worker_id=worker_identity.local_worker_id,
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,
         use_mla=use_mla,
@@ -319,32 +475,11 @@ def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int,
     """
     Calculate the local worker id and local world size.
 
-    Current assumption (TODO: add custom logic in the future):
-    - Tensor Parallel is intra-node
-    - Pipeline Parallel is inter-node
-
     Returns:
         Tuple[int, int]: (local_worker_id, local_world_size)
     """
-    parallel_config = vllm_config.parallel_config
-    global_rank = parallel_config.rank
-    global_world_size = parallel_config.world_size
-    torch_dev, dev_name = get_vllm_torch_dev()
-    num_gpus = torch_dev.device_count()
-    if global_world_size <= num_gpus:
-        # single node case
-        return parallel_config.rank, parallel_config.world_size
-    else:
-        tp_size = parallel_config.tensor_parallel_size
-        pp_size = parallel_config.pipeline_parallel_size
-        local_world_size = global_world_size // pp_size
-        assert local_world_size == tp_size, (
-            "LMCache is operating under the assumption that the "
-            "local world size is equal to the tensor parallel size "
-            "in multi-node deployment."
-        )
-        local_worker_id = global_rank % local_world_size
-        return local_worker_id, local_world_size
+    worker_identity = resolve_vllm_worker_identity(vllm_config)
+    return worker_identity.local_worker_id, worker_identity.local_world_size
 
 
 def validate_mla_config(config: LMCacheEngineConfig, use_mla: bool) -> None:

--- a/lmcache/integration/vllm/vllm_service_factory.py
+++ b/lmcache/integration/vllm/vllm_service_factory.py
@@ -162,14 +162,20 @@ class VllmServiceFactory(BaseServiceFactory):
             self.role == "scheduler"
             and not self.lmcache_config.enable_scheduler_bypass_lookup
         ):
-            # Create PrometheusLogger for scheduler without engine
+            # In kv_both mode, worker and scheduler services share the same
+            # EngineCore process. The worker-side engine already creates the
+            # process-global Prometheus logger, so recreating it for the
+            # scheduler-only path would trip the singleton metadata guard.
             # First Party
             from lmcache.observability import PrometheusLogger
 
-            PrometheusLogger.GetOrCreate(
-                self.metadata,
-                config=self.lmcache_config,
-            )
+            kv_transfer_config = getattr(self.vllm_config, "kv_transfer_config", None)
+            kv_role = getattr(kv_transfer_config, "kv_role", None)
+            if kv_role != "kv_both":
+                PrometheusLogger.GetOrCreate(
+                    self.metadata,
+                    config=self.lmcache_config,
+                )
             return None
 
         # First Party

--- a/lmcache/integration/vllm/vllm_service_factory.py
+++ b/lmcache/integration/vllm/vllm_service_factory.py
@@ -148,6 +148,8 @@ class VllmServiceFactory(BaseServiceFactory):
             chunk_size=self.lmcache_config.chunk_size,
             engine_id=engine_id,
             kv_connector_extra_config=kv_connector_extra_config,
+            rpc_world_size=worker_identity.rpc_world_size,
+            rpc_worker_id=worker_identity.rpc_worker_id,
         )
         return self.metadata
 

--- a/lmcache/integration/vllm/vllm_service_factory.py
+++ b/lmcache/integration/vllm/vllm_service_factory.py
@@ -71,8 +71,8 @@ class VllmServiceFactory(BaseServiceFactory):
         # First Party
         from lmcache.integration.vllm.utils import (
             calculate_draft_layers,
-            calculate_local_rank_and_world_size,
             mla_enabled,
+            resolve_vllm_worker_identity,
             validate_mla_config,
         )
 
@@ -133,21 +133,13 @@ class VllmServiceFactory(BaseServiceFactory):
                     kv_transfer_config, "kv_connector_extra_config", None
                 )
 
-        if self.role == "scheduler":
-            # Avoid GPU probing for scheduler-only metadata path;
-            # scheduler may run on CPU-only control-plane nodes.
-            local_worker_id = parallel_config.rank
-            local_world_size = parallel_config.world_size
-        else:
-            local_worker_id, local_world_size = calculate_local_rank_and_world_size(
-                self.vllm_config
-            )
+        worker_identity = resolve_vllm_worker_identity(self.vllm_config)
         self.metadata = LMCacheMetadata(
             model_name=model_config.model,
-            world_size=parallel_config.world_size,
-            local_world_size=local_world_size,
-            worker_id=parallel_config.rank,
-            local_worker_id=local_worker_id,
+            world_size=worker_identity.world_size,
+            local_world_size=worker_identity.local_world_size,
+            worker_id=worker_identity.worker_id,
+            local_worker_id=worker_identity.local_worker_id,
             kv_dtype=kv_dtype,
             kv_shape=kv_shape,
             use_mla=use_mla,

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -264,6 +264,8 @@ class DiskCacheMetadata:
     cached_positions: Optional[torch.Tensor] = None
     fmt: Optional[MemoryFormat] = None
     pin_count: int = 0
+    shapes: Optional[list[torch.Size]] = None
+    dtypes: Optional[list[torch.dtype]] = None
 
     def pin(self) -> bool:
         self.pin_count += 1

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -108,10 +108,11 @@ class LMCacheEngine:
         self.gpu_connector = gpu_connector
         self.broadcast_fn = broadcast_fn
         self.broadcast_object_fn = broadcast_object_fn
-        # save_only_first_rank only works when use mla
+        # save_only_first_rank only works for multi-rank engine-local MLA groups.
         self.save_only_first_rank = (
             self.config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
             and metadata.use_mla
+            and metadata.has_rpc_peer_workers()
         )
 
         if self.save_only_first_rank and self.gpu_connector is not None:
@@ -288,7 +289,7 @@ class LMCacheEngine:
                 self.lmcache_worker is not None
                 or self.use_layerwise
                 or not self.save_only_first_rank
-                or self.metadata.is_first_rank()
+                or self.metadata.is_rpc_first_rank()
                 or len(lookup_server_worker_ids) == 0
                 or self.metadata.get_rpc_worker_id() in lookup_server_worker_ids
             ):
@@ -1465,7 +1466,7 @@ class LMCacheEngine:
     ) -> int:
         # TODO: need to clear by request_configs
         if self.save_only_first_rank:
-            if self.metadata.is_first_rank():
+            if self.metadata.is_rpc_first_rank():
                 num_removed = self._clear(tokens, locations, request_configs)
                 return num_removed
             else:
@@ -1702,7 +1703,7 @@ class LMCacheEngine:
           * Receives chunk data and populates reordered_chunks
           * Updates ret_mask to mark received positions as True
         """
-        if self.metadata.is_first_rank():
+        if self.metadata.is_rpc_first_rank():
             # Broadcast total chunk count
             chunk_count = len(reordered_chunks)
             self.broadcast_object_fn(chunk_count, self.metadata.first_rank)
@@ -1764,7 +1765,7 @@ class LMCacheEngine:
         A 'passive' CacheEngine means that the node itself will not store/retrieve
         the data directly, but from the "active" worker (i.e., rank 0 in MLA)
         """
-        return self.save_only_first_rank and not self.metadata.is_first_rank()
+        return self.save_only_first_rank and not self.metadata.is_rpc_first_rank()
 
     def _get_slot_mapping_list(
         self,
@@ -1892,12 +1893,13 @@ class LMCacheEngineBuilder:
             return CuFileMemoryAllocator(config.cufile_buffer_size * 1024**2)
 
         max_local_cpu_size = config.max_local_cpu_size
-        # save_only_first_rank only works when use mla
+        # save_only_first_rank only works for multi-rank engine-local MLA groups.
         save_only_first_rank = (
             config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
             and metadata.use_mla
+            and metadata.has_rpc_peer_workers()
         )
-        if save_only_first_rank and metadata.is_first_rank():
+        if save_only_first_rank and metadata.is_rpc_first_rank():
             # Only the first rank will save the cache,
             # so we need to set it lager than other ranks
             first_rank_max_local_cpu_size = (

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -282,7 +282,7 @@ class LMCacheEngine:
         if not self.post_inited:
             logger.info("Post initializing LMCacheEngine")
             lookup_server_worker_ids = self.config.get_lookup_server_worker_ids(
-                self.metadata.use_mla, self.metadata.world_size
+                self.metadata.use_mla, self.metadata.get_rpc_world_size()
             )
             if (
                 self.lmcache_worker is not None
@@ -290,12 +290,15 @@ class LMCacheEngine:
                 or not self.save_only_first_rank
                 or self.metadata.is_first_rank()
                 or len(lookup_server_worker_ids) == 0
-                or self.metadata.worker_id in lookup_server_worker_ids
+                or self.metadata.get_rpc_worker_id() in lookup_server_worker_ids
             ):
                 logger.info(
-                    f"Initialize storage manager on rank {self.metadata.worker_id}, "
-                    f"use layerwise: {self.use_layerwise},"
-                    f"save only first rank: {self.save_only_first_rank}"
+                    "Initialize storage manager on rank %s (rpc rank %s), "
+                    "use layerwise: %s,save only first rank: %s",
+                    self.metadata.worker_id,
+                    self.metadata.get_rpc_worker_id(),
+                    self.use_layerwise,
+                    self.save_only_first_rank,
                 )
                 async_lookup_server = kwargs.get("async_lookup_server", None)
                 self.storage_manager = StorageManager(

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -66,9 +66,12 @@ def CreateGPUConnector(
             VLLMPagedMemLayerwiseGPUConnector,
         )
 
-        local_worker_id = metadata.local_worker_id
         torch_dev, dev_name = get_vllm_torch_dev()
-        torch_dev.set_device(local_worker_id)
+        try:
+            local_worker_id = torch_dev.current_device()
+        except (AttributeError, RuntimeError):
+            local_worker_id = metadata.local_worker_id
+            torch_dev.set_device(local_worker_id)
         device = torch.device(f"{dev_name}:{local_worker_id}")
 
         if config.use_layerwise:

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -4,12 +4,15 @@ import torch
 
 # First Party
 from lmcache.integration.vllm.utils import get_vllm_torch_dev
+from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector.gpu_connectors import GPUConnectorInterface
 from lmcache.v1.gpu_connector.mock_gpu_connector import MockGPUConnector
 from lmcache.v1.gpu_connector.utils import need_gpu_interm_buffer
 from lmcache.v1.metadata import LMCacheMetadata
+
+logger = init_logger(__name__)
 
 
 def CreateGPUConnector(
@@ -85,7 +88,13 @@ def CreateGPUConnector(
                 )
 
         if dev_name == "cuda":
-            if config.use_gpu_connector_v3:
+            if config.use_gpu_connector_v3 or metadata.get_num_groups() > 1:
+                if not config.use_gpu_connector_v3 and metadata.get_num_groups() > 1:
+                    logger.info(
+                        "Detected %d KV layer group(s); using "
+                        "VLLMPagedMemGPUConnectorV3 for grouped KV transfer.",
+                        metadata.get_num_groups(),
+                    )
                 return VLLMPagedMemGPUConnectorV3.from_metadata(
                     metadata, use_gpu, device
                 )

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -73,6 +73,12 @@ def CreateGPUConnector(
         try:
             local_worker_id = torch_dev.current_device()
         except (AttributeError, RuntimeError):
+            logger.warning(
+                "Could not read the current %s device from vLLM; "
+                "falling back to LMCache metadata local_worker_id=%s.",
+                dev_name,
+                metadata.local_worker_id,
+            )
             local_worker_id = metadata.local_worker_id
             torch_dev.set_device(local_worker_id)
         device = torch.device(f"{dev_name}:{local_worker_id}")

--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -119,12 +119,12 @@ class LookupClientFactory:
         )
 
         lookup_server_worker_ids = config.get_lookup_server_worker_ids(
-            metadata.use_mla, metadata.world_size
+            metadata.use_mla, metadata.get_rpc_world_size()
         )
 
         if config.external_lookup_client is None and (
             len(lookup_server_worker_ids) == 0
-            or metadata.worker_id in lookup_server_worker_ids
+            or metadata.get_rpc_worker_id() in lookup_server_worker_ids
         ):
             # First Party
             from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
@@ -209,9 +209,10 @@ class LookupClientFactory:
         )
 
         lookup_ids = config.get_lookup_server_worker_ids(
-            metadata.use_mla, metadata.world_size
+            metadata.use_mla, metadata.get_rpc_world_size()
         )
-        ranks = lookup_ids if len(lookup_ids) > 0 else list(range(metadata.world_size))
+        rpc_world_size = metadata.get_rpc_world_size()
+        ranks = lookup_ids if len(lookup_ids) > 0 else list(range(rpc_world_size))
 
         socket_params = [
             SocketParams(
@@ -244,7 +245,7 @@ class LookupClientFactory:
             metadata.engine_id,
             "lookup",
             rpc_port,
-            metadata.worker_id,
+            metadata.get_rpc_worker_id(),
         )
         return ZmqRouterServerTransport(
             socket_path=socket_path,

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -61,9 +61,9 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         rpc_port = kv_connector_extra_config.get("lmcache_rpc_port", 0)
         engine_id = metadata.engine_id
         assert engine_id is not None, "engine_id is required for RPC communication"
-        self.world_size = metadata.world_size
+        self.world_size = metadata.get_rpc_world_size()
         self.lookup_server_worker_ids = config.get_lookup_server_worker_ids(
-            metadata.use_mla, metadata.world_size
+            metadata.use_mla, metadata.get_rpc_world_size()
         )
 
         self.push_sockets = []
@@ -316,7 +316,10 @@ class LMCacheAsyncLookupServer:
             "engine_id is required for RPC communication"
         )
         worker_socket_path = get_zmq_rpc_path_lmcache(
-            metadata.engine_id, "lookup_worker", rpc_port, metadata.worker_id
+            metadata.engine_id,
+            "lookup_worker",
+            rpc_port,
+            metadata.get_rpc_worker_id(),
         )
         scheduler_socket_path = get_zmq_rpc_path_lmcache(
             metadata.engine_id, "lookup_scheduler", rpc_port, 0

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -177,6 +177,57 @@ class LMCacheManager:
         if self._runtime_plugin_launcher is not None:
             self._runtime_plugin_launcher.launch_plugins()
 
+    def _maybe_refresh_vllm_gpu_connector(self) -> None:
+        """
+        Recreate the vLLM GPU connector when grouped KV metadata requires V3.
+
+        The worker-side connector is created before vLLM registers its live
+        KV caches, so multi-group KV metadata is not available yet. Once
+        `register_kv_caches()` builds the layer groups, refresh the connector
+        so store/load paths use the group-aware V3 implementation.
+        """
+        if self._lmcache_engine is None:
+            return
+
+        if self._config.use_layerwise:
+            return
+
+        metadata = getattr(self._lmcache_engine, "metadata", None)
+        gpu_connector = getattr(self._lmcache_engine, "gpu_connector", None)
+        if metadata is None or gpu_connector is None:
+            return
+        if getattr(metadata, "role", None) != "worker":
+            return
+
+        get_num_groups = getattr(metadata, "get_num_groups", None)
+        if get_num_groups is None:
+            return
+
+        num_groups = get_num_groups()
+        if not isinstance(num_groups, int) or num_groups <= 1:
+            return
+
+        # First Party
+        from lmcache.utils import EngineType
+        from lmcache.v1.gpu_connector import CreateGPUConnector
+        from lmcache.v1.gpu_connector.gpu_connectors import (
+            VLLMPagedMemGPUConnectorV3,
+        )
+
+        if isinstance(gpu_connector, VLLMPagedMemGPUConnectorV3):
+            return
+
+        logger.info(
+            "Detected %d KV layer group(s) after KV cache registration; "
+            "recreating the vLLM GPU connector with V3.",
+            num_groups,
+        )
+        self._lmcache_engine.gpu_connector = CreateGPUConnector(
+            self._config,
+            metadata,
+            EngineType.VLLM,
+        )
+
     def post_init(self) -> None:
         """
         Post-initialization after KV caches are registered.
@@ -204,6 +255,7 @@ class LMCacheManager:
                 assert isinstance(self._lookup_server, LMCacheAsyncLookupServer)
                 async_lookup_server = self._lookup_server
 
+            self._maybe_refresh_vllm_gpu_connector()
             self._lmcache_engine.post_init(async_lookup_server=async_lookup_server)
 
             # Initialize health monitor after engine post_init completes

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -73,6 +73,14 @@ class LMCacheMetadata:
         """Check if the current worker is the first rank"""
         return self.worker_id == self.first_rank
 
+    def has_rpc_peer_workers(self) -> bool:
+        """Check whether the engine-local RPC topology spans multiple workers."""
+        return self.get_rpc_world_size() > 1
+
+    def is_rpc_first_rank(self) -> bool:
+        """Check if the current worker is the first engine-local RPC rank."""
+        return self.get_rpc_worker_id() == self.first_rank
+
     def get_rpc_world_size(self) -> int:
         """Return the engine-local world size used by lookup RPC."""
         return self.world_size if self.rpc_world_size is None else self.rpc_world_size

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -64,10 +64,22 @@ class LMCacheMetadata:
     engine_id: Optional[str] = None
     """ extra config from kv_connector (e.g., lmcache_rpc_port) """
     kv_connector_extra_config: Optional[dict] = None
+    """ engine-local world size for lookup RPC topology """
+    rpc_world_size: Optional[int] = None
+    """ engine-local worker id for lookup RPC topology """
+    rpc_worker_id: Optional[int] = None
 
     def is_first_rank(self) -> bool:
         """Check if the current worker is the first rank"""
         return self.worker_id == self.first_rank
+
+    def get_rpc_world_size(self) -> int:
+        """Return the engine-local world size used by lookup RPC."""
+        return self.world_size if self.rpc_world_size is None else self.rpc_world_size
+
+    def get_rpc_worker_id(self) -> int:
+        """Return the engine-local worker id used by lookup RPC."""
+        return self.worker_id if self.rpc_worker_id is None else self.rpc_worker_id
 
     # TODO(chunxiaozheng): some uts do not `build_kv_layer_groups`
     def get_dtypes(self) -> list[torch.dtype]:

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -310,6 +310,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
             metadata is not None
             and config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
             and metadata.use_mla
+            and metadata.has_rpc_peer_workers()
         )
         if not save_only_first_rank:
             # Do not adjust cpu_size if save_only_first_rank is False for now
@@ -355,9 +356,10 @@ class LocalCPUBackend(AllocatorBackendInterface):
             save_only_first_rank = (
                 config.get_extra_config_value("save_only_first_rank", metadata.use_mla)
                 and metadata.use_mla
+                and metadata.has_rpc_peer_workers()
             )
 
-            if save_only_first_rank and metadata.is_first_rank():
+            if save_only_first_rank and metadata.is_rpc_first_rank():
                 # Only the first rank will save the cache,
                 # so we need to set it larger than other ranks
                 cpu_size = config.get_extra_config_value(

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -283,9 +283,9 @@ class LocalDiskBackend(StorageBackendInterface):
         dtypes: Optional[list[torch.dtype]] = None,
     ) -> None:
         path = self._key_to_path(key)
-        if shape is None and shapes is not None:
+        if shape is None and shapes:
             shape = shapes[0]
-        if dtype is None and dtypes is not None:
+        if dtype is None and dtypes:
             dtype = dtypes[0]
 
         has_stored = False

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -33,6 +33,18 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _get_disk_cache_layout(
+    disk_meta: DiskCacheMetadata,
+) -> tuple[torch.Size | list[torch.Size], torch.dtype | list[torch.dtype]]:
+    """Return the saved tensor layout for disk-backed MemoryObj allocation."""
+    if disk_meta.shapes is not None and disk_meta.dtypes is not None:
+        return disk_meta.shapes, disk_meta.dtypes
+
+    assert disk_meta.shape is not None
+    assert disk_meta.dtype is not None
+    return disk_meta.shape, disk_meta.dtype
+
+
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
 class LocalDiskWorker:
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
@@ -263,12 +275,18 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
         size: int,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shape: Optional[torch.Size],
+        dtype: Optional[torch.dtype],
         fmt: MemoryFormat,
         cached_positions: Optional[torch.Tensor] = None,
+        shapes: Optional[list[torch.Size]] = None,
+        dtypes: Optional[list[torch.dtype]] = None,
     ) -> None:
         path = self._key_to_path(key)
+        if shape is None and shapes is not None:
+            shape = shapes[0]
+        if dtype is None and dtypes is not None:
+            dtype = dtypes[0]
 
         has_stored = False
         with self.disk_lock:
@@ -278,7 +296,15 @@ class LocalDiskBackend(StorageBackendInterface):
                 has_stored = True
             else:
                 self.dict[key] = DiskCacheMetadata(
-                    path, size, shape, dtype, cached_positions, fmt, 0
+                    path=path,
+                    size=size,
+                    shape=shape,
+                    dtype=dtype,
+                    shapes=shapes,
+                    dtypes=dtypes,
+                    cached_positions=cached_positions,
+                    fmt=fmt,
+                    pin_count=0,
                 )
 
         # Push kv admit msg with batching
@@ -303,8 +329,6 @@ class LocalDiskBackend(StorageBackendInterface):
             after the disk write completes. Callback exceptions are caught
             and logged.
         """
-        assert memory_obj.tensor is not None
-
         # skip repeated save
         if self.exists_in_put_tasks(key):
             logger.debug(f"Put task for {key} is already in progress.")
@@ -394,16 +418,11 @@ class LocalDiskBackend(StorageBackendInterface):
 
         disk_meta = self.dict[key]
         path = disk_meta.path
-        dtype = disk_meta.dtype
-        shape = disk_meta.shape
         fmt = disk_meta.fmt
-        assert dtype is not None
-        assert shape is not None
+        shapes, dtypes = _get_disk_cache_layout(disk_meta)
 
         self.disk_lock.release()
-        memory_obj = self.load_bytes_from_disk(
-            key, path, dtype=dtype, shape=shape, fmt=fmt
-        )
+        memory_obj = self.load_bytes_from_disk(key, path, dtypes, shapes, fmt)
 
         return memory_obj
 
@@ -421,17 +440,14 @@ class LocalDiskBackend(StorageBackendInterface):
             self.disk_lock.acquire()
             assert key in self.dict, f"Key {key} not found in disk cache after pinning"
 
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
-
-            assert dtype is not None
-            assert shape is not None
+            disk_meta = self.dict[key]
+            path = disk_meta.path
+            fmt = disk_meta.fmt
+            shapes, dtypes = _get_disk_cache_layout(disk_meta)
 
             memory_obj = self.local_cpu_backend.allocate(
-                shape,
-                dtype,
+                shapes,
+                dtypes,
                 fmt,
             )
 
@@ -491,8 +507,6 @@ class LocalDiskBackend(StorageBackendInterface):
             write completes for this key. Callback exceptions are caught and
             logged.
         """
-        kv_chunk = memory_obj.tensor
-        assert kv_chunk is not None
         buffer = memory_obj.byte_array
         path = self._key_to_path(key)
 
@@ -512,11 +526,22 @@ class LocalDiskBackend(StorageBackendInterface):
         size = memory_obj.get_physical_size()
         shape = memory_obj.metadata.shape
         dtype = memory_obj.metadata.dtype
+        shapes = memory_obj.metadata.shapes
+        dtypes = memory_obj.metadata.dtypes
         fmt = memory_obj.metadata.fmt
         cached_positions = memory_obj.metadata.cached_positions
         memory_obj.ref_count_down()
 
-        self.insert_key(key, size, shape, dtype, fmt, cached_positions=cached_positions)
+        self.insert_key(
+            key,
+            size,
+            shape,
+            dtype,
+            fmt,
+            cached_positions=cached_positions,
+            shapes=shapes,
+            dtypes=dtypes,
+        )
 
         self.disk_worker.remove_put_task(key)
 
@@ -559,15 +584,15 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
         path: str,
-        dtype: torch.dtype,
-        shape: torch.Size,
+        dtypes: torch.dtype | list[torch.dtype],
+        shapes: torch.Size | list[torch.Size],
         fmt: MemoryFormat,
     ) -> Optional[MemoryObj]:
         """
         Load bytearray from disk.
         """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
+        memory_obj = self.local_cpu_backend.allocate(shapes, dtypes, fmt)
         assert memory_obj is not None, "Memory allocation failed during disk load."
 
         buffer = memory_obj.byte_array

--- a/tests/v1/lookup_client/test_lmcache_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_lookup_client.py
@@ -30,6 +30,7 @@ from lmcache.v1.lookup_client.lmcache_lookup_client import (
     LMCacheLookupClient,
     LMCacheLookupServer,
 )
+from lmcache.v1.metadata import LMCacheMetadata
 from tests.v1.utils import (
     create_test_config,
     create_test_metadata,
@@ -455,3 +456,64 @@ class TestLMCacheLookupClientServer:
                 lookup_id = "test_large"
                 result = client.lookup(tokens.tolist(), lookup_id)
                 assert result == num_tokens, f"Expected {num_tokens}, got {result}"
+
+    def test_dp_aware_metadata_uses_local_rpc_topology_for_lookup(self):
+        """DP-aware cache identity must not suppress per-engine lookup servers."""
+        instance_id = f"test_lookup_dp_{uuid.uuid4().hex[:8]}"
+        config = create_test_config(instance_id=instance_id)
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=8,
+            local_world_size=8,
+            worker_id=6,
+            local_worker_id=6,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 1, 256, 8, 128),
+            use_mla=True,
+            engine_id=instance_id,
+            rpc_world_size=1,
+            rpc_worker_id=0,
+        )
+        connector = MockGPUConnector(kv_shape=(4, 1, 256, 8, 128))
+        engine = LMCacheEngineBuilder.get_or_create(
+            instance_id=instance_id,
+            config=config,
+            metadata=metadata,
+            gpu_connector=connector,
+            broadcast_fn=mock_up_broadcast_fn,
+            broadcast_object_fn=mock_up_broadcast_object_fn,
+        )
+        engine.post_init()
+
+        try:
+            assert engine.storage_manager is not None
+
+            server = LookupClientFactory.create_lookup_server(engine, metadata)
+            assert server is not None
+            client = LookupClientFactory.create_lookup_client(config, metadata)
+
+            device = "cpu"
+            num_tokens = 256
+            num_blocks = 64
+            block_size = 16
+            tokens = generate_tokens(num_tokens, device, fixed=True)
+            kv_cache = generate_kv_cache_paged_list_tensors(
+                num_blocks, device, block_size
+            )
+            slot_mapping = torch.tensor(
+                random.sample(range(0, num_blocks * block_size), num_tokens),
+                device=device,
+            )
+
+            engine.store(tokens=tokens, kvcaches=kv_cache, slot_mapping=slot_mapping)
+            recover_engine_states(engine)
+            time.sleep(0.5)
+
+            with server, client:
+                assert client.lookup(tokens.tolist(), "dp-aware-request") == num_tokens
+        finally:
+            engine.close()
+            LMCacheEngineBuilder._instances.pop(instance_id, None)
+            LMCacheEngineBuilder._cfgs.pop(instance_id, None)
+            LMCacheEngineBuilder._metadatas.pop(instance_id, None)
+            LMCacheEngineBuilder._stat_loggers.pop(instance_id, None)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -12,6 +12,7 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryFormat
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -186,4 +187,42 @@ class TestLocalDiskBackend:
 
         assert result is None
 
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_grouped_memory_obj_roundtrip(self, local_disk_backend):
+        """Grouped KV buffers should round-trip through disk without reshape."""
+        key = create_test_key(3)
+        shapes = [torch.Size([1, 2, 4, 3]), torch.Size([1, 2, 4, 5])]
+        dtypes = [torch.uint8, torch.uint8]
+        memory_obj = local_disk_backend.local_cpu_backend.allocate(
+            shapes,
+            dtypes,
+            MemoryFormat.KV_MLA_FMT,
+        )
+        assert memory_obj is not None
+
+        raw_tensor = memory_obj.raw_tensor
+        assert raw_tensor is not None
+        raw_tensor.copy_(torch.arange(raw_tensor.numel(), dtype=torch.uint8))
+        expected = raw_tensor.clone()
+
+        local_disk_backend.disk_worker.insert_put_task(key)
+        memory_obj.ref_count_up()
+        local_disk_backend.async_save_bytes_to_disk(key, memory_obj)
+        memory_obj.ref_count_down()
+
+        assert key in local_disk_backend.dict
+        disk_meta = local_disk_backend.dict[key]
+        assert disk_meta.shapes == shapes
+        assert disk_meta.dtypes == dtypes
+
+        loaded = local_disk_backend.get_blocking(key)
+        assert loaded is not None
+        assert loaded.metadata.shapes == shapes
+        assert loaded.metadata.dtypes == dtypes
+        loaded_raw_tensor = loaded.raw_tensor
+        assert loaded_raw_tensor is not None
+        assert torch.equal(loaded_raw_tensor, expected)
+
+        loaded.ref_count_down()
         local_disk_backend.local_cpu_backend.memory_allocator.close()

--- a/tests/v1/test_manager.py
+++ b/tests/v1/test_manager.py
@@ -11,6 +11,7 @@ import pytest
 
 # First Party
 from lmcache.integration.base_service_factory import BaseServiceFactory
+from lmcache.utils import EngineType
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.manager import LMCacheManager
 
@@ -255,6 +256,40 @@ class TestLMCacheManagerPostInit:
         mock_engine.post_init.assert_called_once_with(
             async_lookup_server=mock_lookup_server
         )
+
+    def test_post_init_refreshes_grouped_vllm_gpu_connector(self):
+        """Grouped KV metadata should recreate the worker connector with V3."""
+        config = LMCacheEngineConfig.from_defaults()
+        mock_engine = MagicMock()
+        mock_metadata = MagicMock()
+        mock_metadata.role = "worker"
+        mock_metadata.get_num_groups.return_value = 2
+        mock_engine.metadata = mock_metadata
+        mock_engine.gpu_connector = object()
+        factory = _make_mock_factory(engine=mock_engine)
+
+        manager = LMCacheManager(
+            config=config,
+            service_factory=factory,
+        )
+
+        refreshed_connector = object()
+        with (
+            patch(
+                "lmcache.v1.gpu_connector.CreateGPUConnector",
+                return_value=refreshed_connector,
+            ) as mock_create_gpu_connector,
+            patch.object(manager, "_init_health_monitor"),
+        ):
+            manager.post_init()
+
+        mock_create_gpu_connector.assert_called_once_with(
+            config,
+            mock_engine.metadata,
+            EngineType.VLLM,
+        )
+        assert manager._lmcache_engine.gpu_connector is refreshed_connector
+        mock_engine.post_init.assert_called_once_with(async_lookup_server=None)
 
 
 class TestLMCacheManagerShutdown:

--- a/tests/v1/test_vllm_integration.py
+++ b/tests/v1/test_vllm_integration.py
@@ -11,7 +11,10 @@ from lmcache.integration.vllm.utils import (
     create_lmcache_metadata,
     resolve_vllm_worker_identity,
 )
+from lmcache.utils import EngineType
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.gpu_connector import CreateGPUConnector
+from lmcache.v1.metadata import LMCacheMetadata
 
 
 def _make_vllm_config(
@@ -150,3 +153,45 @@ def test_create_lmcache_metadata_is_dp_aware_for_dense_workers():
     assert metadata.local_world_size == 8
     assert metadata.local_worker_id == 7
     assert metadata.kv_shape == (61, 1, 256, 1, 576)
+
+
+def test_create_gpu_connector_uses_v3_for_grouped_vllm_metadata():
+    """Grouped KV metadata should force the group-aware V3 connector."""
+
+    config = LMCacheEngineConfig.from_defaults()
+    metadata = LMCacheMetadata(
+        model_name="test-model",
+        world_size=8,
+        local_world_size=8,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.uint8,
+        kv_shape=(61, 1, 256, 1, 132),
+        use_mla=True,
+    )
+    metadata.kv_layer_groups_manager.kv_layer_groups = [
+        SimpleNamespace(num_layers=30, hidden_dim_size=132, dtype=torch.uint8),
+        SimpleNamespace(num_layers=31, hidden_dim_size=128, dtype=torch.uint8),
+    ]
+    fake_torch_dev = SimpleNamespace(current_device=lambda: 7)
+
+    with (
+        patch(
+            "lmcache.v1.gpu_connector.get_vllm_torch_dev",
+            return_value=(fake_torch_dev, "cuda"),
+        ),
+        patch(
+            "lmcache.v1.gpu_connector.gpu_connectors."
+            "VLLMPagedMemGPUConnectorV2.from_metadata"
+        ) as mock_v2,
+        patch(
+            "lmcache.v1.gpu_connector.gpu_connectors."
+            "VLLMPagedMemGPUConnectorV3.from_metadata",
+            return_value="v3-connector",
+        ) as mock_v3,
+    ):
+        connector = CreateGPUConnector(config, metadata, EngineType.VLLM)
+
+    assert connector == "v3-connector"
+    mock_v2.assert_not_called()
+    mock_v3.assert_called_once()

--- a/tests/v1/test_vllm_integration.py
+++ b/tests/v1/test_vllm_integration.py
@@ -11,10 +11,17 @@ from lmcache.integration.vllm.utils import (
     create_lmcache_metadata,
     resolve_vllm_worker_identity,
 )
-from lmcache.utils import EngineType
+from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
+from lmcache.utils import (
+    EngineType,
+    mock_up_broadcast_fn,
+    mock_up_broadcast_object_fn,
+)
+from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector import CreateGPUConnector
 from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.token_database import ChunkedTokenDatabase
 
 
 def _make_vllm_config(
@@ -26,6 +33,7 @@ def _make_vllm_config(
     dp_local_rank: int = 0,
     dp_size: int = 1,
     api_process_count: int = 1,
+    kv_role: str = "kv_both",
 ):
     model_config = SimpleNamespace(
         model="test-model",
@@ -57,6 +65,7 @@ def _make_vllm_config(
     kv_transfer_config = SimpleNamespace(
         engine_id="test-engine-id",
         kv_connector_extra_config={},
+        kv_role=kv_role,
     )
 
     return SimpleNamespace(
@@ -64,6 +73,7 @@ def _make_vllm_config(
         parallel_config=parallel_config,
         cache_config=cache_config,
         kv_transfer_config=kv_transfer_config,
+        speculative_config=None,
     )
 
 
@@ -201,3 +211,127 @@ def test_create_gpu_connector_uses_v3_for_grouped_vllm_metadata():
     assert connector == "v3-connector"
     mock_v2.assert_not_called()
     mock_v3.assert_called_once()
+
+
+def test_dp_only_mla_engine_keeps_nonzero_dp_worker_active():
+    """DP-only MLA workers should not become passive local cache followers."""
+
+    config = LMCacheEngineConfig.from_defaults()
+    metadata = LMCacheMetadata(
+        model_name="test-model",
+        world_size=8,
+        local_world_size=8,
+        worker_id=7,
+        local_worker_id=7,
+        kv_dtype=torch.uint8,
+        kv_shape=(61, 1, 256, 1, 576),
+        use_mla=True,
+        rpc_world_size=1,
+        rpc_worker_id=0,
+    )
+    engine = LMCacheEngine(
+        config=config,
+        metadata=metadata,
+        token_database=ChunkedTokenDatabase(config, metadata),
+        gpu_connector=None,
+        broadcast_fn=mock_up_broadcast_fn,
+        broadcast_object_fn=mock_up_broadcast_object_fn,
+    )
+    try:
+        assert metadata.is_rpc_first_rank() is True
+        assert engine.save_only_first_rank is False
+        with patch.object(engine, "_clear", return_value=17) as mock_clear:
+            assert engine.clear(tokens=[]) == 17
+            mock_clear.assert_called_once_with([], None, None)
+    finally:
+        engine.close()
+
+
+def test_multi_rank_mla_engine_uses_rpc_rank_for_first_rank_logic():
+    """MLA first-rank gating should follow engine-local RPC rank, not global rank."""
+
+    config = LMCacheEngineConfig.from_defaults()
+    active_metadata = LMCacheMetadata(
+        model_name="test-model",
+        world_size=16,
+        local_world_size=16,
+        worker_id=8,
+        local_worker_id=8,
+        kv_dtype=torch.uint8,
+        kv_shape=(61, 1, 256, 1, 576),
+        use_mla=True,
+        rpc_world_size=2,
+        rpc_worker_id=0,
+    )
+    active_engine = LMCacheEngine(
+        config=config,
+        metadata=active_metadata,
+        token_database=ChunkedTokenDatabase(config, active_metadata),
+        gpu_connector=None,
+        broadcast_fn=mock_up_broadcast_fn,
+        broadcast_object_fn=mock_up_broadcast_object_fn,
+    )
+    passive_metadata = LMCacheMetadata(
+        model_name="test-model",
+        world_size=16,
+        local_world_size=16,
+        worker_id=9,
+        local_worker_id=9,
+        kv_dtype=torch.uint8,
+        kv_shape=(61, 1, 256, 1, 576),
+        use_mla=True,
+        rpc_world_size=2,
+        rpc_worker_id=1,
+    )
+    passive_engine = LMCacheEngine(
+        config=config,
+        metadata=passive_metadata,
+        token_database=ChunkedTokenDatabase(config, passive_metadata),
+        gpu_connector=None,
+        broadcast_fn=mock_up_broadcast_fn,
+        broadcast_object_fn=mock_up_broadcast_object_fn,
+    )
+    try:
+        assert active_metadata.is_rpc_first_rank() is True
+        assert passive_metadata.is_rpc_first_rank() is False
+        assert active_engine.save_only_first_rank is True
+        assert passive_engine.save_only_first_rank is True
+
+        with patch.object(active_engine, "_clear", return_value=23) as mock_clear:
+            assert active_engine.clear(tokens=[]) == 23
+            mock_clear.assert_called_once_with([], None, None)
+
+        with patch.object(passive_engine, "_clear") as mock_clear:
+            assert passive_engine.clear(tokens=[]) == 0
+            mock_clear.assert_not_called()
+    finally:
+        active_engine.close()
+        passive_engine.close()
+
+
+def test_scheduler_without_engine_skips_prometheus_logger_in_kv_both_mode():
+    """kv_both scheduler path should reuse the worker-side logger in-process."""
+
+    config = LMCacheEngineConfig.from_defaults()
+    vllm_config = _make_vllm_config(kv_role="kv_both")
+    factory = VllmServiceFactory(config, vllm_config, "scheduler")
+
+    with patch("lmcache.observability.PrometheusLogger.GetOrCreate") as mock_get:
+        engine = factory.get_or_create_lmcache_engine()
+
+    assert engine is None
+    mock_get.assert_not_called()
+
+
+def test_scheduler_without_engine_creates_prometheus_logger_in_scheduler_only_mode():
+    """Scheduler-only deployments should still create a Prometheus logger."""
+
+    config = LMCacheEngineConfig.from_defaults()
+    vllm_config = _make_vllm_config(kv_role="kv_consumer")
+    factory = VllmServiceFactory(config, vllm_config, "scheduler")
+
+    with patch("lmcache.observability.PrometheusLogger.GetOrCreate") as mock_get:
+        engine = factory.get_or_create_lmcache_engine()
+
+    assert engine is None
+    mock_get.assert_called_once()

--- a/tests/v1/test_vllm_integration.py
+++ b/tests/v1/test_vllm_integration.py
@@ -1,2 +1,152 @@
 # SPDX-License-Identifier: Apache-2.0
-# TODO (Jiayi)
+# Standard
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.integration.vllm.utils import (
+    create_lmcache_metadata,
+    resolve_vllm_worker_identity,
+)
+from lmcache.v1.config import LMCacheEngineConfig
+
+
+def _make_vllm_config(
+    *,
+    tp_pp_rank: int = 0,
+    tp_pp_world_size: int = 1,
+    tp_pp_local_world_size: int = 1,
+    dp_rank: int = 0,
+    dp_local_rank: int = 0,
+    dp_size: int = 1,
+    api_process_count: int = 1,
+):
+    model_config = SimpleNamespace(
+        model="test-model",
+        dtype=torch.bfloat16,
+        use_mla=True,
+        served_model_name="test-served-model",
+    )
+    model_config.get_num_layers = lambda parallel_config: 61
+    model_config.get_num_kv_heads = lambda parallel_config: 1
+    model_config.get_head_size = lambda: 576
+
+    parallel_config = SimpleNamespace(
+        rank=tp_pp_rank,
+        world_size=tp_pp_world_size,
+        local_world_size=tp_pp_local_world_size,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        data_parallel_size=dp_size,
+        data_parallel_size_local=1,
+        data_parallel_rank=0,
+        data_parallel_rank_local=dp_local_rank,
+        data_parallel_index=dp_rank,
+        _api_process_count=api_process_count,
+        distributed_executor_backend=None,
+        nnodes=1,
+    )
+
+    cache_config = SimpleNamespace(cache_dtype="auto")
+    kv_transfer_config = SimpleNamespace(
+        engine_id="test-engine-id",
+        kv_connector_extra_config={},
+    )
+
+    return SimpleNamespace(
+        model_config=model_config,
+        parallel_config=parallel_config,
+        cache_config=cache_config,
+        kv_transfer_config=kv_transfer_config,
+    )
+
+
+def test_resolve_vllm_worker_identity_uses_dp_rank_and_current_device():
+    """Dense-model DP workers should keep distinct LMCache identity/device."""
+
+    vllm_config = _make_vllm_config(
+        dp_rank=6,
+        dp_local_rank=6,
+        dp_size=1,
+        api_process_count=8,
+    )
+    fake_torch_dev = SimpleNamespace(
+        device_count=lambda: 8,
+        current_device=lambda: 6,
+    )
+
+    with patch(
+        "lmcache.integration.vllm.utils.get_vllm_torch_dev",
+        return_value=(fake_torch_dev, "cuda"),
+    ):
+        identity = resolve_vllm_worker_identity(vllm_config)
+
+    assert identity.world_size == 8
+    assert identity.worker_id == 6
+    assert identity.local_world_size == 8
+    assert identity.local_worker_id == 6
+
+
+def test_resolve_vllm_worker_identity_falls_back_to_dp_local_rank():
+    """DP local rank should still work when current_device is unavailable."""
+
+    vllm_config = _make_vllm_config(
+        dp_rank=5,
+        dp_local_rank=5,
+        dp_size=1,
+        api_process_count=8,
+    )
+
+    class FakeTorchDevice:
+        def device_count(self) -> int:
+            return 8
+
+        def current_device(self) -> int:
+            raise RuntimeError("device not initialized")
+
+    with patch(
+        "lmcache.integration.vllm.utils.get_vllm_torch_dev",
+        return_value=(FakeTorchDevice(), "cuda"),
+    ):
+        identity = resolve_vllm_worker_identity(vllm_config)
+
+    assert identity.world_size == 8
+    assert identity.worker_id == 5
+    assert identity.local_world_size == 8
+    assert identity.local_worker_id == 5
+
+
+def test_create_lmcache_metadata_is_dp_aware_for_dense_workers():
+    """Metadata should not collapse all dense-model DP workers to rank 0."""
+
+    vllm_config = _make_vllm_config(
+        dp_rank=7,
+        dp_local_rank=7,
+        dp_size=1,
+        api_process_count=8,
+    )
+    fake_torch_dev = SimpleNamespace(
+        device_count=lambda: 8,
+        current_device=lambda: 7,
+    )
+
+    with (
+        patch(
+            "lmcache.integration.vllm.utils.get_vllm_torch_dev",
+            return_value=(fake_torch_dev, "cuda"),
+        ),
+        patch(
+            "lmcache.integration.vllm.utils.lmcache_get_or_create_config",
+            return_value=LMCacheEngineConfig.from_defaults(),
+        ),
+    ):
+        metadata, _ = create_lmcache_metadata(vllm_config=vllm_config, role="worker")
+
+    assert metadata.world_size == 8
+    assert metadata.worker_id == 7
+    assert metadata.local_world_size == 8
+    assert metadata.local_worker_id == 7
+    assert metadata.kv_shape == (61, 1, 256, 1, 576)

--- a/tests/v1/test_vllm_integration.py
+++ b/tests/v1/test_vllm_integration.py
@@ -91,6 +91,8 @@ def test_resolve_vllm_worker_identity_uses_dp_rank_and_current_device():
     assert identity.worker_id == 6
     assert identity.local_world_size == 8
     assert identity.local_worker_id == 6
+    assert identity.rpc_world_size == 1
+    assert identity.rpc_worker_id == 0
 
 
 def test_resolve_vllm_worker_identity_falls_back_to_dp_local_rank():
@@ -120,6 +122,8 @@ def test_resolve_vllm_worker_identity_falls_back_to_dp_local_rank():
     assert identity.worker_id == 5
     assert identity.local_world_size == 8
     assert identity.local_worker_id == 5
+    assert identity.rpc_world_size == 1
+    assert identity.rpc_worker_id == 0
 
 
 def test_create_lmcache_metadata_is_dp_aware_for_dense_workers():
@@ -152,6 +156,8 @@ def test_create_lmcache_metadata_is_dp_aware_for_dense_workers():
     assert metadata.worker_id == 7
     assert metadata.local_world_size == 8
     assert metadata.local_worker_id == 7
+    assert metadata.rpc_world_size == 1
+    assert metadata.rpc_worker_id == 0
     assert metadata.kv_shape == (61, 1, 256, 1, 576)
 
 


### PR DESCRIPTION
## Summary
- fix LMCache worker identity for vLLM dense DP so cache identity and CUDA device stay aligned with the GPU selected by vLLM
- handle grouped MLA KV caches with the group-aware GPU connector and disk metadata paths to avoid shape mismatches on save/load
- separate global DP worker identity from engine-local lookup RPC topology so each DP engine still starts and connects to its own local rank-0 lookup server

## Root Causes
- dense DP workers were previously collapsed to rank 0 inside LMCache metadata and CUDA device selection
- grouped KV metadata for DeepSeek-V3.2 MLA was still flowing through single-shape connector and local-disk paths
- lookup server selection reused global DP worker_id/world_size instead of engine-local TP/PP rpc rank/world_size, causing repeated lookup timeouts on DP1..DP7

## Validation
- added regression coverage for DP-aware vLLM metadata, grouped KV integration, and lookup RPC topology
- `python3 -m py_compile lmcache/integration/vllm/utils.py lmcache/v1/cache_engine.py lmcache/v1/lookup_client/factory.py lmcache/v1/lookup_client/lmcache_async_lookup_client.py lmcache/v1/manager.py lmcache/v1/metadata.py tests/v1/lookup_client/test_lmcache_lookup_client.py tests/v1/test_vllm_integration.py`
- validated against a DeepSeek-V3.2 vLLM deployment with `--data-parallel-size 8` after the fixes
- `pytest` was not available in the current environment
