### PR TITLE
[MP][1/2] Create new cuda kernel for MP mode with a kernel testing tool

### DIFF
--- a/lmcache/tools/kernel_harness/DESIGN.md
+++ b/lmcache/tools/kernel_harness/DESIGN.md
@@ -1,0 +1,76 @@
+# Design: Block Transfer Kernel Test Harness
+
+## Motivation
+
+The existing `multi_layer_kv_transfer` kernel operates at token granularity via `slot_mapping`. The new `multi_layer_block_kv_transfer` kernel operates at **block granularity** via `block_ids`, which is more natural for the MP (multi-process) mode where entire blocks of KV cache are transferred between GPU and CPU.
+
+## Architecture
+
+```
+__main__.py          CLI entry point, dispatches to correctness/benchmark
+    |
+    +-- config.py          TestConfig dataclass, 6 predefined test configs
+    |
+    +-- tensor_factory.py  Creates vLLM tensors, LMCache memory objects, block_ids
+    |
+    +-- reference.py       Pure Python reference implementation (correctness oracle)
+    |
+    +-- correctness.py     D2H -> H2D roundtrip verification
+    |
+    +-- benchmark.py       CUDA-event-based timing, throughput reporting
+    |
+    +-- csrc/              Standalone CUDA extension (stub kernel + pybind)
+```
+
+## Memory Layouts
+
+### LMCache Memory Objects
+
+- Non-MLA: `[2, num_layers, tokens_per_object, num_heads * head_size]`
+  - Dimension 0: K/V (0=key, 1=value)
+- MLA: `[1, num_layers, tokens_per_object, head_size]`
+  - No K/V split (compressed latent representation)
+
+### vLLM Paged Buffers
+
+**NORMAL (`NL_X_TWO_NB_BS_NH_HS`)**: L separate tensors
+- Each: `[2, num_blocks, block_size, num_heads, head_size]`
+- Dimension 0: K/V
+
+**CROSS_LAYER (`NB_NL_TWO_BS_NH_HS`)**: Single tensor
+- Shape: `[num_blocks, num_layers, 2, block_size, num_heads, head_size]`
+- All layers packed into one allocation
+
+**MLA (`NL_X_NB_BS_HS`)**: L separate tensors
+- Each: `[num_blocks, block_size, head_size]`
+- No K/V split, single head
+
+## Block-Level Mapping
+
+Given `block_ids = [b0, b1, ..., b63]` and 4 memory objects with 256 tokens each (16 blocks per object):
+
+```
+memory_objects[0] <-> block_ids[0:16]   (tokens 0-255)
+memory_objects[1] <-> block_ids[16:32]  (tokens 256-511)
+memory_objects[2] <-> block_ids[32:48]  (tokens 512-767)
+memory_objects[3] <-> block_ids[48:64]  (tokens 768-1023)
+```
+
+For block `block_ids[j]` mapping to memory object `i` at local block index `k`:
+- `i = j // blocks_per_object`
+- `k = j % blocks_per_object`
+- Token range in memory object: `[k * block_size, (k+1) * block_size)`
+
+## Correctness Strategy
+
+Using **different** block IDs for D2H and H2D proves the data actually flows through the memory objects:
+
+1. D2H reads from source blocks `B_src = {5, 42, 100, ...}` into memory objects
+2. H2D writes from memory objects to target blocks `B_dst = {7, 88, 200, ...}`
+3. If `target[B_dst[i]] == source[B_src[i]]`, the transfer is correct
+
+This catches bugs where the kernel might accidentally do a direct GPU-GPU copy instead of going through CPU memory.
+
+## Standalone Build
+
+The `csrc/` directory has its own `setup.py` so the kernel can be developed independently of the main LMCache build. This allows rapid iteration on the kernel code without rebuilding the entire project.

--- a/lmcache/tools/kernel_harness/DESIGN.md
+++ b/lmcache/tools/kernel_harness/DESIGN.md
@@ -2,14 +2,14 @@
 
 ## Motivation
 
-The existing `multi_layer_kv_transfer` kernel operates at token granularity via `slot_mapping`. The new `multi_layer_block_kv_transfer` kernel operates at **block granularity** via `block_ids`, which is more natural for the MP (multi-process) mode where entire blocks of KV cache are transferred between GPU and CPU.
+The existing `multi_layer_kv_transfer` kernel operates at token granularity via `slot_mapping`. The new `multi_layer_block_kv_transfer` kernel operates at **block granularity** via `block_ids`, which is more natural for the MP (multi-process) mode where entire blocks of KV cache are transferred between GPU paged buffers and LMCache memory objects.
 
 ## Architecture
 
 ```
 __main__.py          CLI entry point, dispatches to correctness/benchmark
     |
-    +-- config.py          TestConfig dataclass, 6 predefined test configs
+    +-- config.py          TestConfig dataclass, 12 predefined test configs (6 formats x 2 dtypes)
     |
     +-- tensor_factory.py  Creates vLLM tensors, LMCache memory objects, block_ids
     |
@@ -19,19 +19,26 @@ __main__.py          CLI entry point, dispatches to correctness/benchmark
     |
     +-- benchmark.py       CUDA-event-based timing, throughput reporting
     |
-    +-- csrc/              Standalone CUDA extension (stub kernel + pybind)
+    +-- csrc/              Standalone CUDA extension
+        +-- multi_layer_block_kv_transfer.cuh   Header: enums, structs, declarations
+        +-- multi_layer_block_kv_transfer.cu    Kernel implementation
+        +-- pybind.cpp                          Python bindings
 ```
 
 ## Memory Layouts
 
 ### LMCache Memory Objects
 
+Memory objects can reside on GPU (default) or pinned CPU memory (via `--mem-device cpu`).
+
 - Non-MLA: `[2, num_layers, tokens_per_object, num_heads * head_size]`
   - Dimension 0: K/V (0=key, 1=value)
 - MLA: `[1, num_layers, tokens_per_object, head_size]`
   - No K/V split (compressed latent representation)
 
-### vLLM Paged Buffers
+### vLLM/SGLang Paged Buffers
+
+Six GPU KV formats are supported:
 
 **NORMAL (`NL_X_TWO_NB_BS_NH_HS`)**: L separate tensors
 - Each: `[2, num_blocks, block_size, num_heads, head_size]`
@@ -41,9 +48,47 @@ __main__.py          CLI entry point, dispatches to correctness/benchmark
 - Shape: `[num_blocks, num_layers, 2, block_size, num_heads, head_size]`
 - All layers packed into one allocation
 
+**FLASH_INFER (`NL_X_NB_TWO_BS_NH_HS`)**: L separate tensors
+- Each: `[num_blocks, 2, block_size, num_heads, head_size]`
+- K/V interleaved per block (dim 1)
+
 **MLA (`NL_X_NB_BS_HS`)**: L separate tensors
 - Each: `[num_blocks, block_size, head_size]`
 - No K/V split, single head
+
+**SGLANG_MHA (`TWO_X_NL_X_NBBS_NH_HS`)**: 2L separate tensors
+- First L tensors = K per layer, next L tensors = V per layer
+- Each: `[NB*BS, num_heads, head_size]` (flat token indexing)
+
+**SGLANG_MLA (`NL_X_NBBS_ONE_HS`)**: L separate tensors
+- Each: `[NB*BS, 1, head_size]` (flat token indexing)
+- No K/V split
+
+## Kernel Interface
+
+The kernel receives data pointers rather than tensor objects:
+
+- **`paged_buffer_ptrs_tensor`**: GPU int64 tensor of raw data pointers, one per vLLM tensor. Cross-layer has 1 pointer; SGLang MHA has 2L pointers; all others have L pointers.
+- **`lmcache_objects_ptrs`**: List of raw int64 data pointers to LMCache memory objects (1-4 objects).
+- **`PageBufferShapeDesc`**: Struct with `kv_size, nl, nb, bs, nh, hs, element_size`.
+
+### Kernel Dispatch
+
+- Grid: `dim3(kv_size, num_blocks_per_object, num_layers)`
+- Block: `dim3(min(scalars_per_head, 32), num_heads)`
+- Each thread block handles one (block, layer, k_or_v) region
+- Each `threadIdx.y` handles one head
+- Inner loop over tokens within the block
+
+### Offset Calculations
+
+`calculate_engine_global_offset` computes the byte offset to the start of a block within the paged buffer tensor, accounting for format-specific dimension ordering. `calculate_engine_local_offset` computes the per-token, per-head offset within the block.
+
+For SGLang MHA, the K/V distinction is handled by **pointer selection** (`paged_buffer_ptrs[k_or_v * nl + layer_idx]`) rather than offset arithmetic, since K and V reside in separate tensors.
+
+### PTX Streaming Copy
+
+The `warp_copy` function uses PTX `ld.global.cs` / `st.global.cs` instructions for `uint4` loads and stores, bypassing the L2 cache to avoid cache pollution during bulk transfers.
 
 ## Block-Level Mapping
 
@@ -61,6 +106,10 @@ For block `block_ids[j]` mapping to memory object `i` at local block index `k`:
 - `k = j % blocks_per_object`
 - Token range in memory object: `[k * block_size, (k+1) * block_size)`
 
+## Skip Prefix
+
+The `skip_prefix_n_blocks` parameter skips the first N blocks **globally** (not per-object). The kernel computes `global_block_idx = start_block_idx + block_idx_in_batch` and returns early if it is below the skip threshold.
+
 ## Correctness Strategy
 
 Using **different** block IDs for D2H and H2D proves the data actually flows through the memory objects:
@@ -69,7 +118,7 @@ Using **different** block IDs for D2H and H2D proves the data actually flows thr
 2. H2D writes from memory objects to target blocks `B_dst = {7, 88, 200, ...}`
 3. If `target[B_dst[i]] == source[B_src[i]]`, the transfer is correct
 
-This catches bugs where the kernel might accidentally do a direct GPU-GPU copy instead of going through CPU memory.
+This catches bugs where the kernel might accidentally do a direct GPU-GPU copy instead of going through the memory objects.
 
 ## Standalone Build
 

--- a/lmcache/tools/kernel_harness/README.md
+++ b/lmcache/tools/kernel_harness/README.md
@@ -1,0 +1,88 @@
+# LMCache Block Transfer Kernel Test Harness
+
+Test harness for developing and benchmarking the `multi_layer_block_kv_transfer` CUDA kernel, which copies KV cache data between vLLM paged buffers (GPU) and LMCache contiguous memory objects (pinned CPU) at block granularity.
+
+## Quick Start
+
+### Run with Python reference (no CUDA build needed)
+
+```bash
+# All tests (correctness + benchmark)
+python -m lmcache.tools.kernel_harness --use-reference
+
+# Correctness only
+python -m lmcache.tools.kernel_harness --mode correctness --use-reference
+
+# Benchmark only
+python -m lmcache.tools.kernel_harness --mode benchmark --use-reference
+```
+
+### Build and run with CUDA kernel
+
+```bash
+# Build the kernel extension
+cd lmcache/tools/kernel_harness
+python setup.py build_ext --inplace
+cd ../../..
+
+# Run with the CUDA kernel
+python -m lmcache.tools.kernel_harness
+```
+
+## Command Line Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--mode` | `all` | What to run: `correctness`, `benchmark`, or `all` |
+| `--use-reference` | `false` | Use Python reference instead of CUDA kernel |
+| `--format` | `all` | vLLM format: `normal`, `cross_layer`, `mla`, or `all` |
+| `--dtype` | `all` | Data type: `bf16`, `fp8`, or `all` |
+| `--num-bench-iters` | `100` | Number of benchmark iterations |
+| `--num-warmup-iters` | `10` | Number of warmup iterations |
+| `--skip-prefix-n-blocks` | `0` | Number of prefix blocks to skip |
+
+## Test Configurations
+
+The harness tests 6 combinations (3 formats x 2 dtypes):
+
+| Case | Layers | NH | HS | vLLM Tensor Shape | GPUKVFormat |
+|------|--------|----|----|-------------------|-------------|
+| Normal | 64 | 8 | 128 | L x [2, NB, BS, NH, HS] | `NL_X_TWO_NB_BS_NH_HS` |
+| Cross-layer | 64 | 8 | 128 | [NB, NL, 2, BS, NH, HS] | `NB_NL_TWO_BS_NH_HS` |
+| MLA | 104 | 1 | 576 | L x [NB, BS, HS] | `NL_X_NB_BS_HS` |
+
+All cases use: NB=1000, BS=16, 4 memory objects with 256 tokens each (64 total blocks).
+
+## Implementing the Kernel
+
+1. Edit `csrc/multi_layer_block_kv_transfer.cu` with your kernel implementation
+2. Build: `python setup.py build_ext --inplace`
+3. Test: `python -m lmcache.tools.kernel_harness --mode correctness`
+4. Benchmark: `python -m lmcache.tools.kernel_harness --mode benchmark`
+
+### Kernel Function Signature
+
+```cpp
+void multi_layer_block_kv_transfer(
+    const std::vector<torch::Tensor>& key_value_tensors,
+    std::vector<torch::Tensor>& memory_objects,
+    const torch::Tensor& block_ids,
+    const torch::Device& device,
+    TransferDirection direction,
+    GPUKVFormat gpu_kv_format,
+    int block_size,
+    int num_blocks,
+    int skip_prefix_n_blocks);
+```
+
+## Correctness Test
+
+The test performs a D2H -> H2D roundtrip with **different** block IDs:
+
+1. Fill source vLLM tensors with random data
+2. D2H: copy blocks `B_src` from source -> memory objects
+3. H2D: copy memory objects -> target vLLM at blocks `B_dst` (disjoint from `B_src`)
+4. Verify: `target[B_dst[i]] == source[B_src[i]]` for all i, all layers
+5. Verify: untouched blocks in target remain zero
+
+A skip-prefix test additionally verifies `skip_prefix_n_blocks` behavior.

--- a/lmcache/tools/kernel_harness/README.md
+++ b/lmcache/tools/kernel_harness/README.md
@@ -1,6 +1,6 @@
 # LMCache Block Transfer Kernel Test Harness
 
-Test harness for developing and benchmarking the `multi_layer_block_kv_transfer` CUDA kernel, which copies KV cache data between vLLM paged buffers (GPU) and LMCache contiguous memory objects (pinned CPU) at block granularity.
+Test harness for developing and benchmarking the `multi_layer_block_kv_transfer` CUDA kernel, which copies KV cache data between vLLM/SGLang paged buffers (GPU) and LMCache contiguous memory objects at block granularity.
 
 ## Quick Start
 
@@ -12,9 +12,6 @@ python -m lmcache.tools.kernel_harness --use-reference
 
 # Correctness only
 python -m lmcache.tools.kernel_harness --mode correctness --use-reference
-
-# Benchmark only
-python -m lmcache.tools.kernel_harness --mode benchmark --use-reference
 ```
 
 ### Build and run with CUDA kernel
@@ -25,8 +22,14 @@ cd lmcache/tools/kernel_harness
 python setup.py build_ext --inplace
 cd ../../..
 
-# Run with the CUDA kernel
+# Run all tests
 python -m lmcache.tools.kernel_harness
+
+# Correctness only
+python -m lmcache.tools.kernel_harness --mode correctness
+
+# Benchmark only
+python -m lmcache.tools.kernel_harness --mode benchmark --num-bench-iters 100
 ```
 
 ## Command Line Options
@@ -35,43 +38,40 @@ python -m lmcache.tools.kernel_harness
 |--------|---------|-------------|
 | `--mode` | `all` | What to run: `correctness`, `benchmark`, or `all` |
 | `--use-reference` | `false` | Use Python reference instead of CUDA kernel |
-| `--format` | `all` | vLLM format: `normal`, `cross_layer`, `mla`, or `all` |
+| `--format` | `all` | vLLM format: `normal`, `cross_layer`, `mla`, `flash_infer`, `sglang_mha`, `sglang_mla`, or `all` |
 | `--dtype` | `all` | Data type: `bf16`, `fp8`, or `all` |
+| `--mem-device` | `gpu` | Device for LMCache memory objects: `gpu` or `cpu` |
 | `--num-bench-iters` | `100` | Number of benchmark iterations |
 | `--num-warmup-iters` | `10` | Number of warmup iterations |
 | `--skip-prefix-n-blocks` | `0` | Number of prefix blocks to skip |
 
 ## Test Configurations
 
