### PR TITLE
[CORE] Add nixl_endpoint_list for per-worker object-storage endpoint distribution

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -334,9 +334,9 @@ Settings for using Nixl as a storage backend instead of disaggregated prefill. T
     extra_config: 
       # enable_nixl_storage will disable disaggregated prefill mode.
       enable_nixl_storage: true
-      nixl_backend: "POSIX"  # Options: "GDS", "GDS_MT", "POSIX", "HF3FS"
+      nixl_backend: "POSIX"  # Options: "GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ"
       nixl_path: "/path/to/storage/"
-      nixl_file_pool_size: 64
+      nixl_pool_size: 64
 
 .. list-table::
    :header-rows: 1
@@ -347,11 +347,13 @@ Settings for using Nixl as a storage backend instead of disaggregated prefill. T
    * - enable_nixl_storage
      - Whether to enable Nixl storage backend. Values: true/false
    * - nixl_backend
-     - Storage backend type. Options: "GDS", "GDS_MT", "POSIX", "HF3FS"
+     - Storage backend type. Options: "GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ"
    * - nixl_path
      - File system path for Nixl storage
-   * - nixl_file_pool_size
-     - Number of files in the storage pool
+   * - nixl_pool_size
+     - Number of files or objects in the storage pool
+   * - nixl_endpoint_list
+     - List of object-storage endpoint URLs for per-worker distribution. Overrides ``nixl_backend_params.endpoint_override`` when set.
 
 
 Additional Storage Configurations

--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -117,7 +117,7 @@ Per-Worker Endpoint Distribution
 When using the OBJ backend with multiple tensor-parallel (TP) workers, you can
 distribute workers across multiple object-storage endpoints by providing a list of
 endpoints via ``nixl_endpoint_list``. Each worker selects an endpoint in
-round-robin order based on its ``worker_id``.
+round-robin order based on its ``local_worker_id`` (the worker ID within its host).
 
 .. code-block:: yaml
 

--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -111,6 +111,36 @@ Example ``lmcache-config.yaml`` for AZURE_BLOB backend to offload using Azure Bl
         account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
         container_name: <your_container_name>
 
+Per-Worker Endpoint Distribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using the OBJ backend with multiple tensor-parallel (TP) workers, you can
+distribute workers across multiple object-storage endpoints by providing a list of
+endpoints via ``nixl_endpoint_list``. Each worker selects an endpoint in
+round-robin order based on its ``worker_id``.
+
+.. code-block:: yaml
+
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: OBJ
+      nixl_pool_size: 64
+      nixl_path: /mnt/nixl/cache/
+      nixl_endpoint_list:
+        - https://node-0.object-storage:9021
+        - https://node-1.object-storage:9021
+        - https://node-2.object-storage:9021
+      nixl_backend_params:
+        access_key: <your_access_key>
+        secret_key: <your_secret_key>
+        bucket: <your_bucket>
+        region: <your_region>
+
+.. note::
+
+    When ``nixl_endpoint_list`` is set, any ``endpoint_override`` value in
+    ``nixl_backend_params`` is ignored (a warning is logged).
+
 Dynamic Mode
 ~~~~~~~~~~~~~
 

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -127,7 +127,7 @@ class NixlStorageConfig:
 
         # Per-worker endpoint distribution: if nixl_endpoint_list is set,
         # override endpoint_override so each TP worker targets a different
-        # object-storage endpoint (round-robin by worker_id).
+        # object-storage endpoint (round-robin by local_worker_id).
         endpoint_list = extra_config.get("nixl_endpoint_list")
         if endpoint_list is not None and len(endpoint_list) == 0:
             raise ValueError("nixl_endpoint_list is set but empty")
@@ -138,7 +138,7 @@ class NixlStorageConfig:
                     "nixl_backend_params.endpoint_override (%s)",
                     backend_params["endpoint_override"],
                 )
-            ep = endpoint_list[metadata.worker_id % len(endpoint_list)]
+            ep = endpoint_list[metadata.local_worker_id % len(endpoint_list)]
             if not ep.startswith(("http://", "https://")):
                 raise ValueError(
                     f"nixl_endpoint_list entry {ep!r} is not a valid URL "
@@ -147,7 +147,7 @@ class NixlStorageConfig:
             backend_params["endpoint_override"] = ep
             logger.info(
                 "Worker %d using endpoint %s (from %d endpoints)",
-                metadata.worker_id,
+                metadata.local_worker_id,
                 ep,
                 len(endpoint_list),
             )

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -119,10 +119,38 @@ class NixlStorageConfig:
 
         enable_presence_cache = extra_config.get("nixl_presence_cache", False)
         enable_async_put = extra_config.get("nixl_async_put", False)
-        backend_params = extra_config.get("nixl_backend_params", {})
+        backend_params = dict(extra_config.get("nixl_backend_params", {}))
         use_direct_io = extra_config.get("use_direct_io", False)
         pool_size = extra_config.get("nixl_pool_size")
+
         backend = extra_config.get("nixl_backend")
+
+        # Per-worker endpoint distribution: if nixl_endpoint_list is set,
+        # override endpoint_override so each TP worker targets a different
+        # object-storage endpoint (round-robin by worker_id).
+        endpoint_list = extra_config.get("nixl_endpoint_list")
+        if endpoint_list is not None and len(endpoint_list) == 0:
+            raise ValueError("nixl_endpoint_list is set but empty")
+        if backend == "OBJ" and endpoint_list:
+            if "endpoint_override" in backend_params:
+                logger.warning(
+                    "nixl_endpoint_list is set; ignoring "
+                    "nixl_backend_params.endpoint_override (%s)",
+                    backend_params["endpoint_override"],
+                )
+            ep = endpoint_list[metadata.worker_id % len(endpoint_list)]
+            if not ep.startswith(("http://", "https://")):
+                raise ValueError(
+                    f"nixl_endpoint_list entry {ep!r} is not a valid URL "
+                    "(must start with 'http://' or 'https://')"
+                )
+            backend_params["endpoint_override"] = ep
+            logger.info(
+                "Worker %d using endpoint %s (from %d endpoints)",
+                metadata.worker_id,
+                ep,
+                len(endpoint_list),
+            )
         path = extra_config.get("nixl_path")
         enable_prog_thread = extra_config.get("nixl_enable_prog_thread", True)
         sync_mode_str = extra_config.get("nixl_sync_mode", None)

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -71,7 +71,7 @@ def create_test_config(
     config.extra_config = {
         "enable_nixl_storage": True,
         "nixl_backend": backend,
-        "nixl_file_pool_size": 10,
+        "nixl_pool_size": 10,
         "nixl_path": tempfile.mkdtemp(),  # Create a temporary directory for testing
     }
     return config
@@ -117,6 +117,124 @@ def test_nixl_storage_config():
     assert NixlStorageConfig.validate_nixl_backend("POSIX", "cpu")
     assert not NixlStorageConfig.validate_nixl_backend("POSIX", "cuda")
     assert not NixlStorageConfig.validate_nixl_backend("INVALID", "cpu")
+
+
+def _make_obj_config(
+    extra_overrides: dict | None = None,
+) -> LMCacheEngineConfig:
+    """Create a minimal OBJ-backend config for endpoint-list tests."""
+    config = LMCacheEngineConfig()
+    config.nixl_buffer_size = 2**30  # 1 GB
+    config.nixl_buffer_device = "cpu"
+    config.extra_config = {
+        "enable_nixl_storage": True,
+        "nixl_backend": "OBJ",
+        "nixl_pool_size": 0,
+        "nixl_path": tempfile.mkdtemp(),
+    }
+    if extra_overrides:
+        config.extra_config.update(extra_overrides)
+    return config
+
+
+def _make_metadata(worker_id: int = 0) -> LMCacheMetadata:
+    """Create test metadata with a configurable worker_id."""
+    return LMCacheMetadata(
+        model_name="test_model",
+        worker_id=worker_id,
+        local_world_size=1,
+        local_worker_id=0,
+        world_size=1,
+        kv_dtype=torch.bfloat16,
+        kv_shape=(32, 2, 256, 1024, 128),
+    )
+
+
+@pytest.mark.no_shared_allocator
+def test_endpoint_list_round_robin():
+    """nixl_endpoint_list should assign endpoints to workers round-robin."""
+    endpoints = [
+        "https://node-0:9021",
+        "https://node-1:9021",
+        "https://node-2:9021",
+    ]
+    config = _make_obj_config({"nixl_endpoint_list": endpoints})
+
+    for worker_id in range(6):
+        metadata = _make_metadata(worker_id=worker_id)
+        nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
+        expected = endpoints[worker_id % len(endpoints)]
+        assert nixl_config.backend_params["endpoint_override"] == expected
+
+
+@pytest.mark.no_shared_allocator
+def test_endpoint_list_overrides_endpoint_override():
+    """nixl_endpoint_list takes precedence over backend_params endpoint_override."""
+    endpoints = ["https://node-0:9021"]
+    config = _make_obj_config(
+        {
+            "nixl_endpoint_list": endpoints,
+            "nixl_backend_params": {
+                "endpoint_override": "https://should-be-ignored:9021",
+                "access_key": "key",
+            },
+        }
+    )
+    metadata = _make_metadata(worker_id=0)
+
+    nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
+
+    assert nixl_config.backend_params["endpoint_override"] == endpoints[0]
+    # other params must be preserved
+    assert nixl_config.backend_params["access_key"] == "key"
+
+
+@pytest.mark.no_shared_allocator
+def test_endpoint_list_does_not_mutate_original_config():
+    """Setting nixl_endpoint_list must not mutate the original backend_params dict."""
+    original_params = {"access_key": "key", "secret_key": "secret"}
+    config = _make_obj_config(
+        {
+            "nixl_endpoint_list": ["https://node-0:9021"],
+            "nixl_backend_params": original_params,
+        }
+    )
+    metadata = _make_metadata(worker_id=0)
+
+    NixlStorageConfig.from_cache_engine_config(config, metadata)
+
+    assert "endpoint_override" not in original_params
+
+
+@pytest.mark.no_shared_allocator
+def test_endpoint_list_empty_raises():
+    """nixl_endpoint_list=[] should raise ValueError before any nixl ops."""
+    config = _make_obj_config({"nixl_endpoint_list": []})
+    metadata = _make_metadata(worker_id=0)
+
+    with pytest.raises(ValueError, match="nixl_endpoint_list is set but empty"):
+        NixlStorageConfig.from_cache_engine_config(config, metadata)
+
+
+@pytest.mark.no_shared_allocator
+def test_no_endpoint_list_leaves_backend_params_unchanged():
+    """When nixl_endpoint_list is absent, endpoint_override must not be injected."""
+    config = _make_obj_config()  # no nixl_endpoint_list key
+    metadata = _make_metadata(worker_id=0)
+
+    nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
+
+    assert "endpoint_override" not in nixl_config.backend_params
+
+
+@pytest.mark.no_shared_allocator
+def test_endpoint_list_malformed_url_raises():
+    """A non-http(s) entry in nixl_endpoint_list should raise ValueError."""
+    config = _make_obj_config({"nixl_endpoint_list": ["htps://typo.example.com"]})
+    metadata = _make_metadata(worker_id=0)
+
+    with pytest.raises(ValueError, match="is not a valid URL"):
+        NixlStorageConfig.from_cache_engine_config(config, metadata)
 
 
 @pytest.mark.no_shared_allocator

--- a/tests/disagg/test_nixl_storage_backend.py
+++ b/tests/disagg/test_nixl_storage_backend.py
@@ -137,13 +137,13 @@ def _make_obj_config(
     return config
 
 
-def _make_metadata(worker_id: int = 0) -> LMCacheMetadata:
-    """Create test metadata with a configurable worker_id."""
+def _make_metadata(local_worker_id: int = 0) -> LMCacheMetadata:
+    """Create test metadata with a configurable local_worker_id."""
     return LMCacheMetadata(
         model_name="test_model",
-        worker_id=worker_id,
+        worker_id=local_worker_id,
         local_world_size=1,
-        local_worker_id=0,
+        local_worker_id=local_worker_id,
         world_size=1,
         kv_dtype=torch.bfloat16,
         kv_shape=(32, 2, 256, 1024, 128),
@@ -160,10 +160,10 @@ def test_endpoint_list_round_robin():
     ]
     config = _make_obj_config({"nixl_endpoint_list": endpoints})
 
-    for worker_id in range(6):
-        metadata = _make_metadata(worker_id=worker_id)
+    for local_worker_id in range(6):
+        metadata = _make_metadata(local_worker_id=local_worker_id)
         nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
-        expected = endpoints[worker_id % len(endpoints)]
+        expected = endpoints[local_worker_id % len(endpoints)]
         assert nixl_config.backend_params["endpoint_override"] == expected
 
 
@@ -180,7 +180,7 @@ def test_endpoint_list_overrides_endpoint_override():
             },
         }
     )
