### PR TITLE
Relax worker port count assertion

### DIFF
--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -118,11 +118,11 @@ class LMCacheWorker:
         )
         if not lmcache_worker_ids:
             # start lmcache worker on all ranks
-            assert len(config.lmcache_worker_ports) == metadata.world_size
+            assert len(config.lmcache_worker_ports) >= metadata.world_size
             lmcache_worker_port = config.lmcache_worker_ports[self.worker_id]
         else:
             # start lmcache worker on given worker ids
-            assert len(lmcache_worker_ids) == len(config.lmcache_worker_ports)
+            assert len(config.lmcache_worker_ports) >= len(lmcache_worker_ids)
             index = lmcache_worker_ids.index(self.worker_id)
             lmcache_worker_port = config.lmcache_worker_ports[index]
 


### PR DESCRIPTION
## Problem

The strict `==` assertions on `lmcache_worker_ports` length in `LMCacheWorker` reject valid configurations where more ports are provided than the effective `world_size` or worker count.

This is problematic in two scenarios:
1. **MLA models** reduce the effective `world_size` (vLLM divides by `tp_size`), so users providing ports based on total GPU count (TP × PP) hit the assertion. For example, on a p5 instance with 8 GPUs, providing 8 ports fails when MLA reduces `world_size` to 1.
2. **Config reuse across instance types** — a single config with 8 ports (for p5) fails on `g5.24xlarge` which only has 4 GPUs.

## Fix

Change `==` to `>=` in both assertions in `worker.py`:
- `len(config.lmcache_worker_ports) >= metadata.world_size`
- `len(config.lmcache_worker_ports) >= len(lmcache_worker_ids)`

Extra ports are simply unused — they are never bound to sockets or registered with the controller. The port selection logic indexes by `worker_id` or `lmcache_worker_ids.index()`, so extra entries are harmless. This is consistent with how P2P ports (`p2p_init_ports`, `p2p_lookup_ports`) already work.

Split out from #2732 per reviewer feedback.