### PR TITLE
fix(security): expand multimodal hash entropy for cache keys

### DIFF
--- a/lmcache/integration/vllm/tests/test_mm_hash_utils.py
+++ b/lmcache/integration/vllm/tests/test_mm_hash_utils.py
@@ -8,8 +8,10 @@ import torch
 # First Party
 from lmcache.integration.vllm.utils import (
     apply_mm_hashes_to_token_ids,
-    hex_hash_to_int16,
+    hex_hash_to_int64,
 )
+
+INT64_MAX = 0xFFFFFFFFFFFFFFFF
 
 
 @dataclasses.dataclass(frozen=True)
@@ -18,58 +20,70 @@ class DummyPlaceholderRange:
     length: int
 
 
-def test_hex_hash_to_int16_accepts_hex_and_non_hex() -> None:
+def test_hex_hash_to_int64_accepts_hex_and_non_hex() -> None:
     # Hex behavior preserved (with and without 0x prefix).
-    assert hex_hash_to_int16("0000") == 0
-    assert hex_hash_to_int16("ffff") == 0xFFFF
-    assert hex_hash_to_int16("0xFFFF") == 0xFFFF
-    assert hex_hash_to_int16("0x0001") == 1
+    assert hex_hash_to_int64("0000") == 0
+    assert hex_hash_to_int64("ffff") == 0xFFFF
+    assert hex_hash_to_int64("0xFFFF") == 0xFFFF
+    assert hex_hash_to_int64("0x0001") == 1
 
     # Non-hex identifiers must not raise and must be deterministic.
     s = "chatcmpl-a2a48871c4aad192-image-0"
-    v1 = hex_hash_to_int16(s)
-    v2 = hex_hash_to_int16(s)
+    v1 = hex_hash_to_int64(s)
+    v2 = hex_hash_to_int64(s)
     assert isinstance(v1, int)
-    assert 0 <= v1 <= 0xFFFF
+    assert 0 <= v1 <= INT64_MAX
     assert v1 == v2
 
 
-def test_hex_hash_to_int16_hex_variants_whitespace_and_truncation() -> None:
+def test_hex_hash_to_int64_hex_variants_whitespace_and_truncation() -> None:
     # Whitespace should be ignored and case should not matter.
-    assert hex_hash_to_int16(" FfFf ") == 0xFFFF
-    assert hex_hash_to_int16("\n0x00aB\t") == 0x00AB
+    assert hex_hash_to_int64(" FfFf ") == 0xFFFF
+    assert hex_hash_to_int64("\n0x00aB\t") == 0x00AB
 
-    # Long hex should be truncated to 16 bits via masking.
-    assert hex_hash_to_int16("123456") == 0x3456
-    assert hex_hash_to_int16("0x123456") == 0x3456
+    # Long hex should be truncated to 64 bits via masking.
+    assert hex_hash_to_int64("123456") == 0x123456
+    # Values that exceed 64 bits should be masked.
+    big_hex = "1" + "0" * 16  # 2^64, exceeds 64-bit range
+    assert hex_hash_to_int64(big_hex) == int(big_hex, 16) & INT64_MAX
 
 
-def test_hex_hash_to_int16_empty_and_invalid_hex_are_safe_and_deterministic() -> None:
+def test_hex_hash_to_int64_empty_and_invalid_hex_are_safe_and_deterministic() -> None:
     # Empty (or effectively empty) values should not raise.
     for s in ("", "   ", "0x"):
-        v1 = hex_hash_to_int16(s)
-        v2 = hex_hash_to_int16(s)
+        v1 = hex_hash_to_int64(s)
+        v2 = hex_hash_to_int64(s)
         assert isinstance(v1, int)
-        assert 0 <= v1 <= 0xFFFF
+        assert 0 <= v1 <= INT64_MAX
         assert v1 == v2
 
     # Invalid "hex-looking" strings must fall back to hashing.
     for s in ("0xGG", "deadbeeg", "0x12xz"):
-        v1 = hex_hash_to_int16(s)
-        v2 = hex_hash_to_int16(s)
+        v1 = hex_hash_to_int64(s)
+        v2 = hex_hash_to_int64(s)
         assert isinstance(v1, int)
-        assert 0 <= v1 <= 0xFFFF
+        assert 0 <= v1 <= INT64_MAX
         assert v1 == v2
 
 
-def test_hex_hash_to_int16_non_string_inputs_are_safe() -> None:
+def test_hex_hash_to_int64_non_string_inputs_are_safe() -> None:
     # Be defensive: callers may pass None or other non-string types.
     for val in (None, 0, 12345, 3.14, b"deadbeef"):
-        v1 = hex_hash_to_int16(val)  # type: ignore[arg-type]
-        v2 = hex_hash_to_int16(val)  # type: ignore[arg-type]
+        v1 = hex_hash_to_int64(val)  # type: ignore[arg-type]
+        v2 = hex_hash_to_int64(val)  # type: ignore[arg-type]
         assert isinstance(v1, int)
-        assert 0 <= v1 <= 0xFFFF
+        assert 0 <= v1 <= INT64_MAX
         assert v1 == v2
+
+
+def test_hex_hash_to_int64_different_inputs_no_collision() -> None:
+    """With 64-bit output, distinct OpenAI-style identifiers should not collide
+    across a realistic working set."""
+    seen: set[int] = set()
+    for i in range(10_000):
+        h = hex_hash_to_int64(f"chatcmpl-test-{i:05d}-image-0")
+        assert h not in seen, f"Unexpected collision at i={i}"
+        seen.add(h)
 
 
 def test_apply_mm_hashes_to_token_ids_handles_non_hex_mm_hash() -> None:
@@ -78,7 +92,7 @@ def test_apply_mm_hashes_to_token_ids_handles_non_hex_mm_hash() -> None:
     mm_positions = [DummyPlaceholderRange(offset=2, length=4)]
 
     out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
-    expected_val = hex_hash_to_int16(mm_hashes[0])
+    expected_val = hex_hash_to_int64(mm_hashes[0])
     assert out[2:6].tolist() == [expected_val] * 4
 
 
@@ -102,8 +116,8 @@ def test_apply_mm_hashes_to_token_ids_multiple_placeholders_and_length_mismatch(
     ]
 
     out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
-    v0 = hex_hash_to_int16(mm_hashes[0])
-    v1 = hex_hash_to_int16(mm_hashes[1])
+    v0 = hex_hash_to_int64(mm_hashes[0])
+    v1 = hex_hash_to_int64(mm_hashes[1])
 
     assert out[0:3].tolist() == [v0] * 3
     assert out[5:9].tolist() == [v1] * 4

--- a/lmcache/integration/vllm/tests/test_mm_hash_utils.py
+++ b/lmcache/integration/vllm/tests/test_mm_hash_utils.py
@@ -11,7 +11,7 @@ from lmcache.integration.vllm.utils import (
     hex_hash_to_int64,
 )
 
-INT64_MAX = 0xFFFFFFFFFFFFFFFF
+INT64_MAX = 0x7FFFFFFFFFFFFFFF  # signed int64 max (torch.long)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -41,10 +41,10 @@ def test_hex_hash_to_int64_hex_variants_whitespace_and_truncation() -> None:
     assert hex_hash_to_int64(" FfFf ") == 0xFFFF
     assert hex_hash_to_int64("\n0x00aB\t") == 0x00AB
 
-    # Long hex should be truncated to 64 bits via masking.
+    # Long hex should be truncated to 63 bits via masking (signed int64 safe).
     assert hex_hash_to_int64("123456") == 0x123456
-    # Values that exceed 64 bits should be masked.
-    big_hex = "1" + "0" * 16  # 2^64, exceeds 64-bit range
+    # Values that exceed 63 bits should be masked.
+    big_hex = "1" + "0" * 16  # 2^64, exceeds signed int64 range
     assert hex_hash_to_int64(big_hex) == int(big_hex, 16) & INT64_MAX
 
 
@@ -74,6 +74,15 @@ def test_hex_hash_to_int64_non_string_inputs_are_safe() -> None:
         assert isinstance(v1, int)
         assert 0 <= v1 <= INT64_MAX
         assert v1 == v2
+
+
+def test_hex_hash_to_int64_fits_in_signed_int64() -> None:
+    """Ensure the hash value never exceeds signed int64 max (torch.long safe)."""
+    for i in range(1_000):
+        h = hex_hash_to_int64(f"chatcmpl-overflow-test-{i}-image-0")
+        assert 0 <= h <= INT64_MAX, f"Hash {h:#x} overflows signed int64"
+    # Explicit large hex input.
+    assert hex_hash_to_int64("0xFFFFFFFFFFFFFFFF") == INT64_MAX
 
 
 def test_hex_hash_to_int64_different_inputs_no_collision() -> None:

--- a/lmcache/integration/vllm/tests/test_mm_hash_utils.py
+++ b/lmcache/integration/vllm/tests/test_mm_hash_utils.py
@@ -3,15 +3,17 @@
 import dataclasses
 
 # Third Party
+import pytest
 import torch
 
 # First Party
 from lmcache.integration.vllm.utils import (
     apply_mm_hashes_to_token_ids,
+    hex_hash_to_int16,
     hex_hash_to_int64,
 )
 
-INT64_MAX = 0x7FFFFFFFFFFFFFFF  # signed int64 max (torch.long)
+INT64_MAX = 0x7FFFFFFFFFFFFFFF
 
 
 @dataclasses.dataclass(frozen=True)
@@ -41,11 +43,9 @@ def test_hex_hash_to_int64_hex_variants_whitespace_and_truncation() -> None:
     assert hex_hash_to_int64(" FfFf ") == 0xFFFF
     assert hex_hash_to_int64("\n0x00aB\t") == 0x00AB
 
-    # Long hex should be truncated to 63 bits via masking (signed int64 safe).
+    # Long hex should be masked to signed int64 range.
     assert hex_hash_to_int64("123456") == 0x123456
-    # Values that exceed 63 bits should be masked.
-    big_hex = "1" + "0" * 16  # 2^64, exceeds signed int64 range
-    assert hex_hash_to_int64(big_hex) == int(big_hex, 16) & INT64_MAX
+    assert hex_hash_to_int64("0xFFFFFFFFFFFFFFFF") == INT64_MAX
 
 
 def test_hex_hash_to_int64_empty_and_invalid_hex_are_safe_and_deterministic() -> None:
@@ -76,22 +76,18 @@ def test_hex_hash_to_int64_non_string_inputs_are_safe() -> None:
         assert v1 == v2
 
 
-def test_hex_hash_to_int64_fits_in_signed_int64() -> None:
-    """Ensure the hash value never exceeds signed int64 max (torch.long safe)."""
-    for i in range(1_000):
-        h = hex_hash_to_int64(f"chatcmpl-overflow-test-{i}-image-0")
-        assert 0 <= h <= INT64_MAX, f"Hash {h:#x} overflows signed int64"
-    # Explicit large hex input.
-    assert hex_hash_to_int64("0xFFFFFFFFFFFFFFFF") == INT64_MAX
+def test_hex_hash_to_int16_deprecated_alias_matches_int64() -> None:
+    s = "chatcmpl-a2a48871c4aad192-image-0"
+    with pytest.deprecated_call(match="hex_hash_to_int16 is deprecated"):
+        legacy_value = hex_hash_to_int16(s)
+    assert legacy_value == hex_hash_to_int64(s)
 
 
-def test_hex_hash_to_int64_different_inputs_no_collision() -> None:
-    """With 64-bit output, distinct OpenAI-style identifiers should not collide
-    across a realistic working set."""
+def test_hex_hash_to_int64_different_inputs_do_not_collide_in_working_set() -> None:
     seen: set[int] = set()
     for i in range(10_000):
         h = hex_hash_to_int64(f"chatcmpl-test-{i:05d}-image-0")
-        assert h not in seen, f"Unexpected collision at i={i}"
+        assert h not in seen
         seen.add(h)
 
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -17,7 +17,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.config import LMCacheEngineConfig, load_ec_engine_config
 from lmcache.v1.config_base import apply_remote_configs, fetch_remote_config
 
 if TYPE_CHECKING:
@@ -102,6 +102,10 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
                         "the environment variable: LMCACHE_CONFIG_FILE"
                     )
                     _config_instance = LMCacheEngineConfig.from_env()
