### PR TITLE
Support l2 adapter check and improve basic_check tool 

### DIFF
--- a/lmcache/v1/basic_check.py
+++ b/lmcache/v1/basic_check.py
@@ -21,8 +21,9 @@ def parse_args():
     parser.add_argument(
         "--num-keys",
         type=int,
-        default=100,
-        help="Number of keys to generate (gen mode only)",
+        default=5,
+        help="Number of keys for gen mode or test iterations "
+        "for test_* modes (default: 5)",
     )
     parser.add_argument(
         "--concurrency",
@@ -45,6 +46,20 @@ def parse_args():
         metavar="JSON",
         help="L2 adapter spec as JSON (test_l2_adapter mode). "
         'e.g. \'{"type":"mock","max_size_gb":1}\'.',
+    )
+    parser.add_argument(
+        "--obj-size",
+        dest="obj_size",
+        type=int,
+        default=None,
+        help="Object size in number of elements (default: 1024)",
+    )
+    parser.add_argument(
+        "--kv-dtype",
+        dest="kv_dtype",
+        type=str,
+        default=None,
+        help="KV dtype, e.g. float32, bfloat16, float16 (default depends on mode)",
     )
     return parser.parse_args()
 
@@ -76,6 +91,8 @@ async def main():
         "concurrency": args.concurrency,
         "offset": args.offset,
         "l2_adapter": args.l2_adapter,
+        "obj_size": args.obj_size,
+        "kv_dtype": args.kv_dtype,
     }
 
     # Execute the mode function

--- a/lmcache/v1/basic_check.py
+++ b/lmcache/v1/basic_check.py
@@ -61,6 +61,14 @@ def parse_args():
         default=None,
         help="KV dtype, e.g. float32, bfloat16, float16 (default depends on mode)",
     )
+    parser.add_argument(
+        "--settle-time",
+        dest="settle_time",
+        type=float,
+        default=0.0,
+        help="Seconds to wait after store before load "
+        "(default: 0, useful for remote backends)",
+    )
     return parser.parse_args()
 
 
@@ -93,6 +101,7 @@ async def main():
         "l2_adapter": args.l2_adapter,
         "obj_size": args.obj_size,
         "kv_dtype": args.kv_dtype,
+        "settle_time": args.settle_time,
     }
 
     # Execute the mode function

--- a/lmcache/v1/basic_check.py
+++ b/lmcache/v1/basic_check.py
@@ -36,6 +36,16 @@ def parse_args():
         default=0,
         help="Offset for key generation (gen mode only)",
     )
+    parser.add_argument(
+        "--l2-adapter",
+        dest="l2_adapter",
+        action="append",
+        default=[],
+        type=str,
+        metavar="JSON",
+        help="L2 adapter spec as JSON (test_l2_adapter mode). "
+        'e.g. \'{"type":"mock","max_size_gb":1}\'.',
+    )
     return parser.parse_args()
 
 
@@ -65,6 +75,7 @@ async def main():
         "num_keys": args.num_keys,
         "concurrency": args.concurrency,
         "offset": args.offset,
+        "l2_adapter": args.l2_adapter,
     }
 
     # Execute the mode function

--- a/lmcache/v1/check/check_mode_test_l2_adapter.py
+++ b/lmcache/v1/check/check_mode_test_l2_adapter.py
@@ -13,6 +13,9 @@ import torch
 # First Party
 from lmcache.v1.check import check_mode
 from lmcache.v1.check.utils import (
+    DEFAULT_KV_DTYPE_STR,
+    DEFAULT_OBJ_SIZE,
+    parse_kv_dtype,
     print_performance_results,
 )
 from lmcache.v1.distributed.api import ObjectKey
@@ -26,8 +29,7 @@ from lmcache.v1.memory_management import (
     TensorMemoryObj,
 )
 
-_OBJ_SIZE = 1024
-_POLL_TIMEOUT_MS = 10000
+_POLL_TIMEOUT_MS = 100000
 
 
 def _create_object_key(model: str, key_id: str) -> ObjectKey:
@@ -41,15 +43,17 @@ def _create_object_key(model: str, key_id: str) -> ObjectKey:
 
 def _create_memory_obj(
     fill_value: float = 0.0,
+    obj_size: int = DEFAULT_OBJ_SIZE,
+    dtype: torch.dtype = torch.float32,
 ) -> TensorMemoryObj:
     """Create a test TensorMemoryObj."""
-    raw_data = torch.empty(_OBJ_SIZE, dtype=torch.float32)
+    raw_data = torch.empty(obj_size, dtype=dtype)
     raw_data.fill_(fill_value)
     metadata = MemoryObjMetadata(
-        shape=torch.Size([_OBJ_SIZE]),
-        dtype=torch.float32,
+        shape=torch.Size([obj_size]),
+        dtype=dtype,
         address=0,
-        phy_size=_OBJ_SIZE * 4,
+        phy_size=obj_size * raw_data.element_size(),
         fmt=MemoryFormat.KV_2LTD,
         ref_count=1,
     )
@@ -122,6 +126,13 @@ async def run_test_mode(model: str, **kwargs):
         print("Error: --l2-adapter is required for test_l2_adapter mode")
         return
 
+    obj_size = kwargs.get("obj_size") or DEFAULT_OBJ_SIZE
+    kv_dtype_str = kwargs.get("kv_dtype") or DEFAULT_KV_DTYPE_STR
+    kv_dtype = parse_kv_dtype(kv_dtype_str)
+    if kv_dtype is None:
+        print("Error: unsupported --kv-dtype '%s'" % kv_dtype_str)
+        return
+
     # Build adapter config via the standard parser
     ns = argparse.Namespace(l2_adapter=l2_adapter_raw)
     l2_cfg = parse_args_to_l2_adapters_config(ns)
@@ -129,28 +140,42 @@ async def run_test_mode(model: str, **kwargs):
         print("Error: no L2 adapter configs parsed")
         return
 
-    num_tests = 5
+    num_tests = kwargs.get("num_keys", 5)
 
     for idx, adapter_cfg in enumerate(l2_cfg.adapters):
         adapter = create_l2_adapter(adapter_cfg)
         print("=== Testing L2 adapter #%d (%s) ===" % (idx, type(adapter).__name__))
 
         try:
-            _test_single_adapter(adapter, model, num_tests)
+            _test_single_adapter(
+                adapter,
+                model,
+                num_tests,
+                obj_size=obj_size,
+                kv_dtype=kv_dtype,
+            )
         except Exception as e:
             print("  Test Failed - Error: %s" % e)
         finally:
             adapter.close()
 
 
-def _test_single_adapter(adapter, model, num_tests):
+def _test_single_adapter(
+    adapter,
+    model,
+    num_tests,
+    obj_size=DEFAULT_OBJ_SIZE,
+    kv_dtype=torch.float32,
+):
     """Run all test phases against one adapter."""
     # -- Prepare test data -----------------------------------
     exist_keys = [_create_object_key(model, "exist_%d" % i) for i in range(num_tests)]
     non_exist_keys = [
         _create_object_key(model, "nonexist_%d" % i) for i in range(num_tests)
     ]
-    store_objs = [_create_memory_obj(float(i + 1)) for i in range(num_tests)]
+    store_objs = [
+        _create_memory_obj(float(i + 1), obj_size, kv_dtype) for i in range(num_tests)
+    ]
 
     # -- Phase 1: lookup non-existing keys -------------------
     print("Phase 1: Lookup non-existing keys...")
@@ -195,7 +220,9 @@ def _test_single_adapter(adapter, model, num_tests):
 
     # -- Phase 4: load existing keys -------------------------
     print("Phase 4: Load operations...")
-    load_buffers = [_create_memory_obj(0.0) for _ in range(num_tests)]
+    load_buffers = [
+        _create_memory_obj(0.0, obj_size, kv_dtype) for _ in range(num_tests)
+    ]
     ld_ms, ld_bitmap = _run_load_phase(adapter, exist_keys, load_buffers)
     load_pass = 0
     content_pass = 0
@@ -217,6 +244,7 @@ def _test_single_adapter(adapter, model, num_tests):
     adapter.submit_unlock(exist_keys)
 
     # -- Summary ---------------------------------------------
+    obj_bytes = obj_size * store_objs[0].tensor.element_size()
     stats_data = [
         (
             "LOOKUP (absent)",
@@ -259,4 +287,4 @@ def _test_single_adapter(adapter, model, num_tests):
             content_pass,
         ),
     ]
-    print_performance_results(stats_data)
+    print_performance_results(stats_data, obj_bytes=obj_bytes)

--- a/lmcache/v1/check/check_mode_test_l2_adapter.py
+++ b/lmcache/v1/check/check_mode_test_l2_adapter.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test mode implementation for MP mode L2 adapter basic checks"""
+
+# Standard
+import argparse
+import os
+import select
+import time
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.check import check_mode
+from lmcache.v1.check.utils import (
+    print_performance_results,
+)
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters import create_l2_adapter
+from lmcache.v1.distributed.l2_adapters.config import (
+    parse_args_to_l2_adapters_config,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+
+_OBJ_SIZE = 1024
+_POLL_TIMEOUT_MS = 10000
+
+
+def _create_object_key(model: str, key_id: str) -> ObjectKey:
+    """Create a test ObjectKey."""
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(hash(key_id) & 0xFFFFFFFF),
+        model_name=model,
+        kv_rank=0,
+    )
+
+
+def _create_memory_obj(
+    fill_value: float = 0.0,
+) -> TensorMemoryObj:
+    """Create a test TensorMemoryObj."""
+    raw_data = torch.empty(_OBJ_SIZE, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([_OBJ_SIZE]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=_OBJ_SIZE * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def _wait_event_fd(efd: int, timeout_ms: int = _POLL_TIMEOUT_MS) -> bool:
+    """Wait for an eventfd to be signaled."""
+    poll = select.poll()
+    poll.register(efd, select.POLLIN)
+    events = poll.poll(timeout_ms)
+    if events:
+        try:
+            os.eventfd_read(efd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+def _run_store_phase(adapter, keys, objects):
+    """Run store phase and return (stats, success)."""
+    efd = adapter.get_store_event_fd()
+    start = time.perf_counter()
+    task_id = adapter.submit_store_task(keys, objects)
+    if not _wait_event_fd(efd):
+        print("  Store: timed out waiting for eventfd")
+        return None, False
+    completed = adapter.pop_completed_store_tasks()
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    ok = completed.get(task_id, False)
+    return elapsed_ms, ok
+
+
+def _run_lookup_phase(adapter, keys):
+    """Run lookup phase and return (stats, bitmap)."""
+    efd = adapter.get_lookup_and_lock_event_fd()
+    start = time.perf_counter()
+    task_id = adapter.submit_lookup_and_lock_task(keys)
+    if not _wait_event_fd(efd):
+        print("  Lookup: timed out waiting for eventfd")
+        return None, None
+    bitmap = adapter.query_lookup_and_lock_result(task_id)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    return elapsed_ms, bitmap
+
+
+def _run_load_phase(adapter, keys, buffers):
+    """Run load phase and return (stats, bitmap)."""
+    efd = adapter.get_load_event_fd()
+    start = time.perf_counter()
+    task_id = adapter.submit_load_task(keys, buffers)
+    if not _wait_event_fd(efd):
+        print("  Load: timed out waiting for eventfd")
+        return None, None
+    bitmap = adapter.query_load_result(task_id)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    return elapsed_ms, bitmap
+
+
+@check_mode("test_l2_adapter")
+async def run_test_mode(model: str, **kwargs):
+    """Run L2 adapter test mode.
+
+    Requires ``l2_adapter`` in *kwargs* (list of JSON
+    strings from ``--l2-adapter``).
+    """
+    l2_adapter_raw = kwargs.get("l2_adapter")
+    if not l2_adapter_raw:
+        print("Error: --l2-adapter is required for test_l2_adapter mode")
+        return
+
+    # Build adapter config via the standard parser
+    ns = argparse.Namespace(l2_adapter=l2_adapter_raw)
+    l2_cfg = parse_args_to_l2_adapters_config(ns)
+    if not l2_cfg.adapters:
+        print("Error: no L2 adapter configs parsed")
+        return
+
+    num_tests = 5
+
+    for idx, adapter_cfg in enumerate(l2_cfg.adapters):
+        adapter = create_l2_adapter(adapter_cfg)
+        print("=== Testing L2 adapter #%d (%s) ===" % (idx, type(adapter).__name__))
+
+        try:
+            _test_single_adapter(adapter, model, num_tests)
+        except Exception as e:
+            print("  Test Failed - Error: %s" % e)
+        finally:
+            adapter.close()
+
+
+def _test_single_adapter(adapter, model, num_tests):
+    """Run all test phases against one adapter."""
+    # -- Prepare test data -----------------------------------
+    exist_keys = [_create_object_key(model, "exist_%d" % i) for i in range(num_tests)]
+    non_exist_keys = [
+        _create_object_key(model, "nonexist_%d" % i) for i in range(num_tests)
+    ]
+    store_objs = [_create_memory_obj(float(i + 1)) for i in range(num_tests)]
+
+    # -- Phase 1: lookup non-existing keys -------------------
+    print("Phase 1: Lookup non-existing keys...")
+    lk_ms, lk_bitmap = _run_lookup_phase(adapter, non_exist_keys)
+    if lk_bitmap is None:
+        print("  FAIL: lookup returned None bitmap")
+        ne_pass = 0
+    else:
+        ne_pass = sum(1 for i in range(num_tests) if not lk_bitmap.test(i))
+    print("  Validation: %d/%d correctly absent" % (ne_pass, num_tests))
+    # Unlock the looked-up keys (contract)
+    adapter.submit_unlock(non_exist_keys)
+
+    # -- Phase 2: store existing keys ------------------------
+    print("Phase 2: Store operations...")
+    store_times = []
+    store_pass = 0
+    for i in range(num_tests):
+        ms, ok = _run_store_phase(
+            adapter,
+            [exist_keys[i]],
+            [store_objs[i]],
+        )
+        if ms is not None:
+            store_times.append(ms)
+        if ok:
+            store_pass += 1
+        print(
+            "  Store %d/%d %s (%.2fms)"
+            % (i + 1, num_tests, "OK" if ok else "FAIL", ms or 0)
+        )
+
+    # -- Phase 3: lookup existing keys -----------------------
+    print("Phase 3: Lookup existing keys...")
+    lk_ms, lk_bitmap = _run_lookup_phase(adapter, exist_keys)
+    if lk_bitmap is None:
+        print("  FAIL: lookup returned None bitmap")
+        exist_pass = 0
+    else:
+        exist_pass = sum(1 for i in range(num_tests) if lk_bitmap.test(i))
+    print("  Validation: %d/%d found" % (exist_pass, num_tests))
+
+    # -- Phase 4: load existing keys -------------------------
+    print("Phase 4: Load operations...")
+    load_buffers = [_create_memory_obj(0.0) for _ in range(num_tests)]
+    ld_ms, ld_bitmap = _run_load_phase(adapter, exist_keys, load_buffers)
+    load_pass = 0
+    content_pass = 0
+    if ld_bitmap is not None:
+        for i in range(num_tests):
+            if ld_bitmap.test(i):
+                load_pass += 1
+                if torch.equal(
+                    load_buffers[i].tensor,
+                    store_objs[i].tensor,
+                ):
+                    content_pass += 1
+                else:
+                    print("  Key %d: data mismatch" % i)
+    print("  Validation (loaded): %d/%d" % (load_pass, num_tests))
+    print("  Validation (content): %d/%d" % (content_pass, num_tests))
+
+    # Unlock after load
+    adapter.submit_unlock(exist_keys)
+
+    # -- Summary ---------------------------------------------
+    stats_data = [
+        (
+            "LOOKUP (absent)",
+            {
+                "avg": lk_ms or 0,
+                "max": lk_ms or 0,
+                "min": lk_ms or 0,
+            },
+            [False] * num_tests,
+            ne_pass,
+        ),
+        (
+            "STORE",
+            {
+                "avg": (sum(store_times) / len(store_times) if store_times else 0),
+                "max": (max(store_times) if store_times else 0),
+                "min": (min(store_times) if store_times else 0),
+            },
+            [True] * store_pass + [False] * (num_tests - store_pass),
+            store_pass,
+        ),
+        (
+            "LOOKUP (exist)",
+            {
+                "avg": lk_ms or 0,
+                "max": lk_ms or 0,
+                "min": lk_ms or 0,
+            },
+            [True] * exist_pass + [False] * (num_tests - exist_pass),
+            exist_pass,
+        ),
+        (
+            "LOAD",
+            {
+                "avg": ld_ms or 0,
+                "max": ld_ms or 0,
+                "min": ld_ms or 0,
+            },
+            [True] * content_pass + [False] * (num_tests - content_pass),
+            content_pass,
+        ),
+    ]
+    print_performance_results(stats_data)

--- a/lmcache/v1/check/check_mode_test_l2_adapter.py
+++ b/lmcache/v1/check/check_mode_test_l2_adapter.py
@@ -182,7 +182,7 @@ def _test_single_adapter(
 
     # -- Phase 1: lookup non-existing keys -------------------
     print("Phase 1: Lookup non-existing keys...")
-    lk_ms, lk_bitmap = _run_lookup_phase(adapter, non_exist_keys)
+    lk_absent_ms, lk_bitmap = _run_lookup_phase(adapter, non_exist_keys)
     if lk_bitmap is None:
         print("  FAIL: lookup returned None bitmap")
         ne_pass = 0
@@ -204,7 +204,7 @@ def _test_single_adapter(
 
     # -- Phase 3: lookup existing keys -----------------------
     print("Phase 3: Lookup existing keys...")
-    lk_ms, lk_bitmap = _run_lookup_phase(adapter, exist_keys)
+    lk_exist_ms, lk_bitmap = _run_lookup_phase(adapter, exist_keys)
     if lk_bitmap is None:
         print("  FAIL: lookup returned None bitmap")
         exist_pass = 0
@@ -243,9 +243,9 @@ def _test_single_adapter(
         (
             "LOOKUP (absent)",
             {
-                "avg": lk_ms or 0,
-                "max": lk_ms or 0,
-                "min": lk_ms or 0,
+                "avg": lk_absent_ms or 0,
+                "max": lk_absent_ms or 0,
+                "min": lk_absent_ms or 0,
             },
             [False] * num_tests,
             ne_pass,
@@ -263,9 +263,9 @@ def _test_single_adapter(
         (
             "LOOKUP (exist)",
             {
-                "avg": lk_ms or 0,
-                "max": lk_ms or 0,
-                "min": lk_ms or 0,
+                "avg": lk_exist_ms or 0,
+                "max": lk_exist_ms or 0,
+                "min": lk_exist_ms or 0,
             },
             [True] * exist_pass + [False] * (num_tests - exist_pass),
             exist_pass,

--- a/lmcache/v1/check/check_mode_test_l2_adapter.py
+++ b/lmcache/v1/check/check_mode_test_l2_adapter.py
@@ -141,6 +141,7 @@ async def run_test_mode(model: str, **kwargs):
         return
 
     num_tests = kwargs.get("num_keys", 5)
+    settle_time = kwargs.get("settle_time", 0.0)
 
     for idx, adapter_cfg in enumerate(l2_cfg.adapters):
         adapter = create_l2_adapter(adapter_cfg)
@@ -153,6 +154,7 @@ async def run_test_mode(model: str, **kwargs):
                 num_tests,
                 obj_size=obj_size,
                 kv_dtype=kv_dtype,
+                settle_time=settle_time,
             )
         except Exception as e:
             print("  Test Failed - Error: %s" % e)
@@ -166,6 +168,7 @@ def _test_single_adapter(
     num_tests,
     obj_size=DEFAULT_OBJ_SIZE,
     kv_dtype=torch.float32,
+    settle_time=0.0,
 ):
     """Run all test phases against one adapter."""
     # -- Prepare test data -----------------------------------
@@ -190,23 +193,14 @@ def _test_single_adapter(
     adapter.submit_unlock(non_exist_keys)
 
     # -- Phase 2: store existing keys ------------------------
-    print("Phase 2: Store operations...")
-    store_times = []
-    store_pass = 0
-    for i in range(num_tests):
-        ms, ok = _run_store_phase(
-            adapter,
-            [exist_keys[i]],
-            [store_objs[i]],
-        )
-        if ms is not None:
-            store_times.append(ms)
-        if ok:
-            store_pass += 1
-        print(
-            "  Store %d/%d %s (%.2fms)"
-            % (i + 1, num_tests, "OK" if ok else "FAIL", ms or 0)
-        )
+    print("Phase 2: Store operations (batch of %d)..." % num_tests)
+    st_ms, st_ok = _run_store_phase(adapter, exist_keys, store_objs)
+    store_pass = num_tests if st_ok else 0
+    print("  Batch store %s (%.2fms)" % ("OK" if st_ok else "FAIL", st_ms or 0))
+
+    if settle_time > 0:
+        print("  Waiting %.1fs for data to settle..." % settle_time)
+        time.sleep(settle_time)
 
     # -- Phase 3: lookup existing keys -----------------------
     print("Phase 3: Lookup existing keys...")
@@ -244,7 +238,7 @@ def _test_single_adapter(
     adapter.submit_unlock(exist_keys)
 
     # -- Summary ---------------------------------------------
-    obj_bytes = obj_size * store_objs[0].tensor.element_size()
+    total_bytes = obj_size * store_objs[0].tensor.element_size() * num_tests
     stats_data = [
         (
             "LOOKUP (absent)",
@@ -259,9 +253,9 @@ def _test_single_adapter(
         (
             "STORE",
             {
-                "avg": (sum(store_times) / len(store_times) if store_times else 0),
-                "max": (max(store_times) if store_times else 0),
-                "min": (min(store_times) if store_times else 0),
+                "avg": st_ms or 0,
+                "max": st_ms or 0,
+                "min": st_ms or 0,
             },
             [True] * store_pass + [False] * (num_tests - store_pass),
             store_pass,
@@ -287,4 +281,4 @@ def _test_single_adapter(
             content_pass,
         ),
     ]
-    print_performance_results(stats_data, obj_bytes=obj_bytes)
+    print_performance_results(stats_data, obj_bytes=total_bytes)

--- a/lmcache/v1/check/check_mode_test_remote.py
+++ b/lmcache/v1/check/check_mode_test_remote.py
@@ -136,7 +136,10 @@ async def run_test_mode(model: str, **kwargs):
 
         # Run the common test framework
         num_tests = kwargs.get("num_keys", 5)
-        await run_common_test_framework(test_context, model, num_tests=num_tests)
+        settle_time = kwargs.get("settle_time", 0.0)
+        await run_common_test_framework(
+            test_context, model, num_tests=num_tests, settle_time=settle_time
+        )
 
     except Exception as e:
         print(f"Test Failed - Error: {e}")

--- a/lmcache/v1/check/check_mode_test_remote.py
+++ b/lmcache/v1/check/check_mode_test_remote.py
@@ -10,9 +10,11 @@ from lmcache.v1.check import check_mode
 
 # Import shared utilities
 from lmcache.v1.check.utils import (
+    DEFAULT_KV_DTYPE_STR,
     EventLoopManager,
     _get_default_metadata,
     create_test_key,
+    parse_kv_dtype,
     run_common_test_framework,
     validate_get_results,
 )
@@ -63,15 +65,22 @@ def create_test_memory_obj(
     )
 
 
-def create_test_data_for_backend(backend, local_cpu_backend, model, num_tests):
+def create_test_data_for_backend(
+    backend,
+    local_cpu_backend,
+    model,
+    num_tests,
+    kv_dtype=None,
+):
     """Create test data for backend based tests"""
     # Group 1: Non-existing keys
+    kw = {} if kv_dtype is None else {"kv_dtype": kv_dtype}
     non_exist_keys = [
-        create_test_key(model, f"non_exist_{i}") for i in range(num_tests)
+        create_test_key(model, f"non_exist_{i}", **kw) for i in range(num_tests)
     ]
 
     # Group 2: Existing keys
-    exist_keys = [create_test_key(model, f"exist_{i}") for i in range(num_tests)]
+    exist_keys = [create_test_key(model, f"exist_{i}", **kw) for i in range(num_tests)]
     exist_memories = [
         create_test_memory_obj(backend, local_cpu_backend) for _ in range(num_tests)
     ]
@@ -82,8 +91,16 @@ def create_test_data_for_backend(backend, local_cpu_backend, model, num_tests):
 @check_mode("test_remote")
 async def run_test_mode(model: str, **kwargs):
     """Run connector test mode"""
+    kv_dtype_str = kwargs.get("kv_dtype") or DEFAULT_KV_DTYPE_STR
+    kv_dtype = parse_kv_dtype(kv_dtype_str)
+    if kv_dtype is None:
+        print("Error: unsupported --kv-dtype '%s'" % kv_dtype_str)
+        return
+
+    obj_size = kwargs.get("obj_size")
+
     config = lmcache_get_or_create_config()
-    metadata = _get_default_metadata(model)
+    metadata = _get_default_metadata(model, kv_dtype=kv_dtype, obj_size=obj_size)
 
     # Create and start event loop manager
     loop_manager = EventLoopManager()
@@ -110,11 +127,16 @@ async def run_test_mode(model: str, **kwargs):
             "async_get_func": async_get_backend,
             "validate_get_func": validate_get_results,
             "test_object": backend,
-            "extra_args": [local_cpu_backend],  # Additional argument for backend tests
+            "extra_args": [
+                local_cpu_backend,
+            ],
+            "kv_dtype": kv_dtype,
+            "obj_size": obj_size,
         }
 
         # Run the common test framework
-        await run_common_test_framework(test_context, model, num_tests=5)
+        num_tests = kwargs.get("num_keys", 5)
+        await run_common_test_framework(test_context, model, num_tests=num_tests)
 
     except Exception as e:
         print(f"Test Failed - Error: {e}")

--- a/lmcache/v1/check/check_mode_test_storage_manager.py
+++ b/lmcache/v1/check/check_mode_test_storage_manager.py
@@ -126,7 +126,10 @@ async def run_test_mode(model: str, **kwargs):
 
         # Run the common test framework
         num_tests = kwargs.get("num_keys", 5)
-        await run_common_test_framework(test_context, model, num_tests=num_tests)
+        settle_time = kwargs.get("settle_time", 0.0)
+        await run_common_test_framework(
+            test_context, model, num_tests=num_tests, settle_time=settle_time
+        )
 
     except Exception as e:
         print(f"Test Failed - Error: {e}")

--- a/lmcache/v1/check/check_mode_test_storage_manager.py
+++ b/lmcache/v1/check/check_mode_test_storage_manager.py
@@ -9,10 +9,12 @@ from lmcache.v1.check import check_mode
 
 # Import shared utilities
 from lmcache.v1.check.utils import (
+    DEFAULT_KV_DTYPE_STR,
     create_storage_manager_with_config,
     create_test_key,
     create_test_memory_obj_for_storage_manager,
     find_remote_backend,
+    parse_kv_dtype,
     run_common_test_framework,
     validate_get_results,
     wait_put_tasks_complete,
@@ -49,15 +51,22 @@ async def async_submit_put_storage_manager(storage_manager, key, memory_obj):
         return False
 
 
-def create_test_data_for_storage_manager(storage_manager, metadata, model, num_tests):
+def create_test_data_for_storage_manager(
+    storage_manager,
+    metadata,
+    model,
+    num_tests,
+    kv_dtype=None,
+):
     """Create test data for storage manager based tests"""
     # Group 1: Non-existing keys
+    kw = {} if kv_dtype is None else {"kv_dtype": kv_dtype}
     non_exist_keys = [
-        create_test_key(model, f"non_exist_{i}") for i in range(num_tests)
+        create_test_key(model, f"non_exist_{i}", **kw) for i in range(num_tests)
     ]
 
     # Group 2: Existing keys
-    exist_keys = [create_test_key(model, f"exist_{i}") for i in range(num_tests)]
+    exist_keys = [create_test_key(model, f"exist_{i}", **kw) for i in range(num_tests)]
     exist_memories = []
     for i in range(num_tests):
         memory_obj = create_test_memory_obj_for_storage_manager(
@@ -85,8 +94,20 @@ def create_test_data_for_storage_manager(storage_manager, metadata, model, num_t
 @check_mode("test_storage_manager")
 async def run_test_mode(model: str, **kwargs):
     """Run connector test mode"""
+    kv_dtype_str = kwargs.get("kv_dtype") or DEFAULT_KV_DTYPE_STR
+    kv_dtype = parse_kv_dtype(kv_dtype_str)
+    if kv_dtype is None:
+        print("Error: unsupported --kv-dtype '%s'" % kv_dtype_str)
+        return
+
+    obj_size = kwargs.get("obj_size")
+
     # Create storage manager using common function
-    storage_manager = create_storage_manager_with_config(model)
+    storage_manager = create_storage_manager_with_config(
+        model,
+        kv_dtype=kv_dtype,
+        obj_size=obj_size,
+    )
 
     try:
         print("Test: Passed - Created storage manager with valid config")
@@ -99,10 +120,13 @@ async def run_test_mode(model: str, **kwargs):
             "async_get_func": async_get_storage_manager,
             "validate_get_func": validate_get_results,
             "test_object": storage_manager,
+            "kv_dtype": kv_dtype,
+            "obj_size": obj_size,
         }
 
         # Run the common test framework
-        await run_common_test_framework(test_context, model, num_tests=5)
+        num_tests = kwargs.get("num_keys", 5)
+        await run_common_test_framework(test_context, model, num_tests=num_tests)
 
     except Exception as e:
         print(f"Test Failed - Error: {e}")

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -20,28 +20,85 @@ from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.remote_backend import RemoteBackend
 from lmcache.v1.storage_backend.storage_manager import StorageManager
 
+DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
 
-def _get_default_metadata(model: str) -> LMCacheMetadata:
-    """Get default metadata for testing"""
+DEFAULT_KV_DTYPE_STR = "bfloat16"
+DEFAULT_OBJ_SIZE = 1024
+
+
+def _compute_kv_shape(
+    obj_size: int,
+) -> tuple:
+    """Compute a kv_shape that yields the given obj_size.
+
+    The returned shape is in vllm format:
+    ``(num_layers, 2, num_tokens, num_heads, head_size)``.
+
+    The final KV_2LTD tensor has
+    ``2 * num_layers * num_tokens * (num_heads * head_size)``
+    elements, which equals *obj_size*.
+
+    We fix ``num_layers=1, num_heads=1`` and split the
+    remaining factor between ``num_tokens`` and ``head_size``
+    so that ``num_tokens * head_size = obj_size // 2``.
+    """
+    if obj_size % 2 != 0:
+        raise ValueError("obj_size must be even (got %d)" % obj_size)
+    half = obj_size // 2
+    # (num_layers, kv_dim, num_tokens, num_heads, head_size)
+    return (1, 2, half, 1, 1)
+
+
+def parse_kv_dtype(kv_dtype_str: str) -> Optional[torch.dtype]:
+    """Parse a kv_dtype string to a torch.dtype.
+
+    Returns None if the string is not recognized.
+    """
+    return DTYPE_MAP.get(kv_dtype_str)
+
+
+def _get_default_metadata(
+    model: str,
+    kv_dtype: torch.dtype = torch.bfloat16,
+    obj_size: Optional[int] = None,
+) -> LMCacheMetadata:
+    """Get default metadata for testing.
+
+    When *obj_size* is given the ``kv_shape`` is computed so
+    that the resulting KV_2LTD tensor has exactly *obj_size*
+    elements.  Otherwise a small default shape is used.
+    """
+    if obj_size is not None:
+        kv_shape = _compute_kv_shape(obj_size)
+    else:
+        kv_shape = _compute_kv_shape(DEFAULT_OBJ_SIZE)
     return LMCacheMetadata(
         model_name=model,
         world_size=8,
         local_world_size=8,
         worker_id=0,
         local_worker_id=0,
-        kv_dtype=torch.bfloat16,
-        kv_shape=(8, 2, 16, 8, 16),
+        kv_dtype=kv_dtype,
+        kv_shape=kv_shape,
     )
 
 
-def create_test_key(model: str, key_id: str = "test_key") -> CacheEngineKey:
+def create_test_key(
+    model: str,
+    key_id: str = "test_key",
+    kv_dtype: torch.dtype = torch.bfloat16,
+) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey(
         model_name=model,
         world_size=8,
         worker_id=0,
         chunk_hash=int(hashlib.sha256(key_id.encode()).hexdigest(), 16),
-        dtype=torch.bfloat16,
+        dtype=kv_dtype,
     )
 
 
@@ -75,14 +132,18 @@ def create_test_memory_obj_for_storage_manager(
     return memory_obj
 
 
-def create_storage_manager_with_config(model: str):
+def create_storage_manager_with_config(
+    model: str,
+    kv_dtype: torch.dtype = torch.bfloat16,
+    obj_size: Optional[int] = None,
+):
     """Create storage manager with default configuration"""
     # First Party
     from lmcache.integration.vllm.utils import lmcache_get_or_create_config
     from lmcache.v1.event_manager import EventManager
 
     config = lmcache_get_or_create_config()
-    metadata = _get_default_metadata(model)
+    metadata = _get_default_metadata(model, kv_dtype=kv_dtype, obj_size=obj_size)
 
     # Create event manager
     event_manager = EventManager()
@@ -212,25 +273,79 @@ async def run_perf_test_with_timeout(func, args_list, timeout=30.0):
         return {"time_stats": {"avg": 0, "max": 0, "min": 0}, "results": []}
 
 
-def print_performance_results(stats_data):
-    """Print performance results in a formatted table"""
+def _format_throughput(avg_ms: float, obj_bytes: int) -> str:
+    """Format throughput as a human-readable string."""
+    if avg_ms <= 0 or obj_bytes <= 0:
+        return "N/A"
+    bps = obj_bytes / (avg_ms / 1000.0)
+    if bps >= 1 << 30:
+        return "%.2f GB/s" % (bps / (1 << 30))
+    if bps >= 1 << 20:
+        return "%.2f MB/s" % (bps / (1 << 20))
+    return "%.2f KB/s" % (bps / (1 << 10))
+
+
+def print_performance_results(
+    stats_data,
+    obj_bytes: int = 0,
+    throughput_ops: Optional[set] = None,
+):
+    """Print performance results in a formatted table.
+
+    Args:
+        stats_data: list of (op, stats, results, pass_count).
+        obj_bytes: size of one object in bytes.  When > 0 a
+            throughput column is shown for operations listed
+            in *throughput_ops*.
+        throughput_ops: set of operation name prefixes that
+            should show throughput (e.g. {"STORE", "LOAD"}).
+            Defaults to common data-transfer operations.
+    """
+    if throughput_ops is None:
+        throughput_ops = {
+            "STORE",
+            "LOAD",
+            "PUT",
+            "GET",
+        }
+    show_tp = obj_bytes > 0
+
+    sep_len = 118 if show_tp else 100
+    tp_hdr = " | %s" % "Throughput".center(14) if show_tp else ""
     print("\nPerformance Results:")
-    print("-" * 100)
+    print("-" * sep_len)
     print(
-        f"| {'Operation':<20} | {'Avg (ms)':>12} | {'Max (ms)':>12} "
-        f"| {'Min (ms)':>12} | {'Pass/All':>10} | {'Pass Rate':>10} |"
+        f"| {'Operation':<20} | {'Avg (ms)':>12} "
+        f"| {'Max (ms)':>12} "
+        f"| {'Min (ms)':>12} "
+        f"| {'Pass/All':>10} "
+        f"| {'Pass Rate':>10} |" + tp_hdr
     )
-    print("-" * 100)
+    print("-" * sep_len)
     for op, stats, results, pass_count in stats_data:
         total = len(results)
         pass_all = f"{pass_count}/{total}"
         pass_rate = pass_count / total * 100 if total > 0 else 0
+        tp_col = ""
+        if show_tp:
+            is_data_op = any(op.startswith(p) for p in throughput_ops)
+            if is_data_op:
+                tp_col = " | %s" % _format_throughput(
+                    stats["avg"],
+                    obj_bytes,
+                ).center(14)
+            else:
+                tp_col = " | %s" % "-".center(14)
 
         print(
-            f"| {op:<20} | {stats['avg']:>12.6f} | {stats['max']:>12.6f} "
-            f"| {stats['min']:>12.6f} | {pass_all:>10} | {pass_rate:>9.1f}% |"
+            f"| {op:<20} "
+            f"| {stats['avg']:>12.6f} "
+            f"| {stats['max']:>12.6f} "
+            f"| {stats['min']:>12.6f} "
+            f"| {pass_all:>10} "
+            f"| {pass_rate:>9.1f}% |" + tp_col
         )
-    print("-" * 100)
+    print("-" * sep_len)
 
 
 def validate_get_results(get_results, exist_keys, exist_memories, num_tests):
@@ -300,14 +415,25 @@ async def run_common_test_framework(
 
     # Create test data using the provided function
     extra_args = test_context.get("extra_args", [])
+    extra_kwargs = {}
+    if "kv_dtype" in test_context:
+        extra_kwargs["kv_dtype"] = test_context["kv_dtype"]
     if extra_args:
         non_exist_keys, exist_keys, exist_memories, num_tests = test_context[
             "create_test_data_func"
-        ](test_context["test_object"], *extra_args, model, num_tests)
+        ](test_context["test_object"], *extra_args, model, num_tests, **extra_kwargs)
     else:
+        kv_dtype = test_context.get("kv_dtype")
+        obj_size = test_context.get("obj_size")
+        meta_kw = {}
+        if kv_dtype:
+            meta_kw["kv_dtype"] = kv_dtype
+        if obj_size is not None:
+            meta_kw["obj_size"] = obj_size
+        metadata = _get_default_metadata(model, **meta_kw)
         non_exist_keys, exist_keys, exist_memories, num_tests = test_context[
             "create_test_data_func"
-        ](test_context["test_object"], _get_default_metadata(model), model, num_tests)
+        ](test_context["test_object"], metadata, model, num_tests, **extra_kwargs)
 
     # Phase 1: exists test (key does not exist)
     print("Phase 1: Testing exists for non-existing keys...")
@@ -390,8 +516,13 @@ async def run_common_test_framework(
         ("GET", get_stats, get_res["results"], get_pass_count),
     ]
 
+    # Compute per-object byte size for throughput display
+    tp_obj_size = test_context.get("obj_size") or DEFAULT_OBJ_SIZE
+    tp_kv_dtype = test_context.get("kv_dtype") or torch.bfloat16
+    obj_bytes = tp_obj_size * torch.tensor([], dtype=tp_kv_dtype).element_size()
+
     # Use common performance results printing
-    print_performance_results(stats_data)
+    print_performance_results(stats_data, obj_bytes=obj_bytes)
 
 
 class EventLoopManager:

--- a/lmcache/v1/check/utils.py
+++ b/lmcache/v1/check/utils.py
@@ -395,6 +395,7 @@ async def run_common_test_framework(
     test_context,
     model: str,
     num_tests: int = 5,
+    settle_time: float = 0.0,
 ):
     """
     Common test framework for both storage manager and remote backend tests.