-    metadata = _make_metadata(worker_id=0)
+    metadata = _make_metadata(local_worker_id=0)
 
     nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
 
@@ -199,7 +199,7 @@ def test_endpoint_list_does_not_mutate_original_config():
             "nixl_backend_params": original_params,
         }
     )
-    metadata = _make_metadata(worker_id=0)
+    metadata = _make_metadata(local_worker_id=0)
 
     NixlStorageConfig.from_cache_engine_config(config, metadata)
 
@@ -210,7 +210,7 @@ def test_endpoint_list_does_not_mutate_original_config():
 def test_endpoint_list_empty_raises():
     """nixl_endpoint_list=[] should raise ValueError before any nixl ops."""
     config = _make_obj_config({"nixl_endpoint_list": []})
-    metadata = _make_metadata(worker_id=0)
+    metadata = _make_metadata(local_worker_id=0)
 
     with pytest.raises(ValueError, match="nixl_endpoint_list is set but empty"):
         NixlStorageConfig.from_cache_engine_config(config, metadata)
@@ -220,7 +220,7 @@ def test_endpoint_list_empty_raises():
 def test_no_endpoint_list_leaves_backend_params_unchanged():
     """When nixl_endpoint_list is absent, endpoint_override must not be injected."""
     config = _make_obj_config()  # no nixl_endpoint_list key
