### PR TITLE
feat: Handle partial retrive failure in LMCache MP mode

### DIFF
--- a/docs/design/v1/distributed/storage-manager/storage-manager-read-path.md
+++ b/docs/design/v1/distributed/storage-manager/storage-manager-read-path.md
@@ -1,0 +1,101 @@
+# StorageManager read path
+
+## Scope
+
+This document covers the L1 read APIs in
+`lmcache/v1/distributed/storage_manager.py` that are used after a
+prefetch or lookup has reserved read locks:
+
+- `read_prefetched_results()`
+- `read_prefetched_results_partial()`
+- `finish_read_prefetched()`
+- `PartialReadResult`
+
+The APIs all read from L1 memory. L2 lookup and prefetch decide which
+objects should be present before this path runs.
+
+## Full-read API
+
+`read_prefetched_results(keys)` is the all-or-nothing read API. It calls
+L1 `unsafe_read(keys)` and yields:
+
+- `list[MemoryObj]` when every key is readable.
+- `None` when any key cannot be read.
+
+On failure, or if the caller raises while inside the context manager,
+the storage manager releases read locks for the keys that were read
+successfully and publishes `SM_READ_PREFETCHED_FINISHED`.
+
+On normal success, the caller owns the read locks and must later call
+`finish_read_prefetched(keys)` when it is done consuming the memory
+objects.
+
+## Partial-read API
+
+`read_prefetched_results_partial(keys)` is the partial-recovery variant.
+It never turns a partial miss into `None`. Instead, it yields a
+`PartialReadResult`:
+
+```python
+@dataclass(frozen=True)
+class PartialReadResult:
+    good_objs: list[MemoryObj]
+    good_indices: list[int]
+    bad_indices: list[int]
+```
+
+The index lists are positions in the original `keys` list:
+
+- `good_objs[i]` corresponds to `keys[good_indices[i]]`.
+- `bad_indices` contains positions whose keys were not readable from L1.
+- The order of `good_indices` follows the order of the input keys.
+
+Example:
+
+```python
+keys = [key0, key1, key2, key3]
+
+with storage_manager.read_prefetched_results_partial(keys) as result:
+    # Suppose key1 is missing.
+    assert result.good_indices == [0, 2, 3]
+    assert result.bad_indices == [1]
+```
+
+The partial API is used by multiprocess retrieve so the server can copy
+the chunks that are still available and report exactly which GPU blocks
+were not filled.
+
+## Lock ownership
+
+The partial context manager follows the same ownership rule as the full
+read API for successfully-read objects:
+
+| Exit path | Read locks for good keys |
+|---|---|
+| Normal context exit | Remain held by the caller |
+| Caller exception | Released by the context manager |
+| Internal read exception | Released by the context manager |
+
+On normal exit, callers must call:
+
+```python
+good_keys = [keys[i] for i in result.good_indices]
+storage_manager.finish_read_prefetched(good_keys)
+```
+
+Keys in `bad_indices` did not produce `MemoryObj` values and do not have
+read locks to release.
+
+## Failure classification
+
+Both read APIs share the same internal classification step:
+
+1. Call L1 `unsafe_read(keys)`.
+2. Preserve successful objects and their original input positions.
+3. Track failed key positions separately.
+4. Split failures into `KEY_NOT_EXIST` and `KEY_NOT_READABLE` buckets for
+   anomaly reporting.
+
+`KEY_NOT_EXIST` and `KEY_NOT_READABLE` after prefetch are treated as L1
+read-failure anomalies because the caller is expected to read only after
+reserving the objects.

--- a/docs/design/v1/multiprocess/partial-retrieve.md
+++ b/docs/design/v1/multiprocess/partial-retrieve.md
@@ -1,0 +1,109 @@
+# Multiprocess partial retrieve
+
+## Scope
+
+This document covers the partial-recovery behavior in the multiprocess
+`RETRIEVE` request path:
+
+- Protocol response in `lmcache/v1/multiprocess/protocols/engine.py`
+- Server retrieve implementation in `lmcache/v1/multiprocess/server.py`
+- Interaction with `StorageManager.read_prefetched_results_partial()`
+
+## Protocol contract
+
+`RETRIEVE` returns:
+
+```python
+tuple[bytes, tuple[bool, list[int]]]
+```
+
+The outer `bytes` value is the CUDA event IPC handle. The inner tuple is:
+
+- `bool`: `True` if the server completed the retrieve path and copied all
+  available chunks. This can still be true when some chunks were missing.
+- `list[int]`: GPU block IDs that were not filled because their source
+  chunks were missing from L1.
+
+On full success, the failed block list is empty:
+
+```python
+(event_handle, (True, []))
+```
+
+On partial success, the failed block list contains the exact destination
+GPU block IDs for missing chunks:
+
+```python
+(event_handle, (True, failed_block_ids))
+```
+
+On an exception that prevents retrieve from completing, the server returns
+all requested GPU block IDs as failed:
+
+```python
+(event_handle, (False, list(gpu_block_ids)))
+```
+
+Callers must treat `success=True` as "the server completed the operation",
+not as "every requested block was filled". The authoritative per-block
+failure signal is `failed_block_ids`.
+
+## Why there are two copy loops
+
+The full-hit path uses `_retrieve_loop()`. It batches contiguous chunks
+because the memory objects and destination GPU block IDs have the same
+dense ordering.
+
+The partial-hit path uses `_partial_retrieve_loop()`. It processes one
+chunk at a time because missing chunks make the source objects sparse:
+
+```text
+keys:             [k0, k1, k2, k3]
+good_indices:     0       2   3
+bad_indices:          1
+gpu block ranges: [b0] [b1] [b2] [b3]
+```
+
+`good_objs` contains only `[obj0, obj2, obj3]`, so batching it as a dense
+list would scatter `obj2` into `b1`. The partial loop uses
+`good_indices` to slice the correct destination block range for each
+object.
+
+## Retrieve flow
+
+1. Convert the IPC key into per-chunk `ObjectKey` values.
+2. Stage all destination GPU block IDs once.
+3. Enter `read_prefetched_results_partial(obj_keys)`.
+4. Convert every `bad_index` into its GPU block-ID range and append it to
+   `failed_block_ids`.
+5. Copy available chunks:
+   - Use `_retrieve_loop()` when there are no bad indices.
+   - Use `_partial_retrieve_loop()` when some chunks are missing.
+6. On normal context exit, schedule `finish_read_prefetched(good_keys)` on
+   the host callback path so read locks are released after GPU work is
+   enqueued.
+7. Return the event IPC handle and `(True, failed_block_ids)`.
+
+## Lock ownership
+
+`read_prefetched_results_partial()` leaves read locks held on normal exit.
+`MPCacheEngine.retrieve()` therefore builds:
+
+```python
+prefetched_keys = [obj_keys[i] for i in partial_result.good_indices]
+```
+
+and calls `finish_read_prefetched(prefetched_keys)` after the GPU copy has
+been enqueued. Missing chunks never acquired read locks and are not passed
+to `finish_read_prefetched()`.
+
+If an exception occurs inside the context manager, the storage manager
+releases any successfully acquired read locks before the exception leaves
+the context.
+
+## APC-aligned skips
+
+Both loops honor `skip_first_n_tokens`. This prevents retrieve from
+overwriting APC-shared prefix blocks. The full loop computes the skip for
+each dense batch; the partial loop computes it for each surviving chunk
+using that chunk's original index.

