### PR TITLE
[MP] Introduce a simple way to register_gauge metrics.

### DIFF
--- a/lmcache/v1/mp_observability/METRICS.md
+++ b/lmcache/v1/mp_observability/METRICS.md
@@ -89,4 +89,18 @@ For implementation guidance on adding new events and subscribers, see [README.md
 
 ---
 
+## MPCacheEngine Observable Gauges
+
+These metrics are registered directly via `register_gauge` (pull-based OTel
+observable gauges) rather than through the EventBus, because they represent
+point-in-time state snapshots that do not correspond to discrete events.
+
+| OTel metric name | Prometheus name | Type | Source | Calculation |
+|---|---|---|---|---|
+| `lmcache_mp.active_prefetch_jobs` | `lmcache_mp_active_prefetch_jobs` | ObservableGauge | `MPCacheEngine._prefetch_jobs` | `len(_prefetch_jobs)` at scrape time |
+
+**What it answers:** How many prefetch jobs are currently in-flight? A sustained high value may indicate slow L2 backends or client-side polling delays.
+
+---
+
 For event metadata contracts (what keys each `EventType` carries), see [EVENTS.md](EVENTS.md).

--- a/lmcache/v1/mp_observability/otel_init.py
+++ b/lmcache/v1/mp_observability/otel_init.py
@@ -13,6 +13,9 @@ Supports two modes, controlled by the ``otlp_endpoint`` field in
 # Future
 from __future__ import annotations
 
+# Standard
+from collections.abc import Callable
+
 # First Party
 from lmcache.logging import init_logger
 
@@ -105,3 +108,38 @@ def init_otel_tracing(otlp_endpoint: str | None = None) -> None:
         "OTel TracerProvider initialised with OTLP exporter (%s)",
         otlp_endpoint,
     )
+
+
+def register_gauge(
+    meter_name: str,
+    gauge_name: str,
+    description: str,
+    func: Callable[[], int | float],
+) -> None:
+    """Register an OTel observable gauge with a callback.
+
+    This is a convenience wrapper that hides the OTel boilerplate.
+    If OTel is not available, the call is silently ignored.
+
+    Args:
+        meter_name: OTel meter name (e.g. ``lmcache.mp_engine``).
+        gauge_name: Metric name (e.g.
+            ``lmcache_mp.active_prefetch_jobs``).
+        description: Human-readable description of the gauge.
+        func: Zero-arg callable returning the current value.
+    """
+    try:
+        # Third Party
+        from opentelemetry import metrics as otel_metrics
+
+        meter = otel_metrics.get_meter(meter_name)
+        meter.create_observable_gauge(
+            gauge_name,
+            callbacks=[lambda _: [otel_metrics.Observation(func())]],
+            description=description,
+        )
+    except ImportError:
+        logger.debug(
+            "opentelemetry package not found, skipping gauge %s",
+            gauge_name,
+        )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
+from functools import partial
 from itertools import islice
 from typing import Generator
 import argparse
