### PR TITLE
[Feat] add mp support for sglang

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,9 @@ steps:
       uv pip install -e . --no-build-isolation
       uv pip freeze
 
+      LMCACHE_TRACK_USAGE="false" \
+      pytest --maxfail=1 tests/v1/test_sglang_integration.py
+
       if command -v nvidia-smi >/dev/null 2>&1; then
         LMCACHE_TRACK_USAGE="false" \
         pytest --maxfail=1 --cov=lmcache \
@@ -37,6 +40,7 @@ steps:
           --cov-report=xml:coverage-test.xml --html=durations/test.html \
           --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
           --ignore=tests/v1/test_nixl_storage.py \
+          --ignore=tests/v1/test_sglang_integration.py \
           --ignore=tests/skipped \
           --ignore=tests/v1/storage_backend/test_eic.py
       else
@@ -46,6 +50,7 @@ steps:
           --cov-report=xml:coverage-test.xml --html=durations/test.html \
           --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
           --ignore=tests/v1/test_nixl_storage.py \
+          --ignore=tests/v1/test_sglang_integration.py \
           --ignore=tests/skipped \
           --ignore=tests/v1/multiprocess \
           --ignore=tests/v1/storage_backend/test_eic.py

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -73,6 +73,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
       .. note::
          Configure LMCache via the config file. See :doc:`../api_reference/configurations` for the full list.
+         For LMCache multi-process mode with SGLang, see :doc:`../mp/quickstart`.
 
 (Terminal 2) Test LMCache in Action
 -----------------------------------

--- a/docs/source/mp/quickstart.rst
+++ b/docs/source/mp/quickstart.rst
@@ -127,14 +127,23 @@ In a new terminal:
 
 .. code-block:: bash
 
+    PROMPT=$(python - <<'PY'
+    print(" ".join(f"tok{i}" for i in range(1, 201)))
+    PY
+    )
+
+    cat >/tmp/sglang-mp-request.json <<EOF
+    {
+      "model": "Qwen/Qwen3-0.6B",
+      "messages": [{"role": "user", "content": "${PROMPT}"}],
+      "temperature": 0,
+      "max_tokens": 16
+    }
+    EOF
+
     curl http://127.0.0.1:30000/v1/chat/completions \
         -H "Content-Type: application/json" \
-        -d '{
-          "model": "Qwen/Qwen3-0.6B",
-          "messages": [{"role": "user", "content": "tok1 tok2 tok3 tok4 tok5 tok6 tok7 tok8 tok9 tok10 tok11 tok12 tok13 tok14 tok15 tok16 tok17 tok18 tok19 tok20 tok21 tok22 tok23 tok24 tok25 tok26 tok27 tok28 tok29 tok30 tok31 tok32 tok33 tok34 tok35 tok36 tok37 tok38 tok39 tok40 tok41 tok42 tok43 tok44 tok45 tok46 tok47 tok48 tok49 tok50 tok51 tok52 tok53 tok54 tok55 tok56 tok57 tok58 tok59 tok60 tok61 tok62 tok63 tok64 tok65 tok66 tok67 tok68 tok69 tok70 tok71 tok72 tok73 tok74 tok75 tok76 tok77 tok78 tok79 tok80 tok81 tok82 tok83 tok84 tok85 tok86 tok87 tok88 tok89 tok90 tok91 tok92 tok93 tok94 tok95 tok96 tok97 tok98 tok99 tok100 tok101 tok102 tok103 tok104 tok105 tok106 tok107 tok108 tok109 tok110 tok111 tok112 tok113 tok114 tok115 tok116 tok117 tok118 tok119 tok120 tok121 tok122 tok123 tok124 tok125 tok126 tok127 tok128 tok129 tok130 tok131 tok132 tok133 tok134 tok135 tok136 tok137 tok138 tok139 tok140 tok141 tok142 tok143 tok144 tok145 tok146 tok147 tok148 tok149 tok150 tok151 tok152 tok153 tok154 tok155 tok156 tok157 tok158 tok159 tok160 tok161 tok162 tok163 tok164 tok165 tok166 tok167 tok168 tok169 tok170 tok171 tok172 tok173 tok174 tok175 tok176 tok177 tok178 tok179 tok180 tok181 tok182 tok183 tok184 tok185 tok186 tok187 tok188 tok189 tok190 tok191 tok192 tok193 tok194 tok195 tok196 tok197 tok198 tok199 tok200"}],
-          "temperature": 0,
-          "max_tokens": 16
-        }'
+        -d @/tmp/sglang-mp-request.json
 
 Example result observed during validation:
 

--- a/docs/source/mp/quickstart.rst
+++ b/docs/source/mp/quickstart.rst
@@ -87,6 +87,73 @@ Second identical request -- tokens are **retrieved** from cache:
 
     LMCache INFO: Retrieved 768 tokens in 0.001 seconds
 
+Tested SGLang Example
+---------------------
+
+The same LMCache MP server can also be used from SGLang.
+
+**Step 1: Start the LMCache server**
+
+.. code-block:: bash
+
+    python3 -m lmcache.v1.multiprocess.server \
+        --host 127.0.0.1 \
+        --port 65000 \
+        --l1-size-gb 10 \
+        --eviction-policy LRU
+
+**Step 2: Start SGLang with LMCache MP**
+
+In a new terminal:
+
+.. code-block:: bash
+
+    export LMCACHE_CONFIG_FILE=$PWD/lmc_config.yaml
+
+    python -m sglang.launch_server \
+        --model-path Qwen/Qwen3-0.6B \
+        --host 127.0.0.1 \
+        --port 30000 \
+        --enable-lmcache \
+        --lmcache-mp-host 127.0.0.1 \
+        --lmcache-mp-port 65000
+
+.. note::
+   During local validation, SGLang needed ``--disable-piecewise-cuda-graph``
+   and ``--disable-cuda-graph`` in this environment to avoid an unrelated
+   startup CUDA issue. That was not required by LMCache MP itself.
+
+**Step 3: Send the same deterministic request twice**
+
+.. code-block:: bash
+
+    curl http://127.0.0.1:30000/v1/chat/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+          "model": "Qwen/Qwen3-0.6B",
+          "messages": [{"role": "user", "content": "tok1 tok2 tok3 tok4 tok5 tok6 tok7 tok8 tok9 tok10 tok11 tok12 tok13 tok14 tok15 tok16 tok17 tok18 tok19 tok20 tok21 tok22 tok23 tok24 tok25 tok26 tok27 tok28 tok29 tok30 tok31 tok32 tok33 tok34 tok35 tok36 tok37 tok38 tok39 tok40 tok41 tok42 tok43 tok44 tok45 tok46 tok47 tok48 tok49 tok50 tok51 tok52 tok53 tok54 tok55 tok56 tok57 tok58 tok59 tok60 tok61 tok62 tok63 tok64 tok65 tok66 tok67 tok68 tok69 tok70 tok71 tok72 tok73 tok74 tok75 tok76 tok77 tok78 tok79 tok80 tok81 tok82 tok83 tok84 tok85 tok86 tok87 tok88 tok89 tok90 tok91 tok92 tok93 tok94 tok95 tok96 tok97 tok98 tok99 tok100 tok101 tok102 tok103 tok104 tok105 tok106 tok107 tok108 tok109 tok110 tok111 tok112 tok113 tok114 tok115 tok116 tok117 tok118 tok119 tok120 tok121 tok122 tok123 tok124 tok125 tok126 tok127 tok128 tok129 tok130 tok131 tok132 tok133 tok134 tok135 tok136 tok137 tok138 tok139 tok140 tok141 tok142 tok143 tok144 tok145 tok146 tok147 tok148 tok149 tok150 tok151 tok152 tok153 tok154 tok155 tok156 tok157 tok158 tok159 tok160 tok161 tok162 tok163 tok164 tok165 tok166 tok167 tok168 tok169 tok170 tok171 tok172 tok173 tok174 tok175 tok176 tok177 tok178 tok179 tok180 tok181 tok182 tok183 tok184 tok185 tok186 tok187 tok188 tok189 tok190 tok191 tok192 tok193 tok194 tok195 tok196 tok197 tok198 tok199 tok200"}],
+          "temperature": 0,
+          "max_tokens": 16
+        }'
+
+Example result observed during validation:
+
+.. code-block:: text
+
+    first request:  cached_tokens=0
+    second request: cached_tokens=768
+    output text: " tok200 tok201 tok202 tok203"
+
+We also validated deterministic in-process vs MP output parity on:
+
+- ``Qwen3-0.6B``
+- ``facebook/opt-125m``
+- ``Qwen3-8B``
+- ``Qwen2.5-14B-Instruct``
+
+and confirmed that two independent SGLang servers can connect to the same
+LMCache MP daemon and reuse cached KV across servers.
+
 Docker Quick Start
 ------------------
 

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -14,7 +14,11 @@ import torch.distributed as dist
 import zmq
 
 # First Party
-from lmcache.integration.sglang.sglang_adapter import LoadMetadata, StoreMetadata
+from lmcache.integration.sglang.sglang_adapter import (
+    LoadMetadata,
+    StoreMetadata,
+    resolve_sglang_kv_pools,
+)
 from lmcache.integration.vllm.vllm_multi_process_adapter import (
     DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_MQ_TIMEOUT,
@@ -63,14 +67,22 @@ class LMCacheMPLayerwiseConnector:
         tp_size: int,
         rank: int,
         page_size: int,
-        k_pool: list[torch.Tensor],
-        v_pool: list[torch.Tensor],
         host: str,
         port: int,
+        k_pool: Optional[list[torch.Tensor]] = None,
+        v_pool: Optional[list[torch.Tensor]] = None,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        token_to_kv_pool_allocator: object | None = None,
+        kvcache: object | None = None,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
+        k_pool, v_pool = resolve_sglang_kv_pools(
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+            kvcache=kvcache,
+            k_pool=k_pool,
+            v_pool=v_pool,
+        )
         if not k_pool or not v_pool:
             raise ValueError("SGLang MP connector requires non-empty K/V pools")
         if len(k_pool) != len(v_pool):

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -200,8 +200,10 @@ class LMCacheMPLayerwiseConnector:
                 f"{slot_mapping.numel()} and page_size={self.page_size}"
             )
 
-        groups = slot_mapping.detach().to(dtype=torch.int64, device="cpu").reshape(
-            -1, self.page_size
+        groups = (
+            slot_mapping.detach()
+            .to(dtype=torch.int64, device="cpu")
+            .reshape(-1, self.page_size)
         )
         starts = groups[:, 0]
         if torch.any(starts % self.page_size != 0):
@@ -390,21 +392,25 @@ class LMCacheMPLayerwiseConnector:
         )
         event = torch.cuda.Event(interprocess=True)
         event.record(torch.cuda.current_stream())
-        success = send_lmcache_request(
-            self.mq_client,
-            RequestType.STORE,
-            [
-                self._create_key(
-                    store_metadata.token_ids,
-                    start=0,
-                    end=aligned_end,
-                    request_id=request_id,
-                ),
-                self.instance_id,
-                block_ids,
-                event.ipc_handle(),
-            ],
-        ).to_cuda_future(device=self.device).result(timeout=self._mq_timeout)
+        success = (
+            send_lmcache_request(
+                self.mq_client,
+                RequestType.STORE,
+                [
+                    self._create_key(
+                        store_metadata.token_ids,
+                        start=0,
+                        end=aligned_end,
+                        request_id=request_id,
+                    ),
+                    self.instance_id,
+                    block_ids,
+                    event.ipc_handle(),
+                ],
+            )
+            .to_cuda_future(device=self.device)
+            .result(timeout=self._mq_timeout)
+        )
         self._end_session(request_id)
         if not success:
             raise RuntimeError("LMCache MP store failed")

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -89,6 +89,8 @@ class LMCacheMPLayerwiseConnector:
             raise ValueError("K/V pool layer counts must match")
         if not k_pool[0].is_cuda:
             raise ValueError("SGLang MP connector requires CUDA KV caches")
+        if tp_size > 1 and tp_group is None:
+            raise ValueError("tp_group is required when tp_size > 1")
 
         self.tp_size = tp_size
         self.worker_id = rank
@@ -148,7 +150,10 @@ class LMCacheMPLayerwiseConnector:
 
     @torch.no_grad()
     def global_min_tokens(
-        self, local_tokens: int, tp_group: dist.ProcessGroup, device: torch.device
+        self,
+        local_tokens: int,
+        tp_group: dist.ProcessGroup | None,
+        device: torch.device,
     ) -> int:
         if self.tp_size == 1:
             return local_tokens
@@ -348,33 +353,37 @@ class LMCacheMPLayerwiseConnector:
             return
 
         finished_indices: list[int] = []
+        failures: list[Exception] = []
         for i, state in enumerate(self._active_retrieves):
             if state.in_flight_layer != layer_id:
                 continue
 