-The harness tests 6 combinations (3 formats x 2 dtypes):
+The harness tests 12 combinations (6 formats x 2 dtypes):
 
 | Case | Layers | NH | HS | vLLM Tensor Shape | GPUKVFormat |
 |------|--------|----|----|-------------------|-------------|
 | Normal | 64 | 8 | 128 | L x [2, NB, BS, NH, HS] | `NL_X_TWO_NB_BS_NH_HS` |
 | Cross-layer | 64 | 8 | 128 | [NB, NL, 2, BS, NH, HS] | `NB_NL_TWO_BS_NH_HS` |
+| Flash Infer | 64 | 8 | 128 | L x [NB, 2, BS, NH, HS] | `NL_X_NB_TWO_BS_NH_HS` |
 | MLA | 104 | 1 | 576 | L x [NB, BS, HS] | `NL_X_NB_BS_HS` |
+| SGLang MHA | 64 | 8 | 128 | 2L x [NBBS, NH, HS] | `TWO_X_NL_X_NBBS_NH_HS` |
+| SGLang MLA | 104 | 1 | 576 | L x [NBBS, 1, HS] | `NL_X_NBBS_ONE_HS` |
 
 All cases use: NB=1000, BS=16, 4 memory objects with 256 tokens each (64 total blocks).
 
-## Implementing the Kernel
-
-1. Edit `csrc/multi_layer_block_kv_transfer.cu` with your kernel implementation
-2. Build: `python setup.py build_ext --inplace`
-3. Test: `python -m lmcache.tools.kernel_harness --mode correctness`
-4. Benchmark: `python -m lmcache.tools.kernel_harness --mode benchmark`
-
-### Kernel Function Signature
+## Kernel Function Signature
 
 ```cpp
 void multi_layer_block_kv_transfer(
-    const std::vector<torch::Tensor>& key_value_tensors,
-    std::vector<torch::Tensor>& memory_objects,
-    const torch::Tensor& block_ids,
+    const torch::Tensor& paged_buffer_ptrs_tensor,  // GPU int64 tensor of data pointers
+    std::vector<int64_t> lmcache_objects_ptrs,       // raw pointers to memory objects
+    const torch::Tensor& block_ids,                  // block indices into paged buffer
     const torch::Device& device,
     TransferDirection direction,
+    PageBufferShapeDesc shape_desc,
+    int lmcache_chunk_size,                          // tokens per memory object
     GPUKVFormat gpu_kv_format,
-    int block_size,
-    int num_blocks,
     int skip_prefix_n_blocks);
 ```
 
@@ -86,3 +86,16 @@ The test performs a D2H -> H2D roundtrip with **different** block IDs:
 5. Verify: untouched blocks in target remain zero
 
 A skip-prefix test additionally verifies `skip_prefix_n_blocks` behavior.
+
+## Examples
+
+```bash
+# Test only the normal format with bf16
+python -m lmcache.tools.kernel_harness --mode correctness --format normal --dtype bf16
+
+# Benchmark with memory objects on CPU (pinned)
+python -m lmcache.tools.kernel_harness --mode benchmark --mem-device cpu
+
+# Test all formats with fp8
+python -m lmcache.tools.kernel_harness --mode correctness --dtype fp8
+```

--- a/lmcache/tools/kernel_harness/__init__.py
+++ b/lmcache/tools/kernel_harness/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache/tools/kernel_harness/__main__.py
+++ b/lmcache/tools/kernel_harness/__main__.py
@@ -6,11 +6,20 @@ import logging
 import os
 import sys
 
+# Third Party
+import torch
+
 # Local
 from .benchmark import print_benchmark_table, run_benchmark
-from .config import filter_configs, get_all_test_configs
+from .config import Direction, VLLMBufferFormat, filter_configs, get_all_test_configs
 from .correctness import run_correctness_test, run_skip_prefix_test
 from .reference import reference_multi_layer_block_kv_transfer
+
+BENCHMARK_FORMATS = {
+    VLLMBufferFormat.NORMAL,
+    VLLMBufferFormat.CROSS_LAYER,
+    VLLMBufferFormat.MLA,
+}
 
 logger = logging.getLogger(__name__)
 
@@ -43,41 +52,58 @@ def _get_kernel_fn(use_reference: bool):
         )
         return reference_multi_layer_block_kv_transfer
 
-    # Wrap the C++ kernel to match the Python reference signature
-    def cuda_kernel_wrapper(vllm_tensors, memory_objects, block_ids, config, direction):
-        # Local
-        from .config import Direction
+    FORMAT_MAP = {
+        VLLMBufferFormat.NORMAL: kernel_harness_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # noqa: E501
+        VLLMBufferFormat.CROSS_LAYER: kernel_harness_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,  # noqa: E501
+        VLLMBufferFormat.MLA: kernel_harness_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        VLLMBufferFormat.FLASH_INFER: kernel_harness_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # noqa: E501
+        VLLMBufferFormat.SGLANG_MHA: kernel_harness_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,  # noqa: E501
+        VLLMBufferFormat.SGLANG_MLA: kernel_harness_ops.GPUKVFormat.NL_X_NBBS_ONE_HS,  # noqa: E501
+    }
 
+    def cuda_kernel_wrapper(vllm_tensors, memory_objects, block_ids, config, direction):
+        """Wrap the C++ kernel to match the Python reference signature."""
         cpp_direction = (
             kernel_harness_ops.TransferDirection.H2D
             if direction == Direction.H2D
             else kernel_harness_ops.TransferDirection.D2H
         )
+        gpu_kv_format = FORMAT_MAP[config.vllm_format]
 
-        # Map VLLMBufferFormat to GPUKVFormat
-        # Local
-        from .config import VLLMBufferFormat
+        # Build PageBufferShapeDesc
+        shape_desc = kernel_harness_ops.PageBufferShapeDesc()
+        shape_desc.kv_size = config.kv_dim
+        shape_desc.nl = config.num_layers
+        shape_desc.nb = config.num_blocks
+        shape_desc.bs = config.block_size
+        shape_desc.nh = config.num_heads
+        shape_desc.hs = config.head_size
+        shape_desc.element_size = vllm_tensors[0].element_size()
 
-        format_map = {
-            VLLMBufferFormat.NORMAL: kernel_harness_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # noqa: E501
-            VLLMBufferFormat.CROSS_LAYER: kernel_harness_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,  # noqa: E501
-            VLLMBufferFormat.MLA: kernel_harness_ops.GPUKVFormat.NL_X_NB_BS_HS,
-        }
-        gpu_kv_format = format_map[config.vllm_format]
+        # Build paged_buffer_ptrs_tensor: GPU tensor of data pointers.
+        # One pointer per tensor in vllm_tensors — the kernel resolves
+        # layer indexing internally (e.g., cross-layer has 1 pointer,
+        # SGLang MHA has 2*NL pointers, per-layer formats have NL).
+        ptrs = [t.data_ptr() for t in vllm_tensors]
+        paged_buffer_ptrs_tensor = torch.tensor(
+            ptrs,
+            dtype=torch.int64,
+            device=vllm_tensors[0].device,
+        )
 
-        # Third Party
-        import torch
+        # Build lmcache_objects_ptrs: list of raw pointers
+        lmcache_objects_ptrs = [m.data_ptr() for m in memory_objects]
 
-        device = torch.device("cuda")
+        device = vllm_tensors[0].device
         kernel_harness_ops.multi_layer_block_kv_transfer(
-            vllm_tensors,
-            memory_objects,
+            paged_buffer_ptrs_tensor,
+            lmcache_objects_ptrs,
             block_ids,
             device,
             cpp_direction,
+            shape_desc,
+            config.tokens_per_object,
             gpu_kv_format,
-            config.block_size,
-            config.num_blocks,
             config.skip_prefix_n_blocks,
         )
 
@@ -101,9 +127,17 @@ def main():
     )
     parser.add_argument(
         "--format",
-        choices=["normal", "cross_layer", "mla", "all"],
+        choices=[
+            "normal",
+            "cross_layer",
+            "mla",
+            "flash_infer",
+            "sglang_mha",
+            "sglang_mla",
+            "all",
+        ],
         default="all",
-        help="Which vLLM format to test (default: all)",
+        help="Which GPU KV format to test (default: all)",
     )
     parser.add_argument(
         "--dtype",
@@ -181,14 +215,18 @@ def main():
             print("Some correctness tests FAILED.")
         print()
 
-    # Benchmark
+    # Benchmark (only for the 3 core formats)
     if args.mode in ("benchmark", "all"):
         print("=" * 60)
         print("Benchmark")
         print("=" * 60)
 
+        bench_configs = [c for c in configs if c.vllm_format in BENCHMARK_FORMATS]
+        if not bench_configs:
+            print("  No benchmark configurations match the given filters.")
+
         results = []
-        for config in configs:
+        for config in bench_configs:
             print(f"  Benchmarking {config.name}...")
             result = run_benchmark(config, kernel_fn)
             results.append(result)

--- a/lmcache/tools/kernel_harness/__main__.py
+++ b/lmcache/tools/kernel_harness/__main__.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Try to import the CUDA kernel module.
 # The .so is built in-place in the kernel_harness directory.
+# torch must be imported first so libc10.so / libtorch.so are loaded.
 _harness_dir = os.path.dirname(os.path.abspath(__file__))
 if _harness_dir not in sys.path:
     sys.path.insert(0, _harness_dir)
@@ -34,8 +35,9 @@ try:
     import kernel_harness_ops
 
     HAS_KERNEL = True
-except ImportError:
+except ImportError as e:
     HAS_KERNEL = False
+    logger.debug("kernel_harness_ops import failed: %s", e)
 
 
 def _get_kernel_fn(use_reference: bool):
@@ -163,6 +165,12 @@ def main():
         default=0,
         help="Number of prefix blocks to skip (default: 0)",
     )
+    parser.add_argument(
+        "--mem-device",
+        choices=["cpu", "gpu"],
+        default="gpu",
+        help="Device for LMCache memory objects (default: gpu)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -182,8 +190,10 @@ def main():
         return
 
     kernel_fn = _get_kernel_fn(args.use_reference)
+    mem_device = torch.device("cuda" if args.mem_device == "gpu" else "cpu")
     mode_label = "reference" if args.use_reference else "CUDA kernel"
     print(f"Using: {mode_label}")
+    print(f"Memory object device: {mem_device}")
     print(f"Test configurations: {len(configs)}")
     print()
 
@@ -195,14 +205,14 @@ def main():
 
         all_passed = True
         for config in configs:
-            result = run_correctness_test(config, kernel_fn)
+            result = run_correctness_test(config, kernel_fn, mem_device)
             status = "PASS" if result else "FAIL"
             print(f"  [{status}] {config.name}")
             if not result:
                 all_passed = False
 
             # Also run skip prefix test
-            skip_result = run_skip_prefix_test(config, kernel_fn)
+            skip_result = run_skip_prefix_test(config, kernel_fn, mem_device)
             skip_status = "PASS" if skip_result else "FAIL"
             print(f"  [{skip_status}] {config.name} (skip_prefix=4)")
             if not skip_result:
@@ -228,7 +238,7 @@ def main():
         results = []
         for config in bench_configs:
             print(f"  Benchmarking {config.name}...")
-            result = run_benchmark(config, kernel_fn)
+            result = run_benchmark(config, kernel_fn, mem_device)
             results.append(result)
 
         print_benchmark_table(results)

--- a/lmcache/tools/kernel_harness/__main__.py
+++ b/lmcache/tools/kernel_harness/__main__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from typing import Callable
 import argparse
 import logging
 import os
@@ -40,7 +41,7 @@ except ImportError as e:
     logger.debug("kernel_harness_ops import failed: %s", e)
 
 
-def _get_kernel_fn(use_reference: bool):
+def _get_kernel_fn(use_reference: bool) -> Callable:
     """Get the kernel function to use for testing."""
     if use_reference:
         return reference_multi_layer_block_kv_transfer
@@ -112,7 +113,7 @@ def _get_kernel_fn(use_reference: bool):
     return cuda_kernel_wrapper
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="LMCache Block Transfer Kernel Test Harness"
     )
@@ -238,8 +239,8 @@ def main():
         results = []
         for config in bench_configs:
             print(f"  Benchmarking {config.name}...")
-            result = run_benchmark(config, kernel_fn, mem_device)
-            results.append(result)
+            r = run_benchmark(config, kernel_fn, mem_device)
+            results.append(r)
 
         print_benchmark_table(results)
 