--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -198,8 +198,12 @@ methods:
 - ``reserve_write()`` / ``finish_write()`` -- Two-phase write into L1.
 - ``submit_prefetch_task()`` / ``query_prefetch_status()`` -- Async lookup +
   L2 prefetch.
-- ``read_prefetched_results()`` / ``finish_read_prefetched()`` -- Read
-  prefetched data from L1 with automatic lock management.
+- ``read_prefetched_results()`` -- Read prefetched data from L1 with
+  all-or-nothing semantics.
+- ``read_prefetched_results_partial()`` -- Read partial prefetched data from
+  L1 with per-key success and failure indices.
+- ``finish_read_prefetched()`` -- Release read locks after prefetched data has
+  been consumed.
 
 L1Manager
 ~~~~~~~~~

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1125,8 +1125,7 @@ class LMCacheMPWorkerAdapter:
             success, failed_block_ids = r_result
             if failed_block_ids:
                 logger.warning(
-                    "Retrieve for request_id=%s had %d failed block(s) "
-                    "out of %d total",
+                    "Retrieve for request_id=%s had %d failed block(s) out of %d total",
                     request_id,
                     len(failed_block_ids),
                     len(r_block_ids),

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -291,7 +291,8 @@ class LoadStoreOp:
 
 
 StoreResult = bool
-RetrieveResult = bool
+# (success, failed_block_ids): failed_block_ids is empty on full success.
+RetrieveResult = tuple[bool, list[int]]
 LookupResult = int
 
 
@@ -1114,20 +1115,32 @@ class LMCacheMPWorkerAdapter:
                     request_id,
                 )
 
-        for request_id, (r_future, _) in self.retrieve_futures.items():
+        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
             if not r_future.query():
                 continue
 
             r_result = r_future.result()
             finished_retrieves.add(request_id)
 
-            if not r_result:
-                logger.error(
-                    "Something went wrong when processing the "
-                    "retrieve request for request_id=%s, result=%s",
+            success, failed_block_ids = r_result
+            if failed_block_ids:
+                logger.warning(
+                    "Retrieve for request_id=%s had %d failed block(s) "
+                    "out of %d total",
                     request_id,
-                    r_result,
+                    len(failed_block_ids),
+                    len(r_block_ids),
                 )
+                self.error_block_ids.update(failed_block_ids)
+            elif not success:
+                # No block-level detail available; mark all blocks as failed.
+                logger.error(
+                    "Retrieve for request_id=%s failed with no block details; "
+                    "marking all %d block(s) as failed",
+                    request_id,
+                    len(r_block_ids),
+                )
+                self.error_block_ids.update(r_block_ids)
 
         # Remove the finished requests from the tracking dicts
         for request_id in finished_stores:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1124,22 +1124,21 @@ class LMCacheMPWorkerAdapter:
 
             success, failed_block_ids = r_result
             if failed_block_ids:
-                logger.warning(
-                    "Retrieve for request_id=%s had %d failed block(s) out of %d total",
-                    request_id,
-                    len(failed_block_ids),
-                    len(r_block_ids),
-                )
+                if not success:
+                    logger.error(
+                        "Retrieve for request_id=%s failed entirely; "
+                        "%d block(s) marked as failed",
+                        request_id,
+                        len(failed_block_ids),
+                    )
+                else:
+                    logger.warning(
+                        "Retrieve for request_id=%s: %d/%d block(s) failed",
+                        request_id,
+                        len(failed_block_ids),
+                        len(r_block_ids),
+                    )
                 self.error_block_ids.update(failed_block_ids)
-            elif not success:
-                # No block-level detail available; mark all blocks as failed.
-                logger.error(
-                    "Retrieve for request_id=%s failed with no block details; "
-                    "marking all %d block(s) as failed",
-                    request_id,
-                    len(r_block_ids),
-                )
-                self.error_block_ids.update(r_block_ids)
 
         # Remove the finished requests from the tracking dicts
         for request_id in finished_stores:

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -5,6 +5,7 @@ Distributed multi-tier storage manager for MP mode
 
 # Standard
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Iterator, Literal
 import time
 
@@ -47,6 +48,46 @@ from lmcache.v1.mp_observability.trace.decorator import (
 )
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class PartialReadResult:
+    """Outcome of a partial L1 read where some keys may be missing."""
+
+    good_objs: list[MemoryObj]
+    """Memory objects found in L1 storage."""
+
+    good_indices: list[int]
+    """Positions of the found keys in the original keys list."""
+
+    bad_indices: list[int]
+    """Positions of the missing keys in the original keys list."""
+
+
+@dataclass(frozen=True)
+class _ReadClassification:
+    """Classified outcome of a single unsafe_read call."""
+
+    good_keys: list[ObjectKey]
+    """Keys whose objects were successfully read."""
+
+    good_objs: list[MemoryObj]
+    """Memory objects corresponding to good_keys, in the same order."""
+
+    good_indices: list[int]
+    """Positions of good_keys in the original keys list."""
+
+    bad_keys: list[ObjectKey]
+    """Keys whose read failed for any reason."""
+
+    bad_indices: list[int]
+    """Positions of bad_keys in the original keys list."""
+
+    not_found_keys: list[ObjectKey]
+    """Subset of bad_keys that were absent from L1 (KEY_NOT_EXIST)."""
+
+    write_locked_keys: list[ObjectKey]
+    """Subset of bad_keys that were write-locked (KEY_NOT_READABLE)."""
 
 
 class StorageManager:
@@ -263,61 +304,39 @@ class StorageManager:
                 "StorageManager.read_prefetched_results.__enter__",
                 {"keys": keys},
             )
