### PR TITLE
[feat] Support concurrency loading in batched_get for local disk backend and make it configurable

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
 import os
@@ -44,6 +44,7 @@ class LocalDiskWorker:
 
         # TODO(Jiayi): make executor and its parameters configurable
         self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=4)
+        self.reader_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="DiskRWorker")
         self.loop = loop
         self._closed = False
 
@@ -70,6 +71,17 @@ class LocalDiskWorker:
             priority=priority,
             **kwargs,
         )
+
+    def submit_read_task(self, task: Callable, key: CacheEngineKey) -> Future:
+        """
+        Submit read task to threadpool.
+
+        :param Callable task: The target task.
+        :param CacheEngineKey key: The key of MemoryObj.
+
+        :return: a future object.
+        """
+        return self.reader_executor.submit(task, key)
 
     def remove_put_task(self, key: CacheEngineKey):
         with self.put_lock:
@@ -406,6 +418,21 @@ class LocalDiskBackend(StorageBackendInterface):
         )
 
         return memory_obj
+
+    def batched_get_blocking(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> List[Optional[MemoryObj]]:
+        """
+        A blocking function to get the kv cache from the storage backend.
+
+        :param List[CacheEngineKey] keys: The keys of the MemoryObjs.
+
+        :return: a list of memory objects.
+        """
+        futures = [self.disk_worker.submit_read_task(self.get_blocking, key) for key in keys]
+        memory_objs = [future.result() for future in futures]
+        return memory_objs
 
     async def batched_get_non_blocking(
         self,

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -35,7 +35,7 @@ logger = init_logger(__name__)
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
 class LocalDiskWorker:
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(self, loop: asyncio.AbstractEventLoop, pq_workers: int, r_workers: int) -> None:
         self.put_lock = threading.Lock()
         self.put_tasks: List[CacheEngineKey] = []
 
@@ -43,8 +43,8 @@ class LocalDiskWorker:
         self.prefetch_tasks: dict[CacheEngineKey, Future] = {}
 
         # TODO(Jiayi): make executor and its parameters configurable
-        self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=4)
-        self.reader_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="DiskRWorker")
+        self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=pq_workers)
+        self.reader_executor = ThreadPoolExecutor(max_workers=r_workers, thread_name_prefix="DiskRWorker")
         self.loop = loop
         self._closed = False
 
@@ -144,12 +144,16 @@ class LocalDiskBackend(StorageBackendInterface):
         stat = os.statvfs(self.path)
         self.os_disk_bs = stat.f_bsize
         self.use_odirect = False
+        self.pq_workers = 4
+        self.reader_workers = 16
 
         if config.extra_config is not None:
             self.use_odirect = config.extra_config.get("use_odirect", False)
+            self.pq_workers = config.extra_config.get("pq_workers", 4)
+            self.reader_workers = config.extra_config.get("reader_workers", 16)
         logger.info("Using O_DIRECT for disk I/O: %s", self.use_odirect)
 
-        self.disk_worker = LocalDiskWorker(loop)
+        self.disk_worker = LocalDiskWorker(loop, self.pq_workers, self.reader_workers)
 
         # TODO(Jiayi): We need a disk space allocator to avoid fragmentation
         # and hide the following details away from the backend.


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR provide:
- the concurrency read with threadpool in local disk backend. It can enhance the reading bandwidth and also reduce the TTFT in some case (such as the kv cache missing in GPU/NPU memory and Host memory).
- more configurable parameters for executor.

**Special notes for your reviewers**:
We test this case on NPU with long_dock_qa benchmark (with 20k context) in qwen-2.5 7B model with vllm
(disable the prefix-caching to ensuring the external io).
Our result shows that this patch can achieve the following result:

```
Throughput: 2.300 GB/s -> 2.7573 GB/s
TTFT: 0.640s -> 0.555s
```


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces multithreaded disk reads and new concurrency knobs, which can affect performance, ordering, and shutdown/resource behavior under load. Main risk is subtle concurrency issues or threadpool lifecycle leaks rather than functional logic changes.
> 
> **Overview**
> Enables concurrent loading for `LocalDiskBackend.batched_get_blocking` by dispatching per-key `get_blocking` calls onto a dedicated `ThreadPoolExecutor`, allowing multiple disk reads to run in parallel.
> 
> Makes executor sizing configurable via `config.extra_config` by adding `pq_workers` (priority-queue executor) and `reader_workers` (read threadpool), and wires these into the updated `LocalDiskWorker` constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a19d035f48f6d82064a39cb99e3daec011dfa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->