-            if state.future is None:
-                self.cleanup_retrieve_state(state)
-                finished_indices.append(i)
-                raise RuntimeError(
-                    f"LMCache MP retrieve state is missing a future for "
-                    f"request_id={state.request_id}"
-                )
-            if not state.future.result(timeout=self._mq_timeout):
-                self.cleanup_retrieve_state(state)
-                finished_indices.append(i)
-                raise RuntimeError(
-                    f"LMCache MP retrieve failed for request_id={state.request_id}"
-                )
+            try:
+                if state.future is None:
+                    raise RuntimeError(
+                        f"LMCache MP retrieve state is missing a future for "
+                        f"request_id={state.request_id}"
+                    )
+                if not state.future.result(timeout=self._mq_timeout):
+                    raise RuntimeError(
+                        f"LMCache MP retrieve failed for request_id={state.request_id}"
+                    )
 
-            next_layer = layer_id + 1
-            if next_layer < self.num_layers:
-                self.submit_retrieve(state, next_layer)
-            else:
-                self.end_session(state.request_id)
+                next_layer = layer_id + 1
+                if next_layer < self.num_layers:
+                    self.submit_retrieve(state, next_layer)
+                else:
+                    self.end_session(state.request_id)
+                    finished_indices.append(i)
+            except Exception as exc:
+                self.cleanup_retrieve_state(state)
                 finished_indices.append(i)
+                failures.append(exc)
 
         for i in reversed(finished_indices):
             del self._active_retrieves[i]
+        if failures:
+            raise failures[0]
 
     def store_kv(self, store_metadata: StoreMetadata) -> None:
         if not self.is_healthy:

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from dataclasses import dataclass
+from typing import Optional
+import os
+import threading
+import time
+import uuid
+
+# Third Party
+from sglang.srt.configs.model_config import ModelConfig
+import torch
+import torch.distributed as dist
+import zmq
+
+# First Party
+from lmcache.integration.sglang.sglang_adapter import LoadMetadata, StoreMetadata
+from lmcache.integration.vllm.vllm_multi_process_adapter import (
+    DEFAULT_HEARTBEAT_INTERVAL,
+    DEFAULT_MQ_TIMEOUT,
+    HeartbeatThread,
+    get_lmcache_chunk_size,
+    send_lmcache_request,
+)
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.custom_types import (
+    CudaIPCWrapper,
+    IPCCacheEngineKey,
+    KVCacheRegistration,
+)
+from lmcache.v1.multiprocess.futures import CUDAMessagingFuture
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import RequestType
+
+logger = init_logger(__name__)
+
+
+def wrap_sglang_kv_caches(
+    k_pool: list[torch.Tensor],
+    v_pool: list[torch.Tensor],
+) -> list[list[CudaIPCWrapper]]:
+    return [
+        [CudaIPCWrapper(tensor) for tensor in k_pool],
+        [CudaIPCWrapper(tensor) for tensor in v_pool],
+    ]
+
+
+@dataclass
+class _ActiveRetrieveState:
+    request_id: str
+    token_ids: list[int]
+    offset: int
+    matched_end: int
+    block_ids: list[int]
+    in_flight_layer: int
+    future: CUDAMessagingFuture[bool] | None
+
+
+class LMCacheMPLayerwiseConnector:
+    def __init__(
+        self,
+        sgl_config: ModelConfig,
+        tp_size: int,
+        rank: int,
+        page_size: int,
+        k_pool: list[torch.Tensor],
+        v_pool: list[torch.Tensor],
+        host: str,
+        port: int,
+        tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        mq_timeout: float = DEFAULT_MQ_TIMEOUT,
+        heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+    ):
+        if not k_pool or not v_pool:
+            raise ValueError("SGLang MP connector requires non-empty K/V pools")
+        if len(k_pool) != len(v_pool):
+            raise ValueError("K/V pool layer counts must match")
+        if not k_pool[0].is_cuda:
+            raise ValueError("SGLang MP connector requires CUDA KV caches")
+
+        self.tp_size = tp_size
+        self.worker_id = rank
+        self.page_size = page_size
+        self.device = k_pool[0].device
+        self.model_name = sgl_config.model_path
+        self.num_layers = len(k_pool)
+        self.tp_group = tp_group
+        self.instance_id = os.getpid()
+        self._mq_timeout = mq_timeout
+        self._heartbeat_interval = heartbeat_interval
+        self._active_retrieves: list[_ActiveRetrieveState] = []
+        self._registered = False
+        self._heartbeat: HeartbeatThread | None = None
+        self._health_event = threading.Event()
+        self._health_event.set()
+
+        self.context = zmq.Context.instance()
+        self.mq_client = MessageQueueClient(f"tcp://{host}:{port}", self.context)
+
+        self._lmcache_chunk_size = get_lmcache_chunk_size(self.mq_client)
+        if self._lmcache_chunk_size % self.page_size != 0:
+            raise ValueError(
+                "LMCache chunk size must be a multiple of SGLang page size, got "
+                f"{self._lmcache_chunk_size} and {self.page_size}"
+            )
+
+        registration = KVCacheRegistration(
+            instance_id=self.instance_id,
+            model_name=self.model_name,
+            world_size=self.tp_size,
+            engine_type="sglang",
+            block_size=self.page_size,
+            kv_caches=wrap_sglang_kv_caches(k_pool, v_pool),
+        )
+        send_lmcache_request(
+            self.mq_client,
+            RequestType.REGISTER_KV_CACHE,
+            [registration],
+        ).result(timeout=self._mq_timeout)
+        self._registered = True
+        self._start_heartbeat()
+
+    def _start_heartbeat(self) -> None:
+        if self._heartbeat is not None:
+            return
+        self._heartbeat = HeartbeatThread(
+            mq_client=self.mq_client,
+            health_event=self._health_event,
+            interval=self._heartbeat_interval,
+        )
+        self._heartbeat.start()
+
+    @property
+    def is_healthy(self) -> bool:
+        return self._health_event.is_set()
+
+    @torch.no_grad()
+    def global_min_tokens(
+        self, local_tokens: int, tp_group: dist.ProcessGroup, device: torch.device
+    ) -> int:
+        if self.tp_size == 1:
+            return local_tokens
+        if tp_group is None:
+            raise ValueError("tp_group is required when tp_size > 1")
+
+        t = torch.tensor([local_tokens], dtype=torch.int32, device=device)
+        dist.all_reduce(t, op=dist.ReduceOp.MIN, group=tp_group)
+        return int(t.item())
+
+    def _create_key(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        no_worker_id: bool = False,
+    ) -> IPCCacheEngineKey:
+        return IPCCacheEngineKey(
+            model_name=self.model_name,
+            world_size=self.tp_size,
+            worker_id=None if no_worker_id else self.worker_id,
+            token_ids=tuple(token_ids),
+            start=start,
+            end=end,
+            request_id=request_id,
+        )
+
+    def _wait_for_lookup(self, job_id: int) -> int:
+        deadline = time.monotonic() + self._mq_timeout
+        while True:
+            matched_chunks = send_lmcache_request(
+                self.mq_client,
+                RequestType.QUERY_PREFETCH_STATUS,
+                [job_id],
+            ).result(timeout=self._mq_timeout)
+            if matched_chunks is not None:
+                return matched_chunks * self._lmcache_chunk_size
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Timed out waiting for LMCache prefetch to finish")
+            time.sleep(0.001)
+
+    def _slot_mapping_to_block_ids(self, slot_mapping: torch.Tensor) -> list[int]:
+        if slot_mapping.numel() == 0:
+            return []
+        if slot_mapping.numel() % self.page_size != 0:
+            raise ValueError(
+                "Slot mapping length must be page-aligned for MP mode, got "
+                f"{slot_mapping.numel()} and page_size={self.page_size}"
+            )
+
+        groups = slot_mapping.detach().to(dtype=torch.int64, device="cpu").reshape(
+            -1, self.page_size
+        )
+        starts = groups[:, 0]
+        if torch.any(starts % self.page_size != 0):
+            raise ValueError("Slot mapping does not start on page boundaries")
+
+        expected = starts[:, None] + torch.arange(self.page_size, dtype=torch.int64)
+        if not torch.equal(groups, expected):
+            raise ValueError("Slot mapping must cover full contiguous pages in MP mode")
+
+        return (starts // self.page_size).tolist()
+
+    def _submit_retrieve(
+        self,
+        state: _ActiveRetrieveState,
+        layer_id: int,
+    ) -> CUDAMessagingFuture[bool]:
+        event = torch.cuda.Event(interprocess=True)
+        event.record(torch.cuda.current_stream())
+        future = send_lmcache_request(
+            self.mq_client,
+            RequestType.RETRIEVE,
+            [
+                self._create_key(
+                    state.token_ids,
+                    start=state.offset,
+                    end=state.matched_end,
+                    request_id=state.request_id,
+                ),
+                self.instance_id,
+                state.block_ids,
+                event.ipc_handle(),
+                0,
+                layer_id,
+                layer_id + 1,
+            ],
+        ).to_cuda_future(device=self.device)
+        state.in_flight_layer = layer_id
+        state.future = future
+        return future
+
+    def _free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+    ) -> None:
+        if start >= end or not self.is_healthy:
+            return
+        send_lmcache_request(
+            self.mq_client,
+            RequestType.FREE_LOOKUP_LOCKS,
+            [
+                self._create_key(
+                    token_ids,
+                    start=start,
+                    end=end,
+                    request_id=request_id,
+                    no_worker_id=True,
+                ),
+                self.tp_size,
+            ],
+        )
+
+    def _end_session(self, request_id: str) -> None:
+        if not self.is_healthy:
+            return
+        send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
+
+    def _cleanup_retrieve_state(self, state: _ActiveRetrieveState) -> None:
+        self._free_lookup_locks(
+            state.token_ids, state.offset, state.matched_end, state.request_id
+        )
+        self._end_session(state.request_id)
+
+    def chunk_size(self) -> int:
+        return self._lmcache_chunk_size
+
+    def start_load_kv(self, load_metadata: LoadMetadata) -> int:
+        if not self.is_healthy:
+            return 0
+
+        aligned_end = (len(load_metadata.token_ids) // self._lmcache_chunk_size) * (
+            self._lmcache_chunk_size
+        )
+        offset = load_metadata.offset
+        if aligned_end == 0 or offset >= aligned_end:
+            return 0
+        if offset % self._lmcache_chunk_size != 0:
+            raise ValueError(
+                "LMCache MP mode requires chunk-aligned offsets, got "
+                f"{offset} and chunk_size={self._lmcache_chunk_size}"
+            )
+
+        request_id = str(uuid.uuid4())
+        lookup_key = self._create_key(
+            load_metadata.token_ids,
+            start=0,
+            end=aligned_end,
+            request_id=request_id,
+            no_worker_id=True,
+        )
+
+        job_id = send_lmcache_request(
+            self.mq_client,
+            RequestType.LOOKUP,
+            [lookup_key, self.tp_size],
+        ).result(timeout=self._mq_timeout)
+        retrieve_token_num = self._wait_for_lookup(job_id)
+
+        retrieve_token_num = self.global_min_tokens(
+            retrieve_token_num, self.tp_group, self.device
+        )
+
+        if retrieve_token_num <= offset:
+            self._free_lookup_locks(
+                load_metadata.token_ids, 0, retrieve_token_num, request_id
+            )
+            self._end_session(request_id)
+            return 0
+
+        self._free_lookup_locks(load_metadata.token_ids, 0, offset, request_id)
+        block_ids = self._slot_mapping_to_block_ids(
+            load_metadata.slot_mapping[offset:retrieve_token_num]
+        )
+
+        state = _ActiveRetrieveState(
+            request_id=request_id,
+            token_ids=load_metadata.token_ids,
+            offset=offset,
+            matched_end=retrieve_token_num,
+            block_ids=block_ids,
+            in_flight_layer=0,
+            future=None,
+        )
+        self._submit_retrieve(state, 0)
+        self._active_retrieves.append(state)
+        return retrieve_token_num - offset
+
+    def load_kv_layerwise(self, layer_id: int) -> None:
+        if not self._active_retrieves:
+            return
+
+        finished_indices: list[int] = []
+        for i, state in enumerate(self._active_retrieves):
+            if state.in_flight_layer != layer_id:
+                continue
+
+            if state.future is None:
+                self._cleanup_retrieve_state(state)
+                finished_indices.append(i)
+                raise RuntimeError(
+                    f"LMCache MP retrieve state is missing a future for "
+                    f"request_id={state.request_id}"
+                )
+            if not state.future.result(timeout=self._mq_timeout):
+                self._cleanup_retrieve_state(state)
+                finished_indices.append(i)
+                raise RuntimeError(
+                    f"LMCache MP retrieve failed for request_id={state.request_id}"
+                )
+
+            next_layer = layer_id + 1
+            if next_layer < self.num_layers:
+                self._submit_retrieve(state, next_layer)
+            else:
+                self._end_session(state.request_id)
+                finished_indices.append(i)
+
+        for i in reversed(finished_indices):
+            del self._active_retrieves[i]
+
+    def store_kv(self, store_metadata: StoreMetadata) -> None:
+        if not self.is_healthy:
+            return
+
+        aligned_end = (len(store_metadata.token_ids) // self._lmcache_chunk_size) * (
+            self._lmcache_chunk_size
+        )
+        if aligned_end == 0:
+            return
+
+        request_id = str(uuid.uuid4())
+        block_ids = self._slot_mapping_to_block_ids(
+            store_metadata.kv_indices[:aligned_end]
+        )
+        event = torch.cuda.Event(interprocess=True)
+        event.record(torch.cuda.current_stream())
+        success = send_lmcache_request(
+            self.mq_client,
+            RequestType.STORE,
+            [
+                self._create_key(
+                    store_metadata.token_ids,
+                    start=0,
+                    end=aligned_end,
+                    request_id=request_id,
+                ),
+                self.instance_id,
+                block_ids,
+                event.ipc_handle(),
+            ],
+        ).to_cuda_future(device=self.device).result(timeout=self._mq_timeout)
+        self._end_session(request_id)
+        if not success:
+            raise RuntimeError("LMCache MP store failed")
+
+    def reset(self) -> None:
+        while self._active_retrieves:
+            state = self._active_retrieves.pop()
+            self._cleanup_retrieve_state(state)
+
+    def close(self) -> None:
+        self.reset()
+        if self._heartbeat is not None:
+            self._heartbeat.stop()
+            self._heartbeat = None
+        if self._registered:
+            try:
+                send_lmcache_request(
+                    self.mq_client,
+                    RequestType.UNREGISTER_KV_CACHE,
+                    [self.instance_id],
+                ).result(timeout=self._mq_timeout)
+            except Exception:
+                logger.warning("Failed to unregister SGLang MP KV cache", exc_info=True)
+            self._registered = False
+        self.mq_client.close()

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -130,9 +130,9 @@ class LMCacheMPLayerwiseConnector:
             [registration],
         ).result(timeout=self._mq_timeout)
         self._registered = True
