### PR TITLE
[Build] Support CUDA 13 Docker builds by rebuilding LMCache from source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - "release-**"
     paths:
       - '**.py'
+      - 'docker/**'
       - 'pyproject.toml'
       - 'requirements/**.txt'
       - '.github/workflows/test.yml' # This workflow
@@ -18,6 +19,7 @@ on:
       - "release-**"
     paths:
       - '**.py'
+      - 'docker/**'
       - 'pyproject.toml'
       - 'requirements/**.txt'
       - '.github/workflows/test.yml' # This workflow
@@ -86,4 +88,3 @@ jobs:
             --ignore=tests/v1/mp_observability/ \
             --ignore=tests/skipped \
             --ignore=tests/v1/storage_backend/test_eic.py
-

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ For more details, please check our [Ray Summit talk](https://www.youtube.com/wat
 
 ## Installation
 
-To use LMCache, simply install `lmcache` from your package manager, e.g. pip:
+To use LMCache, install `lmcache` from your package manager, e.g. pip:
 
 ```bash
 pip install lmcache
 ```
 
-Works on Linux NVIDIA GPU platform.
+Works on Linux NVIDIA GPU platforms with the published CUDA 12 wheel stack.
+If you are running a CUDA 13 environment such as `vllm/vllm-openai:latest-cu130`,
+install LMCache from source so its native extension is rebuilt against the local
+CUDA/Torch toolchain.
 
 More [detailed installation instructions](https://docs.lmcache.ai/getting_started/installation) are available in the docs, particularly if you are not using the latest stable version of vllm or using another serving engine with different dependencies. Any "undefined symbol" or torch mismatch versions can be resolved in the documentation. 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ ARG PYTHON_VERSION=3.12
 ARG UBUNTU_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/venv/bin:${PATH}"
+ENV LMCACHE_FILTER_TORCH_CUDA_ARCH_LIST=/usr/local/bin/lmcache-filter-torch-cuda-arch-list
 
 # Install Python and other dependencies
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
@@ -34,6 +35,28 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && uv venv /opt/venv \
     && . /opt/venv/bin/activate \
     && python3 --version
+
+RUN cat <<'EOF' >/usr/local/bin/lmcache-filter-torch-cuda-arch-list
+#!/bin/sh
+set -eu
+
+printf '%s\n' "${1:-}" | awk '
+BEGIN { first = 1 }
+{
+    for (i = 1; i <= NF; ++i) {
+        if ($i != "7.0" && $i != "7.0+PTX") {
+            if (!first) {
+                printf " "
+            }
+            printf "%s", $i
+            first = 0
+        }
+    }
+}
+END { print "" }'
+EOF
+
+RUN chmod +x "${LMCACHE_FILTER_TORCH_CUDA_ARCH_LIST}"
 
 WORKDIR /workspace
 
@@ -102,7 +125,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     LM_TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" && \
     if [ "$CUDA_MAJOR" -ge 13 ]; then \
-        LM_TORCH_CUDA_ARCH_LIST="$(printf '%s\n' "${TORCH_CUDA_ARCH_LIST}" | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; ++i) if ($i != "7.0" && $i != "7.0+PTX") { if (!first) printf " "; printf "%s", $i; first = 0 } } END { print "" }')"; \
+        LM_TORCH_CUDA_ARCH_LIST="$(${LMCACHE_FILTER_TORCH_CUDA_ARCH_LIST} "${TORCH_CUDA_ARCH_LIST}")"; \
     fi && \
     TORCH_CUDA_ARCH_LIST="${LM_TORCH_CUDA_ARCH_LIST}" \
         python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
@@ -138,7 +161,7 @@ RUN . /opt/venv/bin/activate && \
     if [ "$CUDA_MAJOR" -ge 13 ]; then \
         apt-get update -y && \
         apt-get install -y --no-install-recommends ${BUILD_PKGS} && \
-        LM_TORCH_CUDA_ARCH_LIST="$(printf '%s\n' "${TORCH_CUDA_ARCH_LIST}" | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; ++i) if ($i != "7.0" && $i != "7.0+PTX") { if (!first) printf " "; printf "%s", $i; first = 0 } } END { print "" }')" && \
+        LM_TORCH_CUDA_ARCH_LIST="$(${LMCACHE_FILTER_TORCH_CUDA_ARCH_LIST} "${TORCH_CUDA_ARCH_LIST}")" && \
         TORCH_CUDA_ARCH_LIST="${LM_TORCH_CUDA_ARCH_LIST}" \
             uv pip install . --verbose --no-build-isolation --no-deps && \
         apt-get purge -y ${BUILD_PKGS} && \
@@ -146,7 +169,7 @@ RUN . /opt/venv/bin/activate && \
     else \
         uv pip install lmcache --verbose; \
     fi && \
-    rm -rf /workspace/LMCache /workspace/build.txt dist_lmcache
+    rm -rf /workspace/LMCache /workspace/build.txt
 
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,8 +41,13 @@ WORKDIR /workspace
 COPY ./requirements/common.txt common.txt
 COPY ./requirements/cuda.txt cuda.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}" && \
     . /opt/venv/bin/activate && \
-    uv pip install -r cuda.txt
+    uv pip install -r cuda.txt && \
+    if [ "$CUDA_MAJOR" -ge 13 ]; then \
+        uv pip uninstall cupy-cuda12x nixl nixl-cu12 || true && \
+        uv pip install cupy-cuda13x nixl-cu13; \
+    fi
 
 # CUDA arch list used by torch
 ARG torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0+PTX'
