### PR TITLE
[Bugfix] fix the invalid image path

### DIFF
--- a/docs/source/kv_cache_management/index.rst
+++ b/docs/source/kv_cache_management/index.rst
@@ -18,7 +18,7 @@ The LMCache Worker is a thread within a rank process, which is responsible for t
 - send chunk information to the KV Controller, which include admit and evict message.
 - listens on a port to receive commands from the Cluster Executor and performs corresponding processing.
 
-.. image:: ../../assets/lmcache-controller.png
+.. image:: ../assets/lmcache-controller.png
     :alt: LMCache Controller Architecture Diagram
 
 P2P Related

--- a/docs/source/kv_cache_management/index.rst
+++ b/docs/source/kv_cache_management/index.rst
@@ -18,7 +18,7 @@ The LMCache Worker is a thread within a rank process, which is responsible for t
 - send chunk information to the KV Controller, which include admit and evict message.
 - listens on a port to receive commands from the Cluster Executor and performs corresponding processing.
 
-.. image:: ../assets/lmcache-controller.png
+.. image:: /assets/lmcache-controller.png
     :alt: LMCache Controller Architecture Diagram
 
 P2P Related


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
image path is invalid
<img width="908" height="561" alt="image" src="https://github.com/user-attachments/assets/52c0cc37-2ff5-4223-ac20-9fe2488ecc44" />

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
