### PR TITLE
[Chore][Docs] Fix mp docs for store policy: skip_l1

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -162,9 +162,9 @@ Source: ``lmcache/v1/distributed/config.py``
      - L2 store policy.  Determines which adapters receive each key
        and whether keys are deleted from L1 after L2 store.
        The ``default`` policy stores all keys to all adapters and keeps L1.
-       The ``noop`` policy stores all keys to all adapters and then
+       The ``skip_l1`` policy stores all keys to all adapters and then
        deletes them from L1 (buffer-only mode).
-       Choices: ``default``, ``noop``.
+       Choices: ``default``, ``skip_l1``.
    * - ``--l2-prefetch-policy``
      - ``default``
      - L2 prefetch policy.  Determines which adapter loads each key
@@ -367,7 +367,7 @@ Full Example
         --l1-write-ttl-seconds 600 \
         --l1-read-ttl-seconds 300 \
         --eviction-policy noop \
-        --l2-store-policy noop \
+        --l2-store-policy skip_l1 \
         --eviction-trigger-watermark 0.9 \
         --eviction-ratio 0.1 \
         --l2-prefetch-policy default \

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -186,7 +186,7 @@ Select policies via CLI:
      - ``default``
      - Store all keys to all adapters.  Never delete from L1.
    * - ``--l2-store-policy``
-     - ``noop``
+     - ``skip_l1``
      - Buffer-only mode.  Store all keys to all adapters, then
        **delete them from L1** immediately.  Pair with
        ``--eviction-policy noop`` to avoid useless LRU overhead.
@@ -198,7 +198,7 @@ Buffer-Only Mode
 ~~~~~~~~~~~~~~~~~
 
 When L1 is used purely as a write buffer (all data lives in L2), use
-``--l2-store-policy noop`` together with ``--eviction-policy noop``.
+``--l2-store-policy skip_l1`` together with ``--eviction-policy noop``.
 This combination deletes keys from L1 as soon as they are stored to L2
 and disables the LRU eviction tracker entirely, reducing memory and CPU
 overhead.
@@ -206,7 +206,7 @@ overhead.
 .. code-block:: bash
 
     --eviction-policy noop \
-    --l2-store-policy noop \
+    --l2-store-policy skip_l1 \
     --l2-prefetch-policy default
 
 Policies are extensible -- new policies can be added by creating a file


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes documentation references to the renamed L2 store policy. The `noop` store policy was renamed to `skip_l1` but the docs still referenced the old name in `configuration.rst` and `l2_storage.rst`.

**Special notes for your reviewers**:

Docs-only change — no code modifications.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests