### PR TITLE
fix: skip vLLM lookup when hash_algorithm is 'builtin'

### DIFF
--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -81,12 +81,7 @@ class TokenHasher:
 
         # Short-circuit: 'builtin' means Python's built-in hash(), no vLLM lookup needed
         if hash_algorithm == "builtin":
-            logger.info(
-                "Using LMCache builtin hash (Python hash). "
-                "For production environments (non-testing scenarios), "
-                "consider setting a stable hash algorithm (e.g., sha256_cbor) "
-                "to ensure consistent hashing across processes and nodes."
-            )
+            logger.info("Using LMCache builtin hash (Python hash)")
             if os.getenv("PYTHONHASHSEED") is None:
                 logger.warning(
                     "Using builtin hash without PYTHONHASHSEED set. "

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -79,6 +79,22 @@ class TokenHasher:
             logger.info("Using blake3 hash function")
             return _make_blake3_hash_func()
 
+        # Short-circuit: 'builtin' means Python's built-in hash(), no vLLM lookup needed
+        if hash_algorithm == "builtin":
+            logger.info(
+                "Using LMCache builtin hash (Python hash). "
+                "For production environments (non-testing scenarios), "
+                "consider setting a stable hash algorithm (e.g., sha256_cbor) "
+                "to ensure consistent hashing across processes and nodes."
+            )
+            if os.getenv("PYTHONHASHSEED") is None:
+                logger.warning(
+                    "Using builtin hash without PYTHONHASHSEED set. "
+                    "For consistent hashing across processes, "
+                    "set PYTHONHASHSEED (e.g., export PYTHONHASHSEED=0)."
+                )
+            return hash
+
         # Try get_hash_fn_by_name from both locations (PR#27151)
         for module_path in ["vllm.utils.hashing", "vllm.utils"]:
             try:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -103,6 +103,22 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         - Direct imports as fallback
         - sha256_cbor_64bit -> sha256_cbor rename (PR#23673)
         """
+        # Short-circuit: 'builtin' means Python's built-in hash(), no vLLM lookup needed
+        if hash_algorithm == "builtin":
+            logger.info(
+                "Using LMCache builtin hash (Python hash). "
+                "For production environments (non-testing scenarios), "
+                "consider setting a stable hash algorithm (e.g., sha256_cbor) "
+                "to ensure consistent hashing across processes and nodes."
+            )
+            if os.getenv("PYTHONHASHSEED") is None:
+                logger.warning(
+                    "Using builtin hash without PYTHONHASHSEED set. "
+                    "For consistent hashing across processes, "
+                    "set PYTHONHASHSEED (e.g., export PYTHONHASHSEED=0)."
+                )
+            return hash
+
         # Try get_hash_fn_by_name from both locations (PR#27151)
         for module_path in ["vllm.utils.hashing", "vllm.utils"]:
             try:

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -105,12 +105,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         """
         # Short-circuit: 'builtin' means Python's built-in hash(), no vLLM lookup needed
         if hash_algorithm == "builtin":
-            logger.info(
-                "Using LMCache builtin hash (Python hash). "
-                "For production environments (non-testing scenarios), "
-                "consider setting a stable hash algorithm (e.g., sha256_cbor) "
-                "to ensure consistent hashing across processes and nodes."
-            )
+            logger.info("Using LMCache builtin hash (Python hash)")
             if os.getenv("PYTHONHASHSEED") is None:
                 logger.warning(
                     "Using builtin hash without PYTHONHASHSEED set. "

--- a/tests/v1/multiprocess/test_token_hasher.py
+++ b/tests/v1/multiprocess/test_token_hasher.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for TokenHasher."""
 
+# Standard
+from unittest.mock import MagicMock, patch
+import sys
+
 # Third Party
 import numpy as np
 import pytest
@@ -26,6 +30,14 @@ class TestTokenHasher:
         hasher = TokenHasher(chunk_size=256, hash_algorithm="blake3")
         assert hasher.chunk_size == 256
         assert hasher.none_hash is not None
+
+    def test_init_builtin(self) -> None:
+        """builtin hash returns Python's hash() without vLLM lookup."""
+        mock_vllm_hashing = MagicMock()
+        with patch.dict(sys.modules, {"vllm.utils.hashing": mock_vllm_hashing}):
+            hasher = TokenHasher(chunk_size=256, hash_algorithm="builtin")
+        assert hasher.hash_func is hash
+        mock_vllm_hashing.get_hash_fn_by_name.assert_not_called()
 
     def test_hash_tokens_returns_bytes(self, hasher: TokenHasher) -> None:
         h = hasher.hash_tokens([1, 2, 3, 4])

--- a/tests/v1/multiprocess/test_token_hasher.py
+++ b/tests/v1/multiprocess/test_token_hasher.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for TokenHasher."""
 
-# Standard
-from unittest.mock import MagicMock, patch
-import sys
-
 # Third Party
 import numpy as np
 import pytest
@@ -32,12 +28,9 @@ class TestTokenHasher:
         assert hasher.none_hash is not None
 
     def test_init_builtin(self) -> None:
-        """builtin hash returns Python's hash() without vLLM lookup."""
-        mock_vllm_hashing = MagicMock()
-        with patch.dict(sys.modules, {"vllm.utils.hashing": mock_vllm_hashing}):
-            hasher = TokenHasher(chunk_size=256, hash_algorithm="builtin")
+        """builtin hash returns Python's hash() directly."""
+        hasher = TokenHasher(chunk_size=256, hash_algorithm="builtin")
         assert hasher.hash_func is hash
-        mock_vllm_hashing.get_hash_fn_by_name.assert_not_called()
 
     def test_hash_tokens_returns_bytes(self, hasher: TokenHasher) -> None:
         h = hasher.hash_tokens([1, 2, 3, 4])

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from unittest.mock import MagicMock, patch
 import os
-import sys
 
 # Third Party
 import pytest
@@ -67,16 +65,13 @@ def test_chunked_token_database(chunk_length, save_unfull_chunk):
 
 
 def test_builtin_hash_skips_vllm_lookup():
-    """hash_algorithm='builtin' uses Python hash() and skips vLLM lookup."""
-    mock_vllm_hashing = MagicMock()
-    with patch.dict(sys.modules, {"vllm.utils.hashing": mock_vllm_hashing}):
-        cfg = LMCacheEngineConfig.from_legacy(
-            chunk_size=256, backend="cpu", pre_caching_hash_algorithm="builtin"
-        )
-        metadata = dumb_metadata()
-        db = ChunkedTokenDatabase(cfg, metadata)
+    """hash_algorithm='builtin' uses Python hash() directly."""
+    cfg = LMCacheEngineConfig.from_legacy(
+        chunk_size=256, backend="cpu", pre_caching_hash_algorithm="builtin"
+    )
+    metadata = dumb_metadata()
+    db = ChunkedTokenDatabase(cfg, metadata)
     assert db.hash_func is hash
-    mock_vllm_hashing.get_hash_fn_by_name.assert_not_called()
 
 
 @pytest.mark.parametrize("prefix_length", [0, 16, 64, 256])

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import MagicMock, patch
 import os
+import sys
 
 # Third Party
 import pytest
@@ -62,6 +64,19 @@ def test_chunked_token_database(chunk_length, save_unfull_chunk):
             st, ed, key = new_results[j]
             assert st == original_results[j + i][0]
             assert ed == original_results[j + i][1]
+
+
+def test_builtin_hash_skips_vllm_lookup():
+    """hash_algorithm='builtin' uses Python hash() and skips vLLM lookup."""
+    mock_vllm_hashing = MagicMock()
+    with patch.dict(sys.modules, {"vllm.utils.hashing": mock_vllm_hashing}):
+        cfg = LMCacheEngineConfig.from_legacy(
+            chunk_size=256, backend="cpu", pre_caching_hash_algorithm="builtin"
+        )
+        metadata = dumb_metadata()
+        db = ChunkedTokenDatabase(cfg, metadata)
+    assert db.hash_func is hash
+    mock_vllm_hashing.get_hash_fn_by_name.assert_not_called()
 
 
 @pytest.mark.parametrize("prefix_length", [0, 16, 64, 256])


### PR DESCRIPTION
Fixes #2891

**What this PR does / why we need it**:

When `hash_algorithm` is set to `"builtin"`, LMCache was passing that string to vLLM's `get_hash_fn_by_name`, which doesn't recognize it. This caused an unnecessary fallback path and a misleading warning like "Hash function builtin not found in vLLM".

The fix adds an early return in `_get_vllm_hash_func` (`token_database.py`) and `_get_hash_func` (`token_hasher.py`) when the algorithm is `"builtin"`, returning Python's built-in `hash()` directly without ever calling into vLLM. Also logs an INFO message instead of the misleading WARNING, and checks for `PYTHONHASHSEED` in the builtin path.

**Special notes for your reviewers**:

Both `token_database.py` and `token_hasher.py` have the same logic (the multiprocess version is adapted from the single-process one), so both got the same fix.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests