### PR TITLE
examples(kv_cache_calculator): add Hunyuan & DeepSeek models, fix head_dim/CLA calculation, add i18n UI

### DIFF
--- a/examples/kv_cache_calculator/generate_config.py
+++ b/examples/kv_cache_calculator/generate_config.py
@@ -34,25 +34,30 @@ def main():
             "num_key_value_heads": getattr(config, "num_key_value_heads", None),
         }
 
-        if args.model == "deepseek-ai/DeepSeek-V3":
+        # DeepSeek MLA models (V3, V3.1, V3.2, … and R1) store
+        # KV in latent space
+        if (
+            args.model.lower().startswith("deepseek-ai/deepseek-v3")
+            or args.model == "deepseek-ai/DeepSeek-R1"
+        ):
             config_data["kv_lora_rank"] = getattr(config, "kv_lora_rank", None)
             config_data["qk_rope_head_dim"] = getattr(config, "qk_rope_head_dim", None)
 
-        # Check for Qwen3 models (fuzzy matching) or GLM4 models
+        # Models whose head_dim is explicit in config and may
+        # differ from hidden_size / num_heads:
+        # Qwen3, GLM4, and Hunyuan dense variants.
         if (
             "qwen/qwen3-" in args.model.lower()
             or "zai-org/glm-4." in args.model.lower()
+            or (
+                args.model.lower().startswith("tencent/hunyuan-")
+                and args.model.lower() != "tencent/hunyuan-large"
+            )
         ):
             config_data["head_dim"] = getattr(config, "head_dim", None)
 
-        # Check for Hunyuan dense models (explicit head_dim, may differ from hidden/heads)
-        if (
-            args.model.lower().startswith("tencent/hunyuan-")
-            and args.model.lower() != "tencent/hunyuan-large"
-        ):
-            config_data["head_dim"] = getattr(config, "head_dim", None)
-
-        # Check for Hunyuan-Large (CLA: cross-layer attention sharing)
+        # Hunyuan-Large uses CLA (Cross-Layer Attention):
+        # KV layers = num_hidden_layers / cla_share_factor
         if args.model.lower() == "tencent/hunyuan-large":
             config_data["cla_share_factor"] = getattr(config, "cla_share_factor", None)
 

--- a/examples/kv_cache_calculator/generate_config.py
+++ b/examples/kv_cache_calculator/generate_config.py
@@ -45,6 +45,17 @@ def main():
         ):
             config_data["head_dim"] = getattr(config, "head_dim", None)
 
+        # Check for Hunyuan dense models (explicit head_dim, may differ from hidden/heads)
+        if (
+            args.model.lower().startswith("tencent/hunyuan-")
+            and args.model.lower() != "tencent/hunyuan-large"
+        ):
+            config_data["head_dim"] = getattr(config, "head_dim", None)
+
+        # Check for Hunyuan-Large (CLA: cross-layer attention sharing)
+        if args.model.lower() == "tencent/hunyuan-large":
+            config_data["cla_share_factor"] = getattr(config, "cla_share_factor", None)
+
         # Convert to JSON and print
         string = json.dumps(config_data, indent=4)
 

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -5,141 +5,353 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KV Cache Size Calculator</title>
     <style>
-        .container {
-            font-family: Arial, sans-serif;
-            max-width: 400px;
-            margin: 0 auto;
-            padding: 20px;
-            border: 1px solid #ccc;
-            border-radius: 8px;
+        *, *::before, *::after { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: flex-start;
             background-color: #f9f9f9;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+            padding: 24px 12px 48px;
         }
 
-        label, select, input, button {
+        .lang-bar {
+            width: 100%;
+            max-width: 480px;
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 8px;
+            gap: 6px;
+        }
+
+        .lang-btn {
+            padding: 4px 12px;
+            font-size: 13px;
+            border: 1px solid #b0c4de;
+            border-radius: 20px;
+            background: #fff;
+            color: #3898ec;
+            cursor: pointer;
+            transition: background 0.15s, color 0.15s;
+        }
+        .lang-btn.active, .lang-btn:hover {
+            background: #3898ec;
+            color: #fff;
+            border-color: #3898ec;
+        }
+
+        .card {
+            width: 100%;
+            max-width: 480px;
+            background: #fff;
+            border-radius: 14px;
+            box-shadow: 0 4px 24px rgba(56, 152, 236, 0.10), 0 1px 4px rgba(0,0,0,0.06);
+            padding: 32px 28px 24px;
+        }
+
+        .card h1 {
+            margin: 0 0 24px;
+            font-size: 22px;
+            font-weight: 700;
+            color: #1a2e4a;
+            letter-spacing: -0.3px;
+        }
+
+        .field {
+            margin-bottom: 18px;
+        }
+
+        .field label {
+            display: block;
+            font-size: 13px;
+            font-weight: 600;
+            color: #4a5568;
+            margin-bottom: 6px;
+            letter-spacing: 0.1px;
+        }
+
+        .field select, .field input {
+            width: 100%;
+            padding: 9px 12px;
+            font-size: 15px;
+            border: 1.5px solid #d0d9e8;
+            border-radius: 8px;
+            background: #f7faff;
+            color: #1a2e4a;
+            outline: none;
+            transition: border-color 0.15s, box-shadow 0.15s;
+            appearance: none;
+            -webkit-appearance: none;
+        }
+        .select-wrap {
+            position: relative;
+        }
+        .select-wrap::after {
+            content: "▾";
+            position: absolute;
+            right: 12px;
+            top: 50%;
+            transform: translateY(-50%);
+            pointer-events: none;
+            color: #8aa4c8;
+            font-size: 14px;
+        }
+        .field select:focus, .field input:focus {
+            border-color: #3898ec;
+            box-shadow: 0 0 0 3px rgba(56,152,236,0.12);
+            background: #fff;
+        }
+
+        .calc-btn {
             display: block;
             width: 100%;
-            margin-bottom: 15px;
-        }
-
-        label {
-            font-weight: bold;
-            margin-bottom: 5px;
-        }
-
-        select, input, button {
-            padding: 10px;
-            font-size: 16px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-            box-sizing: border-box;
-        }
-
-        button {
-            background-color: #3898ec;
-            color: white;
+            padding: 11px;
+            font-size: 15px;
+            font-weight: 600;
+            background: #3898ec;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
             cursor: pointer;
+            transition: background 0.15s, transform 0.1s;
+            margin-top: 4px;
         }
-
-        button:hover {
-            background-color: #0056b3;
-        }
+        .calc-btn:hover { background: #1a7fd4; }
+        .calc-btn:active { transform: scale(0.98); }
 
         #result {
             margin-top: 20px;
-            font-size: 16px;
-            font-weight: bold;
+            padding: 14px 16px;
+            background: linear-gradient(90deg, #e8f4fd, #f0f8ff);
+            border-left: 4px solid #3898ec;
+            border-radius: 6px;
+            font-size: 20px;
+            font-weight: 700;
+            color: #1a5fa8;
+            display: none;
         }
 
-        /* New CSS for calculation steps */
         #calculation-steps {
-            font-size: 12px;
-            margin-top: 10px;
-            color: #555;
+            margin-top: 14px;
+            padding: 14px 16px;
+            background: #f7faff;
+            border: 1px solid #d8e8f8;
+            border-radius: 8px;
+            font-size: 12.5px;
+            line-height: 1.8;
+            color: #4a5568;
+            display: none;
         }
 
-        /* New button for GitHub repo */
-        #githubButton {
-            background-color: #d3d3d3; /* Light grey color */
-            color: black; /* Black text color */
-            text-align: center;
+        .github-btn {
+            display: block;
+            width: 100%;
+            padding: 9px;
+            margin-top: 18px;
+            font-size: 13px;
+            font-weight: 500;
+            background: #f0f4fa;
+            color: #4a5568;
+            border: 1.5px solid #d0d9e8;
+            border-radius: 8px;
             cursor: pointer;
-            margin-top: 20px;
-            border: 1px solid #ccc;
+            text-align: center;
+            transition: background 0.15s;
         }
-
-        #githubButton:hover {
-            background-color: #b3b3b3; /* Darker grey when hovered */
-        }
+        .github-btn:hover { background: #e2eaf6; }
 
         footer {
-            text-align: center;
-            margin-top: 20px;
+            margin-top: 24px;
             font-size: 12px;
-            color: #555;
+            color: #8aa4c8;
         }
-
     </style>
 </head>
 <body>
-    <div class="container">
-        <h1>KV Cache Size Calculator</h1>
-        <label for="model">Select LLM Model:</label>
-        <select id="model">
-            <!-- Options will be dynamically generated -->
-        </select>
-        <label for="dtype">Select data type:</label>
-        <select id="dtype">
-            <option value="float16">float16</option>
-            <option value="bfloat16">bfloat16</option>
-            <option value="float32">float32</option>
-            <option value="int8">int8</option>
-        </select>
-        <label for="tokens">Enter Number of Tokens:</label>
-        <input type="number" id="tokens" placeholder="Enter number of tokens">
-        <button onclick="calculateKVCache()">Calculate KV Cache Size</button>
-        <div id="result"></div>
-        <!-- New div for calculation steps -->
-        <div id="calculation-steps"></div>
-        <button id="githubButton" onclick="openGitHubRepo()">Contribute new models on GitHub</button>
+    <div class="lang-bar">
+        <button class="lang-btn active" onclick="setLang('en')" id="btn-en">English</button>
+        <button class="lang-btn" onclick="setLang('zh')" id="btn-zh">中文</button>
     </div>
-    <footer>
-        Developed by Zhuohan Gu @ LMCache team
-    </footer>
+    <div class="card">
+        <h1 id="title">KV Cache Size Calculator</h1>
+
+        <div class="field">
+            <label id="lbl-model" for="model">Select LLM Model</label>
+            <div class="select-wrap">
+                <select id="model"></select>
+            </div>
+        </div>
+
+        <div class="field">
+            <label id="lbl-dtype" for="dtype">Data Type</label>
+            <div class="select-wrap">
+                <select id="dtype">
+                    <option value="float16">float16</option>
+                    <option value="bfloat16">bfloat16</option>
+                    <option value="float32">float32</option>
+                    <option value="int8">int8</option>
+                </select>
+            </div>
+        </div>
+
+        <div class="field">
+            <label id="lbl-tokens" for="tokens">Number of Tokens</label>
+            <input type="number" id="tokens" placeholder="e.g. 4096">
+        </div>
+
+        <button class="calc-btn" onclick="calculateKVCache()" id="btn-calc">Calculate</button>
+
+        <div id="result"></div>
+        <div id="calculation-steps"></div>
+
+        <button class="github-btn" onclick="openGitHubRepo()" id="btn-github">
+            ➕ Contribute new models on GitHub
+        </button>
+    </div>
+    <footer id="footer">Developed by Zhuohan Gu @ LMCache team</footer>
+
     <script>
         let modelConfigs = {};
+        let currentLang = 'en';
+
+        const i18n = {
+            en: {
+                title: 'KV Cache Size Calculator',
+                lblModel: 'Select LLM Model',
+                lblDtype: 'Data Type',
+                lblTokens: 'Number of Tokens',
+                tokenPlaceholder: 'e.g. 4096',
+                btnCalc: 'Calculate',
+                btnGithub: '➕ Contribute new models on GitHub',
+                footer: 'Developed by Zhuohan Gu @ LMCache team',
+                errTokens: 'Please enter a valid number of tokens.',
+                errModel: 'Model not recognized.',
+                errDtype: 'Invalid data type selected.',
+                errLoad: 'Failed to load model configurations. Please try again later.',
+                detailsTitle: 'Calculation Details',
+                fldModel: 'Selected Model',
+                fldLayers: 'Number of Hidden Layers',
+                fldKvLoraRank: 'KV-LoRA Rank (latent dim)',
+                fldQkRopeHeadDim: 'QK-Rope Head Dim',
+                fldDtypeSize: 'Data Type Size',
+                fldTotalElem: 'Total Elements',
+                fldTotalBytes: 'Total Bytes',
+                fldKvSize: 'KV Cache Size',
+                fldKvHeads: 'Number of Key-Value Heads',
+                fldHeadDim: 'Head Dim',
+                fldClaFactor: 'CLA Share Factor',
+                fldEffLayers: 'Effective KV Layers',
+                fldHeadSize: 'Head Size',
+                fldHiddenSize: 'Hidden Size',
+                fldAttnHeads: 'Number of Attention Heads',
+                claNote: (f) => `every ${f} layers share one KV cache`,
+                headSizeNote: 'Hidden Size / Attention Heads',
+                bytes: 'bytes',
+                result: (gb) => `KV Cache Size: ${gb} GB`,
+            },
+            zh: {
+                title: 'KV Cache 大小计算器',
+                lblModel: '选择 LLM 模型',
+                lblDtype: '数据类型',
+                lblTokens: 'Token 数量',
+                tokenPlaceholder: '例如：4096',
+                btnCalc: '开始计算',
+                btnGithub: '➕ 在 GitHub 上贡献新模型',
+                footer: '由 LMCache 团队 Zhuohan Gu 开发',
+                errTokens: '请输入有效的 Token 数量。',
+                errModel: '未识别的模型。',
+                errDtype: '无效的数据类型。',
+                errLoad: '模型配置加载失败，请稍后重试。',
+                detailsTitle: '计算详情',
+                fldModel: '所选模型',
+                fldLayers: '隐藏层数',
+                fldKvLoraRank: 'KV-LoRA 秩（隐空间维度）',
+                fldQkRopeHeadDim: 'QK-RoPE Head Dim',
+                fldDtypeSize: '数据类型大小',
+                fldTotalElem: '总元素数',
+                fldTotalBytes: '总字节数',
+                fldKvSize: 'KV Cache 大小',
+                fldKvHeads: 'KV 头数',
+                fldHeadDim: 'Head Dim',
+                fldClaFactor: 'CLA 共享因子',
+                fldEffLayers: '有效 KV 层数',
+                fldHeadSize: 'Head Size',
+                fldHiddenSize: '隐藏层维度',
+                fldAttnHeads: '注意力头数',
+                claNote: (f) => `每 ${f} 层共享一份 KV Cache`,
+                headSizeNote: '隐藏层维度 / 注意力头数',
+                bytes: '字节',
+                result: (gb) => `KV Cache 大小：${gb} GB`,
+            }
+        };
+
+        function t(key, ...args) {
+            const v = i18n[currentLang][key];
+            return typeof v === 'function' ? v(...args) : v;
+        }
+
+        function setLang(lang) {
+            currentLang = lang;
+            document.getElementById('btn-en').classList.toggle('active', lang === 'en');
+            document.getElementById('btn-zh').classList.toggle('active', lang === 'zh');
+            document.getElementById('title').textContent = t('title');
+            document.getElementById('lbl-model').textContent = t('lblModel');
+            document.getElementById('lbl-dtype').textContent = t('lblDtype');
+            document.getElementById('lbl-tokens').textContent = t('lblTokens');
+            document.getElementById('tokens').placeholder = t('tokenPlaceholder');
+            document.getElementById('btn-calc').textContent = t('btnCalc');
+            document.getElementById('btn-github').textContent = t('btnGithub');
+            document.getElementById('footer').textContent = t('footer');
+            // Re-render result if visible
+            if (document.getElementById('result').style.display !== 'none') {
+                calculateKVCache();
+            }
+        }
 
         function openGitHubRepo() {
             const githubUrl = 'https://github.com/LMCache/LMCache/issues/244#:~:text=https%3A//github.com/LMCache/LMCache/tree/dev/examples/kv_cache_calculator';
             window.open(githubUrl, '_blank');
         }
 
-
-        // Load model configurations from GitHub
+        // Load model configurations: prefer local file, fallback to GitHub
         async function loadModelConfigs() {
-            const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
+            const localUrl = './modelconfig.json';
+            const remoteUrl = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
+            // Try local first
             try {
-                const response = await fetch(url);
-                if (!response.ok) {
-                    throw new Error(`HTTP error! Status: ${response.status}`);
+                let response = await fetch(localUrl);
+                if (response.ok) {
+                    modelConfigs = await response.json();
+                    populateModelDropdown();
+                    return;
                 }
+            } catch (e) {
+                // ignore local fetch errors and fallback
+                console.debug('Local modelconfig.json not available locally, falling back to remote.');
+            }
+
+            // Fallback to remote
+            try {
+                const response = await fetch(remoteUrl);
+                if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
                 modelConfigs = await response.json();
-                console.log('Model configurations loaded successfully:', modelConfigs);
                 populateModelDropdown();
             } catch (error) {
                 console.error('Failed to load model configurations:', error);
-                document.getElementById('result').textContent = "Failed to load model configurations. Please try again later.";
+                showResult(t('errLoad'), true);
             }
         }
 
         // Populate the model dropdown dynamically
         function populateModelDropdown() {
             const modelSelect = document.getElementById('model');
-            modelSelect.innerHTML = ""; // Clear existing options
-
-            // Sort model names using natural/numeric ordering
-            const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base'});
+            modelSelect.innerHTML = "";
+            const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
             const sortedModelNames = Object.keys(modelConfigs).sort(collator.compare);
-            
             for (const modelName of sortedModelNames) {
                 const option = document.createElement('option');
                 option.value = modelName;
@@ -148,32 +360,37 @@
             }
         }
 
+        function showResult(html, isError = false) {
+            const el = document.getElementById('result');
+            el.innerHTML = html;
+            el.style.display = 'block';
+            el.style.borderLeftColor = isError ? '#e05252' : '#3898ec';
+            el.style.color = isError ? '#a02020' : '#1a5fa8';
+        }
+
         async function calculateKVCache() {
-            // Ensure model configs are loaded before running calculations
-            if (Object.keys(modelConfigs).length === 0) {
-                await loadModelConfigs();
-            }
+            if (Object.keys(modelConfigs).length === 0) await loadModelConfigs();
 
             const model = document.getElementById('model').value;
             const tokens = parseInt(document.getElementById('tokens').value);
             const dtype = document.getElementById('dtype').value;
 
             if (isNaN(tokens) || tokens <= 0) {
-                document.getElementById('result').textContent = "Please enter a valid number of tokens.";
-                document.getElementById('calculation-steps').innerHTML = "";
+                showResult(t('errTokens'), true);
+                document.getElementById('calculation-steps').style.display = 'none';
                 return;
             }
 
             const config = modelConfigs[model];
             if (!config) {
-                document.getElementById('result').textContent = "Model not recognized.";
-                document.getElementById('calculation-steps').innerHTML = "";
+                showResult(t('errModel'), true);
+                document.getElementById('calculation-steps').style.display = 'none';
                 return;
             }
 
             let hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads;
-            let kv_lora_rank, qk_rope_head_dim; // for deepseek-ai/DeepSeek-V3
-            let head_size;
+            let kv_lora_rank, qk_rope_head_dim;
+            let head_dim, head_size;
 
             // Check for DeepSeek models (exact matching)
             const isDeepSeekModel = model === "deepseek-ai/DeepSeek-V3" || model === "deepseek-ai/DeepSeek-R1";
@@ -184,14 +401,23 @@
             // Check for GLM4 models (prefix matching)
             const isGLM4Model = model.startsWith("zai-org/GLM-4.");
 
-            const isGQAWithHeadDimModel = isQwen3Model || isGLM4Model;
+            // Check for Hunyuan dense models (explicit head_dim, may differ from hidden/heads)
+            const isHunyuanDenseModel = model.toLowerCase().startsWith("tencent/hunyuan-") && model.toLowerCase() !== "tencent/hunyuan-large";
+
+            // Check for Hunyuan-Large (CLA: cross-layer attention sharing)
+            const isHunyuanLargeModel = model.toLowerCase() === "tencent/hunyuan-large";
+
+            const isGQAWithHeadDimModel = isQwen3Model || isGLM4Model || isHunyuanDenseModel;
 
             if (isDeepSeekModel) {
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, kv_lora_rank, qk_rope_head_dim } = config);
+            } else if (isHunyuanLargeModel) {
+                // Hunyuan-Large uses CLA (Cross-Layer Attention): every cla_share_factor layers share one KV cache.
+                ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads } = config);
+                head_size = hidden_size / num_attention_heads;
             } else if (isGQAWithHeadDimModel) {
-                // The Qwen3 series and GLM use GQA, and `head_dim` needs to be read from config file.
+                // Qwen3, GLM4, and Hunyuan dense models all have an explicit head_dim in their configs.
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, head_dim } = config);
-                console.log(config);
             } else {
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads } = config);
                 head_size = hidden_size / num_attention_heads;