@@ -81,6 +86,7 @@ WORKDIR /workspace/LMCache
 # This means that LMCache is in sync with the vLLM torch version.
 RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}" && \
     . /opt/venv/bin/activate && \
     if [ "$VLLM_VERSION" = "nightly" ]; then \
         uv pip install --prerelease=allow \
@@ -94,8 +100,13 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
             'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' ; \
     fi && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
-    python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
-    uv pip install ./dist_lmcache/*.whl --verbose
+    LM_TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" && \
+    if [ "$CUDA_MAJOR" -ge 13 ]; then \
+        LM_TORCH_CUDA_ARCH_LIST="$(printf '%s\n' "${TORCH_CUDA_ARCH_LIST}" | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; ++i) if ($i != "7.0" && $i != "7.0+PTX") { if (!first) printf " "; printf "%s", $i; first = 0 } } END { print "" }')"; \
+    fi && \
+    TORCH_CUDA_ARCH_LIST="${LM_TORCH_CUDA_ARCH_LIST}" \
+        python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
+    uv pip install ./dist_lmcache/*.whl --verbose --no-deps
 
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
@@ -105,12 +116,37 @@ ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 
 FROM base AS image-release
 
-# Install LMCache and vLLM stable releases.
-# It is imperative that LMCache uses the same torch version as the 
-# vLLM stable release.
+ARG CUDA_VERSION
+
+# Copy LMCache sources so CUDA 13 builds can be compiled when needed.
+COPY ./requirements/build.txt /workspace/build.txt
+COPY . /workspace/LMCache
+WORKDIR /workspace/LMCache
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    . /opt/venv/bin/activate && \
+    uv pip install -r /workspace/build.txt
+
+# Install vLLM stable release and LMCache.
+# CUDA 12 uses the published LMCache wheel.
+# CUDA 13 builds LMCache from source against the image-local CUDA/Torch stack.
 RUN . /opt/venv/bin/activate && \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}" && \
+    CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-') && \
+    BUILD_PKGS="libcusparse-dev-${CUDA_VERSION_DASH} libcublas-dev-${CUDA_VERSION_DASH} libcusolver-dev-${CUDA_VERSION_DASH}" && \
     uv pip install --prerelease=allow vllm[runai,tensorizer,flashinfer] && \
-    uv pip install lmcache --verbose
+    if [ "$CUDA_MAJOR" -ge 13 ]; then \
+        apt-get update -y && \
+        apt-get install -y --no-install-recommends ${BUILD_PKGS} && \
+        LM_TORCH_CUDA_ARCH_LIST="$(printf '%s\n' "${TORCH_CUDA_ARCH_LIST}" | awk 'BEGIN { first = 1 } { for (i = 1; i <= NF; ++i) if ($i != "7.0" && $i != "7.0+PTX") { if (!first) printf " "; printf "%s", $i; first = 0 } } END { print "" }')" && \
+        TORCH_CUDA_ARCH_LIST="${LM_TORCH_CUDA_ARCH_LIST}" \
+            uv pip install . --verbose --no-build-isolation --no-deps && \
+        apt-get purge -y ${BUILD_PKGS} && \
+        rm -rf /var/lib/apt/lists/*; \
+    else \
+        uv pip install lmcache --verbose; \
+    fi && \
+    rm -rf /workspace/LMCache /workspace/build.txt dist_lmcache
 
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,11 @@ This directory contains Dockerfiles for building different LMCache images. Each 
 
 **Build Targets**:
 - `image-build`: Builds with vLLM nightly and LMCache from source
-- `image-release`: Uses stable vLLM release and LMCache from PyPI
+- `image-release`: Uses stable vLLM release; installs LMCache from PyPI on CUDA 12 and rebuilds LMCache from source on CUDA 13
+
+For CUDA 13 builds, both targets rebuild LMCache from source so the native
+extension links against the CUDA/Torch stack inside the image instead of the
+published CUDA 12 wheel.
 
 **Usage**:
 
@@ -210,4 +214,3 @@ docker pull lmcache/standalone:latest
 - [vLLM Documentation](https://docs.vllm.ai/)
 - [Installation Guide](https://docs.lmcache.ai/getting_started/installation.html)
 - [Docker Deployment Guide](https://docs.lmcache.ai/production/docker_deployment.html)
-

--- a/docs/source/developer_guide/docker_file.rst
+++ b/docs/source/developer_guide/docker_file.rst
@@ -19,6 +19,15 @@ To build the container image, run the following command from the root directory 
 Replace `<IMAGE_NAME>` and `<TAG>` with your desired image name and tag. See example build file in `docker <https://github.com/LMCache/LMCache/tree/dev/docker>`_
 for explanation of all arguments.
 
+CUDA-specific behavior
+----------------------
+
+The Dockerfile supports both CUDA 12 and CUDA 13 container builds.
+
+- CUDA 12 uses the published LMCache wheel from PyPI together with the CUDA 12 dependency stack.
+- CUDA 13 switches the image to the CUDA 13 runtime packages (for example ``cupy-cuda13x`` and ``nixl-cu13``) and builds LMCache from source inside the image so the extension matches the local CUDA and Torch toolchain.
+
+When you need to target a non-default CUDA version, pass ``--build-arg CUDA_VERSION=<major.minor>`` to ``docker build``.
 
 
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -24,6 +24,11 @@ Prerequisites
 The simplest way to install the latest stable release of LMCache is through PyPI.
 If you require a different version of torch for the LMCache instance that you built with (symbol undefined error), please follow the install from source instructions below.
 
+.. note::
+    The published LMCache wheel is built against the CUDA 12 toolchain. For CUDA 13
+    environments, install LMCache from source so ``lmcache.c_ops`` is rebuilt against
+    the local CUDA/Torch stack.
+
 .. code-block:: bash
 
     uv venv --python 3.12
@@ -98,6 +103,21 @@ linker issues that will show up as undefined symbol references.
 
     # no build isolation requires torch to already be installed
     # with your desired version
+    uv pip install -e . --no-build-isolation
+
+If you are installing from source on CUDA 13, make sure the CUDA 13 development
+packages are available and set a CUDA 13 compatible architecture list before the
+build. For example, on the ``vllm/vllm-openai:latest-cu130`` base image:
+
+.. code-block:: bash
+
+    apt-get update -y
+    apt-get install -y --no-install-recommends \
+        libcusparse-dev-13-0 \
+        libcublas-dev-13-0 \
+        libcusolver-dev-13-0
+    export CUDA_HOME=/usr/local/cuda
+    export TORCH_CUDA_ARCH_LIST="8.9"
     uv pip install -e . --no-build-isolation
 
 You can quickly test whether you have undefined symbol references by running: 

--- a/docs/source/production/docker_deployment.rst
+++ b/docs/source/production/docker_deployment.rst
@@ -28,6 +28,12 @@ See example run file in `docker <https://github.com/LMCache/LMCache/tree/dev/doc
 
 .. note::
 
+    The published LMCache Python wheel is built for the CUDA 12 stack. For CUDA 13
+    container builds, the Dockerfile rebuilds LMCache from source and swaps in the
+    CUDA 13 dependency variants such as ``cupy-cuda13x`` and ``nixl-cu13``.
+
+.. note::
+
     DockerHub contains the following image types:
 
     - Nightly build images of LMCache and vLLM latest code (e.g. tagged with `latest-nightly` and `nightly-<date>`)

--- a/tests/test_dockerfile_cuda13_contract.py
+++ b/tests/test_dockerfile_cuda13_contract.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+
+DOCKERFILE = Path(__file__).resolve().parents[1] / "docker" / "Dockerfile"
+
+
+def _section_between(text: str, start_marker: str, end_marker: str) -> str:
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return text[start:end]
+
+
+def test_runtime_dependencies_switch_to_cuda13_packages() -> None:
+    dockerfile = DOCKERFILE.read_text()
+    runtime_section = _section_between(
+        dockerfile,
+        "# Install runtime dependencies",
+        "# CUDA arch list used by torch",
+    )
+
+    assert 'if [ "$CUDA_MAJOR" -ge 13 ]; then \\' in runtime_section
+    assert "uv pip uninstall cupy-cuda12x nixl nixl-cu12 || true" in runtime_section
+    assert "uv pip install cupy-cuda13x nixl-cu13" in runtime_section
+    assert "uv pip install -r cuda.txt" in runtime_section
+
+
+def test_runtime_dependencies_preserve_cuda12_defaults() -> None:
+    dockerfile = DOCKERFILE.read_text()
+    runtime_section = _section_between(
+        dockerfile,
+        "# Install runtime dependencies",
+        "# CUDA arch list used by torch",
+    )
+    cuda13_branch = runtime_section.split(
+        'if [ "$CUDA_MAJOR" -ge 13 ]; then \\',
+        maxsplit=1,
+    )[1].split("fi", maxsplit=1)[0]
+
+    assert "uv pip install -r cuda.txt" in runtime_section
+    assert "cupy-cuda12x" in runtime_section
+    assert "nixl-cu12" in runtime_section
+    assert "cupy-cuda13x" in cuda13_branch
+    assert "nixl-cu13" in cuda13_branch
+
+
+def test_release_path_builds_lmcache_from_source_for_cuda13() -> None:
+    dockerfile = DOCKERFILE.read_text()
+    release_section = _section_between(
+        dockerfile,
+        "# Install vLLM stable release and LMCache.",
+        "WORKDIR /workspace",
+    )
+
+    assert 'if [ "$CUDA_MAJOR" -ge 13 ]; then \\' in release_section
+    assert "COPY ./requirements/build.txt /workspace/build.txt" in dockerfile
+    assert "uv pip install -r /workspace/build.txt" in dockerfile
+    assert "apt-get install -y --no-install-recommends ${BUILD_PKGS}" in release_section
+    assert "uv pip install . --verbose --no-build-isolation --no-deps" in release_section
+    assert "uv pip install lmcache --verbose" in release_section
+    cuda13_branch = release_section.split(
+        'if [ "$CUDA_MAJOR" -ge 13 ]; then \\',
+        maxsplit=1,
+    )[1].split("else \\", maxsplit=1)[0]
+    cuda12_branch = release_section.split("else \\", maxsplit=1)[1]
+    assert "uv pip install lmcache --verbose" not in cuda13_branch
+    assert "cu12" not in cuda13_branch.lower()
+    assert "uv pip install lmcache --verbose" in cuda12_branch
+    assert "--no-build-isolation" not in cuda12_branch

--- a/tests/test_dockerfile_cuda13_contract.py
+++ b/tests/test_dockerfile_cuda13_contract.py
@@ -13,6 +13,7 @@ def _section_between(text: str, start_marker: str, end_marker: str) -> str:
 
 
 def test_runtime_dependencies_switch_to_cuda13_packages() -> None:
+    """Verify that CUDA 13 runtime dependencies switch to CUDA 13 packages."""
     dockerfile = DOCKERFILE.read_text()
     runtime_section = _section_between(
         dockerfile,
@@ -27,6 +28,7 @@ def test_runtime_dependencies_switch_to_cuda13_packages() -> None:
 
 
 def test_runtime_dependencies_preserve_cuda12_defaults() -> None:
+    """Verify that the default CUDA 12 path remains present in the runtime section."""
     dockerfile = DOCKERFILE.read_text()
     runtime_section = _section_between(
         dockerfile,
@@ -46,6 +48,7 @@ def test_runtime_dependencies_preserve_cuda12_defaults() -> None:
 
 
 def test_release_path_builds_lmcache_from_source_for_cuda13() -> None:
+    """Verify that the release image builds LMCache from source for CUDA 13."""
     dockerfile = DOCKERFILE.read_text()
     release_section = _section_between(
         dockerfile,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #2843.

This makes LMCache's Docker/runtime path explicitly support CUDA 13 for the latest vLLM OpenAI image path.

Related cross-project issue: vllm-project/vllm#37801.

In the CUDA 13 branch, this PR:
- switches runtime dependencies to `cupy-cuda13x` and `nixl-cu13`
- avoids the generic `lmcache` wheel for CUDA 13
- rebuilds/installs LMCache from source with `--no-build-isolation --no-deps`
- keeps the existing CUDA 12 behavior intact

**Special notes for your reviewers**:

- Base branch is `dev`, per the contribution guide.
- This change is intentionally scoped to Docker/runtime compatibility and tests.
- The paired vLLM-side fix is tracked in vllm-project/vllm#37801.
- CUDA 12 was revalidated after this change so the default build path remains covered.
- I used AI assistance while preparing this change, and I manually reviewed the patch and validated the listed tests/results.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

## Test evidence

Targeted tests:

```text
$ pytest -q --noconftest tests/test_dockerfile_cuda13_contract.py
3 passed
```

Docs sanity:

```text
$ sphinx -b dummy docs/source .sphinx-dummy
succeeded
```

CUDA 12 validation:
- built `docker/Dockerfile` `image-release`
- runtime import of `lmcache.integration.vllm.vllm_v1_adapter` succeeded
- LMCache CPU+disk offload and replay hits succeeded

CUDA 13 validation:
- built a CUDA 13 image on top of `vllm/vllm-openai:latest-cu130`
- served `Qwen/Qwen3-0.6B`
- confirmed `LocalCPUBackend` and `LocalDiskBackend`
- confirmed disk offload writes
- confirmed replay cache hits
- confirmed OpenAI-compatible replay responses exposed `usage.prompt_tokens_details.cached_tokens = 6144`