-        read_results = self._l1_manager.unsafe_read(keys)
-        good_keys: list[ObjectKey] = []
-        good_objs: list[MemoryObj] = []
-        bad_keys: list[ObjectKey] = []
-        not_found_keys: list[ObjectKey] = []
-        write_locked_keys: list[ObjectKey] = []
-        all_good = True
-        for k, (e, o) in read_results.items():
-            if o is None:
-                logger.error(
-                    "Failed to read prefetched object %s from L1 storage: %s",
-                    k,
-                    strerror(e),
-                )
-                bad_keys.append(k)
-                all_good = False
-                if e == L1Error.KEY_NOT_EXIST:
-                    not_found_keys.append(k)
-                elif e == L1Error.KEY_NOT_READABLE:
-                    write_locked_keys.append(k)
-                continue
-
-            good_keys.append(k)
-            good_objs.append(o)
+        cls = self._classify_unsafe_read(keys)
 
         # L1 read-failure anomaly reporting: unsafe_read is required to be
         # called post-reserve_read, so any failure here is a lock/eviction
         # race, not a normal cache miss.
-        if not_found_keys:
+        if cls.not_found_keys:
             self._event_bus.publish(
                 Event(
                     event_type=EventType.L1_READ_FAILED,
                     metadata={
                         "during": "l1_retrieve",
                         "reason": "not_found",
-                        "keys": not_found_keys,
+                        "keys": cls.not_found_keys,
                     },
                 )
             )
-        if write_locked_keys:
+        if cls.write_locked_keys:
             self._event_bus.publish(
                 Event(
                     event_type=EventType.L1_READ_FAILED,
                     metadata={
                         "during": "l1_retrieve",
                         "reason": "write_locked",
-                        "keys": write_locked_keys,
+                        "keys": cls.write_locked_keys,
                     },
                 )
             )
 
+        all_good = not cls.bad_keys
         successfully_yielded = False
 
         try:
-            yield good_objs if all_good else None
+            yield cls.good_objs if all_good else None
             successfully_yielded = True
         except Exception:
             logger.exception(
@@ -328,13 +347,13 @@ class StorageManager:
             # Decrease the read lock for all successfully read memory objects
             # if None is yielded or exception occurs during caller's processing
             if not all_good or not successfully_yielded:
-                self._l1_manager.finish_read(good_keys)
+                self._l1_manager.finish_read(cls.good_keys)
                 self._event_bus.publish(
                     Event(
                         event_type=EventType.SM_READ_PREFETCHED_FINISHED,
                         metadata={
-                            "succeeded_keys": good_keys,
-                            "failed_keys": bad_keys,
+                            "succeeded_keys": cls.good_keys,
+                            "failed_keys": cls.bad_keys,
                         },
                     )
                 )
@@ -343,6 +362,62 @@ class StorageManager:
                     "lmcache.v1.distributed.storage_manager."
                     "StorageManager.read_prefetched_results.__exit__",
                     {"keys": keys},
+                )
+
+    @contextmanager
+    def read_prefetched_results_partial(
+        self,
+        keys: list[ObjectKey],
+    ) -> Iterator[PartialReadResult]:
+        """
+        Like read_prefetched_results, but yields partial results instead of
+        aborting when some keys are missing.
+
+        Always yields a PartialReadResult with the objects that were found and
+        the indices of both hits and misses in the original keys list.
+
+        Args:
+            keys (list[ObjectKey]): List of object keys to read from L1.
+
+        Yields:
+            PartialReadResult: Found memory objects and their positions, plus
+                the positions of every key that was not found.
+
+        Note:
+            On the normal exit path the caller is responsible for calling
+            finish_read_prefetched() with the good keys once done.
+
+            On exception, read locks for successfully-read objects are released
+            automatically and the corresponding event is published.
+
+            Keys that were not found never acquired a read lock.
+        """
+        cls = self._classify_unsafe_read(keys)
+
+        successfully_yielded = False
+        try:
+            yield PartialReadResult(
+                good_objs=cls.good_objs,
+                good_indices=cls.good_indices,
+                bad_indices=cls.bad_indices,
+            )
+            successfully_yielded = True
+        except Exception:
+            logger.exception(
+                "Exception occurred while processing read prefetched results",
+            )
+            raise
+        finally:
+            if not successfully_yielded:
+                self._l1_manager.finish_read(cls.good_keys)
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.SM_READ_PREFETCHED_FINISHED,
+                        metadata={
+                            "succeeded_keys": cls.good_keys,
+                            "failed_keys": cls.bad_keys,
+                        },
+                    )
                 )
 
     @enable_tracing()
@@ -639,3 +714,52 @@ class StorageManager:
             True if memory is consistent, False otherwise.
         """
         return self._l1_manager.memcheck()
+
+    def _classify_unsafe_read(self, keys: list[ObjectKey]) -> _ReadClassification:
+        """Call L1 unsafe_read and split results into typed good/bad buckets.
+
+        Args:
+            keys: Ordered list of object keys to read from L1.
+
+        Returns:
+            _ReadClassification with all success/failure buckets populated,
+            preserving the original key order in good_indices and bad_indices.
+        """
+        read_results = self._l1_manager.unsafe_read(keys)
+
+        good_keys: list[ObjectKey] = []
+        good_objs: list[MemoryObj] = []
+        good_indices: list[int] = []
+        bad_keys: list[ObjectKey] = []
+        bad_indices: list[int] = []
+        not_found_keys: list[ObjectKey] = []
+        write_locked_keys: list[ObjectKey] = []
+
+        for idx, k in enumerate(keys):
+            e, o = read_results[k]
+            if o is None:
+                logger.error(
+                    "Failed to read prefetched object %s from L1 storage: %s",
+                    k,
+                    strerror(e),
+                )
+                bad_keys.append(k)
+                bad_indices.append(idx)
+                if e == L1Error.KEY_NOT_EXIST:
+                    not_found_keys.append(k)
+                elif e == L1Error.KEY_NOT_READABLE:
+                    write_locked_keys.append(k)
+            else:
+                good_keys.append(k)
+                good_objs.append(o)
+                good_indices.append(idx)
+
+        return _ReadClassification(
+            good_keys=good_keys,
+            good_objs=good_objs,
+            good_indices=good_indices,
+            bad_keys=bad_keys,
+            bad_indices=bad_indices,
+            not_found_keys=not_found_keys,
+            write_locked_keys=write_locked_keys,
+        )

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -90,10 +90,16 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         #   - event_ipc_handle: bytes - CUDA event IPC handle for synchronization
         #   - skip_first_n_tokens: int - Number of tokens to skip writing at the
         #     start of the retrieve range (to avoid overwriting APC-shared blocks)
-        # Returns: tuple[bytes, bool] - (CUDA event handle, success flag)
+        # Returns: tuple[bytes, tuple[bool, list[int]]]
+        #   - bytes: CUDA event IPC handle signalling completion
+        #   - tuple[bool, list[int]]:
+        #       - bool: True if at least some chunks were retrieved successfully,
+        #               False if the entire operation failed (e.g. exception)
+        #       - list[int]: GPU block IDs that failed to load.
+        #                    Empty on full success; all block IDs on total failure.
         "RETRIEVE": ProtocolDefinition(
             payload_classes=[KeyType, int, list[int], bytes, int],
-            response_class=tuple[bytes, bool],
+            response_class=tuple[bytes, tuple[bool, list[int]]],
             handler_type=HandlerType.BLOCKING,
         ),
         # Submit a prefix lookup; job is tracked server-side by request_id

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -578,8 +578,19 @@ class MPCacheEngine:
             good_objs: list[MemoryObj],
             good_indices: list[int],
         ) -> None:
+            """Copy a sparse subset of memory objects to GPU.
+
+            Used when only some chunks were found (partial cache hit), so
+            objects must be processed individually because their positions
+            within the full block-ID list are non-contiguous.
+
+            Args:
+                good_objs: Memory objects that were successfully retrieved
+                good_indices: Chunk indices that correspond to each entry in good_objs.
+            """
             # Partial failure path: indices are non-contiguous so process
             # each chunk individually instead of batching.
+            num_groups = gpu_context.kv_layer_groups_manager.num_groups
             for memory_obj, chunk_idx in zip(good_objs, good_indices, strict=True):
                 chunk_start_token = chunk_idx * self.chunk_size
                 effective_start = max(chunk_start_token, skip_first_n_tokens)
@@ -603,22 +614,26 @@ class MPCacheEngine:
                 block_end = block_start + blocks_per_chunk
                 chunk_block_ids_gpu = all_block_ids_gpu[block_start:block_end]
 
-                tmp_buffers = gpu_context.get_tmp_gpu_buffer_batched(self.chunk_size, 1)
-                tmp_buffer = tmp_buffers[0]
-                assert memory_obj.tensor is not None
-                lmcache_memcpy_async_h2d(memory_obj, tmp_buffer)
-
-                lmc_ops.multi_layer_block_kv_transfer(
-                    gpu_context.kv_pointers,
-                    [tmp_buffer.data_ptr()],
-                    chunk_block_ids_gpu,
-                    gpu_context.device,
-                    lmc_ops.TransferDirection.H2D,
-                    gpu_context.shape_desc,
-                    self.chunk_size,
-                    gpu_context.gpu_kv_format_,
-                    skip_blocks_in_chunk,
+                lmcache_memcpy_async_h2d(
+                    memory_obj,
+                    gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=0),
                 )
+                for group_idx in range(num_groups):
+                    tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
+                        1, group_idx
+                    )
+                    group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
+                    lmc_ops.multi_layer_block_kv_transfer(
+                        group_kv_pointers,
+                        [tmp_buffers[0].data_ptr()],
+                        chunk_block_ids_gpu,
+                        gpu_context.device,
+                        lmc_ops.TransferDirection.H2D,
+                        gpu_context.get_shape_desc(group_idx),
+                        self.chunk_size,
+                        gpu_context.gpu_kv_format_,
+                        skip_blocks_in_chunk,
+                    )
 
         with (
             torch.cuda.device(gpu_context.device),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -25,7 +25,11 @@ from lmcache.v1.distributed.config import (
     add_storage_manager_args,
     parse_args_to_config,
 )
-from lmcache.v1.distributed.storage_manager import PrefetchHandle, StorageManager
+from lmcache.v1.distributed.storage_manager import (
+    PartialReadResult,
+    PrefetchHandle,
+    StorageManager,
+)
 from lmcache.v1.gpu_connector.gpu_ops import (
     lmcache_memcpy_async_d2h,
     lmcache_memcpy_async_h2d,
@@ -442,7 +446,7 @@ class MPCacheEngine:
         gpu_block_ids: list[int],
         event_ipc_handle: bytes,
         skip_first_n_tokens: int = 0,
-    ) -> tuple[bytes, bool]:
+    ) -> tuple[bytes, tuple[bool, list[int]]]:
         """
         Retrieves the CPU KV cache and put into GPU blocks.
 
@@ -458,9 +462,11 @@ class MPCacheEngine:
                 requests.
 
         Returns:
-            tuple[bytes, bool]: The first element is the IPC handle of the event
-                that signals the completion of the retrieve operation. The second
-                element indicates whether the key was successfully retrieved.
+            tuple[bytes, tuple[bool, list[int]]]: The first element is the IPC
+                handle of the event that signals completion. The second element
+                is (success, failed_block_ids). success is False only on an
+                unrecoverable exception; failed_block_ids lists GPU block IDs
+                that were not loaded (empty on full success).
         """
         session = self.session_manager.get_or_create(key.request_id)
         session.set_tokens(list(key.token_ids))
@@ -569,6 +575,52 @@ class MPCacheEngine:
                         skip_blocks_in_chunk,
                     )
 
+        def _partial_retrieve_loop(
+            good_objs: list[MemoryObj],
+            good_indices: list[int],
+        ) -> None:
+            # Partial failure path: indices are non-contiguous so process
+            # each chunk individually instead of batching.
+            for memory_obj, chunk_idx in zip(good_objs, good_indices, strict=False):
+                chunk_start_token = chunk_idx * self.chunk_size
+                effective_start = max(chunk_start_token, skip_first_n_tokens)
+                if effective_start >= chunk_start_token + self.chunk_size:
+                    # Entire chunk is within APC range, skip it
+                    continue
+
+                skip_tokens_in_chunk = max(0, effective_start - chunk_start_token)
+                if skip_tokens_in_chunk % gpu_context.block_size != 0:
+                    logger.error(
+                        "skip_first_n_tokens (%d) is not aligned to block_size (%d), "
+                        "rounding down from %d tokens to %d blocks",
+                        skip_first_n_tokens,
+                        gpu_context.block_size,
+                        skip_tokens_in_chunk,
+                        skip_tokens_in_chunk // gpu_context.block_size,
+                    )
+                skip_blocks_in_chunk = skip_tokens_in_chunk // gpu_context.block_size
+
+                block_start = chunk_idx * blocks_per_chunk
+                block_end = block_start + blocks_per_chunk
+                chunk_block_ids_gpu = all_block_ids_gpu[block_start:block_end]
+
+                tmp_buffers = gpu_context.get_tmp_gpu_buffer_batched(self.chunk_size, 1)
+                tmp_buffer = tmp_buffers[0]
+                assert memory_obj.tensor is not None
+                lmcache_memcpy_async_h2d(memory_obj, tmp_buffer)
+
+                lmc_ops.multi_layer_block_kv_transfer(
+                    gpu_context.kv_pointers,
+                    [tmp_buffer.data_ptr()],
+                    chunk_block_ids_gpu,
+                    gpu_context.device,
+                    lmc_ops.TransferDirection.H2D,
+                    gpu_context.shape_desc,
+                    self.chunk_size,
+                    gpu_context.gpu_kv_format_,
+                    skip_blocks_in_chunk,
+                )
+
         with (
             torch.cuda.device(gpu_context.device),
             torch.cuda.stream(gpu_context.stream),
@@ -579,15 +631,29 @@ class MPCacheEngine:
             event = torch.cuda.Event(interprocess=True)
 
             prefetched_keys: list[ObjectKey] = []
+            failed_block_ids: list[int] = []
             retrieve_succeeded = False
             total_bytes = 0
             try:
-                with self.storage_manager.read_prefetched_results(
+                with self.storage_manager.read_prefetched_results_partial(
                     obj_keys
-                ) as memory_objs:
-                    if not memory_objs or len(memory_objs) != len(obj_keys):
-                        logger.error("Some keys not found during retrieve!")
-                        return event.ipc_handle(), False
+                ) as partial_result:
+                    for bad_idx in partial_result.bad_indices:
+                        block_start = bad_idx * blocks_per_chunk
+                        block_end = block_start + blocks_per_chunk
+                        failed_block_ids.extend(gpu_block_ids[block_start:block_end])
+
+                    if partial_result.good_objs:
+                        prefetched_keys = [
+                            obj_keys[i] for i in partial_result.good_indices
+                        ]
+                        if partial_result.bad_indices:
+                            _partial_retrieve_loop(
+                                partial_result.good_objs,
+                                partial_result.good_indices,
+                            )
+                        else:
+                            _retrieve_loop(obj_keys, partial_result.good_objs)
 
                     prefetched_keys = obj_keys[: len(memory_objs)]
                     total_bytes = sum(mo.get_size() for mo in memory_objs)
@@ -596,10 +662,10 @@ class MPCacheEngine:
                 retrieve_succeeded = True
             except Exception:
                 logger.exception("Cannot retrieve keys due to exception")
-                return event.ipc_handle(), False
+                return event.ipc_handle(), (False, list(gpu_block_ids))
             finally:
                 event.record()
-                if retrieve_succeeded:
+                if retrieve_succeeded and prefetched_keys:
                     gpu_context.cupy_stream.launch_host_func(
                         self.storage_manager.finish_read_prefetched,
                         prefetched_keys,
@@ -619,15 +685,26 @@ class MPCacheEngine:
                         },
                     ),
                 )
-        tokens_retrieved = len(obj_keys) * self.chunk_size
+        tokens_retrieved = len(prefetched_keys) * self.chunk_size
         ed = time.perf_counter()
-        logger.info(
-            "Retrieved %d tokens in %.3f seconds",
-            tokens_retrieved,
-            ed - st,
-        )
+        if failed_block_ids:
+            logger.warning(
+                "Partial retrieve: %d/%d chunks succeeded (%d tokens), "
+                "%d block(s) failed, in %.3f seconds",
+                len(prefetched_keys),
+                len(obj_keys),
+                tokens_retrieved,
+                len(failed_block_ids),
+                ed - st,
+            )
+        else:
+            logger.info(
+                "Retrieved %d tokens in %.3f seconds",
+                tokens_retrieved,
+                ed - st,
+            )
 
-        return event.ipc_handle(), True
+        return event.ipc_handle(), (True, failed_block_ids)
 
     def _find_layout_desc(
         self,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -26,7 +26,6 @@ from lmcache.v1.distributed.config import (
     parse_args_to_config,
 )
 from lmcache.v1.distributed.storage_manager import (
-    PartialReadResult,
     PrefetchHandle,
     StorageManager,
 )
@@ -604,7 +603,6 @@ class MPCacheEngine:
                 block_end = block_start + blocks_per_chunk
                 chunk_block_ids_gpu = all_block_ids_gpu[block_start:block_end]
 
-                # Stage the single chunk to a temp GPU buffer, then scatter it into the designated physical blocks
                 tmp_buffers = gpu_context.get_tmp_gpu_buffer_batched(self.chunk_size, 1)
                 tmp_buffer = tmp_buffers[0]
                 assert memory_obj.tensor is not None
@@ -655,7 +653,6 @@ class MPCacheEngine:
                                 partial_result.good_indices,
                             )
                         else:
-                            # If there are no bad indices, we can batch the retrieve loop instead of per-chunk copies.
                             _retrieve_loop(obj_keys, partial_result.good_objs)
 
                     prefetched_keys = obj_keys[: len(memory_objs)]

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -510,9 +510,47 @@ class MPCacheEngine:
 
         blocks_per_chunk = self.chunk_size // gpu_context.block_size
 
+        def _copy_batch_to_gpu(
+            memory_obj_batch: tuple[MemoryObj, ...],
+            chunk_block_ids_gpu: torch.Tensor,
+            skip_blocks_in_chunk: int,
+        ) -> None:
+            """H2D copy and KV scatter for one contiguous batch of chunks.
+
+            Args:
+                memory_obj_batch: One or more CPU memory objects to transfer,
+                    each occupying its own batch slot (chunk_idx 0, 1, …).
+                chunk_block_ids_gpu: GPU block IDs covering the full batch.
+                skip_blocks_in_chunk: Number of leading blocks to skip when
+                    scattering (APC-aligned skip).
+            """
+            batch_len = len(memory_obj_batch)
+            num_groups = gpu_context.kv_layer_groups_manager.num_groups
+            # H2D copy: each memory_obj maps to its own batch slot
+            for chunk_idx, memory_obj in enumerate(memory_obj_batch):
+                lmcache_memcpy_async_h2d(
+                    memory_obj,
+                    gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
+                )
+            for group_idx in range(num_groups):
+                tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
+                    batch_len, group_idx
+                )
+                group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
+                lmc_ops.multi_layer_block_kv_transfer(
+                    group_kv_pointers,
+                    [tb.data_ptr() for tb in tmp_buffers],
+                    chunk_block_ids_gpu,
+                    gpu_context.device,
+                    lmc_ops.TransferDirection.H2D,
+                    gpu_context.get_shape_desc(group_idx),
+                    self.chunk_size,
+                    gpu_context.gpu_kv_format_,
+                    skip_blocks_in_chunk,
+                )
+
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
             _BATCH_SIZE = gpu_context.max_batch_size
-            num_groups = gpu_context.kv_layer_groups_manager.num_groups
             for batch_idx, memory_obj_batch in enumerate(
                 batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
             ):
@@ -550,29 +588,9 @@ class MPCacheEngine:
                 ]
 
                 # Copy from CPU to GPU tmp buffers, then scatter to paged KV — per group
-                # H2D copy: each memory_obj maps to its own batch slot
-                for chunk_idx, memory_obj in enumerate(memory_obj_batch):
-                    lmcache_memcpy_async_h2d(
-                        memory_obj,
-                        gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
-                    )
-                for group_idx in range(num_groups):
-                    tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
-                        batch_len, group_idx
-                    )
-                    group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-
-                    lmc_ops.multi_layer_block_kv_transfer(
-                        group_kv_pointers,
-                        [tb.data_ptr() for tb in tmp_buffers],
-                        chunk_block_ids_gpu,
-                        gpu_context.device,
-                        lmc_ops.TransferDirection.H2D,
-                        gpu_context.get_shape_desc(group_idx),
-                        self.chunk_size,
-                        gpu_context.gpu_kv_format_,
-                        skip_blocks_in_chunk,
-                    )
+                _copy_batch_to_gpu(
+                    memory_obj_batch, chunk_block_ids_gpu, skip_blocks_in_chunk
+                )
 
         def _partial_retrieve_loop(
             good_objs: list[MemoryObj],
@@ -590,7 +608,6 @@ class MPCacheEngine:
             """
             # Partial failure path: indices are non-contiguous so process
             # each chunk individually instead of batching.
