### PR TITLE
[MP]feat: support different kv cache shape and dtype across layers

### DIFF
--- a/csrc/mp_mem_kernels.cu
+++ b/csrc/mp_mem_kernels.cu
@@ -217,17 +217,41 @@ __global__ void multi_layer_block_transfer_kernel(
       shape_desc, lmcache_chunk_size);
 }
 
-#define LAUNCH_BLOCK_KERNEL_WITH_FORMAT(DIRECTION, FORMAT)               \
-  multi_layer_block_transfer_kernel<uint4, DIRECTION, FORMAT>            \
+#define LAUNCH_KERNEL(DIRECTION, FORMAT)                                 \
+  multi_layer_block_transfer_kernel<ScalarType, DIRECTION, FORMAT>       \
       <<<grid, block, 0, stream>>>(lmcache_obj4, paged_buffer_ptrs,      \
                                    block_ids_ptr, num_blocks_per_object, \
                                    shape_desc, lmcache_chunk_size,       \
                                    skip_prefix_n_blocks);                \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-}  // namespace
+#define DISPATCH_FORMAT(DIRECTION)                                  \
+  switch (gpu_kv_format) {                                          \
+    case GPUKVFormat::NB_NL_TWO_BS_NH_HS:                           \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NB_NL_TWO_BS_NH_HS);    \
+      break;                                                        \
+    case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:                         \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);  \
+      break;                                                        \
+    case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:                         \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);  \
+      break;                                                        \
+    case GPUKVFormat::NL_X_NB_BS_HS:                                \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NB_BS_HS);         \
+      break;                                                        \
+    case GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS:                        \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS); \
+      break;                                                        \
+    case GPUKVFormat::NL_X_NBBS_ONE_HS:                             \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NBBS_ONE_HS);      \
+      break;                                                        \
+    default:                                                        \
+      TORCH_CHECK(false, "Unsupported GPUKVFormat: ",               \
+                  static_cast<int>(gpu_kv_format));                 \
+  }
 
-void multi_layer_block_kv_transfer(
+template <typename ScalarType>
+void multi_layer_block_kv_transfer_templated(
     const torch::Tensor& paged_buffer_ptrs_tensor,
     std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
     const torch::Device& device, TransferDirection direction,
@@ -249,23 +273,19 @@ void multi_layer_block_kv_transfer(
               num_blocks_per_object * shape_desc.bs,
               ") must equal lmcache_chunk_size (", lmcache_chunk_size, ")");
 
-  TORCH_CHECK(
-      shape_desc.hs * shape_desc.element_size % sizeof(uint4) == 0,
-      "head_size * element_size (", shape_desc.hs * shape_desc.element_size,
-      ") must be divisible by ", sizeof(uint4), " for uint4 vectorized access");
-
   // --- Build MemoryObj4 ---
-  MemoryObj4<uint4> lmcache_obj4;
+  MemoryObj4<ScalarType> lmcache_obj4;
   lmcache_obj4.num_objects = num_objects;
   for (int i = 0; i < 4; ++i) {
     lmcache_obj4.objects[i] =
-        (i < num_objects) ? reinterpret_cast<uint4*>(lmcache_objects_ptrs[i])
-                          : nullptr;
+        (i < num_objects)
+            ? reinterpret_cast<ScalarType*>(lmcache_objects_ptrs[i])
+            : nullptr;
   }
 
   // --- Build paged buffer pointer array ---
-  uint4** paged_buffer_ptrs =
-      reinterpret_cast<uint4**>(paged_buffer_ptrs_tensor.data_ptr());
+  ScalarType** paged_buffer_ptrs =
+      reinterpret_cast<ScalarType**>(paged_buffer_ptrs_tensor.data_ptr());
 
   const at::cuda::OptionalCUDAGuard device_guard(device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -274,68 +294,51 @@ void multi_layer_block_kv_transfer(
   const int64_t* block_ids_ptr = block_ids.data_ptr<int64_t>();
 
   // --- Grid and block dimensions ---
-  int elements_per_head =
-      shape_desc.hs * shape_desc.element_size / sizeof(uint4);
+  int elements_per_head = shape_desc.hs * shape_desc.element_size /
+                          static_cast<int>(sizeof(ScalarType));
   int thread_dim_x = std::min(elements_per_head, 32);
   int thread_dim_y = shape_desc.nh;
 
   dim3 block(thread_dim_x, thread_dim_y);
   dim3 grid(shape_desc.kv_size, total_blocks, shape_desc.nl);
 
-  // --- Dispatch on direction x format ---
   if (direction == TransferDirection::H2D) {
-    switch (gpu_kv_format) {
-      case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true, GPUKVFormat::NB_NL_TWO_BS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true,
-                                        GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true,
-                                        GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_NB_BS_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true, GPUKVFormat::NL_X_NB_BS_HS);
-        break;
-      case GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true,
-                                        GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_NBBS_ONE_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(true, GPUKVFormat::NL_X_NBBS_ONE_HS);
-        break;
-      default:
-        TORCH_CHECK(false, "Unsupported GPUKVFormat: ",
-                    static_cast<int>(gpu_kv_format));
-    }
+    DISPATCH_FORMAT(true);
   } else {
-    switch (gpu_kv_format) {
-      case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false, GPUKVFormat::NB_NL_TWO_BS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false,
-                                        GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false,
-                                        GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_NB_BS_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false, GPUKVFormat::NL_X_NB_BS_HS);
-        break;
-      case GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false,
-                                        GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS);
-        break;
-      case GPUKVFormat::NL_X_NBBS_ONE_HS:
-        LAUNCH_BLOCK_KERNEL_WITH_FORMAT(false, GPUKVFormat::NL_X_NBBS_ONE_HS);
-        break;
-      default:
-        TORCH_CHECK(false, "Unsupported GPUKVFormat: ",
-                    static_cast<int>(gpu_kv_format));
-    }
+    DISPATCH_FORMAT(false);
   }
 }
+
+#undef DISPATCH_FORMAT
+#undef LAUNCH_KERNEL
+
+}  // namespace
+
+#define LAUNCH_TEMPLATED(type)                                             \
+  do {                                                                     \
+    multi_layer_block_kv_transfer_templated<type>(                         \
+        paged_buffer_ptrs_tensor, lmcache_objects_ptrs, block_ids, device, \
+        direction, shape_desc, lmcache_chunk_size, gpu_kv_format,          \
+        skip_prefix_n_blocks);                                             \
+  } while (0)
+
+void multi_layer_block_kv_transfer(
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks) {
+  int head_bytes = shape_desc.hs * shape_desc.element_size;
+  TORCH_CHECK(head_bytes % sizeof(uint16_t) == 0, "head_size * element_size (",
+              head_bytes, ") must be divisible by 2 for vectorized access");
+
+  if (head_bytes % sizeof(uint4) == 0) {
+    LAUNCH_TEMPLATED(uint4);  // 16 bytes per copy
+  } else if (head_bytes % sizeof(uint32_t) == 0) {
+    LAUNCH_TEMPLATED(uint32_t);  // 4 bytes per copy
+  } else {
+    LAUNCH_TEMPLATED(uint16_t);  // 2 bytes per copy (minimum granularity)
+  }
+}
+
+#undef LAUNCH_TEMPLATED

