### PR TITLE
[Feature] add a pure C++ LMCache MP server (L1 supported only)

### DIFF
--- a/csrc/server/CMakeLists.txt
+++ b/csrc/server/CMakeLists.txt
@@ -1,0 +1,186 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Allow FetchContent projects with old cmake_minimum_required
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "")
+
+project(lmcache-server LANGUAGES C CXX CUDA ASM)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_STANDARD 17)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+# CUDA architectures: Ampere(80,86), Ada(89), Hopper(90)
+set(CMAKE_CUDA_ARCHITECTURES "80;86;89;90")
+set(TORCH_CUDA_ARCH_LIST "8.0 8.6 8.9 9.0" CACHE STRING "" FORCE)
+
+# ============================================================================
+# Dependencies
+# ============================================================================
+
+# 1. CUDAToolkit
+find_package(CUDAToolkit REQUIRED)
+
+# 2. Torch (libtorch) — found via Python-installed torch
+execute_process(
+  COMMAND python3 -c "import torch; print(torch.utils.cmake_prefix_path)"
+  OUTPUT_VARIABLE TORCH_CMAKE_PREFIX
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _torch_result
+)
+if(NOT _torch_result EQUAL 0)
+  message(FATAL_ERROR "Could not determine torch cmake prefix path. Is PyTorch installed?")
+endif()
+list(APPEND CMAKE_PREFIX_PATH "${TORCH_CMAKE_PREFIX}")
+find_package(Torch REQUIRED)
+
+# 3. ZeroMQ — use the system shared library + FetchContent for headers
+include(FetchContent)
+
+# We have libzmq.so.5 at runtime but no dev headers.
+# Fetch cppzmq (header-only C++ binding) which also provides zmq.h.
+# Link against the system libzmq.so.5 directly.
+FetchContent_Declare(
+  libzmq_headers
+  GIT_REPOSITORY https://github.com/zeromq/libzmq.git
+  GIT_TAG        v4.3.5
+  GIT_SHALLOW    TRUE
+)
+# We only need the include directory, don't build libzmq
+FetchContent_GetProperties(libzmq_headers)
+if(NOT libzmq_headers_POPULATED)
+  FetchContent_Populate(libzmq_headers)
+endif()
+
+FetchContent_Declare(
+  cppzmq
+  GIT_REPOSITORY https://github.com/zeromq/cppzmq.git
+  GIT_TAG        v4.10.0
+  GIT_SHALLOW    TRUE
+)
+FetchContent_GetProperties(cppzmq)
+if(NOT cppzmq_POPULATED)
+  FetchContent_Populate(cppzmq)
+endif()
+
+# Create an imported target for the system libzmq
+add_library(libzmq_system SHARED IMPORTED)
+set_target_properties(libzmq_system PROPERTIES
+  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libzmq.so.5"
+  INTERFACE_INCLUDE_DIRECTORIES "${libzmq_headers_SOURCE_DIR}/include"
+)
+
+# 4. msgpack-cxx (header-only, C++ only — NOT msgpack-c which needs Boost)
+FetchContent_Declare(
+  msgpackcxx
+  GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git
+  GIT_TAG        cpp-6.1.1
+  GIT_SHALLOW    TRUE
+)
+# Don't use FetchContent_MakeAvailable — it pulls in Boost via CMakeLists.txt.
+# Just fetch the source and create a header-only interface target.
+FetchContent_GetProperties(msgpackcxx)
+if(NOT msgpackcxx_POPULATED)
+  FetchContent_Populate(msgpackcxx)
+endif()
+add_library(msgpack_header_only INTERFACE)
+target_include_directories(msgpack_header_only INTERFACE
+  ${msgpackcxx_SOURCE_DIR}/include
+)
+target_compile_definitions(msgpack_header_only INTERFACE MSGPACK_NO_BOOST)
+
+# 5. BLAKE3 — C library
+FetchContent_Declare(
+  blake3
+  GIT_REPOSITORY https://github.com/BLAKE3-team/BLAKE3.git
+  GIT_TAG        1.8.2
+  GIT_SHALLOW    TRUE
+)
+FetchContent_GetProperties(blake3)
+if(NOT blake3_POPULATED)
+  FetchContent_Populate(blake3)
+endif()
+# Build blake3 C library as a static lib
+add_library(blake3_lib STATIC
+  ${blake3_SOURCE_DIR}/c/blake3.c
+  ${blake3_SOURCE_DIR}/c/blake3_dispatch.c
+  ${blake3_SOURCE_DIR}/c/blake3_portable.c
+)
+# Add SIMD implementations if available
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+  target_sources(blake3_lib PRIVATE
+    ${blake3_SOURCE_DIR}/c/blake3_sse2_x86-64_unix.S
+    ${blake3_SOURCE_DIR}/c/blake3_sse41_x86-64_unix.S
+    ${blake3_SOURCE_DIR}/c/blake3_avx2_x86-64_unix.S
+    ${blake3_SOURCE_DIR}/c/blake3_avx512_x86-64_unix.S
+  )
+endif()
+target_include_directories(blake3_lib PUBLIC ${blake3_SOURCE_DIR}/c)
+
+# ============================================================================
+# Existing sources (compiled directly, no pybind11)
+# ============================================================================
+
+set(LMCACHE_CSRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
+# ============================================================================
+# Main target
+# ============================================================================
+
+add_executable(lmcache-server
+  main.cpp
+  types.cpp
+  wire_protocol.cpp
+  tensor_bridge.cpp
+  gpu_context.cpp
+  cache_engine.cpp
+  mq_server.cpp
+  l1_store.cpp
+  token_hasher.cpp
+  session_manager.cpp
+
+  # Existing C++ sources reused directly
+  ${LMCACHE_CSRC_DIR}/mem_kernels.cu
+  ${LMCACHE_CSRC_DIR}/mp_mem_kernels.cu
+  ${LMCACHE_CSRC_DIR}/storage_manager/bitmap.cpp
+  ${LMCACHE_CSRC_DIR}/storage_manager/ttl_lock.cpp
+)
+
+target_include_directories(lmcache-server PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${LMCACHE_CSRC_DIR}
+  ${cppzmq_SOURCE_DIR}
+  ${libzmq_headers_SOURCE_DIR}/include
+)
+
+target_link_libraries(lmcache-server PRIVATE
+  ${TORCH_LIBRARIES}
+  CUDA::cudart
+  CUDA::cuda_driver
+  libzmq_system
+  blake3_lib
+  msgpack_header_only
+  pthread
+)
+
+# Torch requires position-independent code
+set_target_properties(lmcache-server PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  CUDA_SEPARABLE_COMPILATION ON
+  # Add rpath for nvidia pip packages (libnvJitLink etc.)
+  BUILD_RPATH "/usr/local/lib/python3.12/dist-packages/nvidia/nvjitlink/lib"
+  INSTALL_RPATH "/usr/local/lib/python3.12/dist-packages/nvidia/nvjitlink/lib"
+)
+
+# Help the linker find libnvJitLink from the nvidia pip package
+target_link_directories(lmcache-server PRIVATE
+  /usr/local/lib/python3.12/dist-packages/nvidia/nvjitlink/lib
+)
+
+# Suppress torch-generated warnings
+target_compile_options(lmcache-server PRIVATE
+  $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+)
+
+# Enable readable symbol names in backtrace_symbols
+target_link_options(lmcache-server PRIVATE -rdynamic)

--- a/csrc/server/CUDA_ANALYSIS.md
+++ b/csrc/server/CUDA_ANALYSIS.md
@@ -1,0 +1,195 @@
+# LMCache Pure C++ Server — Implementation Complete
+
+## Status: WORKING (aligned with origin/dev)
+
+The pure C++ LMCache server is **implemented and operational**. It has been tested with DeepSeek-V3.1 on 8x NVIDIA H20 GPUs with TP=8, fp8 KV cache, MLA attention, and successfully handles store/retrieve/lookup operations from vLLM clients. Tested with 20 concurrent requests sent in two rounds.
+
+The server is aligned with the `origin/dev` branch: it uses the block-level kernel (`multi_layer_block_kv_transfer`), affinity/normal thread pools, and the `QUERY_PREFETCH_LOOKUP_HITS` request type (no `SYNC_LOOKUP`).
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────┐
+│           lmcache-server binary             │
+│        (LMCache-repo/csrc/server/)          │
+├─────────────────────────────────────────────┤
+│  main.cpp — CLI, signal handlers, wiring    │
+│  ├─ 13 IRequestHandler classes              │
+│  ├─ CacheEngine orchestrator                │
+│  └─ MessageQueueServer (ZMQ ROUTER)         │
+├─────────────────────────────────────────────┤
+│  CacheEngine (cache_engine.cpp)             │
+│  ├─ GPUContext — per-GPU IPC + streams      │
+│  ├─ L1Store — mmap slab + cudaHostRegister  │
+│  ├─ TokenHasher — BLAKE3 rolling hashes     │
+│  └─ SessionManager — per-request state      │
+├─────────────────────────────────────────────┤
+│  Wire Protocol (wire_protocol.cpp)          │
+│  ├─ msgpack encode/decode                   │
+│  └─ Python pickle parser (CudaIPCWrapper)   │
+├─────────────────────────────────────────────┤
+│  Reused C++ Sources                         │
+│  ├─ mem_kernels.cu — token-level kernels    │
+│  ├─ mp_mem_kernels.cu — block-level kernel  │
+│  ├─ bitmap.cpp — bitwise operations         │
+│  └─ ttl_lock.cpp — TTL-based locking        │
+├─────────────────────────────────────────────┤
+│  Dependencies                               │
+│  ├─ libtorch (ATen tensors, CUDA guards)    │
+│  ├─ libzmq (ZMQ ROUTER socket)              │
+│  ├─ msgpack-cxx (wire serialization)        │
+│  ├─ BLAKE3 (token hashing)                  │
+│  └─ CUDA runtime + driver APIs              │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## File Inventory (5,427 lines total)
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `wire_protocol.cpp` | 913 | msgpack encode/decode + Python pickle parser |
+| `mq_server.cpp` | 593 | ZMQ ROUTER + eventfd + affinity/normal thread pools |
+| `l1_store.cpp` | 572 | Mmap slab storage with state machine |
+| `cache_engine.cpp` | 534 | Store/retrieve/lookup orchestration (block-level kernel) |
+| `main.cpp` | 507 | Entry point, handlers, CLI |
+| `gpu_context.cpp` | 491 | Per-GPU IPC, streams, block_ids staging, batched buffers |
+| `types.h` | 278 | All shared type definitions |
+| `tensor_bridge.cpp` | 211 | ATen ↔ raw CUDA bridge |
+| `wire_protocol.h` | 173 | Encoder/Decoder declarations |
+| `gpu_context.h` | 148 | GPUContext class (with PageBufferShapeDesc, stage_block_ids) |
+| `cache_engine.h` | 147 | CacheEngine class |
+| `session_manager.cpp` | 133 | Per-request hash cache |
+| `token_hasher.cpp` | 129 | BLAKE3 rolling prefix hash |
+| `l1_store.h` | 110 | L1Store abstract interface |
+| `l2_adapter.h` | 111 | L2 interface (placeholder) |
+| `session_manager.h` | 95 | SessionManager class |
+| `mq_server.h` | 91 | MessageQueueServer class |
+| `tensor_bridge.h` | 84 | Tensor bridge declarations |
+| `token_hasher.h` | 69 | TokenHasher class |
+| `types.cpp` | 38 | ipc_key_to_object_keys() |
+
+---
+
+## Key Technical Details
+
+### 1. Wire Protocol Compatibility
+
+The C++ server is **wire-compatible** with existing Python vLLM clients. No client changes needed.
+
+- ZMQ ROUTER socket (same as Python `MessageQueueServer`)
+- msgpack serialization matching `msgspec.msgpack` format
+- CudaIPCWrapper parsed from Python pickle protocol 4 (Ext type code 1)
+- IPCCacheEngineKey decoded as msgpack MAP (dict with string keys)
+
+### 2. CUDA IPC Handle Management
+
+- Uses `c10::cuda::CUDACachingAllocator::getIpcDevPtr()` (not raw `cudaIpcOpenMemHandle`)
+- Supports PyTorch 2.10+ expanded 66-byte handle format
+- IPC tensors stored as class members to keep shared_ptr alive (critical for handle lifetime)
+- `c10::cuda::CUDAGuard` + `at::cuda::CUDAStreamGuard` for device/stream scoping
+
+### 3. GPU KV Transfer (Block-Level Kernel)
+
+Uses `multi_layer_block_kv_transfer` from `csrc/mp_mem_kernels.cu`:
+- **Block-level**: operates on block IDs directly, not slot mappings
+- **Batched retrieve**: processes up to 4 chunks per kernel launch
+- **PageBufferShapeDesc**: shape descriptor struct passed to the kernel
+- **stage_block_ids()**: pre-allocated GPU buffer (1M int64 elements) for block IDs
+- Store: GPU KV cache → tmp_buffer → L1 slab (D2H)
+- Retrieve: L1 slab → tmp_buffer → GPU KV cache (H2D)
+- Supports MLA format (format=3, `NL_X_NB_BS_HS`) and all 5 other vLLM/SGLang formats
+
+### 4. Thread Pool Architecture
+
+Two pool types (matching `origin/dev` Python server):
+- **AffinityThreadPool** (STORE, RETRIEVE): routes requests from the same ZMQ identity to the same worker thread (hash identity → worker index), eliminating per-instance GPU transfer locks
+- **NormalThreadPool** (LOOKUP, QUERY_PREFETCH_LOOKUP_HITS, FREE_LOOKUP_LOCKS, etc.): standard round-robin worker pool for CPU-bound handlers
+- All blocking handlers **must** have a pool assigned before `start()` (validated at startup)
+
+### 5. L1 Slab Storage
+
+- mmap'd memory region + `cudaHostRegister` for zero-copy DMA
+- State machine: Free → Writing → Ready → Reading → Ready
+- LRU eviction when capacity exhausted
+- TTL-based read lock management via existing C++ `TTLLock`
+
+### 6. Token Hashing
+
+- BLAKE3 rolling prefix hash (same algorithm as Python server)
+- Session-based hash caching for incremental updates
+
+---
+
+## Build & Run
+
+```bash
+# Build
+cd LMCache-repo/csrc/server
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+
+# Run
+./lmcache-server \
+    --host 0.0.0.0 \
+    --port 15555 \
+    --chunk-size 256 \
+    --l1-capacity-gib 64 \
+    --max-gpu-workers 16 \
+    --max-cpu-workers 8
+```
+
+### CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Bind address |
+| `--port` | `8001` | Bind port |
+| `--chunk-size` | `256` | Tokens per chunk |
+| `--l1-capacity-gib` | `8` | L1 slab capacity in GiB |
+| `--max-workers` | `8` | Thread pool workers (sets both GPU and CPU) |
+| `--max-gpu-workers` | `8` | Affinity pool workers for STORE/RETRIEVE |
+| `--max-cpu-workers` | `8` | Normal pool workers for LOOKUP etc. |
+| `--hugepages` | off | Use huge pages for L1 slab |
+| `--no-cuda-host-register` | off | Disable cudaHostRegister |
+
+---
+
+## Dependencies
+
+| Dependency | Version | How Resolved |
+|------------|---------|-------------|
+| libtorch | from pip PyTorch | `torch.utils.cmake_prefix_path` |
+| CUDA Toolkit | 12.x | system install |
+| libzmq | 4.3.5 | system .so + FetchContent headers |
+| cppzmq | 4.10.0 | FetchContent (header-only) |
+| msgpack-cxx | 6.1.1 | FetchContent (header-only, no Boost) |
+| BLAKE3 | 1.8.2 | FetchContent (static lib with SIMD) |
+| c10_cuda | from libtorch | for `getIpcDevPtr()` |
+
+---
+
+## Known Limitations
+
+1. **L2 adapter not implemented** — only L1 (host memory) caching; L2 (Redis/NitroFS) is a placeholder
+2. **No telemetry** — the Python server's telemetry system is not ported
+3. **Blend operations not implemented** — CB_* request types are defined but not handled
+4. **No hot-reload** — server must be restarted for config changes
+
+---
+
+## Bugs Fixed During Development
+
+| Bug | Root Cause | Fix |
+|-----|-----------|-----|
+| `cudaIpcOpenMemHandle` invalid argument | PyTorch 2.10+ uses 66-byte expanded handle | Use `getIpcDevPtr()` instead |
+| Segfault in `getIpcDevPtr` | CUDA caching allocator not initialized | Call `CUDACachingAllocator::init()` before engine |
+| CUDA illegal memory access in kernel | IPC tensor pointers dangled after constructor | Store IPC tensors as class members |
+| IPCCacheEngineKey decode failure | msgspec encodes as MAP, not array | Handle both MAP and ARRAY formats |
+| `uint8` dtype unknown | fp8 KV cache uses `torch.uint8` | Map `"uint8"` → `DType::Int8` → `at::ScalarType::Byte` |
+| Empty `device_uuid` | Pickle doesn't contain "GPU-" prefix | Parse bare UUID, prepend "GPU-" |
+| `c10::ScalarType` namespace mismatch | Per-operator ATen includes | Use `#include <torch/all.h>` |

--- a/csrc/server/DEV_DOC.md
+++ b/csrc/server/DEV_DOC.md
@@ -1,0 +1,857 @@
+# Pure C++ LMCache Server — Developer Documentation
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Build System](#build-system)
+4. [File Reference](#file-reference)
+5. [Wire Protocol](#wire-protocol)
+6. [CUDA IPC & GPU Context](#cuda-ipc--gpu-context)
+7. [L1 Slab Storage](#l1-slab-storage)
+8. [Token Hashing & Sessions](#token-hashing--sessions)
+9. [ZMQ Message Queue Server](#zmq-message-queue-server)
+10. [Cache Engine Orchestration](#cache-engine-orchestration)
+11. [Request Handlers](#request-handlers)
+12. [Initialization & Startup Ordering](#initialization--startup-ordering)
+13. [Debugging History & Lessons Learned](#debugging-history--lessons-learned)
+14. [Configuration & Deployment](#configuration--deployment)
+15. [Known Limitations & Future Work](#known-limitations--future-work)
+
+---
+
+## Overview
+
+This is a complete pure C++ rewrite of the LMCache multiprocess server (originally `lmcache/v1/multiprocess/server.py`). It replaces the Python server process with a single C++ binary that is wire-compatible with existing Python vLLM clients. No client-side changes are needed.
+
+The server is aligned with the `origin/dev` branch: it uses the block-level kernel (`multi_layer_block_kv_transfer` from `mp_mem_kernels.cu`), affinity/normal thread pools, `QUERY_PREFETCH_LOOKUP_HITS` request type, and batched retrieve (batch_size=4).
+
+**Tested configuration:** DeepSeek-V3.1 on 8× NVIDIA H20 GPUs, TP=8, fp8 KV cache, MLA attention, block_size=64, 61 layers, hidden_dim=576.
+
+**Codebase stats:** 5,427 lines across 20 files (10 .cpp, 10 .h), plus reused `mem_kernels.cu`, `mp_mem_kernels.cu`, `bitmap.cpp`, and `ttl_lock.cpp`.
+
+---
+
+## Architecture
+
+```
+vLLM Worker (Python)                     C++ LMCache Server
+┌──────────────┐                      ┌──────────────────────────┐
+│  TP Worker 0 │─── ZMQ DEALER ──────>│                          │
+│  TP Worker 1 │─── ZMQ DEALER ──────>│  MessageQueueServer      │
+│  ...         │                      │  (ZMQ ROUTER + eventfd)  │
+│  TP Worker 7 │─── ZMQ DEALER ──────>│                          │
+└──────────────┘                      ├──────────────────────────┤
+                                      │  Main Loop (zmq_poll)    │
+                                      │  ├─ SYNC handlers        │
+                                      │  └─ Thread pools         │
+                                      │     ├─ Affinity (GPU)    │
+                                      │     │  STORE, RETRIEVE   │
+                                      │     └─ Normal (CPU)      │
+                                      │        LOOKUP, FREE, etc.│
+                                      ├──────────────────────────┤
+                                      │  CacheEngine             │
+                                      │  ├─ GPUContext[0..7]     │
+                                      │  ├─ L1Store (mmap slab)  │
+                                      │  ├─ TokenHasher (BLAKE3) │
+                                      │  └─ SessionManager       │
+                                      └──────────────────────────┘
+```
+
+### Data Flow: Store Operation
+
+```
+vLLM Worker (TP rank X, device X):
+  1. Encode STORE request: [key, instance_id, gpu_block_ids, event_ipc_handle]
+  2. Send via ZMQ DEALER to server
+
+C++ Server (affinity pool worker thread):
+  1. Decode msgpack frames → StorePayload
+  2. Compute token chunk hashes (BLAKE3 rolling prefix)
+  3. Map to ObjectKeys (model_name + chunk_hash + kv_rank)
+  4. L1Store::reserve_write() → get slab write slots
+  5. Set CUDA device + stream guards for this GPU
+  6. Stage all block_ids to pre-allocated GPU buffer
+  7. Wait on vLLM's CUDA event (ensure GPU writes complete)
+  8. For each chunk:
+     a. Slice block_ids for this chunk's blocks
+     b. multi_layer_block_kv_transfer(D2H): GPU KV cache → tmp_gpu_buffer
+     c. cudaMemcpyAsync(D2H): tmp_gpu_buffer → L1 slab
+  9. cudaStreamSynchronize
+  10. L1Store::finish_write() → transition slots to Ready
+  11. Create + record completion CUDA event
+  12. Encode response: [event_handle, true]
+```
+
+### Data Flow: Retrieve Operation (Batched)
+
+```
+Same as Store but reversed, with batching:
+  - Stage all block_ids to GPU once (stage_block_ids)
+  - L1Store::reserve_read()
+  - Process in batches of 4 chunks:
+    a. get_tmp_gpu_buffer_batched(chunk_size, batch_size) → 4 buffer views
+    b. cudaMemcpyAsync(H2D): L1 slab → tmp_buffers (one per chunk)
+    c. multi_layer_block_kv_transfer(H2D): tmp_buffers → GPU KV cache
+       with skip_prefix_n_blocks for APC skip
+  - L1Store::finish_read()
+  - Uses high-priority CUDA stream
+```
+
+### Data Flow: Lookup (Two-Phase Async)
+
+```
+Phase 1 — LOOKUP:
+  1. Compute chunk hashes → ObjectKeys
+  2. L1Store::prefix_lookup() → count leading hits
+  3. Register PrefetchJob with hit count
+  4. Return job_id
+
+Phase 2 — QUERY_PREFETCH_STATUS or QUERY_PREFETCH_LOOKUP_HITS:
+  - QUERY_PREFETCH_LOOKUP_HITS: returns hit count if lookup done, None if pending
+  - QUERY_PREFETCH_STATUS: returns hit count and removes job entry (exactly-once)
+```
+
+---
+
+## Build System
+
+### CMakeLists.txt
+
+The build uses CMake 3.20+ with C++17 and CUDA 17. Dependencies are resolved via:
+
+| Dependency | Resolution |
+|------------|-----------|
+| **libtorch** | Auto-discovered via `python3 -c "import torch; print(torch.utils.cmake_prefix_path)"` |
+| **CUDA Toolkit** | `find_package(CUDAToolkit)` — system install |
+| **libzmq** | System `.so.5` + FetchContent for headers (avoids needing dev packages) |
+| **cppzmq** | FetchContent header-only C++ binding |
+| **msgpack-cxx** | FetchContent header-only, compiled with `MSGPACK_NO_BOOST` |
+| **BLAKE3** | FetchContent, built as static library with SIMD assembly (SSE2/SSE4.1/AVX2/AVX512) |
+
+### CUDA Architectures
+
+```
+CMAKE_CUDA_ARCHITECTURES: 80 (Ampere), 86 (Ampere), 89 (Ada), 90 (Hopper)
+```
+
+### Reused Sources
+
+Four existing LMCache C++ files are compiled directly (not via pybind11):
+
+```
+csrc/mem_kernels.cu              — Token-level CUDA transfer kernels
+csrc/mp_mem_kernels.cu           — Block-level CUDA transfer kernel
+csrc/storage_manager/bitmap.cpp  — Bitmap bitwise operations
+csrc/storage_manager/ttl_lock.cpp — TTL-based lock management
+```
+
+### Build Commands
+
+```bash
+cd LMCache-repo/csrc/server
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release   # or Debug
+make -j$(nproc)
+# Binary: ./lmcache-server
+```
+
+### Important Linker Flags
+
+- `-rdynamic` — enables readable symbol names in `backtrace_symbols()` for crash handler
+- RPATH includes `/usr/local/lib/python3.12/dist-packages/nvidia/nvjitlink/lib` for `libnvJitLink.so`
+
+---
+
+## File Reference
+
+### Headers (.h)
+
+| File | Lines | Key Contents |
+|------|-------|-------------|
+| `types.h` | 278 | `RequestType` enum (1-21, no SYNC_LOOKUP), `DType`, `ObjectKey`+hash, `IPCCacheEngineKey`, `CudaIpcTensorDesc`, `MemorySlabRef`, `PrefetchHandle`, `compute_extra_count()` |
+| `wire_protocol.h` | 173 | `Encoder`/`Decoder` classes, payload structs (`StorePayload`, `RetrievePayload`, `LookupPayload`, `QueryPrefetchLookupHitsPayload`, etc.) |
+| `gpu_context.h` | 148 | `GPUContext` class — per-GPU IPC handles, streams, `PageBufferShapeDesc`, `stage_block_ids()`, `get_tmp_gpu_buffer_batched()` |
+| `cache_engine.h` | 147 | `CacheEngine` class, `PrefetchJob`, `query_prefetch_lookup_hits()` |
+| `l1_store.h` | 110 | `L1Store` abstract interface + `L1StoreConfig` |
+| `l2_adapter.h` | 111 | `L2Adapter` abstract interface (placeholder) |
+| `session_manager.h` | 95 | `Session` + `SessionManager` classes |
+| `mq_server.h` | 91 | `IRequestHandler` + `MessageQueueServer` (`add_affinity_thread_pool`, `add_normal_thread_pool`) |
+| `tensor_bridge.h` | 84 | `wrap_as_tensor()`, `open_ipc_tensor()`, `open_ipc_event()`, `create_ipc_event()` |
+| `token_hasher.h` | 69 | `TokenHasher` class |
+
+### Implementations (.cpp)
+
+| File | Lines | Key Contents |
+|------|-------|-------------|
+| `wire_protocol.cpp` | 913 | msgpack encode/decode, Python pickle protocol 4 parser, `map_find()` helper |
+| `mq_server.cpp` | 593 | `AffinityThreadPool`, `NormalThreadPool`, ZMQ ROUTER, eventfd, `zmq_poll` main loop |
+| `l1_store.cpp` | 572 | `SlabL1Store` implementation: mmap, cudaHostRegister, state machine, LRU eviction |
+| `cache_engine.cpp` | 534 | `store()`, `retrieve()` (batched, block-level kernel), `lookup()`, `query_prefetch_lookup_hits()`, `free_lookup_locks()` |
+| `main.cpp` | 507 | 13 handler classes, CLI parsing, CUDA init, affinity/normal pool wiring |
+| `gpu_context.cpp` | 491 | IPC handle opening, format discovery, stream creation, `stage_block_ids()`, `get_tmp_gpu_buffer_batched()` |
+| `tensor_bridge.cpp` | 211 | `getIpcDevPtr()`, `from_blob()`, CUDA event IPC helpers |
+| `session_manager.cpp` | 133 | Hash caching with TTL cleanup |
+| `token_hasher.cpp` | 129 | BLAKE3 rolling prefix hash |
+| `types.cpp` | 38 | `ipc_key_to_object_keys()` |
+
+---
+
+## Wire Protocol
+
+### ZMQ Frame Layout
+
+Each request is a multipart ZMQ message:
+
+```
+Frame 0: ZMQ routing identity (auto-managed by ROUTER)
+Frame 1: RequestUID (int64, msgpack-encoded)
+Frame 2: RequestType (int, msgpack-encoded)
+Frame 3+: Payload frames (varies by request type)
+```
+
+Each response:
+
+```
+Frame 0: ZMQ routing identity (echoed back)
+Frame 1: RequestUID (echoed back)
+Frame 2: RequestType (echoed back)
+Frame 3: Encoded response (msgpack)
+```
+
+### Payload Formats by Request Type
+
+| RequestType | Payload Frames | Response |
+|-------------|---------------|----------|
+| `REGISTER_KV_CACHE` (1) | `[instance_id, kv_caches_list, model_name, world_size]` | None |
+| `UNREGISTER_KV_CACHE` (2) | `[instance_id]` | None |
+| `STORE` (3) | `[key, instance_id, gpu_block_ids, event_ipc_handle]` | `(bytes, bool)` |
+| `RETRIEVE` (4) | `[key, instance_id, gpu_block_ids, event_ipc_handle, skip_tokens]` | `(bytes, bool)` |
+| `LOOKUP` (5) | `[key, tp_size]` | `int` |
+| `QUERY_PREFETCH_STATUS` (6) | `[prefetch_job_id]` | `int \| None` |
+| `QUERY_PREFETCH_LOOKUP_HITS` (7) | `[prefetch_job_id]` | `int \| None` |
+| `FREE_LOOKUP_LOCKS` (8) | `[key, tp_size]` | None |
+| `END_SESSION` (9) | `[request_id]` | None |
+| `CLEAR` (10) | (none) | None |
+| `GET_CHUNK_SIZE` (11) | (none) | `int` |
+| `PING` (12) | (none) | `bool` |
+| `NOOP` (13) | (none) | `str` |
+
+### IPCCacheEngineKey Encoding
+
+The Python client encodes `IPCCacheEngineKey` as a **msgpack MAP** (dict with string keys), NOT an array. The C++ decoder handles both formats via `map_find()` helper:
+
+```
+{
+  "model_name": str,
+  "world_size": int,
+  "worker_id": int | None,
+  "token_ids": [int, ...],
+  "start": int,
+  "end": int,
+  "request_id": str
+}
+```
+
+### CudaIPCWrapper (Pickle Protocol 4)
+
+CUDA IPC tensor descriptors are serialized by Python as pickle Ext type code 1. The C++ parser extracts:
+
+1. **`ipc_handle_blob`**: First `BINBYTES`/`SHORT_BINBYTES` object ≥64 bytes (this is `handle[1]` from `_share_cuda_()`)
+2. **`storage_size_bytes`**: `handle[2]` — extracted from int after the handle blob
+3. **`device_uuid`**: `SHORT_BINUNICODE` string after the `'device_uuid'` field name in the pickle stream. The pickle contains a bare UUID; we prepend `"GPU-"` for CUDA device matching.
+4. **`dtype`**: Extracted from `STACK_GLOBAL` opcode (e.g., `"uint8"` for fp8)
+5. **`shape`/`stride`**: Extracted from `TUPLE2`/`TUPLE3` opcodes (small tuples) or `MARK`...`TUPLE` (large tuples)
+6. **`storage_offset`**: Last `int` before final `TUPLE`
+
+### DType Mapping
+
+| Wire string | DType enum | at::ScalarType | Element size |
+|-------------|-----------|---------------|-------------|
+| `"uint8"` | `Int8` | `Byte` | 1 |
+| `"float16"` | `Float16` | `Half` | 2 |
+| `"bfloat16"` | `BFloat16` | `BFloat16` | 2 |
+| `"float32"` | `Float32` | `Float` | 4 |
+| `"float8_e4m3fn"` | `Float8E4M3FN` | `Float8_e4m3fn` | 1 |
+
+Note: fp8 KV cache uses `torch.uint8` on the wire, which maps to `DType::Int8` → `at::ScalarType::Byte`.
+
+---
+
+## CUDA IPC & GPU Context
+
+### GPUContext Class (`gpu_context.h`, `gpu_context.cpp`)
+
+Each vLLM TP worker registers its KV cache via `REGISTER_KV_CACHE`. The server creates one `GPUContext` per instance_id (= per TP worker PID).
+
+#### Construction Flow
+
+```
+1. Match device UUID from first tensor descriptor to local CUDA device index
+   (iterate cudaGetDeviceProperties, format UUID as "GPU-%02x%02x...")
+2. Open IPC tensor handles via c10::cuda::CUDACachingAllocator::getIpcDevPtr()
+   → Creates at::Tensor objects that MUST stay alive (stored as class member)
+3. Discover GPU KV format from tensor shapes:
+   - 5D [2,NB,BS,NH,HS] → NL_X_TWO_NB_BS_NH_HS (flash attn)
+   - 5D [NB,2,BS,NH,HS] → NL_X_NB_TWO_BS_NH_HS (flash infer)
+   - 3D [NB,BS,HS] → NL_X_NB_BS_HS (MLA)
+4. Extract shape parameters: num_blocks, block_size, hidden_dim_size, num_heads, head_size
+5. Build PageBufferShapeDesc for the block-level kernel
+6. Upload KV cache pointers to GPU as int64 tensor [num_layers]
+7. Pre-compute slot mapping: [num_blocks, block_size] where slot[b][s] = b*bs+s
+8. Allocate temporary GPU buffer for transfers (sized for 4× chunk_size for batching)
+9. Allocate pre-allocated GPU buffer for block IDs (1M int64 elements)
+10. Create normal + high-priority CUDA streams
+```
+
+#### Key Methods
+
+- **`stage_block_ids(block_ids)`**: Copies int32 block IDs → int64 on pre-allocated GPU buffer. Returns a tensor view. Avoids per-call cudaMalloc.
+- **`get_tmp_gpu_buffer_batched(num_tokens, batch_size)`**: Returns `batch_size` non-overlapping tensor views into the pre-allocated tmp buffer (sized for `kMaxBatchSize=4`).
+- **`shape_desc()`**: Returns `PageBufferShapeDesc` struct for the block-level kernel.
+
+#### Critical: IPC Tensor Lifetime
+
+```cpp
+// WRONG (original bug — dangling pointers after constructor):
+std::vector<at::Tensor> kv_tensors;  // local variable, destroyed at end of ctor
+for (int i = 0; i < num_layers_; ++i) {
+    at::Tensor t = open_ipc_tensor(desc, device_idx);
+    kv_cache_ptrs_[i] = t.data_ptr();  // saves raw pointer
+    kv_tensors.push_back(std::move(t)); // tensor destroyed when kv_tensors goes out of scope!
+}
+
+// CORRECT (fixed):
+kv_cache_ipc_tensors_.reserve(num_layers_);  // class member!
+for (int i = 0; i < num_layers_; ++i) {
+    at::Tensor t = open_ipc_tensor(desc, device_idx);
+    kv_cache_ptrs_[i] = t.data_ptr();
+    kv_cache_ipc_tensors_.push_back(std::move(t));  // kept alive for GPUContext lifetime
+}
+```
+
+**Why this matters:** `getIpcDevPtr()` returns `shared_ptr<void>`. PyTorch's IPC cache stores only `weak_ptr`. When the tensor (which holds the `shared_ptr` in its storage) is destroyed, the IPC handle is closed and the GPU memory is unmapped. Any subsequent kernel access to the raw pointer is an illegal memory access.
+
+### Tensor Bridge (`tensor_bridge.h`, `tensor_bridge.cpp`)
+
+#### `open_ipc_tensor()`
+
+```cpp
+// 1. Open IPC handle via PyTorch's caching allocator
+std::string handle_str(blob.data(), blob.size());
+auto dev_ptr = c10::cuda::CUDACachingAllocator::getIpcDevPtr(std::move(handle_str));
+
+// 2. Apply storage_offset
+void* offset_ptr = static_cast<char*>(dev_ptr.get()) + storage_offset * elem_size;
+
+// 3. Create tensor with custom deleter holding shared_ptr
+auto ref = std::make_shared<std::shared_ptr<void>>(std::move(dev_ptr));
+auto deleter = [ref](void*) { /* ref drops when tensor dies */ };
+return at::from_blob(offset_ptr, shape, stride, deleter, options);
+```
+
+**Why `getIpcDevPtr()` instead of `cudaIpcOpenMemHandle()`:** PyTorch 2.10+ with CUDA 12.x uses an expanded 66-byte handle format (not the raw 64-byte `cudaIpcMemHandle_t`). `getIpcDevPtr()` handles both formats.
+
+### CUDA Device & Stream Scoping
+
+Every GPU operation in `store()` and `retrieve()` uses ATen guards:
+
+```cpp
+// Set the correct CUDA device
+c10::cuda::CUDAGuard device_guard(gpu_ctx->device_index());
+
+// Direct all ATen + CUDA operations to this GPU's stream
+at::cuda::CUDAStream torch_stream =
+    at::cuda::getStreamFromExternal(gpu_ctx->stream(), gpu_ctx->device_index());
+at::cuda::CUDAStreamGuard stream_guard(torch_stream);
+```
+
+This matches the Python server's `with torch.cuda.device(dev), torch.cuda.stream(stream):` pattern.
+
+---
+
+## L1 Slab Storage
+
+### Architecture
+
+```
+┌─────────────────────────────────────────┐
+│           L1 Slab (mmap'd)              │
+│  ┌──────┬──────┬──────┬──────┬────────┐ │
+│  │Slot 0│Slot 1│Slot 2│ ...  │Slot N-1│ │
+│  │ FREE │READY │WRITE │      │READING │ │
+│  └──────┴──────┴──────┴──────┴────────┘ │
+│  cudaHostRegister'd → zero-copy DMA     │
+├─────────────────────────────────────────┤
+│  Metadata (hash map):                   │
+│    ObjectKey → { slot_index, state,     │
+│                  lock_count, lru_pos }  │
+│  TTLLock for read lock management       │
+│  LRU eviction when capacity exhausted   │
+└─────────────────────────────────────────┘
+```
+
+### State Machine
+
+```
+ ┌──── Free ◄─── evict()/delete_key()
+ │       │
+ │  reserve_write()
+ │       │
+ │       ▼
+ │    Writing
+ │       │
+ │  finish_write()
+ │       │
+ │       ▼
+ └──── Ready ◄─── finish_read()
+          │
+     reserve_read()
+          │
+          ▼
+       Reading ───► Ready (when lock_count → 0)
+```
+
+### MLA Multi-Reader Locking
+
+For MLA models, all TP workers share the same KV cache object (since there's only one KV head). The `extra_count` parameter in `reserve_read()`/`finish_read()` handles this:
+
+```cpp
+int extra_count = compute_extra_count(tp_size, world_size);
+// Non-MLA: extra_count = 0 (each worker has distinct KV shard)
+// MLA: extra_count = tp_size - 1 (all workers share same object)
+```
+
+---
+
+## Token Hashing & Sessions
+
+### TokenHasher (`token_hasher.h`, `token_hasher.cpp`)
+
+Computes rolling prefix hashes using BLAKE3:
+
+```
+Chunk 0 hash = BLAKE3(none_hash || tokens[0:chunk_size])
+Chunk 1 hash = BLAKE3(chunk_0_hash || tokens[chunk_size:2*chunk_size])
+Chunk N hash = BLAKE3(chunk_{N-1}_hash || tokens[N*chunk_size:(N+1)*chunk_size])
+```
+
+Where `none_hash` is `BLAKE3(b"None")` — the initial prefix context.
+
+Only complete chunks are hashed (trailing tokens < chunk_size are ignored).
+
+### SessionManager (`session_manager.h`, `session_manager.cpp`)
+
+- `Session` stores per-request state: token_ids, cached hashes
+- `get_hashes(start, end)` returns chunk hashes for the range, using cached values when possible
+- Thread-safe (mutex per session)
+- `cleanup_expired()` removes sessions older than TTL
+
+---
+
+## ZMQ Message Queue Server
+
+### Architecture
+
+```
+                          ┌──────────────┐
+  ZMQ ROUTER socket ─────┤  Main Loop   │
+  (tcp://host:port)       │  zmq_poll()  │
+                          │  [socket_fd, │
+                          │   eventfd]   │
+                          └──────┬───────┘
+                                 │
+             ┌───────────────────┼───────────────────┐
+             │                   │                   │
+     ┌───────▼───────┐  ┌───────▼───────┐  ┌───────▼───────┐
+     │ SYNC handler  │  │ Affinity pool │  │ Normal pool   │
+     │ (main thread) │  │ (GPU-bound)   │  │ (CPU-bound)   │
+     │               │  │ STORE,RETRIEVE│  │ LOOKUP, FREE  │
+     │ GET_CHUNK_SIZE│  │ Identity-     │  │ QUERY, END,   │
+     │ REGISTER, etc.│  │ pinned routing│  │ CLEAR, PING   │
+     └───────────────┘  └───────┬───────┘  └───────┬───────┘
+                                │                   │
+                         eventfd write ◄────────────┘
+                         (wakes main loop to send ZMQ response)
+```
+
+### Thread Pool Types
+
+#### AffinityThreadPool
+- Routes requests to workers by `identity_hash % num_workers`
+- Same ZMQ client identity → same worker thread (deterministic)
+- Eliminates need for per-instance GPU transfer locks
+- Each worker has its own task queue (no contention between workers)
+- Used for: `STORE`, `RETRIEVE`
+
+#### NormalThreadPool
+- Standard shared-queue round-robin dispatch
+- Used for: `LOOKUP`, `QUERY_PREFETCH_STATUS`, `QUERY_PREFETCH_LOOKUP_HITS`, `FREE_LOOKUP_LOCKS`, `END_SESSION`, `CLEAR`, `PING`
+
+### Key Design Points
+
+1. **SYNC handlers** run in the main ZMQ poll loop (fast, non-blocking)
+2. **BLOCKING handlers** are dispatched to their assigned pool
+3. **All blocking handlers must have a pool assigned** — validated at `start()` time
+4. **eventfd** bridges thread pool → main loop: worker writes 1 to eventfd, main loop wakes up and sends the ZMQ response
+5. Responses are always sent from the main loop (ZMQ sockets are not thread-safe)
+
+### Handler Classification
+
+| Handler Type | Request Types |
+|-------------|--------------|
+| **SYNC** | `REGISTER_KV_CACHE`, `UNREGISTER_KV_CACHE`, `QUERY_PREFETCH_STATUS`, `GET_CHUNK_SIZE`, `NOOP` |
+| **BLOCKING** (affinity) | `STORE`, `RETRIEVE` |
+| **BLOCKING** (normal) | `LOOKUP`, `QUERY_PREFETCH_LOOKUP_HITS`, `FREE_LOOKUP_LOCKS`, `END_SESSION`, `CLEAR`, `PING` |
+
+---
+
+## Cache Engine Orchestration
+
+### Store Flow (Block-Level Kernel)
+
+```cpp
+std::pair<std::vector<uint8_t>, bool> CacheEngine::store(
+    const IPCCacheEngineKey& key,
+    int instance_id,
+    const std::vector<int32_t>& gpu_block_ids,
+    const std::vector<uint8_t>& event_ipc_handle)
+{
+  // 1. Session management + hash computation
+  auto session = session_manager_.get_or_create(key.request_id);
+  session->set_tokens(key.token_ids);
+  auto chunk_hashes = session->get_hashes(key.start, key.end);
+  auto obj_keys = ipc_key_to_object_keys(...);
+
+  // 2. GPU context lookup
+  auto& gpu_ctx = gpu_contexts_[instance_id];
+  int blocks_per_chunk = chunk_size_ / gpu_ctx->block_size();
+
+  // 3. CUDA device + stream guards
+  c10::cuda::CUDAGuard device_guard(gpu_ctx->device_index());
+  at::cuda::CUDAStreamGuard stream_guard(...);
+
+  // 4. Stage all block_ids to GPU once (pre-allocated buffer)
+  at::Tensor all_block_ids_gpu = gpu_ctx->stage_block_ids(gpu_block_ids);
+
+  // 5. Wait for vLLM to finish writing KV cache
+  cudaStreamWaitEvent(gpu_ctx->stream(), vllm_event, 0);
+
+  // 6. Reserve L1 write slots
+  auto reserved = l1_store_->reserve_write(obj_keys, layout, "new");
+
+  // 7. Transfer each chunk: GPU → tmp_buffer → L1 (not batched — skip gaps)
+  {
+    std::lock_guard<std::mutex> lk(gpu_ctx->transfer_lock());
+    for (size_t idx = 0; idx < obj_keys.size(); ++idx) {
+      if (reserved.find(obj_keys[idx]) == reserved.end()) continue;
+
+      at::Tensor chunk_block_ids_gpu = all_block_ids_gpu.slice(...);
+      at::Tensor tmp_buf = gpu_ctx->get_tmp_gpu_buffer(chunk_size_);
+
+      // Block-level kernel: GPU KV cache → tmp_buffer
+      multi_layer_block_kv_transfer(
+          gpu_ctx->kv_pointers(),
+          {tmp_buf.data_ptr()}, chunk_block_ids_gpu,
+          device, D2H, gpu_ctx->shape_desc(), chunk_size_,
+          gpu_kv_format, 0);
+
+      // tmp_buffer → L1 slab (async memcpy)
+      cudaMemcpyAsync(slab_ref.data, tmp_buf.data_ptr(), ...);
+    }
+  }
+
+  // 8. Sync and finish
+  cudaStreamSynchronize(gpu_ctx->stream());
+  l1_store_->finish_write(written_keys);
+  return {done_event_bytes, true};
+}
+```
+
+### Retrieve Flow (Batched)
+
+Same structure as Store but:
+- Uses **high-priority stream** (for latency-sensitive path)
+- **Batched**: processes up to 4 chunks per kernel launch
+- Uses `get_tmp_gpu_buffer_batched()` for 4 separate buffer views
+- Applies `skip_prefix_n_blocks` (skips blocks already in GPU cache via APC)
+- Transfer direction is H2D (host → device)
+
+```cpp
+// Process in batches of 4 chunks
+for (batch_start = 0; batch_start < obj_keys.size(); batch_start += 4) {
+  auto tmp_bufs = gpu_ctx->get_tmp_gpu_buffer_batched(chunk_size_, actual_batch);
+
+  // H2D memcpy for each chunk in batch
+  for (bi = 0; bi < actual_batch; ++bi)
+    cudaMemcpyAsync(tmp_bufs[bi].data_ptr(), slab_ref.data, ...);
+
+  // Single kernel launch for the whole batch
+  multi_layer_block_kv_transfer(
+      gpu_ctx->kv_pointers(),
+      lmcache_ptrs,  // vector of 1-4 tmp buffer pointers
+      batch_block_ids_gpu,
+      device, H2D, shape_desc, chunk_size_, format,
+      skip_blocks_in_batch);
+}
+```
+
+### Lookup Flow
+
+```cpp
+int CacheEngine::lookup(const IPCCacheEngineKey& key, int tp_size) {
+  // 1. Compute chunk hashes
+  auto chunk_hashes = token_hasher_.compute_chunk_hashes(key.token_ids);
+  auto obj_keys = ipc_key_to_object_keys(...);
+
+  // 2. L1 prefix lookup (find longest prefix of existing keys)
+  int64_t l1_hits = l1_store_->prefix_lookup(obj_keys);
+
+  // 3. Register prefetch job
+  int job_id = next_prefetch_job_id_++;
+  prefetch_jobs_[job_id] = PrefetchJob{handle, world_size, request_id};
+  return job_id;
+}
+```
+
+### Free Lookup Locks
+
+Simplified — just releases L1 read locks directly:
+
+```cpp
+void CacheEngine::free_lookup_locks(const IPCCacheEngineKey& key, int tp_size) {
+  auto chunk_hashes = token_hasher_.compute_chunk_hashes(key.token_ids, start, end);
+  auto obj_keys = ipc_key_to_object_keys(...);
+  int extra_count = compute_extra_count(tp_size, key.world_size);
+  l1_store_->finish_read(obj_keys, extra_count);
+}
+```
+
+---
+
+## Request Handlers
+
+All 13 handlers are defined in `main.cpp` as concrete `IRequestHandler` implementations:
+
+| Class | Request Type | Handler Type | Pool | Action |
+|-------|-------------|-------------|------|--------|
+| `RegisterHandler` | `REGISTER_KV_CACHE` | SYNC | — | `engine.register_kv_cache()` |
+| `UnregisterHandler` | `UNREGISTER_KV_CACHE` | SYNC | — | `engine.unregister_kv_cache()` |
+| `StoreHandler` | `STORE` | BLOCKING | Affinity | `engine.store()` |
+| `RetrieveHandler` | `RETRIEVE` | BLOCKING | Affinity | `engine.retrieve()` |
+| `LookupHandler` | `LOOKUP` | BLOCKING | Normal | `engine.lookup()` |
+| `QueryPrefetchStatusHandler` | `QUERY_PREFETCH_STATUS` | SYNC | — | `engine.query_prefetch_status()` |
+| `QueryPrefetchLookupHitsHandler` | `QUERY_PREFETCH_LOOKUP_HITS` | BLOCKING | Normal | `engine.query_prefetch_lookup_hits()` |
+| `FreeLookupLocksHandler` | `FREE_LOOKUP_LOCKS` | BLOCKING | Normal | `engine.free_lookup_locks()` |
+| `EndSessionHandler` | `END_SESSION` | BLOCKING | Normal | `engine.end_session()` |
+| `ClearHandler` | `CLEAR` | BLOCKING | Normal | `engine.clear()` |
+| `GetChunkSizeHandler` | `GET_CHUNK_SIZE` | SYNC | — | `engine.get_chunk_size()` |
+| `PingHandler` | `PING` | BLOCKING | Normal | `engine.ping()` |
+| `NoopHandler` | `NOOP` | SYNC | — | Returns "OK" |
+
+---
+
+## Initialization & Startup Ordering
+
+**Critical ordering in `main()`:**
+
+```cpp
+// 1. Signal handlers (SIGINT, SIGTERM → clean shutdown; SIGSEGV, SIGABRT → backtrace)
+std::signal(SIGSEGV, crash_handler);
+
+// 2. Parse CLI arguments
+auto cfg = parse_args(argc, argv);
+
+// 3. Initialize CUDA runtime BEFORE CacheEngine
+//    This MUST happen before cudaHostRegister (in L1Store) or it silently fails!
+for (int i = 0; i < device_count; ++i) {
+    cudaSetDevice(i);
+    cudaFree(nullptr);  // Force lazy CUDA init
+}
+cudaSetDevice(0);
+c10::cuda::CUDACachingAllocator::init(device_count);  // Required for getIpcDevPtr()
+
+// 4. Create CacheEngine (L1 slab mmap + cudaHostRegister happens here)
+CacheEngine engine(cfg.chunk_size, l1_config, nullptr);
+
+// 5. Create ZMQ server + register all 13 handlers
+MessageQueueServer server(bind_url, 0);
+server.add_handler(RequestType::STORE, std::make_unique<StoreHandler>(engine));
+// ... all 13 handlers ...
+
+// 6. Assign thread pools
+server.add_affinity_thread_pool({STORE, RETRIEVE}, cfg.max_gpu_workers);
+server.add_normal_thread_pool({LOOKUP, QUERY_PREFETCH_LOOKUP_HITS, ...}, cfg.max_cpu_workers);
+
+// 7. Start server (validates all blocking handlers have pools, spawns main loop)
+server.start();
+
+// 8. Sleep loop until shutdown signal
+while (!g_shutdown) sleep(1);
+```
+
+**Why CUDA init must come first:**
+- `cudaHostRegister()` requires a CUDA context to exist. Without `cudaFree(nullptr)` first, the register call silently fails.
+- Later `cudaMemcpyAsync` from the slab hits illegal memory access because the slab wasn't actually pinned.
+- `c10::cuda::CUDACachingAllocator::init()` is required for `getIpcDevPtr()` to work.
+
+---
+
+## Debugging History & Lessons Learned
+
+### Bug 1: PyTorch 2.10+ IPC Handle Format
+
+**Symptom:** `cudaIpcOpenMemHandle` returned `CUDA_ERROR_INVALID_VALUE`
+**Root Cause:** PyTorch 2.10+ with CUDA 12.x uses a 66-byte expanded handle format, not the raw 64-byte `cudaIpcMemHandle_t`.
+**Fix:** Use `c10::cuda::CUDACachingAllocator::getIpcDevPtr()` which handles both formats.
+
+### Bug 2: CUDA Caching Allocator Not Initialized
+
+**Symptom:** Segfault inside `getIpcDevPtr()`
+**Root Cause:** `c10::cuda::CUDACachingAllocator` was not initialized before the first `getIpcDevPtr()` call.
+**Fix:** Call `c10::cuda::CUDACachingAllocator::init(device_count)` in `main()` before creating `CacheEngine`.
+
+### Bug 3: Dangling IPC Pointers (The Final Critical Bug)
+
+**Symptom:** First store on one GPU succeeded, then `multi_layer_kv_transfer` crashed with illegal memory access on subsequent stores. CUDA error became "sticky" and broke all subsequent operations (including `cudaIpcOpenEventHandle`).
+**Root Cause:** IPC tensors were stored in a **local variable** in the `GPUContext` constructor. When the constructor returned, the tensors were destroyed, releasing the `shared_ptr` from `getIpcDevPtr()`, which closed the IPC handle and unmapped the GPU memory. `kv_cache_ptrs_` then contained dangling pointers.
+**Fix:** Store IPC tensors as a **class member** `kv_cache_ipc_tensors_` so they live as long as the `GPUContext`.
+
+### Bug 4: IPCCacheEngineKey MAP vs ARRAY
+
+**Symptom:** Key decode failed — fields were all zeros/empty.
+**Root Cause:** Python `msgspec.msgpack.encode()` for `@msgspec.Struct` classes produces msgpack MAP (dict with string keys), not ARRAY. The decoder assumed ARRAY format.
+**Fix:** Support both formats with a `map_find()` helper function.
+
+### Bug 5: Pickle Parser Issues
+
+**Symptom:** Empty `device_uuid`, wrong IPC handle extraction, shape parsing failures.
+**Root Cause (multiple):**
+1. `device_uuid`: Pickle contains bare UUID, not "GPU-" prefixed → prepend "GPU-" after extraction
+2. IPC handle: Originally took last 64-byte blob (handle[6] = event handle) → take FIRST ≥64-byte `BINBYTES` (handle[1] = storage handle)
+3. Shape: Pickle uses `TUPLE2`/`TUPLE3` opcodes for small tuples, not `MARK`...`TUPLE` → handle both formats
+
+### Bug 6: uint8 DType Not Recognized
+
+**Symptom:** fp8 KV cache dtype failed to parse.
+**Root Cause:** fp8 uses `torch.uint8` on the wire, which wasn't in the dtype mapping.
+**Fix:** Add `"uint8"` → `DType::Int8` → `at::ScalarType::Byte` mapping.
+
+### Bug 7: ATen Header Namespace Conflicts
+
+**Symptom:** Compilation error — `c10::ScalarType` vs `at::ScalarType` mismatch under NVCC.
+**Root Cause:** Per-operator ATen includes (`ATen/ops/*.h`) caused namespace aliasing to break in PyTorch 2.10+.
+**Fix:** Use `#include <torch/all.h>` everywhere (sets up proper namespace aliasing).
+
+### Bug 8: CUDA Init Before L1 Slab
+
+**Symptom:** `cudaMemcpyAsync(D2H)` to the L1 slab caused illegal memory access.
+**Root Cause:** `cudaHostRegister()` was called before CUDA was initialized. It returned `cudaSuccess` but silently did nothing.
+**Fix:** Move CUDA initialization (`cudaFree(nullptr)` per device) before `CacheEngine` construction.
+
+---
+
+## Configuration & Deployment
+
+### Launch Scripts
+
+**C++ LMCache server** (`launch_lmc_cpp_server.sh`):
+```bash
+LMCache-repo/csrc/server/build/lmcache-server \
+    --host 0.0.0.0 \
+    --port 15555 \
+    --chunk-size 256 \
+    --l1-capacity-gib 64 \
+    --max-gpu-workers 16 \
+    --max-cpu-workers 8
+```
+
+**vLLM with C++ LMCache** (`launch_vllm_server.sh`):
+```bash
+vllm serve "$MODEL" \
+    -tp 8 --kv-cache-dtype fp8 --block-size 64 \
+    --max-model-len 16384 --enforce-eager \
+    --kv-transfer-config '{"kv_connector":"LMCacheMPConnectorDynamic",
+        "kv_connector_extra_config":{"lmcache.mp.port":15555}}'
+```
+
+### Log Locations
+
+When using nohup:
+- LMCache server: `/tmp/lmc_out.log` (or wherever redirected)
+- vLLM server: `/disc/data1/riggins/hover/vllm_server.log`
+
+### Process Management
+
+```bash
+# Kill all related processes
+kill -9 $(pgrep -f lmcache-server) $(pgrep -f "vllm serve") 2>/dev/null
+
+# Verify GPU memory is freed
+nvidia-smi
+```
+
+---
+
+## Known Limitations & Future Work
+
+### Not Implemented
+
+1. **L2 Adapter** — `l2_adapter.h` is an abstract interface only. No Redis, filesystem, or NitroFS backend.
+   - The `run_prefetch_load()` method is a stub returning 0
+   - L2 lookup/lock/load paths are not implemented
+
+2. **Telemetry** — No equivalent of the Python server's telemetry system (START/END events, span correlation, JSONL output).
+
+3. **Blend Operations** — `CB_*` request types (14-21) are defined in `types.h` but no handlers are registered.
+
+4. **Hot Reload** — Server must be restarted for any configuration changes.
+
+5. **Graceful Shutdown** — CUDA cleanup on shutdown is best-effort. IPC handles are leaked (cleaned up by OS on exit).
+
+### Potential Improvements
+
+1. **Concurrent stores to different GPUs** — With affinity pools, same-identity requests serialize on one worker. Different identities (different TP workers) run on different workers concurrently.
+
+2. **L1 eviction policy** — Current LRU eviction is simple. Could add frequency-based or cost-aware eviction.
+
+3. **Error recovery** — A CUDA error on one device currently corrupts all CUDA state. Could add per-device error isolation.
+
+4. **Metrics endpoint** — No Prometheus/HTTP metrics. Could add a lightweight HTTP server or ZMQ stats channel.
+
+---
+
+## Testing
+
+### Quick Smoke Test
+
+```bash
+# Terminal 1: Start C++ LMCache server
+bash launch_lmc_cpp_server.sh
+
+# Terminal 2: Start vLLM
+bash launch_vllm_server.sh 2>&1 | tee vllm_server.log
+
+# Terminal 3: Run benchmark (wait for vLLM to be ready)
+bash easy_bench.sh
+
+# Check logs
+cat /tmp/lmc_out.log   # Should show REGISTER, LOOKUP, STORE operations
+```
+
+### Expected Log Output (Success)
+
+```
+lmcache-server (pure C++)
+  bind: tcp://0.0.0.0:15555
+  chunk_size: 256
+  L1 capacity: 64 GiB
+  max_gpu_workers: 16
+  max_cpu_workers: 8
+CUDA initialized: 8 device(s)
+Starting server...
+LMCache C++ server is running on tcp://0.0.0.0:15555
+CacheEngine: registered KV cache for instance XXXXX (61 layers, model=..., ws=1)
+  [repeated 8 times, one per TP worker]
+CacheEngine: stored 23 chunks (5888 tokens)
+  [repeated 8 times, one per TP worker]
+```

--- a/csrc/server/cache_engine.cpp
+++ b/csrc/server/cache_engine.cpp
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — CacheEngine orchestrator implementation
+//
+// Mirrors Python MPCacheEngine from server.py: wires GPUContext, L1Store,
+// TokenHasher, SessionManager together with the async prefetch pool.
+
+#include "cache_engine.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <functional>
+#include <future>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+
+#include <cuda_runtime_api.h>
+
+#include "tensor_bridge.h"
+
+// Kernel entry points (mp_mem_kernels.cuh includes mem_kernels.cuh)
+#include "mp_mem_kernels.cuh"
+
+// ATen CUDA guards for device/stream scoping
+#include <torch/all.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAEvent.h>
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Simple thread pool for async prefetch
+// ============================================================================
+
+struct CacheEngine::ThreadPool {
+  std::vector<std::thread> workers;
+  std::queue<std::function<void()>> tasks;
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool stop = false;
+
+  explicit ThreadPool(int num_workers) {
+    for (int i = 0; i < num_workers; ++i) {
+      workers.emplace_back([this] {
+        while (true) {
+          std::function<void()> task;
+          {
+            std::unique_lock<std::mutex> lk(mutex);
+            cv.wait(lk, [this] { return stop || !tasks.empty(); });
+            if (stop && tasks.empty()) return;
+            task = std::move(tasks.front());
+            tasks.pop();
+          }
+          task();
+        }
+      });
+    }
+  }
+
+  template <typename F>
+  std::future<int> submit(F&& f) {
+    auto task = std::make_shared<std::packaged_task<int()>>(std::forward<F>(f));
+    auto fut = task->get_future();
+    {
+      std::lock_guard<std::mutex> lk(mutex);
+      tasks.push([task]() { (*task)(); });
+    }
+    cv.notify_one();
+    return fut;
+  }
+
+  ~ThreadPool() {
+    {
+      std::lock_guard<std::mutex> lk(mutex);
+      stop = true;
+    }
+    cv.notify_all();
+    for (auto& w : workers) {
+      if (w.joinable()) w.join();
+    }
+  }
+};
+
+// ============================================================================
+// Constructor / Destructor
+// ============================================================================
+
+CacheEngine::CacheEngine(int chunk_size, const L1StoreConfig& l1_config,
+                         std::unique_ptr<L2Adapter> l2_adapter)
+    : chunk_size_(chunk_size),
+      l1_store_(L1Store::create(l1_config)),
+      l2_adapter_(std::move(l2_adapter)),
+      token_hasher_(chunk_size),
+      session_manager_(token_hasher_),
+      prefetch_pool_(std::make_unique<ThreadPool>(8)) {
+  std::fprintf(stderr,
+               "CacheEngine: initialized (chunk_size=%d, L1=%.1f GiB)\n",
+               chunk_size_,
+               static_cast<double>(l1_config.capacity_bytes) /
+                   (1024.0 * 1024.0 * 1024.0));
+}
+
+CacheEngine::~CacheEngine() { close(); }
+
+// ============================================================================
+// GPU registration
+// ============================================================================
+
+void CacheEngine::register_kv_cache(
+    int instance_id, const std::vector<CudaIpcTensorDesc>& kv_caches,
+    const std::string& model_name, int world_size) {
+  auto ctx = std::make_unique<GPUContext>(kv_caches, chunk_size_);
+  gpu_contexts_[instance_id] = std::move(ctx);
+  gpu_context_meta_[instance_id] = {model_name, world_size};
+  std::fprintf(stderr,
+               "CacheEngine: registered KV cache for instance %d "
+               "(%d layers, model=%s, ws=%d)\n",
+               instance_id, gpu_contexts_[instance_id]->num_layers(),
+               model_name.c_str(), world_size);
+}
+
+void CacheEngine::unregister_kv_cache(int instance_id) {
+  auto it = gpu_contexts_.find(instance_id);
+  if (it != gpu_contexts_.end()) {
+    gpu_contexts_.erase(it);
+    gpu_context_meta_.erase(instance_id);
+    std::fprintf(stderr, "CacheEngine: unregistered KV cache for instance %d\n",
+                 instance_id);
+  } else {
+    std::fprintf(stderr, "WARNING: CacheEngine: no KV cache for instance %d\n",
+                 instance_id);
+  }
+}
+
+// ============================================================================
+// Layout descriptor helper
+// ============================================================================
+
+MemoryLayoutDesc CacheEngine::find_layout_desc(const std::string& model_name,
+                                               int world_size) const {
+  for (const auto& [gpu_id, meta] : gpu_context_meta_) {
+    if (meta.first == model_name && meta.second == world_size) {
+      auto it = gpu_contexts_.find(gpu_id);
+      if (it != gpu_contexts_.end()) {
+        auto shape = it->second->get_kv_buffer_shape(chunk_size_);
+        DType dt = it->second->dtype();
+        return MemoryLayoutDesc{{ShapeDesc{shape}}, {dt}};
+      }
+    }
+  }
+  return {};  // empty = not found
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+std::pair<std::vector<uint8_t>, bool> CacheEngine::store(
+    const IPCCacheEngineKey& key, int instance_id,
+    const std::vector<int32_t>& gpu_block_ids,
+    const std::vector<uint8_t>& event_ipc_handle) {
+  // Get session and compute hashes
+  auto session = session_manager_.get_or_create(key.request_id);
+  session->set_tokens(key.token_ids);
+  auto chunk_hashes = session->get_hashes(key.start, key.end);
+
+  auto obj_keys = ipc_key_to_object_keys(key.model_name, key.world_size,
+                                         key.worker_id, chunk_hashes);
+
+  // Find GPU context
+  auto ctx_it = gpu_contexts_.find(instance_id);
+  if (ctx_it == gpu_contexts_.end()) {
+    std::fprintf(stderr, "ERROR: KV cache not registered for instance %d\n",
+                 instance_id);
+    cudaEvent_t ev;
+    auto ev_bytes = create_ipc_event(ev);
+    cudaEventDestroy(ev);
+    return {ev_bytes, false};
+  }
+  auto& gpu_ctx = ctx_it->second;
+
+  int blocks_per_chunk = chunk_size_ / gpu_ctx->block_size();
+
+  // Set device and stream guards
+  c10::cuda::CUDAGuard device_guard(gpu_ctx->device_index());
+  at::cuda::CUDAStream torch_stream = at::cuda::getStreamFromExternal(
+      gpu_ctx->stream(), gpu_ctx->device_index());
+  at::cuda::CUDAStreamGuard stream_guard(torch_stream);
+
+  // Stage all block_ids to GPU once
+  at::Tensor all_block_ids_gpu = gpu_ctx->stage_block_ids(gpu_block_ids);
+
+  // Wait for vLLM to finish writing
+  cudaEvent_t vllm_event = open_ipc_event(event_ipc_handle.data());
+  cudaStreamWaitEvent(gpu_ctx->stream(), vllm_event, 0);
+  cudaEventDestroy(vllm_event);
+
+  // Get layout and reserve L1 write slots
+  auto layout = find_layout_desc(key.model_name, key.world_size);
+  auto reserved = l1_store_->reserve_write(obj_keys, layout, "new");
+
+  // Transfer: GPU → tmp_buffer → L1 slab (via the block-level CUDA kernel)
+  // NOTE: Store is not batched because some obj_keys may be skipped
+  // (not in reserved_dict), making block_ids non-contiguous.
+  {
+    std::lock_guard<std::mutex> lk(gpu_ctx->transfer_lock());
+
+    for (size_t idx = 0; idx < obj_keys.size(); ++idx) {
+      auto it = reserved.find(obj_keys[idx]);
+      if (it == reserved.end()) continue;
+
+      // Slice block_ids for this chunk
+      int start_block = static_cast<int>(idx) * blocks_per_chunk;
+      int end_block = start_block + blocks_per_chunk;
+      at::Tensor chunk_block_ids_gpu =
+          all_block_ids_gpu.slice(0, start_block, end_block);
+
+      at::Tensor tmp_buf = gpu_ctx->get_tmp_gpu_buffer(chunk_size_);
+
+      // GPU KV cache → tmp_buffer (D2H staging) via block-level kernel
+      multi_layer_block_kv_transfer(
+          gpu_ctx->kv_pointers(),
+          {reinterpret_cast<int64_t>(tmp_buf.data_ptr())}, chunk_block_ids_gpu,
+          at::Device(at::kCUDA, gpu_ctx->device_index()),
+          TransferDirection::D2H, gpu_ctx->shape_desc(), chunk_size_,
+          static_cast<GPUKVFormat>(gpu_ctx->gpu_kv_format()), 0);
+
+      // tmp_buffer → L1 slab (async memcpy D2H)
+      auto& slab_ref = it->second;
+      cudaMemcpyAsync(slab_ref.data, tmp_buf.data_ptr(), slab_ref.size_bytes,
+                      cudaMemcpyDeviceToHost, gpu_ctx->stream());
+    }
+  }
+
+  // Record completion event
+  cudaEvent_t done_event;
+  auto done_bytes = create_ipc_event(done_event);
+  cudaEventRecord(done_event, gpu_ctx->stream());
+
+  // Synchronize and finish write
+  cudaStreamSynchronize(gpu_ctx->stream());
+  std::vector<ObjectKey> written_keys;
+  for (const auto& [k, _] : reserved) {
+    written_keys.push_back(k);
+  }
+  l1_store_->finish_write(written_keys);
+
+  cudaEventDestroy(done_event);
+
+  if (!reserved.empty()) {
+    std::fprintf(stderr, "CacheEngine: stored %zu chunks (%d tokens)\n",
+                 reserved.size(),
+                 static_cast<int>(reserved.size()) * chunk_size_);
+  }
+
+  return {done_bytes, true};
+}
+
+// ============================================================================
+// Retrieve
+// ============================================================================
+
+std::pair<std::vector<uint8_t>, bool> CacheEngine::retrieve(
+    const IPCCacheEngineKey& key, int instance_id,
+    const std::vector<int32_t>& gpu_block_ids,
+    const std::vector<uint8_t>& event_ipc_handle, int skip_first_n_tokens) {
+  auto session = session_manager_.get_or_create(key.request_id);
+  session->set_tokens(key.token_ids);
+  auto chunk_hashes = session->get_hashes(key.start, key.end);
+
+  auto obj_keys = ipc_key_to_object_keys(key.model_name, key.world_size,
+                                         key.worker_id, chunk_hashes);
+
+  auto ctx_it = gpu_contexts_.find(instance_id);
+  if (ctx_it == gpu_contexts_.end()) {
+    std::fprintf(stderr, "ERROR: KV cache not registered for instance %d\n",
+                 instance_id);
+    cudaEvent_t ev;
+    auto ev_bytes = create_ipc_event(ev);
+    cudaEventDestroy(ev);
+    return {ev_bytes, false};
+  }
+  auto& gpu_ctx = ctx_it->second;
+
+  int blocks_per_chunk = chunk_size_ / gpu_ctx->block_size();
+  static constexpr int kBatchSize = 4;
+
+  // Set device and stream guards — use high-priority stream for retrieve
+  c10::cuda::CUDAGuard device_guard(gpu_ctx->device_index());
+  at::cuda::CUDAStream torch_hp_stream = at::cuda::getStreamFromExternal(
+      gpu_ctx->high_priority_stream(), gpu_ctx->device_index());
+  at::cuda::CUDAStreamGuard stream_guard(torch_hp_stream);
+
+  // Stage all block_ids to GPU once
+  at::Tensor all_block_ids_gpu = gpu_ctx->stage_block_ids(gpu_block_ids);
+
+  // Wait for vLLM
+  cudaEvent_t vllm_event = open_ipc_event(event_ipc_handle.data());
+  cudaStreamWaitEvent(gpu_ctx->high_priority_stream(), vllm_event, 0);
+  cudaEventDestroy(vllm_event);
+
+  // Read from L1
+  auto read_refs = l1_store_->reserve_read(obj_keys);
+  if (read_refs.empty()) {
+    std::fprintf(stderr, "ERROR: retrieve: no keys found in L1\n");
+    cudaEvent_t ev;
+    auto ev_bytes = create_ipc_event(ev);
+    cudaEventRecord(ev, gpu_ctx->high_priority_stream());
+    cudaEventDestroy(ev);
+    return {ev_bytes, false};
+  }
+
+  // Transfer: L1 slab → tmp_buffer → GPU KV cache (batched, block-level)
+  {
+    std::lock_guard<std::mutex> lk(gpu_ctx->transfer_lock());
+
+    // Process in batches of kBatchSize chunks
+    for (size_t batch_start = 0; batch_start < obj_keys.size();
+         batch_start += kBatchSize) {
+      size_t batch_end = std::min(batch_start + kBatchSize, obj_keys.size());
+      int actual_batch_size = static_cast<int>(batch_end - batch_start);
+
+      int chunk_start_tok = static_cast<int>(batch_start) * chunk_size_;
+      int chunk_end_tok = static_cast<int>(batch_end) * chunk_size_;
+
+      int effective_start = std::max(chunk_start_tok, skip_first_n_tokens);
+      if (effective_start >= chunk_end_tok) continue;
+
+      int skip_tokens_in_batch =
+          std::max(0, std::min(effective_start - chunk_start_tok,
+                               chunk_size_ * kBatchSize - 1));
+      int skip_blocks_in_batch = skip_tokens_in_batch / gpu_ctx->block_size();
+
+      // Slice block_ids for this batch
+      int block_start = static_cast<int>(batch_start) * blocks_per_chunk;
+      int block_end = static_cast<int>(batch_end) * blocks_per_chunk;
+      at::Tensor batch_block_ids_gpu =
+          all_block_ids_gpu.slice(0, block_start, block_end);
+
+      // Get batched tmp buffers
+      auto tmp_bufs =
+          gpu_ctx->get_tmp_gpu_buffer_batched(chunk_size_, actual_batch_size);
+
+      // H2D memcpy for each chunk in the batch
+      for (int bi = 0; bi < actual_batch_size; ++bi) {
+        size_t idx = batch_start + bi;
+        auto it = read_refs.find(obj_keys[idx]);
+        if (it == read_refs.end()) continue;
+
+        auto& slab_ref = it->second;
+        cudaMemcpyAsync(tmp_bufs[bi].data_ptr(), slab_ref.data,
+                        slab_ref.size_bytes, cudaMemcpyHostToDevice,
+                        gpu_ctx->high_priority_stream());
+      }
+
+      // Build lmcache_objects_ptrs for the block-level kernel
+      std::vector<int64_t> lmcache_ptrs;
+      lmcache_ptrs.reserve(actual_batch_size);
+      for (int bi = 0; bi < actual_batch_size; ++bi) {
+        lmcache_ptrs.push_back(
+            reinterpret_cast<int64_t>(tmp_bufs[bi].data_ptr()));
+      }
+
+      // tmp_buffers → GPU KV cache via block-level kernel
+      multi_layer_block_kv_transfer(
+          gpu_ctx->kv_pointers(), lmcache_ptrs, batch_block_ids_gpu,
+          at::Device(at::kCUDA, gpu_ctx->device_index()),
+          TransferDirection::H2D, gpu_ctx->shape_desc(), chunk_size_,
+          static_cast<GPUKVFormat>(gpu_ctx->gpu_kv_format()),
+          skip_blocks_in_batch);
+    }
+  }
+
+  // Record completion
+  cudaEvent_t done_event;
+  auto done_bytes = create_ipc_event(done_event);
+  cudaEventRecord(done_event, gpu_ctx->high_priority_stream());
+
+  // Schedule finish_read after GPU completes
+  cudaStreamSynchronize(gpu_ctx->high_priority_stream());
+  l1_store_->finish_read(obj_keys);
+
+  cudaEventDestroy(done_event);
+
+  std::fprintf(stderr, "CacheEngine: retrieved %zu chunks (%d tokens)\n",
+               obj_keys.size(),
+               static_cast<int>(obj_keys.size()) * chunk_size_);
+
+  return {done_bytes, true};
+}
+
+// ============================================================================
+// Lookup (async two-phase)
+// ============================================================================
+
+int CacheEngine::lookup(const IPCCacheEngineKey& key, int tp_size) {
+  auto layout = find_layout_desc(key.model_name, key.world_size);
+  if (layout.shapes.empty()) {
+    std::fprintf(stderr, "ERROR: lookup: no GPU context for model=%s ws=%d\n",
+                 key.model_name.c_str(), key.world_size);
+    std::lock_guard<std::mutex> lk(prefetch_job_lock_);
+    int job_id = next_prefetch_job_id_++;
+    prefetch_jobs_[job_id] = PrefetchJob{
+        PrefetchHandle{-1, key.request_id, 0, 0, 0.0}, 1, key.request_id};
+    return job_id;
+  }
+
+  auto chunk_hashes = token_hasher_.compute_chunk_hashes(key.token_ids);
+  if (chunk_hashes.empty()) {
+    std::lock_guard<std::mutex> lk(prefetch_job_lock_);
+    int job_id = next_prefetch_job_id_++;
+    prefetch_jobs_[job_id] = PrefetchJob{
+        PrefetchHandle{-1, key.request_id, 0, 0, 0.0}, 1, key.request_id};
+    return job_id;
+  }
+
+  auto obj_keys = ipc_key_to_object_keys(key.model_name, key.world_size,
+                                         key.worker_id, chunk_hashes);
+
+  // L1 prefix lookup
+  int64_t l1_hits = l1_store_->prefix_lookup(obj_keys);
+
+  // Register prefetch job
+  std::lock_guard<std::mutex> lk(prefetch_job_lock_);
+  int job_id = next_prefetch_job_id_++;
+  prefetch_jobs_[job_id] =
+      PrefetchJob{PrefetchHandle{-1, key.request_id, l1_hits,
+                                 static_cast<int64_t>(obj_keys.size()), 0.0},
+                  key.world_size, key.request_id};
+  return job_id;
+}
+
+// ============================================================================
+// Query prefetch lookup hits
+// ============================================================================
+
+int CacheEngine::query_prefetch_lookup_hits(int prefetch_job_id) {
+  std::lock_guard<std::mutex> lk(prefetch_job_lock_);
+  auto it = prefetch_jobs_.find(prefetch_job_id);
+  if (it == prefetch_jobs_.end()) {
+    return -1;  // not found or already consumed
+  }
+
+  // For L1-only mode, hits are known immediately
+  int found_count = static_cast<int>(it->second.handle.l1_prefix_hit_count) /
+                    it->second.world_size;
+  return found_count;
+}
+
+// ============================================================================
+// Query prefetch status
+// ============================================================================
+
+int CacheEngine::query_prefetch_status(int prefetch_job_id) {
+  std::lock_guard<std::mutex> lk(prefetch_job_lock_);
+  auto it = prefetch_jobs_.find(prefetch_job_id);
+  if (it == prefetch_jobs_.end()) {
+    return -1;  // not found
+  }
+
+  // For L1-only mode, prefetch is always immediately complete
+  int found_count = static_cast<int>(it->second.handle.l1_prefix_hit_count) /
+                    it->second.world_size;
+  prefetch_jobs_.erase(it);
+  return found_count;
+}
+
+// ============================================================================
+// Free lookup locks
+// ============================================================================
+
+void CacheEngine::free_lookup_locks(const IPCCacheEngineKey& key, int tp_size) {
+  // Release L1 read locks
+  auto chunk_hashes =
+      token_hasher_.compute_chunk_hashes(key.token_ids, key.start, key.end);
+  if (chunk_hashes.empty()) return;
+
+  auto obj_keys = ipc_key_to_object_keys(key.model_name, key.world_size,
+                                         key.worker_id, chunk_hashes);
+
+  int extra_count = compute_extra_count(tp_size, key.world_size);
+  l1_store_->finish_read(obj_keys, extra_count);
+}
+
+// ============================================================================
+// Utility
+// ============================================================================
+
+void CacheEngine::end_session(const std::string& request_id) {
+  session_manager_.remove(request_id);
+}
+
+void CacheEngine::clear() {
+  std::lock_guard<std::mutex> lk(lock_);
+  l1_store_->memcheck();
+  l1_store_->clear(true);
+  l1_store_->memcheck();
+}
+
+void CacheEngine::close() {
+  if (l2_adapter_) {
+    l2_adapter_->close();
+  }
+  prefetch_pool_.reset();
+  gpu_contexts_.clear();
+  std::fprintf(stderr, "CacheEngine: closed\n");
+}
+
+// ============================================================================
+// Prefetch load helper (for L2, used by prefetch pool)
+// ============================================================================
+
+int CacheEngine::run_prefetch_load(
+    const std::string& request_id, const std::vector<ObjectKey>& remaining_keys,
+    const MemoryLayoutDesc& layout_desc,
+    std::unordered_map<int, storage_manager::Bitmap*> l2_lookup_results,
+    int extra_count) {
+  // L2 integration TBD — this is the async L2→L1 transfer path
+  // For now, return 0 (no L2 loads)
+  (void)request_id;
+  (void)remaining_keys;
+  (void)layout_desc;
+  (void)l2_lookup_results;
+  (void)extra_count;
+  return 0;
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/cache_engine.h
+++ b/csrc/server/cache_engine.h
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — Main cache engine orchestrator
+//
+// Mirrors Python MPCacheEngine: ties together GPUContext, L1Store,
+// L2Adapter, TokenHasher, SessionManager, and the async prefetch pool.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gpu_context.h"
+#include "l1_store.h"
+#include "l2_adapter.h"
+#include "session_manager.h"
+#include "token_hasher.h"
+#include "types.h"
+
+// Forward-declare Bitmap
+namespace lmcache {
+namespace storage_manager {
+class Bitmap;
+}
+}  // namespace lmcache
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// CacheEngine — main orchestrator
+// ============================================================================
+
+class CacheEngine {
+ public:
+  /// @param chunk_size       Tokens per chunk (e.g. 256)
+  /// @param l1_config        L1 slab store configuration
+  /// @param l2_adapter       Optional L2 adapter (nullptr = L1 only)
+  CacheEngine(int chunk_size, const L1StoreConfig& l1_config,
+              std::unique_ptr<L2Adapter> l2_adapter = nullptr);
+
+  ~CacheEngine();
+
+  // Non-copyable
+  CacheEngine(const CacheEngine&) = delete;
+  CacheEngine& operator=(const CacheEngine&) = delete;
+
+  // ---- GPU registration ----
+
+  void register_kv_cache(int instance_id,
+                         const std::vector<CudaIpcTensorDesc>& kv_caches,
+                         const std::string& model_name, int world_size);
+
+  void unregister_kv_cache(int instance_id);
+
+  // ---- Store / Retrieve ----
+
+  /// Store GPU KV cache blocks to L1 (+ async L2).
+  /// Returns (event_ipc_handle, success).
+  std::pair<std::vector<uint8_t>, bool> store(
+      const IPCCacheEngineKey& key, int instance_id,
+      const std::vector<int32_t>& gpu_block_ids,
+      const std::vector<uint8_t>& event_ipc_handle);
+
+  /// Retrieve L1 KV cache into GPU blocks.
+  /// Returns (event_ipc_handle, success).
+  std::pair<std::vector<uint8_t>, bool> retrieve(
+      const IPCCacheEngineKey& key, int instance_id,
+      const std::vector<int32_t>& gpu_block_ids,
+      const std::vector<uint8_t>& event_ipc_handle,
+      int skip_first_n_tokens = 0);
+
+  // ---- Lookup paths ----
+
+  /// Async lookup: returns a prefetch job ID.
+  int lookup(const IPCCacheEngineKey& key, int tp_size);
+
+  /// Query the number of hits for a prefetch request before it's finished.
+  /// Returns the hit count if lookup is done, -1 if still in progress or
+  /// invalid.
+  int query_prefetch_lookup_hits(int prefetch_job_id);
+
+  /// Poll async lookup status.  Returns chunk count or -1 if still in progress.
+  int query_prefetch_status(int prefetch_job_id);
+
+  /// Release read locks acquired during lookup.
+  void free_lookup_locks(const IPCCacheEngineKey& key, int tp_size);
+
+  // ---- Utility ----
+
+  bool ping() const { return true; }
+  int get_chunk_size() const { return chunk_size_; }
+  void end_session(const std::string& request_id);
+  void clear();
+  void close();
+
+ private:
+  // L2-to-L1 prefetch helper (runs on prefetch pool)
+  int run_prefetch_load(
+      const std::string& request_id,
+      const std::vector<ObjectKey>& remaining_keys,
+      const MemoryLayoutDesc& layout_desc,
+      std::unordered_map<int, storage_manager::Bitmap*> l2_lookup_results,
+      int extra_count);
+
+  // Find layout desc from a matching GPU context
+  MemoryLayoutDesc find_layout_desc(const std::string& model_name,
+                                    int world_size) const;
+
+  int chunk_size_;
+
+  // GPU contexts: instance_id → GPUContext
+  std::unordered_map<int, std::unique_ptr<GPUContext>> gpu_contexts_;
+  // GPU context metadata: instance_id → (model_name, world_size)
+  std::unordered_map<int, std::pair<std::string, int>> gpu_context_meta_;
+
+  // Storage
+  std::unique_ptr<L1Store> l1_store_;
+  std::unique_ptr<L2Adapter> l2_adapter_;
+
+  // Hashing and sessions
+  TokenHasher token_hasher_;
+  SessionManager session_manager_;
+
+  // Prefetch job tracking
+  struct PrefetchJob {
+    PrefetchHandle handle;
+    int world_size;
+    std::string request_id;
+  };
+  std::mutex prefetch_job_lock_;
+  std::unordered_map<int, PrefetchJob> prefetch_jobs_;
+  int next_prefetch_job_id_ = 0;
+
+  // Thread pool for async L2-to-L1 prefetch (8 workers)
+  struct ThreadPool;
+  std::unique_ptr<ThreadPool> prefetch_pool_;
+
+  // Global engine lock (legacy, for clear())
+  std::mutex lock_;
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/gpu_context.cpp
+++ b/csrc/server/gpu_context.cpp
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — GPUContext implementation
+//
+// Mirrors Python GPUCacheContext: opens IPC handles to vLLM's KV cache,
+// discovers GPU KV format, creates CUDA streams, and manages transfer buffers.
+
+#include "gpu_context.h"
+#include "tensor_bridge.h"
+
+#include <cstdio>
+#include <cstring>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+
+#include <cuda_runtime_api.h>
+
+// Use torch/all.h which correctly sets up the c10/at namespace aliasing
+// in PyTorch 2.10+. Per-operator includes (ATen/ops/*.h) cause
+// c10::ScalarType vs at::ScalarType mismatches.
+#include <torch/all.h>
+
+// Use GPUKVFormat from mem_kernels.cuh (included via gpu_context.h →
+// mp_mem_kernels.cuh)
+namespace {
+
+/// Discover GPU KV format from per-layer tensor shapes (vLLM only).
+GPUKVFormat discover_format(
+    const std::vector<lmcache::server::CudaIpcTensorDesc>& descs) {
+  if (descs.empty()) {
+    throw std::runtime_error("discover_format: empty kv_cache descriptors");
+  }
+
+  const auto& first = descs[0];
+  int tensor_dim = static_cast<int>(first.shape.size());
+
+  if (tensor_dim == 5) {
+    // 5-D: either [2, NB, BS, NH, HS] (flash attn) or [NB, 2, BS, NH, HS]
+    // (flash infer)
+    if (first.shape[0] == 2) {
+      return GPUKVFormat::NL_X_TWO_NB_BS_NH_HS;
+    } else if (first.shape[1] == 2) {
+      return GPUKVFormat::NL_X_NB_TWO_BS_NH_HS;
+    }
+    throw std::runtime_error(
+        "discover_format: 5-D tensor but neither dim[0]==2 nor dim[1]==2");
+  } else if (tensor_dim == 3) {
+    // 3-D: [NB, BS, HS] → MLA
+    return GPUKVFormat::NL_X_NB_BS_HS;
+  }
+
+  throw std::runtime_error(
+      "discover_format: unsupported tensor_dim=" + std::to_string(tensor_dim) +
+      " for vLLM (expected 3 or 5)");
+}
+
+bool format_is_mla(GPUKVFormat fmt) {
+  return fmt == GPUKVFormat::NL_X_NB_BS_HS ||
+         fmt == GPUKVFormat::NL_X_NBBS_ONE_HS;
+}
+
+}  // anonymous namespace
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Constructor
+// ============================================================================
+
+GPUContext::GPUContext(const std::vector<CudaIpcTensorDesc>& kv_cache_descs,
+                       int chunk_size) {
+  if (kv_cache_descs.empty()) {
+    throw std::runtime_error("GPUContext: empty kv_cache_descs");
+  }
+
+  // ---- Determine device index ----
+  // We need to figure out which GPU these tensors belong to.
+  // Use the first descriptor's device_uuid to find the device index.
+  // For now, we discover by iterating CUDA devices and matching UUID.
+  {
+    int num_devices = 0;
+    cudaGetDeviceCount(&num_devices);
+    device_index_ = -1;
+    for (int i = 0; i < num_devices; ++i) {
+      cudaDeviceProp prop;
+      cudaGetDeviceProperties(&prop, i);
+      // Build UUID string like Python:
+      // "GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      char uuid_str[80];
+      const auto& uuid = prop.uuid;
+      std::snprintf(
+          uuid_str, sizeof(uuid_str),
+          "GPU-%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%"
+          "02x%02x",
+          (unsigned char)uuid.bytes[0], (unsigned char)uuid.bytes[1],
+          (unsigned char)uuid.bytes[2], (unsigned char)uuid.bytes[3],
+          (unsigned char)uuid.bytes[4], (unsigned char)uuid.bytes[5],
+          (unsigned char)uuid.bytes[6], (unsigned char)uuid.bytes[7],
+          (unsigned char)uuid.bytes[8], (unsigned char)uuid.bytes[9],
+          (unsigned char)uuid.bytes[10], (unsigned char)uuid.bytes[11],
+          (unsigned char)uuid.bytes[12], (unsigned char)uuid.bytes[13],
+          (unsigned char)uuid.bytes[14], (unsigned char)uuid.bytes[15]);
+      if (kv_cache_descs[0].device_uuid == uuid_str) {
+        device_index_ = i;
+        break;
+      }
+    }
+    if (device_index_ < 0) {
+      // Fallback: use device 0 with a warning
+      std::fprintf(stderr,
+                   "WARNING: GPUContext could not match device UUID '%s', "
+                   "falling back to device 0\n",
+                   kv_cache_descs[0].device_uuid.c_str());
+      device_index_ = 0;
+    }
+  }
+
+  cudaError_t err = cudaSetDevice(device_index_);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("GPUContext: cudaSetDevice failed: ") +
+                             cudaGetErrorString(err));
+  }
+
+  // ---- Open IPC tensors and extract raw pointers ----
+  num_layers_ = static_cast<int>(kv_cache_descs.size());
+  kv_cache_ptrs_.resize(num_layers_);
+
+  // Keep IPC tensors alive for the lifetime of this GPUContext.
+  // getIpcDevPtr() caches via weak_ptr — if we don't hold the shared_ptr
+  // (via the tensor's storage), the IPC handle is closed and kv_cache_ptrs_
+  // become dangling pointers.
+  kv_cache_ipc_tensors_.reserve(num_layers_);
+
+  for (int i = 0; i < num_layers_; ++i) {
+    at::Tensor t = open_ipc_tensor(kv_cache_descs[i], device_index_);
+    kv_cache_ptrs_[i] = t.data_ptr();
+    kv_cache_ipc_tensors_.push_back(std::move(t));
+  }
+
+  // ---- Discover GPU KV format ----
+  auto fmt = discover_format(kv_cache_descs);
+  gpu_kv_format_ = static_cast<int>(fmt);
+  is_mla_ = format_is_mla(fmt);
+
+  // ---- Extract shape parameters from the first tensor ----
+  const auto& shape0 = kv_cache_descs[0].shape;
+
+  switch (fmt) {
+    case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
+      // shape: [2, NB, BS, NH, HS]
+      num_blocks_ = static_cast<int>(shape0[1]);
+      block_size_ = static_cast<int>(shape0[2]);
+      num_heads_ = static_cast<int>(shape0[3]);
+      head_size_ = static_cast<int>(shape0[4]);
+      hidden_dim_size_ = num_heads_ * head_size_;  // NH * HS
+      break;
+
+    case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
+      // shape: [NB, 2, BS, NH, HS]
+      num_blocks_ = static_cast<int>(shape0[0]);
+      block_size_ = static_cast<int>(shape0[2]);
+      num_heads_ = static_cast<int>(shape0[3]);
+      head_size_ = static_cast<int>(shape0[4]);
+      hidden_dim_size_ = num_heads_ * head_size_;  // NH * HS
+      break;
+
+    case GPUKVFormat::NL_X_NB_BS_HS:
+      // shape: [NB, BS, HS] — MLA: num_heads not applicable
+      num_blocks_ = static_cast<int>(shape0[0]);
+      block_size_ = static_cast<int>(shape0[1]);
+      head_size_ = static_cast<int>(shape0[2]);
+      num_heads_ = 1;                 // MLA: single fused head
+      hidden_dim_size_ = head_size_;  // HS
+      break;
+
+    default:
+      throw std::runtime_error("GPUContext: unhandled GPU KV format " +
+                               std::to_string(gpu_kv_format_));
+  }
+
+  // DType from first descriptor
+  dtype_ = kv_cache_descs[0].dtype;
+
+  // Build PageBufferShapeDesc for the block-level kernel
+  shape_desc_.kv_size = is_mla_ ? 1 : 2;
+  shape_desc_.nl = num_layers_;
+  shape_desc_.nb = num_blocks_;
+  shape_desc_.bs = block_size_;
+  shape_desc_.nh = num_heads_;
+  shape_desc_.hs = head_size_;
+  shape_desc_.element_size = static_cast<int>(dtype_size(dtype_));
+
+  std::fprintf(stderr,
+               "GPUContext: device=%d, format=%d, mla=%d, layers=%d, "
+               "blocks=%d, block_size=%d, hidden_dim=%d, num_heads=%d, "
+               "head_size=%d, element_size=%d\n",
+               device_index_, gpu_kv_format_, is_mla_ ? 1 : 0, num_layers_,
+               num_blocks_, block_size_, hidden_dim_size_, num_heads_,
+               head_size_, shape_desc_.element_size);
+
+  // ---- Upload KV cache pointers to GPU (int64 tensor) ----
+  {
+    size_t ptr_bytes = num_layers_ * sizeof(int64_t);
+    err = cudaMalloc(&kv_pointers_gpu_, ptr_bytes);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaMalloc kv_pointers failed: ") +
+          cudaGetErrorString(err));
+    }
+
+    // Reinterpret void* pointers as int64 for upload
+    std::vector<int64_t> ptrs_as_int64(num_layers_);
+    for (int i = 0; i < num_layers_; ++i) {
+      ptrs_as_int64[i] = reinterpret_cast<int64_t>(kv_cache_ptrs_[i]);
+    }
+    err = cudaMemcpy(kv_pointers_gpu_, ptrs_as_int64.data(), ptr_bytes,
+                     cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaMemcpy kv_pointers failed: ") +
+          cudaGetErrorString(err));
+    }
+  }
+
+  // ---- Pre-compute slot mapping on GPU: shape [num_blocks, block_size] ----
+  // slot_mapping[b][s] = b * block_size + s
+  {
+    size_t num_slots = static_cast<size_t>(num_blocks_) * block_size_;
+    size_t slot_bytes = num_slots * sizeof(int64_t);
+    err = cudaMalloc(&slot_mapping_gpu_, slot_bytes);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaMalloc slot_mapping failed: ") +
+          cudaGetErrorString(err));
+    }
+
+    // Build on host then upload
+    std::vector<int64_t> slot_mapping_host(num_slots);
+    for (int b = 0; b < num_blocks_; ++b) {
+      for (int s = 0; s < block_size_; ++s) {
+        slot_mapping_host[b * block_size_ + s] =
+            static_cast<int64_t>(b) * block_size_ + s;
+      }
+    }
+    err = cudaMemcpy(slot_mapping_gpu_, slot_mapping_host.data(), slot_bytes,
+                     cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaMemcpy slot_mapping failed: ") +
+          cudaGetErrorString(err));
+    }
+  }
+
+  // ---- Allocate temporary GPU buffer (sized for kMaxBatchSize chunks) ----
+  {
+    auto buf_shape = get_kv_buffer_shape(chunk_size * kMaxBatchSize);
+    size_t num_elems = 1;
+    for (auto d : buf_shape) num_elems *= static_cast<size_t>(d);
+    tmp_gpu_buffer_bytes_ = num_elems * dtype_size(dtype_);
+
+    err = cudaMalloc(&tmp_gpu_buffer_, tmp_gpu_buffer_bytes_);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaMalloc tmp_buffer failed: ") +
+          cudaGetErrorString(err));
+    }
+  }
+
+  // ---- Allocate pre-allocated GPU buffer for block IDs ----
+  {
+    size_t block_ids_bytes = kMaxBlockIds * sizeof(int64_t);
+    err = cudaMalloc(&block_ids_buffer_, block_ids_bytes);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaMalloc block_ids_buffer failed: ") +
+          cudaGetErrorString(err));
+    }
+  }
+
+  // ---- Create CUDA streams ----
+  {
+    // Normal-priority stream
+    err = cudaStreamCreateWithPriority(&stream_, cudaStreamNonBlocking, 0);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaStreamCreate (normal) failed: ") +
+          cudaGetErrorString(err));
+    }
+
+    // High-priority stream — use the highest priority available
+    int least_priority = 0, greatest_priority = 0;
+    cudaDeviceGetStreamPriorityRange(&least_priority, &greatest_priority);
+    err = cudaStreamCreateWithPriority(
+        &high_priority_stream_, cudaStreamNonBlocking, greatest_priority);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("GPUContext: cudaStreamCreate (high) failed: ") +
+          cudaGetErrorString(err));
+    }
+  }
+
+  std::fprintf(stderr, "GPUContext: initialized on device %d\n", device_index_);
+}
+
+// ============================================================================
+// Destructor
+// ============================================================================
+
+GPUContext::~GPUContext() {
+  // Best-effort cleanup — don't throw from destructors
+  cudaSetDevice(device_index_);
+
+  if (stream_) cudaStreamDestroy(stream_);
+  if (high_priority_stream_) cudaStreamDestroy(high_priority_stream_);
+
+  if (kv_pointers_gpu_) cudaFree(kv_pointers_gpu_);
+  if (slot_mapping_gpu_) cudaFree(slot_mapping_gpu_);
+  if (tmp_gpu_buffer_) cudaFree(tmp_gpu_buffer_);
+  if (block_ids_buffer_) cudaFree(block_ids_buffer_);
+
+  // Close IPC handles — the base pointer is needed (before storage_offset),
+  // but open_ipc_tensor may have adjusted it. We stored data_ptr() which
+  // includes the offset, so we need the original base.
+  // Actually, cudaIpcCloseMemHandle requires the exact pointer returned by
+  // cudaIpcOpenMemHandle. Since we stored data_ptr (which includes offset),
+  // and the offset might be non-zero, we can't close cleanly here.
+  //
+  // For correctness, IPC handles should be closed with the base pointer.
+  // In practice, the server process lifetime matches the IPC handle lifetime,
+  // so the OS cleans up on exit. We skip explicit close to avoid errors.
+  //
+  // If precise cleanup is needed, we'd need to store the base pointers
+  // separately from the offset pointers.
+}
+
+// ============================================================================
+// Tensor accessors
+// ============================================================================
+
+at::Tensor GPUContext::kv_pointers() const {
+  return wrap_as_tensor(kv_pointers_gpu_, {num_layers_}, DType::Int64,
+                        device_index_);
+}
+
+at::Tensor GPUContext::get_slot_mapping_tensor(
+    const std::vector<int32_t>& gpu_block_ids) const {
+  // The precomputed slot_mapping_gpu_ has shape [num_blocks, block_size].
+  // We need to index into it with the given block IDs and flatten.
+  //
+  // Equivalent Python:
+  //   gpu_block_ids_tensor = torch.tensor(gpu_block_ids, device=...,
+  //   dtype=torch.long) return
+  //   self.slot_mapping_tensor_[gpu_block_ids_tensor].flatten().contiguous()
+
+  int num_blocks_requested = static_cast<int>(gpu_block_ids.size());
+
+  // Convert int32 block IDs to int64
+  std::vector<int64_t> block_ids_i64(gpu_block_ids.begin(),
+                                     gpu_block_ids.end());
+
+  // Allocate GPU buffer for block IDs and copy synchronously
+  void* idx_gpu = nullptr;
+  size_t idx_bytes = num_blocks_requested * sizeof(int64_t);
+  cudaError_t err = cudaMalloc(&idx_gpu, idx_bytes);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("get_slot_mapping_tensor: cudaMalloc failed: ") +
+        cudaGetErrorString(err));
+  }
+  err = cudaMemcpy(idx_gpu, block_ids_i64.data(), idx_bytes,
+                   cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    cudaFree(idx_gpu);
+    throw std::runtime_error(
+        std::string("get_slot_mapping_tensor: cudaMemcpy failed: ") +
+        cudaGetErrorString(err));
+  }
+
+  // Wrap as ATen tensors
+  at::Tensor slot_mapping =
+      wrap_as_tensor(slot_mapping_gpu_, {num_blocks_, block_size_},
+                     DType::Int64, device_index_);
+
+  // Wrap GPU index buffer as non-owning tensor, then free after use
+  at::Tensor idx = wrap_as_tensor(idx_gpu, {num_blocks_requested}, DType::Int64,
+                                  device_index_);
+
+  // Index and flatten (all on GPU, same stream via CUDAStreamGuard)
+  at::Tensor result = slot_mapping.index_select(0, idx).flatten().contiguous();
+
+  // Free the temporary index buffer (safe: index_select copies the data)
+  cudaFree(idx_gpu);
+
+  return result;
+}
+
+at::Tensor GPUContext::get_tmp_gpu_buffer(int num_tokens) const {
+  // Full shape: [1or2, num_layers, chunk_size, hidden_dim_size]
+  // Slice to:   [1or2, num_layers, num_tokens, hidden_dim_size]
+  auto full_shape = get_kv_buffer_shape(num_tokens);
+
+  // Compute number of elements for the requested slice
+  size_t num_elems = 1;
+  for (auto d : full_shape) num_elems *= static_cast<size_t>(d);
+  size_t needed_bytes = num_elems * dtype_size(dtype_);
+
+  if (needed_bytes > tmp_gpu_buffer_bytes_) {
+    throw std::runtime_error("GPUContext::get_tmp_gpu_buffer: requested " +
+                             std::to_string(needed_bytes) +
+                             " bytes but buffer has " +
+                             std::to_string(tmp_gpu_buffer_bytes_));
+  }
+
+  return wrap_as_tensor(tmp_gpu_buffer_, full_shape, dtype_, device_index_);
+}
+
+std::vector<int64_t> GPUContext::get_kv_buffer_shape(int num_tokens) const {
+  if (is_mla_) {
+    return {1, num_layers_, num_tokens, hidden_dim_size_};
+  } else {
+    return {2, num_layers_, num_tokens, hidden_dim_size_};
+  }
+}
+
+std::vector<at::Tensor> GPUContext::get_tmp_gpu_buffer_batched(
+    int num_tokens, int batch_size) const {
+  if (batch_size > kMaxBatchSize) {
+    throw std::runtime_error(
+        "GPUContext::get_tmp_gpu_buffer_batched: batch_size " +
+        std::to_string(batch_size) + " exceeds max " +
+        std::to_string(kMaxBatchSize));
+  }
+
+  auto single_shape = get_kv_buffer_shape(num_tokens);
+  size_t single_elems = 1;
+  for (auto d : single_shape) single_elems *= static_cast<size_t>(d);
+  size_t elem_bytes = dtype_size(dtype_);
+
+  std::vector<at::Tensor> result;
+  result.reserve(batch_size);
+  size_t offset = 0;
+  for (int i = 0; i < batch_size; ++i) {
+    void* ptr = static_cast<uint8_t*>(tmp_gpu_buffer_) + offset;
+    result.push_back(wrap_as_tensor(ptr, single_shape, dtype_, device_index_));
+    offset += single_elems * elem_bytes;
+  }
+
+  if (offset > tmp_gpu_buffer_bytes_) {
+    throw std::runtime_error("GPUContext::get_tmp_gpu_buffer_batched: total " +
+                             std::to_string(offset) + " bytes exceeds buffer " +
+                             std::to_string(tmp_gpu_buffer_bytes_));
+  }
+
+  return result;
+}
+
+at::Tensor GPUContext::stage_block_ids(
+    const std::vector<int32_t>& block_ids) const {
+  int n = static_cast<int>(block_ids.size());
+  if (n > kMaxBlockIds) {
+    throw std::runtime_error(
+        "GPUContext::stage_block_ids: " + std::to_string(n) +
+        " block_ids exceeds max " + std::to_string(kMaxBlockIds));
+  }
+
+  // Convert int32 → int64
+  std::vector<int64_t> ids_i64(block_ids.begin(), block_ids.end());
+
+  // Copy to pre-allocated GPU buffer
+  cudaMemcpyAsync(block_ids_buffer_, ids_i64.data(), n * sizeof(int64_t),
+                  cudaMemcpyHostToDevice, stream_);
+
+  return wrap_as_tensor(block_ids_buffer_, {n}, DType::Int64, device_index_);
+}
+
+// ============================================================================
+// CUDA stream helpers
+// ============================================================================
+
+void GPUContext::launch_host_func(cudaHostFn_t fn, void* user_data) {
+  cudaError_t err = cudaLaunchHostFunc(stream_, fn, user_data);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("GPUContext::launch_host_func failed: ") +
+        cudaGetErrorString(err));
+  }
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/gpu_context.h
+++ b/csrc/server/gpu_context.h
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — Per-GPU state management
+//
+// Mirrors Python GPUCacheContext: holds raw CUDA pointers to vLLM's
+// KV cache tensors, CUDA streams, slot mapping, and transfer buffers.
+// Uses the raw CUDA runtime API (no cupy).
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <cuda_runtime_api.h>
+
+#include <torch/all.h>
+
+#include "types.h"
+#include "mp_mem_kernels.cuh"  // PageBufferShapeDesc
+
+namespace lmcache {
+namespace server {
+
+class GPUContext {
+ public:
+  /// Construct from IPC tensor descriptors + chunk_size.
+  /// Opens IPC handles, discovers KV format, creates streams.
+  ///
+  /// @param kv_cache_descs   Per-layer CudaIpcTensorDesc from REGISTER_KV_CACHE
+  /// @param chunk_size       LMCache chunk size (e.g. 256)
+  GPUContext(const std::vector<CudaIpcTensorDesc>& kv_cache_descs,
+             int chunk_size);
+
+  ~GPUContext();
+
+  // Non-copyable, non-movable (owns CUDA resources)
+  GPUContext(const GPUContext&) = delete;
+  GPUContext& operator=(const GPUContext&) = delete;
+
+  // ---- Properties ----
+
+  int device_index() const { return device_index_; }
+  DType dtype() const { return dtype_; }
+  int num_layers() const { return num_layers_; }
+  int num_blocks() const { return num_blocks_; }
+  int block_size() const { return block_size_; }
+  int hidden_dim_size() const { return hidden_dim_size_; }
+  int num_heads() const { return num_heads_; }
+  int head_size() const { return head_size_; }
+  bool is_mla() const { return is_mla_; }
+  int gpu_kv_format() const { return gpu_kv_format_; }
+
+  /// Pre-built PageBufferShapeDesc for the block-level kernel
+  PageBufferShapeDesc shape_desc() const { return shape_desc_; }
+
+  // ---- Tensor accessors (ATen wrappers over raw pointers) ----
+
+  /// GPU tensor of int64 KV cache base pointers, shape [num_layers]
+  at::Tensor kv_pointers() const;
+
+  /// Compute slot mapping tensor for the given block IDs.
+  /// Returns a flattened int64 tensor on the GPU.
+  at::Tensor get_slot_mapping_tensor(
+      const std::vector<int32_t>& gpu_block_ids) const;
+
+  /// Temporary GPU buffer for D2H/H2D transfers, shape [1or2, L, T, D]
+  at::Tensor get_tmp_gpu_buffer(int num_tokens) const;
+
+  /// Shape of the KV buffer for the given number of tokens.
+  /// MLA:     [1, num_layers, num_tokens, hidden_dim_size]
+  /// Non-MLA: [2, num_layers, num_tokens, hidden_dim_size]
+  std::vector<int64_t> get_kv_buffer_shape(int num_tokens) const;
+
+  /// Temporary GPU buffers for batched transfers (batch_size views into
+  /// the pre-allocated buffer).
+  std::vector<at::Tensor> get_tmp_gpu_buffer_batched(int num_tokens,
+                                                     int batch_size) const;
+
+  /// Copy block_ids to pre-allocated GPU buffer and return a view.
+  at::Tensor stage_block_ids(const std::vector<int32_t>& block_ids) const;
+
+  // ---- CUDA streams ----
+
+  /// Normal-priority stream for store operations
+  cudaStream_t stream() const { return stream_; }
+
+  /// High-priority stream for retrieve operations
+  cudaStream_t high_priority_stream() const { return high_priority_stream_; }
+
+  /// Schedule a host callback on the normal-priority stream.
+  /// Replaces cupy's launch_host_func with cudaLaunchHostFunc.
+  void launch_host_func(cudaHostFn_t fn, void* user_data);
+
+  // ---- Serialisation ----
+
+  /// Per-device lock to serialise GPU↔CPU data transfers.
+  /// Prevents GIL ↔ CUDA driver lock order inversion.
+  std::mutex& transfer_lock() { return transfer_lock_; }
+
+ private:
+  int device_index_;
+  DType dtype_;
+  int num_layers_;
+  int num_blocks_;
+  int block_size_;
+  int hidden_dim_size_;
+  int num_heads_;
+  int head_size_;
+  bool is_mla_;
+  int gpu_kv_format_;  // Cast of GPUKVFormat from mem_kernels.cuh
+  PageBufferShapeDesc shape_desc_;
+
+  static constexpr int kMaxBatchSize = 4;
+  static constexpr int kMaxBlockIds = 1000000;
+
+  // Raw KV cache device pointers (opened via IPC)
+  std::vector<void*> kv_cache_ptrs_;
+
+  // ATen tensors wrapping IPC handles — MUST stay alive to keep IPC memory
+  // valid. getIpcDevPtr() returns shared_ptr<void> cached via weak_ptr;
+  // destroying these tensors releases the last shared_ptr, closing the IPC
+  // handle and invalidating kv_cache_ptrs_.
+  std::vector<at::Tensor> kv_cache_ipc_tensors_;
+
+  // GPU tensor of kv_cache_ptrs_ as int64, shape [num_layers]
+  void* kv_pointers_gpu_;  // device memory
+
+  // Pre-computed slot mapping, shape [num_blocks, block_size]
+  void* slot_mapping_gpu_;  // device memory
+
+  // Temporary GPU buffer for transfers
+  void* tmp_gpu_buffer_;  // device memory
+  size_t tmp_gpu_buffer_bytes_;
+
+  // Pre-allocated GPU buffer for block IDs (up to kMaxBlockIds int64 elements)
+  void* block_ids_buffer_;  // device memory
+
+  // CUDA streams
+  cudaStream_t stream_;
+  cudaStream_t high_priority_stream_;
+
+  // Per-device transfer lock
+  std::mutex transfer_lock_;
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/l1_store.cpp
+++ b/csrc/server/l1_store.cpp
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — L1 slab store implementation
+//
+// mmap'd slab allocator with per-slot state machine and LRU eviction.
+
+#include "l1_store.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+#include <sys/mman.h>  // mmap, munmap, MAP_HUGETLB
+
+#include <cuda_runtime.h>  // cudaHostRegister, cudaHostUnregister
+
+#include "storage_manager/ttl_lock.h"
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Monotonic clock helper
+// ============================================================================
+
+static uint64_t now_monotonic_us() {
+  using Clock = std::chrono::steady_clock;
+  auto now = Clock::now();
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          now.time_since_epoch())
+          .count());
+}
+
+// ============================================================================
+// Slot — per-object state
+// ============================================================================
+
+struct Slot {
+  enum class State { FREE, WRITING, READY, READING };
+
+  State state = State::FREE;
+  void* data = nullptr;
+  size_t size_bytes = 0;
+  MemoryLayoutDesc layout;
+  lmcache::storage_manager::TTLLock read_lock;
+  uint64_t last_access_time = 0;
+
+  // Index into the slab free list (the offset within the mmap region).
+  size_t slab_offset = 0;
+
+  explicit Slot(uint32_t ttl_seconds = 300) : read_lock(ttl_seconds) {}
+};
+
+// ============================================================================
+// FreeBlock — bump allocator + free list for slab memory
+// ============================================================================
+
+struct FreeBlock {
+  size_t offset;
+  size_t size;
+};
+
+class SlabAllocator {
+ public:
+  SlabAllocator(size_t capacity) : capacity_(capacity), bump_(0) {}
+
+  // Allocate `size` bytes. Returns offset or (size_t)-1 on failure.
+  size_t allocate(size_t size) {
+    if (size == 0) return 0;
+
+    // Round up to 64-byte alignment for cache-line / DMA friendliness
+    size = align_up(size, 64);
+
+    // First-fit from free list
+    for (auto it = free_list_.begin(); it != free_list_.end(); ++it) {
+      if (it->size >= size) {
+        size_t offset = it->offset;
+        if (it->size == size) {
+          free_list_.erase(it);
+        } else {
+          it->offset += size;
+          it->size -= size;
+        }
+        used_ += size;
+        return offset;
+      }
+    }
+
+    // Bump allocate
+    if (bump_ + size <= capacity_) {
+      size_t offset = bump_;
+      bump_ += size;
+      used_ += size;
+      return offset;
+    }
+
+    return static_cast<size_t>(-1);  // OOM
+  }
+
+  void deallocate(size_t offset, size_t size) {
+    if (size == 0) return;
+    size = align_up(size, 64);
+    free_list_.push_back({offset, size});
+    used_ -= size;
+    coalesce_last();
+  }
+
+  size_t used() const { return used_; }
+  size_t capacity() const { return capacity_; }
+
+ private:
+  static size_t align_up(size_t v, size_t a) { return (v + a - 1) & ~(a - 1); }
+
+  // Try to merge the last inserted free block with neighbours.
+  // Simple O(n) sweep — good enough for typical workloads.
+  void coalesce_last() {
+    if (free_list_.size() < 2) return;
+
+    // Sort by offset, then merge adjacent
+    std::sort(free_list_.begin(), free_list_.end(),
+              [](const FreeBlock& a, const FreeBlock& b) {
+                return a.offset < b.offset;
+              });
+
+    std::deque<FreeBlock> merged;
+    merged.push_back(free_list_.front());
+    for (size_t i = 1; i < free_list_.size(); ++i) {
+      auto& back = merged.back();
+      if (back.offset + back.size == free_list_[i].offset) {
+        back.size += free_list_[i].size;
+      } else {
+        merged.push_back(free_list_[i]);
+      }
+    }
+
+    // Trim bump pointer if the last free block is contiguous with it
+    if (!merged.empty()) {
+      auto& last = merged.back();
+      if (last.offset + last.size == bump_) {
+        bump_ = last.offset;
+        merged.pop_back();
+      }
+    }
+
+    free_list_ = std::move(merged);
+  }
+
+  size_t capacity_;
+  size_t bump_ = 0;
+  size_t used_ = 0;
+  std::deque<FreeBlock> free_list_;
+};
+
+// ============================================================================
+// L1StoreImpl
+// ============================================================================
+
+class L1StoreImpl : public L1Store {
+ public:
+  explicit L1StoreImpl(const L1StoreConfig& config)
+      : config_(config), allocator_(config.capacity_bytes) {
+    // mmap the slab region
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+    if (config.use_hugepages) {
+      flags |= MAP_HUGETLB;
+    }
+
+    slab_ = ::mmap(nullptr, config.capacity_bytes, PROT_READ | PROT_WRITE,
+                   flags, -1, 0);
+    if (slab_ == MAP_FAILED) {
+      // Retry without hugepages
+      if (config.use_hugepages) {
+        flags &= ~MAP_HUGETLB;
+        slab_ = ::mmap(nullptr, config.capacity_bytes, PROT_READ | PROT_WRITE,
+                       flags, -1, 0);
+      }
+      if (slab_ == MAP_FAILED) {
+        throw std::runtime_error("L1StoreImpl: mmap failed for " +
+                                 std::to_string(config.capacity_bytes) +
+                                 " bytes");
+      }
+    }
+
+    // Optionally pin for zero-copy GPU DMA
+    if (config.cuda_host_register) {
+      cudaError_t err = cudaHostRegister(slab_, config.capacity_bytes,
+                                         cudaHostRegisterDefault);
+      if (err != cudaSuccess) {
+        // Non-fatal: log and continue without pinning
+        cuda_registered_ = false;
+      } else {
+        cuda_registered_ = true;
+      }
+    }
+  }
+
+  ~L1StoreImpl() override {
+    // Force-clear to release all state
+    clear(/*force=*/true);
+
+    if (cuda_registered_) {
+      cudaHostUnregister(slab_);
+    }
+    ::munmap(slab_, config_.capacity_bytes);
+  }
+
+  // ------------------------------------------------------------------
+  // Write path
+  // ------------------------------------------------------------------
+
+  std::unordered_map<ObjectKey, MemorySlabRef, ObjectKeyHash> reserve_write(
+      const std::vector<ObjectKey>& keys, const MemoryLayoutDesc& layout,
+      const std::string& mode) override {
+    (void)mode;
+
+    // Compute per-object size from layout
+    size_t obj_size = compute_layout_size(layout);
+
+    std::lock_guard<std::mutex> lk(mu_);
+
+    std::unordered_map<ObjectKey, MemorySlabRef, ObjectKeyHash> result;
+
+    for (const auto& key : keys) {
+      // If key already exists and is not FREE, skip
+      auto it = key_to_slot_.find(key);
+      if (it != key_to_slot_.end()) {
+        auto& slot = slots_[it->second];
+        if (slot.state != Slot::State::FREE) {
+          continue;  // already in use
+        }
+        // Recycle: free the old slab region if sizes differ
+        if (slot.size_bytes != obj_size) {
+          allocator_.deallocate(slot.slab_offset, slot.size_bytes);
+          size_t offset = allocator_.allocate(obj_size);
+          if (offset == static_cast<size_t>(-1)) {
+            // Try eviction
+            evict_locked(obj_size);
+            offset = allocator_.allocate(obj_size);
+            if (offset == static_cast<size_t>(-1)) continue;  // still OOM
+          }
+          slot.slab_offset = offset;
+          slot.data = static_cast<char*>(slab_) + offset;
+          slot.size_bytes = obj_size;
+        }
+        slot.state = Slot::State::WRITING;
+        slot.layout = layout;
+        slot.last_access_time = now_monotonic_us();
+        result[key] = MemorySlabRef{slot.data, slot.size_bytes, slot.layout};
+        continue;
+      }
+
+      // Need to allocate a new slot
+      size_t offset = allocator_.allocate(obj_size);
+      if (offset == static_cast<size_t>(-1)) {
+        evict_locked(obj_size);
+        offset = allocator_.allocate(obj_size);
+        if (offset == static_cast<size_t>(-1)) continue;  // OOM
+      }
+
+      size_t slot_idx = alloc_slot_index();
+      auto& slot = slots_[slot_idx];
+      slot.state = Slot::State::WRITING;
+      slot.slab_offset = offset;
+      slot.data = static_cast<char*>(slab_) + offset;
+      slot.size_bytes = obj_size;
+      slot.layout = layout;
+      slot.last_access_time = now_monotonic_us();
+
+      key_to_slot_[key] = slot_idx;
+      result[key] = MemorySlabRef{slot.data, slot.size_bytes, slot.layout};
+    }
+
+    return result;
+  }
+
+  void finish_write(const std::vector<ObjectKey>& keys) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    for (const auto& key : keys) {
+      auto it = key_to_slot_.find(key);
+      if (it == key_to_slot_.end()) continue;
+      auto& slot = slots_[it->second];
+      if (slot.state == Slot::State::WRITING) {
+        slot.state = Slot::State::READY;
+        slot.last_access_time = now_monotonic_us();
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Read path
+  // ------------------------------------------------------------------
+
+  std::unordered_map<ObjectKey, MemorySlabRef, ObjectKeyHash> reserve_read(
+      const std::vector<ObjectKey>& keys, int extra_count) override {
+    std::lock_guard<std::mutex> lk(mu_);
+
+    std::unordered_map<ObjectKey, MemorySlabRef, ObjectKeyHash> result;
+
+    for (const auto& key : keys) {
+      auto it = key_to_slot_.find(key);
+      if (it == key_to_slot_.end()) continue;
+
+      auto& slot = slots_[it->second];
+      if (slot.state != Slot::State::READY &&
+          slot.state != Slot::State::READING) {
+        continue;
+      }
+
+      // Lock for this reader + extra_count (MLA multi-reader)
+      int lock_count = 1 + extra_count;
+      for (int i = 0; i < lock_count; ++i) {
+        slot.read_lock.lock();
+      }
+      slot.state = Slot::State::READING;
+      slot.last_access_time = now_monotonic_us();
+
+      result[key] = MemorySlabRef{slot.data, slot.size_bytes, slot.layout};
+    }
+
+    return result;
+  }
+
+  void finish_read(const std::vector<ObjectKey>& keys,
+                   int extra_count) override {
+    std::lock_guard<std::mutex> lk(mu_);
+
+    for (const auto& key : keys) {
+      auto it = key_to_slot_.find(key);
+      if (it == key_to_slot_.end()) continue;
+
+      auto& slot = slots_[it->second];
+      if (slot.state != Slot::State::READING) continue;
+
+      int unlock_count = 1 + extra_count;
+      for (int i = 0; i < unlock_count; ++i) {
+        slot.read_lock.unlock();
+      }
+
+      // Transition back to READY if no longer locked
+      if (!slot.read_lock.is_locked()) {
+        slot.state = Slot::State::READY;
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Lookup
+  // ------------------------------------------------------------------
+
+  int64_t prefix_lookup(const std::vector<ObjectKey>& keys) override {
+    std::lock_guard<std::mutex> lk(mu_);
+
+    int64_t count = 0;
+    for (const auto& key : keys) {
+      auto it = key_to_slot_.find(key);
+      if (it == key_to_slot_.end()) break;
+      auto& slot = slots_[it->second];
+      if (slot.state != Slot::State::READY &&
+          slot.state != Slot::State::READING) {
+        break;
+      }
+      ++count;
+    }
+    return count;
+  }
+
+  // ------------------------------------------------------------------
+  // Deletion / eviction
+  // ------------------------------------------------------------------
+
+  L1Error delete_key(const ObjectKey& key) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return delete_key_locked(key);
+  }
+
+  size_t evict(size_t bytes_needed) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return evict_locked(bytes_needed);
+  }
+
+  // ------------------------------------------------------------------
+  // Capacity / diagnostics
+  // ------------------------------------------------------------------
+
+  size_t total_capacity_bytes() const override {
+    return config_.capacity_bytes;
+  }
+
+  size_t used_bytes() const override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return allocator_.used();
+  }
+
+  void clear(bool force) override {
+    std::lock_guard<std::mutex> lk(mu_);
+
+    // Collect all keys to delete
+    std::vector<ObjectKey> to_delete;
+    to_delete.reserve(key_to_slot_.size());
+    for (const auto& [key, idx] : key_to_slot_) {
+      auto& slot = slots_[idx];
+      if (!force && slot.read_lock.is_locked()) continue;
+      to_delete.push_back(key);
+    }
+    for (const auto& key : to_delete) {
+      delete_key_locked_force(key, force);
+    }
+  }
+
+  bool memcheck() const override {
+    std::lock_guard<std::mutex> lk(mu_);
+
+    // Check 1: every entry in key_to_slot_ points to a valid slot
+    for (const auto& [key, idx] : key_to_slot_) {
+      if (idx >= slots_.size()) return false;
+      auto& slot = slots_[idx];
+      if (slot.state == Slot::State::FREE)
+        return false;  // mapped key shouldn't be FREE
+      if (slot.data == nullptr) return false;
+      // data pointer should be within slab region
+      auto* p = static_cast<char*>(slot.data);
+      auto* base = static_cast<char*>(slab_);
+      if (p < base || p >= base + config_.capacity_bytes) return false;
+      if (slot.slab_offset + slot.size_bytes > config_.capacity_bytes)
+        return false;
+    }
+
+    // Check 2: free slot indices should have FREE state
+    for (size_t fi : free_slot_indices_) {
+      if (fi >= slots_.size()) return false;
+      if (slots_[fi].state != Slot::State::FREE) return false;
+    }
+
+    return true;
+  }
+
+ private:
+  // ------------------------------------------------------------------
+  // Internal helpers
+  // ------------------------------------------------------------------
+
+  size_t alloc_slot_index() {
+    if (!free_slot_indices_.empty()) {
+      size_t idx = free_slot_indices_.back();
+      free_slot_indices_.pop_back();
+      return idx;
+    }
+    slots_.emplace_back(config_.ttl_seconds);
+    return slots_.size() - 1;
+  }
+
+  void free_slot_index(size_t idx) {
+    auto& slot = slots_[idx];
+    slot.state = Slot::State::FREE;
+    slot.data = nullptr;
+    slot.size_bytes = 0;
+    slot.layout = {};
+    slot.read_lock.reset();
+    slot.last_access_time = 0;
+    slot.slab_offset = 0;
+    free_slot_indices_.push_back(idx);
+  }
+
+  L1Error delete_key_locked(const ObjectKey& key) {
+    return delete_key_locked_force(key, /*force=*/false);
+  }
+
+  L1Error delete_key_locked_force(const ObjectKey& key, bool force) {
+    auto it = key_to_slot_.find(key);
+    if (it == key_to_slot_.end()) return L1Error::KEY_NOT_EXIST;
+
+    size_t idx = it->second;
+    auto& slot = slots_[idx];
+
+    if (!force && slot.read_lock.is_locked()) {
+      return L1Error::KEY_IS_LOCKED;
+    }
+
+    if (!force && slot.state == Slot::State::WRITING) {
+      return L1Error::KEY_IN_WRONG_STATE;
+    }
+
+    // Release slab memory
+    allocator_.deallocate(slot.slab_offset, slot.size_bytes);
+
+    // Return slot to free list
+    free_slot_index(idx);
+    key_to_slot_.erase(it);
+
+    return L1Error::SUCCESS;
+  }
+
+  // LRU eviction: evict READY slots with oldest access time.
+  // Returns total bytes freed.
+  size_t evict_locked(size_t bytes_needed) {
+    size_t freed = 0;
+
+    while (freed < bytes_needed) {
+      // Find the READY slot with oldest last_access_time
+      ObjectKey victim_key;
+      size_t victim_idx = static_cast<size_t>(-1);
+      uint64_t oldest_time = UINT64_MAX;
+
+      for (const auto& [key, idx] : key_to_slot_) {
+        auto& slot = slots_[idx];
+        if (slot.state == Slot::State::READY && !slot.read_lock.is_locked() &&
+            slot.last_access_time < oldest_time) {
+          oldest_time = slot.last_access_time;
+          victim_idx = idx;
+          victim_key = key;
+        }
+      }
+
+      if (victim_idx == static_cast<size_t>(-1)) {
+        break;  // No more evictable slots
+      }
+
+      size_t victim_size = slots_[victim_idx].size_bytes;
+      delete_key_locked_force(victim_key, /*force=*/false);
+      freed += victim_size;
+    }
+
+    return freed;
+  }
+
+  /// Compute total byte size from a MemoryLayoutDesc
+  static size_t compute_layout_size(const MemoryLayoutDesc& layout) {
+    size_t total = 0;
+    for (size_t i = 0; i < layout.shapes.size(); ++i) {
+      size_t elem_count = 1;
+      for (auto d : layout.shapes[i].dims) {
+        elem_count *= static_cast<size_t>(d);
+      }
+      DType dt = (i < layout.dtypes.size()) ? layout.dtypes[i] : DType::Float16;
+      total += elem_count * dtype_size(dt);
+    }
+    return total;
+  }
+
+  // ------------------------------------------------------------------
+  // Data members
+  // ------------------------------------------------------------------
+
+  L1StoreConfig config_;
+  void* slab_ = nullptr;
+  bool cuda_registered_ = false;
+
+  mutable std::mutex mu_;
+  SlabAllocator allocator_;
+
+  // deque: Slot contains std::atomic (TTLLock) so it's non-movable.
+  // deque never relocates existing elements on push_back.
+  std::deque<Slot> slots_;
+  std::vector<size_t> free_slot_indices_;
+  std::unordered_map<ObjectKey, size_t, ObjectKeyHash> key_to_slot_;
+};
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+std::unique_ptr<L1Store> L1Store::create(const L1StoreConfig& config) {
+  return std::make_unique<L1StoreImpl>(config);
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/l1_store.h
+++ b/csrc/server/l1_store.h
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — L1 slab storage interface
+//
+// Abstract interface for the in-memory (L1) KV cache store.
+// The slab is mmap'd + cudaHostRegister'd for zero-copy DMA.
+//
+// State machine per slot: Free → Writing → Ready → Reading → Ready
+//                                                  ↘ Free (evict/delete)
+//
+// Uses the existing C++ TTLLock for lock state management.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "types.h"
+
+// Forward-declare existing C++ types
+namespace lmcache {
+namespace storage_manager {
+class Bitmap;
+}
+}  // namespace lmcache
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// L1Store configuration
+// ============================================================================
+
+struct L1StoreConfig {
+  size_t capacity_bytes;    // Total slab capacity
+  bool use_hugepages;       // mmap with MAP_HUGETLB
+  bool cuda_host_register;  // cudaHostRegister for zero-copy DMA
+  uint32_t ttl_seconds;     // TTL for read locks (default 300)
+};
+
+// ============================================================================
+// L1Store — abstract interface
+// ============================================================================
+
+class L1Store {
+ public:
+  virtual ~L1Store() = default;
+
+  // ---- Write path ----
+
+  /// Reserve write slots for the given keys.
+  /// Transitions matching free slots to Writing state.
+  /// Returns a map of successfully reserved keys to their slab references.
+  virtual std::unordered_map<ObjectKey, MemorySlabRef, ObjectKeyHash>
+  reserve_write(const std::vector<ObjectKey>& keys,
+                const MemoryLayoutDesc& layout, const std::string& mode) = 0;
+
+  /// Mark writing complete, transition to Ready state.
+  /// Triggers L2 store via callback if configured.
+  virtual void finish_write(const std::vector<ObjectKey>& keys) = 0;
+
+  // ---- Read path ----
+
+  /// Reserve read slots for the given keys.
+  /// Returns slab references for keys in Ready state.
+  /// extra_count: additional reader count for MLA multi-reader locking.
+  virtual std::unordered_map<ObjectKey, MemorySlabRef, ObjectKeyHash>
+  reserve_read(const std::vector<ObjectKey>& keys, int extra_count = 0) = 0;
+
+  /// Release read locks.
+  virtual void finish_read(const std::vector<ObjectKey>& keys,
+                           int extra_count = 0) = 0;
+
+  // ---- Lookup ----
+
+  /// Find the longest contiguous prefix of keys that exist in L1.
+  /// Returns the number of prefix hits.
+  virtual int64_t prefix_lookup(const std::vector<ObjectKey>& keys) = 0;
+
+  // ---- Deletion / eviction ----
+
+  /// Delete a specific key from L1.
+  virtual L1Error delete_key(const ObjectKey& key) = 0;
+
+  /// Evict entries to free at least `bytes_needed` bytes.
+  /// Returns the number of bytes actually freed.
+  virtual size_t evict(size_t bytes_needed) = 0;
+
+  // ---- Capacity / diagnostics ----
+
+  virtual size_t total_capacity_bytes() const = 0;
+  virtual size_t used_bytes() const = 0;
+
+  /// Clear all entries (optionally forced even if locked).
+  virtual void clear(bool force = false) = 0;
+
+  /// Memory consistency check (debug).
+  virtual bool memcheck() const = 0;
+
+  // ---- Factory ----
+
+  /// Create an L1Store instance.
+  static std::unique_ptr<L1Store> create(const L1StoreConfig& config);
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/l2_adapter.h
+++ b/csrc/server/l2_adapter.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — L2 async I/O adapter interface
+//
+// Abstract interface mirroring Python L2AdapterInterface.
+// Non-blocking submit/query model with eventfd signalling for
+// integration with the ZMQ poll loop.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "types.h"
+
+// Forward-declare Bitmap from existing C++ code
+namespace lmcache {
+namespace storage_manager {
+class Bitmap;
+}
+}  // namespace lmcache
+
+namespace lmcache {
+namespace server {
+
+/// Opaque task identifier for L2 async operations
+using L2TaskId = int64_t;
+
+// ============================================================================
+// L2Adapter — abstract interface for L2 storage backends
+// ============================================================================
+
+class L2Adapter {
+ public:
+  virtual ~L2Adapter() = default;
+
+  // ---- Event file descriptors ----
+  //
+  // Each of the three methods MUST return a distinct fd.
+  // The main loop polls these to know when results are available.
+
+  /// eventfd for completed store tasks
+  virtual int get_store_event_fd() const = 0;
+
+  /// eventfd for completed lookup-and-lock tasks
+  virtual int get_lookup_and_lock_event_fd() const = 0;
+
+  /// eventfd for completed load tasks
+  virtual int get_load_event_fd() const = 0;
+
+  // ---- Store path ----
+
+  /// Submit a store task (fire-and-forget with task tracking).
+  /// @param keys     Object keys to store
+  /// @param data     Corresponding slab references with data
+  /// @return         Task ID for tracking completion
+  virtual L2TaskId submit_store_task(
+      const std::vector<ObjectKey>& keys,
+      const std::vector<MemorySlabRef>& data) = 0;
+
+  /// Pop all completed store tasks.
+  /// @return Map of task_id → success/failure
+  virtual std::unordered_map<L2TaskId, bool> pop_completed_store_tasks() = 0;
+
+  // ---- Lookup and lock path ----
+
+  /// Submit a lookup-and-lock task (checks existence, pins objects).
+  /// @param keys  Keys to look up
+  /// @return      Task ID for querying results
+  virtual L2TaskId submit_lookup_and_lock_task(
+      const std::vector<ObjectKey>& keys) = 0;
+
+  /// Query lookup-and-lock result.
+  /// @param task_id  Task ID from submit_lookup_and_lock_task
+  /// @return         Bitmap of hits (1=found), or nullptr if not ready
+  ///                 Non-idempotent: result is consumed on read.
+  virtual storage_manager::Bitmap* query_lookup_and_lock_result(
+      L2TaskId task_id) = 0;
+
+  /// Release pins acquired during lookup (fire-and-forget).
+  virtual void submit_unlock(const std::vector<ObjectKey>& keys) = 0;
+
+  // ---- Load path ----
+
+  /// Submit an L2-to-L1 load task.
+  /// @param keys     Keys to load
+  /// @param targets  L1 slab references to write into
+  /// @return         Task ID for querying results
+  virtual L2TaskId submit_load_task(
+      const std::vector<ObjectKey>& keys,
+      const std::vector<MemorySlabRef>& targets) = 0;
+
+  /// Query load result.
+  /// @param task_id  Task ID from submit_load_task
+  /// @return         Bitmap of per-key success, or nullptr if not ready
+  ///                 Non-idempotent: result is consumed on read.
+  virtual storage_manager::Bitmap* query_load_result(L2TaskId task_id) = 0;
+
+  // ---- Lifecycle ----
+
+  /// Close the adapter and release resources (including eventfds).
+  virtual void close() = 0;
+
+  /// Health check.
+  virtual bool is_healthy() const = 0;
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/main.cpp
+++ b/csrc/server/main.cpp
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — Main entry point
+//
+// Wires CacheEngine + MessageQueueServer with concrete request handlers.
+// Mirrors Python run_cache_server() from server.py.
+
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <execinfo.h>
+#include <unistd.h>
+
+#include "types.h"
+#include "wire_protocol.h"
+#include "cache_engine.h"
+#include "mq_server.h"
+
+#include <cuda_runtime_api.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+using namespace lmcache::server;
+
+static std::atomic<bool> g_shutdown{false};
+
+static void signal_handler(int signum) {
+  (void)signum;
+  g_shutdown.store(true, std::memory_order_release);
+}
+
+static void crash_handler(int signum) {
+  std::fprintf(stderr, "\n=== CRASH: signal %d (%s) ===\n", signum,
+               strsignal(signum));
+  void* frames[64];
+  int n = backtrace(frames, 64);
+  backtrace_symbols_fd(frames, n, STDERR_FILENO);
+  std::fprintf(stderr, "=== END BACKTRACE ===\n");
+  _exit(128 + signum);
+}
+
+// ============================================================================
+// Concrete request handlers — bridge IRequestHandler to CacheEngine methods
+// ============================================================================
+
+// --- REGISTER_KV_CACHE: SYNC, no response ---
+class RegisterHandler : public IRequestHandler {
+ public:
+  explicit RegisterHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::SYNC; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_register_payload(payloads);
+    engine_.register_kv_cache(p.instance_id, p.kv_caches, p.model_name,
+                              p.world_size);
+    return enc_.encode_none_response();
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- UNREGISTER_KV_CACHE: SYNC, no response ---
+class UnregisterHandler : public IRequestHandler {
+ public:
+  explicit UnregisterHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::SYNC; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    if (payloads.empty()) return enc_.encode_none_response();
+    int32_t instance_id =
+        dec_.decode_int_payload(payloads[0].data(), payloads[0].size());
+    engine_.unregister_kv_cache(instance_id);
+    return enc_.encode_none_response();
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- STORE: BLOCKING, returns tuple[bytes, bool] ---
+class StoreHandler : public IRequestHandler {
+ public:
+  explicit StoreHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_store_payload(payloads);
+    auto [ev, ok] = engine_.store(p.key, p.instance_id, p.gpu_block_ids,
+                                  p.event_ipc_handle);
+    return enc_.encode_store_response(ev, ok);
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- RETRIEVE: BLOCKING, returns tuple[bytes, bool] ---
+class RetrieveHandler : public IRequestHandler {
+ public:
+  explicit RetrieveHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_retrieve_payload(payloads);
+    auto [ev, ok] = engine_.retrieve(p.key, p.instance_id, p.gpu_block_ids,
+                                     p.event_ipc_handle, p.skip_first_n_tokens);
+    return enc_.encode_retrieve_response(ev, ok);
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- LOOKUP: BLOCKING, returns int ---
+class LookupHandler : public IRequestHandler {
+ public:
+  explicit LookupHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_lookup_payload(payloads);
+    int result = engine_.lookup(p.key, p.tp_size);
+    return enc_.encode_int_response(result);
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- QUERY_PREFETCH_STATUS: SYNC, returns int|None ---
+class QueryPrefetchStatusHandler : public IRequestHandler {
+ public:
+  explicit QueryPrefetchStatusHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::SYNC; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_query_prefetch_status_payload(payloads);
+    int result = engine_.query_prefetch_status(p.prefetch_job_id);
+    if (result < 0) {
+      return enc_.encode_optional_int_response(0, true);  // None
+    }
+    return enc_.encode_optional_int_response(result, false);
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- QUERY_PREFETCH_LOOKUP_HITS: BLOCKING, returns int|None ---
+class QueryPrefetchLookupHitsHandler : public IRequestHandler {
+ public:
+  explicit QueryPrefetchLookupHitsHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_query_prefetch_lookup_hits_payload(payloads);
+    int result = engine_.query_prefetch_lookup_hits(p.prefetch_job_id);
+    if (result < 0) {
+      return enc_.encode_optional_int_response(0, true);  // None
+    }
+    return enc_.encode_optional_int_response(result, false);
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- FREE_LOOKUP_LOCKS: BLOCKING, no response ---
+class FreeLookupLocksHandler : public IRequestHandler {
+ public:
+  explicit FreeLookupLocksHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_free_lookup_locks_payload(payloads);
+    engine_.free_lookup_locks(p.key, p.tp_size);
+    return enc_.encode_none_response();
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- END_SESSION: BLOCKING, no response ---
+class EndSessionHandler : public IRequestHandler {
+ public:
+  explicit EndSessionHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) override {
+    auto p = dec_.decode_end_session_payload(payloads);
+    engine_.end_session(p.request_id);
+    return enc_.encode_none_response();
+  }
+
+ private:
+  CacheEngine& engine_;
+  Decoder dec_;
+  Encoder enc_;
+};
+
+// --- CLEAR: BLOCKING, no response ---
+class ClearHandler : public IRequestHandler {
+ public:
+  explicit ClearHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    engine_.clear();
+    return enc_.encode_none_response();
+  }
+
+ private:
+  CacheEngine& engine_;
+  Encoder enc_;
+};
+
+// --- GET_CHUNK_SIZE: SYNC, returns int ---
+class GetChunkSizeHandler : public IRequestHandler {
+ public:
+  explicit GetChunkSizeHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::SYNC; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return enc_.encode_int_response(engine_.get_chunk_size());
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+
+ private:
+  CacheEngine& engine_;
+  Encoder enc_;
+};
+
+// --- PING: BLOCKING, returns bool ---
+class PingHandler : public IRequestHandler {
+ public:
+  explicit PingHandler(CacheEngine& e) : engine_(e) {}
+  HandlerType handler_type() const override { return HandlerType::BLOCKING; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return enc_.encode_bool_response(engine_.ping());
+  }
+
+ private:
+  CacheEngine& engine_;
+  Encoder enc_;
+};
+
+// --- NOOP: SYNC, returns str ---
+class NoopHandler : public IRequestHandler {
+ public:
+  HandlerType handler_type() const override { return HandlerType::SYNC; }
+  std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return enc_.encode_string_response("OK");
+  }
+  std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>&) override {
+    return {};
+  }
+
+ private:
+  Encoder enc_;
+};
+
+// ============================================================================
+// CLI argument parsing
+// ============================================================================
+
+struct ServerConfig {
+  std::string host = "0.0.0.0";
+  int port = 8001;
+  int chunk_size = 256;
+  size_t l1_capacity_gib = 8;
+  int max_gpu_workers = 8;
+  int max_cpu_workers = 8;
+  bool hugepages = false;
+  bool cuda_host_register = true;
+};
+
+static ServerConfig parse_args(int argc, char* argv[]) {
+  ServerConfig cfg;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    auto get_next = [&]() -> std::string {
+      if (i + 1 >= argc) {
+        std::fprintf(stderr, "ERROR: %s requires a value\n", arg.c_str());
+        std::exit(1);
+      }
+      return argv[++i];
+    };
+    if (arg == "--host")
+      cfg.host = get_next();
+    else if (arg == "--port")
+      cfg.port = std::stoi(get_next());
+    else if (arg == "--chunk-size")
+      cfg.chunk_size = std::stoi(get_next());
+    else if (arg == "--l1-capacity-gib")
+      cfg.l1_capacity_gib = std::stoull(get_next());
+    else if (arg == "--max-workers")
+      // Legacy: set both GPU and CPU workers
+      cfg.max_gpu_workers = cfg.max_cpu_workers = std::stoi(get_next());
+    else if (arg == "--max-gpu-workers")
+      cfg.max_gpu_workers = std::stoi(get_next());
+    else if (arg == "--max-cpu-workers")
+      cfg.max_cpu_workers = std::stoi(get_next());
+    else if (arg == "--hugepages")
+      cfg.hugepages = true;
+    else if (arg == "--no-cuda-host-register")
+      cfg.cuda_host_register = false;
+    else if (arg == "--help" || arg == "-h") {
+      std::printf(
+          "Usage: lmcache-server [options]\n"
+          "  --host HOST             Bind address (default: 0.0.0.0)\n"
+          "  --port PORT             Bind port (default: 8001)\n"
+          "  --chunk-size N          Tokens per chunk (default: 256)\n"
+          "  --l1-capacity-gib N     L1 slab capacity in GiB (default: 8)\n"
+          "  --max-workers N         Thread pool workers (sets both GPU and "
+          "CPU, default: 8)\n"
+          "  --max-gpu-workers N     Affinity pool workers for STORE/RETRIEVE "
+          "(default: 8)\n"
+          "  --max-cpu-workers N     Normal pool workers for LOOKUP etc. "
+          "(default: 8)\n"
+          "  --hugepages             Use huge pages for L1 slab\n"
+          "  --no-cuda-host-register Disable cudaHostRegister on L1 slab\n");
+      std::exit(0);
+    } else {
+      std::fprintf(stderr, "WARNING: unknown arg: %s\n", arg.c_str());
+    }
+  }
+  return cfg;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char* argv[]) {
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+  std::signal(SIGSEGV, crash_handler);
+  std::signal(SIGABRT, crash_handler);
+  std::signal(SIGBUS, crash_handler);
+  std::signal(SIGFPE, crash_handler);
+
+  auto cfg = parse_args(argc, argv);
+
+  std::printf("lmcache-server (pure C++)\n");
+  std::printf("  bind: tcp://%s:%d\n", cfg.host.c_str(), cfg.port);
+  std::printf("  chunk_size: %d\n", cfg.chunk_size);
+  std::printf("  L1 capacity: %zu GiB\n", cfg.l1_capacity_gib);
+  std::printf("  max_gpu_workers: %d\n", cfg.max_gpu_workers);
+  std::printf("  max_cpu_workers: %d\n", cfg.max_cpu_workers);
+
+  // Create L1 store config
+  L1StoreConfig l1_config{};
+  l1_config.capacity_bytes = cfg.l1_capacity_gib * 1024ULL * 1024 * 1024;
+  l1_config.use_hugepages = cfg.hugepages;
+  l1_config.cuda_host_register = cfg.cuda_host_register;
+  l1_config.ttl_seconds = 300;
+
+  // Initialize CUDA runtime + caching allocator BEFORE creating CacheEngine.
+  // Critical ordering:
+  //   1. CUDA runtime init (cudaFree per device)
+  //   2. libtorch CUDACachingAllocator::init
+  //   3. CacheEngine (creates L1 slab with cudaHostRegister)
+  // If CUDA isn't initialized first, cudaHostRegister silently fails
+  // and later cudaMemcpyAsync D2H hits illegal memory access.
+  {
+    int device_count = 0;
+    cudaGetDeviceCount(&device_count);
+    if (device_count > 0) {
+      for (int i = 0; i < device_count; ++i) {
+        cudaSetDevice(i);
+        cudaFree(nullptr);
+      }
+      cudaSetDevice(0);
+      c10::cuda::CUDACachingAllocator::init(device_count);
+    }
+    std::printf("CUDA initialized: %d device(s)\n", device_count);
+  }
+
+  // Create cache engine (L1 only for now; L2 adapter = nullptr)
+  CacheEngine engine(cfg.chunk_size, l1_config, nullptr);
+
+  // Create ZMQ server (max_workers param unused now, pools assigned below)
+  std::string bind_url = "tcp://" + cfg.host + ":" + std::to_string(cfg.port);
+  MessageQueueServer server(bind_url, 0);
+
+  // Register all handlers (matching Python run_cache_server on origin/dev)
+  server.add_handler(RequestType::REGISTER_KV_CACHE,
+                     std::make_unique<RegisterHandler>(engine));
+  server.add_handler(RequestType::UNREGISTER_KV_CACHE,
+                     std::make_unique<UnregisterHandler>(engine));
+  server.add_handler(RequestType::STORE,
+                     std::make_unique<StoreHandler>(engine));
+  server.add_handler(RequestType::RETRIEVE,
+                     std::make_unique<RetrieveHandler>(engine));
+  server.add_handler(RequestType::LOOKUP,
+                     std::make_unique<LookupHandler>(engine));
+  server.add_handler(RequestType::QUERY_PREFETCH_STATUS,
+                     std::make_unique<QueryPrefetchStatusHandler>(engine));
+  server.add_handler(RequestType::QUERY_PREFETCH_LOOKUP_HITS,
+                     std::make_unique<QueryPrefetchLookupHitsHandler>(engine));
+  server.add_handler(RequestType::FREE_LOOKUP_LOCKS,
+                     std::make_unique<FreeLookupLocksHandler>(engine));
+  server.add_handler(RequestType::END_SESSION,
+                     std::make_unique<EndSessionHandler>(engine));
+  server.add_handler(RequestType::CLEAR,
+                     std::make_unique<ClearHandler>(engine));
+  server.add_handler(RequestType::GET_CHUNK_SIZE,
+                     std::make_unique<GetChunkSizeHandler>(engine));
+  server.add_handler(RequestType::PING, std::make_unique<PingHandler>(engine));
+  server.add_handler(RequestType::NOOP, std::make_unique<NoopHandler>());
+
+  // Affinity pool for GPU-bound handlers (STORE, RETRIEVE)
+  // Same identity → same worker thread, eliminates per-instance GPU locks
+  server.add_affinity_thread_pool({RequestType::STORE, RequestType::RETRIEVE},
+                                  cfg.max_gpu_workers);
+
+  // Normal pool for CPU-bound handlers
+  server.add_normal_thread_pool(
+      {RequestType::LOOKUP, RequestType::QUERY_PREFETCH_LOOKUP_HITS,
+       RequestType::FREE_LOOKUP_LOCKS, RequestType::END_SESSION,
+       RequestType::CLEAR, RequestType::PING},
+      cfg.max_cpu_workers);
+
+  std::printf("Starting server...\n");
+  server.start();
+  std::printf("LMCache C++ server is running on %s\n", bind_url.c_str());
+
+  // Sleep loop until signal
+  while (!g_shutdown.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  std::printf("\nShutting down...\n");
+  server.close();
+  engine.close();
+  std::printf("Done.\n");
+  return 0;
+}

--- a/csrc/server/mq_server.cpp
+++ b/csrc/server/mq_server.cpp
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — ZMQ message queue server implementation
+
+#include "mq_server.h"
+
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <zmq.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// IThreadPool — abstract interface for thread pools
+// ============================================================================
+
+struct IThreadPool {
+  virtual ~IThreadPool() = default;
+  /// Submit a task, optionally with an affinity key for routing.
+  virtual void submit(std::function<void()> task,
+                      uint64_t affinity_key = 0) = 0;
+};
+
+// ============================================================================
+// NormalThreadPool — round-robin worker pool
+// ============================================================================
+
+struct NormalThreadPool : IThreadPool {
+  std::vector<std::thread> workers;
+  std::queue<std::function<void()>> tasks;
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool stop = false;
+
+  explicit NormalThreadPool(int max_workers) {
+    for (int i = 0; i < max_workers; ++i) {
+      workers.emplace_back([this] { worker_loop(); });
+    }
+  }
+
+  ~NormalThreadPool() override {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stop = true;
+    }
+    cv.notify_all();
+    for (auto& w : workers) {
+      if (w.joinable()) w.join();
+    }
+  }
+
+  void submit(std::function<void()> task, uint64_t /*affinity_key*/) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      tasks.push(std::move(task));
+    }
+    cv.notify_one();
+  }
+
+ private:
+  void worker_loop() {
+    while (true) {
+      std::function<void()> task;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [this] { return stop || !tasks.empty(); });
+        if (stop && tasks.empty()) return;
+        task = std::move(tasks.front());
+        tasks.pop();
+      }
+      task();
+    }
+  }
+};
+
+// ============================================================================
+// AffinityThreadPool — routes tasks by affinity_key to fixed workers
+// ============================================================================
+
+struct AffinityThreadPool : IThreadPool {
+  int num_workers_;
+  struct WorkerQueue {
+    std::queue<std::function<void()>> tasks;
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool stop = false;
+  };
+  std::vector<std::unique_ptr<WorkerQueue>> queues_;
+  std::vector<std::thread> workers_;
+
+  explicit AffinityThreadPool(int max_workers) : num_workers_(max_workers) {
+    queues_.reserve(max_workers);
+    workers_.reserve(max_workers);
+    for (int i = 0; i < max_workers; ++i) {
+      queues_.push_back(std::make_unique<WorkerQueue>());
+      auto* q = queues_.back().get();
+      workers_.emplace_back([q] {
+        while (true) {
+          std::function<void()> task;
+          {
+            std::unique_lock<std::mutex> lock(q->mutex);
+            q->cv.wait(lock, [q] { return q->stop || !q->tasks.empty(); });
+            if (q->stop && q->tasks.empty()) return;
+            task = std::move(q->tasks.front());
+            q->tasks.pop();
+          }
+          task();
+        }
+      });
+    }
+  }
+
+  ~AffinityThreadPool() override {
+    for (auto& q : queues_) {
+      {
+        std::lock_guard<std::mutex> lock(q->mutex);
+        q->stop = true;
+      }
+      q->cv.notify_one();
+    }
+    for (auto& w : workers_) {
+      if (w.joinable()) w.join();
+    }
+  }
+
+  void submit(std::function<void()> task, uint64_t affinity_key) override {
+    int slot = static_cast<int>(affinity_key % num_workers_);
+    auto& q = queues_[slot];
+    {
+      std::lock_guard<std::mutex> lock(q->mutex);
+      q->tasks.push(std::move(task));
+    }
+    q->cv.notify_one();
+  }
+};
+
+// ============================================================================
+// ZMQ multipart helpers
+// ============================================================================
+
+/// Receive a complete multipart message from a ZMQ socket.
+/// Returns frames as vector<vector<uint8_t>>.  Returns empty on error.
+static std::vector<std::vector<uint8_t>> zmq_recv_multipart(void* socket) {
+  std::vector<std::vector<uint8_t>> frames;
+  int more = 1;
+  while (more) {
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    int rc = zmq_msg_recv(&msg, socket, 0);
+    if (rc < 0) {
+      zmq_msg_close(&msg);
+      return {};  // error
+    }
+    size_t size = zmq_msg_size(&msg);
+    auto* data = static_cast<uint8_t*>(zmq_msg_data(&msg));
+    frames.emplace_back(data, data + size);
+    size_t more_size = sizeof(more);
+    zmq_getsockopt(socket, ZMQ_RCVMORE, &more, &more_size);
+    zmq_msg_close(&msg);
+  }
+  return frames;
+}
+
+/// Send a multipart message on a ZMQ socket.
+static bool zmq_send_multipart(
+    void* socket, const std::vector<std::vector<uint8_t>>& frames) {
+  for (size_t i = 0; i < frames.size(); ++i) {
+    int flags = (i + 1 < frames.size()) ? ZMQ_SNDMORE : 0;
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, frames[i].size());
+    std::memcpy(zmq_msg_data(&msg), frames[i].data(), frames[i].size());
+    int rc = zmq_msg_send(&msg, socket, flags);
+    if (rc < 0) {
+      zmq_msg_close(&msg);
+      return false;
+    }
+    // zmq_msg_send takes ownership on success — no close needed
+  }
+  return true;
+}
+
+// ============================================================================
+// Decode RequestType from a msgpack-encoded int frame
+// ============================================================================
+
+/// RequestType values are 1–21, which map to msgpack positive fixint (single
+/// byte 0x01–0x15).  For robustness we also handle uint8 (0xcc XX) and
+/// uint16 (0xcd XX XX) formats.
+static RequestType decode_request_type_raw(const uint8_t* data, size_t len) {
+  if (len == 0) {
+    return static_cast<RequestType>(0);
+  }
+  uint8_t head = data[0];
+  // positive fixint: 0x00–0x7f
+  if (head <= 0x7f) {
+    return static_cast<RequestType>(head);
+  }
+  // uint8 format: 0xcc + 1 byte
+  if (head == 0xcc && len >= 2) {
+    return static_cast<RequestType>(data[1]);
+  }
+  // uint16 format: 0xcd + 2 bytes big-endian
+  if (head == 0xcd && len >= 3) {
+    uint16_t val = (static_cast<uint16_t>(data[1]) << 8) | data[2];
+    return static_cast<RequestType>(val);
+  }
+  // negative fixint or other — shouldn't happen for valid request types
+  return static_cast<RequestType>(0);
+}
+
+/// Compute a hash from a ZMQ identity frame for affinity routing.
+static uint64_t identity_hash(const std::vector<uint8_t>& identity) {
+  // FNV-1a hash
+  uint64_t h = 14695981039346656037ULL;
+  for (uint8_t b : identity) {
+    h ^= b;
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
+
+// ============================================================================
+// MessageQueueServer::Impl
+// ============================================================================
+
+struct MessageQueueServer::Impl {
+  std::string bind_url;
+  void* zmq_ctx = nullptr;
+  void* zmq_socket = nullptr;
+  int output_efd = -1;
+
+  std::thread main_thread;
+  std::atomic<bool> is_finished{false};
+
+  // Owned pools
+  std::vector<std::unique_ptr<IThreadPool>> pools;
+
+  // Handlers
+  std::unordered_map<int, std::unique_ptr<IRequestHandler>> handlers;
+
+  // Per-handler pool assignment (request type int → pool pointer)
+  std::unordered_map<int, IThreadPool*> handler_pools;
+
+  // Whether a handler uses affinity routing
+  std::unordered_map<int, bool> handler_uses_affinity;
+
+  // Output queue for responses from blocking handlers
+  std::queue<std::vector<std::vector<uint8_t>>> output_queue;
+  std::mutex output_mutex;
+};
+
+// ============================================================================
+// MessageQueueServer — constructor / destructor
+// ============================================================================
+
+MessageQueueServer::MessageQueueServer(const std::string& bind_url,
+                                       int /*max_workers*/)
+    : impl_(std::make_unique<Impl>()) {
+  impl_->bind_url = bind_url;
+
+  // Create eventfd for thread→main notification
+  impl_->output_efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  if (impl_->output_efd < 0) {
+    throw std::runtime_error("Failed to create eventfd: " +
+                             std::string(strerror(errno)));
+  }
+
+  // Create ZMQ context and ROUTER socket
+  impl_->zmq_ctx = zmq_ctx_new();
+  if (!impl_->zmq_ctx) {
+    ::close(impl_->output_efd);
+    throw std::runtime_error("Failed to create ZMQ context");
+  }
+
+  impl_->zmq_socket = zmq_socket(impl_->zmq_ctx, ZMQ_ROUTER);
+  if (!impl_->zmq_socket) {
+    zmq_ctx_destroy(impl_->zmq_ctx);
+    ::close(impl_->output_efd);
+    throw std::runtime_error("Failed to create ZMQ ROUTER socket");
+  }
+
+  int rc = zmq_bind(impl_->zmq_socket, bind_url.c_str());
+  if (rc != 0) {
+    zmq_close(impl_->zmq_socket);
+    zmq_ctx_destroy(impl_->zmq_ctx);
+    ::close(impl_->output_efd);
+    throw std::runtime_error("Failed to bind ZMQ socket to " + bind_url + ": " +
+                             zmq_strerror(zmq_errno()));
+  }
+
+  std::cerr << "[MQServer] Bound to " << bind_url << std::endl;
+}
+
+MessageQueueServer::~MessageQueueServer() { close(); }
+
+// ============================================================================
+// add_handler / add_affinity_thread_pool / add_normal_thread_pool / start /
+// close
+// ============================================================================
+
+void MessageQueueServer::add_handler(RequestType type,
+                                     std::unique_ptr<IRequestHandler> handler) {
+  int key = static_cast<int>(type);
+  impl_->handlers[key] = std::move(handler);
+}
+
+void MessageQueueServer::add_affinity_thread_pool(
+    const std::vector<RequestType>& request_types, int max_workers) {
+  if (request_types.empty()) return;
+
+  auto pool = std::make_unique<AffinityThreadPool>(max_workers);
+  IThreadPool* pool_ptr = pool.get();
+
+  for (auto rt : request_types) {
+    int key = static_cast<int>(rt);
+    auto it = impl_->handlers.find(key);
+    if (it == impl_->handlers.end()) {
+      throw std::runtime_error(
+          "add_affinity_thread_pool: no handler registered for request type " +
+          std::to_string(key));
+    }
+    if (it->second->handler_type() != HandlerType::BLOCKING) {
+      throw std::runtime_error(
+          "add_affinity_thread_pool: handler for request type " +
+          std::to_string(key) + " is not BLOCKING");
+    }
+    impl_->handler_pools[key] = pool_ptr;
+    impl_->handler_uses_affinity[key] = true;
+  }
+
+  impl_->pools.push_back(std::move(pool));
+  std::cerr << "[MQServer] Created affinity thread pool (max_workers="
+            << max_workers << ") for " << request_types.size()
+            << " request type(s)" << std::endl;
+}
+
+void MessageQueueServer::add_normal_thread_pool(
+    const std::vector<RequestType>& request_types, int max_workers) {
+  if (request_types.empty()) return;
+
+  auto pool = std::make_unique<NormalThreadPool>(max_workers);
+  IThreadPool* pool_ptr = pool.get();
+
+  for (auto rt : request_types) {
+    int key = static_cast<int>(rt);
+    auto it = impl_->handlers.find(key);
+    if (it == impl_->handlers.end()) {
+      throw std::runtime_error(
+          "add_normal_thread_pool: no handler registered for request type " +
+          std::to_string(key));
+    }
+    if (it->second->handler_type() != HandlerType::BLOCKING) {
+      throw std::runtime_error(
+          "add_normal_thread_pool: handler for request type " +
+          std::to_string(key) + " is not BLOCKING");
+    }
+    impl_->handler_pools[key] = pool_ptr;
+    impl_->handler_uses_affinity[key] = false;
+  }
+
+  impl_->pools.push_back(std::move(pool));
+  std::cerr << "[MQServer] Created normal thread pool (max_workers="
+            << max_workers << ") for " << request_types.size()
+            << " request type(s)" << std::endl;
+}
+
+void MessageQueueServer::start() {
+  // Validate all blocking handlers have a pool assigned
+  for (auto& [rt_int, handler] : impl_->handlers) {
+    if (handler->handler_type() == HandlerType::BLOCKING) {
+      if (impl_->handler_pools.find(rt_int) == impl_->handler_pools.end()) {
+        throw std::runtime_error(
+            "BlockingHandler for request type " + std::to_string(rt_int) +
+            " has no thread pool assigned. Call add_affinity_thread_pool or "
+            "add_normal_thread_pool before start().");
+      }
+    }
+  }
+
+  impl_->main_thread = std::thread([this] { main_loop(); });
+  std::cerr << "[MQServer] Started main loop thread" << std::endl;
+}
+
+void MessageQueueServer::close() {
+  if (impl_->is_finished.exchange(true)) return;  // already closed
+
+  // Join main loop thread
+  if (impl_->main_thread.joinable()) {
+    impl_->main_thread.join();
+  }
+
+  // Close ZMQ socket and context
+  if (impl_->zmq_socket) {
+    zmq_close(impl_->zmq_socket);
+    impl_->zmq_socket = nullptr;
+  }
+  if (impl_->zmq_ctx) {
+    zmq_ctx_destroy(impl_->zmq_ctx);
+    impl_->zmq_ctx = nullptr;
+  }
+
+  // Close eventfd
+  if (impl_->output_efd >= 0) {
+    ::close(impl_->output_efd);
+    impl_->output_efd = -1;
+  }
+
+  // Shutdown all owned pools (destructors join worker threads)
+  impl_->pools.clear();
+
+  std::cerr << "[MQServer] Closed" << std::endl;
+}
+
+// ============================================================================
+// main_loop — zmq_poll over ROUTER socket + eventfd
+// ============================================================================
+
+void MessageQueueServer::main_loop() {
+  // Get the ZMQ socket fd for polling alongside eventfd
+  int zmq_fd = -1;
+  size_t zmq_fd_size = sizeof(zmq_fd);
+  zmq_getsockopt(impl_->zmq_socket, ZMQ_FD, &zmq_fd, &zmq_fd_size);
+
+  while (!impl_->is_finished.load(std::memory_order_relaxed)) {
+    // zmq_poll with two items: the ROUTER socket and the eventfd
+    zmq_pollitem_t items[2];
+    items[0].socket = impl_->zmq_socket;
+    items[0].fd = 0;
+    items[0].events = ZMQ_POLLIN;
+    items[0].revents = 0;
+    items[1].socket = nullptr;
+    items[1].fd = impl_->output_efd;
+    items[1].events = ZMQ_POLLIN;
+    items[1].revents = 0;
+
+    int rc = zmq_poll(items, 2, 1000 /* ms */);
+    if (rc < 0) {
+      if (zmq_errno() == EINTR) continue;
+      std::cerr << "[MQServer] zmq_poll error: " << zmq_strerror(zmq_errno())
+                << std::endl;
+      break;
+    }
+
+    // --- Handle inbound requests on the ROUTER socket ---
+    if (items[0].revents & ZMQ_POLLIN) {
+      // ZMQ edge-triggered: drain all available messages
+      while (true) {
+        auto frames = zmq_recv_multipart(impl_->zmq_socket);
+        if (frames.empty()) break;  // EAGAIN or error
+
+        // Need at least 3 frames: [identity, request_uid, request_type, ...]
+        if (frames.size() < 3) {
+          std::cerr << "[MQServer] Received message with too few frames ("
+                    << frames.size() << ")" << std::endl;
+          continue;
+        }
+
+        // Parse identity, request_uid, request_type
+        auto identity = std::move(frames[0]);
+        auto b_request_uid = std::move(frames[1]);
+        auto b_request_type = std::move(frames[2]);
+
+        // Collect payload frames
+        std::vector<std::vector<uint8_t>> payloads;
+        for (size_t i = 3; i < frames.size(); ++i) {
+          payloads.push_back(std::move(frames[i]));
+        }
+
+        // Decode request type
+        RequestType request_type = decode_request_type_raw(
+            b_request_type.data(), b_request_type.size());
+        int rt_int = static_cast<int>(request_type);
+
+        // Look up handler
+        auto handler_it = impl_->handlers.find(rt_int);
+        if (handler_it == impl_->handlers.end()) {
+          std::cerr << "[MQServer] No handler for request type " << rt_int
+                    << std::endl;
+          continue;
+        }
+
+        IRequestHandler* handler = handler_it->second.get();
+
+        // Build prefix frames for the response: [identity, request_uid,
+        // request_type]
+        std::vector<std::vector<uint8_t>> prefix_frames;
+        // Save identity for affinity hashing before moving
+        uint64_t id_hash = identity_hash(identity);
+        prefix_frames.push_back(std::move(identity));
+        prefix_frames.push_back(std::move(b_request_uid));
+        prefix_frames.push_back(std::move(b_request_type));
+
+        if (handler->handler_type() == HandlerType::SYNC) {
+          // ---- SYNC: handle inline and send response immediately ----
+          try {
+            auto response = handler->handle_sync(payloads);
+            auto reply = prefix_frames;
+            if (!response.empty()) {
+              reply.push_back(std::move(response));
+            }
+            zmq_send_multipart(impl_->zmq_socket, reply);
+          } catch (const std::exception& e) {
+            std::cerr << "[MQServer] Error in sync handler for type " << rt_int
+                      << ": " << e.what() << std::endl;
+          }
+        } else {
+          // ---- BLOCKING: submit to assigned thread pool ----
+          auto shared_payloads =
+              std::make_shared<std::vector<std::vector<uint8_t>>>(
+                  std::move(payloads));
+          auto shared_prefix =
+              std::make_shared<std::vector<std::vector<uint8_t>>>(
+                  std::move(prefix_frames));
+          int efd = impl_->output_efd;
+          auto* output_queue = &impl_->output_queue;
+          auto* output_mutex = &impl_->output_mutex;
+
+          // Look up assigned pool
+          auto pool_it = impl_->handler_pools.find(rt_int);
+          if (pool_it == impl_->handler_pools.end()) {
+            std::cerr << "[MQServer] No pool assigned for blocking type "
+                      << rt_int << std::endl;
+            continue;
+          }
+          IThreadPool* pool = pool_it->second;
+
+          pool->submit(
+              [handler, shared_payloads, shared_prefix, efd, output_queue,
+               output_mutex]() {
+                try {
+                  auto response = handler->handle_blocking(*shared_payloads);
+                  auto reply = *shared_prefix;
+                  if (!response.empty()) {
+                    reply.push_back(std::move(response));
+                  }
+
+                  {
+                    std::lock_guard<std::mutex> lock(*output_mutex);
+                    output_queue->push(std::move(reply));
+                  }
+
+                  // Notify main loop via eventfd
+                  uint64_t val = 1;
+                  [[maybe_unused]] auto written =
+                      ::write(efd, &val, sizeof(val));
+                } catch (const std::exception& e) {
+                  std::cerr
+                      << "[MQServer] Error in blocking handler: " << e.what()
+                      << std::endl;
+                }
+              },
+              id_hash);
+        }
+
+        // Check if more messages are available (ZMQ level-triggered within
+        // a single poll wakeup). Use ZMQ_EVENTS to check.
+        int events = 0;
+        size_t events_size = sizeof(events);
+        zmq_getsockopt(impl_->zmq_socket, ZMQ_EVENTS, &events, &events_size);
+        if (!(events & ZMQ_POLLIN)) break;
+      }
+    }
+
+    // --- Handle outbound responses (eventfd readable) ---
+    if (items[1].revents & ZMQ_POLLIN) {
+      // Consume the eventfd counter
+      uint64_t val;
+      [[maybe_unused]] auto rd = ::read(impl_->output_efd, &val, sizeof(val));
+
+      // Drain the output queue
+      std::lock_guard<std::mutex> lock(impl_->output_mutex);
+      while (!impl_->output_queue.empty()) {
+        auto reply = std::move(impl_->output_queue.front());
+        impl_->output_queue.pop();
+        zmq_send_multipart(impl_->zmq_socket, reply);
+      }
+    }
+  }
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/mq_server.h
+++ b/csrc/server/mq_server.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — ZMQ message queue server
+//
+// Mirrors Python MessageQueueServer: ZMQ ROUTER socket with eventfd
+// notification from thread pool callbacks to the main poll loop.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// IRequestHandler — abstract handler interface
+// ============================================================================
+
+class IRequestHandler {
+ public:
+  virtual ~IRequestHandler() = default;
+
+  /// Handle a synchronous request (called in the main loop).
+  /// @param payloads  Raw msgpack payload frames
+  /// @return          Encoded response bytes (empty = no response)
+  virtual std::vector<uint8_t> handle_sync(
+      const std::vector<std::vector<uint8_t>>& payloads) = 0;
+
+  /// Handle a blocking request (called on a thread pool worker).
+  /// @param payloads  Raw msgpack payload frames
+  /// @return          Encoded response bytes (empty = no response)
+  virtual std::vector<uint8_t> handle_blocking(
+      const std::vector<std::vector<uint8_t>>& payloads) = 0;
+
+  /// Whether this handler runs synchronously or on a thread pool.
+  virtual HandlerType handler_type() const = 0;
+};
+
+// ============================================================================
+// MessageQueueServer — ZMQ ROUTER + eventfd + thread pool
+// ============================================================================
+
+class MessageQueueServer {
+ public:
+  /// @param bind_url     ZMQ bind URL (e.g. "tcp://0.0.0.0:8001")
+  /// @param max_workers  Thread pool size for blocking handlers
+  MessageQueueServer(const std::string& bind_url, int max_workers = 4);
+
+  ~MessageQueueServer();
+
+  // Non-copyable
+  MessageQueueServer(const MessageQueueServer&) = delete;
+  MessageQueueServer& operator=(const MessageQueueServer&) = delete;
+
+  /// Register a handler for a request type.
+  void add_handler(RequestType type, std::unique_ptr<IRequestHandler> handler);
+
+  /// Assign an affinity thread pool to specific request types.
+  /// Requests from the same ZMQ identity are always dispatched to the same
+  /// worker thread (hash identity → worker index). Use for GPU-bound handlers.
+  /// Must be called after add_handler() and before start().
+  void add_affinity_thread_pool(const std::vector<RequestType>& request_types,
+                                int max_workers);
+
+  /// Assign a normal (round-robin) thread pool to specific request types.
+  /// Use for non-GPU blocking handlers.
+  /// Must be called after add_handler() and before start().
+  void add_normal_thread_pool(const std::vector<RequestType>& request_types,
+                              int max_workers);
+
+  /// Start the server (spawns the main loop thread).
+  void start();
+
+  /// Stop the server and join threads.
+  void close();
+
+ private:
+  /// Main event loop: zmq_poll over socket fd + eventfd.
+  void main_loop();
+
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/session_manager.cpp
+++ b/csrc/server/session_manager.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — session management implementation
+
+#include "session_manager.h"
+
+#include <cassert>
+#include <chrono>
+
+namespace lmcache {
+namespace server {
+
+// ----------------------------------------------------------------------------
+// Helper: current time in seconds (steady_clock)
+// ----------------------------------------------------------------------------
+
+namespace {
+
+double steady_now() {
+  auto tp = std::chrono::steady_clock::now();
+  return std::chrono::duration<double>(tp.time_since_epoch()).count();
+}
+
+}  // namespace
+
+// ----------------------------------------------------------------------------
+// Session
+// ----------------------------------------------------------------------------
+
+Session::Session(const std::string& request_id, const TokenHasher& hasher)
+    : request_id_(request_id),
+      hasher_(hasher),
+      created_at_(steady_now()),
+      last_prefix_hash_(hasher.none_hash()),
+      num_chunks_processed_(0) {}
+
+void Session::set_tokens(const std::vector<int32_t>& full_token_ids) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  token_ids_ = full_token_ids;
+}
+
+std::vector<HashBytes> Session::get_hashes(int start, int end) {
+  int chunk_size = hasher_.chunk_size();
+  assert(start % chunk_size == 0 && "start must be a multiple of chunk_size");
+  assert(end % chunk_size == 0 && "end must be a multiple of chunk_size");
+
+  int start_chunk = start / chunk_size;
+  int end_chunk = end / chunk_size;
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  compute_hash_up_to(end_chunk);
+
+  // Return the slice [start_chunk, end_chunk)
+  std::vector<HashBytes> result;
+  if (start_chunk < end_chunk &&
+      start_chunk < static_cast<int>(chunk_hashes_.size())) {
+    int actual_end =
+        std::min(end_chunk, static_cast<int>(chunk_hashes_.size()));
+    result.assign(chunk_hashes_.begin() + start_chunk,
+                  chunk_hashes_.begin() + actual_end);
+  }
+  return result;
+}
+
+void Session::compute_hash_up_to(int end_chunk) {
+  // Caller must hold mutex_
+  int chunk_size = hasher_.chunk_size();
+
+  while (num_chunks_processed_ < end_chunk) {
+    int cs = num_chunks_processed_ * chunk_size;
+    int ce = cs + chunk_size;
+
+    // Ensure we have enough tokens
+    if (ce > static_cast<int>(token_ids_.size())) {
+      break;
+    }
+
+    HashBytes h =
+        hasher_.hash_tokens(token_ids_.data() + cs,
+                            static_cast<size_t>(chunk_size), last_prefix_hash_);
+
+    last_prefix_hash_ = h;
+    chunk_hashes_.push_back(std::move(h));
+    num_chunks_processed_++;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// SessionManager
+// ----------------------------------------------------------------------------
+
+SessionManager::SessionManager(const TokenHasher& hasher, double ttl)
+    : hasher_(hasher), ttl_(ttl) {}
+
+std::shared_ptr<Session> SessionManager::get_or_create(
+    const std::string& request_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = sessions_.find(request_id);
+  if (it != sessions_.end()) {
+    return it->second;
+  }
+  auto session = std::make_shared<Session>(request_id, hasher_);
+  sessions_.emplace(request_id, session);
+  return session;
+}
+
+void SessionManager::remove(const std::string& request_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  sessions_.erase(request_id);
+}
+
+int SessionManager::cleanup_expired() {
+  double now = steady_now();
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  int removed = 0;
+  for (auto it = sessions_.begin(); it != sessions_.end();) {
+    if (now - it->second->created_at() > ttl_) {
+      it = sessions_.erase(it);
+      ++removed;
+    } else {
+      ++it;
+    }
+  }
+  return removed;
+}
+
+int SessionManager::active_count() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return static_cast<int>(sessions_.size());
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/session_manager.h
+++ b/csrc/server/session_manager.h
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — Per-request session tracking
+//
+// Caches computed chunk hashes per request_id so that repeated
+// store/retrieve/lookup operations avoid redundant hashing.
+// Thread-safe: multiple TP workers may access the same session.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "token_hasher.h"
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Session — per-request hash cache
+// ============================================================================
+
+class Session {
+ public:
+  Session(const std::string& request_id, const TokenHasher& hasher);
+  ~Session() = default;
+
+  /// Update the full token sequence (idempotent, replaces not extends).
+  void set_tokens(const std::vector<int32_t>& full_token_ids);
+
+  /// Compute and return chunk hashes for [start, end) token range.
+  /// Internally caches rolling hashes up to end, skipping already-computed.
+  /// start and end must be chunk-aligned.
+  std::vector<HashBytes> get_hashes(int start, int end);
+
+  const std::string& request_id() const { return request_id_; }
+
+  /// Creation timestamp (steady clock, seconds).
+  double created_at() const { return created_at_; }
+
+ private:
+  void compute_hash_up_to(int end_chunk);
+
+  std::string request_id_;
+  const TokenHasher& hasher_;
+  double created_at_;
+
+  // Protected by mutex_
+  mutable std::mutex mutex_;
+  std::vector<int32_t> token_ids_;
+  std::vector<HashBytes> chunk_hashes_;
+  HashBytes last_prefix_hash_;
+  int num_chunks_processed_ = 0;
+};
+
+// ============================================================================
+// SessionManager — thread-safe manager for per-request sessions
+// ============================================================================
+
+class SessionManager {
+ public:
+  static constexpr double DEFAULT_SESSION_TTL = 600.0;  // 10 minutes
+
+  /// @param hasher  Reference to the shared TokenHasher (must outlive this)
+  /// @param ttl     Session TTL in seconds
+  SessionManager(const TokenHasher& hasher, double ttl = DEFAULT_SESSION_TTL);
+  ~SessionManager() = default;
+
+  /// Get existing session or create a new one.
+  std::shared_ptr<Session> get_or_create(const std::string& request_id);
+
+  /// Remove a session by request_id.
+  void remove(const std::string& request_id);
+
+  /// Remove sessions that have exceeded their TTL.
+  /// Returns number of sessions removed.
+  int cleanup_expired();
+
+  /// Number of currently tracked sessions.
+  int active_count() const;
+
+ private:
+  const TokenHasher& hasher_;
+  double ttl_;
+
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, std::shared_ptr<Session>> sessions_;
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/tensor_bridge.cpp
+++ b/csrc/server/tensor_bridge.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — ATen <-> raw CUDA bridge implementation
+
+#include "tensor_bridge.h"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime_api.h>
+
+// Use torch/all.h which correctly sets up the c10/at namespace aliasing
+// in PyTorch 2.10+. Per-operator includes (ATen/ops/*.h) cause
+// c10::ScalarType vs at::ScalarType mismatches.
+#include <torch/all.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// DType <-> at::ScalarType conversion
+// ============================================================================
+
+at::ScalarType dtype_to_scalar_type(DType dt) {
+  switch (dt) {
+    case DType::Float16:
+      return at::ScalarType::Half;
+    case DType::BFloat16:
+      return at::ScalarType::BFloat16;
+    case DType::Float32:
+      return at::ScalarType::Float;
+    case DType::Float8E4M3FN:
+      return at::ScalarType::Float8_e4m3fn;
+    case DType::Float8E5M2:
+      return at::ScalarType::Float8_e5m2;
+    case DType::Int8:
+      return at::ScalarType::Byte;  // uint8 on wire (fp8 KV cache)
+    case DType::Int32:
+      return at::ScalarType::Int;
+    case DType::Int64:
+      return at::ScalarType::Long;
+  }
+  throw std::runtime_error("Unknown DType value: " +
+                           std::to_string(static_cast<int>(dt)));
+}
+
+DType scalar_type_to_dtype(at::ScalarType st) {
+  switch (st) {
+    case at::ScalarType::Half:
+      return DType::Float16;
+    case at::ScalarType::BFloat16:
+      return DType::BFloat16;
+    case at::ScalarType::Float:
+      return DType::Float32;
+    case at::ScalarType::Float8_e4m3fn:
+      return DType::Float8E4M3FN;
+    case at::ScalarType::Float8_e5m2:
+      return DType::Float8E5M2;
+    case at::ScalarType::Char:
+      return DType::Int8;
+    case at::ScalarType::Byte:
+      return DType::Int8;
+    case at::ScalarType::Int:
+      return DType::Int32;
+    case at::ScalarType::Long:
+      return DType::Int64;
+    default:
+      throw std::runtime_error(
+          "Unsupported at::ScalarType for DType conversion: " +
+          std::to_string(static_cast<int>(st)));
+  }
+}
+
+// ============================================================================
+// Tensor wrapping
+// ============================================================================
+
+at::Tensor wrap_as_tensor(void* ptr, const std::vector<int64_t>& shape,
+                          DType dtype, int device_idx) {
+  auto scalar_type = dtype_to_scalar_type(dtype);
+  auto options = at::TensorOptions().dtype(scalar_type);
+
+  if (device_idx >= 0) {
+    options = options.device(at::Device(at::kCUDA, device_idx));
+  } else {
+    options = options.device(at::kCPU);
+  }
+
+  // Non-owning: at::from_blob does not take ownership by default.
+  return at::from_blob(ptr, shape, options);
+}
+
+// ============================================================================
+// CUDA IPC tensor operations
+// ============================================================================
+
+at::Tensor open_ipc_tensor(const CudaIpcTensorDesc& desc, int device_idx) {
+  // Set the target device
+  cudaError_t err = cudaSetDevice(device_idx);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("cudaSetDevice failed: ") +
+                             cudaGetErrorString(err));
+  }
+
+  // Use libtorch's CUDACachingAllocator to open the IPC handle.
+  // This handles PyTorch 2.10+ expanded handle format (66+ bytes)
+  // as well as legacy 64-byte raw cudaIpcMemHandle_t.
+  //
+  // Python equivalent: torch.UntypedStorage._new_shared_cuda(device,
+  // *handle[1:]) which internally calls getIpcDevPtr(handle_blob_as_string).
+  std::shared_ptr<void> dev_ptr;
+  try {
+    std::string handle_str(
+        reinterpret_cast<const char*>(desc.ipc_handle_blob.data()),
+        desc.ipc_handle_blob.size());
+    dev_ptr =
+        c10::cuda::CUDACachingAllocator::getIpcDevPtr(std::move(handle_str));
+  } catch (const std::exception& e) {
+    std::fprintf(stderr,
+                 "[open_ipc_tensor] getIpcDevPtr FAILED on device %d: %s\n"
+                 "  ipc_handle_blob size: %zu\n"
+                 "  device_uuid: %s\n"
+                 "  shape: [",
+                 device_idx, e.what(), desc.ipc_handle_blob.size(),
+                 desc.device_uuid.c_str());
+    for (size_t i = 0; i < desc.shape.size(); ++i) {
+      if (i > 0) std::fprintf(stderr, ",");
+      std::fprintf(stderr, "%ld", desc.shape[i]);
+    }
+    std::fprintf(stderr, "]\n");
+    throw;
+  }
+
+  void* base_ptr = dev_ptr.get();
+
+  // Apply storage_offset
+  auto scalar_type = dtype_to_scalar_type(desc.dtype);
+  size_t elem_size = dtype_size(desc.dtype);
+  void* offset_ptr =
+      static_cast<char*>(base_ptr) + desc.storage_offset * elem_size;
+
+  auto options = at::TensorOptions()
+                     .dtype(scalar_type)
+                     .device(at::Device(at::kCUDA, device_idx));
+
+  // Create tensor backed by IPC storage.
+  // We need to ensure the shared_ptr stays alive as long as the tensor exists.
+  // Use from_blob with a custom deleter that holds the shared_ptr.
+  auto ref = std::make_shared<std::shared_ptr<void>>(std::move(dev_ptr));
+  auto deleter = [ref](void*) { /* ref drops when tensor dies */ };
+
+  at::Tensor tensor;
+  if (!desc.stride.empty()) {
+    tensor =
+        at::from_blob(offset_ptr, desc.shape, desc.stride, deleter, options);
+  } else {
+    tensor = at::from_blob(offset_ptr, desc.shape, deleter, options);
+  }
+
+  return tensor;
+}
+
+void close_ipc_tensor(void* dev_ptr) {
+  // With getIpcDevPtr, cleanup is handled by the shared_ptr returned
+  // from getIpcDevPtr (captured in the tensor's deleter).
+  // This function is kept for API compatibility but is now a no-op.
+  (void)dev_ptr;
+}
+
+// ============================================================================
+// CUDA IPC event helpers
+// ============================================================================
+
+cudaEvent_t open_ipc_event(const uint8_t* handle_bytes) {
+  cudaIpcEventHandle_t handle;
+  static_assert(sizeof(handle) == 64, "cudaIpcEventHandle_t must be 64 bytes");
+  std::memcpy(&handle, handle_bytes, sizeof(handle));
+
+  cudaEvent_t event;
+  cudaError_t err = cudaIpcOpenEventHandle(&event, handle);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("cudaIpcOpenEventHandle failed: ") +
+                             cudaGetErrorString(err));
+  }
+  return event;
+}
+
+std::vector<uint8_t> create_ipc_event(cudaEvent_t& event) {
+  cudaError_t err = cudaEventCreateWithFlags(
+      &event, cudaEventInterprocess | cudaEventDisableTiming);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("cudaEventCreate failed: ") +
+                             cudaGetErrorString(err));
+  }
+
+  cudaIpcEventHandle_t handle;
+  err = cudaIpcGetEventHandle(&handle, event);
+  if (err != cudaSuccess) {
+    cudaEventDestroy(event);
+    throw std::runtime_error(std::string("cudaIpcGetEventHandle failed: ") +
+                             cudaGetErrorString(err));
+  }
+
+  std::vector<uint8_t> bytes(sizeof(handle));
+  std::memcpy(bytes.data(), &handle, sizeof(handle));
+  return bytes;
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/tensor_bridge.h
+++ b/csrc/server/tensor_bridge.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — ATen ↔ raw CUDA bridge
+//
+// Lightweight helpers so existing CUDA kernels (which take torch::Tensor)
+// work with our raw pointers.  This is the ONLY header that includes
+// <torch/torch.h>, keeping ATen out of the rest of the codebase.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// CUDA runtime types
+#include <cuda_runtime_api.h>
+
+// ATen forward declarations — full includes in tensor_bridge.cu
+namespace at {
+class Tensor;
+}  // namespace at
+
+// ScalarType must be included (not forward-declared) to avoid creating
+// a distinct at::ScalarType from c10::ScalarType in PyTorch 2.10+.
+#include <c10/core/ScalarType.h>
+
+#include "types.h"
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Tensor wrapping — raw pointer → non-owning ATen tensor
+// ============================================================================
+
+/// Wrap a raw device/host pointer as a non-owning ATen tensor.
+/// The caller is responsible for lifetime: the tensor does NOT free the memory.
+///
+/// @param ptr        Raw pointer (device or host)
+/// @param shape      Tensor dimensions
+/// @param dtype      Our lightweight DType enum
+/// @param device_idx CUDA device index (-1 for CPU)
+/// @return           Non-owning ATen tensor
+at::Tensor wrap_as_tensor(void* ptr, const std::vector<int64_t>& shape,
+                          DType dtype, int device_idx = -1);
+
+// ============================================================================
+// CUDA IPC tensor operations
+// ============================================================================
+
+/// Open a cudaIpcMemHandle and create an ATen tensor view over it.
+///
+/// @param desc       CudaIpcTensorDesc with handle, shape, stride, dtype
+/// @param device_idx Target CUDA device index
+/// @return           ATen tensor backed by IPC-shared memory
+at::Tensor open_ipc_tensor(const CudaIpcTensorDesc& desc, int device_idx);
+
+/// Close a previously opened IPC memory handle.
+void close_ipc_tensor(void* dev_ptr);
+
+// ============================================================================
+// CUDA IPC event helpers
+// ============================================================================
+
+/// Open a CUDA event from an IPC handle (bytes).
+/// @param handle_bytes  Serialised cudaIpcEventHandle_t (64 bytes)
+/// @return              CUDA event
+cudaEvent_t open_ipc_event(const uint8_t* handle_bytes);
+
+/// Create an interprocess CUDA event and return its IPC handle.
+/// @param[out] event   Created CUDA event
+/// @return             IPC handle bytes (64 bytes)
+std::vector<uint8_t> create_ipc_event(cudaEvent_t& event);
+
+// ============================================================================
+// DType ↔ at::ScalarType conversion
+// ============================================================================
+
+/// Convert our DType enum to ATen ScalarType.
+at::ScalarType dtype_to_scalar_type(DType dt);
+
+/// Convert ATen ScalarType to our DType enum.
+DType scalar_type_to_dtype(at::ScalarType st);
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/token_hasher.cpp
+++ b/csrc/server/token_hasher.cpp
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — blake3 token hashing implementation
+
+#include "token_hasher.h"
+
+#include <blake3.h>
+
+#include <cassert>
+#include <cstring>
+
+namespace lmcache {
+namespace server {
+
+// ----------------------------------------------------------------------------
+// Byte-order helpers (big-endian serialization)
+// ----------------------------------------------------------------------------
+
+namespace {
+
+/// Write a signed 64-bit int as 8 bytes big-endian (matches Python's
+/// int.to_bytes(8, 'big', signed=True)).
+inline void write_be_i64(uint8_t* dst, int64_t val) {
+  auto uval = static_cast<uint64_t>(val);
+  dst[0] = static_cast<uint8_t>(uval >> 56);
+  dst[1] = static_cast<uint8_t>(uval >> 48);
+  dst[2] = static_cast<uint8_t>(uval >> 40);
+  dst[3] = static_cast<uint8_t>(uval >> 32);
+  dst[4] = static_cast<uint8_t>(uval >> 24);
+  dst[5] = static_cast<uint8_t>(uval >> 16);
+  dst[6] = static_cast<uint8_t>(uval >> 8);
+  dst[7] = static_cast<uint8_t>(uval);
+}
+
+/// Write a 32-bit unsigned int as 4 bytes big-endian (matches Python's
+/// struct.pack('>I', val)).
+inline void write_be_u32(uint8_t* dst, uint32_t val) {
+  dst[0] = static_cast<uint8_t>(val >> 24);
+  dst[1] = static_cast<uint8_t>(val >> 16);
+  dst[2] = static_cast<uint8_t>(val >> 8);
+  dst[3] = static_cast<uint8_t>(val);
+}
+
+}  // namespace
+
+// ----------------------------------------------------------------------------
+// TokenHasher
+// ----------------------------------------------------------------------------
+
+TokenHasher::TokenHasher(int chunk_size) : chunk_size_(chunk_size) {
+  init_none_hash();
+}
+
+TokenHasher::~TokenHasher() = default;
+
+void TokenHasher::init_none_hash() {
+  // Python equivalent:
+  //   hash_func((0, (0,), None))
+  //   prefix_hash = (0).to_bytes(8, 'big', signed=True)  → 8 zero bytes
+  //   tokens = struct.pack('>1I', 0)                      → 4 zero bytes
+
+  blake3_hasher hasher;
+  blake3_hasher_init(&hasher);
+
+  // prefix_hash = 0 as 8 bytes big-endian signed
+  uint8_t prefix_buf[8];
+  write_be_i64(prefix_buf, 0);
+  blake3_hasher_update(&hasher, prefix_buf, 8);
+
+  // tokens = (0,) as one big-endian uint32
+  uint8_t token_buf[4];
+  write_be_u32(token_buf, 0);
+  blake3_hasher_update(&hasher, token_buf, 4);
+
+  none_hash_.resize(BLAKE3_OUT_LEN);
+  blake3_hasher_finalize(&hasher, none_hash_.data(), BLAKE3_OUT_LEN);
+}
+
+HashBytes TokenHasher::hash_tokens(const int32_t* tokens, size_t count,
+                                   const HashBytes& prefix_hash) const {
+  blake3_hasher hasher;
+  blake3_hasher_init(&hasher);
+
+  // Serialize prefix_hash.
+  // In Python, when prefix_hash is bytes, it does h.update(prefix_hash).
+  // When it's an int, it serializes as 8 bytes big-endian.
+  // In C++ our HashBytes is always the raw 32-byte digest, so we feed it
+  // directly (matches the Python `bytes(prefix_hash)` / `h.update(prefix_hash)`
+  // path).
+  const HashBytes& pfx = prefix_hash.empty() ? none_hash_ : prefix_hash;
+  blake3_hasher_update(&hasher, pfx.data(), pfx.size());
+
+  // Serialize token IDs as big-endian uint32 array.
+  // Python: struct.pack(f'>{len(tokens)}I', *tokens)
+  // We allocate a temporary buffer for the big-endian encoding.
+  std::vector<uint8_t> token_buf(count * 4);
+  for (size_t i = 0; i < count; ++i) {
+    write_be_u32(token_buf.data() + i * 4, static_cast<uint32_t>(tokens[i]));
+  }
+  blake3_hasher_update(&hasher, token_buf.data(), token_buf.size());
+
+  HashBytes result(BLAKE3_OUT_LEN);
+  blake3_hasher_finalize(&hasher, result.data(), BLAKE3_OUT_LEN);
+  return result;
+}
+
+std::vector<HashBytes> TokenHasher::compute_chunk_hashes(
+    const std::vector<int32_t>& token_ids, int start, int end) const {
+  std::vector<HashBytes> hashes;
+
+  int effective_len = (end >= 0)
+                          ? std::min(static_cast<int>(token_ids.size()), end)
+                          : static_cast<int>(token_ids.size());
+
+  // Truncate to complete chunks
+  int num_complete = effective_len - (effective_len % chunk_size_);
+
+  HashBytes prefix = none_hash_;
+  for (int i = 0; i < num_complete; i += chunk_size_) {
+    prefix = hash_tokens(token_ids.data() + i, static_cast<size_t>(chunk_size_),
+                         prefix);
+    if (i >= start) {
+      hashes.push_back(prefix);
+    }
+  }
+  return hashes;
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/token_hasher.h
+++ b/csrc/server/token_hasher.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — blake3 token hashing
+//
+// Rolling prefix hash computation for token chunks.
+// Each chunk's hash depends on all previous chunks (prefix chain).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace lmcache {
+namespace server {
+
+// 32-byte blake3 hash value
+using HashBytes = std::vector<uint8_t>;
+
+// ============================================================================
+// TokenHasher — rolling prefix hash for token chunks
+// ============================================================================
+
+class TokenHasher {
+ public:
+  /// @param chunk_size  Number of tokens per chunk (e.g. 256)
+  explicit TokenHasher(int chunk_size = 256);
+  ~TokenHasher();
+
+  // Non-copyable
+  TokenHasher(const TokenHasher&) = delete;
+  TokenHasher& operator=(const TokenHasher&) = delete;
+
+  /// Compute rolling prefix hashes for all complete chunks.
+  ///
+  /// The rolling hash is always computed from the beginning of token_ids
+  /// (since each chunk's hash depends on all previous chunks), but only
+  /// hashes for chunks within [start, end) are returned.
+  ///
+  /// @param token_ids   Full token sequence
+  /// @param start       Token-level start index (chunk-aligned, default 0)
+  /// @param end         Token-level end index (chunk-aligned, -1 = all)
+  /// @return            Hash bytes for each chunk in [start, end)
+  std::vector<HashBytes> compute_chunk_hashes(
+      const std::vector<int32_t>& token_ids, int start = 0, int end = -1) const;
+
+  /// Hash a single chunk with the given prefix hash context.
+  /// @param tokens       Token IDs for this chunk
+  /// @param prefix_hash  Hash of all preceding chunks (empty = none_hash)
+  /// @return             32-byte blake3 hash
+  HashBytes hash_tokens(const int32_t* tokens, size_t count,
+                        const HashBytes& prefix_hash) const;
+
+  /// The initial prefix hash (hash of the "none" sentinel).
+  /// Equivalent to Python's init_none_hash().
+  const HashBytes& none_hash() const { return none_hash_; }
+
+  int chunk_size() const { return chunk_size_; }
+
+ private:
+  int chunk_size_;
+  HashBytes none_hash_;
+
+  /// Compute the none_hash value
+  void init_none_hash();
+};
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/types.cpp
+++ b/csrc/server/types.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — types.cpp
+//
+// Implements ipc_key_to_object_keys(), mirroring the Python version
+// in lmcache/v1/distributed/api.py.
+
+#include "types.h"
+
+namespace lmcache {
+namespace server {
+
+std::vector<ObjectKey> ipc_key_to_object_keys(
+    const std::string& model_name, int world_size, int worker_id,
+    const std::vector<std::vector<uint8_t>>& chunk_hashes) {
+  std::vector<ObjectKey> keys;
+  keys.reserve(chunk_hashes.size() *
+               static_cast<size_t>(worker_id < 0 ? world_size : 1));
+
+  for (const auto& chunk_hash : chunk_hashes) {
+    if (worker_id < 0) {
+      // Lookup mode: expand each hash to all workers in world_size
+      for (int wid = 0; wid < world_size; ++wid) {
+        int32_t kv_rank =
+            ObjectKey::compute_kv_rank(world_size, wid, world_size, wid);
+        keys.push_back(ObjectKey{chunk_hash, model_name, kv_rank});
+      }
+    } else {
+      int32_t kv_rank = ObjectKey::compute_kv_rank(world_size, worker_id,
+                                                   world_size, worker_id);
+      keys.push_back(ObjectKey{chunk_hash, model_name, kv_rank});
+    }
+  }
+
+  return keys;
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/types.h
+++ b/csrc/server/types.h
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — Shared type definitions
+//
+// All wire types (sent over ZMQ msgpack) and internal types shared between
+// components live here.  Keeps torch/ATen out of the common include path;
+// DType is our own lightweight enum converted to at::ScalarType only in
+// tensor_bridge.h.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// RequestType — exact values matching Python enum.auto() (1-based)
+// ============================================================================
+
+enum class RequestType : int {
+  // Engine operations
+  REGISTER_KV_CACHE = 1,
+  UNREGISTER_KV_CACHE = 2,
+  STORE = 3,
+  RETRIEVE = 4,
+  LOOKUP = 5,
+  QUERY_PREFETCH_STATUS = 6,
+  QUERY_PREFETCH_LOOKUP_HITS = 7,
+  FREE_LOOKUP_LOCKS = 8,
+  END_SESSION = 9,
+
+  // Controller operations
+  CLEAR = 10,
+  GET_CHUNK_SIZE = 11,
+  PING = 12,
+
+  // Debug operations
+  NOOP = 13,
+
+  // Blend operations
+  CB_REGISTER_KV_CACHE = 14,
+  CB_UNREGISTER_KV_CACHE = 15,
+  CB_STORE_PRE_COMPUTED = 16,
+  CB_LOOKUP_PRE_COMPUTED = 17,
+  CB_RETRIEVE_PRE_COMPUTED = 18,
+  CB_STORE_FINAL = 19,
+
+  // Blend V2 operations
+  CB_LOOKUP_PRE_COMPUTED_V2 = 20,
+  CB_RETRIEVE_PRE_COMPUTED_V2 = 21,
+};
+
+// ============================================================================
+// HandlerType — how a request handler is executed
+// ============================================================================
+
+enum class HandlerType : int {
+  SYNC = 1,      // Fast, runs in main loop
+  BLOCKING = 2,  // May block, runs in thread pool
+};
+
+// ============================================================================
+// RequestUID — opaque request identifier on the wire
+// ============================================================================
+
+using RequestUID = int64_t;
+
+// ============================================================================
+// DType — lightweight dtype enum (avoids #include <torch/torch.h> everywhere)
+// ============================================================================
+
+enum class DType : int {
+  Float16 = 0,
+  BFloat16 = 1,
+  Float32 = 2,
+  Float8E4M3FN = 3,
+  Float8E5M2 = 4,
+  Int8 = 5,
+  Int32 = 6,
+  Int64 = 7,
+};
+
+/// Size in bytes of one element of the given dtype.
+inline size_t dtype_size(DType dt) {
+  switch (dt) {
+    case DType::Float16:
+    case DType::BFloat16:
+      return 2;
+    case DType::Float32:
+    case DType::Int32:
+      return 4;
+    case DType::Int64:
+      return 8;
+    case DType::Float8E4M3FN:
+    case DType::Float8E5M2:
+    case DType::Int8:
+      return 1;
+  }
+  return 0;
+}
+
+// ============================================================================
+// ObjectKey — unique identifier for a KV cache object in distributed storage
+// ============================================================================
+
+struct ObjectKey {
+  std::vector<uint8_t>
+      chunk_hash;  // Content hash bytes (typically 32 for blake3)
+  std::string model_name;
+  int32_t kv_rank;
+
+  bool operator==(const ObjectKey& other) const {
+    return chunk_hash == other.chunk_hash && model_name == other.model_name &&
+           kv_rank == other.kv_rank;
+  }
+
+  /// Compute kv_rank from parallelism dimensions.
+  /// Each number uses 8 bits, packed as:
+  ///   (world_size << 24) | (global_rank << 16) |
+  ///   (local_world_size << 8) | local_rank
+  static inline int32_t compute_kv_rank(int world_size, int global_rank,
+                                        int local_world_size, int local_rank) {
+    return (world_size << 24) | (global_rank << 16) | (local_world_size << 8) |
+           local_rank;
+  }
+};
+
+struct ObjectKeyHash {
+  size_t operator()(const ObjectKey& k) const {
+    // FNV-1a over chunk_hash + model_name + kv_rank
+    size_t h = 14695981039346656037ULL;
+    for (uint8_t b : k.chunk_hash) {
+      h ^= b;
+      h *= 1099511628211ULL;
+    }
+    for (char c : k.model_name) {
+      h ^= static_cast<uint8_t>(c);
+      h *= 1099511628211ULL;
+    }
+    h ^= static_cast<size_t>(k.kv_rank);
+    h *= 1099511628211ULL;
+    return h;
+  }
+};
+
+/// Convert an IPCCacheEngineKey + chunk_hashes to a list of ObjectKeys.
+/// When worker_id < 0, expands each chunk hash to all workers in world_size.
+std::vector<ObjectKey> ipc_key_to_object_keys(
+    const std::string& model_name, int world_size,
+    int worker_id,  // -1 means expand to all workers
+    const std::vector<std::vector<uint8_t>>& chunk_hashes);
+
+// ============================================================================
+// IPCCacheEngineKey — token-based cache key sent over ZMQ
+// ============================================================================
+
+struct IPCCacheEngineKey {
+  std::string model_name;
+  int32_t world_size;
+  int32_t worker_id;  // -1 means None (lookup mode)
+
+  std::vector<int32_t> token_ids;
+  int32_t start;
+  int32_t end;
+
+  // Session tracking — not part of cache identity
+  std::string request_id;
+};
+
+// ============================================================================
+// MemoryLayoutDesc — shape + dtype descriptors for memory objects
+// ============================================================================
+
+struct ShapeDesc {
+  std::vector<int64_t> dims;
+};
+
+struct MemoryLayoutDesc {
+  std::vector<ShapeDesc> shapes;
+  std::vector<DType> dtypes;
+};
+
+// ============================================================================
+// CudaIpcTensorDesc — structured replacement for Python CudaIPCWrapper
+//
+// Binary layout for zero-copy decode.  Transition: the C++ decoder handles
+// both the legacy pickle Ext(1) format and the new structured format.
+// ============================================================================
+
+struct CudaIpcTensorDesc {
+  // The full torch serialized IPC handle blob from _share_cuda_()[1]
+  // (typically 66 bytes in PyTorch 2.10+/CUDA 12.x, 64 in older)
+  // Passed to c10::cuda::CUDACachingAllocator::getIpcDevPtr()
+  std::vector<uint8_t> ipc_handle_blob;
+
+  // Legacy 64-byte raw cudaIpcMemHandle_t (for fallback)
+  uint8_t ipc_handle[64];
+
+  // Storage size in bytes (handle[2] from _share_cuda_)
+  int64_t storage_size_bytes;
+
+  DType dtype;
+  std::vector<int64_t> shape;
+  std::vector<int64_t> stride;
+  int64_t storage_offset;
+
+  // GPU UUID string (e.g. "GPU-xxxxxxxx-...")
+  std::string device_uuid;
+};
+
+// ============================================================================
+// L1Error — result codes for L1 slab storage operations
+// ============================================================================
+
+enum class L1Error : int {
+  SUCCESS = 0,
+  KEY_NOT_EXIST = 1,
+  KEY_NOT_READABLE = 2,
+  KEY_NOT_WRITABLE = 3,
+  KEY_IN_WRONG_STATE = 4,
+  KEY_IS_LOCKED = 5,
+  OUT_OF_MEMORY = 6,
+};
+
+// ============================================================================
+// MemorySlabRef — zero-copy reference into L1 slab
+// ============================================================================
+
+struct MemorySlabRef {
+  void* data;         // Pointer into the mmap'd slab
+  size_t size_bytes;  // Size of this object
+  MemoryLayoutDesc layout;
+};
+
+// ============================================================================
+// PrefetchHandle — tracks a prefetch request from submission to completion
+// ============================================================================
+
+struct PrefetchHandle {
+  int64_t prefetch_request_id;  // Opaque L2 tracking ID (-1 if no L2 request)
+  std::string external_request_id;  // Caller's request ID for tracing
+  int64_t l1_prefix_hit_count;      // Leading keys already in L1 at submit time
+  int64_t total_requested_keys;     // Total number of keys originally requested
+  double submit_time;               // Monotonic timestamp (seconds)
+};
+
+// ============================================================================
+// CBMatchResult — sub-sequence match from BlendTokenRangeMatcher
+// ============================================================================
+
+struct CBMatchResult {
+  int32_t old_st;
+  int32_t old_ed;
+  int32_t cur_st;
+  int32_t cur_ed;
+  std::vector<uint8_t> hash;  // Token hash bytes from registration
+};
+
+// ============================================================================
+// compute_extra_count — MLA multi-reader locking logic
+//
+// Non-MLA: each TP worker owns a distinct KV shard, extra_count = 0.
+// MLA: all TP workers share the same object, extra_count = tp_size - 1.
+// Detection: tp > world_size means MLA (world_size was divided by tp).
+// ============================================================================
+
+inline int compute_extra_count(int tp_size, int world_size) {
+  int tp = (tp_size > 1) ? tp_size : world_size;
+  return (tp > world_size) ? (tp - 1) : 0;
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/wire_protocol.cpp
+++ b/csrc/server/wire_protocol.cpp
@@ -1,0 +1,914 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — wire_protocol.cpp
+//
+// msgpack encode/decode matching Python msgspec.msgpack wire format.
+// The Python client uses msgspec Structs (encoded as msgpack arrays of
+// fields in declaration order) and msgspec Ext types for CudaIPCWrapper.
+
+#include "wire_protocol.h"
+
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <msgpack.hpp>
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Encoder
+// ============================================================================
+
+struct Encoder::Impl {
+  // We allocate a fresh sbuffer per call and return the bytes.
+  // This is cheap and avoids lifetime issues.
+};
+
+Encoder::Encoder() : impl_(new Impl()) {}
+Encoder::~Encoder() { delete impl_; }
+
+std::vector<uint8_t> Encoder::encode_request_uid(RequestUID uid) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, uid);
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+std::vector<uint8_t> Encoder::encode_request_type(RequestType type) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, static_cast<int>(type));
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+std::vector<uint8_t> Encoder::encode_store_response(
+    const std::vector<uint8_t>& event_ipc_handle, bool success) {
+  // Python: tuple[bytes, bool] -> msgpack array of 2 elements
+  msgpack::sbuffer buf;
+  msgpack::packer<msgpack::sbuffer> pk(buf);
+  pk.pack_array(2);
+  // bytes -> msgpack bin
+  pk.pack_bin(event_ipc_handle.size());
+  pk.pack_bin_body(reinterpret_cast<const char*>(event_ipc_handle.data()),
+                   event_ipc_handle.size());
+  pk.pack(success);
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+std::vector<uint8_t> Encoder::encode_retrieve_response(
+    const std::vector<uint8_t>& event_ipc_handle, bool success) {
+  // Same format as store response: tuple[bytes, bool]
+  return encode_store_response(event_ipc_handle, success);
+}
+
+std::vector<uint8_t> Encoder::encode_int_response(int64_t value) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, value);
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+std::vector<uint8_t> Encoder::encode_bool_response(bool value) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, value);
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+std::vector<uint8_t> Encoder::encode_none_response() {
+  msgpack::sbuffer buf;
+  msgpack::packer<msgpack::sbuffer> pk(buf);
+  pk.pack_nil();
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+std::vector<uint8_t> Encoder::encode_optional_int_response(int64_t value,
+                                                           bool is_none) {
+  if (is_none) {
+    return encode_none_response();
+  }
+  return encode_int_response(value);
+}
+
+std::vector<uint8_t> Encoder::encode_string_response(const std::string& value) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, value);
+  return {reinterpret_cast<const uint8_t*>(buf.data()),
+          reinterpret_cast<const uint8_t*>(buf.data()) + buf.size()};
+}
+
+// ============================================================================
+// Decoder helpers
+// ============================================================================
+
+namespace {
+
+/// Unpack a single msgpack object from raw bytes.
+msgpack::object_handle unpack_one(const uint8_t* data, size_t len) {
+  return msgpack::unpack(reinterpret_cast<const char*>(data), len);
+}
+
+/// Decode an IPCCacheEngineKey from a msgpack-encoded frame.
+///
+/// Python msgspec encodes a dataclass as a msgpack MAP (dict with string keys):
+///   {"model_name": str, "world_size": int, "worker_id": int|None,
+///    "token_ids": [int...], "start": int, "end": int, "request_id": str}
+///
+/// worker_id may be None (msgpack nil) for lookup requests.
+
+namespace {
+/// Helper: look up a key in a msgpack map, return pointer or nullptr.
+const msgpack::object* map_find(const msgpack::object_map& m, const char* key) {
+  for (uint32_t i = 0; i < m.size; ++i) {
+    if (m.ptr[i].key.type == msgpack::type::STR) {
+      const auto& s = m.ptr[i].key.via.str;
+      if (s.size == std::strlen(key) && std::memcmp(s.ptr, key, s.size) == 0) {
+        return &m.ptr[i].val;
+      }
+    }
+  }
+  return nullptr;
+}
+}  // namespace
+
+IPCCacheEngineKey decode_ipc_key(const uint8_t* data, size_t len) {
+  auto oh = unpack_one(data, len);
+  const auto& obj = oh.get();
+
+  IPCCacheEngineKey key;
+
+  if (obj.type == msgpack::type::MAP) {
+    // Map (dict) encoding — the actual format used by msgspec for dataclasses
+    const auto& m = obj.via.map;
+
+    if (auto* v = map_find(m, "model_name"))
+      key.model_name = v->as<std::string>();
+    if (auto* v = map_find(m, "world_size")) key.world_size = v->as<int32_t>();
+
+    if (auto* v = map_find(m, "worker_id")) {
+      if (v->type == msgpack::type::NIL) {
+        key.worker_id = -1;
+      } else {
+        key.worker_id = v->as<int32_t>();
+      }
+    } else {
+      key.worker_id = -1;
+    }
+
+    if (auto* v = map_find(m, "token_ids")) {
+      const auto& tok_arr = v->via.array;
+      key.token_ids.resize(tok_arr.size);
+      for (uint32_t i = 0; i < tok_arr.size; ++i) {
+        key.token_ids[i] = tok_arr.ptr[i].as<int32_t>();
+      }
+    }
+
+    if (auto* v = map_find(m, "start")) key.start = v->as<int32_t>();
+    if (auto* v = map_find(m, "end")) key.end = v->as<int32_t>();
+    if (auto* v = map_find(m, "request_id"))
+      key.request_id = v->as<std::string>();
+
+  } else if (obj.type == msgpack::type::ARRAY) {
+    // Array encoding (legacy/alternate Struct encoding)
+    const auto& arr = obj.via.array;
+    if (arr.size < 7) {
+      throw std::runtime_error("IPCCacheEngineKey: expected 7 fields, got " +
+                               std::to_string(arr.size));
+    }
+
+    key.model_name = arr.ptr[0].as<std::string>();
+    key.world_size = arr.ptr[1].as<int32_t>();
+
+    if (arr.ptr[2].type == msgpack::type::NIL) {
+      key.worker_id = -1;
+    } else {
+      key.worker_id = arr.ptr[2].as<int32_t>();
+    }
+
+    {
+      const auto& tok_arr = arr.ptr[3].via.array;
+      key.token_ids.resize(tok_arr.size);
+      for (uint32_t i = 0; i < tok_arr.size; ++i) {
+        key.token_ids[i] = tok_arr.ptr[i].as<int32_t>();
+      }
+    }
+
+    key.start = arr.ptr[4].as<int32_t>();
+    key.end = arr.ptr[5].as<int32_t>();
+    key.request_id = arr.ptr[6].as<std::string>();
+
+  } else {
+    throw std::runtime_error(
+        "IPCCacheEngineKey: expected msgpack map or array, got type " +
+        std::to_string(static_cast<int>(obj.type)));
+  }
+
+  return key;
+}
+
+/// Decode a list[int] from msgpack bytes (e.g., gpu_block_ids).
+std::vector<int32_t> decode_int_list(const uint8_t* data, size_t len) {
+  auto oh = unpack_one(data, len);
+  const auto& obj = oh.get();
+  if (obj.type != msgpack::type::ARRAY) {
+    throw std::runtime_error("decode_int_list: expected array");
+  }
+  const auto& arr = obj.via.array;
+  std::vector<int32_t> result(arr.size);
+  for (uint32_t i = 0; i < arr.size; ++i) {
+    result[i] = arr.ptr[i].as<int32_t>();
+  }
+  return result;
+}
+
+/// Decode raw bytes from msgpack bin format.
+std::vector<uint8_t> decode_bytes(const uint8_t* data, size_t len) {
+  auto oh = unpack_one(data, len);
+  const auto& obj = oh.get();
+  if (obj.type != msgpack::type::BIN) {
+    throw std::runtime_error("decode_bytes: expected bin, got type " +
+                             std::to_string(static_cast<int>(obj.type)));
+  }
+  const char* bin_data = obj.via.bin.ptr;
+  uint32_t bin_size = obj.via.bin.size;
+  return {reinterpret_cast<const uint8_t*>(bin_data),
+          reinterpret_cast<const uint8_t*>(bin_data) + bin_size};
+}
+
+/// Map a Python torch.dtype name to our DType enum.
+DType dtype_from_string(const std::string& s) {
+  if (s == "float16") return DType::Float16;
+  if (s == "bfloat16") return DType::BFloat16;
+  if (s == "float32") return DType::Float32;
+  if (s == "float8_e4m3fn") return DType::Float8E4M3FN;
+  if (s == "float8_e5m2") return DType::Float8E5M2;
+  if (s == "int8") return DType::Int8;
+  if (s == "uint8") return DType::Int8;  // fp8 KV cache uses torch.uint8
+  if (s == "int32") return DType::Int32;
+  if (s == "int64") return DType::Int64;
+  std::fprintf(stderr,
+               "WARNING: unknown dtype string: '%s', defaulting to float16\n",
+               s.c_str());
+  return DType::Float16;
+}
+
+/// Structured pickle parser for CudaIPCWrapper objects.
+///
+/// Pickle protocol 4 layout (from pickletools.dis):
+///
+///   PROTO 4
+///   FRAME
+///   SHORT_BINUNICODE 'lmcache.v1.multiprocess.custom_types'
+///   SHORT_BINUNICODE 'CudaIPCWrapper'
+///   STACK_GLOBAL + NEWOBJ (creates empty instance)
+///   EMPTY_DICT
+///   MARK
+///     SHORT_BINUNICODE 'handle'
+///     MARK
+///       BININT1 <device_idx>
+///       SHORT_BINBYTES <66 bytes>         -- handle[1]: storage handle
+///       BININT1 <storage_size>
+///       BININT1 <storage_offset_in_handle>
+///       SHORT_BINBYTES <~27 bytes>        -- handle[4]: storage filename
+///       BININT1 0
+///       SHORT_BINBYTES <64 bytes>         -- handle[6]: cudaIpcMemHandle_t <<<
+///       NEWTRUE
+///     TUPLE
+///     SHORT_BINUNICODE 'dtype'
+///     SHORT_BINUNICODE 'torch'
+///     SHORT_BINUNICODE '<dtype_name>'     -- e.g. 'float16', 'bfloat16'
+///     STACK_GLOBAL
+///     SHORT_BINUNICODE 'shape'
+///     <tuple of ints>
+///     SHORT_BINUNICODE 'stride'
+///     <tuple of ints>
+///     SHORT_BINUNICODE 'storage_offset'
+///     <int>
+///     SHORT_BINUNICODE 'device_uuid'
+///     SHORT_BINUNICODE '<uuid string>'    -- bare UUID, no "GPU-" prefix
+///   SETITEMS
+///   BUILD
+///   STOP
+///
+/// We parse opcodes sequentially, tracking field names from SHORT_BINUNICODE
+/// that precede values, and extracting the fields we need.
+
+// Pickle protocol 4 opcodes we care about
+constexpr uint8_t PK_PROTO = 0x80;
+constexpr uint8_t PK_FRAME = 0x95;
+constexpr uint8_t PK_SHORT_BINUNICODE = 0x8c;
+constexpr uint8_t PK_BINUNICODE = 0x8d;
+constexpr uint8_t PK_SHORT_BINBYTES = 0x43;  // 'C'
+constexpr uint8_t PK_BINBYTES = 0x42;        // 'B'
+constexpr uint8_t PK_BININT1 = 0x4b;         // 'K'
+constexpr uint8_t PK_BININT2 = 0x4d;         // 'M'
+constexpr uint8_t PK_BININT = 0x4a;          // 'J'
+constexpr uint8_t PK_LONG1 = 0x8a;
+constexpr uint8_t PK_MEMOIZE = 0x94;
+constexpr uint8_t PK_MARK = 0x28;   // '('
+constexpr uint8_t PK_TUPLE = 0x74;  // 't'
+constexpr uint8_t PK_TUPLE1 = 0x85;
+constexpr uint8_t PK_TUPLE2 = 0x86;
+constexpr uint8_t PK_TUPLE3 = 0x87;
+constexpr uint8_t PK_EMPTY_TUPLE = 0x29;  // ')'
+constexpr uint8_t PK_EMPTY_DICT = 0x7d;   // '}'
+constexpr uint8_t PK_STACK_GLOBAL = 0x93;
+constexpr uint8_t PK_NEWOBJ = 0x81;
+constexpr uint8_t PK_BUILD = 0x62;     // 'b'
+constexpr uint8_t PK_SETITEMS = 0x75;  // 'u'
+constexpr uint8_t PK_NEWTRUE = 0x88;
+constexpr uint8_t PK_NEWFALSE = 0x89;
+constexpr uint8_t PK_NONE = 0x4e;  // 'N'
+constexpr uint8_t PK_STOP = 0x2e;  // '.'
+
+CudaIpcTensorDesc decode_cuda_ipc_from_pickle(const uint8_t* data, size_t len) {
+  CudaIpcTensorDesc desc{};
+  std::memset(desc.ipc_handle, 0, 64);
+  desc.dtype = DType::Float16;
+  desc.storage_offset = 0;
+  desc.storage_size_bytes = 0;
+
+  // State for tracking dict key-value pairs
+  std::string last_field_name;
+  std::string last_string;         // most recent SHORT_BINUNICODE value
+  std::string second_last_string;  // for STACK_GLOBAL (module, name)
+
+  // Collect bytes objects found in the handle tuple
+  std::vector<std::pair<const uint8_t*, size_t>> bytes_in_handle;
+  bool in_handle_tuple = false;  // true between handle's MARK and TUPLE
+  int mark_depth = 0;
+
+  // We always collect ints into pending_ints.
+  // When a tuple-building opcode fires and last_field_name is
+  // "shape" or "stride", we capture the ints.
+  // For MARK...TUPLE style, we record where the mark was and
+  // take ints from there.  For TUPLE2/TUPLE3 (no mark), we
+  // take the last 2 or 3 ints from pending_ints.
+  std::vector<int64_t> pending_ints;
+  int mark_int_pos = -1;  // index into pending_ints at last MARK
+
+  size_t pos = 0;
+  while (pos < len) {
+    uint8_t op = data[pos++];
+
+    switch (op) {
+      case PK_PROTO:
+        pos++;  // skip version byte
+        break;
+
+      case PK_FRAME:
+        pos += 8;  // skip 8-byte frame length
+        break;
+
+      case PK_SHORT_BINUNICODE: {
+        if (pos >= len) break;
+        uint8_t slen = data[pos++];
+        if (pos + slen > len) break;
+        second_last_string = last_string;
+        last_string =
+            std::string(reinterpret_cast<const char*>(data + pos), slen);
+        pos += slen;
+
+        // Check if this is a field name we care about
+        if (last_string == "handle" || last_string == "dtype" ||
+            last_string == "shape" || last_string == "stride" ||
+            last_string == "storage_offset" || last_string == "device_uuid") {
+          last_field_name = last_string;
+        }
+        // If the field we're filling is device_uuid and this is the value
+        else if (last_field_name == "device_uuid") {
+          desc.device_uuid = last_string;
+          last_field_name.clear();
+        }
+        break;
+      }
+
+      case PK_BINUNICODE: {
+        if (pos + 4 > len) break;
+        uint32_t slen = static_cast<uint32_t>(data[pos]) |
+                        (static_cast<uint32_t>(data[pos + 1]) << 8) |
+                        (static_cast<uint32_t>(data[pos + 2]) << 16) |
+                        (static_cast<uint32_t>(data[pos + 3]) << 24);
+        pos += 4;
+        if (pos + slen > len) break;
+        second_last_string = last_string;
+        last_string =
+            std::string(reinterpret_cast<const char*>(data + pos), slen);
+        pos += slen;
+        break;
+      }
+
+      case PK_SHORT_BINBYTES: {
+        if (pos >= len) break;
+        uint8_t blen = data[pos++];
+        if (pos + blen > len) break;
+        if (in_handle_tuple) {
+          bytes_in_handle.push_back({data + pos, blen});
+        }
+        pos += blen;
+        break;
+      }
+
+      case PK_BINBYTES: {
+        if (pos + 4 > len) break;
+        uint32_t blen = static_cast<uint32_t>(data[pos]) |
+                        (static_cast<uint32_t>(data[pos + 1]) << 8) |
+                        (static_cast<uint32_t>(data[pos + 2]) << 16) |
+                        (static_cast<uint32_t>(data[pos + 3]) << 24);
+        pos += 4;
+        if (pos + blen > len) break;
+        if (in_handle_tuple) {
+          bytes_in_handle.push_back({data + pos, blen});
+        }
+        pos += blen;
+        break;
+      }
+
+      case PK_BININT1: {
+        if (pos >= len) break;
+        int64_t val = data[pos++];
+        if (last_field_name == "storage_offset") {
+          desc.storage_offset = val;
+          last_field_name.clear();
+        }
+        pending_ints.push_back(val);
+        break;
+      }
+
+      case PK_BININT2: {
+        if (pos + 2 > len) break;
+        int64_t val = static_cast<uint16_t>(data[pos]) |
+                      (static_cast<uint16_t>(data[pos + 1]) << 8);
+        pos += 2;
+        if (last_field_name == "storage_offset") {
+          desc.storage_offset = val;
+          last_field_name.clear();
+        }
+        pending_ints.push_back(val);
+        break;
+      }
+
+      case PK_BININT: {
+        if (pos + 4 > len) break;
+        int32_t val;
+        std::memcpy(&val, data + pos, 4);
+        pos += 4;
+        if (last_field_name == "storage_offset") {
+          desc.storage_offset = val;
+          last_field_name.clear();
+        }
+        pending_ints.push_back(val);
+        break;
+      }
+
+      case PK_LONG1: {
+        if (pos >= len) break;
+        uint8_t nbytes = data[pos++];
+        if (pos + nbytes > len) break;
+        int64_t val = 0;
+        for (int i = nbytes - 1; i >= 0; --i) {
+          val = (val << 8) | data[pos + i];
+        }
+        if (nbytes > 0 && (data[pos + nbytes - 1] & 0x80)) {
+          for (size_t i = nbytes; i < 8; ++i) val |= (0xFFLL << (i * 8));
+        }
+        pos += nbytes;
+        if (last_field_name == "storage_offset") {
+          desc.storage_offset = val;
+          last_field_name.clear();
+        }
+        pending_ints.push_back(val);
+        break;
+      }
+
+      case PK_MARK:
+        mark_depth++;
+        if (last_field_name == "handle") {
+          in_handle_tuple = true;
+        }
+        mark_int_pos = static_cast<int>(pending_ints.size());
+        break;
+
+      case PK_TUPLE: {
+        mark_depth--;
+        if (in_handle_tuple && last_field_name == "handle") {
+          in_handle_tuple = false;
+          last_field_name.clear();
+          for (const auto& [ptr, sz] : bytes_in_handle) {
+            if (sz >= 64) {
+              // Store the full blob for libtorch's getIpcDevPtr
+              desc.ipc_handle_blob.assign(ptr, ptr + sz);
+              // Also copy first 64 bytes into legacy field
+              std::memcpy(desc.ipc_handle, ptr, 64);
+              break;
+            }
+          }
+          // Extract storage_size from handle ints.
+          // handle tuple layout: (device_idx, ipc_bytes, storage_size, ...)
+          // The ints collected during handle parsing are:
+          //   [device_idx, storage_size, storage_offset_in_handle, 0, ...]
+          // pending_ints[0] = device_idx, pending_ints[1] = storage_size
+          if (pending_ints.size() >= 2) {
+            desc.storage_size_bytes = pending_ints[1];
+          }
+        }
+        // MARK...TUPLE: ints from mark_int_pos onward
+        if (last_field_name == "shape" && mark_int_pos >= 0) {
+          desc.shape.assign(pending_ints.begin() + mark_int_pos,
+                            pending_ints.end());
+          last_field_name.clear();
+        }
+        if (last_field_name == "stride" && mark_int_pos >= 0) {
+          desc.stride.assign(pending_ints.begin() + mark_int_pos,
+                             pending_ints.end());
+          last_field_name.clear();
+        }
+        pending_ints.clear();
+        mark_int_pos = -1;
+        break;
+      }
+
+      case PK_TUPLE1: {
+        // Pop 1 item → 1-element tuple (no MARK)
+        if (last_field_name == "shape" && pending_ints.size() >= 1) {
+          desc.shape = {pending_ints.back()};
+          last_field_name.clear();
+        } else if (last_field_name == "stride" && pending_ints.size() >= 1) {
+          desc.stride = {pending_ints.back()};
+          last_field_name.clear();
+        }
+        break;
+      }
+
+      case PK_TUPLE2: {
+        // Pop 2 items → 2-element tuple (no MARK)
+        size_t n = pending_ints.size();
+        if (last_field_name == "shape" && n >= 2) {
+          desc.shape = {pending_ints[n - 2], pending_ints[n - 1]};
+          last_field_name.clear();
+        } else if (last_field_name == "stride" && n >= 2) {
+          desc.stride = {pending_ints[n - 2], pending_ints[n - 1]};
+          last_field_name.clear();
+        }
+        break;
+      }
+
+      case PK_TUPLE3: {
+        // Pop 3 items → 3-element tuple (no MARK)
+        size_t n = pending_ints.size();
+        if (last_field_name == "shape" && n >= 3) {
+          desc.shape = {pending_ints[n - 3], pending_ints[n - 2],
+                        pending_ints[n - 1]};
+          last_field_name.clear();
+        } else if (last_field_name == "stride" && n >= 3) {
+          desc.stride = {pending_ints[n - 3], pending_ints[n - 2],
+                         pending_ints[n - 1]};
+          last_field_name.clear();
+        }
+        break;
+      }
+
+      case PK_STACK_GLOBAL:
+        // The two strings before STACK_GLOBAL form module.name.
+        // For dtype: second_last_string="torch", last_string="float16"
+        if (last_field_name == "dtype" && second_last_string == "torch") {
+          desc.dtype = dtype_from_string(last_string);
+          last_field_name.clear();
+        }
+        break;
+
+      case PK_MEMOIZE:
+      case PK_EMPTY_TUPLE:
+      case PK_EMPTY_DICT:
+      case PK_NEWOBJ:
+      case PK_BUILD:
+      case PK_SETITEMS:
+      case PK_NEWTRUE:
+      case PK_NEWFALSE:
+      case PK_NONE:
+        // No-data opcodes
+        break;
+
+      case PK_STOP:
+        goto done;
+
+      default:
+        // Unknown opcode — skip and hope for the best.
+        // This is fragile but works for the known CudaIPCWrapper layout.
+        break;
+    }
+  }
+
+done:
+  // Debug logging: report everything we extracted
+  {
+    // IPC handle: show first 16 bytes hex
+    char ipc_hex[129];
+    for (int i = 0; i < 64; ++i)
+      std::snprintf(ipc_hex + i * 2, 3, "%02x", desc.ipc_handle[i]);
+    ipc_hex[128] = '\0';
+
+    // Check if ipc_handle is all zeros
+    bool all_zero = true;
+    for (int i = 0; i < 64; ++i) {
+      if (desc.ipc_handle[i] != 0) {
+        all_zero = false;
+        break;
+      }
+    }
+
+    std::fprintf(stderr, "[pickle] device_uuid='%s' dtype=%d shape=[",
+                 desc.device_uuid.c_str(), static_cast<int>(desc.dtype));
+    for (size_t i = 0; i < desc.shape.size(); ++i) {
+      if (i > 0) std::fprintf(stderr, ",");
+      std::fprintf(stderr, "%ld", desc.shape[i]);
+    }
+    std::fprintf(stderr, "] stride=[");
+    for (size_t i = 0; i < desc.stride.size(); ++i) {
+      if (i > 0) std::fprintf(stderr, ",");
+      std::fprintf(stderr, "%ld", desc.stride[i]);
+    }
+    std::fprintf(stderr,
+                 "] storage_offset=%ld ipc_handle=%s%s "
+                 "bytes_in_handle=%zu: ",
+                 desc.storage_offset, ipc_hex, all_zero ? " (ALL ZEROS!)" : "",
+                 bytes_in_handle.size());
+    // Print sizes and first 4 bytes of each bytes_in_handle entry
+    for (size_t i = 0; i < bytes_in_handle.size(); ++i) {
+      auto& [ptr, sz] = bytes_in_handle[i];
+      std::fprintf(stderr, "[%zu]=%zu(", i, sz);
+      for (size_t j = 0; j < std::min(sz, (size_t)4); ++j)
+        std::fprintf(stderr, "%02x", ptr[j]);
+      std::fprintf(stderr, "...) ");
+    }
+    std::fprintf(stderr, "\n");
+  }
+
+  if (desc.device_uuid.empty()) {
+    std::fprintf(stderr, "WARNING: pickle parser: device_uuid is empty\n");
+  }
+
+  // Build "GPU-" prefixed UUID for matching with CUDA device properties
+  if (!desc.device_uuid.empty() && desc.device_uuid.substr(0, 4) != "GPU-") {
+    desc.device_uuid = "GPU-" + desc.device_uuid;
+  }
+
+  return desc;
+}
+
+}  // anonymous namespace
+
+// ============================================================================
+// Decoder
+// ============================================================================
+
+struct Decoder::Impl {
+  // Stateless for now; kept for future caching/pooling.
+};
+
+Decoder::Decoder() : impl_(new Impl()) {}
+Decoder::~Decoder() { delete impl_; }
+
+RequestUID Decoder::decode_request_uid(const uint8_t* data, size_t len) {
+  auto oh = unpack_one(data, len);
+  return oh.get().as<int64_t>();
+}
+
+RequestType Decoder::decode_request_type(const uint8_t* data, size_t len) {
+  auto oh = unpack_one(data, len);
+  int val = oh.get().as<int>();
+  return static_cast<RequestType>(val);
+}
+
+RegisterPayload Decoder::decode_register_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [instance_id, kv_cache_list, model_name, world_size]
+  // kv_cache_list is list[CudaIPCWrapper] encoded via custom encoder
+  // (each element is Ext type 1 with pickle bytes)
+  if (frames.size() < 4) {
+    throw std::runtime_error("RegisterPayload: expected 4 frames, got " +
+                             std::to_string(frames.size()));
+  }
+
+  RegisterPayload payload;
+
+  // Frame 0: instance_id (int)
+  {
+    auto oh = unpack_one(frames[0].data(), frames[0].size());
+    payload.instance_id = oh.get().as<int32_t>();
+  }
+
+  // Frame 1: list[CudaIPCWrapper] — msgpack array of Ext(1, pickle_bytes)
+  {
+    auto oh = unpack_one(frames[1].data(), frames[1].size());
+    const auto& obj = oh.get();
+    if (obj.type != msgpack::type::ARRAY) {
+      throw std::runtime_error("RegisterPayload: kv_caches expected array");
+    }
+    const auto& arr = obj.via.array;
+    payload.kv_caches.resize(arr.size);
+    for (uint32_t i = 0; i < arr.size; ++i) {
+      const auto& elem = arr.ptr[i];
+      if (elem.type != msgpack::type::EXT) {
+        throw std::runtime_error(
+            "RegisterPayload: kv_cache element expected Ext type");
+      }
+      const auto& ext = elem.via.ext;
+      if (ext.type() != 1) {
+        throw std::runtime_error("RegisterPayload: expected Ext code 1, got " +
+                                 std::to_string(ext.type()));
+      }
+      payload.kv_caches[i] = decode_cuda_ipc_from_pickle(
+          reinterpret_cast<const uint8_t*>(ext.data()), ext.size);
+    }
+  }
+
+  // Frame 2: model_name (str)
+  {
+    auto oh = unpack_one(frames[2].data(), frames[2].size());
+    payload.model_name = oh.get().as<std::string>();
+  }
+
+  // Frame 3: world_size (int)
+  {
+    auto oh = unpack_one(frames[3].data(), frames[3].size());
+    payload.world_size = oh.get().as<int32_t>();
+  }
+
+  return payload;
+}
+
+StorePayload Decoder::decode_store_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [key, instance_id, gpu_block_ids, event_ipc_handle]
+  if (frames.size() < 4) {
+    throw std::runtime_error("StorePayload: expected 4 frames, got " +
+                             std::to_string(frames.size()));
+  }
+
+  StorePayload payload;
+  payload.key = decode_ipc_key(frames[0].data(), frames[0].size());
+
+  {
+    auto oh = unpack_one(frames[1].data(), frames[1].size());
+    payload.instance_id = oh.get().as<int32_t>();
+  }
+
+  payload.gpu_block_ids = decode_int_list(frames[2].data(), frames[2].size());
+
+  payload.event_ipc_handle = decode_bytes(frames[3].data(), frames[3].size());
+
+  return payload;
+}
+
+RetrievePayload Decoder::decode_retrieve_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [key, instance_id, gpu_block_ids, event_ipc_handle,
+  //            skip_first_n_tokens]
+  if (frames.size() < 5) {
+    throw std::runtime_error("RetrievePayload: expected 5 frames, got " +
+                             std::to_string(frames.size()));
+  }
+
+  RetrievePayload payload;
+  payload.key = decode_ipc_key(frames[0].data(), frames[0].size());
+
+  {
+    auto oh = unpack_one(frames[1].data(), frames[1].size());
+    payload.instance_id = oh.get().as<int32_t>();
+  }
+
+  payload.gpu_block_ids = decode_int_list(frames[2].data(), frames[2].size());
+
+  payload.event_ipc_handle = decode_bytes(frames[3].data(), frames[3].size());
+
+  {
+    auto oh = unpack_one(frames[4].data(), frames[4].size());
+    payload.skip_first_n_tokens = oh.get().as<int32_t>();
+  }
+
+  return payload;
+}
+
+LookupPayload Decoder::decode_lookup_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [key, tp_size]
+  if (frames.size() < 2) {
+    throw std::runtime_error("LookupPayload: expected 2 frames, got " +
+                             std::to_string(frames.size()));
+  }
+
+  LookupPayload payload;
+  payload.key = decode_ipc_key(frames[0].data(), frames[0].size());
+
+  {
+    auto oh = unpack_one(frames[1].data(), frames[1].size());
+    payload.tp_size = oh.get().as<int32_t>();
+  }
+
+  return payload;
+}
+
+FreeLookupLocksPayload Decoder::decode_free_lookup_locks_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [key, tp_size]
+  if (frames.size() < 2) {
+    throw std::runtime_error("FreeLookupLocksPayload: expected 2 frames, got " +
+                             std::to_string(frames.size()));
+  }
+
+  FreeLookupLocksPayload payload;
+  payload.key = decode_ipc_key(frames[0].data(), frames[0].size());
+
+  {
+    auto oh = unpack_one(frames[1].data(), frames[1].size());
+    payload.tp_size = oh.get().as<int32_t>();
+  }
+
+  return payload;
+}
+
+EndSessionPayload Decoder::decode_end_session_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [request_id]
+  if (frames.size() < 1) {
+    throw std::runtime_error("EndSessionPayload: expected 1 frame, got " +
+                             std::to_string(frames.size()));
+  }
+
+  EndSessionPayload payload;
+  {
+    auto oh = unpack_one(frames[0].data(), frames[0].size());
+    payload.request_id = oh.get().as<std::string>();
+  }
+
+  return payload;
+}
+
+QueryPrefetchStatusPayload Decoder::decode_query_prefetch_status_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [prefetch_job_id]
+  if (frames.size() < 1) {
+    throw std::runtime_error(
+        "QueryPrefetchStatusPayload: expected 1 frame, got " +
+        std::to_string(frames.size()));
+  }
+
+  QueryPrefetchStatusPayload payload;
+  {
+    auto oh = unpack_one(frames[0].data(), frames[0].size());
+    payload.prefetch_job_id = oh.get().as<int32_t>();
+  }
+
+  return payload;
+}
+
+QueryPrefetchLookupHitsPayload
+Decoder::decode_query_prefetch_lookup_hits_payload(
+    const std::vector<std::vector<uint8_t>>& frames) {
+  // Protocol: [prefetch_job_id]
+  if (frames.size() < 1) {
+    throw std::runtime_error(
+        "QueryPrefetchLookupHitsPayload: expected 1 frame, got " +
+        std::to_string(frames.size()));
+  }
+
+  QueryPrefetchLookupHitsPayload payload;
+  {
+    auto oh = unpack_one(frames[0].data(), frames[0].size());
+    payload.prefetch_job_id = oh.get().as<int32_t>();
+  }
+
+  return payload;
+}
+
+int32_t Decoder::decode_int_payload(const uint8_t* data, size_t len) {
+  auto oh = unpack_one(data, len);
+  return oh.get().as<int32_t>();
+}
+
+CudaIpcTensorDesc Decoder::decode_cuda_ipc_wrapper(const uint8_t* data,
+                                                   size_t len) {
+  // First, try to unpack as msgpack to see if it's an Ext type
+  auto oh = unpack_one(data, len);
+  const auto& obj = oh.get();
+
+  if (obj.type == msgpack::type::EXT) {
+    const auto& ext = obj.via.ext;
+    if (ext.type() == 1) {
+      // Ext code 1 = CudaIPCWrapper pickle
+      return decode_cuda_ipc_from_pickle(
+          reinterpret_cast<const uint8_t*>(ext.data()), ext.size);
+    }
+  }
+
+  // If it's not an Ext, try to decode as raw pickle bytes
+  return decode_cuda_ipc_from_pickle(data, len);
+}
+
+}  // namespace server
+}  // namespace lmcache

--- a/csrc/server/wire_protocol.h
+++ b/csrc/server/wire_protocol.h
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pure C++ LMCache Server — msgpack wire protocol encode/decode
+//
+// Must produce bytes identical to Python `msgspec.msgpack` so that the
+// existing Python vLLM clients work without modification.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+// msgpack types are only needed in the .cpp (via pimpl); no forward
+// declarations needed here.
+
+namespace lmcache {
+namespace server {
+
+// ============================================================================
+// Typed payload structs — decoded from inbound ZMQ frames
+// ============================================================================
+
+struct RegisterPayload {
+  int32_t instance_id;
+  std::vector<CudaIpcTensorDesc> kv_caches;
+  std::string model_name;
+  int32_t world_size;
+};
+
+struct StorePayload {
+  IPCCacheEngineKey key;
+  int32_t instance_id;
+  std::vector<int32_t> gpu_block_ids;
+  std::vector<uint8_t> event_ipc_handle;  // raw bytes
+};
+
+struct RetrievePayload {
+  IPCCacheEngineKey key;
+  int32_t instance_id;
+  std::vector<int32_t> gpu_block_ids;
+  std::vector<uint8_t> event_ipc_handle;
+  int32_t skip_first_n_tokens;
+};
+
+struct LookupPayload {
+  IPCCacheEngineKey key;
+  int32_t tp_size;
+};
+
+struct FreeLookupLocksPayload {
+  IPCCacheEngineKey key;
+  int32_t tp_size;
+};
+
+struct EndSessionPayload {
+  std::string request_id;
+};
+
+struct QueryPrefetchStatusPayload {
+  int32_t prefetch_job_id;
+};
+
+struct QueryPrefetchLookupHitsPayload {
+  int32_t prefetch_job_id;
+};
+
+// ============================================================================
+// Encoder — serialises response types to msgpack bytes
+// ============================================================================
+
+class Encoder {
+ public:
+  Encoder();
+  ~Encoder();
+
+  /// Encode a RequestUID
+  std::vector<uint8_t> encode_request_uid(RequestUID uid);
+
+  /// Encode a RequestType enum value
+  std::vector<uint8_t> encode_request_type(RequestType type);
+
+  /// Encode a (event_ipc_handle, success) response pair
+  std::vector<uint8_t> encode_store_response(
+      const std::vector<uint8_t>& event_ipc_handle, bool success);
+
+  /// Encode a (event_ipc_handle, success) response pair for retrieve
+  std::vector<uint8_t> encode_retrieve_response(
+      const std::vector<uint8_t>& event_ipc_handle, bool success);
+
+  /// Encode an int response (lookup hit count, chunk_size, etc.)
+  std::vector<uint8_t> encode_int_response(int64_t value);
+
+  /// Encode a bool response (ping)
+  std::vector<uint8_t> encode_bool_response(bool value);
+
+  /// Encode a None response (for void handlers)
+  std::vector<uint8_t> encode_none_response();
+
+  /// Encode an optional int response (None or int)
+  std::vector<uint8_t> encode_optional_int_response(int64_t value,
+                                                    bool is_none);
+
+  /// Encode a string response (debug)
+  std::vector<uint8_t> encode_string_response(const std::string& value);
+
+ private:
+  struct Impl;
+  Impl* impl_;
+};
+
+// ============================================================================
+// Decoder — parses inbound ZMQ frames from msgpack bytes
+// ============================================================================
+
+class Decoder {
+ public:
+  Decoder();
+  ~Decoder();
+
+  /// Decode a RequestUID from raw bytes
+  RequestUID decode_request_uid(const uint8_t* data, size_t len);
+
+  /// Decode a RequestType enum value from raw bytes
+  RequestType decode_request_type(const uint8_t* data, size_t len);
+
+  /// Decode a RegisterPayload
+  RegisterPayload decode_register_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode a StorePayload
+  StorePayload decode_store_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode a RetrievePayload
+  RetrievePayload decode_retrieve_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode a LookupPayload (also used for SYNC_LOOKUP)
+  LookupPayload decode_lookup_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode a FreeLookupLocksPayload
+  FreeLookupLocksPayload decode_free_lookup_locks_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode an EndSessionPayload
+  EndSessionPayload decode_end_session_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode a QueryPrefetchStatusPayload
+  QueryPrefetchStatusPayload decode_query_prefetch_status_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode a QueryPrefetchLookupHitsPayload
+  QueryPrefetchLookupHitsPayload decode_query_prefetch_lookup_hits_payload(
+      const std::vector<std::vector<uint8_t>>& frames);
+
+  /// Decode an int payload (e.g., instance_id for unregister)
+  int32_t decode_int_payload(const uint8_t* data, size_t len);
+
+  /// Decode CudaIPCWrapper from Ext type code 1 (pickle or structured)
+  CudaIpcTensorDesc decode_cuda_ipc_wrapper(const uint8_t* data, size_t len);
+
+ private:
+  struct Impl;
+  Impl* impl_;
+};
+
+}  // namespace server
+}  // namespace lmcache


### PR DESCRIPTION
A C++ implemented LMCache MP server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to introducing a large new C++/CUDA server path that handles CUDA IPC, GPU memory transfers, and ZMQ request routing; failures can cause crashes, data corruption, or GPU-wide sticky CUDA errors.
> 
> **Overview**
> Introduces a new standalone `csrc/server` C++/CUDA LMCache server (`lmcache-server`) that is wire-compatible with existing Python vLLM clients, handling KV cache `REGISTER_KV_CACHE`, `STORE`, `RETRIEVE`, `LOOKUP`, and related control requests over ZMQ.
> 
> Implements the core runtime pieces in C++: `MessageQueueServer` (ROUTER + eventfd + affinity/normal thread pools), `CacheEngine` orchestration, `GPUContext` CUDA IPC tensor/event handling with block-level transfer kernels, and an mmap-based pinned-memory `L1Store` with locking/LRU eviction; L2 is added only as an abstract interface/stub.
> 
> Adds a dedicated CMake build for the server that pulls in libtorch via the local Python `torch` install, fetches header-only deps (cppzmq, msgpack-cxx) and BLAKE3 sources, and links against system `libzmq` and CUDA/Torch libraries with CUDA arch/rpath/linker settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7e980f0c827bff727d24977d38b6f44cb4c3f4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->