@@ -468,6 +469,10 @@ async def run_common_test_framework(
     put_pass_count = sum(1 for r in put_res["results"] if r is True)
     pass_rate = put_pass_count / num_tests * 100
     print(f"  Validation: {put_pass_count}/{num_tests} passed ({pass_rate:.1f}%)")
+
+    if settle_time > 0:
+        print("  Waiting %.1fs for data to settle..." % settle_time)
+        await asyncio.sleep(settle_time)
 
     # Phase 3: exists test (key exists)
     print("Phase 3: Testing exists for existing keys...")

--- a/tests/v1/test_basic_check.py
+++ b/tests/v1/test_basic_check.py
@@ -177,10 +177,14 @@ class TestParseArgs:
     def test_defaults(self) -> None:
         with patch("sys.argv", ["basic_check", "--mode", "x"]):
             args = parse_args()
-        assert args.num_keys == 100
+        assert args.num_keys == 5
         assert args.concurrency == 16
         assert args.offset == 0
         assert args.model == "/lmcache_test_model/"
+        assert args.l2_adapter == []
+        assert args.obj_size is None
+        assert args.kv_dtype is None
+        assert args.settle_time == 0.0
 
 
 # --------------- main() tests ---------------
@@ -255,4 +259,8 @@ class TestMain:
             num_keys=5,
             concurrency=2,
             offset=3,
+            l2_adapter=[],
+            obj_size=None,
+            kv_dtype=None,
+            settle_time=0.0,
         )


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

introduces a new test mode for L2 adapters and enhances existing remote and storage manager test modes by adding support for configurable object sizes, KV data types, and settle times. It also updates the performance reporting utilities to calculate and display throughput

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