--- a/lmcache/v1/gpu_connector/gpu_ops.py
+++ b/lmcache/v1/gpu_connector/gpu_ops.py
@@ -24,19 +24,30 @@ def lmcache_memcpy_async_h2d(
     :param MemoryObj memory_obj: The memory object to be copied.
     :param torch.Tensor gpu_buffer: The GPU buffer to copy the data to.
     """
-    assert memory_obj.tensor is not None
-    assert memory_obj.tensor.numel() == gpu_buffer.numel()
+    src_tensor = memory_obj.raw_tensor
+    if src_tensor is None:
+        raise ValueError(
+            "memory_obj.raw_tensor is None; ensure the MemoryObj has been allocated."
+        )
+    mem_obj_size = memory_obj.get_size()
+    if mem_obj_size != gpu_buffer.nbytes:
+        raise ValueError(
+            f"Size mismatch: memory_obj nbytes={mem_obj_size}, "
+            f"gpu_buffer nbytes={gpu_buffer.nbytes}"
+        )
     if isinstance(memory_obj.parent(), LazyMemoryAllocator):
         lmc_ops.lmcache_memcpy_async(
             gpu_buffer.data_ptr(),
-            memory_obj.tensor.data_ptr(),
-            memory_obj.get_size(),
+            memory_obj.data_ptr,
+            mem_obj_size,
             lmc_ops.TransferDirection.H2D,
             memory_obj.meta.address,
             LazyMemoryAllocator.PIN_CHUNK_SIZE,
         )
     else:
-        gpu_buffer.copy_(memory_obj.tensor, non_blocking=True)
+        gpu_buffer.view(torch.uint8).copy_(
+            src_tensor.view(torch.uint8)[:mem_obj_size], non_blocking=True
+        )
 
 
 def lmcache_memcpy_async_d2h(
@@ -51,16 +62,27 @@ def lmcache_memcpy_async_d2h(
     :param torch.Tensor gpu_buffer: The GPU buffer to copy the data from.
     :param MemoryObj memory_obj: The memory object to be copied to.
     """
-    assert memory_obj.tensor is not None
-    assert memory_obj.tensor.numel() == gpu_buffer.numel()
+    dst_tensor = memory_obj.raw_tensor
+    if dst_tensor is None:
+        raise ValueError(
+            "memory_obj.raw_tensor is None; ensure the MemoryObj has been allocated."
+        )
+    mem_obj_size = memory_obj.get_size()
+    if mem_obj_size != gpu_buffer.nbytes:
+        raise ValueError(
+            f"Size mismatch: memory_obj nbytes={mem_obj_size}, "
+            f"gpu_buffer nbytes={gpu_buffer.nbytes}"
+        )
     if isinstance(memory_obj.parent(), LazyMemoryAllocator):
         lmc_ops.lmcache_memcpy_async(
-            memory_obj.tensor.data_ptr(),
+            memory_obj.data_ptr,
             gpu_buffer.data_ptr(),
-            memory_obj.get_size(),
+            mem_obj_size,
             lmc_ops.TransferDirection.D2H,
             memory_obj.meta.address,
             LazyMemoryAllocator.PIN_CHUNK_SIZE,
         )
     else:
-        memory_obj.tensor.copy_(gpu_buffer, non_blocking=True)
+        dst_tensor.view(torch.uint8)[:mem_obj_size].copy_(
+            gpu_buffer.view(torch.uint8), non_blocking=True
+        )

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -228,3 +228,40 @@ class KVLayerGroupsManager:
 
         # Print the group structure
         logger.info("KV layer groups: %s", kv_layer_groups)
+
+    def build_kv_layer_groups_from_list(self, kv_caches: list[torch.Tensor]) -> None:
+        """Build KV layer groups from a plain list of tensors (one per layer).
+
+        Layers with the same shape and dtype are grouped together.
+        If layer groups are already built (non-empty list), this method does nothing.
+
+        Args:
+            kv_caches: List of KV cache tensors, one per layer.
+        """
+        if len(self.kv_layer_groups) > 0:
+            return
+
+        if not kv_caches:
+            logger.debug("No KV caches available, skipping KV layer groups building")
+            return
+
+        groups_dict: dict[tuple[torch.Size, torch.dtype], list[int]] = defaultdict(list)
+        for idx, tensor in enumerate(kv_caches):
+            key = (tensor.shape, tensor.dtype)
+            groups_dict[key].append(idx)
+
+        sorted_keys = sorted(groups_dict.keys(), key=lambda k: groups_dict[k][0])
+
+        kv_layer_groups: list[KVLayerGroupInfo] = []
+        for shape, dtype in sorted_keys:
+            indices = groups_dict[(shape, dtype)]
+            group_info = KVLayerGroupInfo(
+                layer_names=[str(i) for i in indices],
+                layer_indices=indices,
+                shape=shape,
+                dtype=dtype,
+            )
+            kv_layer_groups.append(group_info)
+
+        self.kv_layer_groups = kv_layer_groups
+        logger.info("KV layer groups (from list): %s", kv_layer_groups)

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -16,7 +16,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import EngineType, _lmcache_nvtx_annotate
+from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     discover_gpu_kv_format,
@@ -32,6 +32,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     is_mla,
 )
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 
 if torch.cuda.is_available():
     import lmcache.c_ops as lmc_ops
@@ -86,21 +87,47 @@ class GPUCacheContext:
         self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
         self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
         self.block_size_ = get_block_size(self.kv_caches_, self.gpu_kv_format_)
-        self.hidden_dim_size_ = get_hidden_dim_size(
-            self.kv_caches_, self.gpu_kv_format_
-        )
-        self.num_heads_ = get_num_heads(self.kv_caches_, self.gpu_kv_format_)
-        self.head_size_ = get_head_size(self.kv_caches_, self.gpu_kv_format_)
 
-        # Pre-built PageBufferShapeDesc for the block-level kernel
-        self.shape_desc_ = lmc_ops.PageBufferShapeDesc()
-        self.shape_desc_.kv_size = 1 if self.is_mla_ else 2
-        self.shape_desc_.nl = self.num_layers_
-        self.shape_desc_.nb = self.num_blocks_
-        self.shape_desc_.bs = self.block_size_
-        self.shape_desc_.nh = self.num_heads_
-        self.shape_desc_.hs = self.head_size_
-        self.shape_desc_.element_size = self.kv_caches_[0].element_size()
+        # Build per-layer KV groups (grouped by shape and dtype)
+        self.kv_layer_groups_manager_ = KVLayerGroupsManager()
+        self.kv_layer_groups_manager_.build_kv_layer_groups_from_list(self.kv_caches_)
+
+        # Per-group attributes: hidden_dim_size, num_heads, head_size,
+        # shape_desc, and kv_pointers — all derived from the representative
+        # first layer of each group. MLA formats have no independent num_heads
+        # dimension; use nh=1 so the kernel thread block has a single row.
+        kv_size = 1 if self.is_mla_ else 2
+        self.hidden_dim_sizes_: list[int] = []
+        self.group_num_heads_: list[int] = []
+        self.group_head_sizes_: list[int] = []
+        self.shape_descs_: list[lmc_ops.PageBufferShapeDesc] = []
+        self.group_kv_pointers_: list[torch.Tensor] = []
+        for group in self.kv_layer_groups_manager_.kv_layer_groups:
+            rep = [self.kv_caches_[group.layer_indices[0]]]
+            hidden_dim = get_hidden_dim_size(rep, self.gpu_kv_format_)
+            nh = 1 if self.is_mla_ else get_num_heads(rep, self.gpu_kv_format_)
+            hs = get_head_size(rep, self.gpu_kv_format_)
+
+            self.hidden_dim_sizes_.append(hidden_dim)
+            self.group_num_heads_.append(nh)
+            self.group_head_sizes_.append(hs)
+
+            sd = lmc_ops.PageBufferShapeDesc()
+            sd.kv_size = kv_size
+            sd.nl = group.num_layers
+            sd.nb = self.num_blocks_
+            sd.bs = self.block_size_
+            sd.nh = nh
+            sd.hs = hs
+            sd.element_size = rep[0].element_size()
+            self.shape_descs_.append(sd)
+
+            self.group_kv_pointers_.append(
+                list_to_gpu_tensor(
+                    [self.kv_caches_[i].data_ptr() for i in group.layer_indices],
+                    self.device_,
+                )
+            )
 
         # Pre-allocated GPU buffer for block IDs (up to 1M elements).
         # The caller copies block_ids into this buffer before launching the
@@ -110,25 +137,37 @@ class GPUCacheContext:
             _MAX_BLOCK_IDS, dtype=torch.long, device=self.device_
         )
 
