### PR TITLE
Clean up on-disk cache files in LocalDiskBackend.close()

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -632,4 +632,6 @@ class LocalDiskBackend(StorageBackendInterface):
     def close(self) -> None:
         if self.batched_msg_sender is not None:
             self.batched_msg_sender.close()
+            self.batched_msg_sender = None  # prevent stale sends during cleanup
+        self.batched_remove(list(self.dict.keys()))
         self.disk_worker.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

`LocalDiskBackend` stores KV cache chunks as `.pt` files on disk, but the key-to-file mapping (`self.dict`) is in-memory only. When the service shuts down, `close()` stops the worker executor without deleting the cached files. Since the mapping is lost on exit, these files become orphaned and silently leak disk space.

This PR adds a `batched_remove()` call in `close()` to delete all cached files before stopping the executor. The `batched_msg_sender` is also set to `None` after closing to prevent stale eviction messages during cleanup.

Fixes #2840

**Special notes for your reviewers**:

Minimal change — two lines added to `close()`. No new APIs or behavioral changes at runtime.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests