### PR TITLE
[MP] Fix UT after merge #2851

### DIFF
--- a/tests/v1/distributed/test_resp_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_resp_l2_adapter_integration.py
@@ -274,7 +274,7 @@ class TestRESPL2AdapterIntegration:
         """Verify the factory can create a RESP L2 adapter from config."""
         # First Party
         from lmcache.v1.distributed.l2_adapters import create_l2_adapter
-        from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+        from lmcache.v1.distributed.l2_adapters.resp_l2_adapter import (
             RESPL2AdapterConfig,
         )
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change updating an import to reference the correct `RESPL2AdapterConfig` location; no production logic is modified.
> 
> **Overview**
> Fixes the RESP L2 adapter integration test to import `RESPL2AdapterConfig` from `resp_l2_adapter` (instead of `native_connector_l2_adapter`), aligning the factory-creation test with the current adapter/config module layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89635c5ee39c7ad7fd63c91c8e88a9dc76f81c87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->