-        self._start_heartbeat()
+        self.start_heartbeat()
 
-    def _start_heartbeat(self) -> None:
+    def start_heartbeat(self) -> None:
         if self._heartbeat is not None:
             return
         self._heartbeat = HeartbeatThread(
@@ -159,7 +159,7 @@ class LMCacheMPLayerwiseConnector:
         dist.all_reduce(t, op=dist.ReduceOp.MIN, group=tp_group)
         return int(t.item())
 
-    def _create_key(
+    def create_key(
         self,
         token_ids: list[int],
         start: int,
@@ -177,7 +177,7 @@ class LMCacheMPLayerwiseConnector:
             request_id=request_id,
         )
 
-    def _wait_for_lookup(self, job_id: int) -> int:
+    def wait_for_lookup(self, job_id: int) -> int:
         deadline = time.monotonic() + self._mq_timeout
         while True:
             matched_chunks = send_lmcache_request(
@@ -191,7 +191,7 @@ class LMCacheMPLayerwiseConnector:
                 raise TimeoutError("Timed out waiting for LMCache prefetch to finish")
             time.sleep(0.001)
 
-    def _slot_mapping_to_block_ids(self, slot_mapping: torch.Tensor) -> list[int]:
+    def slot_mapping_to_block_ids(self, slot_mapping: torch.Tensor) -> list[int]:
         if slot_mapping.numel() == 0:
             return []
         if slot_mapping.numel() % self.page_size != 0:
@@ -215,7 +215,7 @@ class LMCacheMPLayerwiseConnector:
 
         return (starts // self.page_size).tolist()
 
-    def _submit_retrieve(
+    def submit_retrieve(
         self,
         state: _ActiveRetrieveState,
         layer_id: int,
@@ -226,7 +226,7 @@ class LMCacheMPLayerwiseConnector:
             self.mq_client,
             RequestType.RETRIEVE,
             [
-                self._create_key(
+                self.create_key(
                     state.token_ids,
                     start=state.offset,
                     end=state.matched_end,
@@ -244,7 +244,7 @@ class LMCacheMPLayerwiseConnector:
         state.future = future
         return future
 
-    def _free_lookup_locks(
+    def free_lookup_locks(
         self,
         token_ids: list[int],
         start: int,
@@ -257,7 +257,7 @@ class LMCacheMPLayerwiseConnector:
             self.mq_client,
             RequestType.FREE_LOOKUP_LOCKS,
             [
-                self._create_key(
+                self.create_key(
                     token_ids,
                     start=start,
                     end=end,
@@ -268,16 +268,16 @@ class LMCacheMPLayerwiseConnector:
             ],
         )
 
-    def _end_session(self, request_id: str) -> None:
+    def end_session(self, request_id: str) -> None:
         if not self.is_healthy:
             return
         send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
 
-    def _cleanup_retrieve_state(self, state: _ActiveRetrieveState) -> None:
-        self._free_lookup_locks(
+    def cleanup_retrieve_state(self, state: _ActiveRetrieveState) -> None:
+        self.free_lookup_locks(
             state.token_ids, state.offset, state.matched_end, state.request_id
         )
-        self._end_session(state.request_id)
+        self.end_session(state.request_id)
 
     def chunk_size(self) -> int:
         return self._lmcache_chunk_size
@@ -299,7 +299,7 @@ class LMCacheMPLayerwiseConnector:
             )
 
         request_id = str(uuid.uuid4())
-        lookup_key = self._create_key(
+        lookup_key = self.create_key(
             load_metadata.token_ids,
             start=0,
             end=aligned_end,
@@ -312,21 +312,21 @@ class LMCacheMPLayerwiseConnector:
             RequestType.LOOKUP,
             [lookup_key, self.tp_size],
         ).result(timeout=self._mq_timeout)
-        retrieve_token_num = self._wait_for_lookup(job_id)
+        retrieve_token_num = self.wait_for_lookup(job_id)
 
         retrieve_token_num = self.global_min_tokens(
             retrieve_token_num, self.tp_group, self.device
         )
 
         if retrieve_token_num <= offset:
-            self._free_lookup_locks(
+            self.free_lookup_locks(
                 load_metadata.token_ids, 0, retrieve_token_num, request_id
             )
-            self._end_session(request_id)
+            self.end_session(request_id)
             return 0
 
-        self._free_lookup_locks(load_metadata.token_ids, 0, offset, request_id)
-        block_ids = self._slot_mapping_to_block_ids(
+        self.free_lookup_locks(load_metadata.token_ids, 0, offset, request_id)
+        block_ids = self.slot_mapping_to_block_ids(
             load_metadata.slot_mapping[offset:retrieve_token_num]
         )
 
@@ -339,7 +339,7 @@ class LMCacheMPLayerwiseConnector:
             in_flight_layer=0,
             future=None,
         )
-        self._submit_retrieve(state, 0)
+        self.submit_retrieve(state, 0)
         self._active_retrieves.append(state)
         return retrieve_token_num - offset
 
@@ -353,14 +353,14 @@ class LMCacheMPLayerwiseConnector:
                 continue
 
             if state.future is None:
-                self._cleanup_retrieve_state(state)
+                self.cleanup_retrieve_state(state)
                 finished_indices.append(i)
                 raise RuntimeError(
                     f"LMCache MP retrieve state is missing a future for "
                     f"request_id={state.request_id}"
                 )
             if not state.future.result(timeout=self._mq_timeout):
-                self._cleanup_retrieve_state(state)
+                self.cleanup_retrieve_state(state)
                 finished_indices.append(i)
                 raise RuntimeError(
                     f"LMCache MP retrieve failed for request_id={state.request_id}"
@@ -368,9 +368,9 @@ class LMCacheMPLayerwiseConnector:
 
             next_layer = layer_id + 1
             if next_layer < self.num_layers:
-                self._submit_retrieve(state, next_layer)
+                self.submit_retrieve(state, next_layer)
             else:
-                self._end_session(state.request_id)
+                self.end_session(state.request_id)
                 finished_indices.append(i)
 
         for i in reversed(finished_indices):
@@ -387,7 +387,7 @@ class LMCacheMPLayerwiseConnector:
             return
 
         request_id = str(uuid.uuid4())
-        block_ids = self._slot_mapping_to_block_ids(
+        block_ids = self.slot_mapping_to_block_ids(
             store_metadata.kv_indices[:aligned_end]
         )
         event = torch.cuda.Event(interprocess=True)
@@ -397,7 +397,7 @@ class LMCacheMPLayerwiseConnector:
                 self.mq_client,
                 RequestType.STORE,
                 [
-                    self._create_key(
+                    self.create_key(
                         store_metadata.token_ids,
                         start=0,
                         end=aligned_end,
@@ -411,14 +411,14 @@ class LMCacheMPLayerwiseConnector:
             .to_cuda_future(device=self.device)
             .result(timeout=self._mq_timeout)
         )
-        self._end_session(request_id)
+        self.end_session(request_id)
         if not success:
             raise RuntimeError("LMCache MP store failed")
 
     def reset(self) -> None:
         while self._active_retrieves:
             state = self._active_retrieves.pop()
-            self._cleanup_retrieve_state(state)
+            self.cleanup_retrieve_state(state)
 
     def close(self) -> None:
         self.reset()

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable, Optional
 import uuid
 
 # Third Party
@@ -29,14 +29,14 @@ logger = init_logger(__name__)
 @dataclass
 class StoreMetadata:
     last_node: Any
-    token_ids: List[int]
+    token_ids: list[int]
     kv_indices: torch.Tensor
     offset: int
 
 
 @dataclass
 class LoadMetadata:
-    token_ids: List[int]
+    token_ids: list[int]
     slot_mapping: torch.Tensor
     offset: int
 
@@ -45,33 +45,46 @@ def resolve_sglang_kv_pools(
     *,
     token_to_kv_pool_allocator: Any | None = None,
     kvcache: Any | None = None,
-    k_pool: Optional[List[torch.Tensor]] = None,
-    v_pool: Optional[List[torch.Tensor]] = None,
-) -> tuple[List[torch.Tensor], List[torch.Tensor]]:
+    k_pool: list[torch.Tensor] | None = None,
+    v_pool: list[torch.Tensor] | None = None,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     if k_pool is not None or v_pool is not None:
         if k_pool is None or v_pool is None:
             raise ValueError("Both k_pool and v_pool must be provided together")
         return k_pool, v_pool
 
-    def get_kv_pool_buffer(attr_name: str) -> Any:
+    def get_kv_pool_buffer(attr_name: str) -> list[torch.Tensor]:
         if kvcache is not None and hasattr(kvcache, attr_name):
-            return getattr(kvcache, attr_name)
+            buffer = getattr(kvcache, attr_name)
+        else:
+            legacy_kvcache = getattr(token_to_kv_pool_allocator, "_kvcache", None)
+            if legacy_kvcache is not None and hasattr(legacy_kvcache, attr_name):
+                buffer = getattr(legacy_kvcache, attr_name)
+            else:
+                buffer = None
 
-        legacy_kvcache = getattr(token_to_kv_pool_allocator, "_kvcache", None)
-        if legacy_kvcache is not None and hasattr(legacy_kvcache, attr_name):
-            return getattr(legacy_kvcache, attr_name)
-
-        if token_to_kv_pool_allocator is not None:
+        if buffer is None and token_to_kv_pool_allocator is not None:
             get_kvcache = getattr(token_to_kv_pool_allocator, "get_kvcache", None)
             if callable(get_kvcache):
                 active_kvcache = get_kvcache()
                 if active_kvcache is not None and hasattr(active_kvcache, attr_name):
-                    return getattr(active_kvcache, attr_name)
+                    buffer = getattr(active_kvcache, attr_name)
 
-        raise ValueError(
-            "Unsupported SGLang KV cache layout for LMCache. "
-            f"Missing `{attr_name}` on the active KV cache."
-        )
+        if buffer is None:
+            raise ValueError(
+                "Unsupported SGLang KV cache layout for LMCache. "
+                f"Missing `{attr_name}` on the active KV cache."
+            )
+
+        if not isinstance(buffer, list | tuple) or not all(
+            isinstance(tensor, torch.Tensor) for tensor in buffer
+        ):
+            raise TypeError(
+                f"Expected `{attr_name}` to be a sequence of torch.Tensor values, "
+                f"got {type(buffer)}"
+            )
+
+        return list(buffer)
 
     return get_kv_pool_buffer("k_buffer"), get_kv_pool_buffer("v_buffer")
 
@@ -140,8 +153,8 @@ class LMCacheConnector:
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: Optional[List[torch.Tensor]] = None,
-        v_pool: Optional[List[torch.Tensor]] = None,
+        k_pool: list[torch.Tensor] | None = None,
+        v_pool: list[torch.Tensor] | None = None,
         token_to_kv_pool_allocator: Any | None = None,
         kvcache: Any | None = None,
     ):
@@ -247,8 +260,8 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: Optional[List[torch.Tensor]] = None,
-        v_pool: Optional[List[torch.Tensor]] = None,
+        k_pool: list[torch.Tensor] | None = None,
+        v_pool: list[torch.Tensor] | None = None,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         token_to_kv_pool_allocator: Any | None = None,
         kvcache: Any | None = None,
@@ -261,11 +274,11 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         )
         super().__init__(sgl_config, tp_size, rank, k_pool, v_pool)
         self._lmcache_chunk_size = self.lmcache_engine.config.chunk_size
-        self.layerwise_retrievers: List[Any] = []
-        self.layer_load_layer: List[int] = []
+        self.layerwise_retrievers: list[Any] = []
+        self.layer_load_layer: list[int] = []
         self.kvcaches = [k_pool, v_pool]
         self.tp_group = tp_group
-        self.lookup_id_list: List[str] = []
+        self.lookup_id_list: list[str] = []
 
     @torch.no_grad()
     def global_min_tokens(

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -53,7 +53,7 @@ def resolve_sglang_kv_pools(
             raise ValueError("Both k_pool and v_pool must be provided together")
         return k_pool, v_pool
 
-    def _get_kv_pool_buffer(attr_name: str) -> Any:
+    def get_kv_pool_buffer(attr_name: str) -> Any:
         if kvcache is not None and hasattr(kvcache, attr_name):
             return getattr(kvcache, attr_name)
 
@@ -73,7 +73,7 @@ def resolve_sglang_kv_pools(
             f"Missing `{attr_name}` on the active KV cache."
         )
 
-    return _get_kv_pool_buffer("k_buffer"), _get_kv_pool_buffer("v_buffer")
+    return get_kv_pool_buffer("k_buffer"), get_kv_pool_buffer("v_buffer")
 
 
 def init_lmcache_engine(

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -41,6 +41,41 @@ class LoadMetadata:
     offset: int
 
 
+def resolve_sglang_kv_pools(
+    *,
+    token_to_kv_pool_allocator: Any | None = None,
+    kvcache: Any | None = None,
+    k_pool: Optional[List[torch.Tensor]] = None,
+    v_pool: Optional[List[torch.Tensor]] = None,
+) -> tuple[List[torch.Tensor], List[torch.Tensor]]:
+    if k_pool is not None or v_pool is not None:
+        if k_pool is None or v_pool is None:
+            raise ValueError("Both k_pool and v_pool must be provided together")
+        return k_pool, v_pool
+
+    def _get_kv_pool_buffer(attr_name: str) -> Any:
+        if kvcache is not None and hasattr(kvcache, attr_name):
+            return getattr(kvcache, attr_name)
+
+        legacy_kvcache = getattr(token_to_kv_pool_allocator, "_kvcache", None)
+        if legacy_kvcache is not None and hasattr(legacy_kvcache, attr_name):
+            return getattr(legacy_kvcache, attr_name)
+
+        if token_to_kv_pool_allocator is not None:
+            get_kvcache = getattr(token_to_kv_pool_allocator, "get_kvcache", None)
+            if callable(get_kvcache):
+                active_kvcache = get_kvcache()
+                if active_kvcache is not None and hasattr(active_kvcache, attr_name):
+                    return getattr(active_kvcache, attr_name)
+
+        raise ValueError(
+            "Unsupported SGLang KV cache layout for LMCache. "
+            f"Missing `{attr_name}` on the active KV cache."
+        )
+
+    return _get_kv_pool_buffer("k_buffer"), _get_kv_pool_buffer("v_buffer")
+
+
 def init_lmcache_engine(
     model_config: ModelConfig,
     tp_size: int,
@@ -105,9 +140,17 @@ class LMCacheConnector:
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: List[torch.Tensor],
-        v_pool: List[torch.Tensor],
+        k_pool: Optional[List[torch.Tensor]] = None,
+        v_pool: Optional[List[torch.Tensor]] = None,
+        token_to_kv_pool_allocator: Any | None = None,
+        kvcache: Any | None = None,
     ):
+        k_pool, v_pool = resolve_sglang_kv_pools(
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+            kvcache=kvcache,
+            k_pool=k_pool,
+            v_pool=v_pool,
+        )
         if not k_pool:
             raise ValueError("k_pool cannot be empty during initialization.")
         kv_dtype = k_pool[0].dtype
@@ -204,10 +247,18 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: List[torch.Tensor],
-        v_pool: List[torch.Tensor],
+        k_pool: Optional[List[torch.Tensor]] = None,
+        v_pool: Optional[List[torch.Tensor]] = None,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
+        token_to_kv_pool_allocator: Any | None = None,
+        kvcache: Any | None = None,
     ):
+        k_pool, v_pool = resolve_sglang_kv_pools(
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+            kvcache=kvcache,
+            k_pool=k_pool,
+            v_pool=v_pool,
+        )
         super().__init__(sgl_config, tp_size, rank, k_pool, v_pool)
         self._lmcache_chunk_size = self.lmcache_engine.config.chunk_size
         self.layerwise_retrievers: List[Any] = []

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -16,6 +16,7 @@ from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
+    KVCacheRegistration,
     KVCache,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
@@ -523,6 +524,7 @@ class LMCacheMPWorkerAdapter:
             "LMCache chunk size should be a multiple of vLLM block size"
         )
         self.blocks_in_chunk = chunk_size // vllm_block_size
+        self.vllm_block_size = vllm_block_size
 
         # Health state (shared with heartbeat thread)
         self._health_event = threading.Event()
@@ -567,12 +569,14 @@ class LMCacheMPWorkerAdapter:
         future = send_lmcache_request(
             self.mq_client,
             RequestType.REGISTER_KV_CACHE,
-            [
+            [KVCacheRegistration(
                 self.instance_id,
-                wrap_kv_caches(kv_caches),
                 self.model_name,
                 self.world_size,
-            ],
+                "vllm",
+                self.vllm_block_size,
+                wrap_kv_caches(kv_caches),
+            )],
         )
         try:
             future.result(timeout=self._mq_timeout)
@@ -654,6 +658,8 @@ class LMCacheMPWorkerAdapter:
                 op.block_ids,
                 event.ipc_handle(),
                 op.skip_first_n_tokens,
+                -1,
+                -1,
             ],
         ).to_cuda_future()
         self.retrieve_futures[request_id] = (future, list(op.block_ids))

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -16,8 +16,8 @@ from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
-    KVCacheRegistration,
     KVCache,
+    KVCacheRegistration,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
@@ -569,14 +569,16 @@ class LMCacheMPWorkerAdapter:
         future = send_lmcache_request(
             self.mq_client,
             RequestType.REGISTER_KV_CACHE,
-            [KVCacheRegistration(
-                self.instance_id,
-                self.model_name,
-                self.world_size,
-                "vllm",
-                self.vllm_block_size,
-                wrap_kv_caches(kv_caches),
-            )],
+            [
+                KVCacheRegistration(
+                    self.instance_id,
+                    self.model_name,
+                    self.world_size,
+                    "vllm",
+                    self.vllm_block_size,
+                    wrap_kv_caches(kv_caches),
+                )
+            ],
         )
         try:
             future.result(timeout=self._mq_timeout)

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -425,6 +425,13 @@ def is_mla(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
     )
 
 
+def is_sglang_mha(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+    """
+    Check if the GPU KV Format is SGLang MHA.
+    """
+    return gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
+
+
 def get_dtype(kv_caches: Any, gpu_kv_format: "lmc_ops.GPUKVFormat") -> torch.dtype:
     """
     Get the dtype from the kv_caches

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -238,6 +238,8 @@ class KVCacheRegistration:
             raise ValueError(f"Unsupported engine type: {self.engine_type}")
         if self.block_size <= 0:
             raise ValueError(f"block_size must be positive, got {self.block_size}")
+        if not _has_kv_cache_payload(self.kv_caches):
+            raise ValueError("kv_caches must contain at least one KV cache tensor")
 
 
 @dataclass
@@ -254,6 +256,14 @@ _CUSTOMERIZED_SERIALIZERS = {
         code=1,
     ),
 }
+
+
+def _has_kv_cache_payload(kv_caches: Any) -> bool:
+    if kv_caches is None:
+        return False
+    if isinstance(kv_caches, list | tuple):
+        return any(_has_kv_cache_payload(kv_cache) for kv_cache in kv_caches)
+    return True
 
 
 def get_customized_encoder(type: Any) -> msgspec.msgpack.Encoder:

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -223,6 +223,24 @@ KVCache = list[CudaIPCWrapper]
 
 
 @dataclass
+class KVCacheRegistration:
+    """Structured MP registration payload for GPU KV cache workers."""
+
+    instance_id: int
+    model_name: str
+    world_size: int
+    engine_type: str
+    block_size: int
+    kv_caches: Any
+
+    def __post_init__(self) -> None:
+        if self.engine_type not in {"vllm", "sglang"}:
+            raise ValueError(f"Unsupported engine type: {self.engine_type}")
+        if self.block_size <= 0:
+            raise ValueError(f"block_size must be positive, got {self.block_size}")
+
+
+@dataclass
 class CustomizedSerdeConfig:
     serializer: Callable[[Any], bytes]
     deserializer: Callable[[bytes], Any]

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -44,7 +44,15 @@ def unwrap_kv_cache_tensors(kv_caches: Any) -> Any:
         return [unwrap_kv_cache_tensors(kv_cache) for kv_cache in kv_caches]
     if isinstance(kv_caches, tuple):
         return tuple(unwrap_kv_cache_tensors(kv_cache) for kv_cache in kv_caches)
-    return kv_caches.to_tensor()
+    if isinstance(kv_caches, torch.Tensor):
+        return kv_caches
+    to_tensor = getattr(kv_caches, "to_tensor", None)
+    if callable(to_tensor):
+        return to_tensor()
+    raise TypeError(
+        "Expected KV cache leaf to be a torch.Tensor or CUDA IPC wrapper, "
+        f"got {type(kv_caches)}"
+    )
 
 
 def flatten_kv_cache_tensors(kv_caches: Any) -> list[torch.Tensor]:
@@ -53,6 +61,11 @@ def flatten_kv_cache_tensors(kv_caches: Any) -> list[torch.Tensor]:
         for kv_cache in kv_caches:
             flattened.extend(flatten_kv_cache_tensors(kv_cache))
         return flattened
+    if not isinstance(kv_caches, torch.Tensor):
+        raise TypeError(
+            "Expected flattened KV cache leaf to be a torch.Tensor, "
+            f"got {type(kv_caches)}"
+        )
     return [kv_caches]
 
 
@@ -97,15 +110,18 @@ class GPUCacheContext:
                 "page_buffer_size must be divisible by block_size, got "
                 f"{self.page_buffer_size_} and {self.block_size_}"
             )
-        try:
-            expected_num_blocks = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
-        except ValueError:
-            expected_num_blocks = self.page_buffer_size_ // self.block_size_
         self.num_blocks_ = self.page_buffer_size_ // self.block_size_
-        if expected_num_blocks != self.num_blocks_:
+        try:
+            discovered_num_blocks = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
+        except ValueError:
+            discovered_num_blocks = None
+        if (
+            discovered_num_blocks is not None
+            and discovered_num_blocks != self.num_blocks_
+        ):
             raise ValueError(
                 "Registration block_size does not match discovered KV cache "
-                f"layout: expected {expected_num_blocks} blocks, "
+                f"layout: expected {discovered_num_blocks} blocks, "
                 f"got {self.num_blocks_}"
             )
         self.hidden_dim_size_ = get_hidden_dim_size(
@@ -251,10 +267,34 @@ class GPUCacheContext:
                 "Layerwise KV tensor views are only available for "
                 "the SGLang MHA GPUKVFormat"
             )
-        assert isinstance(self.kv_caches_, list) and len(self.kv_caches_) == 2
+        if not isinstance(self.kv_caches_, list) or len(self.kv_caches_) != 2:
+            raise TypeError(
+                "Expected SGLang MHA KV caches to be a list of [key_layers, "
+                f"value_layers], got {type(self.kv_caches_)}"
+            )
         key_layers, value_layers = self.kv_caches_
+        if not isinstance(key_layers, list | tuple) or not isinstance(
+            value_layers, list | tuple
+        ):
+            raise TypeError(
+                "Expected SGLang MHA KV caches to store per-layer tensors in "
+                "two sequences"
+            )
+        if not (0 <= layer_id < len(key_layers)) or not (
+            0 <= layer_id < len(value_layers)
+        ):
+            raise IndexError(
+                f"layer_id={layer_id} is out of bounds for {len(key_layers)} "
+                f"key layers and {len(value_layers)} value layers"
+            )
         key_tensor = key_layers[layer_id]
         value_tensor = value_layers[layer_id]
+        if not isinstance(key_tensor, torch.Tensor) or not isinstance(
+            value_tensor, torch.Tensor
+        ):
+            raise TypeError(
+                "Expected SGLang MHA layerwise KV entries to be torch.Tensor values"
+            )
         num_heads = get_num_heads(self.kv_caches_, self.gpu_kv_format_)
         head_size = get_head_size(self.kv_caches_, self.gpu_kv_format_)
         view_shape = (self.num_blocks_, self.block_size_, num_heads, head_size)

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -8,9 +8,9 @@ This module provides GPU-side KV cache management functionality, including:
 """
 
 # Standard
+from typing import Any
 import array
 import threading
-from typing import Any
 
 # Third Party
 import cupy
@@ -26,8 +26,8 @@ from lmcache.v1.gpu_connector.utils import (
     get_head_size,
     get_hidden_dim_size,
     get_num_blocks,
-    get_num_layers,
     get_num_heads,
+    get_num_layers,
     get_page_buffer_size,
     is_mla,
     is_sglang_mha,
@@ -86,7 +86,9 @@ class GPUCacheContext:
         self.gpu_kv_format_ = discover_gpu_kv_format(self.kv_caches_, self.engine_type_)
         self.is_mla_ = is_mla(self.gpu_kv_format_)
         self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
-        self.page_buffer_size_ = get_page_buffer_size(self.kv_caches_, self.gpu_kv_format_)
+        self.page_buffer_size_ = get_page_buffer_size(
+            self.kv_caches_, self.gpu_kv_format_
+        )
         if block_size is None:
             block_size = get_block_size(self.kv_caches_, self.gpu_kv_format_)
         self.block_size_ = block_size
@@ -173,10 +175,6 @@ class GPUCacheContext:
         return self.kv_caches_
 
     @property
-    def engine_type(self) -> EngineType:
-        return self.engine_type_
-
-    @property
     def kv_pointers(self) -> torch.Tensor:
         """
         Returns a GPU tensor of the KV cache pointers
@@ -245,7 +243,9 @@ class GPUCacheContext:
     def page_buffer_size(self) -> int:
         return self.page_buffer_size_
 
-    def get_layerwise_kv_tensors(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def get_layerwise_kv_tensors(
+        self, layer_id: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if not self.is_sglang_mha:
             raise ValueError(
                 "Layerwise KV tensor views are only available for "

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -23,11 +23,14 @@ from lmcache.v1.gpu_connector.utils import (
     discover_gpu_kv_format,
     get_block_size,
     get_dtype,
+    get_head_size,
     get_hidden_dim_size,
     get_num_blocks,
     get_num_layers,
+    get_num_heads,
     get_page_buffer_size,
     is_mla,
+    is_sglang_mha,
 )
 from lmcache.v1.multiprocess.custom_types import (
     KVCache,
@@ -158,6 +161,10 @@ class GPUCacheContext:
         return get_dtype(self.kv_caches_, self.gpu_kv_format_)
 
     @property
+    def gpu_kv_format(self):
+        return self.gpu_kv_format_
+
+    @property
     def device(self) -> torch.device:
         return self.device_
 
@@ -231,20 +238,25 @@ class GPUCacheContext:
         return self.is_mla_
 
     @property
+    def is_sglang_mha(self) -> bool:
+        return is_sglang_mha(self.gpu_kv_format_)
+
+    @property
     def page_buffer_size(self) -> int:
         return self.page_buffer_size_
 
-    def get_sglang_layer_tensors(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.engine_type_ != EngineType.SGLANG:
-            raise ValueError("SGLang layer tensors are only available for SGLang KV layouts")
-        if self.is_mla_:
-            raise NotImplementedError("SGLang MLA is not supported in MP mode yet")
+    def get_layerwise_kv_tensors(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        if not self.is_sglang_mha:
+            raise ValueError(
+                "Layerwise KV tensor views are only available for "
+                "the SGLang MHA GPUKVFormat"
+            )
         assert isinstance(self.kv_caches_, list) and len(self.kv_caches_) == 2
         key_layers, value_layers = self.kv_caches_
         key_tensor = key_layers[layer_id]
         value_tensor = value_layers[layer_id]
-        num_heads = key_tensor.shape[1]
-        head_size = key_tensor.shape[2]
+        num_heads = get_num_heads(self.kv_caches_, self.gpu_kv_format_)
+        head_size = get_head_size(self.kv_caches_, self.gpu_kv_format_)
         view_shape = (self.num_blocks_, self.block_size_, num_heads, head_size)
         return key_tensor.view(view_shape), value_tensor.view(view_shape)
 

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -10,6 +10,7 @@ This module provides GPU-side KV cache management functionality, including:
 # Standard
 import array
 import threading
+from typing import Any
 
 # Third Party
 import cupy
@@ -25,6 +26,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_hidden_dim_size,
     get_num_blocks,
     get_num_layers,
+    get_page_buffer_size,
     is_mla,
 )
 from lmcache.v1.multiprocess.custom_types import (
@@ -34,12 +36,21 @@ from lmcache.v1.multiprocess.custom_types import (
 logger = init_logger(__name__)
 
 
-def unwrap_kv_cache_tensors(kv_caches: KVCache) -> list[torch.Tensor]:
-    unwrapped_tensors = []
-    for ipc_wrapper in kv_caches:
-        tensor = ipc_wrapper.to_tensor()
-        unwrapped_tensors.append(tensor)
-    return unwrapped_tensors
+def unwrap_kv_cache_tensors(kv_caches: Any) -> Any:
+    if isinstance(kv_caches, list):
+        return [unwrap_kv_cache_tensors(kv_cache) for kv_cache in kv_caches]
+    if isinstance(kv_caches, tuple):
+        return tuple(unwrap_kv_cache_tensors(kv_cache) for kv_cache in kv_caches)
+    return kv_caches.to_tensor()
+
+
+def flatten_kv_cache_tensors(kv_caches: Any) -> list[torch.Tensor]:
+    if isinstance(kv_caches, list | tuple):
+        flattened: list[torch.Tensor] = []
+        for kv_cache in kv_caches:
+            flattened.extend(flatten_kv_cache_tensors(kv_cache))
+        return flattened
+    return [kv_caches]
 
 
 def list_to_gpu_tensor(lis: list[int], device: torch.device) -> torch.Tensor:
@@ -53,20 +64,45 @@ class GPUCacheContext:
     Manages the shape and pointers to vLLM GPU KV cache tensors.
     """
 
-    def __init__(self, kv_caches: KVCache, lmcache_chunk_size: int = 256):
+    def __init__(
+        self,
+        kv_caches: Any,
+        lmcache_chunk_size: int = 256,
+        engine_type: EngineType = EngineType.VLLM,
+        block_size: int | None = None,
+    ):
         self.kv_caches_ = unwrap_kv_cache_tensors(kv_caches)
-        self.device_ = self.kv_caches_[0].device
+        self.engine_type_ = engine_type
+        self.flat_kv_caches_ = flatten_kv_cache_tensors(self.kv_caches_)
+        self.device_ = self.flat_kv_caches_[0].device
 
         # Pointers
-        pointers_list = [t.data_ptr() for t in self.kv_caches_]
+        pointers_list = [t.data_ptr() for t in self.flat_kv_caches_]
         self.kv_cache_pointers_ = list_to_gpu_tensor(pointers_list, self.device_)
 
-        # TODO support creating GPUCacheContext for SGLang
-        self.gpu_kv_format_ = discover_gpu_kv_format(self.kv_caches_, EngineType.VLLM)
+        self.gpu_kv_format_ = discover_gpu_kv_format(self.kv_caches_, self.engine_type_)
         self.is_mla_ = is_mla(self.gpu_kv_format_)
         self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
-        self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
-        self.block_size_ = get_block_size(self.kv_caches_, self.gpu_kv_format_)
+        self.page_buffer_size_ = get_page_buffer_size(self.kv_caches_, self.gpu_kv_format_)
+        if block_size is None:
+            block_size = get_block_size(self.kv_caches_, self.gpu_kv_format_)
+        self.block_size_ = block_size
+        if self.page_buffer_size_ % self.block_size_ != 0:
+            raise ValueError(
+                "page_buffer_size must be divisible by block_size, got "
+                f"{self.page_buffer_size_} and {self.block_size_}"
+            )
+        try:
+            expected_num_blocks = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
+        except ValueError:
+            expected_num_blocks = self.page_buffer_size_ // self.block_size_
+        self.num_blocks_ = self.page_buffer_size_ // self.block_size_
+        if expected_num_blocks != self.num_blocks_:
+            raise ValueError(
+                "Registration block_size does not match discovered KV cache "
+                f"layout: expected {expected_num_blocks} blocks, "
+                f"got {self.num_blocks_}"
+            )
         self.hidden_dim_size_ = get_hidden_dim_size(
             self.kv_caches_, self.gpu_kv_format_
         )
@@ -126,8 +162,12 @@ class GPUCacheContext:
         return self.device_
 
     @property
-    def kv_tensors(self) -> list[torch.Tensor]:
+    def kv_tensors(self) -> Any:
         return self.kv_caches_
+
+    @property
+    def engine_type(self) -> EngineType:
+        return self.engine_type_
 
     @property
     def kv_pointers(self) -> torch.Tensor:
@@ -189,6 +229,24 @@ class GPUCacheContext:
         Returns whether the model uses MLA
         """
         return self.is_mla_
+
+    @property
+    def page_buffer_size(self) -> int:
+        return self.page_buffer_size_
+
+    def get_sglang_layer_tensors(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.engine_type_ != EngineType.SGLANG:
+            raise ValueError("SGLang layer tensors are only available for SGLang KV layouts")
+        if self.is_mla_:
+            raise NotImplementedError("SGLang MLA is not supported in MP mode yet")
+        assert isinstance(self.kv_caches_, list) and len(self.kv_caches_) == 2
+        key_layers, value_layers = self.kv_caches_
+        key_tensor = key_layers[layer_id]
+        value_tensor = value_layers[layer_id]
+        num_heads = key_tensor.shape[1]
+        head_size = key_tensor.shape[2]
+        view_shape = (self.num_blocks_, self.block_size_, num_heads, head_size)
+        return key_tensor.view(view_shape), value_tensor.view(view_shape)
 
     def get_tmp_gpu_buffer(self, num_tokens: int) -> torch.Tensor:
         """

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -17,6 +17,7 @@ import zmq
 from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
+    KVCacheRegistration,
     get_customized_decoder,
     get_customized_encoder,
 )
@@ -85,6 +86,10 @@ _SPECIAL_ENCODER_DECODERS = {
     list[CudaIPCWrapper]: (
         get_customized_encoder(list[CudaIPCWrapper]),
         get_customized_decoder(list[CudaIPCWrapper]),
+    ),
+    KVCacheRegistration: (
+        get_customized_encoder(KVCacheRegistration),
+        get_customized_decoder(KVCacheRegistration),
     ),
 }
 

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -13,7 +13,10 @@ This module defines the protocol for:
 """
 
 # First Party
-from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey, KVCache
+from lmcache.v1.multiprocess.custom_types import (
+    IPCCacheEngineKey,
+    KVCacheRegistration,
+)
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
 
 # Define request names for this protocol group
@@ -42,13 +45,10 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
     return {
         # Register KV Cache
         # Payload:
-        #   - instance_id: int - Unique identifier for the vLLM instance
-        #   - kv_cache: KVCache - The KV cache configuration
-        #   - model_name: str - Name of the model associated with the engine
-        #   - world_size: int - World size of the engine
+        #   - registration: KVCacheRegistration - Worker registration metadata
         # Returns: None
         "REGISTER_KV_CACHE": ProtocolDefinition(
-            payload_classes=[int, KVCache, str, int],
+            payload_classes=[KVCacheRegistration],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),
@@ -81,9 +81,11 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         #   - event_ipc_handle: bytes - CUDA event IPC handle for synchronization
         #   - skip_first_n_tokens: int - Number of tokens to skip writing at the
         #     start of the retrieve range (to avoid overwriting APC-shared blocks)
+        #   - layer_begin: int - Inclusive layer index to retrieve, or -1 for all
+        #   - layer_end: int - Exclusive layer index to retrieve, or -1 for all
         # Returns: tuple[bytes, bool] - (CUDA event handle, success flag)
         "RETRIEVE": ProtocolDefinition(
-            payload_classes=[KeyType, int, list[int], bytes, int],
+            payload_classes=[KeyType, int, list[int], bytes, int, int, int],
             response_class=tuple[bytes, bool],
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -328,9 +328,9 @@ class MPCacheEngine:
 
                 assert memory_obj.tensor is not None
                 with gpu_context.transfer_lock:
-                    if gpu_context.engine_type == EngineType.SGLANG and not gpu_context.is_mla:
+                    if gpu_context.is_sglang_mha:
                         for layer_id in range(gpu_context.num_layers):
-                            key_tensor, value_tensor = gpu_context.get_sglang_layer_tensors(
+                            key_tensor, value_tensor = gpu_context.get_layerwise_kv_tensors(
                                 layer_id
                             )
                             lmc_ops.single_layer_kv_transfer_sgl(
@@ -351,7 +351,7 @@ class MPCacheEngine:
                             gpu_context.device,
                             gpu_context.block_size * gpu_context.num_blocks,
                             lmc_ops.TransferDirection.D2H,
-                            gpu_context.gpu_kv_format_,
+                            gpu_context.gpu_kv_format,
                             gpu_context.block_size,
                         )
                         lmcache_memcpy_async_d2h(tmp_buffer, memory_obj)
@@ -480,16 +480,16 @@ class MPCacheEngine:
                             gpu_context.device,
                             gpu_context.page_buffer_size,
                             lmc_ops.TransferDirection.H2D,
-                            gpu_context.gpu_kv_format_,
+                            gpu_context.gpu_kv_format,
                             gpu_context.block_size,
                             skip_in_chunk,
                         )
                     continue
 
-                if gpu_context.engine_type != EngineType.SGLANG or gpu_context.is_mla:
+                if not gpu_context.is_sglang_mha:
                     raise NotImplementedError(
                         "Partial layer-window retrieve is currently supported "
-                        "only for SGLang MHA KV layouts"
+                        "only for the SGLang MHA GPUKVFormat"
                     )
 
                 if memory_obj.tensor is None:
@@ -498,7 +498,7 @@ class MPCacheEngine:
                 slot_mapping = slot_mapping[skip_in_chunk:]
                 with gpu_context.transfer_lock:
                     for layer_id in range(layer_begin, layer_end):
-                        key_tensor, value_tensor = gpu_context.get_sglang_layer_tensors(
+                        key_tensor, value_tensor = gpu_context.get_layerwise_kv_tensors(
                             layer_id
                         )
                         lmc_ops.single_layer_kv_transfer_sgl(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -162,6 +162,40 @@ def resolve_layer_window(
     return layer_begin, layer_end, False
 
 
+def get_sglang_chunk_tensor(
+    memory_obj: MemoryObj,
+    *,
+    layer_begin: int,
+    layer_end: int,
+    token_begin: int,
+    token_end: int,
+) -> torch.Tensor:
+    tensor = memory_obj.tensor
+    if tensor is None:
+        raise ValueError("Prefetched memory object does not contain a tensor")
+    if tensor.ndim != 4:
+        raise ValueError(
+            "Expected SGLang MP memory tensor to have shape "
+            f"[2, num_layers, num_tokens, hidden_dim], got {tuple(tensor.shape)}"
+        )
+    if tensor.shape[0] != 2:
+        raise ValueError(
+            "Expected the first SGLang MP memory tensor dimension to be 2 "
+            f"(K/V), got {tensor.shape[0]}"
+        )
+    if layer_begin < 0 or layer_end > tensor.shape[1]:
+        raise ValueError(
+            f"Layer window [{layer_begin}, {layer_end}) exceeds stored tensor "
+            f"shape {tuple(tensor.shape)}"
+        )
+    if token_begin < 0 or token_end < token_begin or token_end > tensor.shape[2]:
+        raise ValueError(
+            f"Token window [{token_begin}, {token_end}) exceeds stored tensor "
+            f"shape {tuple(tensor.shape)}"
+        )
+    return tensor
+
+
 @dataclass
 class _PrefetchJob:
     handle: PrefetchHandle
@@ -326,15 +360,21 @@ class MPCacheEngine:
                 end = start + self.chunk_size
                 slot_mapping = slot_mapping_tensor[start:end]
 
-                assert memory_obj.tensor is not None
                 with gpu_context.transfer_lock:
                     if gpu_context.is_sglang_mha:
+                        chunk_tensor = get_sglang_chunk_tensor(
+                            memory_obj,
+                            layer_begin=0,
+                            layer_end=gpu_context.num_layers,
+                            token_begin=0,
+                            token_end=self.chunk_size,
+                        )
                         for layer_id in range(gpu_context.num_layers):
                             key_tensor, value_tensor = (
                                 gpu_context.get_layerwise_kv_tensors(layer_id)
                             )
                             lmc_ops.single_layer_kv_transfer_sgl(
-                                memory_obj.tensor[:, layer_id, :, :],
+                                chunk_tensor[:, layer_id, : self.chunk_size, :],
                                 key_tensor,
                                 value_tensor,
                                 slot_mapping,
@@ -492,19 +532,26 @@ class MPCacheEngine:
                         "only for the SGLang MHA GPUKVFormat"
                     )
 
-                if memory_obj.tensor is None:
-                    raise ValueError(
-                        "Prefetched memory object does not contain a tensor"
-                    )
-
                 slot_mapping = slot_mapping[skip_in_chunk:]
+                if slot_mapping.numel() == 0:
+                    continue
+                chunk_tensor = get_sglang_chunk_tensor(
+                    memory_obj,
+                    layer_begin=layer_begin,
+                    layer_end=layer_end,
+                    token_begin=skip_in_chunk,
+                    token_end=self.chunk_size,
+                )
                 with gpu_context.transfer_lock:
                     for layer_id in range(layer_begin, layer_end):
                         key_tensor, value_tensor = gpu_context.get_layerwise_kv_tensors(
                             layer_id
                         )
+                        layer_chunk_tensor = chunk_tensor[
+                            :, layer_id, skip_in_chunk : self.chunk_size, :
+                        ]
                         lmc_ops.single_layer_kv_transfer_sgl(
-                            memory_obj.tensor[:, layer_id, skip_in_chunk:, :],
+                            layer_chunk_tensor,
                             key_tensor,
                             value_tensor,
                             slot_mapping,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -11,7 +11,7 @@ import zmq
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.utils import EngineType, _lmcache_nvtx_annotate
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
@@ -54,7 +54,7 @@ from lmcache.v1.multiprocess.config import (
 )
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
-    KVCache,
+    KVCacheRegistration,
 )
 from lmcache.v1.multiprocess.gpu_context import (
     GPUCacheContext,
@@ -131,6 +131,37 @@ def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayo
     return MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
 
 
+def parse_engine_type(engine_type: str) -> EngineType:
+    try:
+        return EngineType(engine_type)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported engine type: {engine_type}") from exc
+
+
+def resolve_layer_window(
+    gpu_context: GPUCacheContext,
+    layer_begin: int,
+    layer_end: int,
+) -> tuple[int, int, bool]:
+    if layer_begin == -1 and layer_end == -1:
+        return 0, gpu_context.num_layers, True
+
+    if layer_begin < 0 or layer_end < 0:
+        raise ValueError(
+            f"Layer window must be non-negative, got [{layer_begin}, {layer_end})"
+        )
+    if layer_begin >= layer_end:
+        raise ValueError(
+            f"Layer window must be non-empty, got [{layer_begin}, {layer_end})"
+        )
+    if layer_end > gpu_context.num_layers:
+        raise ValueError(
+            f"Layer window [{layer_begin}, {layer_end}) exceeds num_layers="
+            f"{gpu_context.num_layers}"
+        )
+    return layer_begin, layer_end, False
+
+
 @dataclass
 class _PrefetchJob:
     handle: PrefetchHandle
@@ -177,27 +208,28 @@ class MPCacheEngine:
         self._next_prefetch_job_id: int = 0
         self._prefetch_job_lock = threading.Lock()
 
-    def register_kv_cache(
-        self,
-        instance_id: int,
-        kv_caches: KVCache,
-        model_name: str,
-        world_size: int,
-    ) -> None:
+    def register_kv_cache(self, registration: KVCacheRegistration) -> None:
         """
         Registers the KV cache tensors for a given GPU instance ID.
 
         Args:
-            instance_id (int): The GPU instance ID (such as PID).
-            kv_caches (KVCache): The KV cache tensor wrappers from vLLM.
-            model_name (str): The name of the model associated with this KV cache.
-            world_size (int): The world size associated with this KV cache.
+            registration: Worker registration metadata and KV cache wrappers.
         """
-        gpu_context = GPUCacheContext(kv_caches, self.chunk_size)
+        instance_id = registration.instance_id
+        gpu_context = GPUCacheContext(
+            registration.kv_caches,
+            self.chunk_size,
+            engine_type=parse_engine_type(registration.engine_type),
+            block_size=registration.block_size,
+        )
         self.gpu_contexts[instance_id] = gpu_context
-        self.gpu_context_meta[instance_id] = (model_name, world_size)
+        self.gpu_context_meta[instance_id] = (
+            registration.model_name,
+            registration.world_size,
+        )
         logger.info(
-            "Registered KV cache for GPU ID %d with %d layers",
+            "Registered %s KV cache for GPU ID %d with %d layers",
+            registration.engine_type,
             instance_id,
             gpu_context.num_layers,
         )
@@ -294,22 +326,35 @@ class MPCacheEngine:
                 end = start + self.chunk_size
                 slot_mapping = slot_mapping_tensor[start:end]
 
-                # Copy from GPU to CPU
-                tmp_buffer = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
+                assert memory_obj.tensor is not None
                 with gpu_context.transfer_lock:
-                    lmc_ops.multi_layer_kv_transfer(
-                        tmp_buffer,
-                        gpu_context.kv_pointers,
-                        slot_mapping,
-                        gpu_context.device,
-                        gpu_context.block_size * gpu_context.num_blocks,
-                        lmc_ops.TransferDirection.D2H,
-                        gpu_context.gpu_kv_format_,
-                        gpu_context.block_size,
-                    )
-
-                    assert memory_obj.tensor is not None
-                    lmcache_memcpy_async_d2h(tmp_buffer, memory_obj)
+                    if gpu_context.engine_type == EngineType.SGLANG and not gpu_context.is_mla:
+                        for layer_id in range(gpu_context.num_layers):
+                            key_tensor, value_tensor = gpu_context.get_sglang_layer_tensors(
+                                layer_id
+                            )
+                            lmc_ops.single_layer_kv_transfer_sgl(
+                                memory_obj.tensor[:, layer_id, :, :],
+                                key_tensor,
+                                value_tensor,
+                                slot_mapping,
+                                lmc_ops.TransferDirection.D2H,
+                                False,
+                            )
+                    else:
+                        # Copy from GPU to CPU
+                        tmp_buffer = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
+                        lmc_ops.multi_layer_kv_transfer(
+                            tmp_buffer,
+                            gpu_context.kv_pointers,
+                            slot_mapping,
+                            gpu_context.device,
+                            gpu_context.block_size * gpu_context.num_blocks,
+                            lmc_ops.TransferDirection.D2H,
+                            gpu_context.gpu_kv_format_,
+                            gpu_context.block_size,
+                        )
+                        lmcache_memcpy_async_d2h(tmp_buffer, memory_obj)
 
             event.record()
 
@@ -346,6 +391,8 @@ class MPCacheEngine:
         gpu_block_ids: list[int],
         event_ipc_handle: bytes,
         skip_first_n_tokens: int = 0,
+        layer_begin: int = -1,
+        layer_end: int = -1,
     ) -> tuple[bytes, bool]:
         """
         Retrieves the CPU KV cache and put into GPU blocks.
@@ -360,6 +407,10 @@ class MPCacheEngine:
                 the start of the retrieve range. This avoids overwriting
                 APC-shared GPU blocks that may be read concurrently by other
                 requests.
+            layer_begin (int): Inclusive layer index for partial layerwise
+                retrieve, or -1 for all layers.
+            layer_end (int): Exclusive layer index for partial layerwise
+                retrieve, or -1 for all layers.
 
         Returns:
             tuple[bytes, bool]: The first element is the IPC handle of the event
@@ -381,6 +432,10 @@ class MPCacheEngine:
             f"KV cache not registered for GPU ID {instance_id}"
         )
         gpu_context = self.gpu_contexts[instance_id]
+        layer_begin, layer_end, full_layer_range = resolve_layer_window(
+            gpu_context, layer_begin, layer_end
+        )
+        is_final_layer_window = full_layer_range or layer_end == gpu_context.num_layers
 
         if get_telemetry_controller().is_enabled():
             gpu_context.cupy_stream.launch_host_func(
@@ -413,21 +468,47 @@ class MPCacheEngine:
                 )
                 slot_mapping = slot_mapping_tensor[chunk_start:chunk_end]
 
-                # Copy from CPU to GPU
-                tmp_gpu_buffer_ = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
-                with gpu_context.transfer_lock:
-                    lmcache_memcpy_async_h2d(memory_obj, tmp_gpu_buffer_)
-                    lmc_ops.multi_layer_kv_transfer(
-                        tmp_gpu_buffer_,
-                        gpu_context.kv_pointers,
-                        slot_mapping,
-                        gpu_context.device,
-                        gpu_context.block_size * gpu_context.num_blocks,
-                        lmc_ops.TransferDirection.H2D,
-                        gpu_context.gpu_kv_format_,
-                        gpu_context.block_size,
-                        skip_in_chunk,
+                if full_layer_range:
+                    # Copy from CPU to GPU
+                    tmp_gpu_buffer_ = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
+                    with gpu_context.transfer_lock:
+                        lmcache_memcpy_async_h2d(memory_obj, tmp_gpu_buffer_)
+                        lmc_ops.multi_layer_kv_transfer(
+                            tmp_gpu_buffer_,
+                            gpu_context.kv_pointers,
+                            slot_mapping,
+                            gpu_context.device,
+                            gpu_context.page_buffer_size,
+                            lmc_ops.TransferDirection.H2D,
+                            gpu_context.gpu_kv_format_,
+                            gpu_context.block_size,
+                            skip_in_chunk,
+                        )
+                    continue
+
+                if gpu_context.engine_type != EngineType.SGLANG or gpu_context.is_mla:
+                    raise NotImplementedError(
+                        "Partial layer-window retrieve is currently supported "
+                        "only for SGLang MHA KV layouts"
                     )
+
+                if memory_obj.tensor is None:
+                    raise ValueError("Prefetched memory object does not contain a tensor")
+
+                slot_mapping = slot_mapping[skip_in_chunk:]
+                with gpu_context.transfer_lock:
+                    for layer_id in range(layer_begin, layer_end):
+                        key_tensor, value_tensor = gpu_context.get_sglang_layer_tensors(
+                            layer_id
+                        )
+                        lmc_ops.single_layer_kv_transfer_sgl(
+                            memory_obj.tensor[:, layer_id, skip_in_chunk:, :],
+                            key_tensor,
+                            value_tensor,
+                            slot_mapping,
+                            lmc_ops.TransferDirection.H2D,
+                            False,
+                        )
 
         with (
             torch.cuda.device(gpu_context.device),
@@ -456,7 +537,12 @@ class MPCacheEngine:
                 return event.ipc_handle(), False
             finally:
                 event.record()
-                if retrieve_succeeded:
+                if prefetched_keys and (retrieve_succeeded and is_final_layer_window):
+                    gpu_context.cupy_stream.launch_host_func(
+                        self.storage_manager.finish_read_prefetched,
+                        prefetched_keys,
+                    )
+                elif prefetched_keys and not retrieve_succeeded:
                     gpu_context.cupy_stream.launch_host_func(
                         self.storage_manager.finish_read_prefetched,
                         prefetched_keys,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -330,8 +330,8 @@ class MPCacheEngine:
                 with gpu_context.transfer_lock:
                     if gpu_context.is_sglang_mha:
                         for layer_id in range(gpu_context.num_layers):
-                            key_tensor, value_tensor = gpu_context.get_layerwise_kv_tensors(
-                                layer_id
+                            key_tensor, value_tensor = (
+                                gpu_context.get_layerwise_kv_tensors(layer_id)
                             )
                             lmc_ops.single_layer_kv_transfer_sgl(
                                 memory_obj.tensor[:, layer_id, :, :],
@@ -493,7 +493,9 @@ class MPCacheEngine:
                     )
 
                 if memory_obj.tensor is None:
-                    raise ValueError("Prefetched memory object does not contain a tensor")
+                    raise ValueError(
+                        "Prefetched memory object does not contain a tensor"
+                    )
 
                 slot_mapping = slot_mapping[skip_in_chunk:]
                 with gpu_context.transfer_lock:

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -40,6 +40,7 @@ from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
+    KVCacheRegistration,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -176,6 +177,21 @@ class ClientContext:
     def get_kv_cache(self) -> KVCache:
         """Wrap GPU tensors in CudaIPCWrapper for IPC communication."""
         return [CudaIPCWrapper(tensor) for tensor in self.gpu_kv_caches]
+
+    def get_registration(
+        self,
+        instance_id: int,
+        model_name: str = "testmodel",
+        world_size: int = 1,
+    ) -> KVCacheRegistration:
+        return KVCacheRegistration(
+            instance_id=instance_id,
+            model_name=model_name,
+            world_size=world_size,
+            engine_type="vllm",
+            block_size=self.page_size,
+            kv_caches=self.get_kv_cache(),
+        )
 
     def get_tensor_slice(
         self, layer: int, start_page: int, num_pages: int
@@ -407,7 +423,7 @@ def registered_instance(
     # Register KV cache
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
+        [client_context.get_registration(instance_id)],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -1347,7 +1363,7 @@ def test_cb_store_final_then_normal_lookup_retrieve(
     event2.record()
     retrieve_future = client.submit_request(
         RequestType.RETRIEVE,
-        [retrieve_key, registered_instance, gpu_block_ids, event2.ipc_handle(), 0],
+        [retrieve_key, registered_instance, gpu_block_ids, event2.ipc_handle(), 0, -1, -1],
         get_response_class(RequestType.RETRIEVE),
     )
     retrieve_result = retrieve_future.to_cuda_future().result(timeout=DEFAULT_TIMEOUT)

--- a/tests/v1/multiprocess/test_blend_server.py
+++ b/tests/v1/multiprocess/test_blend_server.py
@@ -1363,7 +1363,15 @@ def test_cb_store_final_then_normal_lookup_retrieve(
     event2.record()
     retrieve_future = client.submit_request(
         RequestType.RETRIEVE,
-        [retrieve_key, registered_instance, gpu_block_ids, event2.ipc_handle(), 0, -1, -1],
+        [
+            retrieve_key,
+            registered_instance,
+            gpu_block_ids,
+            event2.ipc_handle(),
+            0,
+            -1,
+            -1,
+        ],
         get_response_class(RequestType.RETRIEVE),
     )
     retrieve_result = retrieve_future.to_cuda_future().result(timeout=DEFAULT_TIMEOUT)

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -1661,7 +1661,15 @@ def test_cb_store_final_v2_then_normal_lookup(
     retrieve_result = (
         client.submit_request(
             RequestType.RETRIEVE,
-            [retrieve_key, registered_instance, gpu_block_ids, event2.ipc_handle(), 0, -1, -1],
+            [
+                retrieve_key,
+                registered_instance,
+                gpu_block_ids,
+                event2.ipc_handle(),
+                0,
+                -1,
+                -1,
+            ],
             get_response_class(RequestType.RETRIEVE),
         )
         .to_cuda_future()

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -47,6 +47,7 @@ from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
+    KVCacheRegistration,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -356,6 +357,18 @@ class ClientContext:
     def get_kv_cache(self) -> KVCache:
         return [CudaIPCWrapper(tensor) for tensor in self.gpu_kv_caches]
 
+    def get_registration(
+        self, instance_id: int, model_name: str = "testmodel", world_size: int = 1
+    ) -> KVCacheRegistration:
+        return KVCacheRegistration(
+            instance_id=instance_id,
+            model_name=model_name,
+            world_size=world_size,
+            engine_type="vllm",
+            block_size=self.page_size,
+            kv_caches=self.get_kv_cache(),
+        )
+
     def get_tensor_slice(
         self, layer: int, start_page: int, num_pages: int
     ) -> torch.Tensor:
@@ -538,7 +551,7 @@ def registered_instance(
 
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
+        [client_context.get_registration(instance_id)],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     assert future.result(timeout=DEFAULT_TIMEOUT) is None
@@ -1648,7 +1661,7 @@ def test_cb_store_final_v2_then_normal_lookup(
     retrieve_result = (
         client.submit_request(
             RequestType.RETRIEVE,
-            [retrieve_key, registered_instance, gpu_block_ids, event2.ipc_handle(), 0],
+            [retrieve_key, registered_instance, gpu_block_ids, event2.ipc_handle(), 0, -1, -1],
             get_response_class(RequestType.RETRIEVE),
         )
         .to_cuda_future()

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -23,6 +23,7 @@ from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
+    KVCacheRegistration,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -118,6 +119,21 @@ class ClientContext:
         Wrap GPU tensors in CudaIPCWrapper for IPC communication.
         """
         return [CudaIPCWrapper(tensor) for tensor in self.gpu_kv_caches]
+
+    def get_registration(
+        self,
+        instance_id: int,
+        model_name: str = "testmodel",
+        world_size: int = 1,
+    ) -> KVCacheRegistration:
+        return KVCacheRegistration(
+            instance_id=instance_id,
+            model_name=model_name,
+            world_size=world_size,
+            engine_type="vllm",
+            block_size=self.page_size,
+            kv_caches=self.get_kv_cache(),
+        )
 
     def get_tensor_slice(
         self, layer: int, start_page: int, num_pages: int
@@ -218,7 +234,7 @@ def retrieve_keys(
         block_ids = gpu_block_ids[start:end]
         future = client.submit_request(
             RequestType.RETRIEVE,
-            [key, instance_id, block_ids, event.ipc_handle(), 0],
+            [key, instance_id, block_ids, event.ipc_handle(), 0, -1, -1],
             get_response_class(RequestType.RETRIEVE),
         )
         result = future.to_cuda_future().result(timeout=timeout)
@@ -331,7 +347,7 @@ def registered_instance(
     # Register KV cache
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
+        [client_context.get_registration(instance_id)],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -381,7 +397,7 @@ def test_register_unregister_kv_cache(
     # Register
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1],
+        [client_context.get_registration(instance_id)],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -12,7 +12,11 @@ import torch
 import zmq
 
 # First Party
-from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper, IPCCacheEngineKey
+from lmcache.v1.multiprocess.custom_types import (
+    CudaIPCWrapper,
+    IPCCacheEngineKey,
+    KVCacheRegistration,
+)
 from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,
@@ -350,7 +354,7 @@ def test_mq_noop_multiple_clients():
 def test_mq_register_kv_cache():
     """
     Test MessageQueue with REGISTER_KV_CACHE request type.
-    REGISTER_KV_CACHE takes (gpu_id: int, kv_cache: KVCache) and returns None.
+    REGISTER_KV_CACHE takes a KVCacheRegistration and returns None.
     """
     # Create test KV cache (list of CudaIPCWrapper objects)
     kv_cache = []
@@ -359,7 +363,14 @@ def test_mq_register_kv_cache():
         wrapper = CudaIPCWrapper(tensor)
         kv_cache.append(wrapper)
 
-    gpu_id = 0
+    registration = KVCacheRegistration(
+        instance_id=0,
+        model_name="testmodel",
+        world_size=1,
+        engine_type="vllm",
+        block_size=1,
+        kv_caches=kv_cache,
+    )
 
     # Create test helper and register handler
     helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5559")
@@ -370,7 +381,7 @@ def test_mq_register_kv_cache():
     # Run test with REGISTER_KV_CACHE request
     helper.run_test(
         request_type=RequestType.REGISTER_KV_CACHE,
-        payloads=[gpu_id, kv_cache, "testmodel", 1],
+        payloads=[registration],
         expected_response=None,
         num_requests=1,
     )
@@ -452,7 +463,8 @@ def test_mq_retrieve():
     """
     Test MessageQueue with RETRIEVE request type.
     RETRIEVE takes (key: KeyType, gpu_id: int, gpu_block_ids: list[int],
-    event_ipc_handle: bytes) and returns (bytes, bool).
+    event_ipc_handle: bytes, skip_first_n_tokens: int, layer_begin: int,
+    layer_end: int) and returns (bytes, bool).
     """
     # Create test key
     key = create_cache_key(0)
@@ -469,7 +481,7 @@ def test_mq_retrieve():
     # Run test with RETRIEVE request
     helper.run_test(
         request_type=RequestType.RETRIEVE,
-        payloads=[key, gpu_id, gpu_block_ids, test_handle, 0],
+        payloads=[key, gpu_id, gpu_block_ids, test_handle, 0, -1, -1],
         expected_response=(b"\x01" * 64, True),
         num_requests=1,
     )

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -7,7 +7,7 @@ and passed between processes during multiprocessing tests.
 """
 
 # First Party
-from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.custom_types import KVCacheRegistration
 from lmcache.v1.multiprocess.protocol import KeyType
 
 # ==============================================================================
@@ -28,34 +28,36 @@ def noop_handler() -> str:
 # ==============================================================================
 
 
-def register_kv_cache_handler(
-    gpu_id: int, kv_cache: KVCache, model_name: str, world_size: int
-) -> None:
+def register_kv_cache_handler(registration: KVCacheRegistration) -> None:
     """
     Dummy handler for REGISTER_KV_CACHE requests.
 
     Args:
-        gpu_id: GPU device ID
-        kv_cache: List of CudaIPCWrapper objects representing KV cache
-        model_name: Name of the model associated with this KV cache
-        world_size: World size associated with this KV cache
+        registration: Structured registration payload
 
     Returns:
         None
     """
     # In a real implementation, this would register the KV cache
     # For testing, we just validate the inputs are received correctly
-    assert isinstance(gpu_id, int), f"Expected gpu_id to be int, got {type(gpu_id)}"
-    assert isinstance(kv_cache, list), (
-        f"Expected kv_cache to be list, got {type(kv_cache)}"
+    assert isinstance(registration, KVCacheRegistration), (
+        f"Expected KVCacheRegistration, got {type(registration)}"
     )
-    assert isinstance(model_name, str), (
-        f"Expected model_name to be str, got {type(model_name)}"
+    assert isinstance(registration.instance_id, int), (
+        f"Expected instance_id to be int, got {type(registration.instance_id)}"
     )
-    assert isinstance(world_size, int), (
-        f"Expected world_size to be int, got {type(world_size)}"
+    assert isinstance(registration.model_name, str), (
+        f"Expected model_name to be str, got {type(registration.model_name)}"
     )
-    # No return value (returns None implicitly)
+    assert isinstance(registration.world_size, int), (
+        f"Expected world_size to be int, got {type(registration.world_size)}"
+    )
+    assert isinstance(registration.engine_type, str), (
+        f"Expected engine_type to be str, got {type(registration.engine_type)}"
+    )
+    assert isinstance(registration.block_size, int), (
+        f"Expected block_size to be int, got {type(registration.block_size)}"
+    )
 
 
 # ==============================================================================
@@ -121,6 +123,8 @@ def retrieve_handler(
     gpu_block_ids: list[int],
     event_handler: bytes,
     skip_first_n_tokens: int = 0,
+    layer_begin: int = -1,
+    layer_end: int = -1,
 ) -> tuple[bytes, bool]:
     """
     Dummy handler for RETRIEVE requests.
@@ -131,6 +135,8 @@ def retrieve_handler(
         gpu_block_ids: List of GPU block IDs
         event_handler: CUDA event IPC handle
         skip_first_n_tokens: Number of tokens to skip at retrieve start
+        layer_begin: Inclusive layer index, or -1 for all layers
+        layer_end: Exclusive layer index, or -1 for all layers
 
     Returns:
         tuple[bytes, bool]: (event handle, success flag)
@@ -145,6 +151,12 @@ def retrieve_handler(
     )
     assert isinstance(skip_first_n_tokens, int), (
         f"Expected skip_first_n_tokens to be int, got {type(skip_first_n_tokens)}"
+    )
+    assert isinstance(layer_begin, int), (
+        f"Expected layer_begin to be int, got {type(layer_begin)}"
+    )
+    assert isinstance(layer_end, int), (
+        f"Expected layer_end to be int, got {type(layer_end)}"
     )
     return b"\x01" * 64, True
 

--- a/tests/v1/test_sglang_integration.py
+++ b/tests/v1/test_sglang_integration.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from types import ModuleType, SimpleNamespace
+import importlib
+import sys
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import KVCacheRegistration
+from lmcache.v1.multiprocess.gpu_context import unwrap_kv_cache_tensors
+from lmcache.v1.multiprocess.server import get_sglang_chunk_tensor
+
+
+def _install_fake_sglang(monkeypatch: pytest.MonkeyPatch):
+    class FakeModelConfig:
+        def __init__(self, model_path: str = "fake-model"):
+            self.model_path = model_path
+
+    sglang_pkg = ModuleType("sglang")
+    sglang_pkg.__path__ = []
+    srt_pkg = ModuleType("sglang.srt")
+    srt_pkg.__path__ = []
+    configs_pkg = ModuleType("sglang.srt.configs")
+    configs_pkg.__path__ = []
+    model_config_mod = ModuleType("sglang.srt.configs.model_config")
+    model_config_mod.ModelConfig = FakeModelConfig  # type: ignore[attr-defined]
+
+    for name in [
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.configs",
+        "sglang.srt.configs.model_config",
+        "lmcache.integration.sglang.sglang_adapter",
+        "lmcache.integration.sglang.multi_process_adapter",
+    ]:
+        sys.modules.pop(name, None)
+
+    monkeypatch.setitem(sys.modules, "sglang", sglang_pkg)
+    monkeypatch.setitem(sys.modules, "sglang.srt", srt_pkg)
+    monkeypatch.setitem(sys.modules, "sglang.srt.configs", configs_pkg)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.configs.model_config",
+        model_config_mod,
+    )
+    return FakeModelConfig
+
+
+def _import_sglang_modules(monkeypatch: pytest.MonkeyPatch):
+    model_config_cls = _install_fake_sglang(monkeypatch)
+    sglang_adapter = importlib.import_module(
+        "lmcache.integration.sglang.sglang_adapter"
+    )
+    mp_adapter = importlib.import_module(
+        "lmcache.integration.sglang.multi_process_adapter"
+    )
+    return model_config_cls, sglang_adapter, mp_adapter
+
+
+def test_resolve_sglang_kv_pools_from_kvcache(monkeypatch: pytest.MonkeyPatch):
+    _, sglang_adapter, _ = _import_sglang_modules(monkeypatch)
+
+    k_pool = [torch.zeros(2, 3), torch.ones(2, 3)]
+    v_pool = [torch.full((2, 3), 2.0), torch.full((2, 3), 3.0)]
+    resolved_k_pool, resolved_v_pool = sglang_adapter.resolve_sglang_kv_pools(
+        kvcache=SimpleNamespace(k_buffer=k_pool, v_buffer=v_pool)
+    )
+
+    assert resolved_k_pool == k_pool
+    assert resolved_v_pool == v_pool
+
+
+def test_resolve_sglang_kv_pools_rejects_non_tensor_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, sglang_adapter, _ = _import_sglang_modules(monkeypatch)
+
+    with pytest.raises(TypeError, match="sequence of torch.Tensor"):
+        sglang_adapter.resolve_sglang_kv_pools(
+            kvcache=SimpleNamespace(k_buffer=["bad"], v_buffer=["bad"])
+        )
+
+
+def test_mp_connector_requires_tp_group(monkeypatch: pytest.MonkeyPatch):
+    model_config_cls, _, mp_adapter = _import_sglang_modules(monkeypatch)
+
+    fake_tensor = SimpleNamespace(is_cuda=True, device=torch.device("cuda:0"))
+    with pytest.raises(ValueError, match="tp_group is required"):
+        mp_adapter.LMCacheMPLayerwiseConnector(
+            sgl_config=model_config_cls("fake-model"),
+            tp_size=2,
+            rank=0,
+            page_size=16,
+            host="127.0.0.1",
+            port=5555,
+            k_pool=[fake_tensor],
+            v_pool=[fake_tensor],
+            tp_group=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("future", "message"),
+    [
+        (None, "missing a future"),
+        (SimpleNamespace(result=lambda timeout: False), "retrieve failed"),
+    ],
+)
+def test_load_kv_layerwise_cleans_failed_state_before_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    future,
+    message: str,
+):
+    _, _, mp_adapter = _import_sglang_modules(monkeypatch)
+
+    connector = mp_adapter.LMCacheMPLayerwiseConnector.__new__(
+        mp_adapter.LMCacheMPLayerwiseConnector
+    )
+    connector._mq_timeout = 1.0
+    connector.num_layers = 1
+    cleanup_calls: list[str] = []
+    end_calls: list[str] = []
+    submit_calls: list[int] = []
+
+    monkeypatch.setattr(
+        connector,
+        "cleanup_retrieve_state",
+        lambda state: cleanup_calls.append(state.request_id),
+    )
+    monkeypatch.setattr(
+        connector,
+        "end_session",
+        lambda request_id: end_calls.append(request_id),
+    )
+    monkeypatch.setattr(
+        connector,
+        "submit_retrieve",
+        lambda state, layer_id: submit_calls.append(layer_id),
+    )
+
+    connector._active_retrieves = [
+        mp_adapter._ActiveRetrieveState(
+            request_id="req-1",
+            token_ids=[1, 2, 3],
+            offset=0,
+            matched_end=256,
+            block_ids=[0],
+            in_flight_layer=0,
+            future=future,
+        )
+    ]
+
+    with pytest.raises(RuntimeError, match=message):
+        connector.load_kv_layerwise(0)
+
+    assert cleanup_calls == ["req-1"]
+    assert end_calls == []
+    assert submit_calls == []
+    assert connector._active_retrieves == []
+
+
+def test_kv_cache_registration_rejects_empty_payload():
+    with pytest.raises(ValueError, match="must contain at least one KV cache tensor"):
+        KVCacheRegistration(
+            instance_id=1,
+            model_name="model",
+            world_size=1,
+            engine_type="sglang",
+            block_size=16,
+            kv_caches=[[], []],
+        )
+
+
+def test_unwrap_kv_cache_tensors_rejects_invalid_leaf():
+    with pytest.raises(TypeError, match="torch.Tensor or CUDA IPC wrapper"):
+        unwrap_kv_cache_tensors(object())
+
+
+def test_get_sglang_chunk_tensor_validates_shape_and_ranges():
+    chunk_tensor = torch.zeros(2, 4, 256, 128)
+    memory_obj = SimpleNamespace(tensor=chunk_tensor)
+
+    returned_tensor = get_sglang_chunk_tensor(
+        memory_obj,
+        layer_begin=1,
+        layer_end=3,
+        token_begin=8,
+        token_end=128,
+    )
+    assert returned_tensor is chunk_tensor
+
+    with pytest.raises(ValueError, match="shape"):
+        get_sglang_chunk_tensor(
+            SimpleNamespace(tensor=torch.zeros(2, 4, 256)),
+            layer_begin=0,
+            layer_end=1,
+            token_begin=0,
+            token_end=16,
+        )
+
+    with pytest.raises(ValueError, match="Token window"):
+        get_sglang_chunk_tensor(
+            memory_obj,
+            layer_begin=0,
+            layer_end=2,
+            token_begin=0,
+            token_end=300,
+        )


### PR DESCRIPTION
  **What this PR does / why we need it**:

Sglang side PR : https://github.com/sgl-project/sglang/pull/21229
  This PR adds LMCache-side support for SGLang multi-process (MP) mode while keeping the MP design generic and keeping SGLang-side changes minimal.

  Before this change, LMCache MP was still effectively vLLM-shaped:
  - `REGISTER_KV_CACHE` used a positional payload
  - `GPUCacheContext` still assumed vLLM layout
  - MP `RETRIEVE` could not express real layerwise progress for SGLang
  - SGLang integration was still using the older in-process layerwise path

  This PR fixes that by extending the existing LMCache MP path instead of adding a SGLang-only backend path.

  Main changes:
  - replace the positional `REGISTER_KV_CACHE` payload with a structured `KVCacheRegistration`
  - make `GPUCacheContext` discover and handle SGLang KV layout through GPUKVFormat
  - extend MP `RETRIEVE` with a generic layer window so SGLang can drive true `load_kv_layerwise()` behavior
  - add an LMCache-side SGLang MP connector that reuses existing MP client pieces:
    - MQ client setup
    - chunk-size fetch
    - lookup / prefetch polling
    - lookup lock release
    - session end
    - store / retrieve request flow
  - keep the in-process SGLang path unchanged
  - keep the protocol generic rather than adding SGLang-only request types

  Scope:
  - validated on the SGLang MHA path
  - in-process behavior remains unchanged
  - vLLM MP adapter is updated to use the new registration / retrieve protocol

  Example flow that this PR enables:

  1. Start LMCache MP daemon.
  2. Start SGLang with:
     - `--enable-lmcache`
     - `--lmcache-mp-host <host>`
     - `--lmcache-mp-port <port>`
  3. First request stores KV into LMCache MP.
  4. Second identical request retrieves KV from LMCache MP through SGLang’s existing layerwise connector contract.

  Example test setup used during validation:
  ```bash
  # LMCache MP daemon
  python -m lmcache.v1.multiprocess.server \
    --host 127.0.0.1 \
    --port 65000 \
    --l1-size-gb 10 \
    --eviction-policy LRU

  # SGLang server
  python -m sglang.launch_server \
    --model-path Qwen/Qwen3-0.6B \
    --enable-lmcache \
    --lmcache-mp-host 127.0.0.1 \
    --lmcache-mp-port 65000

  Observed behavior in the tested setup:

  - first request: cached_tokens=0
  - second identical request: non-zero cached_tokens
  - deterministic outputs matched in-process vs MP at temperature=0

  Special notes for your reviewers:

  - This PR is intended to pair with the companion [SGLang PR](https://github.com/sgl-project/sglang/pull/21229).
  - The goal is to keep SGLang-specific translation at the connector boundary and keep LMCache MP generic.
  - I explicitly did not use the “transfer all layers at once and leave load_kv_layerwise() as a no-op” approach.
  - The protocol-level layer-window retrieve extension is generic, but the validated end-to-end SGLang path in this
    branch is the SGLang MHA layout.
  - No LMCache user docs were added in this PR; this PR focuses on the runtime / protocol / test path.

  Tested in this branch:

  - LMCache MP unit tests:
      - tests/v1/multiprocess/test_mq.py
      - tests/v1/multiprocess/test_cache_server.py
      - selected blend-server MP tests
  - deterministic in-process vs MP parity with temperature=0
  - end-to-end SGLang MP cache-hit validation on:
      - Qwen3-0.6B
      - facebook/opt-125m
      - Qwen3-8B
      - Qwen2.5-14B-Instruct
  - two-server validation:
      - two independent SGLang servers connected to the same LMCache MP daemon
      - verified cross-server KV reuse
      - verified a server can flush local cache and still retrieve from LMCache MP

  Representative results:

  - Qwen3-0.6B
      - second request: cached_tokens=768 in-process and MP
      - outputs matched byte-for-byte
  - facebook/opt-125m
      - second request: cached_tokens=1024 in-process and MP
      - outputs matched byte-for-byte
  - Qwen3-8B
      - second request: cached_tokens=768 in-process and MP
      - outputs matched byte-for-byte
  - Qwen2.5-14B-Instruct
      - prompt tokens: 811
      - second request: cached_tokens=800 in-process and MP
      - outputs matched byte-for-byte
```
  If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
