### PR TITLE
[Temp CI Patch]: torch version for UT

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,8 @@ steps:
       if command -v nvidia-smi >/dev/null 2>&1; then
         source .buildkite/scripts/pick-free-gpu.sh 18000
         export CUDA_LAUNCH_BLOCKING=1
+        # Pin torch to a version compatible with the CI machine's CUDA 12.x driver
+        uv pip install "torch>=2.6.0,<2.11.0"
       else
         source .buildkite/scripts/pick-free-gpu-amd.sh 18000
         export AMD_SERIALIZE_KERNEL=1


### PR DESCRIPTION
`torch` 11 was just released built on CUDA 13.0 but our Unit Test CI machine still has CUDA 12.1. temp unblock solution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CI dependency installation for NVIDIA runners; main risk is CI flakes if the pinned `torch` range is too narrow or conflicts with other requirements.
> 
> **Overview**
> Updates the Buildkite unit-test pipeline to **pin `torch` to `>=2.6.0,<2.11.0` on NVIDIA (CUDA) runners**, ensuring compatibility with the CI machines' CUDA 12.x drivers.
> 
> AMD/ROCm installation behavior is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc60cfb99c037dba78f2098d946a2e6906fbb2db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->