@@ -199,86 +425,98 @@
 
             // Determine dtype size in bytes
             let dtype_size;
-            if (dtype === 'float32') {
-                dtype_size = 4;
-            } else if (dtype === 'float16' || dtype === 'bfloat16') {
-                dtype_size = 2;
-            } else if (dtype === 'int8') {
-                dtype_size = 1;
-            } else {
-                document.getElementById('result').textContent = "Invalid data type selected.";
-                document.getElementById('calculation-steps').innerHTML = "";
+            if (dtype === 'float32') dtype_size = 4;
+            else if (dtype === 'float16' || dtype === 'bfloat16') dtype_size = 2;
+            else if (dtype === 'int8') dtype_size = 1;
+            else {
+                showResult(t('errDtype'), true);
+                document.getElementById('calculation-steps').style.display = 'none';
                 return;
             }
 
             // Calculate KV cache size
             let total_elements;
+            let effective_layers;
             if (isDeepSeekModel) {
                 total_elements = num_hidden_layers * tokens * (kv_lora_rank + qk_rope_head_dim);
+            } else if (isHunyuanLargeModel) {
+                const cla_share_factor = config.cla_share_factor;
+                effective_layers = num_hidden_layers / cla_share_factor;
+                total_elements = 2 * effective_layers * tokens * num_key_value_heads * head_size;
             } else if (isGQAWithHeadDimModel) {
                 total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_dim;
             } else {
                 total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_size;
             }
             const total_bytes = total_elements * dtype_size;
-            const kvCacheSizeGB = total_bytes / (1024 ** 3); // Convert bytes to GB
+            const kvCacheSizeGB = total_bytes / (1024 ** 3);
 
-            document.getElementById('result').innerHTML =
-                `KV Cache Size: ${kvCacheSizeGB.toFixed(4)} GB`;
+            showResult(t('result', kvCacheSizeGB.toFixed(4)));
 
             // Prepare calculation steps
-            let steps;
+            const B = (s) => `<b>${s}</b>`;
+            let rows;
             if (isDeepSeekModel) {
-                steps = `
-                <strong>Calculation Details:</strong><br><br>
-                <b>Selected Model:</b> ${model}<br>
-                <b>Number of Hidden Layers:</b> ${num_hidden_layers}<br>
-                <b>KV-LoRA Rank(dimension of latent space):</b> ${kv_lora_rank}<br>
-                <b>QK-Rope Head Dim:</b> ${qk_rope_head_dim}<br>
-                <b>Data Type Size:</b> ${dtype_size} bytes<br>
-                <b>Total Elements:</b> ${num_hidden_layers} × ${tokens} × (${kv_lora_rank} + ${qk_rope_head_dim}) = ${total_elements}<br>
-                <b>Total Bytes:</b> ${total_elements} × ${dtype_size} = ${total_bytes} bytes<br>
-                <b>KV Cache Size:</b> ${total_bytes} / (1024³) ≈ ${kvCacheSizeGB.toFixed(4)} GB
-                `;
+                rows = [
+                    [B(t('fldModel')), model],
+                    [B(t('fldLayers')), num_hidden_layers],
+                    [B(t('fldKvLoraRank')), kv_lora_rank],
+                    [B(t('fldQkRopeHeadDim')), qk_rope_head_dim],
+                    [B(t('fldDtypeSize')), `${dtype_size} ${t('bytes')}`],
+                    [B(t('fldTotalElem')), `${num_hidden_layers} × ${tokens} × (${kv_lora_rank} + ${qk_rope_head_dim}) = ${total_elements}`],
+                    [B(t('fldTotalBytes')), `${total_elements} × ${dtype_size} = ${total_bytes} ${t('bytes')}`],
+                    [B(t('fldKvSize')), `${total_bytes} / 1024³ ≈ ${kvCacheSizeGB.toFixed(4)} GB`],
+                ];
+            } else if (isHunyuanLargeModel) {
+                const cla_share_factor = config.cla_share_factor;
+                rows = [
+                    [B(t('fldModel')), model],
+                    [B(t('fldLayers')), num_hidden_layers],
+                    [B(t('fldClaFactor')), `${cla_share_factor} (${t('claNote', cla_share_factor)})`],
+                    [B(t('fldEffLayers')), `${num_hidden_layers} / ${cla_share_factor} = ${effective_layers}`],
+                    [B(t('fldKvHeads')), num_key_value_heads],
+                    [B(t('fldHeadSize')), `${head_size} (${t('headSizeNote')})`],
+                    [B(t('fldDtypeSize')), `${dtype_size} ${t('bytes')}`],
+                    [B(t('fldTotalElem')), `2 × ${effective_layers} × ${tokens} × ${num_key_value_heads} × ${head_size} = ${total_elements}`],
+                    [B(t('fldTotalBytes')), `${total_elements} × ${dtype_size} = ${total_bytes} ${t('bytes')}`],
+                    [B(t('fldKvSize')), `${total_bytes} / 1024³ ≈ ${kvCacheSizeGB.toFixed(4)} GB`],
+                ];
             } else if (isGQAWithHeadDimModel) {
-                steps = `
-                <strong>Calculation Details:</strong><br><br>
-                <b>Selected Model:</b> ${model}<br>
-                <b>Number of Hidden Layers:</b> ${num_hidden_layers}<br>
-                <b>Number of Key-Value Heads:</b> ${num_key_value_heads}<br>
-                <b>Head dim:</b> ${head_dim}<br>
-                <b>Data Type Size:</b> ${dtype_size} bytes<br>
-                <b>Total Elements:</b> 2 × ${num_hidden_layers} × ${tokens} × ${num_key_value_heads} × ${head_dim} = ${total_elements}<br>
-                <b>Total Bytes:</b> ${total_elements} × ${dtype_size} = ${total_bytes} bytes<br>
-                <b>KV Cache Size:</b> ${total_bytes} / (1024³) ≈ ${kvCacheSizeGB.toFixed(4)} GB
-                `;
+                rows = [
+                    [B(t('fldModel')), model],
+                    [B(t('fldLayers')), num_hidden_layers],
+                    [B(t('fldKvHeads')), num_key_value_heads],
+                    [B(t('fldHeadDim')), head_dim],
+                    [B(t('fldDtypeSize')), `${dtype_size} ${t('bytes')}`],
+                    [B(t('fldTotalElem')), `2 × ${num_hidden_layers} × ${tokens} × ${num_key_value_heads} × ${head_dim} = ${total_elements}`],
+                    [B(t('fldTotalBytes')), `${total_elements} × ${dtype_size} = ${total_bytes} ${t('bytes')}`],
+                    [B(t('fldKvSize')), `${total_bytes} / 1024³ ≈ ${kvCacheSizeGB.toFixed(4)} GB`],
+                ];
             } else {
-                steps = `
-                <strong>Calculation Details:</strong><br><br>
-                <b>Selected Model:</b> ${model}<br>
-                <b>Hidden Size:</b> ${hidden_size}<br>
-                <b>Number of Attention Heads:</b> ${num_attention_heads}<br>
-                <b>Number of Hidden Layers:</b> ${num_hidden_layers}<br>
-                <b>Number of Key-Value Heads:</b> ${num_key_value_heads}<br>
-                <b>Head Size:</b> ${head_size} (Hidden Size / Attention Heads)<br>
-                <b>Data Type Size:</b> ${dtype_size} bytes<br>
-                <b>Total Elements:</b> 2 × ${num_hidden_layers} × ${tokens} × ${num_key_value_heads} × ${head_size} = ${total_elements}<br>
-                <b>Total Bytes:</b> ${total_elements} × ${dtype_size} = ${total_bytes} bytes<br>
-                <b>KV Cache Size:</b> ${total_bytes} / (1024³) ≈ ${kvCacheSizeGB.toFixed(4)} GB
-            `;
+                rows = [
+                    [B(t('fldModel')), model],
+                    [B(t('fldHiddenSize')), hidden_size],
+                    [B(t('fldAttnHeads')), num_attention_heads],
+                    [B(t('fldLayers')), num_hidden_layers],
+                    [B(t('fldKvHeads')), num_key_value_heads],
+                    [B(t('fldHeadSize')), `${head_size} (${t('headSizeNote')})`],
+                    [B(t('fldDtypeSize')), `${dtype_size} ${t('bytes')}`],
+                    [B(t('fldTotalElem')), `2 × ${num_hidden_layers} × ${tokens} × ${num_key_value_heads} × ${head_size} = ${total_elements}`],
+                    [B(t('fldTotalBytes')), `${total_elements} × ${dtype_size} = ${total_bytes} ${t('bytes')}`],
+                    [B(t('fldKvSize')), `${total_bytes} / 1024³ ≈ ${kvCacheSizeGB.toFixed(4)} GB`],
+                ];
             }
-            // Display calculation steps
-            document.getElementById('calculation-steps').innerHTML = steps;
+
+            const stepsEl = document.getElementById('calculation-steps');
+            stepsEl.innerHTML = `<b>${t('detailsTitle')}</b><br><br>` +
+                rows.map(([k, v]) => `${k}: ${v}`).join('<br>');
+            stepsEl.style.display = 'block';
         }
 