+                    # from_env() doesn't call validate(); the file path
+                    # gets it via update_config_from_env() below, but the
+                    # env-only path needs an explicit call.
+                    _config_instance.validate()
                 else:
                     config_file = os.environ["LMCACHE_CONFIG_FILE"]
                     logger.info(f"Loading LMCache config file {config_file}")
@@ -132,9 +136,14 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
     return _config_instance
 
 
+def create_lmcache_ec_config() -> LMCacheEngineConfig:
+    """Create EC config from LMCache config plus EC-specific overrides."""
+    return load_ec_engine_config(base_config=lmcache_get_or_create_config())
+
+
 def hex_hash_to_int64(s: str) -> int:
     """
-    Convert a hash identifier into a 64-bit integer.
+    Convert a hash identifier into a signed-int64-safe integer.
 
     Historically, LMCache expected multimodal identifiers to be hex strings.
     In practice (e.g., OpenAI-style multimodal requests), identifiers may be
@@ -143,10 +152,8 @@ def hex_hash_to_int64(s: str) -> int:
       - Falls back to a stable string hash (SHA-256) when the input is not hex.
 
     The result is masked to 63 bits so it fits in a torch.long (signed int64)
-    tensor without overflow.
-    Previous versions truncated to 16 bits (2^16 = 65 536 values), which made
-    birthday-paradox collisions likely after only ~300 distinct images and
-    could cause KV-cache poisoning across unrelated requests.
+    tensor without overflow. Previous versions truncated to 16 bits, which made
+    birthday-paradox collisions likely after only a few hundred distinct images.
     """
     # Be defensive: vLLM may pass non-string identifiers.
     s = "" if s is None else str(s)
@@ -163,19 +170,22 @@ def hex_hash_to_int64(s: str) -> int:
 
     # Fallback: stable 63-bit value derived from the full identifier string.
     digest = hashlib.sha256(s_stripped.encode("utf-8")).digest()
-    return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
+    return (
+        int.from_bytes(digest[:8], byteorder="big", signed=False)
+        & 0x7FFFFFFFFFFFFFFF
+    )
 
 
 def hex_hash_to_int16(s: str) -> int:
     """Deprecated: use ``hex_hash_to_int64`` instead.
 
-    This wrapper exists solely for backward compatibility. It now returns a
-    63-bit (signed-int64-safe) value, **not** a 16-bit value. The old 16-bit
-    truncation caused KV-cache poisoning via hash collisions.
+    This wrapper exists for backward compatibility. It now returns the
+    signed-int64-safe value from ``hex_hash_to_int64`` rather than truncating
+    multimodal identifiers to 16 bits.
     """
     warnings.warn(
-        "hex_hash_to_int16 is deprecated and now returns a 63-bit value. "
-        "Use hex_hash_to_int64 instead.",
+        "hex_hash_to_int16 is deprecated and now returns a signed-int64-safe "
+        "value. Use hex_hash_to_int64 instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -353,31 +363,6 @@ def get_size_bytes(shapes: list[torch.Size], kv_dtypes: list[torch.dtype]):
     )
 
 
-def get_vllm_torch_dev():
-    """
-    Returns the torch device and device name for the vLLM engine.
-    e.g. (torch.cuda, "cuda") or (torch.xpu, "xpu")
-    """
-    # Third Party
-    from vllm.platforms import current_platform
-
-    if current_platform.is_cuda_alike():
-        logger.info("CUDA device is available. Using CUDA for LMCache engine.")
-        torch_dev = torch.cuda
-        dev_name = "cuda"
-    elif current_platform.is_xpu():
-        logger.info("XPU device is available. Using XPU for LMCache engine.")
-        torch_dev = torch.xpu
-        dev_name = "xpu"
-    elif hasattr(torch, "hpu") and torch.hpu.is_available():
-        logger.info("HPU device is available. Using HPU for LMCache engine.")
-        torch_dev = torch.hpu
-        dev_name = "hpu"
-    else:
-        raise RuntimeError("Unsupported device platform for LMCache engine.")
-    return torch_dev, dev_name
-
-
 def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int, int]:
     """
     Calculate the local worker id and local world size.
@@ -389,10 +374,12 @@ def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int,
     Returns:
         Tuple[int, int]: (local_worker_id, local_world_size)
     """
+    # First Party
+    from lmcache import torch_dev
+
     parallel_config = vllm_config.parallel_config
     global_rank = parallel_config.rank
     global_world_size = parallel_config.world_size
-    torch_dev, dev_name = get_vllm_torch_dev()
     num_gpus = torch_dev.device_count()
     if global_world_size <= num_gpus:
         # single node case

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -141,9 +141,24 @@ def create_lmcache_ec_config() -> LMCacheEngineConfig:
     return load_ec_engine_config(base_config=lmcache_get_or_create_config())
 
 
-def hex_hash_to_int64(s: str) -> int:
+def hex_hash_to_int16(s: str) -> int:
+    """Deprecated: use ``hex_hash_to_int64`` instead.
+
+    This wrapper exists for backward compatibility. It now returns the
+    signed-int64-safe value from ``hex_hash_to_int64`` rather than truncating
+    multimodal identifiers to 16 bits.
     """
-    Convert a hash identifier into a signed-int64-safe integer.
+    warnings.warn(
+        "hex_hash_to_int16 is deprecated and now returns a signed-int64-safe "
+        "value. Use hex_hash_to_int64 instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return hex_hash_to_int64(s)
+
+
+def hex_hash_to_int64(s: str) -> int:
+    """Convert a hash identifier into a signed-int64-safe integer.
 
     Historically, LMCache expected multimodal identifiers to be hex strings.
     In practice (e.g., OpenAI-style multimodal requests), identifiers may be
@@ -174,22 +189,6 @@ def hex_hash_to_int64(s: str) -> int:
         int.from_bytes(digest[:8], byteorder="big", signed=False)
         & 0x7FFFFFFFFFFFFFFF
     )
-
-
-def hex_hash_to_int16(s: str) -> int:
-    """Deprecated: use ``hex_hash_to_int64`` instead.
-
-    This wrapper exists for backward compatibility. It now returns the
-    signed-int64-safe value from ``hex_hash_to_int64`` rather than truncating
-    multimodal identifiers to 16 bits.
-    """
-    warnings.warn(
-        "hex_hash_to_int16 is deprecated and now returns a signed-int64-safe "
-        "value. Use hex_hash_to_int64 instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return hex_hash_to_int64(s)
 
 
 def apply_mm_hashes_to_token_ids(

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import string
 import threading
+import warnings
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
@@ -141,7 +142,8 @@ def hex_hash_to_int64(s: str) -> int:
       - Parses hex strings (optionally prefixed with `0x`) as before, or
       - Falls back to a stable string hash (SHA-256) when the input is not hex.
 
-    The result is masked to 64 bits so it fits in a torch.long (int64) tensor.
+    The result is masked to 63 bits so it fits in a torch.long (signed int64)
+    tensor without overflow.
     Previous versions truncated to 16 bits (2^16 = 65 536 values), which made
     birthday-paradox collisions likely after only ~300 distinct images and
     could cause KV-cache poisoning across unrelated requests.
@@ -154,18 +156,30 @@ def hex_hash_to_int64(s: str) -> int:
     hex_part = s_stripped[2:] if s_stripped.lower().startswith("0x") else s_stripped
     if hex_part and all(c in string.hexdigits for c in hex_part):
         try:
-            return int(hex_part, 16) & 0xFFFFFFFFFFFFFFFF
+            return int(hex_part, 16) & 0x7FFFFFFFFFFFFFFF
         except ValueError:
             # Extremely unlikely (e.g., oversized/odd formatting); fall back to hashing.
             pass
 
-    # Fallback: stable 64-bit value derived from the full identifier string.
+    # Fallback: stable 63-bit value derived from the full identifier string.
     digest = hashlib.sha256(s_stripped.encode("utf-8")).digest()
-    return int.from_bytes(digest[:8], byteorder="big", signed=False)
+    return int.from_bytes(digest[:8], byteorder="big", signed=False) & 0x7FFFFFFFFFFFFFFF
 
 
-# Backward-compatible alias (deprecated).
-hex_hash_to_int16 = hex_hash_to_int64
+def hex_hash_to_int16(s: str) -> int:
+    """Deprecated: use ``hex_hash_to_int64`` instead.
+
+    This wrapper exists solely for backward compatibility. It now returns a
+    63-bit (signed-int64-safe) value, **not** a 16-bit value. The old 16-bit
+    truncation caused KV-cache poisoning via hash collisions.
+    """
+    warnings.warn(
+        "hex_hash_to_int16 is deprecated and now returns a 63-bit value. "
+        "Use hex_hash_to_int64 instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return hex_hash_to_int64(s)
 
 
 def apply_mm_hashes_to_token_ids(

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -131,15 +131,20 @@ def lmcache_get_or_create_config() -> LMCacheEngineConfig:
     return _config_instance
 
 
-def hex_hash_to_int16(s: str) -> int:
+def hex_hash_to_int64(s: str) -> int:
     """
-    Convert a hash identifier into a 16-bit integer.
+    Convert a hash identifier into a 64-bit integer.
 
     Historically, LMCache expected multimodal identifiers to be hex strings.
     In practice (e.g., OpenAI-style multimodal requests), identifiers may be
     arbitrary strings like `chatcmpl-...-image-0`. This function therefore:
       - Parses hex strings (optionally prefixed with `0x`) as before, or
       - Falls back to a stable string hash (SHA-256) when the input is not hex.
+
+    The result is masked to 64 bits so it fits in a torch.long (int64) tensor.
+    Previous versions truncated to 16 bits (2^16 = 65 536 values), which made
+    birthday-paradox collisions likely after only ~300 distinct images and
+    could cause KV-cache poisoning across unrelated requests.
     """
     # Be defensive: vLLM may pass non-string identifiers.
     s = "" if s is None else str(s)
@@ -149,14 +154,18 @@ def hex_hash_to_int16(s: str) -> int:
     hex_part = s_stripped[2:] if s_stripped.lower().startswith("0x") else s_stripped
     if hex_part and all(c in string.hexdigits for c in hex_part):
         try:
-            return int(hex_part, 16) & 0xFFFF
+            return int(hex_part, 16) & 0xFFFFFFFFFFFFFFFF
         except ValueError:
             # Extremely unlikely (e.g., oversized/odd formatting); fall back to hashing.
             pass
 
-    # Fallback: stable 16-bit value derived from the full identifier string.
+    # Fallback: stable 64-bit value derived from the full identifier string.
     digest = hashlib.sha256(s_stripped.encode("utf-8")).digest()
-    return int.from_bytes(digest[:2], byteorder="big", signed=False)
+    return int.from_bytes(digest[:8], byteorder="big", signed=False)
+
+
+# Backward-compatible alias (deprecated).
+hex_hash_to_int16 = hex_hash_to_int64
 
 
 def apply_mm_hashes_to_token_ids(
@@ -174,7 +183,7 @@ def apply_mm_hashes_to_token_ids(
         if start >= n:
             continue
         end = min(start + length, n)
-        token_ids[start:end] = hex_hash_to_int16(hash_str)
+        token_ids[start:end] = hex_hash_to_int64(hash_str)
     return token_ids
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Replaces the old 16-bit multimodal hash key material with a signed-int64-safe 63-bit value before writing it into token IDs used for cache key computation.
- Adds `hex_hash_to_int64()` and keeps `hex_hash_to_int16()` as a deprecated compatibility wrapper that delegates to the safer implementation.
- Updates multimodal hash tests for signed int64 bounds, deterministic non-hex handling, large-hex masking, deprecated alias compatibility, and collision resistance across a realistic working set.

Fixes LMCache/LMCache#3301

**Special notes for your reviewers**:

The implementation masks to `0x7FFFFFFFFFFFFFFF` rather than the full unsigned 64-bit range so values remain safe for `torch.long` / signed int64 tensors.

This branch has been refreshed so GitHub reports it as mergeable with the current `dev` branch.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Test Plan**:

- [x] `python -m compileall -q lmcache/integration/vllm/utils.py lmcache/integration/vllm/tests/test_mm_hash_utils.py`
- [x] `git diff --check`
- [x] `ruff check lmcache/integration/vllm/utils.py lmcache/integration/vllm/tests/test_mm_hash_utils.py`
- [ ] `pytest -q lmcache/integration/vllm/tests/test_mm_hash_utils.py` (blocked locally: current Python environment is missing `torch`)