-    metadata = _make_metadata(worker_id=0)
+    metadata = _make_metadata(local_worker_id=0)
 
     nixl_config = NixlStorageConfig.from_cache_engine_config(config, metadata)
 
@@ -231,7 +231,7 @@ def test_no_endpoint_list_leaves_backend_params_unchanged():
 def test_endpoint_list_malformed_url_raises():
     """A non-http(s) entry in nixl_endpoint_list should raise ValueError."""
     config = _make_obj_config({"nixl_endpoint_list": ["htps://typo.example.com"]})
-    metadata = _make_metadata(worker_id=0)
+    metadata = _make_metadata(local_worker_id=0)
 
     with pytest.raises(ValueError, match="is not a valid URL"):
         NixlStorageConfig.from_cache_engine_config(config, metadata)

--- a/tests/v1/test_nixl_storage.py
+++ b/tests/v1/test_nixl_storage.py
@@ -16,7 +16,10 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import PagedTensorMemoryAllocator
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import CreateStorageBackends
-from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageBackend
+from lmcache.v1.storage_backend.nixl_storage_backend import (
+    NixlStorageBackend,
+    NixlStorageConfig,
+)
 
 
 def create_key(chunk_hash: str):
@@ -244,6 +247,49 @@ def test_nixl_gds_cpu_backend():
     config.extra_config["enable_cuda"] = False
 
     run(config, shape, dtype)
+
+
+@pytest.mark.no_shared_allocator
+def test_nixl_endpoint_list_empty_raises():
+    """nixl_endpoint_list=[] should raise ValueError before any nixl ops."""
+    BASE_DIR = Path(__file__).parent
+    config = LMCacheEngineConfig.from_file(BASE_DIR / "data/nixl.yaml")
+    config.extra_config["nixl_endpoint_list"] = []
+
+    metadata = LMCacheMetadata(
+        model_name="Llama-3.1-70B-Instruct",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.bfloat16,
+        kv_shape=[2048, 2048],
+    )
+
+    with pytest.raises(ValueError, match="nixl_endpoint_list is set but empty"):
+        NixlStorageConfig.from_cache_engine_config(config, metadata)
+
+
+@pytest.mark.no_shared_allocator
+def test_nixl_endpoint_list_malformed_url_raises():
+    """A non-http(s) entry in nixl_endpoint_list should raise ValueError."""
+    BASE_DIR = Path(__file__).parent
+    config = LMCacheEngineConfig.from_file(BASE_DIR / "data/nixl.yaml")
+    config.extra_config["nixl_endpoint_list"] = ["htps://typo.example.com"]
+    config.extra_config["nixl_backend"] = "OBJ"
+
+    metadata = LMCacheMetadata(
+        model_name="Llama-3.1-70B-Instruct",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.bfloat16,
+        kv_shape=[2048, 2048],
+    )
+
+    with pytest.raises(ValueError, match="is not a valid URL"):
+        NixlStorageConfig.from_cache_engine_config(config, metadata)
 
 
 @pytest.mark.no_shared_allocator


### PR DESCRIPTION
Allow TP workers to target different object-storage endpoints when using the NIXL OBJ backend. When nixl_endpoint_list is set in extra_config, each worker selects an endpoint round-robin by worker_id, overriding any nixl_backend_params.endpoint_override (with a logged warning).

Also copies nixl_backend_params into a new dict before mutating it to avoid modifying the original config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NIXL OBJ backend configuration to dynamically override `endpoint_override` per worker, which can alter where cache data is stored/retrieved in multi-worker deployments. Adds validation and new config keys/renames, so misconfiguration could cause startup failures or unexpected routing.
> 
> **Overview**
> Adds `extra_config.nixl_endpoint_list` to the NIXL `OBJ` storage backend so tensor-parallel workers pick object-storage endpoints round-robin by `worker_id`, overriding `nixl_backend_params.endpoint_override` (with a warning) and validating non-empty, http(s) URLs.
> 
> Renames the config key `nixl_file_pool_size` to `nixl_pool_size` and updates docs/tests accordingly, including documentation for the new `OBJ` backend option and endpoint-list behavior; also ensures `nixl_backend_params` is copied before mutation to avoid modifying the original config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63673fb08b14485091fee042f1ba8caf6c517d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->