-        // Add event listener for Enter key
         document.getElementById('tokens').addEventListener('keydown', function(event) {
-            if (event.key === 'Enter') {
-                calculateKVCache();
-            }
+            if (event.key === 'Enter') calculateKVCache();
         });
 
-        // Load model configurations when the page loads
         window.onload = function() {
             loadModelConfigs();
         };

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -392,8 +392,8 @@
             let kv_lora_rank, qk_rope_head_dim;
             let head_dim, head_size;
 
-            // Check for DeepSeek models (exact matching)
-            const isDeepSeekModel = model === "deepseek-ai/DeepSeek-V3" || model === "deepseek-ai/DeepSeek-R1";
+            // Check for DeepSeek MLA models (prefix match covers V3, V3.1, V3.2, … ; plus R1)
+            const isDeepSeekModel = model.startsWith("deepseek-ai/DeepSeek-V3") || model === "deepseek-ai/DeepSeek-R1";
 
             // Check for Qwen3 models (fuzzy matching)
             const isQwen3Model = model.toLowerCase().includes("qwen/qwen3-");

--- a/examples/kv_cache_calculator/modelconfig.json
+++ b/examples/kv_cache_calculator/modelconfig.json
@@ -128,14 +128,14 @@
         "num_hidden_layers": 32,
         "num_key_value_heads": 32
     },
