### PR TITLE
[CI]: add pytest-timeout with 10-minute per-test default

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,6 @@ pytest-benchmark
 pytest-benchmark[histogram]
 pytest-cov
 pytest-html>=3.2,<5.0  # 4.x requires external assets; 3.2 is stable
+pytest-timeout
 jinja2<3.2
 python-multipart

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 log_cli = true
 log_cli_level = INFO
+timeout = 600
 markers =
     no_shared_allocator: Disable the shared-allocator monkeypatch for this test


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `pytest-timeout` to prevent individual unit tests from hanging indefinitely and blocking the entire CI run.

Currently there is no per-test timeout — if a test hangs (e.g. on a bare `future.result()` call or a deadlocked async loop), the CI job runs until the GitHub Actions 6-hour job timeout kills it. This wastes CI resources and makes it hard to identify which test is stuck.

With this change, any test that exceeds 10 minutes is killed and `pytest-timeout` prints the full stack trace showing exactly where the test was hung, then moves on to the next test.

**Changes:**
- `requirements/test.txt`: add `pytest-timeout` dependency
- `tests/pytest.ini`: add `timeout = 600` (10 min per test)

**Special notes for your reviewers**:

Individual tests can override the default with `@pytest.mark.timeout(N)` if they legitimately need more (or less) time.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