-        # Pre-computed slot mapping (used by the old token-level kernel)
-        # shape: [num_blocks, block_size]
-        block_ids = torch.arange(
-            0, self.num_blocks_, dtype=torch.long, device=self.device_
-        ).unsqueeze(1)
-        offsets = torch.arange(
-            0, self.block_size_, dtype=torch.long, device=self.device_
-        ).unsqueeze(0)
-        self.slot_mapping_tensor_ = (offsets + block_ids * self.block_size_).reshape(
-            (self.num_blocks, self.block_size_)
-        )
-
-        # Temporary GPU buffer for transfers
+        # Temporary GPU buffer for transfers — a single flat uint8 buffer
+        # laid out in chunk-major order so that each chunk's data matches
+        # the layout of a MemoryObj.raw_data (all groups concatenated):
+        #
+        #   [ chunk_0: group_0_bytes | group_1_bytes | ... ]
+        #   [ chunk_1: group_0_bytes | group_1_bytes | ... ]
+        #   ...
+        #
+        # This lets callers copy an entire chunk to/from a MemoryObj with a
+        # single memcpy, without needing to know the per-group layout.
+        # max_batch_size is the max number of chunks processed concurrently.
         self.max_batch_size = 4
-        tmp_buffer_shape = self.get_kv_buffer_shape(
-            lmcache_chunk_size * self.max_batch_size
-        )
+        self.lmcache_chunk_size = lmcache_chunk_size
+        # Byte size of one chunk entry (= one chunk across all groups).
+        # tmp_chunk_group_offsets_[g] is the byte offset of group g within
+        # a single chunk; tmp_chunk_group_offsets_[num_groups] ==
+        # tmp_chunk_bytes_.
+        self.tmp_chunk_group_offsets_: list[int] = [0]
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            shape = self.get_kv_buffer_shape(lmcache_chunk_size, group_idx)
+            byte_size = shape.numel() * group.dtype.itemsize
+            self.tmp_chunk_group_offsets_.append(
+                self.tmp_chunk_group_offsets_[-1] + byte_size
+            )
+        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
         self.tmp_gpu_buffer_ = torch.empty(
-            tmp_buffer_shape, dtype=self.dtype, device=self.device_
+            self.tmp_chunk_bytes_ * self.max_batch_size,
+            dtype=torch.uint8,
+            device=self.device_,
         )
 
         # Cuda streams
@@ -213,25 +252,6 @@ class GPUCacheContext:
         return self.num_blocks_
 
     @property
-    def hidden_dim_size(self) -> int:
-        """
-        Returns the hidden dimension size of the model
-        """
-        return self.hidden_dim_size_
-
-    @property
-    def num_heads(self) -> int:
-        """Returns the number of attention heads in the model"""
-        return self.num_heads_
-
-    @property
-    def head_size(self) -> int:
-        """
-        Returns the head size of the KV cache
-        """
-        return self.head_size_
-
-    @property
     def is_mla(self) -> bool:
         """
         Returns whether the model uses MLA
@@ -239,8 +259,18 @@ class GPUCacheContext:
         return self.is_mla_
 
     @property
-    def shape_desc(self) -> "lmc_ops.PageBufferShapeDesc":
-        return self.shape_desc_
+    def hidden_dim_sizes(self) -> list[int]:
+        """Returns the hidden dimension sizes for each KV layer group."""
+        return self.hidden_dim_sizes_
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for the given KV layer group."""
+        return self.shape_descs_[group_idx]
+
+    @property
+    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
+        return self.kv_layer_groups_manager_
 
     def gpu_kv_format_name(self) -> str:
         """Returns the GPU KV format enum name (e.g. ``'NL_X_TWO_NB_BS_NH_HS'``)."""
@@ -261,39 +291,70 @@ class GPUCacheContext:
         """Returns the GPU KV shape with actual numeric values substituted."""
         return get_concrete_gpu_kv_shape(self.kv_caches_, self.gpu_kv_format_)
 
-    def get_tmp_gpu_buffer(self, num_tokens: int) -> torch.Tensor:
-        """
-        Returns the temporary GPU buffer for transfers
+    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        """Returns the pre-computed GPU tensor of KV cache pointers for the
+        given group."""
+        return self.group_kv_pointers_[group_idx]
 
-        Note:
-            The returned buffer is guaranteed to be contiguous
-        """
-        shape = self.get_kv_buffer_shape(num_tokens)
-        num_elems = shape.numel()
-        return self.tmp_gpu_buffer_.flatten()[:num_elems].view(shape)
+    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        """Returns the flat uint8 view of the temporary GPU buffer for the
+        given chunk index, covering all KV layer groups.
 
-    def get_tmp_gpu_buffer_batched(
-        self, num_tokens: int, batch_size: int
+        The returned tensor will fit a memory full object corresponding
+        ``self.chunk_size`` tokens, so it can be copied to/from a MemoryObj
+        with a single memcpy.
+
+        Args:
+            chunk_idx: Chunk index (0 <= chunk_idx < max_batch_size).
+        """
+        if chunk_idx >= self.max_batch_size:
+            raise ValueError(
+                f"chunk_idx {chunk_idx} exceeds max_batch_size {self.max_batch_size}"
+            )
+        start = chunk_idx * self.tmp_chunk_bytes_
+        return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        """
+        Returns a view of the temporary GPU buffer for the given group,
+        sized for a single chunk of ``lmcache_chunk_size`` tokens.
+
+        Args:
+            group_idx: Index of the KV layer group (default 0).
+        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
+        start = self.tmp_chunk_group_offsets_[group_idx]
+        end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
+
+    def get_tmp_chunk_gpu_buffer_batched(
+        self, batch_size: int, group_idx: int = 0
     ) -> list[torch.Tensor]:
         """
-        Returns a list of temporary GPU buffer for batched transfers
+        Returns a list of ``batch_size`` non-overlapping views into the
+        pre-allocated temporary GPU buffer for the given group, each
+        sized for ``lmcache_chunk_size`` tokens.
 
-        Note:
-            Each returned buffer is guaranteed to be contiguous.
+        Args:
+            batch_size: Number of concurrent requests (must be <= max_batch_size).
+            group_idx: Index of the KV layer group (default 0).
         """
-        assert batch_size <= self.max_batch_size, (
-            f"Batch size {batch_size} exceeds max {self.max_batch_size}"
-        )
-        ret = []
-        start_offset = 0
-        flatten_view = self.tmp_gpu_buffer_.flatten()
-        for i in range(batch_size):
-            shape = self.get_kv_buffer_shape(num_tokens)
-            num_elems = shape.numel()
-            buf = flatten_view[start_offset : start_offset + num_elems].view(shape)
-            ret.append(buf)
-            start_offset += num_elems
-        return ret
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                f"batch_size {batch_size} exceeds max_batch_size {self.max_batch_size}"
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
+        g_start = self.tmp_chunk_group_offsets_[group_idx]
+        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return [
+            self.tmp_gpu_buffer_[i * chunk + g_start : i * chunk + g_end]
+            .view(group.dtype)
+            .view(shape)
+            for i in range(batch_size)
+        ]
 
     def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
         """Copy block_ids into the pre-allocated GPU buffer and return a
@@ -312,29 +373,33 @@ class GPUCacheContext:
         buf.copy_(cpu_tensor, non_blocking=True)
         return buf
 
-    @_lmcache_nvtx_annotate
-    def get_slot_mapping_tensor(self, gpu_block_ids: list[int]) -> torch.Tensor:
+    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
         """
-        Returns the slot mapping tensor for the KV cache on GPU
-        """
-        gpu_block_ids_tensor = list_to_gpu_tensor(gpu_block_ids, self.device_)
-        return self.slot_mapping_tensor_[gpu_block_ids_tensor].flatten().contiguous()
+        Returns the shape of the KV buffer for the given number of tokens.
 
-    def get_kv_buffer_shape(self, num_tokens: int) -> torch.Size:
+        Args:
+            num_tokens: Number of tokens.
+            group_idx: Index of the KV layer group (default 0).
         """
-        Returns the shape of the KV buffer for the given number of tokens
-        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        num_layers_in_group = group.num_layers
+        hidden_dim = self.hidden_dim_sizes[group_idx]
         if self.is_mla_:
-            return torch.Size((1, self.num_layers_, num_tokens, self.hidden_dim_size_))
+            return torch.Size((1, num_layers_in_group, num_tokens, hidden_dim))
         else:
-            return torch.Size((2, self.num_layers_, num_tokens, self.hidden_dim_size_))
+            return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
 
     def cache_size_per_token(self) -> int:
         """
-        Returns the cache size per token (in bytes)
+        Returns the cache size per token (in bytes), summed across all groups.
         """
-        numels = self.get_kv_buffer_shape(1).numel()
-        return numels * self.dtype.itemsize
+        total = 0
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            numels = self.get_kv_buffer_shape(1, group_idx).numel()
+            total += numels * group.dtype.itemsize
+        return total
 
 
 class PlainGPUCacheContext:

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -112,6 +112,8 @@ def compute_extra_count(
 def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
     """Get the memory layout description for a given GPU context and number of tokens.
 
+    Supports multiple KV layer groups with different shapes and dtypes.
+
     Args:
         gpu_context: The GPU cache context containing the KV cache information.
         num_tokens: The number of tokens to determine the layout for.
@@ -119,9 +121,16 @@ def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayo
     Returns:
         MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
     """
-    shape = gpu_context.get_kv_buffer_shape(num_tokens)
-    dtype = gpu_context.dtype
-    return MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+    num_groups = gpu_context.kv_layer_groups_manager.num_groups
+    shapes = [
+        gpu_context.get_kv_buffer_shape(num_tokens, group_idx)
+        for group_idx in range(num_groups)
+    ]
+    dtypes = [
+        gpu_context.kv_layer_groups_manager.kv_layer_groups[group_idx].dtype
+        for group_idx in range(num_groups)
+    ]
+    return MemoryLayoutDesc(shapes=shapes, dtypes=dtypes)
 
 
 def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None]:
@@ -311,6 +320,7 @@ class MPCacheEngine:
             # skipped (not in reserved_dict), making block_ids
             # non-contiguous. Batching would require torch.cat to
             # reassemble block_ids, negating the benefit.
+            num_groups = gpu_context.kv_layer_groups_manager.num_groups
             for idx, obj_key in enumerate(obj_keys):
                 if obj_key in reserved_dict:
                     memory_obj = reserved_dict[obj_key]
@@ -321,21 +331,25 @@ class MPCacheEngine:
                     idx * blocks_per_chunk : (idx + 1) * blocks_per_chunk
                 ]
 
-                # Copy from paged buffer to tmp GPU buffer, then to CPU
-                assert memory_obj.tensor is not None
-                tmp_buffer = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
-                lmc_ops.multi_layer_block_kv_transfer(
-                    gpu_context.kv_pointers,
-                    [tmp_buffer.data_ptr()],
-                    chunk_block_ids_gpu,
-                    gpu_context.device,
-                    lmc_ops.TransferDirection.D2H,
-                    gpu_context.shape_desc,
-                    self.chunk_size,
-                    gpu_context.gpu_kv_format_,
-                    0,
+                # Copy from GPU paged buffer to tmp buffer, then to CPU — per group
+                for group_idx in range(num_groups):
+                    tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
+                    group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
+                    lmc_ops.multi_layer_block_kv_transfer(
+                        group_kv_pointers,
+                        [tmp_buffer.data_ptr()],
+                        chunk_block_ids_gpu,
+                        gpu_context.device,
+                        lmc_ops.TransferDirection.D2H,
+                        gpu_context.get_shape_desc(group_idx),
+                        self.chunk_size,
+                        gpu_context.gpu_kv_format_,
+                        0,
+                    )
+                # Store is not batched, so we always use chunk_idx=0 (single slot)
+                lmcache_memcpy_async_d2h(
+                    gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=0), memory_obj
                 )
-                lmcache_memcpy_async_d2h(tmp_buffer, memory_obj)
 
             event.record()
 
@@ -421,12 +435,14 @@ class MPCacheEngine:
         blocks_per_chunk = self.chunk_size // gpu_context.block_size
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
-            _BATCH_SIZE = 4
+            _BATCH_SIZE = gpu_context.max_batch_size
+            num_groups = gpu_context.kv_layer_groups_manager.num_groups
             for batch_idx, memory_obj_batch in enumerate(
                 batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
             ):
+                batch_len = len(memory_obj_batch)
                 chunk_start = batch_idx * self.chunk_size * _BATCH_SIZE
-                chunk_end = chunk_start + self.chunk_size * len(memory_obj_batch)
+                chunk_end = chunk_start + self.chunk_size * batch_len
 
                 effective_start = max(chunk_start, skip_first_n_tokens)
                 if effective_start >= chunk_end:
@@ -436,7 +452,8 @@ class MPCacheEngine:
                 skip_tokens_in_chunk = max(
                     0,
                     min(
-                        effective_start - chunk_start, self.chunk_size * _BATCH_SIZE - 1
+                        effective_start - chunk_start,
+                        self.chunk_size * batch_len - 1,
                     ),
                 )
                 if skip_tokens_in_chunk % gpu_context.block_size != 0:
@@ -451,35 +468,35 @@ class MPCacheEngine:
                 skip_blocks_in_chunk = skip_tokens_in_chunk // gpu_context.block_size
 
                 start_chunk_id = batch_idx * _BATCH_SIZE
-                end_chunk_id = start_chunk_id + len(memory_obj_batch)
+                end_chunk_id = start_chunk_id + batch_len
                 chunk_block_ids_gpu = all_block_ids_gpu[
                     start_chunk_id * blocks_per_chunk : end_chunk_id * blocks_per_chunk
                 ]
 
-                # TODO: implement get_gpu_buffer_batched
-                tmp_buffers = gpu_context.get_tmp_gpu_buffer_batched(
-                    self.chunk_size, len(memory_obj_batch)
-                )
+                # Copy from CPU to GPU tmp buffers, then scatter to paged KV — per group
+                # H2D copy: each memory_obj maps to its own batch slot
+                for chunk_idx, memory_obj in enumerate(memory_obj_batch):
+                    lmcache_memcpy_async_h2d(
+                        memory_obj,
+                        gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
+                    )
+                for group_idx in range(num_groups):
+                    tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
+                        batch_len, group_idx
+                    )
+                    group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
 
-                # launch h2d for all the chunks in the batch
-                for tmp_buffer, memory_obj in zip(
-                    tmp_buffers, memory_obj_batch, strict=False
-                ):
-                    assert memory_obj.tensor is not None
-                    lmcache_memcpy_async_h2d(memory_obj, tmp_buffer)
-
-                # launch multi_layer_block_kv_transfer for all the chunks in the batch
-                lmc_ops.multi_layer_block_kv_transfer(
-                    gpu_context.kv_pointers,
-                    [tb.data_ptr() for tb in tmp_buffers],
-                    chunk_block_ids_gpu,
-                    gpu_context.device,
-                    lmc_ops.TransferDirection.H2D,
-                    gpu_context.shape_desc,
-                    self.chunk_size,
-                    gpu_context.gpu_kv_format_,
-                    skip_blocks_in_chunk,
-                )
+                    lmc_ops.multi_layer_block_kv_transfer(
+                        group_kv_pointers,
+                        [tb.data_ptr() for tb in tmp_buffers],
+                        chunk_block_ids_gpu,
+                        gpu_context.device,
+                        lmc_ops.TransferDirection.H2D,
+                        gpu_context.get_shape_desc(group_idx),
+                        self.chunk_size,
+                        gpu_context.gpu_kv_format_,
+                        skip_blocks_in_chunk,
+                    )
 
         with (
             torch.cuda.device(gpu_context.device),
@@ -797,7 +814,7 @@ class MPCacheEngine:
                 entry["kv_cache_layout"] = {
                     "num_layers": ctx.num_layers,
                     "block_size": ctx.block_size,
-                    "hidden_dim_size": ctx.hidden_dim_size,
+                    "hidden_dim_sizes": str(ctx.hidden_dim_sizes),
                     "dtype": str(ctx.dtype),
                     "is_mla": ctx.is_mla,
                     "num_blocks": ctx.num_blocks,

--- a/tests/v1/multiprocess/test_gpu_context.py
+++ b/tests/v1/multiprocess/test_gpu_context.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for GPUCacheContext.get_tmp_gpu_buffer and
-get_tmp_gpu_buffer_batched — verifying contiguity, shape, and
-non-overlapping guarantees.
+"""Unit tests for GPUCacheContext.get_tmp_chunk_gpu_buffer,
+get_tmp_chunk_gpu_buffer_batched and get_tmp_gpu_buffer_flat — verifying
+contiguity, shape, non-overlapping guarantees, and multi-group layout.
 
 These tests construct a minimal GPUCacheContext-like object that has
 just the fields the buffer methods need, avoiding the full KVCache /
@@ -18,6 +18,10 @@ pytestmark = pytest.mark.skipif(
 )
 
 # First Party
+from lmcache.v1.kv_layer_groups import (  # noqa: E402
+    KVLayerGroupInfo,
+    KVLayerGroupsManager,
+)
 from lmcache.v1.multiprocess.gpu_context import GPUCacheContext  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -33,60 +37,146 @@ def _make_context(
     chunk_size: int = 256,
     dtype: torch.dtype = torch.bfloat16,
 ) -> GPUCacheContext:
-    """Build a GPUCacheContext by directly setting internal fields,
-    bypassing the KVCache/IPC wrapper construction."""
+    """Build a GPUCacheContext with a single KV layer group by directly
+    setting internal fields, bypassing the KVCache/IPC wrapper construction."""
     ctx = object.__new__(GPUCacheContext)
     ctx.is_mla_ = is_mla
     ctx.num_layers_ = num_layers
-    ctx.hidden_dim_size_ = num_heads * head_size
     ctx.max_batch_size = 4
 
-    kv_dim = 1 if is_mla else 2
-    total_tokens = chunk_size * ctx.max_batch_size
-    shape = torch.Size((kv_dim, num_layers, total_tokens, num_heads * head_size))
-    ctx.tmp_gpu_buffer_ = torch.empty(shape, dtype=dtype, device="cuda")
+    hidden_dim = num_heads * head_size
+    ctx.hidden_dim_sizes_ = [hidden_dim]
+
+    # Build a minimal KVLayerGroupsManager with a single group
+    kv_size = 1 if is_mla else 2
+    dummy_shape = torch.Size([kv_size, 1, 1, num_heads, head_size])
+    group = KVLayerGroupInfo(
+        layer_names=[str(i) for i in range(num_layers)],
+        layer_indices=list(range(num_layers)),
+        shape=dummy_shape,
+        dtype=dtype,
+    )
+    manager = KVLayerGroupsManager(kv_layer_groups=[group])
+    ctx.kv_layer_groups_manager_ = manager
+
+    # Build flat tmp_gpu_buffer_ with prefix-sum offsets (new layout)
+    ctx.tmp_chunk_group_offsets_ = [0]
+    for gidx, grp in enumerate(manager.kv_layer_groups):
+        shape = ctx.get_kv_buffer_shape(chunk_size, gidx)
+        byte_size = shape.numel() * grp.dtype.itemsize
+        ctx.tmp_chunk_group_offsets_.append(
+            ctx.tmp_chunk_group_offsets_[-1] + byte_size
+        )
+    ctx.tmp_chunk_bytes_ = ctx.tmp_chunk_group_offsets_[-1]
+    ctx.lmcache_chunk_size = chunk_size
+    ctx.tmp_gpu_buffer_ = torch.empty(
+        ctx.tmp_chunk_bytes_ * ctx.max_batch_size,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    return ctx
+
+
+def _make_context_multi_group(
+    groups: list[dict],
+    chunk_size: int = 256,
+    is_mla: bool = False,
+) -> GPUCacheContext:
+    """Build a GPUCacheContext with multiple KV layer groups.
+
+    Args:
+        groups: List of dicts, each with keys:
+            - num_layers (int)
+            - num_heads  (int)
+            - head_size  (int)
+            - dtype      (torch.dtype, optional, default bfloat16)
+        chunk_size: Tokens per chunk.
+        is_mla: Whether to use MLA (kv_dim=1) layout.
+    """
+    ctx = object.__new__(GPUCacheContext)
+    ctx.is_mla_ = is_mla
+    ctx.max_batch_size = 4
+
+    kv_size = 1 if is_mla else 2
+    kv_layer_groups = []
+    hidden_dim_sizes = []
+    layer_offset = 0
+    for g in groups:
+        nl = g["num_layers"]
+        nh = g["num_heads"]
+        hs = g["head_size"]
+        dt = g.get("dtype", torch.bfloat16)
+        hidden_dim = nh * hs
+        hidden_dim_sizes.append(hidden_dim)
+        dummy_shape = torch.Size([kv_size, 1, 1, nh, hs])
+        kv_layer_groups.append(
+            KVLayerGroupInfo(
+                layer_names=[str(i) for i in range(layer_offset, layer_offset + nl)],
+                layer_indices=list(range(layer_offset, layer_offset + nl)),
+                shape=dummy_shape,
+                dtype=dt,
+            )
+        )
+        layer_offset += nl
+
+    ctx.num_layers_ = layer_offset
+    ctx.hidden_dim_sizes_ = hidden_dim_sizes
+    manager = KVLayerGroupsManager(kv_layer_groups=kv_layer_groups)
+    ctx.kv_layer_groups_manager_ = manager
+
+    # Build flat tmp_gpu_buffer_ with prefix-sum offsets
+    ctx.tmp_chunk_group_offsets_ = [0]
+    for gidx, grp in enumerate(manager.kv_layer_groups):
+        shape = ctx.get_kv_buffer_shape(chunk_size, gidx)
+        byte_size = shape.numel() * grp.dtype.itemsize
+        ctx.tmp_chunk_group_offsets_.append(
+            ctx.tmp_chunk_group_offsets_[-1] + byte_size
+        )
+    ctx.tmp_chunk_bytes_ = ctx.tmp_chunk_group_offsets_[-1]
+    ctx.lmcache_chunk_size = chunk_size
+    ctx.tmp_gpu_buffer_ = torch.empty(
+        ctx.tmp_chunk_bytes_ * ctx.max_batch_size,
+        dtype=torch.uint8,
+        device="cuda",
+    )
     return ctx
 
 
 # ---------------------------------------------------------------------------
-# get_tmp_gpu_buffer tests
+# get_tmp_chunk_gpu_buffer tests
 # ---------------------------------------------------------------------------
 
 
-class TestGetTmpGpuBuffer:
-    @pytest.mark.parametrize("num_tokens", [64, 128, 256, 512, 1024])
-    def test_contiguity(self, num_tokens: int) -> None:
-        ctx = _make_context()
-        buf = ctx.get_tmp_gpu_buffer(num_tokens)
-        assert buf.is_contiguous(), f"Buffer not contiguous for num_tokens={num_tokens}"
+class TestGetTmpChunkGpuBuffer:
+    def test_contiguity(self) -> None:
+        ctx = _make_context(chunk_size=256)
+        buf = ctx.get_tmp_chunk_gpu_buffer()
+        assert buf.is_contiguous(), "Buffer not contiguous"
 
-    @pytest.mark.parametrize("num_tokens", [64, 128, 256])
-    def test_shape(self, num_tokens: int) -> None:
-        ctx = _make_context()
-        buf = ctx.get_tmp_gpu_buffer(num_tokens)
-        expected = ctx.get_kv_buffer_shape(num_tokens)
+    def test_shape(self) -> None:
+        ctx = _make_context(chunk_size=256)
+        buf = ctx.get_tmp_chunk_gpu_buffer()
+        expected = ctx.get_kv_buffer_shape(256)
         assert buf.shape == expected
 
-    @pytest.mark.parametrize("num_tokens", [64, 128, 256])
-    def test_shape_mla(self, num_tokens: int) -> None:
-        ctx = _make_context(is_mla=True, num_heads=1, head_size=576)
-        buf = ctx.get_tmp_gpu_buffer(num_tokens)
-        expected = ctx.get_kv_buffer_shape(num_tokens)
+    def test_shape_mla(self) -> None:
+        ctx = _make_context(is_mla=True, num_heads=1, head_size=576, chunk_size=256)
+        buf = ctx.get_tmp_chunk_gpu_buffer()
+        expected = ctx.get_kv_buffer_shape(256)
         assert buf.shape == expected
         assert buf.shape[0] == 1  # kv_dim=1 for MLA
 
-    def test_different_sizes_dont_alias(self) -> None:
-        """Two calls with different sizes should start at the same base
-        (they reuse the same pre-allocated buffer)."""
-        ctx = _make_context()
-        buf_small = ctx.get_tmp_gpu_buffer(64)
-        buf_large = ctx.get_tmp_gpu_buffer(128)
-        assert buf_small.data_ptr() == buf_large.data_ptr()
+    def test_repeated_calls_same_ptr(self) -> None:
+        """Two calls should return the same base pointer (same pre-allocated slot)."""
+        ctx = _make_context(chunk_size=256)
+        buf1 = ctx.get_tmp_chunk_gpu_buffer()
+        buf2 = ctx.get_tmp_chunk_gpu_buffer()
+        assert buf1.data_ptr() == buf2.data_ptr()
 
     def test_write_read_roundtrip(self) -> None:
         """Write a pattern, read it back to verify the view is correct."""
-        ctx = _make_context(num_layers=2, num_heads=2, head_size=16)
-        buf = ctx.get_tmp_gpu_buffer(32)
+        ctx = _make_context(num_layers=2, num_heads=2, head_size=16, chunk_size=32)
+        buf = ctx.get_tmp_chunk_gpu_buffer()
         buf.fill_(42.0)
         assert buf.to(torch.float32).sum().item() == pytest.approx(
             42.0 * buf.numel(), rel=1e-3
@@ -94,23 +184,23 @@ class TestGetTmpGpuBuffer:
 
 
 # ---------------------------------------------------------------------------
-# get_tmp_gpu_buffer_batched tests
+# get_tmp_chunk_gpu_buffer_batched tests
 # ---------------------------------------------------------------------------
 
 
-class TestGetTmpGpuBufferBatched:
+class TestGetTmpChunkGpuBufferBatched:
     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4])
     def test_contiguity(self, batch_size: int) -> None:
-        ctx = _make_context()
-        buffers = ctx.get_tmp_gpu_buffer_batched(256, batch_size)
+        ctx = _make_context(chunk_size=256)
+        buffers = ctx.get_tmp_chunk_gpu_buffer_batched(batch_size)
         assert len(buffers) == batch_size
         for i, buf in enumerate(buffers):
             assert buf.is_contiguous(), f"Buffer {i} not contiguous"
 
     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4])
     def test_shapes(self, batch_size: int) -> None:
-        ctx = _make_context()
-        buffers = ctx.get_tmp_gpu_buffer_batched(256, batch_size)
+        ctx = _make_context(chunk_size=256)
+        buffers = ctx.get_tmp_chunk_gpu_buffer_batched(batch_size)
         expected_shape = ctx.get_kv_buffer_shape(256)
         for buf in buffers:
             assert buf.shape == expected_shape
@@ -118,8 +208,8 @@ class TestGetTmpGpuBufferBatched:
     @pytest.mark.parametrize("batch_size", [2, 3, 4])
     def test_non_overlapping(self, batch_size: int) -> None:
         """Buffers in a batch must not overlap in memory."""
-        ctx = _make_context()
-        buffers = ctx.get_tmp_gpu_buffer_batched(256, batch_size)
+        ctx = _make_context(chunk_size=256)
+        buffers = ctx.get_tmp_chunk_gpu_buffer_batched(batch_size)
         for i in range(len(buffers)):
             for j in range(i + 1, len(buffers)):
                 start_i = buffers[i].data_ptr()
@@ -132,8 +222,8 @@ class TestGetTmpGpuBufferBatched:
 
     def test_write_isolation(self) -> None:
         """Writing to one buffer must not affect another."""
-        ctx = _make_context(num_layers=2, num_heads=2, head_size=16)
-        buffers = ctx.get_tmp_gpu_buffer_batched(32, 4)
+        ctx = _make_context(num_layers=2, num_heads=2, head_size=16, chunk_size=32)
+        buffers = ctx.get_tmp_chunk_gpu_buffer_batched(4)
 
         # Write distinct values to each buffer
         for i, buf in enumerate(buffers):
@@ -150,24 +240,188 @@ class TestGetTmpGpuBufferBatched:
             )
 
     def test_batch_exceeds_max_raises(self) -> None:
-        ctx = _make_context()
-        with pytest.raises(AssertionError, match="exceeds max"):
-            ctx.get_tmp_gpu_buffer_batched(256, 5)
+        ctx = _make_context(chunk_size=256)
+        with pytest.raises(ValueError, match="exceeds max"):
+            ctx.get_tmp_chunk_gpu_buffer_batched(5)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4])
     def test_mla(self, batch_size: int) -> None:
-        ctx = _make_context(is_mla=True, num_heads=1, head_size=576)
-        buffers = ctx.get_tmp_gpu_buffer_batched(256, batch_size)
+        ctx = _make_context(is_mla=True, num_heads=1, head_size=576, chunk_size=256)
+        buffers = ctx.get_tmp_chunk_gpu_buffer_batched(batch_size)
         for buf in buffers:
             assert buf.is_contiguous()
             assert buf.shape[0] == 1  # kv_dim=1 for MLA
 
     def test_consistent_with_single(self) -> None:
-        """get_tmp_gpu_buffer_batched(n, 1)[0] should have the same data_ptr
-        and shape as get_tmp_gpu_buffer(n)."""
-        ctx = _make_context()
-        single = ctx.get_tmp_gpu_buffer(256)
-        batched = ctx.get_tmp_gpu_buffer_batched(256, 1)
+        """get_tmp_chunk_gpu_buffer_batched(1)[0] should have the same data_ptr
+        and shape as get_tmp_chunk_gpu_buffer()."""
+        ctx = _make_context(chunk_size=256)
+        single = ctx.get_tmp_chunk_gpu_buffer()
+        batched = ctx.get_tmp_chunk_gpu_buffer_batched(1)
         assert len(batched) == 1
         assert batched[0].data_ptr() == single.data_ptr()
         assert batched[0].shape == single.shape
+
+
+# ---------------------------------------------------------------------------
+# Multi-group tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiGroup:
+    """Tests for multi-group flat buffer layout."""
+
+    GROUPS_SAME_DTYPE = [
+        {"num_layers": 4, "num_heads": 8, "head_size": 128, "dtype": torch.bfloat16},
+        {"num_layers": 4, "num_heads": 8, "head_size": 128, "dtype": torch.bfloat16},
+    ]
+    GROUPS_DIFF_DTYPE = [
+        {"num_layers": 4, "num_heads": 8, "head_size": 128, "dtype": torch.bfloat16},
+        {"num_layers": 2, "num_heads": 4, "head_size": 64, "dtype": torch.float16},
+    ]
+
+    def test_prefix_sum_length(self) -> None:
+        """tmp_chunk_group_offsets_ should have num_groups+1 entries."""
+        ctx = _make_context_multi_group(self.GROUPS_SAME_DTYPE)
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+        assert len(ctx.tmp_chunk_group_offsets_) == num_groups + 1
+
+    def test_prefix_sum_monotone(self) -> None:
+        """Offsets must be strictly increasing."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE)
+        offsets = ctx.tmp_chunk_group_offsets_
+        for i in range(1, len(offsets)):
+            assert offsets[i] > offsets[i - 1], (
+                f"Offset not increasing at index {i}: {offsets}"
+            )
+
+    def test_flat_buffer_total_size(self) -> None:
+        """tmp_gpu_buffer_ byte count == tmp_chunk_bytes_ * max_batch_size."""
+        ctx = _make_context_multi_group(self.GROUPS_SAME_DTYPE)
+        assert ctx.tmp_gpu_buffer_.numel() == ctx.tmp_chunk_bytes_ * ctx.max_batch_size
+
+    def test_groups_non_overlapping_in_chunk(self) -> None:
+        """Within a single chunk, different groups must occupy disjoint byte ranges."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE)
+        offsets = ctx.tmp_chunk_group_offsets_
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+        for i in range(num_groups):
+            for j in range(i + 1, num_groups):
+                # [offsets[i], offsets[i+1]) vs [offsets[j], offsets[j+1])
+                assert offsets[i + 1] <= offsets[j] or offsets[j + 1] <= offsets[i], (
+                    f"Groups {i} and {j} overlap in chunk layout"
+                )
+
+    def test_get_tmp_chunk_gpu_buffer_shape_per_group(self) -> None:
+        """get_tmp_chunk_gpu_buffer returns the correct shape for each group."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE, chunk_size=256)
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+        for gidx in range(num_groups):
+            buf = ctx.get_tmp_chunk_gpu_buffer(group_idx=gidx)
+            expected = ctx.get_kv_buffer_shape(256, gidx)
+            assert buf.shape == expected, (
+                f"Group {gidx}: expected {expected}, got {buf.shape}"
+            )
+
+    def test_get_tmp_chunk_gpu_buffer_dtype_per_group(self) -> None:
+        """get_tmp_chunk_gpu_buffer returns the correct dtype for each group."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE, chunk_size=256)
+        groups = ctx.kv_layer_groups_manager_.kv_layer_groups
+        for gidx, grp in enumerate(groups):
+            buf = ctx.get_tmp_chunk_gpu_buffer(group_idx=gidx)
+            assert buf.dtype == grp.dtype, (
+                f"Group {gidx}: expected dtype {grp.dtype}, got {buf.dtype}"
+            )
+
+    def test_groups_data_ptr_matches_offsets(self) -> None:
+        """data_ptr of each group's buffer should equal base + group offset."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE, chunk_size=256)
+        base_ptr = ctx.tmp_gpu_buffer_.data_ptr()
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+        for gidx in range(num_groups):
+            buf = ctx.get_tmp_chunk_gpu_buffer(group_idx=gidx)
+            expected_ptr = base_ptr + ctx.tmp_chunk_group_offsets_[gidx]
+            assert buf.data_ptr() == expected_ptr, (
+                f"Group {gidx}: expected ptr offset "
+                f"{ctx.tmp_chunk_group_offsets_[gidx]}, "
+                f"got {buf.data_ptr() - base_ptr}"
+            )
+
+    def test_write_isolation_across_groups(self) -> None:
+        """Writing to one group's buffer must not corrupt another group."""
+        ctx = _make_context_multi_group(self.GROUPS_SAME_DTYPE, chunk_size=64)
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+        buffers = [ctx.get_tmp_chunk_gpu_buffer(group_idx=g) for g in range(num_groups)]
+
+        for i, buf in enumerate(buffers):
+            buf.fill_(float(i + 1))
+
+        for i, buf in enumerate(buffers):
+            expected = float(i + 1)
+            assert buf.to(torch.float32).min().item() == pytest.approx(
+                expected, rel=1e-3
+            ), f"Group {i} was corrupted"
+            assert buf.to(torch.float32).max().item() == pytest.approx(
+                expected, rel=1e-3
+            ), f"Group {i} was corrupted"
+
+    @pytest.mark.parametrize("batch_size", [1, 2, 4])
+    def test_batched_non_overlapping_across_groups_and_chunks(
+        self, batch_size: int
+    ) -> None:
+        """All (group, chunk_idx) combinations must occupy disjoint memory."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE, chunk_size=256)
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+
+        # Collect (data_ptr, end_ptr) for every (group, chunk) combination
+        regions: list[tuple[int, int, str]] = []
+        for gidx in range(num_groups):
+            bufs = ctx.get_tmp_chunk_gpu_buffer_batched(batch_size, group_idx=gidx)
+            for cidx, buf in enumerate(bufs):
+                start = buf.data_ptr()
+                end = start + buf.nelement() * buf.element_size()
+                regions.append((start, end, f"group={gidx},chunk={cidx}"))
+
+        for i in range(len(regions)):
+            for j in range(i + 1, len(regions)):
+                s_i, e_i, label_i = regions[i]
+                s_j, e_j, label_j = regions[j]
+                assert e_i <= s_j or e_j <= s_i, (
+                    f"Overlap between {label_i} and {label_j}"
+                )
+
+    def test_flat_buffer_covers_all_groups(self) -> None:
+        """get_tmp_gpu_buffer_flat covers the full chunk (all groups)."""
+        ctx = _make_context_multi_group(self.GROUPS_DIFF_DTYPE, chunk_size=256)
+        flat = ctx.get_tmp_gpu_buffer_flat(chunk_idx=0)
+        assert flat.numel() == ctx.tmp_chunk_bytes_
+        assert flat.dtype == torch.uint8
+
+    def test_flat_buffer_chunk_idx_raises(self) -> None:
+        """chunk_idx >= max_batch_size should raise ValueError."""
+        ctx = _make_context_multi_group(self.GROUPS_SAME_DTYPE)
+        with pytest.raises(ValueError, match="exceeds max_batch_size"):
+            ctx.get_tmp_gpu_buffer_flat(chunk_idx=ctx.max_batch_size)
+
+    def test_flat_buffer_contains_group_data(self) -> None:
+        """Data written via get_tmp_chunk_gpu_buffer should be visible in flat view."""
+        ctx = _make_context_multi_group(self.GROUPS_SAME_DTYPE, chunk_size=64)
+        num_groups = len(ctx.kv_layer_groups_manager_.kv_layer_groups)
+
+        # Fill each group with a distinct byte value
+        for gidx in range(num_groups):
+            buf = ctx.get_tmp_chunk_gpu_buffer(group_idx=gidx)
+            # Use view(torch.uint8) to fill raw bytes
+            buf.view(torch.uint8).fill_(gidx + 1)
+
+        flat = ctx.get_tmp_gpu_buffer_flat(chunk_idx=0)
+        for gidx in range(num_groups):
+            g_start = ctx.tmp_chunk_group_offsets_[gidx]
+            g_end = ctx.tmp_chunk_group_offsets_[gidx + 1]
+            region = flat[g_start:g_end]
+            assert region.min().item() == gidx + 1, (
+                f"Group {gidx} flat region has wrong min value"
+            )
+            assert region.max().item() == gidx + 1, (
+                f"Group {gidx} flat region has wrong max value"
+            )

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -839,3 +839,131 @@ def test_lmcache_memcpy_async():
     ptr = big_cpu_tensor.data_ptr()
     for i in range(num_chunks):
         rt.cudaHostUnregister(ptr + i * chunk_size)
+
+
+def test_lmcache_memcpy_async_int8_hidden132():
+    """Test lmcache_memcpy_async with int8 dtype and hidden_size=132.
+
+    hidden_size=132 means each token occupies 132 bytes, which is NOT a
+    multiple of 4 (uint32 size). This tests that the kernel correctly handles
+    non-uint32-aligned data sizes when splitting copies across registered
+    memory chunk boundaries.
+
+    The KV buffer shape is (2, num_layers, num_tokens, hidden_size), so the
+    total bytes = 2 * num_layers * num_tokens * 132. We pick values such that
+    the copy spans across at least one PIN_CHUNK_SIZE (64 MB) boundary.
+    """
+    # Use PIN_CHUNK_SIZE = 64 MB as the registration granularity
+    chunk_size = 1 << 26  # 64 MB
+    num_chunks = 2
+    dtype = torch.int8
+    hidden_size = 132  # NOT a multiple of 4 — tests uint32 alignment handling
+
+    # Total bytes must span at least one chunk boundary.
+    # We allocate num_chunks * chunk_size bytes worth of int8 elements.
+    total_bytes = chunk_size * num_chunks
+    total_elements = total_bytes  # int8: 1 byte per element
+
+    cpu_tensor = torch.randint(-128, 127, (total_elements,), dtype=dtype, device="cpu")
+    gpu_tensor = torch.zeros(total_elements, dtype=dtype, device="cuda")
+
+    rt = torch.cuda.cudart()
+
+    # Register the cpu memory in PIN_CHUNK_SIZE chunks
+    ptr = cpu_tensor.data_ptr()
+    for i in range(num_chunks):
+        rt.cudaHostRegister(ptr + i * chunk_size, chunk_size, 0)
+
+    def check_equal(gpu_t: torch.Tensor, cpu_t: torch.Tensor):
+        assert torch.equal(gpu_t.cpu(), cpu_t), "GPU and CPU tensors are not equal"
+
+    # Test cases: copy ranges that cross chunk boundaries with non-4-byte-aligned
+    # sizes, simulating real KV cache transfers where hidden_size=132 (int8).
+    #
+    # Each "KV row" is hidden_size=132 bytes. We pick copy sizes that are
+    # multiples of 132 but NOT multiples of 4, so the copy boundary falls on
+    # a non-uint32-aligned offset within a registered chunk.
+    #
+    # num_tokens=3: 3 * 132 = 396 bytes (396 % 4 == 0, but 132 % 4 != 0)
+    # num_tokens=1: 1 * 132 = 132 bytes (132 % 4 == 0)
+    # num_tokens=5: 5 * 132 = 660 bytes (660 % 4 == 0)
+    # Use an offset that puts the copy right across the 64MB boundary.
+    boundary = chunk_size  # 64 MB boundary in bytes
+
+    # Place the copy so it straddles the chunk boundary:
+    # start = boundary - 2 * hidden_size, length = 4 * hidden_size
+    # This means 2 * hidden_size bytes before the boundary and 2 * hidden_size
+    # bytes after — each segment is 264 bytes, not a multiple of 4*hidden_size.
+    test_cases = [
+        # (start_bytes, num_hidden_rows)
+        (boundary - 2 * hidden_size, 4),  # straddles boundary, 528 bytes
+        (boundary - hidden_size, 3),  # straddles boundary, 396 bytes
+        (boundary - 3 * hidden_size, 6),  # straddles boundary, 792 bytes
+        (0, 1),  # single row at start, 132 bytes
+        (total_bytes - hidden_size, 1),  # single row at end, 132 bytes
+    ]
+
+    for start_bytes, num_rows in test_cases:
+        nbytes = num_rows * hidden_size
+        end_bytes = start_bytes + nbytes
+        assert end_bytes <= total_bytes, (
+            f"Test case out of bounds: start={start_bytes}, nbytes={nbytes}"
+        )
+
+        # Reset gpu_tensor slice to zeros so we can detect the copy
+        gpu_tensor[start_bytes:end_bytes].zero_()
+
+        # H2D copy
+        lmc_ops.lmcache_memcpy_async(
+            gpu_tensor.data_ptr() + start_bytes,
+            cpu_tensor.data_ptr() + start_bytes,
+            nbytes,
+            lmc_ops.TransferDirection.H2D,
+            start_bytes,
+            chunk_size,
+        )
+        torch.cuda.synchronize()
+
+        check_equal(
+            gpu_tensor[start_bytes:end_bytes],
+            cpu_tensor[start_bytes:end_bytes],
+        )
+
+    # D2H copy: write known values to GPU, copy back to CPU, verify
+    gpu_src = torch.randint(-128, 127, (total_elements,), dtype=dtype, device="cuda")
+    cpu_dst = torch.zeros(total_elements, dtype=dtype, device="cpu")
+
+    # Register cpu_dst for D2H
+    ptr_dst = cpu_dst.data_ptr()
+    for i in range(num_chunks):
+        rt.cudaHostRegister(ptr_dst + i * chunk_size, chunk_size, 0)
+
+    for start_bytes, num_rows in test_cases:
+        nbytes = num_rows * hidden_size
+        end_bytes = start_bytes + nbytes
+
+        cpu_dst[start_bytes:end_bytes].zero_()
+
+        lmc_ops.lmcache_memcpy_async(
+            cpu_dst.data_ptr() + start_bytes,
+            gpu_src.data_ptr() + start_bytes,
+            nbytes,
+            lmc_ops.TransferDirection.D2H,
+            start_bytes,
+            chunk_size,
+        )
+        torch.cuda.synchronize()
+
+        check_equal(
+            gpu_src[start_bytes:end_bytes],
+            cpu_dst[start_bytes:end_bytes],
+        )
+
+    # Unregister memory
+    ptr = cpu_tensor.data_ptr()
+    for i in range(num_chunks):
+        rt.cudaHostUnregister(ptr + i * chunk_size)
+
+    ptr_dst = cpu_dst.data_ptr()
+    for i in range(num_chunks):
+        rt.cudaHostUnregister(ptr_dst + i * chunk_size)


### PR DESCRIPTION
support different kv cache shape and dtype across layers

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds support for heterogeneous KV cache shapes and dtypes across layers (e.g., models where different layers have different KV head dimensions or data types).

Previously, GPUCacheContext assumed all layers share the same shape and dtype. This PR introduces KVLayerGroupsManager to group layers by (shape, dtype), and updates the D2H/H2D transfer logic in server.py to iterate over each group independently, using per-group tmp_gpu_buffer, kv_pointers, and tensor views.

Key changes:

`kv_layer_groups.py`: Add `build_kv_layer_groups_from_list()` to build layer groups from a raw list of KV cache tensors (no layer names required), grouping by (shape, dtype).

`gpu_context.py`: Replace single hidden_dim_size_ / tmp_gpu_buffer_ with per-group lists (hidden_dim_sizes_, tmp_gpu_buffers_); expose get_tmp_gpu_buffer(num_tokens, group_idx), get_kv_buffer_shape(num_tokens, group_idx), and kv_layer_groups_manager property.

`server.py`: Update get_layout_desc() to produce per-group shapes/dtypes; refactor D2H (store) and H2D (retrieve) loops to iterate over all groups.

`memory_management.py`: Improve error handling in tensor property and get_tensor() — replace bare assert with descriptive ValueError; make tensor fall back to get_tensor(0) in multi-group scenarios.

`mock_l2_adapter.py`: Replace bare assert with ValueError for cleaner error messages.

**Special notes for your reviewers**:
The grouping logic in `build_kv_layer_groups_from_list()` is order-preserving: groups are sorted by the first layer index they contain.

get_tmp_gpu_buffer and get_kv_buffer_shape are backward-compatible — group_idx defaults to 0, so single-group models are unaffected.

The tensor property on TensorMemoryObj now delegates to get_tensor(0) when per-group metadata is present, maintaining backward compatibility with callers that only use the single-tensor interface.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates CUDA transfer kernels and the MP server store/retrieve path to handle per-layer-group shapes/dtypes, which can affect correctness and performance of GPU<->CPU KV transfers. Added tests mitigate risk but changes touch core memory copy and layout logic.
> 
> **Overview**
> Enables multiprocessing cache store/retrieve to support **heterogeneous KV cache shapes and dtypes across layers** by grouping layers with identical `(shape, dtype)` and transferring each group independently.
> 
> `GPUCacheContext` now builds `KVLayerGroupsManager`, maintains per-group `PageBufferShapeDesc` and pointer arrays, and replaces the old single temporary KV buffer with a **flat `uint8` chunk buffer** that concatenates all groups (with helpers to view per-group/per-batch slices). `server.py`’s layout description, store (D2H), and retrieve (H2D) paths are updated to iterate over groups and copy via the new flat buffer.
> 
> CUDA `multi_layer_block_kv_transfer` is generalized to dispatch over vector widths (`uint4`/`uint32_t`/`uint16_t`) based on alignment instead of requiring `uint4`, and Python GPU memcpy helpers now validate sizes and copy raw bytes for non-lazy allocators. New unit tests cover multi-group temp-buffer layout and non-4-byte-aligned `lmcache_memcpy_async` copies (e.g. `int8` hidden size 132).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ece3ce74bbc4bcedd026f51e039b95786777a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->