@@ -39,6 +40,7 @@ from lmcache.v1.mp_observability.config import (
 )
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.mp_observability.otel_init import register_gauge
 from lmcache.v1.multiprocess.config import (
     MPServerConfig,
     add_mp_server_args,
@@ -198,6 +200,8 @@ class MPCacheEngine:
         self._prefetch_jobs: dict[int, _PrefetchJob] = {}
         self._next_prefetch_job_id: int = 0
         self._prefetch_job_lock = threading.Lock()
+
+        self._setup_metrics()
 
     def register_kv_cache(
         self,
@@ -834,6 +838,7 @@ class MPCacheEngine:
             "registered_gpu_ids": list(self.gpu_contexts.keys()),
             "gpu_context_meta": gpu_context_meta,
             "active_sessions": self.session_manager.active_count(),
+            "active_prefetch_jobs": self._active_prefetch_count(),
             "storage_manager": sm,
         }
 
@@ -873,6 +878,20 @@ class MPCacheEngine:
 
         # Release GPU contexts
         self.gpu_contexts.clear()
+
+    def _active_prefetch_count(self) -> int:
+        """Return the number of active prefetch jobs (thread-safe)."""
+        with self._prefetch_job_lock:
+            return len(self._prefetch_jobs)
+
+    def _setup_metrics(self) -> None:
+        """Register OTel observable gauges for MP engine metrics."""
+        _gauge = partial(register_gauge, "lmcache.mp_engine")
+        _gauge(
+            "lmcache_mp.active_prefetch_jobs",
+            "Number of active prefetch jobs",
+            self._active_prefetch_count,
+        )
 
 
 def add_handler_helper(

--- a/tests/v1/mp_observability/test_register_gauge.py
+++ b/tests/v1/mp_observability/test_register_gauge.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for register_gauge in otel_init."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# First Party
+from lmcache.v1.mp_observability.otel_init import register_gauge
+
+
+class TestRegisterGauge:
+    """Tests for the register_gauge convenience wrapper."""
+
+    def test_creates_observable_gauge(self):
+        """Gauge is created on the correct meter."""
+        # Standard
+        import sys
+
+        mock_meter = MagicMock()
+        mock_otel = MagicMock()
+        mock_otel.get_meter.return_value = mock_meter
+        mock_otel.metrics = mock_otel
+
+        saved = {
+            k: sys.modules.get(k) for k in ("opentelemetry", "opentelemetry.metrics")
+        }
+        sys.modules["opentelemetry"] = mock_otel
+        sys.modules["opentelemetry.metrics"] = mock_otel
+        try:
+            register_gauge(
+                "test.meter",
+                "test.gauge",
+                "A test gauge",
+                lambda: 42,
+            )
+            mock_otel.get_meter.assert_called_once_with("test.meter")
+            mock_meter.create_observable_gauge.assert_called_once()
+            call_kwargs = mock_meter.create_observable_gauge.call_args
+            assert call_kwargs[0][0] == "test.gauge"
+            assert call_kwargs[1]["description"] == "A test gauge"
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    sys.modules.pop(k, None)
+                else:
+                    sys.modules[k] = v
+
+    def test_callback_invokes_func(self):
+        """The OTel callback delegates to the user-provided func."""
+        mock_meter = MagicMock()
+        mock_otel = MagicMock()
+        mock_otel.get_meter.return_value = mock_meter
+        mock_otel.Observation = lambda v: v
+
+        # Standard
+        import sys
+
+        saved = {
+            k: sys.modules.get(k) for k in ("opentelemetry", "opentelemetry.metrics")
+        }
+        sys.modules["opentelemetry"] = mock_otel
+        sys.modules["opentelemetry.metrics"] = mock_otel
+        mock_otel.metrics = mock_otel
+        try:
+            counter = {"value": 0}
+
+            def my_func():
+                counter["value"] += 1
+                return 99
+
+            register_gauge("m", "g", "desc", my_func)
+
+            # Extract the callback that was passed
+            cb_list = mock_meter.create_observable_gauge.call_args[1]["callbacks"]
+            assert len(cb_list) == 1
+            result = cb_list[0](None)
+            assert result == [99]
+            assert counter["value"] == 1
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    sys.modules.pop(k, None)
+                else:
+                    sys.modules[k] = v
+
+    def test_no_otel_logs_debug(self):
+        """When opentelemetry is missing, log debug and skip."""
+        # Standard
+        import sys
+
+        saved = {
+            k: sys.modules.pop(k, None)
+            for k in list(sys.modules)
+            if k.startswith("opentelemetry")
+        }
+        try:
+            # Force ImportError by removing the module
+            with patch(
+                "builtins.__import__",
+                side_effect=ImportError("no otel"),
+            ):
+                # Should not raise
+                register_gauge("m", "g", "desc", lambda: 0)
+        finally:
+            sys.modules.update({k: v for k, v in saved.items() if v is not None})
+
+    def test_register_multiple_gauges(self):
+        """Multiple gauges can be registered without error."""
+        mock_meter = MagicMock()
+        mock_otel = MagicMock()
+        mock_otel.get_meter.return_value = mock_meter
+
+        # Standard
+        import sys
+
+        saved = {
+            k: sys.modules.get(k) for k in ("opentelemetry", "opentelemetry.metrics")
+        }
+        sys.modules["opentelemetry"] = mock_otel
+        sys.modules["opentelemetry.metrics"] = mock_otel
+        mock_otel.metrics = mock_otel
+        try:
+            register_gauge("m", "g1", "d1", lambda: 1)
+            register_gauge("m", "g2", "d2", lambda: 2)
+            assert mock_meter.create_observable_gauge.call_count == 2
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    sys.modules.pop(k, None)
+                else:
+                    sys.modules[k] = v


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Introduce a simple way to register_gauge metrics

<img width="1362" height="944" alt="Clipboard_Screenshot_1774872681" src="https://github.com/user-attachments/assets/be8a1d3f-6c63-4d57-b181-4dbb11b04c0d" />


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change that adds a new OTel observable gauge and a small status-field addition; main concern is correctness of the gauge callback wiring under different OTel versions.
> 
> **Overview**
> Adds a `register_gauge` helper in `otel_init.py` to simplify creating OTel *observable gauges* (no-op with debug log when `opentelemetry` isn’t installed).
> 
> Hooks this into `MPCacheEngine` to export a new `lmcache_mp.active_prefetch_jobs` gauge (thread-safe count of `_prefetch_jobs`) and includes the same value in `report_status`. Updates `METRICS.md` to document the new gauge and adds unit tests covering gauge creation, callback behavior, and missing-OTel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b66f9870a7df198a537c6bf26caacce6e421964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->