--- a/lmcache/tools/kernel_harness/__main__.py
+++ b/lmcache/tools/kernel_harness/__main__.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import argparse
+import logging
+import os
+import sys
+
+# Local
+from .benchmark import print_benchmark_table, run_benchmark
+from .config import filter_configs, get_all_test_configs
+from .correctness import run_correctness_test, run_skip_prefix_test
+from .reference import reference_multi_layer_block_kv_transfer
+
+logger = logging.getLogger(__name__)
+
+# Try to import the CUDA kernel module.
+# The .so is built in-place in the kernel_harness directory.
+_harness_dir = os.path.dirname(os.path.abspath(__file__))
+if _harness_dir not in sys.path:
+    sys.path.insert(0, _harness_dir)
+
+try:
+    # Third Party
+    import kernel_harness_ops
+
+    HAS_KERNEL = True
+except ImportError:
+    HAS_KERNEL = False
+
+
+def _get_kernel_fn(use_reference: bool):
+    """Get the kernel function to use for testing."""
+    if use_reference:
+        return reference_multi_layer_block_kv_transfer
+
+    if not HAS_KERNEL:
+        print(
+            "WARNING: kernel_harness_ops not built. "
+            "Falling back to Python reference.\n"
+            "Build with: cd lmcache/tools/kernel_harness && "
+            "python setup.py build_ext --inplace"
+        )
+        return reference_multi_layer_block_kv_transfer
+
+    # Wrap the C++ kernel to match the Python reference signature
+    def cuda_kernel_wrapper(vllm_tensors, memory_objects, block_ids, config, direction):
+        # Local
+        from .config import Direction
+
+        cpp_direction = (
+            kernel_harness_ops.TransferDirection.H2D
+            if direction == Direction.H2D
+            else kernel_harness_ops.TransferDirection.D2H
+        )
+
+        # Map VLLMBufferFormat to GPUKVFormat
+        # Local
+        from .config import VLLMBufferFormat
+
+        format_map = {
+            VLLMBufferFormat.NORMAL: kernel_harness_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # noqa: E501
+            VLLMBufferFormat.CROSS_LAYER: kernel_harness_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,  # noqa: E501
+            VLLMBufferFormat.MLA: kernel_harness_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        }
+        gpu_kv_format = format_map[config.vllm_format]
+
+        # Third Party
+        import torch
+
+        device = torch.device("cuda")
+        kernel_harness_ops.multi_layer_block_kv_transfer(
+            vllm_tensors,
+            memory_objects,
+            block_ids,
+            device,
+            cpp_direction,
+            gpu_kv_format,
+            config.block_size,
+            config.num_blocks,
+            config.skip_prefix_n_blocks,
+        )
+
+    return cuda_kernel_wrapper
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="LMCache Block Transfer Kernel Test Harness"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["correctness", "benchmark", "all"],
+        default="all",
+        help="What to run (default: all)",
+    )
+    parser.add_argument(
+        "--use-reference",
+        action="store_true",
+        help="Use Python reference implementation instead of CUDA kernel",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["normal", "cross_layer", "mla", "all"],
+        default="all",
+        help="Which vLLM format to test (default: all)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["bf16", "fp8", "all"],
+        default="all",
+        help="Which dtype to test (default: all)",
+    )
+    parser.add_argument(
+        "--num-bench-iters",
+        type=int,
+        default=100,
+        help="Number of benchmark iterations (default: 100)",
+    )
+    parser.add_argument(
+        "--num-warmup-iters",
+        type=int,
+        default=10,
+        help="Number of warmup iterations (default: 10)",
+    )
+    parser.add_argument(
+        "--skip-prefix-n-blocks",
+        type=int,
+        default=0,
+        help="Number of prefix blocks to skip (default: 0)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(levelname)s: %(message)s",
+    )
+
+    configs = get_all_test_configs(
+        num_warmup=args.num_warmup_iters,
+        num_bench=args.num_bench_iters,
+        skip_prefix_n_blocks=args.skip_prefix_n_blocks,
+    )
+    configs = filter_configs(configs, args.format, args.dtype)
+
+    if not configs:
+        print("No test configurations match the given filters.")
+        return
+
+    kernel_fn = _get_kernel_fn(args.use_reference)
+    mode_label = "reference" if args.use_reference else "CUDA kernel"
+    print(f"Using: {mode_label}")
+    print(f"Test configurations: {len(configs)}")
+    print()
+
+    # Correctness tests
+    if args.mode in ("correctness", "all"):
+        print("=" * 60)
+        print("Correctness Tests")
+        print("=" * 60)
+
+        all_passed = True
+        for config in configs:
+            result = run_correctness_test(config, kernel_fn)
+            status = "PASS" if result else "FAIL"
+            print(f"  [{status}] {config.name}")
+            if not result:
+                all_passed = False
+
+            # Also run skip prefix test
+            skip_result = run_skip_prefix_test(config, kernel_fn)
+            skip_status = "PASS" if skip_result else "FAIL"
+            print(f"  [{skip_status}] {config.name} (skip_prefix=4)")
+            if not skip_result:
+                all_passed = False
+
+        print()
+        if all_passed:
+            print("All correctness tests PASSED.")
+        else:
+            print("Some correctness tests FAILED.")
+        print()
+
+    # Benchmark
+    if args.mode in ("benchmark", "all"):
+        print("=" * 60)
+        print("Benchmark")
+        print("=" * 60)
+
+        results = []
+        for config in configs:
+            print(f"  Benchmarking {config.name}...")
+            result = run_benchmark(config, kernel_fn)
+            results.append(result)
+
+        print_benchmark_table(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/tools/kernel_harness/benchmark.py
+++ b/lmcache/tools/kernel_harness/benchmark.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from dataclasses import dataclass
+from typing import Callable
+
+# Third Party
+import torch
+
+# Local
+from .config import Direction, TestConfig
+from .reference import reference_multi_layer_block_kv_transfer
+from .tensor_factory import (
+    create_block_ids,
+    create_memory_objects,
+    create_vllm_tensors,
+)
+
+
+@dataclass
+class BenchmarkResult:
+    """Results from a single benchmark run."""
+
+    config_name: str
+    dtype: str
+    d2h_latency_ms: float
+    h2d_latency_ms: float
+    d2h_throughput_gbps: float
+    h2d_throughput_gbps: float
+    total_bytes: int
+
+
+def _compute_total_bytes(config: TestConfig) -> int:
+    """Compute total bytes transferred per kernel call."""
+    element_size = 1 if config.dtype == torch.float8_e4m3fn else config.dtype.itemsize
+    return (
+        config.num_memory_objects
+        * config.tokens_per_object
+        * config.num_layers
+        * config.hidden_dim
+        * config.kv_dim
+        * element_size
+    )
+
+
+def run_benchmark(
+    config: TestConfig,
+    kernel_fn: Callable = reference_multi_layer_block_kv_transfer,
+) -> BenchmarkResult:
+    """Benchmark D2H and H2D transfers separately.
+
+    Uses CUDA events for precise GPU-side timing.
+    """
+    device = torch.device("cuda")
+
+    # Set up tensors
+    vllm_tensors = create_vllm_tensors(config, device)
+    mem_objects = create_memory_objects(config)
+    block_ids = create_block_ids(config, seed=42)
+
+    total_bytes = _compute_total_bytes(config)
+    dtype_name = "bf16" if config.dtype == torch.bfloat16 else "fp8"
+
+    # Warmup
+    for _ in range(config.num_warmup_iters):
+        kernel_fn(vllm_tensors, mem_objects, block_ids, config, Direction.D2H)
+        torch.cuda.synchronize()
+        kernel_fn(vllm_tensors, mem_objects, block_ids, config, Direction.H2D)
+        torch.cuda.synchronize()
+
+    # Benchmark D2H
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    start.record()
+    for _ in range(config.num_bench_iters):
+        kernel_fn(vllm_tensors, mem_objects, block_ids, config, Direction.D2H)
+    end.record()
+    torch.cuda.synchronize()
+    d2h_ms = start.elapsed_time(end) / config.num_bench_iters
+
+    # Benchmark H2D
+    start.record()
+    for _ in range(config.num_bench_iters):
+        kernel_fn(vllm_tensors, mem_objects, block_ids, config, Direction.H2D)
+    end.record()
+    torch.cuda.synchronize()
+    h2d_ms = start.elapsed_time(end) / config.num_bench_iters
+
+    # Compute throughput
+    d2h_gbps = total_bytes / (d2h_ms * 1e-3) / 1e9 if d2h_ms > 0 else 0.0
+    h2d_gbps = total_bytes / (h2d_ms * 1e-3) / 1e9 if h2d_ms > 0 else 0.0
+
+    return BenchmarkResult(
+        config_name=config.name,
+        dtype=dtype_name,
+        d2h_latency_ms=d2h_ms,
+        h2d_latency_ms=h2d_ms,
+        d2h_throughput_gbps=d2h_gbps,
+        h2d_throughput_gbps=h2d_gbps,
+        total_bytes=total_bytes,
+    )
+
+
+def print_benchmark_table(results: list) -> None:
+    """Print benchmark results as a formatted table."""
+    header = (
+        f"{'Config':<20} {'Dtype':<6} "
+        f"{'D2H ms':>10} {'H2D ms':>10} "
+        f"{'D2H GB/s':>10} {'H2D GB/s':>10} "
+        f"{'Bytes':>14}"
+    )
+    separator = "=" * len(header)
+
+    print()
+    print(separator)
+    print("LMCache Block Transfer Kernel Benchmark Results")
+    print(separator)
+    print(header)
+    print("-" * len(header))
+
+    for r in results:
+        print(
+            f"{r.config_name:<20} {r.dtype:<6} "
+            f"{r.d2h_latency_ms:>10.3f} {r.h2d_latency_ms:>10.3f} "
+            f"{r.d2h_throughput_gbps:>10.2f} {r.h2d_throughput_gbps:>10.2f} "
+            f"{r.total_bytes:>14,}"
+        )
+
+    print(separator)
+    print()

--- a/lmcache/tools/kernel_harness/benchmark.py
+++ b/lmcache/tools/kernel_harness/benchmark.py
@@ -46,6 +46,7 @@ def _compute_total_bytes(config: TestConfig) -> int:
 def run_benchmark(
     config: TestConfig,
     kernel_fn: Callable = reference_multi_layer_block_kv_transfer,
+    mem_device: torch.device = None,
 ) -> BenchmarkResult:
     """Benchmark D2H and H2D transfers separately.
 
@@ -55,7 +56,7 @@ def run_benchmark(
 
     # Set up tensors
     vllm_tensors = create_vllm_tensors(config, device)
-    mem_objects = create_memory_objects(config)
+    mem_objects = create_memory_objects(config, mem_device)
     block_ids = create_block_ids(config, seed=42)
 
     total_bytes = _compute_total_bytes(config)

--- a/lmcache/tools/kernel_harness/build.sh
+++ b/lmcache/tools/kernel_harness/build.sh
@@ -1,0 +1,1 @@
+CUDA_VISIBLE_DEVICES=0 python3 setup.py build_ext --inplace

--- a/lmcache/tools/kernel_harness/config.py
+++ b/lmcache/tools/kernel_harness/config.py
@@ -9,11 +9,14 @@ import torch
 
 
 class VLLMBufferFormat(Enum):
-    """Which vLLM paged buffer configuration to test."""
+    """Which vLLM/SGLang paged buffer configuration to test."""
 
-    NORMAL = auto()  # NL_X_TWO_NB_BS_NH_HS: L separate tensors [2, NB, BS, NH, HS]
+    NORMAL = auto()  # NL_X_TWO_NB_BS_NH_HS: L tensors [2, NB, BS, NH, HS]
     CROSS_LAYER = auto()  # NB_NL_TWO_BS_NH_HS: single tensor [NB, NL, 2, BS, NH, HS]
-    MLA = auto()  # NL_X_NB_BS_HS: L separate tensors [NB, BS, HS]
+    MLA = auto()  # NL_X_NB_BS_HS: L tensors [NB, BS, HS]
+    FLASH_INFER = auto()  # NL_X_NB_TWO_BS_NH_HS: L tensors [NB, 2, BS, NH, HS]
+    SGLANG_MHA = auto()  # TWO_X_NL_X_NBBS_NH_HS: 2L tensors [NBBS, NH, HS]
+    SGLANG_MLA = auto()  # NL_X_NBBS_ONE_HS: L tensors [NBBS, 1, HS]
 
 
 class Direction(Enum):
@@ -63,7 +66,20 @@ class TestConfig:
 
     @property
     def is_mla(self) -> bool:
-        return self.vllm_format == VLLMBufferFormat.MLA
+        return self.vllm_format in (VLLMBufferFormat.MLA, VLLMBufferFormat.SGLANG_MLA)
+
+    @property
+    def uses_flat_indexing(self) -> bool:
+        """SGLang formats use NBBS flat token indexing instead of [NB, BS]."""
+        return self.vllm_format in (
+            VLLMBufferFormat.SGLANG_MHA,
+            VLLMBufferFormat.SGLANG_MLA,
+        )
+
+    @property
+    def nbbs(self) -> int:
+        """Total token capacity in paged buffer: NB * BS."""
+        return self.num_blocks * self.block_size
 
     @property
     def kv_dim(self) -> int:
@@ -81,12 +97,15 @@ def get_all_test_configs(
     num_bench: int = DEFAULT_NUM_BENCH,
     skip_prefix_n_blocks: int = 0,
 ) -> list:
-    """Generate all 6 test configurations (3 formats x 2 dtypes)."""
+    """Generate all 12 test configurations (6 formats x 2 dtypes)."""
     format_params = [
         # (format, num_layers, num_heads, head_size)
         (VLLMBufferFormat.NORMAL, 64, 8, 128),
         (VLLMBufferFormat.CROSS_LAYER, 64, 8, 128),
         (VLLMBufferFormat.MLA, 104, 1, 576),
+        (VLLMBufferFormat.FLASH_INFER, 64, 8, 128),
+        (VLLMBufferFormat.SGLANG_MHA, 64, 8, 128),
+        (VLLMBufferFormat.SGLANG_MLA, 104, 1, 576),
     ]
     dtypes = [torch.bfloat16, torch.float8_e4m3fn]
 
@@ -122,6 +141,9 @@ def filter_configs(
         "normal": VLLMBufferFormat.NORMAL,
         "cross_layer": VLLMBufferFormat.CROSS_LAYER,
         "mla": VLLMBufferFormat.MLA,
+        "flash_infer": VLLMBufferFormat.FLASH_INFER,
+        "sglang_mha": VLLMBufferFormat.SGLANG_MHA,
+        "sglang_mla": VLLMBufferFormat.SGLANG_MLA,
     }
     dtype_map = {
         "bf16": torch.bfloat16,

--- a/lmcache/tools/kernel_harness/config.py
+++ b/lmcache/tools/kernel_harness/config.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from dataclasses import dataclass
+from enum import Enum, auto
+
+# Third Party
+import torch
+
+
+class VLLMBufferFormat(Enum):
+    """Which vLLM paged buffer configuration to test."""
+
+    NORMAL = auto()  # NL_X_TWO_NB_BS_NH_HS: L separate tensors [2, NB, BS, NH, HS]
+    CROSS_LAYER = auto()  # NB_NL_TWO_BS_NH_HS: single tensor [NB, NL, 2, BS, NH, HS]
+    MLA = auto()  # NL_X_NB_BS_HS: L separate tensors [NB, BS, HS]
+
+
+class Direction(Enum):
+    """Transfer direction."""
+
+    H2D = 0  # LMCache -> vLLM (host to device)
+    D2H = 1  # vLLM -> LMCache (device to host)
+
+
+DEFAULT_NUM_BLOCKS = 1000
+DEFAULT_BLOCK_SIZE = 16
+DEFAULT_NUM_MEMORY_OBJECTS = 4
+DEFAULT_TOKENS_PER_OBJECT = 256
+DEFAULT_NUM_WARMUP = 10
+DEFAULT_NUM_BENCH = 100
+
+
+@dataclass
+class TestConfig:
+    """Configuration for a single test case."""
+
+    vllm_format: VLLMBufferFormat
+    dtype: torch.dtype
+    num_layers: int
+    num_blocks: int
+    block_size: int
+    num_heads: int
+    head_size: int
+    num_memory_objects: int
+    tokens_per_object: int
+    num_warmup_iters: int
+    num_bench_iters: int
+    skip_prefix_n_blocks: int
+
+    @property
+    def hidden_dim(self) -> int:
+        return self.num_heads * self.head_size
+
+    @property
+    def total_blocks(self) -> int:
+        """Total number of block_ids = num_memory_objects * blocks_per_object."""
+        return self.num_memory_objects * self.blocks_per_object
+
+    @property
+    def blocks_per_object(self) -> int:
+        return self.tokens_per_object // self.block_size
+
+    @property
+    def is_mla(self) -> bool:
+        return self.vllm_format == VLLMBufferFormat.MLA
+
+    @property
+    def kv_dim(self) -> int:
+        """First dimension of LMCache memory object: 2 for non-MLA, 1 for MLA."""
+        return 1 if self.is_mla else 2
+
+    @property
+    def name(self) -> str:
+        dtype_name = "bf16" if self.dtype == torch.bfloat16 else "fp8"
+        return f"{self.vllm_format.name.lower()}_{dtype_name}"
+
+
+def get_all_test_configs(
+    num_warmup: int = DEFAULT_NUM_WARMUP,
+    num_bench: int = DEFAULT_NUM_BENCH,
+    skip_prefix_n_blocks: int = 0,
+) -> list:
+    """Generate all 6 test configurations (3 formats x 2 dtypes)."""
+    format_params = [
+        # (format, num_layers, num_heads, head_size)
+        (VLLMBufferFormat.NORMAL, 64, 8, 128),
+        (VLLMBufferFormat.CROSS_LAYER, 64, 8, 128),
+        (VLLMBufferFormat.MLA, 104, 1, 576),
+    ]
+    dtypes = [torch.bfloat16, torch.float8_e4m3fn]
+
+    configs = []
+    for fmt, nl, nh, hs in format_params:
+        for dt in dtypes:
+            configs.append(
+                TestConfig(
+                    vllm_format=fmt,
+                    dtype=dt,
+                    num_layers=nl,
+                    num_blocks=DEFAULT_NUM_BLOCKS,
+                    block_size=DEFAULT_BLOCK_SIZE,
+                    num_heads=nh,
+                    head_size=hs,
+                    num_memory_objects=DEFAULT_NUM_MEMORY_OBJECTS,
+                    tokens_per_object=DEFAULT_TOKENS_PER_OBJECT,
+                    num_warmup_iters=num_warmup,
+                    num_bench_iters=num_bench,
+                    skip_prefix_n_blocks=skip_prefix_n_blocks,
+                )
+            )
+    return configs
+
+
+def filter_configs(
+    configs: list,
+    format_filter: str = "all",
+    dtype_filter: str = "all",
+) -> list:
+    """Filter configs by format and dtype CLI arguments."""
+    format_map = {
+        "normal": VLLMBufferFormat.NORMAL,
+        "cross_layer": VLLMBufferFormat.CROSS_LAYER,
+        "mla": VLLMBufferFormat.MLA,
+    }
+    dtype_map = {
+        "bf16": torch.bfloat16,
+        "fp8": torch.float8_e4m3fn,
+    }
+
+    result = configs
+    if format_filter != "all":
+        target_fmt = format_map[format_filter]
+        result = [c for c in result if c.vllm_format == target_fmt]
+    if dtype_filter != "all":
+        target_dt = dtype_map[dtype_filter]
+        result = [c for c in result if c.dtype == target_dt]
+    return result

--- a/lmcache/tools/kernel_harness/config.py
+++ b/lmcache/tools/kernel_harness/config.py
@@ -132,10 +132,10 @@ def get_all_test_configs(
 
 
 def filter_configs(
-    configs: list,
+    configs: list[TestConfig],
     format_filter: str = "all",
     dtype_filter: str = "all",
-) -> list:
+) -> list[TestConfig]:
     """Filter configs by format and dtype CLI arguments."""
     format_map = {
         "normal": VLLMBufferFormat.NORMAL,

--- a/lmcache/tools/kernel_harness/correctness.py
+++ b/lmcache/tools/kernel_harness/correctness.py
@@ -27,14 +27,28 @@ def _get_block_data(
     block_idx: int,
 ) -> list:
     """Extract all layer data for a given block, returned as a list of tensors."""
+    bs = config.block_size
+    nl = config.num_layers
     results = []
-    for layer_idx in range(config.num_layers):
+    for layer_idx in range(nl):
         if config.vllm_format == VLLMBufferFormat.NORMAL:
             results.append(vllm_tensors[layer_idx][:, block_idx, :, :, :].clone())
         elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
             results.append(vllm_tensors[0][block_idx, layer_idx, :, :, :, :].clone())
         elif config.vllm_format == VLLMBufferFormat.MLA:
             results.append(vllm_tensors[layer_idx][block_idx, :, :].clone())
+        elif config.vllm_format == VLLMBufferFormat.FLASH_INFER:
+            results.append(vllm_tensors[layer_idx][block_idx, :, :, :, :].clone())
+        elif config.vllm_format == VLLMBufferFormat.SGLANG_MHA:
+            token_start = block_idx * bs
+            token_end = token_start + bs
+            k = vllm_tensors[layer_idx][token_start:token_end, :, :].clone()
+            v = vllm_tensors[nl + layer_idx][token_start:token_end, :, :].clone()
+            results.append(torch.stack([k, v], dim=0))
+        elif config.vllm_format == VLLMBufferFormat.SGLANG_MLA:
+            token_start = block_idx * bs
+            token_end = token_start + bs
+            results.append(vllm_tensors[layer_idx][token_start:token_end, 0, :].clone())
     return results
 
 
@@ -58,13 +72,27 @@ def _check_block_is_zero(
     block_idx: int,
 ) -> bool:
     """Check if a block in the vLLM tensors is all zeros."""
-    for layer_idx in range(config.num_layers):
+    bs = config.block_size
+    nl = config.num_layers
+    for layer_idx in range(nl):
         if config.vllm_format == VLLMBufferFormat.NORMAL:
             block = vllm_tensors[layer_idx][:, block_idx, :, :, :]
         elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
             block = vllm_tensors[0][block_idx, layer_idx, :, :, :, :]
         elif config.vllm_format == VLLMBufferFormat.MLA:
             block = vllm_tensors[layer_idx][block_idx, :, :]
+        elif config.vllm_format == VLLMBufferFormat.FLASH_INFER:
+            block = vllm_tensors[layer_idx][block_idx, :, :, :, :]
+        elif config.vllm_format == VLLMBufferFormat.SGLANG_MHA:
+            token_start = block_idx * bs
+            token_end = token_start + bs
+            k = vllm_tensors[layer_idx][token_start:token_end, :, :]
+            v = vllm_tensors[nl + layer_idx][token_start:token_end, :, :]
+            block = torch.cat([k, v], dim=0)
+        elif config.vllm_format == VLLMBufferFormat.SGLANG_MLA:
+            token_start = block_idx * bs
+            token_end = token_start + bs
+            block = vllm_tensors[layer_idx][token_start:token_end, 0, :]
         else:
             return False
 

--- a/lmcache/tools/kernel_harness/correctness.py
+++ b/lmcache/tools/kernel_harness/correctness.py
@@ -147,8 +147,8 @@ def run_correctness_test(
         if i < config.skip_prefix_n_blocks:
             continue
 
-        src_block_id = block_ids_d2h[i].item()
-        tgt_block_id = block_ids_h2d[i].item()
+        src_block_id = block_ids_d2h[i]
+        tgt_block_id = block_ids_h2d[i]
 
         src_data = _get_block_data(source_vllm, config, src_block_id)
         tgt_data = _get_block_data(target_vllm, config, tgt_block_id)
@@ -163,7 +163,7 @@ def run_correctness_test(
             passed = False
 
     # Verify: blocks that were NOT written should remain zero
-    h2d_set = set(block_ids_h2d.tolist())
+    h2d_set = set(block_ids_h2d)
     # Sample a few untouched blocks to check
     untouched_blocks = [
         b for b in range(min(config.num_blocks, 200)) if b not in h2d_set
@@ -176,7 +176,7 @@ def run_correctness_test(
     # Verify skip_prefix_n_blocks: skipped blocks in target should be zero
     if config.skip_prefix_n_blocks > 0:
         for i in range(config.skip_prefix_n_blocks):
-            tgt_block_id = block_ids_h2d[i].item()
+            tgt_block_id = block_ids_h2d[i]
             if not _check_block_is_zero(target_vllm, config, tgt_block_id):
                 logger.error(
                     "FAIL: Skipped prefix block %d (tgt_block=%d) is not zero",

--- a/lmcache/tools/kernel_harness/correctness.py
+++ b/lmcache/tools/kernel_harness/correctness.py
@@ -107,12 +107,13 @@ def _check_block_is_zero(
 def run_correctness_test(
     config: TestConfig,
     kernel_fn: Callable = reference_multi_layer_block_kv_transfer,
+    mem_device: torch.device = None,
 ) -> bool:
     """Run D2H -> H2D roundtrip correctness test.
 
     Steps:
     1. Create source vLLM tensors with random data on GPU
-    2. Create empty memory objects on pinned CPU
+    2. Create empty memory objects on mem_device (default: GPU)
     3. D2H: copy source -> memory objects using block_ids_d2h
     4. H2D: copy memory objects -> target vLLM using block_ids_h2d (different blocks)
     5. Verify: target[h2d_block] == source[d2h_block] for all corresponding pairs
@@ -125,7 +126,7 @@ def run_correctness_test(
     # Create tensors
     source_vllm = create_vllm_tensors(config, device)
     target_vllm = create_zero_vllm_tensors(config, device)
-    mem_objects = create_memory_objects(config)
+    mem_objects = create_memory_objects(config, mem_device)
 
     # Create disjoint block ID sets
     block_ids_d2h = create_block_ids(config, seed=42)
@@ -190,6 +191,7 @@ def run_correctness_test(
 def run_skip_prefix_test(
     config: TestConfig,
     kernel_fn: Callable = reference_multi_layer_block_kv_transfer,
+    mem_device: torch.device = None,
 ) -> bool:
     """Test that skip_prefix_n_blocks correctly skips the first N blocks.
 
@@ -200,4 +202,4 @@ def run_skip_prefix_test(
     from dataclasses import replace
 
     modified_config = replace(config, skip_prefix_n_blocks=4)
-    return run_correctness_test(modified_config, kernel_fn)
+    return run_correctness_test(modified_config, kernel_fn, mem_device)

--- a/lmcache/tools/kernel_harness/correctness.py
+++ b/lmcache/tools/kernel_harness/correctness.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Callable
+import logging
+
+# Third Party
+import torch
+
+# Local
+from .config import Direction, TestConfig, VLLMBufferFormat
+from .reference import reference_multi_layer_block_kv_transfer
+from .tensor_factory import (
+    create_block_ids,
+    create_h2d_block_ids,
+    create_memory_objects,
+    create_vllm_tensors,
+    create_zero_vllm_tensors,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_block_data(
+    vllm_tensors: list,
+    config: TestConfig,
+    block_idx: int,
+) -> list:
+    """Extract all layer data for a given block, returned as a list of tensors."""
+    results = []
+    for layer_idx in range(config.num_layers):
+        if config.vllm_format == VLLMBufferFormat.NORMAL:
+            results.append(vllm_tensors[layer_idx][:, block_idx, :, :, :].clone())
+        elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+            results.append(vllm_tensors[0][block_idx, layer_idx, :, :, :, :].clone())
+        elif config.vllm_format == VLLMBufferFormat.MLA:
+            results.append(vllm_tensors[layer_idx][block_idx, :, :].clone())
+    return results
+
+
+def _check_blocks_equal(
+    source_data: list,
+    target_data: list,
+    config: TestConfig,
+) -> bool:
+    """Check if two sets of per-layer block data are equal."""
+    for layer_idx in range(config.num_layers):
+        src = source_data[layer_idx]
+        tgt = target_data[layer_idx]
+        if not torch.equal(src, tgt):
+            return False
+    return True
+
+
+def _check_block_is_zero(
+    vllm_tensors: list,
+    config: TestConfig,
+    block_idx: int,
+) -> bool:
+    """Check if a block in the vLLM tensors is all zeros."""
+    for layer_idx in range(config.num_layers):
+        if config.vllm_format == VLLMBufferFormat.NORMAL:
+            block = vllm_tensors[layer_idx][:, block_idx, :, :, :]
+        elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+            block = vllm_tensors[0][block_idx, layer_idx, :, :, :, :]
+        elif config.vllm_format == VLLMBufferFormat.MLA:
+            block = vllm_tensors[layer_idx][block_idx, :, :]
+        else:
+            return False
+
+        # For FP8, compare as float
+        if block.dtype == torch.float8_e4m3fn:
+            block = block.to(torch.float32)
+        if block.abs().sum().item() != 0:
+            return False
+    return True
+
+
+def run_correctness_test(
+    config: TestConfig,
+    kernel_fn: Callable = reference_multi_layer_block_kv_transfer,
+) -> bool:
+    """Run D2H -> H2D roundtrip correctness test.
+
+    Steps:
+    1. Create source vLLM tensors with random data on GPU
+    2. Create empty memory objects on pinned CPU
+    3. D2H: copy source -> memory objects using block_ids_d2h
+    4. H2D: copy memory objects -> target vLLM using block_ids_h2d (different blocks)
+    5. Verify: target[h2d_block] == source[d2h_block] for all corresponding pairs
+    6. Verify: untouched blocks in target remain zero
+
+    Returns True if all checks pass.
+    """
+    device = torch.device("cuda")
+
+    # Create tensors
+    source_vllm = create_vllm_tensors(config, device)
+    target_vllm = create_zero_vllm_tensors(config, device)
+    mem_objects = create_memory_objects(config)
+
+    # Create disjoint block ID sets
+    block_ids_d2h = create_block_ids(config, seed=42)
+    block_ids_h2d = create_h2d_block_ids(config, exclude=block_ids_d2h, seed=123)
+
+    # D2H: source vLLM -> memory objects
+    kernel_fn(source_vllm, mem_objects, block_ids_d2h, config, Direction.D2H)
+    torch.cuda.synchronize()
+
+    # H2D: memory objects -> target vLLM
+    kernel_fn(target_vllm, mem_objects, block_ids_h2d, config, Direction.H2D)
+    torch.cuda.synchronize()
+
+    # Verify: corresponding blocks should match
+    passed = True
+    for i in range(config.total_blocks):
+        # Skip prefix blocks
+        if i < config.skip_prefix_n_blocks:
+            continue
+
+        src_block_id = block_ids_d2h[i].item()
+        tgt_block_id = block_ids_h2d[i].item()
+
+        src_data = _get_block_data(source_vllm, config, src_block_id)
+        tgt_data = _get_block_data(target_vllm, config, tgt_block_id)
+
+        if not _check_blocks_equal(src_data, tgt_data, config):
+            logger.error(
+                "FAIL: Block mismatch at index %d (src_block=%d, tgt_block=%d)",
+                i,
+                src_block_id,
+                tgt_block_id,
+            )
+            passed = False
+
+    # Verify: blocks that were NOT written should remain zero
+    h2d_set = set(block_ids_h2d.tolist())
+    # Sample a few untouched blocks to check
+    untouched_blocks = [
+        b for b in range(min(config.num_blocks, 200)) if b not in h2d_set
+    ][:10]
+    for block_idx in untouched_blocks:
+        if not _check_block_is_zero(target_vllm, config, block_idx):
+            logger.error("FAIL: Untouched block %d is not zero", block_idx)
+            passed = False
+
+    # Verify skip_prefix_n_blocks: skipped blocks in target should be zero
+    if config.skip_prefix_n_blocks > 0:
+        for i in range(config.skip_prefix_n_blocks):
+            tgt_block_id = block_ids_h2d[i].item()
+            if not _check_block_is_zero(target_vllm, config, tgt_block_id):
+                logger.error(
+                    "FAIL: Skipped prefix block %d (tgt_block=%d) is not zero",
+                    i,
+                    tgt_block_id,
+                )
+                passed = False
+
+    return passed
+
+
+def run_skip_prefix_test(
+    config: TestConfig,
+    kernel_fn: Callable = reference_multi_layer_block_kv_transfer,
+) -> bool:
+    """Test that skip_prefix_n_blocks correctly skips the first N blocks.
+
+    Creates a modified config with skip_prefix_n_blocks=4 and verifies
+    that the first 4 blocks are not copied.
+    """
+    # Standard
+    from dataclasses import replace
+
+    modified_config = replace(config, skip_prefix_n_blocks=4)
+    return run_correctness_test(modified_config, kernel_fn)

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_layer_block_kv_transfer.cuh"
+
+/**
+ * Stub implementation of block-level multi-layer KV transfer.
+ *
+ * TODO: Replace this stub with the actual CUDA kernel implementation.
+ *
+ * The kernel should:
+ * 1. For each block in block_ids (after skipping skip_prefix_n_blocks):
+ *    - Determine which memory_object and local offset this block maps to
+ *    - For each layer: copy BS tokens between the vLLM paged buffer and
+ *      the LMCache memory object
+ * 2. Handle all GPUKVFormat layouts:
+ *    - NL_X_TWO_NB_BS_NH_HS: L separate tensors [2, NB, BS, NH, HS]
+ *    - NB_NL_TWO_BS_NH_HS: single tensor [NB, NL, 2, BS, NH, HS]
+ *    - NL_X_NB_BS_HS: L separate tensors [NB, BS, HS] (MLA)
+ * 3. Support both bfloat16 and float8_e4m3fn
+ * 4. Use async CUDA memcpy for efficient H2D/D2H transfers
+ */
+void multi_layer_block_kv_transfer(
+    const std::vector<torch::Tensor>& key_value_tensors,
+    std::vector<torch::Tensor>& memory_objects, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    GPUKVFormat gpu_kv_format, int block_size, int num_blocks,
+    int skip_prefix_n_blocks) {
+  TORCH_CHECK(false,
+              "multi_layer_block_kv_transfer CUDA kernel not yet implemented. "
+              "Use --use-reference flag to run with the Python reference "
+              "implementation.");
+}

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
@@ -165,48 +165,31 @@ __device__ void multi_layer_block_transfer_single_block(
 }
 
 template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
-__device__ void multi_layer_block_transfer_single_object(
-    ScalarType* __restrict__ lmcache_object,
-    ScalarType** __restrict__ paged_buffer_ptrs,
-    const int64_t* engine_block_ids, const int start_block_idx,
-    const int num_blocks_in_batch, const PageBufferShapeDesc shape_desc,
-    const int lmcache_chunk_size,  // e.g., 256, used to calculate global offset
-                                   // in LMCache object
-    const int skip_prefix_n_blocks) {
-  const int block_idx_in_batch = blockIdx.y % num_blocks_in_batch;
-  const int global_block_idx = start_block_idx + block_idx_in_batch;
-  if (global_block_idx < skip_prefix_n_blocks) {
-    // this block is in the prefix that we need to skip, so we do nothing
-    return;
-  }
-
-  const int engine_block_idx =
-      engine_block_ids[start_block_idx + block_idx_in_batch];
-  multi_layer_block_transfer_single_block<ScalarType, lmcache_to_engine,
-                                          format>(
-      lmcache_object, paged_buffer_ptrs, engine_block_idx,
-      block_idx_in_batch * shape_desc.bs,  // offset in LMCache block
-      shape_desc, lmcache_chunk_size);
-}
-
-template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
 __global__ void multi_layer_block_transfer_kernel(
     MemoryObj4<ScalarType> lmcache_objects,
     ScalarType** __restrict__ paged_buffer_ptrs,
     const int64_t* engine_block_ids,
-    const int num_blocks_in_lmcache_object,  // e.g. 16 for lmcache chunk size =
-                                             // 256 and block size = 16
+    const int num_blocks_per_object,  // e.g. 16 for lmcache chunk size =
+                                      // 256 and block size = 16
     const PageBufferShapeDesc shape_desc,
     const int lmcache_chunk_size,  // e.g., 256, used to calculate global offset
                                    // in LMCache object
     const int skip_prefix_n_blocks) {
-  for (int obj_idx = 0; obj_idx < lmcache_objects.num_objects; ++obj_idx) {
-    multi_layer_block_transfer_single_object<ScalarType, lmcache_to_engine,
-                                             format>(
-        lmcache_objects.objects[obj_idx], paged_buffer_ptrs, engine_block_ids,
-        obj_idx * num_blocks_in_lmcache_object, num_blocks_in_lmcache_object,
-        shape_desc, lmcache_chunk_size, skip_prefix_n_blocks);
+  // blockIdx.y spans all blocks across all objects (total_blocks).
+  // Derive which object and local block index from the flat index.
+  const int flat_block_idx = blockIdx.y;
+  if (flat_block_idx < skip_prefix_n_blocks) {
+    return;
   }
+  const int obj_idx = flat_block_idx / num_blocks_per_object;
+  const int block_idx_in_object = flat_block_idx % num_blocks_per_object;
+
+  const int engine_block_idx = engine_block_ids[flat_block_idx];
+  multi_layer_block_transfer_single_block<ScalarType, lmcache_to_engine,
+                                          format>(
+      lmcache_objects.objects[obj_idx], paged_buffer_ptrs, engine_block_idx,
+      block_idx_in_object * shape_desc.bs,  // offset in LMCache object
+      shape_desc, lmcache_chunk_size);
 }
 
 }  // namespace
@@ -367,7 +350,7 @@ void multi_layer_block_kv_transfer(
   int thread_dim_y = shape_desc.nh;
 
   dim3 block(thread_dim_x, thread_dim_y);
-  dim3 grid(shape_desc.kv_size, num_blocks_per_object, shape_desc.nl);
+  dim3 grid(shape_desc.kv_size, total_blocks, shape_desc.nl);
 
   // --- Dispatch on direction x format ---
   if (direction == TransferDirection::H2D) {

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
@@ -211,6 +211,96 @@ __global__ void multi_layer_block_transfer_kernel(
 
 }  // namespace
 
+// ---------------------------------------------------------------------------
+// Pinned ring buffer: pre-allocated cudaHostAlloc region for staging small
+// host data (e.g. block_ids) that the GPU kernel reads via zero-copy.
+//
+// Thread-local so no locking needed across threads. Pinned host memory is
+// accessible from any GPU device, so one buffer per thread is sufficient
+// regardless of which device is active.
+//
+// Multi-stream: tracks which streams have outstanding borrows. On wrap,
+// syncs all of them to guarantee every borrowed region has been consumed
+// before reuse. Wrap is rare (32 MB / ~512 B per call ≈ 65 K calls).
+//
+// After each kernel launch, the caller registers a cudaLaunchHostFunc
+// callback to release the borrowed region back to the ring buffer.
+// ---------------------------------------------------------------------------
+
+static constexpr size_t RING_BUFFER_CAPACITY = 32 * 1024 * 1024;  // 32 MB
+static constexpr size_t RING_BUFFER_ALIGNMENT = 256;
+
+class PinnedRingBuffer {
+ public:
+  PinnedRingBuffer() : buffer_(nullptr), head_(0), tail_(0) {
+    C10_CUDA_CHECK(
+        cudaHostAlloc(&buffer_, RING_BUFFER_CAPACITY, cudaHostAllocMapped));
+  }
+
+  ~PinnedRingBuffer() {
+    if (buffer_) {
+      // At thread exit the CUDA context may already be torn down.
+      // Ignore errors — the OS reclaims the memory on process exit.
+      cudaFreeHost(buffer_);
+    }
+  }
+
+  PinnedRingBuffer(const PinnedRingBuffer&) = delete;
+  PinnedRingBuffer& operator=(const PinnedRingBuffer&) = delete;
+
+  // Borrow a region of `size` bytes. Returns a pinned host pointer that is
+  // accessible from both CPU and GPU (via CUDA unified addressing).
+  void* borrow(size_t size, cudaStream_t stream) {
+    size_t aligned = align_up(size);
+    if (head_ + aligned > RING_BUFFER_CAPACITY) {
+      // Wrap: sync ALL streams that have outstanding borrows to ensure
+      // every borrowed region has been consumed before we reuse the buffer.
+      for (cudaStream_t s : active_streams_) {
+        C10_CUDA_CHECK(cudaStreamSynchronize(s));
+      }
+      active_streams_.clear();
+      head_ = 0;
+      tail_ = 0;
+    }
+    void* ptr = buffer_ + head_;
+    head_ += aligned;
+    active_streams_.insert(stream);
+    return ptr;
+  }
+
+  // Called asynchronously from cudaLaunchHostFunc after the kernel that
+  // uses the borrowed region has completed on the stream.
+  void release(size_t size) { tail_ += align_up(size); }
+
+ private:
+  char* buffer_;
+  size_t head_;               // next byte to allocate
+  std::atomic<size_t> tail_;  // advanced by async callbacks
+  std::unordered_set<cudaStream_t> active_streams_;
+
+  static size_t align_up(size_t size) {
+    return (size + RING_BUFFER_ALIGNMENT - 1) & ~(RING_BUFFER_ALIGNMENT - 1);
+  }
+};
+
+static PinnedRingBuffer& get_ring_buffer() {
+  thread_local PinnedRingBuffer ring;
+  return ring;
+}
+
+struct RingReleaseInfo {
+  PinnedRingBuffer* ring;
+  size_t size;
+};
+
+static void CUDART_CB ring_release_callback(void* data) {
+  auto* info = static_cast<RingReleaseInfo*>(data);
+  info->ring->release(info->size);
+  delete info;
+}
+
+// ---------------------------------------------------------------------------
+
 #define LAUNCH_BLOCK_KERNEL_WITH_FORMAT(DIRECTION, FORMAT)               \
   multi_layer_block_transfer_kernel<uint4, DIRECTION, FORMAT>            \
       <<<grid, block, 0, stream>>>(lmcache_obj4, paged_buffer_ptrs,      \
@@ -221,7 +311,7 @@ __global__ void multi_layer_block_transfer_kernel(
 
 void multi_layer_block_kv_transfer(
     const torch::Tensor& paged_buffer_ptrs_tensor,
-    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    std::vector<int64_t> lmcache_objects_ptrs, std::vector<int64_t> block_ids,
     const torch::Device& device, TransferDirection direction,
     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
     GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks) {
@@ -230,7 +320,7 @@ void multi_layer_block_kv_transfer(
   TORCH_CHECK(num_objects >= 1 && num_objects <= 4,
               "Expected 1-4 LMCache objects, got ", num_objects);
 
-  int total_blocks = block_ids.size(0);
+  int total_blocks = static_cast<int>(block_ids.size());
   TORCH_CHECK(total_blocks % num_objects == 0, "block_ids length (",
               total_blocks, ") must be divisible by num_objects (", num_objects,
               ")");
@@ -259,8 +349,16 @@ void multi_layer_block_kv_transfer(
   uint4** paged_buffer_ptrs =
       reinterpret_cast<uint4**>(paged_buffer_ptrs_tensor.data_ptr());
 
-  // --- Block IDs pointer ---
-  const int64_t* block_ids_ptr = block_ids.data_ptr<int64_t>();
+  const at::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // --- Stage block_ids into pinned ring buffer (GPU-accessible via UVA) ---
+  size_t block_ids_bytes = total_blocks * sizeof(int64_t);
+  PinnedRingBuffer& ring = get_ring_buffer();
+  int64_t* block_ids_pinned =
+      static_cast<int64_t*>(ring.borrow(block_ids_bytes, stream));
+  std::memcpy(block_ids_pinned, block_ids.data(), block_ids_bytes);
+  const int64_t* block_ids_ptr = block_ids_pinned;
 
   // --- Grid and block dimensions ---
   int elements_per_head =
@@ -270,9 +368,6 @@ void multi_layer_block_kv_transfer(
 
   dim3 block(thread_dim_x, thread_dim_y);
   dim3 grid(shape_desc.kv_size, num_blocks_per_object, shape_desc.nl);
-
-  const at::cuda::OptionalCUDAGuard device_guard(device);
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   // --- Dispatch on direction x format ---
   if (direction == TransferDirection::H2D) {
@@ -330,6 +425,11 @@ void multi_layer_block_kv_transfer(
                     static_cast<int>(gpu_kv_format));
     }
   }
+
+  // --- Release ring buffer region after kernel completes on stream ---
+  auto* release_info = new RingReleaseInfo{&ring, block_ids_bytes};
+  C10_CUDA_CHECK(
+      cudaLaunchHostFunc(stream, ring_release_callback, release_info));
 }
 
 #undef LAUNCH_BLOCK_KERNEL_WITH_FORMAT

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
@@ -23,17 +23,29 @@ __device__ inline size_t calculate_engine_global_offset(
   size_t scalars_per_block = shape_desc.scalars_per_block<ScalarType>();
   // will use kv_size, nb, nl, scalars per block
   if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+    // Cross-layer: single tensor [NB, NL, 2, BS, NH, HS]
     return k_or_v * scalars_per_block +
            layer_idx * shape_desc.kv_size * scalars_per_block +
            engine_block_idx * shape_desc.kv_size * scalars_per_block *
                shape_desc.nl;
   } else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+    // Normal: L tensors [2, NB, BS, NH, HS]
     return engine_block_idx * scalars_per_block +
            k_or_v * shape_desc.nb * scalars_per_block;
+  } else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+    // Flash Infer: L tensors [NB, 2, BS, NH, HS]
+    return engine_block_idx * shape_desc.kv_size * scalars_per_block +
+           k_or_v * scalars_per_block;
   } else if constexpr (format == GPUKVFormat::NL_X_NB_BS_HS) {
+    // MLA: L tensors [NB, BS, HS]
     return engine_block_idx * scalars_per_block;
-  } else
-    return 0;  // TODO: not implemented, do it later
+  } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
+    // SGLang MHA: 2L tensors [NBBS, NH, HS] — K/V via separate tensor ptrs
+    return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == GPUKVFormat::NL_X_NBBS_ONE_HS) {
+    // SGLang MLA: L tensors [NBBS, 1, HS]
+    return engine_block_idx * scalars_per_block;
+  }
 }
 
 template <typename ScalarType, GPUKVFormat format>
@@ -70,21 +82,41 @@ __device__ inline size_t calculate_lmcache_local_offset(
   return head_idx * scalars_per_head + token_offset * scalars_per_token;
 }
 
+__device__ inline uint4 ld_cs(const uint4* addr) {
+  uint4 val;
+  asm volatile("ld.global.cs.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "l"(addr));
+  return val;
+}
+
+__device__ inline void st_cs(uint4* addr, uint4 val) {
+  asm volatile("st.global.cs.v4.u32 [%0], {%1, %2, %3, %4};"
+               :
+               : "l"(addr), "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w));
+}
+
 template <typename ScalarType>
 __device__ inline void warp_copy(ScalarType* __restrict__ dst,
                                  const ScalarType* __restrict__ src,
                                  size_t num_elements) {
-  // we can use cs/cg to stream data and bypass L2 cache
   int idx = threadIdx.x;
-  for (size_t i = idx; i < num_elements; i += warpSize) {
-    dst[i] = src[i];
+  int stride = blockDim.x;
+  if constexpr (std::is_same_v<ScalarType, uint4>) {
+    for (size_t i = idx; i < num_elements; i += stride) {
+      st_cs(dst + i, ld_cs(src + i));
+    }
+  } else {
+    for (size_t i = idx; i < num_elements; i += stride) {
+      dst[i] = src[i];
+    }
   }
 }
 
 template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
 __device__ void multi_layer_block_transfer_single_block(
-    ScalarType __restrict__* lmcache_object,
-    ScalarType __restrict__** paged_buffer_ptrs, const int engine_block_idx,
+    ScalarType* __restrict__ lmcache_object,
+    ScalarType** __restrict__ paged_buffer_ptrs, const int engine_block_idx,
     const int offset_in_lmcache_block, const PageBufferShapeDesc shape_desc,
     const int lmcache_chunk_size  // e.g., 256, used to calculate global offset
                                   // in LMCache object
@@ -103,6 +135,10 @@ __device__ void multi_layer_block_transfer_single_block(
   ScalarType* paged_buffer_layer_ptr;
   if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
     paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[0];
+  } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
+    // SGLang MHA: ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V per layer
+    paged_buffer_layer_ptr =
+        (ScalarType*)paged_buffer_ptrs[k_or_v * shape_desc.nl + layer_idx];
   } else {
     paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[layer_idx];
   }
@@ -138,7 +174,8 @@ __device__ void multi_layer_block_transfer_single_object(
                                    // in LMCache object
     const int skip_prefix_n_blocks) {
   const int block_idx_in_batch = blockIdx.y % num_blocks_in_batch;
-  if (block_idx_in_batch < skip_prefix_n_blocks) {
+  const int global_block_idx = start_block_idx + block_idx_in_batch;
+  if (global_block_idx < skip_prefix_n_blocks) {
     // this block is in the prefix that we need to skip, so we do nothing
     return;
   }
@@ -184,11 +221,10 @@ __global__ void multi_layer_block_transfer_kernel(
 
 void multi_layer_block_kv_transfer(
     const torch::Tensor& paged_buffer_ptrs_tensor,
-    std::vector<uintptr_t>& lmcache_objects_ptrs,
-    const torch::Tensor& block_ids, const torch::Device& device,
-    TransferDirection direction, PageBufferShapeDesc shape_desc,
-    int lmcache_chunk_size, GPUKVFormat gpu_kv_format,
-    int skip_prefix_n_blocks) {
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks) {
   // --- Validation ---
   int num_objects = static_cast<int>(lmcache_objects_ptrs.size());
   TORCH_CHECK(num_objects >= 1 && num_objects <= 4,

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cu
@@ -2,31 +2,298 @@
 
 #include "multi_layer_block_kv_transfer.cuh"
 
+namespace {
+
 /**
- * Stub implementation of block-level multi-layer KV transfer.
- *
- * TODO: Replace this stub with the actual CUDA kernel implementation.
- *
- * The kernel should:
- * 1. For each block in block_ids (after skipping skip_prefix_n_blocks):
- *    - Determine which memory_object and local offset this block maps to
- *    - For each layer: copy BS tokens between the vLLM paged buffer and
- *      the LMCache memory object
- * 2. Handle all GPUKVFormat layouts:
- *    - NL_X_TWO_NB_BS_NH_HS: L separate tensors [2, NB, BS, NH, HS]
- *    - NB_NL_TWO_BS_NH_HS: single tensor [NB, NL, 2, BS, NH, HS]
- *    - NL_X_NB_BS_HS: L separate tensors [NB, BS, HS] (MLA)
- * 3. Support both bfloat16 and float8_e4m3fn
- * 4. Use async CUDA memcpy for efficient H2D/D2H transfers
+ * Key logic in the kernel implementation:
+ * 1 Each thread block is for (BS, NH, HS) part (i.e., a single block in the
+ * paged buffer) 2 Within a thread block, each warp is for a single head. Number
+ * of warps in a thread block is equal to the number of heads (NH). 3 Within a
+ * thread block, we do the loop over the BS (i.e., number of tokens in the
+ * block) dimension. 4 The grid will take over (2, NB, NL) dimensions. No matter
+ * what the actual layout in memory is, we will calculate the global offset for
+ * the start of the block 5 For LMCache, we assume it is always using 2LTD
+ * layout, e.g., [2, L, 256, NH * HS], where 256 means that 256 tokens
  */
-void multi_layer_block_kv_transfer(
-    const std::vector<torch::Tensor>& key_value_tensors,
-    std::vector<torch::Tensor>& memory_objects, const torch::Tensor& block_ids,
-    const torch::Device& device, TransferDirection direction,
-    GPUKVFormat gpu_kv_format, int block_size, int num_blocks,
-    int skip_prefix_n_blocks) {
-  TORCH_CHECK(false,
-              "multi_layer_block_kv_transfer CUDA kernel not yet implemented. "
-              "Use --use-reference flag to run with the Python reference "
-              "implementation.");
+
+template <typename ScalarType, GPUKVFormat format>
+__device__ inline size_t calculate_engine_global_offset(
+    const int k_or_v, const int engine_block_idx, const int layer_idx,
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_block = shape_desc.scalars_per_block<ScalarType>();
+  // will use kv_size, nb, nl, scalars per block
+  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+    return k_or_v * scalars_per_block +
+           layer_idx * shape_desc.kv_size * scalars_per_block +
+           engine_block_idx * shape_desc.kv_size * scalars_per_block *
+               shape_desc.nl;
+  } else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+    return engine_block_idx * scalars_per_block +
+           k_or_v * shape_desc.nb * scalars_per_block;
+  } else if constexpr (format == GPUKVFormat::NL_X_NB_BS_HS) {
+    return engine_block_idx * scalars_per_block;
+  } else
+    return 0;  // TODO: not implemented, do it later
 }
+
+template <typename ScalarType, GPUKVFormat format>
+__device__ inline size_t calculate_engine_local_offset(
+    const int token_offset, const int head_idx,
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_head = shape_desc.scalars_per_head<ScalarType>();
+  size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
+  // for now, everything is BS, NH, HS, so we only have a single case
+  return head_idx * scalars_per_head + token_offset * scalars_per_token;
+}
+
+template <typename ScalarType, GPUKVFormat format>
+__device__ inline size_t calculate_lmcache_global_offset(
+    const int k_or_v,
+    const int
+        token_offset_in_lmcache_block,  // 0~255 if LMCache block size is 256
+    const int layer_idx,
+    const int lmcache_chunk_size,  // e.g., 256
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
+  // LMCache is using 2LTD all the times
+  return token_offset_in_lmcache_block * scalars_per_token +
+         layer_idx * lmcache_chunk_size * scalars_per_token +
+         k_or_v * shape_desc.nl * lmcache_chunk_size * scalars_per_token;
+}
+
+template <typename ScalarType, GPUKVFormat format>
+__device__ inline size_t calculate_lmcache_local_offset(
+    const int token_offset, const int head_idx,
+    const PageBufferShapeDesc shape_desc) {
+  size_t scalars_per_head = shape_desc.scalars_per_head<ScalarType>();
+  size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
+  return head_idx * scalars_per_head + token_offset * scalars_per_token;
+}
+
+template <typename ScalarType>
+__device__ inline void warp_copy(ScalarType* __restrict__ dst,
+                                 const ScalarType* __restrict__ src,
+                                 size_t num_elements) {
+  // we can use cs/cg to stream data and bypass L2 cache
+  int idx = threadIdx.x;
+  for (size_t i = idx; i < num_elements; i += warpSize) {
+    dst[i] = src[i];
+  }
+}
+
+template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
+__device__ void multi_layer_block_transfer_single_block(
+    ScalarType __restrict__* lmcache_object,
+    ScalarType __restrict__** paged_buffer_ptrs, const int engine_block_idx,
+    const int offset_in_lmcache_block, const PageBufferShapeDesc shape_desc,
+    const int lmcache_chunk_size  // e.g., 256, used to calculate global offset
+                                  // in LMCache object
+) {
+  const int head_idx = threadIdx.y;
+  const int k_or_v = blockIdx.x;
+  const int layer_idx = blockIdx.z;
+
+  const size_t engine_global_offset =
+      calculate_engine_global_offset<ScalarType, format>(
+          k_or_v, engine_block_idx, layer_idx, shape_desc);
+  const size_t lmcache_global_offset =
+      calculate_lmcache_global_offset<ScalarType, format>(
+          k_or_v, offset_in_lmcache_block, layer_idx, lmcache_chunk_size,
+          shape_desc);
+  ScalarType* paged_buffer_layer_ptr;
+  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+    paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[0];
+  } else {
+    paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[layer_idx];
+  }
+
+  for (int token_offset = 0; token_offset < shape_desc.bs; ++token_offset) {
+    const size_t engine_local_offset =
+        calculate_engine_local_offset<ScalarType, format>(token_offset,
+                                                          head_idx, shape_desc);
+    const size_t lmcache_local_offset =
+        calculate_lmcache_local_offset<ScalarType, format>(
+            token_offset, head_idx, shape_desc);
+    ScalarType* engine_ptr =
+        paged_buffer_layer_ptr + engine_global_offset + engine_local_offset;
+    ScalarType* lmcache_ptr =
+        lmcache_object + lmcache_global_offset + lmcache_local_offset;
+    if constexpr (lmcache_to_engine) {
+      warp_copy<ScalarType>(engine_ptr, lmcache_ptr,
+                            shape_desc.scalars_per_head<ScalarType>());
+    } else {
+      warp_copy<ScalarType>(lmcache_ptr, engine_ptr,
+                            shape_desc.scalars_per_head<ScalarType>());
+    }
+  }
+}
+
+template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
+__device__ void multi_layer_block_transfer_single_object(
+    ScalarType* __restrict__ lmcache_object,
+    ScalarType** __restrict__ paged_buffer_ptrs,
+    const int64_t* engine_block_ids, const int start_block_idx,
+    const int num_blocks_in_batch, const PageBufferShapeDesc shape_desc,
+    const int lmcache_chunk_size,  // e.g., 256, used to calculate global offset
+                                   // in LMCache object
+    const int skip_prefix_n_blocks) {
+  const int block_idx_in_batch = blockIdx.y % num_blocks_in_batch;
+  if (block_idx_in_batch < skip_prefix_n_blocks) {
+    // this block is in the prefix that we need to skip, so we do nothing
+    return;
+  }
+
+  const int engine_block_idx =
+      engine_block_ids[start_block_idx + block_idx_in_batch];
+  multi_layer_block_transfer_single_block<ScalarType, lmcache_to_engine,
+                                          format>(
+      lmcache_object, paged_buffer_ptrs, engine_block_idx,
+      block_idx_in_batch * shape_desc.bs,  // offset in LMCache block
+      shape_desc, lmcache_chunk_size);
+}
+
+template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
+__global__ void multi_layer_block_transfer_kernel(
+    MemoryObj4<ScalarType> lmcache_objects,
+    ScalarType** __restrict__ paged_buffer_ptrs,
+    const int64_t* engine_block_ids,
+    const int num_blocks_in_lmcache_object,  // e.g. 16 for lmcache chunk size =
+                                             // 256 and block size = 16
+    const PageBufferShapeDesc shape_desc,
+    const int lmcache_chunk_size,  // e.g., 256, used to calculate global offset
+                                   // in LMCache object
+    const int skip_prefix_n_blocks) {
+  for (int obj_idx = 0; obj_idx < lmcache_objects.num_objects; ++obj_idx) {
+    multi_layer_block_transfer_single_object<ScalarType, lmcache_to_engine,
+                                             format>(
+        lmcache_objects.objects[obj_idx], paged_buffer_ptrs, engine_block_ids,
+        obj_idx * num_blocks_in_lmcache_object, num_blocks_in_lmcache_object,
+        shape_desc, lmcache_chunk_size, skip_prefix_n_blocks);
+  }
+}
+
+}  // namespace
+
+#define LAUNCH_BLOCK_KERNEL_WITH_FORMAT(DIRECTION, FORMAT)               \
+  multi_layer_block_transfer_kernel<uint4, DIRECTION, FORMAT>            \
+      <<<grid, block, 0, stream>>>(lmcache_obj4, paged_buffer_ptrs,      \
+                                   block_ids_ptr, num_blocks_per_object, \
+                                   shape_desc, lmcache_chunk_size,       \
+                                   skip_prefix_n_blocks);                \
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+void multi_layer_block_kv_transfer(
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<uintptr_t>& lmcache_objects_ptrs,
+    const torch::Tensor& block_ids, const torch::Device& device,
+    TransferDirection direction, PageBufferShapeDesc shape_desc,
+    int lmcache_chunk_size, GPUKVFormat gpu_kv_format,
+    int skip_prefix_n_blocks) {
+  // --- Validation ---
+  int num_objects = static_cast<int>(lmcache_objects_ptrs.size());
+  TORCH_CHECK(num_objects >= 1 && num_objects <= 4,
+              "Expected 1-4 LMCache objects, got ", num_objects);
+
+  int total_blocks = block_ids.size(0);
+  TORCH_CHECK(total_blocks % num_objects == 0, "block_ids length (",
+              total_blocks, ") must be divisible by num_objects (", num_objects,
+              ")");
+  int num_blocks_per_object = total_blocks / num_objects;
+
+  TORCH_CHECK(num_blocks_per_object * shape_desc.bs == lmcache_chunk_size,
+              "blocks_per_object * block_size (",
+              num_blocks_per_object * shape_desc.bs,
+              ") must equal lmcache_chunk_size (", lmcache_chunk_size, ")");
+
+  TORCH_CHECK(
+      shape_desc.hs * shape_desc.element_size % sizeof(uint4) == 0,
+      "head_size * element_size (", shape_desc.hs * shape_desc.element_size,
+      ") must be divisible by ", sizeof(uint4), " for uint4 vectorized access");
+
+  // --- Build MemoryObj4 ---
+  MemoryObj4<uint4> lmcache_obj4;
+  lmcache_obj4.num_objects = num_objects;
+  for (int i = 0; i < 4; ++i) {
+    lmcache_obj4.objects[i] =
+        (i < num_objects) ? reinterpret_cast<uint4*>(lmcache_objects_ptrs[i])
+                          : nullptr;
+  }
+
+  // --- Build paged buffer pointer array ---
+  uint4** paged_buffer_ptrs =
+      reinterpret_cast<uint4**>(paged_buffer_ptrs_tensor.data_ptr());
+
+  // --- Block IDs pointer ---
+  const int64_t* block_ids_ptr = block_ids.data_ptr<int64_t>();
+
+  // --- Grid and block dimensions ---
+  int elements_per_head =
+      shape_desc.hs * shape_desc.element_size / sizeof(uint4);
+  int thread_dim_x = std::min(elements_per_head, 32);
+  int thread_dim_y = shape_desc.nh;
+
+  dim3 block(thread_dim_x, thread_dim_y);
+  dim3 grid(shape_desc.kv_size, num_blocks_per_object, shape_desc.nl);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // --- Dispatch on direction x format ---
+  if (direction == TransferDirection::H2D) {
+    switch (gpu_kv_format) {
+      case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true, GPUKVFormat::NB_NL_TWO_BS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true,
+                                        GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true,
+                                        GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_NB_BS_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true, GPUKVFormat::NL_X_NB_BS_HS);
+        break;
+      case GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true,
+                                        GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_NBBS_ONE_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true, GPUKVFormat::NL_X_NBBS_ONE_HS);
+        break;
+      default:
+        TORCH_CHECK(false, "Unsupported GPUKVFormat: ",
+                    static_cast<int>(gpu_kv_format));
+    }
+  } else {
+    switch (gpu_kv_format) {
+      case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false, GPUKVFormat::NB_NL_TWO_BS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false,
+                                        GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false,
+                                        GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_NB_BS_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false, GPUKVFormat::NL_X_NB_BS_HS);
+        break;
+      case GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false,
+                                        GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS);
+        break;
+      case GPUKVFormat::NL_X_NBBS_ONE_HS:
+        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false, GPUKVFormat::NL_X_NBBS_ONE_HS);
+        break;
+      default:
+        TORCH_CHECK(false, "Unsupported GPUKVFormat: ",
+                    static_cast<int>(gpu_kv_format));
+    }
+  }
+}
+
+#undef LAUNCH_BLOCK_KERNEL_WITH_FORMAT

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <vector>
 
 enum class TransferDirection : int {
@@ -56,21 +58,20 @@ struct MemoryObj4 {
  * Block-level multi-layer KV transfer between vLLM paged buffers and
  * LMCache contiguous memory objects.
  *
- * @param key_value_tensors  vLLM paged buffer tensors (per-layer or single
- * cross-layer)
- * @param memory_objects     LMCache memory objects (pinned CPU tensors)
- * @param block_ids          Block indices in vLLM paged buffer (pinned CPU
- * int64)
- * @param device             CUDA device of vLLM tensors
- * @param direction          H2D (LMCache->vLLM) or D2H (vLLM->LMCache)
- * @param gpu_kv_format      GPUKVFormat identifier
- * @param block_size         Block size (BS) for vLLM paged buffers
- * @param num_blocks         Number of blocks (NB) for vLLM paged buffers
- * @param skip_prefix_n_blocks  Number of blocks to skip at the beginning
+ * @param paged_buffer_ptrs_tensor  GPU int64 tensor of data pointers into
+ *                                  vLLM paged buffers (one per tensor)
+ * @param lmcache_objects_ptrs      Raw pointers to LMCache memory objects
+ * @param block_ids                 Block indices in vLLM paged buffer
+ * @param device                    CUDA device of vLLM tensors
+ * @param direction                 H2D (LMCache->vLLM) or D2H (vLLM->LMCache)
+ * @param shape_desc                Shape descriptor for the paged buffer
+ * @param lmcache_chunk_size        Tokens per LMCache memory object
+ * @param gpu_kv_format             GPUKVFormat identifier
+ * @param skip_prefix_n_blocks      Number of blocks to skip at the beginning
  */
 void multi_layer_block_kv_transfer(
-    const std::vector<torch::Tensor>& key_value_tensors,
-    std::vector<torch::Tensor>& memory_objects, const torch::Tensor& block_ids,
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
     const torch::Device& device, TransferDirection direction,
-    GPUKVFormat gpu_kv_format, int block_size, int num_blocks,
-    int skip_prefix_n_blocks);
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks);

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <torch/all.h>
+#include <vector>
+
+enum class TransferDirection : int {
+  H2D = 0,
+  D2H = 1,
+};
+
+enum class GPUKVFormat : int {
+  NB_NL_TWO_BS_NH_HS = 0,    // vLLM cross-layer: single tensor
+  NL_X_TWO_NB_BS_NH_HS = 1,  // vLLM non-MLA flash attention: L separate tensors
+  NL_X_NB_BS_HS = 3,         // vLLM MLA: L separate tensors
+};
+
+/**
+ * Block-level multi-layer KV transfer between vLLM paged buffers and
+ * LMCache contiguous memory objects.
+ *
+ * @param key_value_tensors  vLLM paged buffer tensors (per-layer or single
+ * cross-layer)
+ * @param memory_objects     LMCache memory objects (pinned CPU tensors)
+ * @param block_ids          Block indices in vLLM paged buffer (pinned CPU
+ * int64)
+ * @param device             CUDA device of vLLM tensors
+ * @param direction          H2D (LMCache->vLLM) or D2H (vLLM->LMCache)
+ * @param gpu_kv_format      GPUKVFormat identifier
+ * @param block_size         Block size (BS) for vLLM paged buffers
+ * @param num_blocks         Number of blocks (NB) for vLLM paged buffers
+ * @param skip_prefix_n_blocks  Number of blocks to skip at the beginning
+ */
+void multi_layer_block_kv_transfer(
+    const std::vector<torch::Tensor>& key_value_tensors,
+    std::vector<torch::Tensor>& memory_objects, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    GPUKVFormat gpu_kv_format, int block_size, int num_blocks,
+    int skip_prefix_n_blocks);

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
@@ -5,6 +5,7 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <unordered_set>
 #include <vector>
 
 enum class TransferDirection : int {
@@ -71,7 +72,7 @@ struct MemoryObj4 {
  */
 void multi_layer_block_kv_transfer(
     const torch::Tensor& paged_buffer_ptrs_tensor,
-    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    std::vector<int64_t> lmcache_objects_ptrs, std::vector<int64_t> block_ids,
     const torch::Device& device, TransferDirection direction,
     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
     GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks);

--- a/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
+++ b/lmcache/tools/kernel_harness/csrc/multi_layer_block_kv_transfer.cuh
@@ -11,9 +11,45 @@ enum class TransferDirection : int {
 };
 
 enum class GPUKVFormat : int {
-  NB_NL_TWO_BS_NH_HS = 0,    // vLLM cross-layer: single tensor
-  NL_X_TWO_NB_BS_NH_HS = 1,  // vLLM non-MLA flash attention: L separate tensors
-  NL_X_NB_BS_HS = 3,         // vLLM MLA: L separate tensors
+  NB_NL_TWO_BS_NH_HS =
+      0,  // vLLM cross-layer: single tensor [NB, NL, 2, BS, NH, HS]
+  NL_X_TWO_NB_BS_NH_HS =
+      1,  // vLLM flash attention: L tensors [2, NB, BS, NH, HS]
+  NL_X_NB_TWO_BS_NH_HS = 2,   // vLLM flash infer: L tensors [NB, 2, BS, NH, HS]
+  NL_X_NB_BS_HS = 3,          // vLLM MLA: L tensors [NB, BS, HS]
+  TWO_X_NL_X_NBBS_NH_HS = 4,  // SGLang MHA: 2L tensors [NBBS, NH, HS]
+  NL_X_NBBS_ONE_HS = 5,       // SGLang MLA: L tensors [NBBS, 1, HS]
+};
+
+struct PageBufferShapeDesc {
+  int kv_size;       // 1 or 2
+  int nl;            // num layers
+  int nb;            // num blocks
+  int bs;            // block size
+  int nh;            // num heads
+  int hs;            // head size
+  int element_size;  // bytes (1 or 2)
+
+  template <typename ScalarType>
+  __host__ __device__ inline size_t scalars_per_head() const {
+    return hs * element_size / sizeof(ScalarType);
+  }
+
+  template <typename ScalarType>
+  __host__ __device__ inline size_t scalars_per_token() const {
+    return nh * hs * element_size / sizeof(ScalarType);
+  }
+
+  template <typename ScalarType>
+  __host__ __device__ inline size_t scalars_per_block() const {
+    return bs * nh * hs * element_size / sizeof(ScalarType);
+  }
+};
+
+template <typename ScalarType>
+struct MemoryObj4 {
+  ScalarType* objects[4];
+  int num_objects;  // 0 - 4
 };
 
 /**

--- a/lmcache/tools/kernel_harness/csrc/pybind.cpp
+++ b/lmcache/tools/kernel_harness/csrc/pybind.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "multi_layer_block_kv_transfer.cuh"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(kernel_harness_ops, m) {
+  m.doc() = "LMCache kernel harness: block-level multi-layer KV transfer";
+
+  py::enum_<TransferDirection>(m, "TransferDirection")
+      .value("H2D", TransferDirection::H2D)
+      .value("D2H", TransferDirection::D2H)
+      .export_values();
+
+  py::enum_<GPUKVFormat>(m, "GPUKVFormat")
+      .value("NB_NL_TWO_BS_NH_HS", GPUKVFormat::NB_NL_TWO_BS_NH_HS)
+      .value("NL_X_TWO_NB_BS_NH_HS", GPUKVFormat::NL_X_TWO_NB_BS_NH_HS)
+      .value("NL_X_NB_BS_HS", GPUKVFormat::NL_X_NB_BS_HS)
+      .export_values();
+
+  m.def("multi_layer_block_kv_transfer", &multi_layer_block_kv_transfer,
+        py::arg("key_value_tensors"), py::arg("memory_objects"),
+        py::arg("block_ids"), py::arg("device"), py::arg("direction"),
+        py::arg("gpu_kv_format"), py::arg("block_size"), py::arg("num_blocks"),
+        py::arg("skip_prefix_n_blocks"),
+        py::call_guard<py::gil_scoped_release>());
+}

--- a/lmcache/tools/kernel_harness/csrc/pybind.cpp
+++ b/lmcache/tools/kernel_harness/csrc/pybind.cpp
@@ -2,6 +2,8 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <torch/torch.h>
+#include <torch/extension.h>
 #include "multi_layer_block_kv_transfer.cuh"
 
 namespace py = pybind11;

--- a/lmcache/tools/kernel_harness/csrc/pybind.cpp
+++ b/lmcache/tools/kernel_harness/csrc/pybind.cpp
@@ -17,13 +17,26 @@ PYBIND11_MODULE(kernel_harness_ops, m) {
   py::enum_<GPUKVFormat>(m, "GPUKVFormat")
       .value("NB_NL_TWO_BS_NH_HS", GPUKVFormat::NB_NL_TWO_BS_NH_HS)
       .value("NL_X_TWO_NB_BS_NH_HS", GPUKVFormat::NL_X_TWO_NB_BS_NH_HS)
+      .value("NL_X_NB_TWO_BS_NH_HS", GPUKVFormat::NL_X_NB_TWO_BS_NH_HS)
       .value("NL_X_NB_BS_HS", GPUKVFormat::NL_X_NB_BS_HS)
+      .value("TWO_X_NL_X_NBBS_NH_HS", GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS)
+      .value("NL_X_NBBS_ONE_HS", GPUKVFormat::NL_X_NBBS_ONE_HS)
       .export_values();
 
   m.def("multi_layer_block_kv_transfer", &multi_layer_block_kv_transfer,
-        py::arg("key_value_tensors"), py::arg("memory_objects"),
+        py::arg("paged_buffer_ptrs_tensor"), py::arg("lmcache_objects_ptrs"),
         py::arg("block_ids"), py::arg("device"), py::arg("direction"),
-        py::arg("gpu_kv_format"), py::arg("block_size"), py::arg("num_blocks"),
-        py::arg("skip_prefix_n_blocks"),
+        py::arg("shape_desc"), py::arg("lmcache_chunk_size"),
+        py::arg("gpu_kv_format"), py::arg("skip_prefix_n_blocks"),
         py::call_guard<py::gil_scoped_release>());
+
+  py::class_<PageBufferShapeDesc>(m, "PageBufferShapeDesc")
+      .def(py::init<>())
+      .def_readwrite("kv_size", &PageBufferShapeDesc::kv_size)
+      .def_readwrite("nl", &PageBufferShapeDesc::nl)
+      .def_readwrite("nb", &PageBufferShapeDesc::nb)
+      .def_readwrite("bs", &PageBufferShapeDesc::bs)
+      .def_readwrite("nh", &PageBufferShapeDesc::nh)
+      .def_readwrite("hs", &PageBufferShapeDesc::hs)
+      .def_readwrite("element_size", &PageBufferShapeDesc::element_size);
 }

--- a/lmcache/tools/kernel_harness/reference.py
+++ b/lmcache/tools/kernel_harness/reference.py
@@ -16,10 +16,11 @@ def _get_vllm_block(
     """Extract a single block from vLLM tensors for a given layer.
 
     Returns:
-    - NORMAL: shape [2, BS, NH, HS]
-    - CROSS_LAYER: shape [2, BS, NH, HS]
-    - MLA: shape [BS, HS]
+    - Non-MLA formats: shape [2, BS, NH, HS]
+    - MLA formats: shape [BS, HS]
     """
+    bs = config.block_size
+
     if config.vllm_format == VLLMBufferFormat.NORMAL:
         # vllm_tensors[layer]: [2, NB, BS, NH, HS]
         return vllm_tensors[layer_idx][:, block_idx, :, :, :]
@@ -32,6 +33,26 @@ def _get_vllm_block(
         # vllm_tensors[layer]: [NB, BS, HS]
         return vllm_tensors[layer_idx][block_idx, :, :]
 
+    elif config.vllm_format == VLLMBufferFormat.FLASH_INFER:
+        # vllm_tensors[layer]: [NB, 2, BS, NH, HS]
+        return vllm_tensors[layer_idx][block_idx, :, :, :, :]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MHA:
+        # vllm_tensors[layer] = K, vllm_tensors[nl + layer] = V
+        # each: [NBBS, NH, HS], flat token indexing
+        token_start = block_idx * bs
+        token_end = token_start + bs
+        nl = config.num_layers
+        k_block = vllm_tensors[layer_idx][token_start:token_end, :, :]
+        v_block = vllm_tensors[nl + layer_idx][token_start:token_end, :, :]
+        return torch.stack([k_block, v_block], dim=0)  # [2, BS, NH, HS]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MLA:
+        # vllm_tensors[layer]: [NBBS, 1, HS], flat token indexing
+        token_start = block_idx * bs
+        token_end = token_start + bs
+        return vllm_tensors[layer_idx][token_start:token_end, 0, :]  # [BS, HS]
+
     raise ValueError(f"Unknown format: {config.vllm_format}")
 
 
@@ -43,6 +64,8 @@ def _set_vllm_block(
     data: torch.Tensor,
 ) -> None:
     """Write a block into vLLM tensors for a given layer."""
+    bs = config.block_size
+
     if config.vllm_format == VLLMBufferFormat.NORMAL:
         vllm_tensors[layer_idx][:, block_idx, :, :, :] = data
 
@@ -51,6 +74,23 @@ def _set_vllm_block(
 
     elif config.vllm_format == VLLMBufferFormat.MLA:
         vllm_tensors[layer_idx][block_idx, :, :] = data
+
+    elif config.vllm_format == VLLMBufferFormat.FLASH_INFER:
+        vllm_tensors[layer_idx][block_idx, :, :, :, :] = data
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MHA:
+        # data: [2, BS, NH, HS] → split into K and V flat tensors
+        token_start = block_idx * bs
+        token_end = token_start + bs
+        nl = config.num_layers
+        vllm_tensors[layer_idx][token_start:token_end, :, :] = data[0]
+        vllm_tensors[nl + layer_idx][token_start:token_end, :, :] = data[1]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MLA:
+        # data: [BS, HS] → write into flat tensor
+        token_start = block_idx * bs
+        token_end = token_start + bs
+        vllm_tensors[layer_idx][token_start:token_end, 0, :] = data
 
 
 def reference_multi_layer_block_kv_transfer(
@@ -117,17 +157,15 @@ def reference_multi_layer_block_kv_transfer(
                                 vllm_block[kv].reshape(bs, config.hidden_dim).cpu()
                             )
                     else:
-                        for kv in range(2):
-                            block_data = (
+                        combined = torch.stack(
+                            [
                                 mem_obj[kv, layer_idx, token_start:token_end, :]
                                 .reshape(bs, config.num_heads, config.head_size)
                                 .to(vllm_tensors[0].device)
-                            )
-                            if config.vllm_format == VLLMBufferFormat.NORMAL:
-                                vllm_tensors[layer_idx][kv, block_id, :, :, :] = (
-                                    block_data
-                                )
-                            elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
-                                vllm_tensors[0][block_id, layer_idx, kv, :, :, :] = (
-                                    block_data
-                                )
+                                for kv in range(2)
+                            ],
+                            dim=0,
+                        )  # [2, BS, NH, HS]
+                        _set_vllm_block(
+                            vllm_tensors, config, layer_idx, block_id, combined
+                        )

--- a/lmcache/tools/kernel_harness/reference.py
+++ b/lmcache/tools/kernel_harness/reference.py
@@ -134,7 +134,7 @@ def reference_multi_layer_block_kv_transfer(
                     # MLA: vllm_block is [BS, HS], mem_obj is [1, L, T, D]
                     if direction == Direction.D2H:
                         mem_obj[0, layer_idx, token_start:token_end, :] = (
-                            vllm_block.reshape(bs, config.hidden_dim).cpu()
+                            vllm_block.reshape(bs, config.hidden_dim).to(mem_obj.device)
                         )
                     else:
                         _set_vllm_block(
@@ -152,7 +152,9 @@ def reference_multi_layer_block_kv_transfer(
                     if direction == Direction.D2H:
                         for kv in range(2):
                             mem_obj[kv, layer_idx, token_start:token_end, :] = (
-                                vllm_block[kv].reshape(bs, config.hidden_dim).cpu()
+                                vllm_block[kv]
+                                .reshape(bs, config.hidden_dim)
+                                .to(mem_obj.device)
                             )
                     else:
                         combined = torch.stack(

--- a/lmcache/tools/kernel_harness/reference.py
+++ b/lmcache/tools/kernel_harness/reference.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+import torch
+
+# Local
+from .config import Direction, TestConfig, VLLMBufferFormat
+
+
+def _get_vllm_block(
+    vllm_tensors: list,
+    config: TestConfig,
+    layer_idx: int,
+    block_idx: int,
+) -> torch.Tensor:
+    """Extract a single block from vLLM tensors for a given layer.
+
+    Returns:
+    - NORMAL: shape [2, BS, NH, HS]
+    - CROSS_LAYER: shape [2, BS, NH, HS]
+    - MLA: shape [BS, HS]
+    """
+    if config.vllm_format == VLLMBufferFormat.NORMAL:
+        # vllm_tensors[layer]: [2, NB, BS, NH, HS]
+        return vllm_tensors[layer_idx][:, block_idx, :, :, :]
+
+    elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+        # vllm_tensors[0]: [NB, NL, 2, BS, NH, HS]
+        return vllm_tensors[0][block_idx, layer_idx, :, :, :, :]
+
+    elif config.vllm_format == VLLMBufferFormat.MLA:
+        # vllm_tensors[layer]: [NB, BS, HS]
+        return vllm_tensors[layer_idx][block_idx, :, :]
+
+    raise ValueError(f"Unknown format: {config.vllm_format}")
+
+
+def _set_vllm_block(
+    vllm_tensors: list,
+    config: TestConfig,
+    layer_idx: int,
+    block_idx: int,
+    data: torch.Tensor,
+) -> None:
+    """Write a block into vLLM tensors for a given layer."""
+    if config.vllm_format == VLLMBufferFormat.NORMAL:
+        vllm_tensors[layer_idx][:, block_idx, :, :, :] = data
+
+    elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+        vllm_tensors[0][block_idx, layer_idx, :, :, :, :] = data
+
+    elif config.vllm_format == VLLMBufferFormat.MLA:
+        vllm_tensors[layer_idx][block_idx, :, :] = data
+
+
+def reference_multi_layer_block_kv_transfer(
+    vllm_tensors: list,
+    memory_objects: list,
+    block_ids: torch.Tensor,
+    config: TestConfig,
+    direction: Direction,
+) -> None:
+    """Pure Python/PyTorch reference implementation of block transfer.
+
+    Performs the copy between vLLM paged buffers and LMCache memory objects
+    at block granularity.
+
+    Args:
+        vllm_tensors: vLLM paged buffer tensors on GPU.
+        memory_objects: LMCache memory objects on pinned CPU.
+        block_ids: Block indices into the vLLM paged buffer.
+        config: Test configuration.
+        direction: D2H (vLLM->LMCache) or H2D (LMCache->vLLM).
+    """
+    bs = config.block_size
+    bpo = config.blocks_per_object
+    skip = config.skip_prefix_n_blocks
+
+    for obj_idx, mem_obj in enumerate(memory_objects):
+        obj_block_ids = block_ids[obj_idx * bpo : (obj_idx + 1) * bpo]
+
+        for local_block_idx, block_id in enumerate(obj_block_ids):
+            # Global block index across all memory objects
+            global_block_idx = obj_idx * bpo + local_block_idx
+            if global_block_idx < skip:
+                continue
+
+            block_id = block_id.item()
+            token_start = local_block_idx * bs
+            token_end = token_start + bs
+
+            for layer_idx in range(config.num_layers):
+                vllm_block = _get_vllm_block(vllm_tensors, config, layer_idx, block_id)
+
+                if config.is_mla:
+                    # MLA: vllm_block is [BS, HS], mem_obj is [1, L, T, D]
+                    if direction == Direction.D2H:
+                        mem_obj[0, layer_idx, token_start:token_end, :] = (
+                            vllm_block.reshape(bs, config.hidden_dim).cpu()
+                        )
+                    else:
+                        _set_vllm_block(
+                            vllm_tensors,
+                            config,
+                            layer_idx,
+                            block_id,
+                            mem_obj[0, layer_idx, token_start:token_end, :]
+                            .reshape(bs, config.head_size)
+                            .to(vllm_tensors[layer_idx].device),
+                        )
+                else:
+                    # Non-MLA: vllm_block is [2, BS, NH, HS],
+                    # mem_obj is [2, L, T, D]
+                    if direction == Direction.D2H:
+                        for kv in range(2):
+                            mem_obj[kv, layer_idx, token_start:token_end, :] = (
+                                vllm_block[kv].reshape(bs, config.hidden_dim).cpu()
+                            )
+                    else:
+                        for kv in range(2):
+                            block_data = (
+                                mem_obj[kv, layer_idx, token_start:token_end, :]
+                                .reshape(bs, config.num_heads, config.head_size)
+                                .to(vllm_tensors[0].device)
+                            )
+                            if config.vllm_format == VLLMBufferFormat.NORMAL:
+                                vllm_tensors[layer_idx][kv, block_id, :, :, :] = (
+                                    block_data
+                                )
+                            elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+                                vllm_tensors[0][block_id, layer_idx, kv, :, :, :] = (
+                                    block_data
+                                )

--- a/lmcache/tools/kernel_harness/reference.py
+++ b/lmcache/tools/kernel_harness/reference.py
@@ -96,7 +96,7 @@ def _set_vllm_block(
 def reference_multi_layer_block_kv_transfer(
     vllm_tensors: list,
     memory_objects: list,
-    block_ids: torch.Tensor,
+    block_ids: list,
     config: TestConfig,
     direction: Direction,
 ) -> None:
@@ -107,7 +107,7 @@ def reference_multi_layer_block_kv_transfer(
 
     Args:
         vllm_tensors: vLLM paged buffer tensors on GPU.
-        memory_objects: LMCache memory objects on pinned CPU.
+        memory_objects: LMCache memory objects.
         block_ids: Block indices into the vLLM paged buffer.
         config: Test configuration.
         direction: D2H (vLLM->LMCache) or H2D (LMCache->vLLM).
@@ -124,8 +124,6 @@ def reference_multi_layer_block_kv_transfer(
             global_block_idx = obj_idx * bpo + local_block_idx
             if global_block_idx < skip:
                 continue
-
-            block_id = block_id.item()
             token_start = local_block_idx * bs
             token_end = token_start + bs
 

--- a/lmcache/tools/kernel_harness/run.sh
+++ b/lmcache/tools/kernel_harness/run.sh
@@ -1,0 +1,7 @@
+CUDA_VISIBLE_DEVICES=0 python -m lmcache.tools.kernel_harness \
+    --mode benchmark \
+    --use-reference \
+    --format normal \
+    --dtype bf16 \
+    --num-bench-iters 5 \
+    --num-warmup-iters 2 

--- a/lmcache/tools/kernel_harness/setup.py
+++ b/lmcache/tools/kernel_harness/setup.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standalone build script for the kernel harness CUDA extension.
+
+Usage:
+    cd lmcache/tools/kernel_harness
+    python setup.py build_ext --inplace
+
+This produces kernel_harness_ops.*.so in the current directory.
+"""
+
+# Third Party
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+setup(
+    name="kernel_harness_ops",
+    ext_modules=[
+        CUDAExtension(
+            "kernel_harness_ops",
+            sources=[
+                "csrc/pybind.cpp",
+                "csrc/multi_layer_block_kv_transfer.cu",
+            ],
+            extra_compile_args={
+                "cxx": ["-std=c++17", "-O3"],
+                "nvcc": ["-O3"],
+            },
+        ),
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/lmcache/tools/kernel_harness/tensor_factory.py
+++ b/lmcache/tools/kernel_harness/tensor_factory.py
@@ -40,15 +40,19 @@ def create_vllm_tensors(
     """Create vLLM paged buffer tensors based on the format.
 
     Returns a list of tensors:
-    - NORMAL: list of L tensors, each [2, NB, BS, NH, HS]
-    - CROSS_LAYER: list with a single tensor [NB, NL, 2, BS, NH, HS]
-    - MLA: list of L tensors, each [NB, BS, HS]
+    - NORMAL: L tensors [2, NB, BS, NH, HS]
+    - CROSS_LAYER: 1 tensor [NB, NL, 2, BS, NH, HS]
+    - MLA: L tensors [NB, BS, HS]
+    - FLASH_INFER: L tensors [NB, 2, BS, NH, HS]
+    - SGLANG_MHA: 2L tensors [NBBS, NH, HS] (first L=K, next L=V)
+    - SGLANG_MLA: L tensors [NBBS, 1, HS]
     """
     nb = config.num_blocks
     bs = config.block_size
     nh = config.num_heads
     hs = config.head_size
     nl = config.num_layers
+    nbbs = config.nbbs
 
     if config.vllm_format == VLLMBufferFormat.NORMAL:
         shape = [2, nb, bs, nh, hs]
@@ -60,6 +64,20 @@ def create_vllm_tensors(
 
     elif config.vllm_format == VLLMBufferFormat.MLA:
         shape = [nb, bs, hs]
+        return [_create_random_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.FLASH_INFER:
+        shape = [nb, 2, bs, nh, hs]
+        return [_create_random_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MHA:
+        shape = [nbbs, nh, hs]
+        return [
+            _create_random_tensor(shape, config.dtype, device) for _ in range(2 * nl)
+        ]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MLA:
+        shape = [nbbs, 1, hs]
         return [_create_random_tensor(shape, config.dtype, device) for _ in range(nl)]
 
     raise ValueError(f"Unknown format: {config.vllm_format}")
@@ -75,6 +93,7 @@ def create_zero_vllm_tensors(
     nh = config.num_heads
     hs = config.head_size
     nl = config.num_layers
+    nbbs = config.nbbs
 
     if config.vllm_format == VLLMBufferFormat.NORMAL:
         shape = [2, nb, bs, nh, hs]
@@ -86,6 +105,18 @@ def create_zero_vllm_tensors(
 
     elif config.vllm_format == VLLMBufferFormat.MLA:
         shape = [nb, bs, hs]
+        return [_create_zero_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.FLASH_INFER:
+        shape = [nb, 2, bs, nh, hs]
+        return [_create_zero_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MHA:
+        shape = [nbbs, nh, hs]
+        return [_create_zero_tensor(shape, config.dtype, device) for _ in range(2 * nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.SGLANG_MLA:
+        shape = [nbbs, 1, hs]
         return [_create_zero_tensor(shape, config.dtype, device) for _ in range(nl)]
 
     raise ValueError(f"Unknown format: {config.vllm_format}")

--- a/lmcache/tools/kernel_harness/tensor_factory.py
+++ b/lmcache/tools/kernel_harness/tensor_factory.py
@@ -155,28 +155,26 @@ def create_memory_objects(config: TestConfig, device: torch.device = None) -> li
     return objects
 
 
-def create_block_ids(config: TestConfig, seed: int = 42) -> torch.Tensor:
-    """Create random unique block indices as a pinned CPU int64 tensor.
+def create_block_ids(config: TestConfig, seed: int = 42) -> list:
+    """Create random unique block indices as a list of ints.
 
-    Returns tensor of shape [total_blocks] with unique values in [0, num_blocks).
+    Returns a list of total_blocks unique values in [0, num_blocks).
     """
     rng = random.Random(seed)
-    ids = rng.sample(range(config.num_blocks), config.total_blocks)
-    return torch.tensor(ids, dtype=torch.int64, pin_memory=True)
+    return rng.sample(range(config.num_blocks), config.total_blocks)
 
 
 def create_h2d_block_ids(
     config: TestConfig,
-    exclude: torch.Tensor,
+    exclude: list,
     seed: int = 123,
-) -> torch.Tensor:
+) -> list:
     """Create a set of block IDs disjoint from `exclude`.
 
     Used for the H2D target so we can verify correctness (writing to
     different blocks than we read from).
     """
-    excluded_set = set(exclude.tolist())
+    excluded_set = set(exclude)
     available = [i for i in range(config.num_blocks) if i not in excluded_set]
     rng = random.Random(seed)
-    ids = rng.sample(available, config.total_blocks)
-    return torch.tensor(ids, dtype=torch.int64, pin_memory=True)
+    return rng.sample(available, config.total_blocks)

--- a/lmcache/tools/kernel_harness/tensor_factory.py
+++ b/lmcache/tools/kernel_harness/tensor_factory.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import random
+
+# Third Party
+import torch
+
+# Local
+from .config import TestConfig, VLLMBufferFormat
+
+
+def _create_random_tensor(
+    shape: list,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Create a random tensor, handling FP8 which doesn't support torch.rand."""
+    if dtype == torch.float8_e4m3fn:
+        # FP8 doesn't support direct random generation; create as bf16 then cast
+        return torch.rand(shape, dtype=torch.bfloat16, device=device).to(dtype)
+    return torch.rand(shape, dtype=dtype, device=device)
+
+
+def _create_zero_tensor(
+    shape: list,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Create a zero tensor, handling FP8."""
+    if dtype == torch.float8_e4m3fn:
+        return torch.zeros(shape, dtype=torch.bfloat16, device=device).to(dtype)
+    return torch.zeros(shape, dtype=dtype, device=device)
+
+
+def create_vllm_tensors(
+    config: TestConfig,
+    device: torch.device,
+) -> list:
+    """Create vLLM paged buffer tensors based on the format.
+
+    Returns a list of tensors:
+    - NORMAL: list of L tensors, each [2, NB, BS, NH, HS]
+    - CROSS_LAYER: list with a single tensor [NB, NL, 2, BS, NH, HS]
+    - MLA: list of L tensors, each [NB, BS, HS]
+    """
+    nb = config.num_blocks
+    bs = config.block_size
+    nh = config.num_heads
+    hs = config.head_size
+    nl = config.num_layers
+
+    if config.vllm_format == VLLMBufferFormat.NORMAL:
+        shape = [2, nb, bs, nh, hs]
+        return [_create_random_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+        shape = [nb, nl, 2, bs, nh, hs]
+        return [_create_random_tensor(shape, config.dtype, device)]
+
+    elif config.vllm_format == VLLMBufferFormat.MLA:
+        shape = [nb, bs, hs]
+        return [_create_random_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    raise ValueError(f"Unknown format: {config.vllm_format}")
+
+
+def create_zero_vllm_tensors(
+    config: TestConfig,
+    device: torch.device,
+) -> list:
+    """Create zeroed vLLM tensors (same shapes as create_vllm_tensors)."""
+    nb = config.num_blocks
+    bs = config.block_size
+    nh = config.num_heads
+    hs = config.head_size
+    nl = config.num_layers
+
+    if config.vllm_format == VLLMBufferFormat.NORMAL:
+        shape = [2, nb, bs, nh, hs]
+        return [_create_zero_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    elif config.vllm_format == VLLMBufferFormat.CROSS_LAYER:
+        shape = [nb, nl, 2, bs, nh, hs]
+        return [_create_zero_tensor(shape, config.dtype, device)]
+
+    elif config.vllm_format == VLLMBufferFormat.MLA:
+        shape = [nb, bs, hs]
+        return [_create_zero_tensor(shape, config.dtype, device) for _ in range(nl)]
+
+    raise ValueError(f"Unknown format: {config.vllm_format}")
+
+
+def create_memory_objects(config: TestConfig) -> list:
+    """Create LMCache memory objects as pinned CPU tensors.
+
+    Returns a list of num_memory_objects tensors:
+    - Non-MLA: each [2, L, tokens_per_object, hidden_dim]
+    - MLA: each [1, L, tokens_per_object, hidden_dim]
+    """
+    kv = config.kv_dim
+    nl = config.num_layers
+    t = config.tokens_per_object
+    d = config.hidden_dim
+
+    shape = [kv, nl, t, d]
+
+    objects = []
+    for _ in range(config.num_memory_objects):
+        if config.dtype == torch.float8_e4m3fn:
+            tensor = torch.zeros(shape, dtype=torch.bfloat16, pin_memory=True).to(
+                config.dtype
+            )
+        else:
+            tensor = torch.zeros(shape, dtype=config.dtype, pin_memory=True)
+        objects.append(tensor)
+    return objects
+
+
+def create_block_ids(config: TestConfig, seed: int = 42) -> torch.Tensor:
+    """Create random unique block indices as a pinned CPU int64 tensor.
+
+    Returns tensor of shape [total_blocks] with unique values in [0, num_blocks).
+    """
+    rng = random.Random(seed)
+    ids = rng.sample(range(config.num_blocks), config.total_blocks)
+    return torch.tensor(ids, dtype=torch.int64, pin_memory=True)
+
+
+def create_h2d_block_ids(
+    config: TestConfig,
+    exclude: torch.Tensor,
+    seed: int = 123,
+) -> torch.Tensor:
+    """Create a set of block IDs disjoint from `exclude`.
+
+    Used for the H2D target so we can verify correctness (writing to
+    different blocks than we read from).
+    """
+    excluded_set = set(exclude.tolist())
+    available = [i for i in range(config.num_blocks) if i not in excluded_set]
+    rng = random.Random(seed)
+    ids = rng.sample(available, config.total_blocks)
+    return torch.tensor(ids, dtype=torch.int64, pin_memory=True)

--- a/lmcache/tools/kernel_harness/tensor_factory.py
+++ b/lmcache/tools/kernel_harness/tensor_factory.py
@@ -122,8 +122,11 @@ def create_zero_vllm_tensors(
     raise ValueError(f"Unknown format: {config.vllm_format}")
 
 
-def create_memory_objects(config: TestConfig) -> list:
-    """Create LMCache memory objects as pinned CPU tensors.
+def create_memory_objects(config: TestConfig, device: torch.device = None) -> list:
+    """Create LMCache memory objects on the given device.
+
+    If device is None or a CUDA device, tensors are created on GPU.
+    If device is CPU, tensors are created as pinned CPU memory.
 
     Returns a list of num_memory_objects tensors:
     - Non-MLA: each [2, L, tokens_per_object, hidden_dim]
@@ -136,14 +139,18 @@ def create_memory_objects(config: TestConfig) -> list:
 
     shape = [kv, nl, t, d]
 
+    if device is None:
+        device = torch.device("cuda")
+
     objects = []
     for _ in range(config.num_memory_objects):
         if config.dtype == torch.float8_e4m3fn:
-            tensor = torch.zeros(shape, dtype=torch.bfloat16, pin_memory=True).to(
-                config.dtype
-            )
+            tensor = torch.zeros(shape, dtype=torch.bfloat16, device=device)
+            tensor = tensor.to(config.dtype)
         else:
-            tensor = torch.zeros(shape, dtype=config.dtype, pin_memory=True)
+            tensor = torch.zeros(shape, dtype=config.dtype, device=device)
+        if device.type == "cpu":
+            tensor = tensor.pin_memory()
         objects.append(tensor)
     return objects
 

--- a/lmcache/tools/kernel_harness/tensor_factory.py
+++ b/lmcache/tools/kernel_harness/tensor_factory.py
@@ -36,7 +36,7 @@ def _create_zero_tensor(
 def create_vllm_tensors(
     config: TestConfig,
     device: torch.device,
-) -> list:
+) -> list[torch.Tensor]:
     """Create vLLM paged buffer tensors based on the format.
 
     Returns a list of tensors:
@@ -86,7 +86,7 @@ def create_vllm_tensors(
 def create_zero_vllm_tensors(
     config: TestConfig,
     device: torch.device,
-) -> list:
+) -> list[torch.Tensor]:
     """Create zeroed vLLM tensors (same shapes as create_vllm_tensors)."""
     nb = config.num_blocks
     bs = config.block_size
@@ -122,7 +122,9 @@ def create_zero_vllm_tensors(
     raise ValueError(f"Unknown format: {config.vllm_format}")
 
 
-def create_memory_objects(config: TestConfig, device: torch.device = None) -> list:
+def create_memory_objects(
+    config: TestConfig, device: torch.device = None
+) -> list[torch.Tensor]:
     """Create LMCache memory objects on the given device.
 
     If device is None or a CUDA device, tensors are created on GPU.


### PR DESCRIPTION
Please see #2838

---

**What this PR does / why we need it**:

Adds a standalone CUDA kernel test harness (`lmcache/tools/kernel_harness/`) for the new `multi_layer_block_kv_transfer` kernel, which transfers KV cache between vLLM/SGLang paged buffers and LMCache memory objects at block granularity (vs token-level `slot_mapping`).

The harness includes:
- CUDA kernel supporting 6 GPU KV formats: Normal, Cross-layer, Flash Infer, MLA, SGLang MHA, SGLang MLA (bf16 + fp8)
- Pure Python reference implementation for correctness oracle
- D2H ↔ H2D roundtrip correctness tests (24 configs: 6 formats × 2 dtypes × 2 skip modes)
- CUDA-event-based benchmarking with throughput reporting
- PTX `ld.global.cs` / `st.global.cs` streaming copy to bypass L2 cache
- CLI with `--format`, `--dtype`, `--mem-device` (gpu/cpu), `--skip-prefix-n-blocks` flags

**Special notes for your reviewers**:

- The kernel uses a pointer-based interface (`paged_buffer_ptrs_tensor` + `lmcache_objects_ptrs`) rather than passing tensor objects directly
- For SGLang MHA, K/V distinction is handled by pointer selection (`ptrs[k_or_v * nl + layer_idx]`) rather than offset arithmetic, since K and V reside in separate tensors
- The harness builds independently via `python setup.py build_ext --inplace` in the kernel_harness directory
- Memory objects default to GPU; `--mem-device cpu` uses pinned CPU memory

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests