### PR TITLE
[refactor]: Replace use_cufile with use_gds/gds_backend config flags

### DIFF
--- a/.buildkite/configs/multi_device.yaml
+++ b/.buildkite/configs/multi_device.yaml
@@ -8,7 +8,7 @@ docker:
     - "LMCACHE_LOCAL_CPU=True"
     - "LMCACHE_MAX_LOCAL_CPU_SIZE=5"
     - "LMCACHE_GDS_PATH=/tmp/"
-    - "LMCACHE_CUFILE_BUFFER_SIZE=4096"
+    - "LMCACHE_GDS_BUFFER_SIZE=4096"
     - "LMCACHE_EXTRA_CONFIG={\"use_direct_io\": true}"
     - "LMCACHE_INTERNAL_API_SERVER_ENABLED=True"
     - "LMCACHE_INTERNAL_API_SERVER_SOCKET_PATH_PREFIX=/tmp/lmcache_internal_api_server/socket"

--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -351,9 +351,15 @@ Settings for different storage backends and paths.
    * - gds_path_sharding
      - LMCACHE_GDS_PATH_SHARDING
      - Strategy for selecting a path when multiple paths are provided. Currently only ``"by_gpu"`` is supported, which selects paths based on GPU device ID (default: "by_gpu").
-   * - cufile_buffer_size
-     - LMCACHE_CUFILE_BUFFER_SIZE
-     - Buffer size for cuFile/hipFile operations
+   * - gds_buffer_size
+     - LMCACHE_GDS_BUFFER_SIZE
+     - Buffer size for GDS operations
+   * - use_gds
+     - LMCACHE_USE_GDS
+     - Enable or disable GPU Direct Storage API usage (default: true)
+   * - gds_backend
+     - LMCACHE_GDS_BACKEND
+     - GDS library backend to use (default: "cufile")
 
 Custom Prometheus Histogram Buckets
 ------------------------------------

--- a/docs/source/kv_cache/storage_backends/gds.rst
+++ b/docs/source/kv_cache/storage_backends/gds.rst
@@ -24,8 +24,8 @@ Ways to configure LMCache GDS Backend
     export LMCACHE_CHUNK_SIZE=256
     # Path to store files
     export LMCACHE_GDS_PATH="/mnt/gds/cache"
-    # CuFile Buffer Size in MiB
-    export LMCACHE_CUFILE_BUFFER_SIZE="8192"
+    # GDS Buffer Size in MiB
+    export LMCACHE_GDS_BUFFER_SIZE="8192"
     # Disabling CPU RAM offload is sometimes recommended as the
     # CPU can get in the way of GPUDirect operations
     export LMCACHE_LOCAL_CPU=False
@@ -44,8 +44,8 @@ Example ``config.yaml``:
     local_cpu: false
     # Path to file system, local, remote or GDS-enabled mount
     gds_path: "/mnt/gds/cache"
-    # CuFile Buffer Size in MiB
-    cufile_buffer_size: 8192
+    # GDS Buffer Size in MiB
+    gds_buffer_size: 8192
 
 
 Multi-Path (Multi-Device) Support
@@ -106,10 +106,10 @@ prior run.  Writes, however, always go to the single affinity-selected path.
                           the entry lives on
 
 
-CuFile Buffer Size Explanation
-------------------------------
+GDS Buffer Size Explanation
+---------------------------
 
-The backend currently pre-registers buffer space to speed up cuFile operations. This buffer space
+The backend currently pre-registers buffer space to speed up GDS operations. This buffer space
 is registered in VRAM so options like ``--gpu-memory-utilization`` from ``vllm`` should be considered
 when setting it. For example, a good rule of thumb for H100 which generally has 80GiBs of VRAM would
 be to start with 8GiB and set ``--gpu-memory-utilization 0.85`` and depending on your workflow fine-tune
@@ -154,22 +154,21 @@ Successful output will show ``True`` for ``Kernel P2PDMA support``, ``HIP runtim
 
 **LMCache configuration:**
 
-To use AMD hipFile instead of NVIDIA cuFile, add the following to your configuration:
+To use AMD hipFile instead of NVIDIA cuFile, set the GDS backend:
 
 **Environment Variables:**
 
 .. code-block:: bash
 
-    export LMCACHE_EXTRA_CONFIG='{"use_hipfile": true}'
+    export LMCACHE_GDS_BACKEND=hipfile
 
 **Configuration File:**
 
 .. code-block:: yaml
 
-    extra_config:
-        use_hipfile: true
+    gds_backend: "hipfile"
 
-Note: The ``cufile_buffer_size`` configuration is used for both cuFile and hipFile buffers.
+Note: The ``gds_buffer_size`` configuration is used for both cuFile and hipFile buffers.
 
 
 Setup Example
@@ -222,7 +221,7 @@ Create a an lmcache configuration file called: ``gds-backend.yaml``
     local_cpu: false
     chunk_size: 256
     gds_path: "/mnt/gds/cache"
-    cufile_buffer_size: 8192
+    gds_buffer_size: 8192
 
 If you don't want to use a config file, uncomment the first three environment variables
 and then comment out the ``LMCACHE_CONFIG_FILE`` below:
@@ -232,7 +231,7 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     # LMCACHE_LOCAL_CPU=False \
     # LMCACHE_CHUNK_SIZE=256 \
     # LMCACHE_GDS_PATH="/mnt/gds/cache" \
-    # LMCACHE_CUFILE_BUFFER_SIZE=8192 \
+    # LMCACHE_GDS_BUFFER_SIZE=8192 \
     LMCACHE_CONFIG_FILE="gds-backend.yaml" \
     vllm serve \
         meta-llama/Llama-3.1-8B-Instruct \
@@ -246,13 +245,26 @@ POSIX fallback
 
 In some cases, libcufile implements its own internal POSIX fallback without `GdsBackend` being aware.
 In others, an error such as `RuntimeError: cuFileHandleRegister failed (cuFile err=5030, cuda_err=0)` may be throwned.
-Thus, backend can be configured to fallback to its own POSIX implementation when the usage of the libcufile APIs is not successful.
+Thus, backend can be configured to fallback to its own POSIX implementation when the usage of the GDS APIs is not successful.
 
-To force `GdsBackend` not use libcufile APIs for any reason, you can override its behavior via `extra_config`,
-e.g:
+To force `GdsBackend` not use GDS APIs for any reason, you can override its behavior via configuration:
 
 .. code-block:: yaml
 
-    LMCACHE_EXTRA_CONFIG='{"use_cufile": false}'
+    use_gds: false
+
+Or via environment variable:
+
+.. code-block:: bash
+
+    LMCACHE_USE_GDS=False
+
+The ``gds_backend`` field (default: ``cufile``) selects which GDS library to use. Supported
+backends are ``cufile`` (NVIDIA cuFile) and ``hipfile`` (AMD hipFile):
+
+.. code-block:: yaml
+
+    use_gds: true
+    gds_backend: "cufile"   # or "hipfile"
 
 Note that under this mode it would still use CUDA APIs to map and do operations the pre-registered GPU memory.

--- a/docs/source/kv_cache/storage_backends/weka.rst
+++ b/docs/source/kv_cache/storage_backends/weka.rst
@@ -22,8 +22,8 @@ Ways to configure LMCache WEKA Offloading
     export LMCACHE_CHUNK_SIZE=256
     # Path to Weka Mount
     export LMCACHE_GDS_PATH="/mnt/weka/cache"
-    # CuFile/HipFile Buffer Size in MiB
-    export LMCACHE_CUFILE_BUFFER_SIZE="8192"
+    # GDS Buffer Size in MiB
+    export LMCACHE_GDS_BUFFER_SIZE="8192"
     # Disabling CPU RAM offload is sometimes recommended as the
     # CPU can get in the way of GPUDirect operations
     export LMCACHE_LOCAL_CPU=False
@@ -44,16 +44,16 @@ Example ``config.yaml``:
     local_cpu: false
     # Path to Weka Mount
     gds_path: "/mnt/weka/cache"
-    # CuFile/HipFile Buffer Size in MiB
-    cufile_buffer_size: 8192
+    # GDS Buffer Size in MiB
+    gds_buffer_size: 8192
     # GDS I/O Threads
     extra_config:
       gds_io_threads: 32
 
-CuFile/HipFile Buffer Size Explanation
---------------------------------------
+GDS Buffer Size Explanation
+---------------------------
 
-The backend currently pre-registers buffer space to speed up cuFile/hipFile operations. This buffer space
+The backend currently pre-registers buffer space to speed up GDS operations. This buffer space
 is registered in VRAM so options like ``--gpu-memory-utilization`` from ``vllm`` should be considered
 when setting it. For example, a good rule of thumb for H100 which generally has 80GiBs of VRAM would
 be to start with 8GiB and set ``--gpu-memory-utilization 0.85`` and depending on your workflow fine-tune
@@ -108,7 +108,7 @@ Create a an lmcache configuration file called: ``weka-offload.yaml``
     local_cpu: false
     chunk_size: 256
     gds_path: "/mnt/weka/cache"
-    cufile_buffer_size: 8192
+    gds_buffer_size: 8192
     extra_config:
       gds_io_threads: 32
 
@@ -120,7 +120,7 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     # LMCACHE_LOCAL_CPU=False \
     # LMCACHE_CHUNK_SIZE=256 \
     # LMCACHE_GDS_PATH="/mnt/weka/cache" \
-    # LMCACHE_CUFILE_BUFFER_SIZE=8192 \
+    # LMCACHE_GDS_BUFFER_SIZE=8192 \
     # LMCACHE_EXTRA_CONFIG='{"gds_io_threads": 32}' \
     LMCACHE_CONFIG_FILE="weka-offload.yaml" \
     vllm serve \

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1917,8 +1917,8 @@ class LMCacheEngineBuilder:
             )
 
         if config.gds_path is not None:
-            assert config.cufile_buffer_size is not None
-            return CuFileMemoryAllocator(config.cufile_buffer_size * 1024**2)
+            assert config.gds_buffer_size is not None
+            return CuFileMemoryAllocator(config.gds_buffer_size * 1024**2)
 
         max_local_cpu_size = config.max_local_cpu_size
         # save_only_first_rank only works when use mla

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -246,7 +246,7 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": "by_gpu",
         "env_converter": str,
     },
-    "cufile_buffer_size": {
+    "gds_buffer_size": {
         "type": Optional[int],
         "default": None,
         "env_converter": int,
@@ -257,6 +257,17 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "type": float,
         "default": 4.0,
         "env_converter": float,
+    },
+    # GDS (GPU Direct Storage) settings
+    "use_gds": {
+        "type": bool,
+        "default": True,
+        "env_converter": _to_bool,
+    },
+    "gds_backend": {
+        "type": str,
+        "default": "cufile",
+        "env_converter": str,
     },
     # Other configurations
     # (Deprecated) The url of the actual remote lmcache instance for auditing.

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -148,6 +148,18 @@ async def save_metadata(path: str, tmp: str, metadata: bytes):
 
 
 def get_extra_config_bool(key, config: LMCacheEngineConfig) -> bool | None:
+    """Extract a boolean value from the config's extra_config dict.
+
+    Args:
+        key: The key to look up in extra_config.
+        config: The LMCacheEngineConfig instance.
+
+    Returns:
+        The boolean value if present, or None if not set.
+
+    Raises:
+        RuntimeError: If the value is not a valid boolean representation.
+    """
     value = config.extra_config.get(key, None)
     if value is None:
         return None
@@ -166,17 +178,21 @@ def get_extra_config_bool(key, config: LMCacheEngineConfig) -> bool | None:
 class GdsBackend(AllocatorBackendInterface):
     """
     Originally based on the open sourced WekaGdsBackend, this is a backend that
-    leverages NVIDIA's cuFile API to issue GDS requests directly to the
+    leverages GPU Direct Storage APIs to issue GDS requests directly to the
     GDS-supported remote filesystem.  In order to use it, users need to specify
-    `gds_path` and `cufile_buffer_size` in their LMCache config.
+    `gds_path` and `gds_buffer_size` in their LMCache config.
+
+    The GDS library to use is controlled by the `gds_backend` config field
+    (default: ``"cufile"``). Setting ``use_gds=False`` disables the GDS API
+    and falls back to POSIX I/O via cudart.
 
     Cache Directory Structure created by this Backend:
     /{gds_path}/{first_level}/{second_level}/{data & metadata} This structure
     is semi-arbitrary. We create two levels in the directory hierarchy to
     parallelize loading the data during initialization in the Python code.
 
-    NOTE: If GPUDirect is not supported on that other filesystem, then CuFile will
-    fall back to POSIX I/O.
+    NOTE: If GPUDirect is not supported on that other filesystem, then the GDS
+    library will fall back to POSIX I/O.
     """
 
     def __init__(
@@ -211,50 +227,41 @@ class GdsBackend(AllocatorBackendInterface):
             f" ({len(self.gds_paths)} path(s) configured)"
         )
 
-        # Initialize use_cufile and use_hipfile before creating the memory allocator
-        self.use_cufile = True
-        self.use_hipfile = False
-        use_cufile_from_config = False
-        use_hipfile_from_config = False
+        self.use_gds = config.use_gds
+        self.gds_backend = config.gds_backend
+        # _user_set_keys is populated by LMCacheEngineConfig when a field is
+        # explicitly provided via a config file, environment variable, or
+        # keyword argument — as opposed to falling back to its default value.
+        # We check it here so that the tmpfs/overlayfs auto-disable logic
+        # below can distinguish "the user never mentioned use_gds (default
+        # True)" from "the user explicitly wrote use_gds: true".  In the
+        # first case we auto-disable GDS on unsupported filesystems; in the
+        # second we respect the user's explicit intent and leave it enabled.
+        user_set_keys: set[str] = getattr(config, "_user_set_keys", set())
+        use_gds_explicitly_set = "use_gds" in user_set_keys
 
-        if config.extra_config is not None:
-            use_cufile = get_extra_config_bool("use_cufile", config)
-            if use_cufile is not None:
-                self.use_cufile = use_cufile
-                use_cufile_from_config = True
-
-            use_hipfile = get_extra_config_bool("use_hipfile", config)
-            if use_hipfile is not None:
-                self.use_hipfile = use_hipfile
-                use_hipfile_from_config = True
-
-        # Now initialize the memory allocator after use_hipfile is set
+        # Now initialize the memory allocator
         self.memory_allocator = self.initialize_allocator(config, metadata)
 
         self.data_suffix = _DATA_FILE_SUFFIX
         self._thread_pool = None
 
         if self.fstype in ["tmpfs", "overlayfs"]:
-            # TODO: we can replace the auto-detection of unsupported cufile
-            # file systems by doing a small cufile API test on them. If as
-            # read/write test fails, we can fallback to not using cufile APIs.
-            if use_cufile_from_config or use_hipfile_from_config:
-                logger.warning(
-                    "No automatic disabling of cufile/hipfile usage due to fstype"
-                )
+            # TODO: we can replace the auto-detection of unsupported GDS
+            # file systems by doing a small GDS API test on them. If a
+            # read/write test fails, we can fallback to not using GDS APIs.
+            if use_gds_explicitly_set:
+                logger.warning("No automatic disabling of GDS usage due to fstype")
             else:
-                logger.info("Automatic disabling of cufile/hipfile usage due to fstype")
-                self.use_cufile = False
-                self.use_hipfile = False
+                logger.info("Automatic disabling of GDS usage due to fstype")
+                self.use_gds = False
         elif self.fstype == "wekafs":
-            logger.info("Weka filesystem detected, cufile/hipfile usage is enforced")
-            assert self.use_cufile or self.use_hipfile, (
-                "Weka filesystem requires either cufile or hipfile to be enabled"
-            )
+            logger.info("Weka filesystem detected, GDS usage is enforced")
+            assert self.use_gds
             self.data_suffix = _WEKA_DATA_FILE_SUFFIX
 
         # Always enable the thread pool for parallel I/O
-        self.use_thread_pool = self.use_cufile or self.use_hipfile
+        self.use_thread_pool = self.use_gds
 
         if self.use_thread_pool:
             thread_count = _DEFAULT_THREAD_COUNT
@@ -266,29 +273,31 @@ class GdsBackend(AllocatorBackendInterface):
                 max_workers=thread_count, thread_name_prefix="gds-io"
             )
 
-        if self.use_cufile:
-            logger.info("Using cufile")
-            # HACK(Jiayi): cufile import is buggy on some hardware
-            # (e.g., without GPUDirect), so it's temporarily put here.
-            # Third Party
-            import cufile
+        if self.use_gds:
+            logger.info("Using GDS backend '%s'", self.gds_backend)
+            if self.gds_backend == "cufile":
+                # HACK(Jiayi): cufile import is buggy on some hardware
+                # (e.g., without GPUDirect), so it's temporarily put here.
+                # Third Party
+                import cufile
 
-            self.cudart = None
-            self.cufile = cufile
-            self._cufile_driver = self.cufile.CuFileDriver()
-        elif self.use_hipfile:
-            logger.info("Using hipfile")
-            # HACK: hipfile import may be buggy on some hardware
-            # (e.g., without GPUDirect), so it's temporarily put here.
-            # Third Party
-            import hipfile
+                self.cudart = None
+                self.gds_module = cufile
+                self._gds_driver = self.gds_module.CuFileDriver()
+            elif self.gds_backend == "hipfile":
+                # HACK: hipfile import may be buggy on some hardware
+                # (e.g., without GPUDirect), so it's temporarily put here.
+                # Third Party
+                import hipfile
 
-            self.cudart = None
-            self.cufile = hipfile  # Reuse the same attribute name for compatibility
-            self._cufile_driver = self.cufile.CuFileDriver()
+                self.cudart = None
+                self.gds_module = hipfile
+                self._gds_driver = self.gds_module.CuFileDriver()
+            else:
+                raise ValueError(f"Unsupported gds_backend '{self.gds_backend}'")
         else:
-            logger.info("Not using cufile or hipfile")
-            self.cufile = None
+            logger.info("GDS disabled, using POSIX fallback")
+            self.gds_module = None
             self.cudart = ctypes.CDLL("libcudart.so")
 
         self.use_direct_io = False
@@ -321,10 +330,10 @@ class GdsBackend(AllocatorBackendInterface):
 
         if hasattr(self.memory_allocator, "base_pointer"):
             logger.debug(f"Using base pointer {self.memory_allocator.base_pointer}")
-            self.cufile_base_pointer = self.memory_allocator.base_pointer
+            self.gds_base_pointer = self.memory_allocator.base_pointer
         else:
-            logger.info("No base pointer found, cufile will use bounce buffers")
-            self.cufile_base_pointer = None
+            logger.info("No base pointer found, GDS will use bounce buffers")
+            self.gds_base_pointer = None
         self._scan_metadata_future = asyncio.run_coroutine_threadsafe(
             self._scan_metadata(), self.loop
         )
@@ -608,12 +617,12 @@ class GdsBackend(AllocatorBackendInterface):
                     tmp,
                     kv_chunk,
                     fmt,
-                    self.cufile_base_pointer,
+                    self.gds_base_pointer,
                     memory_obj.metadata.address,
                 )
             except Exception as e:
                 logger.error(
-                    f"GDS/cuFile write operation failed for key {key.to_string()} at "
+                    f"GDS write operation failed for key {key.to_string()} at "
                     f"path {path}: tensor_shape={kv_chunk.shape}, "
                     f"tensor_dtype={kv_chunk.dtype}, "
                     f"tensor_size_bytes={kv_chunk.nbytes}, error={e}",
@@ -809,7 +818,7 @@ class GdsBackend(AllocatorBackendInterface):
             return None
 
         offset = _METADATA_MAX_SIZE
-        if self.cufile_base_pointer is None:
+        if self.gds_base_pointer is None:
             tensor = memory_obj.tensor
             assert tensor is not None
             if self._debug_asserts:
@@ -818,7 +827,7 @@ class GdsBackend(AllocatorBackendInterface):
             addr = ctypes.c_void_p(tensor.data_ptr())
             dev_offset = 0
         else:
-            addr = ctypes.c_void_p(self.cufile_base_pointer)
+            addr = ctypes.c_void_p(self.gds_base_pointer)
             dev_offset = memory_obj.metadata.address
         ret = self._load_gds(path, offset, addr, memory_obj.get_size(), dev_offset)
         if ret != memory_obj.get_size():
@@ -937,8 +946,8 @@ class GdsBackend(AllocatorBackendInterface):
         try:
             with open(tmp_path, "wb") as f:
                 f.write(metadata)
-            if self.cufile:
-                with self.cufile.CuFile(
+            if self.gds_module:
+                with self.gds_module.CuFile(
                     tmp_path, "r+", use_direct_io=self.use_direct_io
                 ) as f:
                     f.write(
@@ -986,8 +995,8 @@ class GdsBackend(AllocatorBackendInterface):
     ) -> int:
         """Read data from disk into a GPU buffer"""
         try:
-            if self.cufile:
-                with self.cufile.CuFile(
+            if self.gds_module:
+                with self.gds_module.CuFile(
                     gds_path, "r", use_direct_io=self.use_direct_io
                 ) as f:
                     return f.read(
@@ -1036,13 +1045,13 @@ class GdsBackend(AllocatorBackendInterface):
                 return size_in_bytes
             else:
                 raise RuntimeError(
-                    "Both cufile and cudart are None, this should not happen"
+                    "Both gds_module and cudart are None, this should not happen"
                 )
         except Exception as e:
             # return -1 on any exception, and log the error.
             # The caller will handle the error by removing the cache entry and
             # returning None.
-            logger.error(f"CuFile read failed for {gds_path}: {e}", exc_info=True)
+            logger.error(f"GDS read failed for {gds_path}: {e}", exc_info=True)
             return -1
 
     def pin(self, key: CacheEngineKey) -> bool:
@@ -1061,12 +1070,13 @@ class GdsBackend(AllocatorBackendInterface):
     def initialize_allocator(
         self, config: LMCacheEngineConfig, metadata: LMCacheMetadata
     ) -> Union[CuFileMemoryAllocator, HipFileMemoryAllocator]:
-        assert config.cufile_buffer_size is not None
-        # Use HipFileMemoryAllocator if hipfile is enabled in the backend
+        assert config.gds_buffer_size is not None
         allocator_cls = (
-            HipFileMemoryAllocator if self.use_hipfile else CuFileMemoryAllocator
+            HipFileMemoryAllocator
+            if self.gds_backend == "hipfile"
+            else CuFileMemoryAllocator
         )
-        return allocator_cls(config.cufile_buffer_size * 1024**2)
+        return allocator_cls(config.gds_buffer_size * 1024**2)
 
     def allocate(
         self,

--- a/tests/v1/data/gds.yaml
+++ b/tests/v1/data/gds.yaml
@@ -2,6 +2,5 @@ chunk_size: 256
 gds_path: "/tmp/gds/test-cache"
 local_cpu: False
 save_decode_cache: True
-cufile_buffer_size: 128
-extra_config:
-  use_cufile: true  # Explicitly enable cuFile for GDS backend
+gds_buffer_size: 128
+gds_backend: "cufile"

--- a/tests/v1/data/hipfile.yaml
+++ b/tests/v1/data/hipfile.yaml
@@ -3,6 +3,5 @@ chunk_size: 256
 gds_path: "/tmp/hipfile/test-cache"
 local_cpu: False
 save_decode_cache: True
-cufile_buffer_size: 128
-extra_config:
-  use_hipfile: true  # This enables HipFileMemoryAllocator instead of CuFileMemoryAllocator
+gds_buffer_size: 128
+gds_backend: "hipfile"

--- a/tests/v1/data/hipfile_gds.yaml
+++ b/tests/v1/data/hipfile_gds.yaml
@@ -3,7 +3,7 @@ chunk_size: 256
 gds_path: "/tmp/hipfile-gds/test-cache"
 local_cpu: False
 save_decode_cache: True
-cufile_buffer_size: 128
+gds_buffer_size: 128
+gds_backend: "hipfile"
 extra_config:
-  use_hipfile: true  # Enable hipFile instead of cuFile
   use_direct_io: true

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -36,7 +36,7 @@ def create_test_config(gds_path: str, gds_path_sharding: str = "by_gpu"):
         gds_path=gds_path,
         gds_path_sharding=gds_path_sharding,
         lmcache_instance_id="test_instance",
-        cufile_buffer_size=256,
+        gds_buffer_size=256,
         extra_config={"use_direct_io": True},
     )
     return config
@@ -443,11 +443,11 @@ class TestGdsBackend:
                     path, _, _, _ = backend._key_to_path(key)
                     assert path.endswith(".weka1")
                     assert backend.data_suffix == ".weka1"
-                    assert backend.use_cufile
+                    assert backend.use_gds
                 finally:
                     backend.close()
 
-    def test_weka_disallows_disabling_cufile(self, temp_gds_path, async_loop):
+    def test_weka_disallows_disabling_gds(self, temp_gds_path, async_loop):
         class DummyAllocator:
             def __init__(self):
                 self.base_pointer = 0
@@ -467,7 +467,7 @@ class TestGdsBackend:
             ),
         ):
             config = create_test_config(temp_gds_path)
-            config.extra_config["use_cufile"] = False
+            config.use_gds = False
             metadata = create_test_metadata()
 
             with pytest.raises(AssertionError):

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -1458,7 +1458,7 @@ def test_multi_device_backends(save_unfull_chunk, autorelease_v1):
                 "local_cpu": True,
                 "max_local_cpu_size": 5,
                 "gds_path": temp_dir,
-                "cufile_buffer_size": 1024,
+                "gds_buffer_size": 1024,
                 "save_unfull_chunk": save_unfull_chunk,
                 "extra_config": {
                     "use_direct_io": True,

--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -67,7 +67,7 @@ def test_gds_backend_sanity():
     try:
         os.makedirs(GDS_DIR, exist_ok=True)
         config_gds = LMCacheEngineConfig.from_file(BASE_DIR / "data/gds.yaml")
-        assert config_gds.cufile_buffer_size == 128
+        assert config_gds.gds_buffer_size == 128
 
         thread_loop = asyncio.new_event_loop()
         thread = threading.Thread(target=thread_loop.run_forever)


### PR DESCRIPTION
Follow up work post #2799 (AMD hipFile AIS support).

Refactor the GDS backend configuration to be backend-agnostic:
- Replace extra_config["use_cufile"] with top-level use_gds (bool) config
- Add gds_backend config field ("cufile" default) to select GDS library
- Rename cufile_buffer_size to gds_buffer_size
- Rename internal attributes: self.cufile -> self.gds_module, self._cufile_driver -> self._gds_driver, self.cufile_base_pointer -> self.gds_base_pointer
- Update tests and documentation accordingly

New env vars: LMCACHE_USE_GDS, LMCACHE_GDS_BACKEND, LMCACHE_GDS_BUFFER_SIZE

Generated with [Devin](https://cli.devin.ai/docs)

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `GdsBackend` initialization and allocator selection paths, which are performance/IO-critical and could change runtime behavior (e.g., auto-disabling GDS on certain filesystems or selecting the wrong backend). Overall scope is contained to configuration and GDS backend wiring, with tests/docs updated accordingly.
> 
> **Overview**
> Refactors GDS configuration to be backend-agnostic: replaces `extra_config` flags (`use_cufile`/`use_hipfile`) with top-level `use_gds` plus a `gds_backend` selector (`cufile`/`hipfile`), and renames `cufile_buffer_size` to `gds_buffer_size` (including new env vars like `LMCACHE_GDS_BUFFER_SIZE`, `LMCACHE_USE_GDS`, `LMCACHE_GDS_BACKEND`).
> 
> Updates `GdsBackend` to route imports/driver setup through the chosen backend module, standardizes internal naming (`gds_module`, `_gds_driver`, `gds_base_pointer`), and tweaks filesystem-based auto-disable logic to only override defaults when `use_gds` wasn’t explicitly set. Tests, sample configs, Buildkite config, and docs are updated to the new keys and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217b6b949931fde108c32df154b30eb780cdcd9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->