-    "zai-org/GLM-4.5":{
+    "zai-org/GLM-4.5": {
         "hidden_size": 5120,
         "num_attention_heads": 96,
         "num_hidden_layers": 92,
         "num_key_value_heads": 8,
         "head_dim": 128
     },
-    "zai-org/GLM-4.6":{
+    "zai-org/GLM-4.6": {
         "hidden_size": 5120,
         "num_attention_heads": 96,
         "num_hidden_layers": 92,
@@ -155,5 +155,47 @@
         "num_hidden_layers": 94,
         "num_key_value_heads": 4,
         "head_dim": 128
+    },
+    "tencent/Hunyuan-0.5B-Instruct": {
+        "hidden_size": 1024,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 24,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
+    "tencent/Hunyuan-1.8B-Instruct": {
+        "hidden_size": 2048,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 32,
+        "num_key_value_heads": 4,
+        "head_dim": 128
+    },
+    "tencent/Hunyuan-4B-Instruct": {
+        "hidden_size": 3072,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 36,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
+    "tencent/Hunyuan-7B-Instruct": {
+        "hidden_size": 4096,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
+    "tencent/Hunyuan-A13B-Instruct": {
+        "hidden_size": 4096,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
+    "tencent/Hunyuan-Large": {
+        "hidden_size": 6400,
+        "num_attention_heads": 80,
+        "num_hidden_layers": 64,
+        "num_key_value_heads": 8,
+        "cla_share_factor": 2
     }
 }

--- a/tests/benchmarks/test_xpu_kernels_microbench.py
+++ b/tests/benchmarks/test_xpu_kernels_microbench.py
@@ -31,7 +31,7 @@ def _xpu_sync():
 @pytest.fixture(scope="module")
 def xops():
     # First Party
-    import lmcache.xpu_ops as XOPS  # noqa: WPS433
+    import lmcache.xpu_ops as XOPS  # noqa: F401
 
     return XOPS
 


### PR DESCRIPTION
## Summary

Extends the KV cache size calculator example with new model support and UI improvements.

### New models in `modelconfig.json`
- `tencent/Hunyuan-0.5B-Instruct` / `1.8B` / `4B` / `7B` / `A13B-Instruct` — all use an explicit `head_dim: 128` that differs from `hidden_size / num_attention_heads` for some sizes (0.5B: 64 vs 128; 4B: 96 vs 128). Using the config-provided `head_dim` is required for correctness.
- `tencent/Hunyuan-Large` — uses Cross-Layer Attention (CLA) with `cla_share_factor: 2`, so effective KV layers = `num_hidden_layers / cla_share_factor`.
- `deepseek-ai/DeepSeek-V3.1` and `deepseek-ai/DeepSeek-V3.2` — same MLA architecture as DeepSeek-V3 (`kv_lora_rank + qk_rope_head_dim`).

### Calculation fixes in `kv_cache_calculator.html`
- Hunyuan dense models are routed through the existing `isGQAWithHeadDimModel` path (same as Qwen3/GLM4) so the explicit `head_dim` is used.
- Hunyuan-Large gets a dedicated `isHunyuanLargeModel` branch that divides layers by `cla_share_factor` before computing cache size.
- DeepSeek-V3.1 and V3.2 are matched by the existing DeepSeek prefix detection.

### `generate_config.py` updates
- Automatically extracts `head_dim` for `tencent/Hunyuan-*` dense models.
- Automatically extracts `cla_share_factor` for `tencent/Hunyuan-Large`.

### UI improvements in `kv_cache_calculator.html`
- Lightweight visual refresh: card layout, focus highlights, cleaner result display.
- **English / 中文 language toggle** — all labels, error messages, and calculation detail fields are fully localized.
- Model config loading now prefers `./modelconfig.json` (local) and falls back to the GitHub raw URL, so the page reflects local changes immediately when served locally.

## Testing
Validation done by serving the page locally with `python3 -m http.server` and verifying:
- All new model names appear in the dropdown.
- Computed KV cache sizes are consistent with manual calculation for Hunyuan-0.5B, 4B (explicit `head_dim`), and Hunyuan-Large (CLA halving).
- Language toggle updates all UI strings without a page reload.