-            num_groups = gpu_context.kv_layer_groups_manager.num_groups
             for memory_obj, chunk_idx in zip(good_objs, good_indices, strict=True):
                 chunk_start_token = chunk_idx * self.chunk_size
                 effective_start = max(chunk_start_token, skip_first_n_tokens)
@@ -614,26 +631,9 @@ class MPCacheEngine:
                 block_end = block_start + blocks_per_chunk
                 chunk_block_ids_gpu = all_block_ids_gpu[block_start:block_end]
 
-                lmcache_memcpy_async_h2d(
-                    memory_obj,
-                    gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=0),
+                _copy_batch_to_gpu(
+                    (memory_obj,), chunk_block_ids_gpu, skip_blocks_in_chunk
                 )
-                for group_idx in range(num_groups):
-                    tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
-                        1, group_idx
-                    )
-                    group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                    lmc_ops.multi_layer_block_kv_transfer(
-                        group_kv_pointers,
-                        [tmp_buffers[0].data_ptr()],
-                        chunk_block_ids_gpu,
-                        gpu_context.device,
-                        lmc_ops.TransferDirection.H2D,
-                        gpu_context.get_shape_desc(group_idx),
-                        self.chunk_size,
-                        gpu_context.gpu_kv_format_,
-                        skip_blocks_in_chunk,
-                    )
 
         with (
             torch.cuda.device(gpu_context.device),
@@ -670,9 +670,6 @@ class MPCacheEngine:
                         else:
                             _retrieve_loop(obj_keys, partial_result.good_objs)
 
-                    prefetched_keys = obj_keys[: len(memory_objs)]
-                    total_bytes = sum(mo.get_size() for mo in memory_objs)
-                    _retrieve_loop(obj_keys, memory_objs)
                 # Only set True when with-block exits normally
                 retrieve_succeeded = True
             except Exception:

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -581,7 +581,7 @@ class MPCacheEngine:
         ) -> None:
             # Partial failure path: indices are non-contiguous so process
             # each chunk individually instead of batching.
-            for memory_obj, chunk_idx in zip(good_objs, good_indices, strict=False):
+            for memory_obj, chunk_idx in zip(good_objs, good_indices, strict=True):
                 chunk_start_token = chunk_idx * self.chunk_size
                 effective_start = max(chunk_start_token, skip_first_n_tokens)
                 if effective_start >= chunk_start_token + self.chunk_size:
@@ -604,6 +604,7 @@ class MPCacheEngine:
                 block_end = block_start + blocks_per_chunk
                 chunk_block_ids_gpu = all_block_ids_gpu[block_start:block_end]
 
+                # Stage the single chunk to a temp GPU buffer, then scatter it into the designated physical blocks
                 tmp_buffers = gpu_context.get_tmp_gpu_buffer_batched(self.chunk_size, 1)
                 tmp_buffer = tmp_buffers[0]
                 assert memory_obj.tensor is not None
@@ -641,7 +642,8 @@ class MPCacheEngine:
                     for bad_idx in partial_result.bad_indices:
                         block_start = bad_idx * blocks_per_chunk
                         block_end = block_start + blocks_per_chunk
-                        failed_block_ids.extend(gpu_block_ids[block_start:block_end])
+                        bad_gpu_block_ids = gpu_block_ids[block_start:block_end]
+                        failed_block_ids.extend(bad_gpu_block_ids)
 
                     if partial_result.good_objs:
                         prefetched_keys = [
@@ -653,6 +655,7 @@ class MPCacheEngine:
                                 partial_result.good_indices,
                             )
                         else:
+                            # If there are no bad indices, we can batch the retrieve loop instead of per-chunk copies.
                             _retrieve_loop(obj_keys, partial_result.good_objs)
 
                     prefetched_keys = obj_keys[: len(memory_objs)]

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -27,7 +27,7 @@ from lmcache.v1.mp_observability.event_bus import EventBusConfig, init_event_bus
 
 try:
     # First Party
-    from lmcache.v1.distributed.storage_manager import StorageManager
+    from lmcache.v1.distributed.storage_manager import PartialReadResult, StorageManager
 except ImportError:
     # Skip tests if L1Manager cannot be imported
     pytest.skip(

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -713,10 +713,12 @@ class TestFailureEventProduction:
 
             # Allow drain thread to deliver the event.
             assert wait_for_condition(
-                lambda: len(
-                    _events_of_type(captured_events, EventType.L1_ALLOCATION_FAILED)
-                )
-                >= 1,
+                lambda: (
+                    len(
+                        _events_of_type(captured_events, EventType.L1_ALLOCATION_FAILED)
+                    )
+                    >= 1
+                ),
                 timeout=2.0,
             )
 
@@ -764,8 +766,9 @@ class TestFailureEventProduction:
                 assert objs is None  # all_good=False because middle key is gone
 
             assert wait_for_condition(
-                lambda: len(_events_of_type(captured_events, EventType.L1_READ_FAILED))
-                >= 1,
+                lambda: (
+                    len(_events_of_type(captured_events, EventType.L1_READ_FAILED)) >= 1
+                ),
                 timeout=2.0,
             )
 
@@ -777,3 +780,148 @@ class TestFailureEventProduction:
             assert keys[1] in meta["keys"]
         finally:
             sm.close()
+
+
+# =============================================================================
+# Tests for read_prefetched_results_partial (partial-recovery path)
+# =============================================================================
+
+
+class TestReadPrefetchedResultsPartial:
+    """Tests for StorageManager.read_prefetched_results_partial.
+
+    Verifies that the partial-read context manager correctly separates
+    good and bad chunks, returns the right indices, and manages read locks
+    without leaks on all exit paths.
+    """
+
+    def _write_and_prefetch(
+        self,
+        sm: StorageManager,
+        keys: list,
+        layout: MemoryLayoutDesc,
+    ) -> None:
+        """Helper: write keys into L1 then reserve read locks via prefetch."""
+        ret = sm.reserve_write(keys, layout, mode="new")
+        for key in keys:
+            assert key in ret
+        sm.finish_write(list(ret.keys()))
+        handle = sm.submit_prefetch_task(keys, layout)
+        hit_count = sm.query_prefetch_status(handle)
+        assert hit_count == len(keys)
+
+    def test_all_keys_present_returns_full_result(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """When all keys are in L1 the result has no bad indices."""
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i) for i in range(4)]
+        self._write_and_prefetch(sm, keys, basic_layout)
+
+        with sm.read_prefetched_results_partial(keys) as result:
+            assert isinstance(result, PartialReadResult)
+            assert len(result.good_objs) == 4
+            assert result.good_indices == list(range(4))
+            assert result.bad_indices == []
+
+        sm.finish_read_prefetched(keys)
+        sm.close()
+
+    def test_all_keys_missing_returns_empty_good(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """When no key is in L1 the result has no good objects."""
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i + 1000) for i in range(3)]
+        # Do NOT write or prefetch — keys are completely absent.
+
+        with sm.read_prefetched_results_partial(keys) as result:
+            assert isinstance(result, PartialReadResult)
+            assert result.good_objs == []
+            assert result.good_indices == []
+            assert result.bad_indices == list(range(3))
+
+        sm.close()
+
+    def test_partial_failure_correct_indices(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """When the middle key is missing, indices reflect the exact positions.
+
+        keys = [key0, key1, key2, key3]
+        Only key0, key2, key3 are in L1 (key1 is absent).
+        Expected: good_indices=[0,2,3], bad_indices=[1]
+        """
+        sm = StorageManager(basic_storage_manager_config)
+        all_keys = [make_object_key(i + 2000) for i in range(4)]
+        present_keys = [all_keys[0], all_keys[2], all_keys[3]]
+
+        # Write and prefetch only the present keys.
+        self._write_and_prefetch(sm, present_keys, basic_layout)
+
+        with sm.read_prefetched_results_partial(all_keys) as result:
+            assert isinstance(result, PartialReadResult)
+            assert len(result.good_objs) == 3
+            assert result.good_indices == [0, 2, 3]
+            assert result.bad_indices == [1]
+
+        sm.finish_read_prefetched(present_keys)
+        sm.close()
+
+    def test_read_locks_released_on_caller_exception(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """On caller exception the context manager releases all read locks.
+
+        After the exception the good keys must be writable again (i.e., no
+        dangling read locks).
+        """
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i + 3000) for i in range(3)]
+        self._write_and_prefetch(sm, keys, basic_layout)
+
+        with pytest.raises(RuntimeError, match="simulated error"):
+            with sm.read_prefetched_results_partial(keys) as result:
+                assert len(result.good_objs) == 3
+                raise RuntimeError("simulated error")
+
+        # Keys should be writable again — no dangling read locks.
+        ret = sm.reserve_write(keys, basic_layout, mode="update")
+        for key in keys:
+            assert key in ret, f"Key {key} should be writable after lock release"
+
+        sm.close()
+
+    def test_no_lock_leak_when_all_keys_missing(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """No lock leak when good_objs is empty (nothing to release)."""
+        sm = StorageManager(basic_storage_manager_config)
+        keys = [make_object_key(i + 4000) for i in range(3)]
+        # Keys are not in L1, so no read locks are ever acquired.
+
+        with sm.read_prefetched_results_partial(keys) as result:
+            assert result.good_objs == []
+
+        # No exception and no assertion error means no lock leak.
+        sm.close()
+
+    def test_good_indices_order_matches_input_keys(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """good_indices must be ordered by position in the original keys list.
+
+        keys = [key3, key1, key0, key2] — non-sequential hashes but all present.
+        good_indices should be [0, 1, 2, 3] (positions, not hash values).
+        """
+        sm = StorageManager(basic_storage_manager_config)
+        # Deliberately non-sequential order to test index tracking.
+        keys = [make_object_key(h + 5000) for h in [3, 1, 0, 2]]
+        self._write_and_prefetch(sm, keys, basic_layout)
+
+        with sm.read_prefetched_results_partial(keys) as result:
+            assert result.good_indices == [0, 1, 2, 3]
+            assert result.bad_indices == []
+
+        sm.finish_read_prefetched(keys)
+        sm.close()

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -1863,7 +1863,7 @@ def test_cb_store_final_v2_then_normal_lookup(
         .to_cuda_future()
         .result(timeout=DEFAULT_TIMEOUT)
     )
-    assert retrieve_result is True
+    assert retrieve_result == (True, [])
 
     torch.cuda.synchronize()
     for layer in range(client_context.num_layers):

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -210,8 +210,11 @@ def retrieve_keys(
     gpu_block_ids: list[int],
     event: torch.cuda.Event,
     timeout: float = DEFAULT_TIMEOUT,
-) -> list[bool]:
-    """Retrieve keys one at a time using the single-key API."""
+) -> list[tuple[bool, list[int]]]:
+    """Retrieve keys one at a time using the single-key API.
+
+    Returns a list of (success, failed_block_ids) tuples, one per key.
+    """
     results = []
     for i, key in enumerate(keys):
         start = i * BLOCKS_PER_KEY
@@ -480,7 +483,9 @@ def test_store_retrieve_verify(
     )
 
     assert len(retrieve_result) == num_keys
-    assert all(retrieve_result), "All keys should be retrieved successfully"
+    assert all(success for success, _ in retrieve_result), (
+        "All keys should be retrieved successfully"
+    )
 
     # Verify correctness by comparing tensors
     for i in range(num_keys):
@@ -511,7 +516,8 @@ def test_retrieve_partial_miss(
 ):
     """
     Test retrieving when some keys exist and some don't.
-    The retrieve should return ALL FALSE if any key is missing.
+    Keys that exist should be retrieved successfully (success=True, no failed blocks).
+    Keys that don't exist should report failed block IDs.
     """
     # Store first 30 keys (480 pages)
     num_stored = 30
@@ -544,11 +550,13 @@ def test_retrieve_partial_miss(
     )
 
     assert len(retrieve_result) == num_requested
-    # First 30 keys exist, remaining 30 don't
-    assert all(retrieve_result[:num_stored]), "Stored keys should be retrieved"
-    assert not any(retrieve_result[num_stored:]), (
-        "Non-existent keys should fail to retrieve"
-    )
+    # First 30 keys exist: success=True, no failed blocks.
+    for success, failed_blocks in retrieve_result[:num_stored]:
+        assert success, "Stored keys should be retrieved successfully"
+        assert failed_blocks == [], "Stored keys should have no failed blocks"
+    # Remaining 30 keys don't exist: should report failed block IDs.
+    for success, failed_blocks in retrieve_result[num_stored:]:
+        assert failed_blocks, "Non-existent keys should report failed block IDs"
 
     # Doing look up again to ensure data is ready
     lookup_result_2 = lookup_all(client, stored_keys)
@@ -562,7 +570,9 @@ def test_retrieve_partial_miss(
         client, stored_keys, registered_instance, retrieve_block_ids_2, event
     )
     assert len(retrieve_result_2) == num_stored
-    assert all(retrieve_result_2), "All stored keys should be retrieved successfully"
+    assert all(success for success, _ in retrieve_result_2), (
+        "All stored keys should be retrieved successfully"
+    )
 
 
 @pytest.mark.skipif(
@@ -636,7 +646,9 @@ def test_multiple_retrieve_operations(
             client, keys, registered_instance, blocks, event
         )
         assert len(retrieve_result) == keys_per_batch
-        assert all(retrieve_result), "All keys should be retrieved successfully"
+        assert all(success for success, _ in retrieve_result), (
+            "All keys should be retrieved successfully"
+        )
 
     # Verify correctness
     for layer in range(client_context.num_layers):

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -467,7 +467,7 @@ def test_mq_retrieve():
     """
     Test MessageQueue with RETRIEVE request type.
     RETRIEVE takes (key: KeyType, gpu_id: int, gpu_block_ids: list[int],
-    event_ipc_handle: bytes) and returns (bytes, bool).
+    event_ipc_handle: bytes) and returns (bytes, (bool, list[int])).
     """
     # Create test key
     key = create_cache_key(0)
@@ -485,7 +485,7 @@ def test_mq_retrieve():
     helper.run_test(
         request_type=RequestType.RETRIEVE,
         payloads=[key, gpu_id, gpu_block_ids, test_handle, 0],
-        expected_response=(b"\x01" * 64, True),
+        expected_response=(b"\x01" * 64, (True, [])),
         num_requests=1,
     )
 

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -136,7 +136,7 @@ def retrieve_handler(
     gpu_block_ids: list[int],
     event_handler: bytes,
     skip_first_n_tokens: int = 0,
-) -> tuple[bytes, bool]:
+) -> tuple[bytes, tuple[bool, list[int]]]:
     """
     Dummy handler for RETRIEVE requests.
 
@@ -148,7 +148,7 @@ def retrieve_handler(
         skip_first_n_tokens: Number of tokens to skip at retrieve start
 
     Returns:
-        tuple[bytes, bool]: (event handle, success flag)
+        tuple[bytes, tuple[bool, list[int]]]: (event handle, (success, failed_block_ids))
     """
     assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
     assert isinstance(gpu_id, int), f"Expected gpu_id to be int, got {type(gpu_id)}"
@@ -161,7 +161,7 @@ def retrieve_handler(
     assert isinstance(skip_first_n_tokens, int), (
         f"Expected skip_first_n_tokens to be int, got {type(skip_first_n_tokens)}"
     )
-    return b"\x01" * 64, True
+    return b"\x01" * 64, (True, [])
 
 
 # ==============================================================================

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -148,7 +148,7 @@ def retrieve_handler(
         skip_first_n_tokens: Number of tokens to skip at retrieve start
 
     Returns:
-        tuple[bytes, tuple[bool, list[int]]]: (event handle, (success, failed_block_ids))
+        tuple[bytes, tuple[bool, list[int]]]: (event handle, (success, bad_block_ids))
     """
     assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
     assert isinstance(gpu_id, int), f"Expected gpu_id to be int, got {type(gpu_id)}"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Solve #2865 

### Why we need it?
In #1835 , we introduced partial retrieval failure handling for the single-process mode. This PR extends that robustness to the MP flow.

### What this PR does? 
1. **Storage Layer:** Updated to yield both successful and failed chunks (previously only yielded successful ones).
2. **Server Layer:** A new partial retrieval - filters and stores only the "good" blocks to the GPU one by one
3. **Client Layer:** Now captures failed_block_ids and updates the error ID set
4. **Protocol:** Refactored the response format from `tuple[bytes, bool]` to `tuple[bytes, tuple[bool, list[int]]]`

**Special notes for your reviewers**:

Except new added unit tests, I also update related tests since we change the protocol in this PR.

At the same time, I am working on a e2e flow to verify this change too

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MP retrieve protocol and server-side GPU copy path to allow partial cache hits and surface failed GPU block IDs; this affects inter-process API compatibility and correctness of GPU writes under partial-miss scenarios.
> 
> **Overview**
> Enables **partial-recovery** for multiprocess `RETRIEVE` so missing chunks no longer fail the entire retrieve; the server now copies only the available chunks to GPU and reports which GPU block IDs could not be loaded.
> 
> This introduces a new storage-manager context manager `read_prefetched_results_partial` (returning `PartialReadResult` with hit/miss indices), updates the MP protocol/handlers to return `tuple[bytes, (success, failed_block_ids)]`, and updates the vLLM MP adapter + tests to consume the new result and track failed blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3038ae1e258dee2d3beddd2075e6dc56e255abae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->