### PR TITLE
[Feat]: Add eviction to L2 Native Backend

### DIFF
--- a/csrc/storage_backends/README.md
+++ b/csrc/storage_backends/README.md
@@ -49,7 +49,7 @@ Therefore the framework enforces:
 |------|---------|
 | `connector_types.h` | `Request`, `Completion`, `BatchState`, `Op` |
 | `connector_interface.h` | `IStorageConnector` — top-level abstract interface |
-| `connector_base.h` | `ConnectorBase<T>` — core harness (eventfd, SQ/CQ, threading, tiling). Override 4 methods per backend |
+| `connector_base.h` | `ConnectorBase<T>` — core harness (eventfd, SQ/CQ, threading, tiling). Override 4 required + 1 optional method per backend |
 | `connector_pybind_utils.h` | Pybind utilities with GIL release + `LMCACHE_BIND_CONNECTOR_METHODS` macro |
 | `redis/` | Reference implementation (RESP2 protocol over TCP) |
 
@@ -61,8 +61,8 @@ each step.
 ### Step 1: C++ connector — inherit from ConnectorBase
 
 Create your connector directory (e.g., `csrc/storage_backends/mybackend/`)
-and inherit from `ConnectorBase<YourConnectionType>`. You only need to
-override 4 methods:
+and inherit from `ConnectorBase<YourConnectionType>`. You need to
+override 4 required methods (and optionally `do_single_delete` for eviction):
 
 ```cpp
 // csrc/storage_backends/mybackend/connector.h
@@ -103,6 +103,11 @@ class MyConnector : public lmcache::connector::ConnectorBase<MyConn> {
   // 4. EXISTS: check if key exists
   bool do_single_exists(MyConn& conn, const std::string& key) override {
     // send EXISTS, return true/false
+  }
+
+  // Optional: delete a key (enables eviction support)
+  bool do_single_delete(MyConn& conn, const std::string& key) override {
+    // send DELETE, return true if deleted, false if not found
   }
 
   // Optional: clean shutdown of connections
@@ -275,7 +280,7 @@ Python eventfd.
 
 ## Checklist for a new backend
 
-- [ ] C++ connector inheriting `ConnectorBase<T>` with 4 method overrides
+- [ ] C++ connector inheriting `ConnectorBase<T>` with 4 required + 1 optional (`do_single_delete`) method overrides
 - [ ] Pybind module using `LMCACHE_BIND_CONNECTOR_METHODS`
 - [ ] `setup.py` entry for the new `CppExtension`
 - [ ] Python client inheriting `ConnectorClientBase` (non-MP mode)

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -130,6 +130,39 @@ class ConnectorBase : public IStorageConnector {
     return batch_future_id;
   }
 
+  uint64_t submit_batch_delete(const std::vector<std::string>& keys) override {
+    if (keys.empty()) {
+      throw std::runtime_error("keys list is empty");
+    }
+
+    size_t num_items = keys.size();
+    auto [batch_future_id, batch_state, num_tiles, tile_size] =
+        prepare_batch_operation(num_items, Op::BATCH_TILE_DELETE);
+
+    // pre-allocate per-key results (1 = deleted, 0 = not found)
+    batch_state->per_key_results.assign(num_items, 0);
+
+    // fan out work to threads
+    for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+      size_t start = tile_idx * tile_size;
+      size_t end = std::min(start + tile_size, num_items);
+
+      Request tile_req;
+      tile_req.op = Op::BATCH_TILE_DELETE;
+      tile_req.future_id = batch_future_id;
+      tile_req.batch = batch_state;
+      tile_req.start_idx = start;
+
+      for (size_t i = start; i < end; ++i) {
+        tile_req.keys.push_back(keys[i]);
+      }
+
+      enqueue_request(std::move(tile_req));
+    }
+
+    return batch_future_id;
+  }
+
   std::vector<Completion> drain_completions() override {
     // Drain the eventfd that triggered this drain_completions callback
     drain_eventfd_();
@@ -216,6 +249,11 @@ class ConnectorBase : public IStorageConnector {
                              size_t chunk_size) = 0;
   virtual bool do_single_exists(ConnectionType& conn,
                                 const std::string& key) = 0;
+  virtual bool do_single_delete(ConnectionType& conn, const std::string& key) {
+    (void)conn;
+    (void)key;
+    return false;  // no-op default for backward compat with plugins
+  }
   virtual void shutdown_connections() {}
 
   bool is_stopping() const { return stop_.load(std::memory_order_acquire); }
@@ -393,6 +431,23 @@ class ConnectorBase : public IStorageConnector {
               }
               comp.ok = true;
               break;
+
+            case Op::BATCH_TILE_DELETE:
+              for (size_t i = 0; i < req.keys.size(); ++i) {
+                try {
+                  bool deleted = do_single_delete(conn, req.keys[i]);
+                  req.batch->per_key_results[req.start_idx + i] =
+                      deleted ? 1 : 0;
+                } catch (const std::exception& e) {
+                  // Per-key error tolerance: record failure
+                  // but continue processing remaining keys
+                  req.batch->per_key_results[req.start_idx + i] = 0;
+                  fprintf(stderr, "[LMCache DELETE] key %s failed: %s\n",
+                          req.keys[i].c_str(), e.what());
+                }
+              }
+              comp.ok = true;
+              break;
           }
         } catch (const std::exception& e) {
           comp.ok = false;
@@ -438,7 +493,8 @@ class ConnectorBase : public IStorageConnector {
       }
       // for batch exists and batch get, move per-key results
       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
-          req.batch->batch_op == Op::BATCH_TILE_GET) {
+          req.batch->batch_op == Op::BATCH_TILE_GET ||
+          req.batch->batch_op == Op::BATCH_TILE_DELETE) {
         batch_comp.result_bytes = std::move(req.batch->per_key_results);
       }
       push_completion(std::move(batch_comp));

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -25,6 +25,9 @@ class:
 - 3. do_single_set()
 - 4. do_single_exists()
 
+optionally override do_single_delete() to support eviction (default returns
+false for all keys).
+
 see the RedisConnector (csrc/redis/) implementing the RESP2 protocol over TCP
 for an example
 */

--- a/csrc/storage_backends/connector_interface.h
+++ b/csrc/storage_backends/connector_interface.h
@@ -81,6 +81,24 @@ class IStorageConnector {
       const std::vector<std::string>& keys) = 0;
 
   /*
+  submit a batch DELETE operation
+
+  deletes multiple keys in parallel. work is automatically divided
+  among worker threads (tiling). returns a single future_id for the entire
+  batch.
+
+  args:
+    keys: vector of key strings to delete
+
+  returns:
+    uint64_t: future id for tracking this batch operation
+    completion will contain result_bytes vector with 0/1 for each key
+    (1 = deleted, 0 = not found)
+  */
+  virtual uint64_t submit_batch_delete(
+      const std::vector<std::string>& keys) = 0;
+
+  /*
   drain all available completions
 
   this is the ONLY method that should be called when the eventfd becomes

--- a/csrc/storage_backends/connector_pybind_utils.h
+++ b/csrc/storage_backends/connector_pybind_utils.h
@@ -36,6 +36,10 @@ example usage (see `redis/pybind.cpp`):
            lmcache::connector::pybind_utils::bind_submit_batch_exists< \
                ConnectorType>(),                                       \
            py::arg("keys"))                                            \
+      .def("submit_batch_delete",                                      \
+           lmcache::connector::pybind_utils::bind_submit_batch_delete< \
+               ConnectorType>(),                                       \
+           py::arg("keys"))                                            \
       .def("drain_completions",                                        \
            lmcache::connector::pybind_utils::bind_drain_completions<   \
                ConnectorType>())                                       \
@@ -110,6 +114,14 @@ auto bind_submit_batch_exists() {
   return [](ConnectorType& self, const std::vector<std::string>& keys) {
     py::gil_scoped_release release;
     return self.submit_batch_exists(keys);
+  };
+}
+
+template <typename ConnectorType>
+auto bind_submit_batch_delete() {
+  return [](ConnectorType& self, const std::vector<std::string>& keys) {
+    py::gil_scoped_release release;
+    return self.submit_batch_delete(keys);
   };
 }
 

--- a/csrc/storage_backends/connector_types.h
+++ b/csrc/storage_backends/connector_types.h
@@ -23,7 +23,12 @@ namespace connector {
 
 // we only support batched operations
 // benefits are fewer submissions and fewer completions
-enum class Op : uint8_t { BATCH_TILE_GET, BATCH_TILE_SET, BATCH_TILE_EXISTS };
+enum class Op : uint8_t {
+  BATCH_TILE_GET,
+  BATCH_TILE_SET,
+  BATCH_TILE_EXISTS,
+  BATCH_TILE_DELETE
+};
 
 /*
 shared communication state between threads executing a single batch operation.

--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -271,5 +271,12 @@ bool FSConnector::do_single_exists(WorkerFSConn& conn, const std::string& key) {
   return std::filesystem::exists(file_path);
 }
 
+bool FSConnector::do_single_delete(WorkerFSConn& conn, const std::string& key) {
+  std::string filename = key_to_filename(key);
+  auto file_path = conn.base_path / filename;
+  std::error_code ec;
+  return std::filesystem::remove(file_path, ec);
+}
+
 }  // namespace connector
 }  // namespace lmcache

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -46,6 +46,7 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   void do_single_set(WorkerFSConn& conn, const std::string& key,
                      const void* buf, size_t len, size_t chunk_size) override;
   bool do_single_exists(WorkerFSConn& conn, const std::string& key) override;
+  bool do_single_delete(WorkerFSConn& conn, const std::string& key) override;
 
  private:
   // Build the filesystem-safe filename from a serialized key string.

--- a/csrc/storage_backends/redis/connector.cpp
+++ b/csrc/storage_backends/redis/connector.cpp
@@ -338,6 +338,32 @@ bool RedisConnector::do_single_exists(WorkerConn& conn,
   }
 }
 
+// RESP DEL
+bool RedisConnector::do_single_delete(WorkerConn& conn,
+                                      const std::string& key) {
+  // build key header using reusable buffer
+  const std::string& key_header = conn.make_key_header(key);
+
+  // send DEL cmd
+  conn.send_multipart({{conn.del_prefix.data(), conn.del_prefix.size()},
+                       {key_header.data(), key_header.size()}});
+
+  // parse response (either :0\r\n or :1\r\n, same format as EXISTS)
+  char response[WorkerConn::exists_response_len];
+  conn.recv_exactly(response, WorkerConn::exists_response_len);
+
+  if (std::memcmp(response, WorkerConn::exists_one.data(),
+                  WorkerConn::exists_response_len) == 0) {
+    return true;  // key was deleted
+  } else if (std::memcmp(response, WorkerConn::exists_zero.data(),
+                         WorkerConn::exists_response_len) == 0) {
+    return false;  // key did not exist
+  } else {
+    throw std::runtime_error(
+        "DEL returned invalid response that wasn't :0\r\n or :1\r\n");
+  }
+}
+
 void RedisConnector::shutdown_connections() {
   std::lock_guard<std::mutex> lk(worker_fds_mu_);
   for (int fd : worker_fds_) {

--- a/csrc/storage_backends/redis/connector.h
+++ b/csrc/storage_backends/redis/connector.h
@@ -34,6 +34,7 @@ struct WorkerConn {
   std::string get_prefix;
   std::string set_prefix;
   std::string exists_prefix;
+  std::string del_prefix;
 
   // reusable buffers for building headers (avoids repeated dynamic allocations)
   std::string key_header_buf;
@@ -53,7 +54,8 @@ struct WorkerConn {
   WorkerConn()
       : get_prefix("*2\r\n$3\r\nGET\r\n"),
         set_prefix("*3\r\n$3\r\nSET\r\n"),
-        exists_prefix("*2\r\n$6\r\nEXISTS\r\n") {
+        exists_prefix("*2\r\n$6\r\nEXISTS\r\n"),
+        del_prefix("*2\r\n$3\r\nDEL\r\n") {
     // pre-allocate key_header_buf to handle typical keys without reallocation
     // typical key format: model_name@world_size@worker_id@chunk_hash_hex@dtype
     // - model_name: 25-50 chars (e.g., "meta-llama/Llama-3-70b-instruct")
@@ -101,6 +103,7 @@ class RedisConnector : public ConnectorBase<WorkerConn> {
   void do_single_set(WorkerConn& conn, const std::string& key, const void* buf,
                      size_t len, size_t chunk_size) override;
   bool do_single_exists(WorkerConn& conn, const std::string& key) override;
+  bool do_single_delete(WorkerConn& conn, const std::string& key) override;
   void shutdown_connections() override;
 
  private:

--- a/docs/design/l2_adapters/l2_eviction.md
+++ b/docs/design/l2_adapters/l2_eviction.md
@@ -197,7 +197,32 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `MockL2Adapter`            | ✓        | ✓           | stored, deleted     |
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `FSL2Adapter`              | no-op    | `(-1, -1)`  | none                |
-| `NativeConnectorL2Adapter` | no-op    | `(-1, -1)`  | none                |
+| `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_bytes`) | stored, deleted |
+
+**Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:
+
+1. The underlying C++ connector must implement `do_single_delete()` (built-in Redis
+   and FS connectors do; third-party plugins may not — in which case `delete()` is a
+   no-op).
+2. The adapter must be configured with `max_capacity_bytes > 0` to enable client-side
+   size tracking for `get_usage()`. Without it, `get_usage()` returns `(-1, -1)` and
+   the eviction controller will not trigger.
+
+Example configuration with eviction enabled:
+
+```json
+{
+  "type": "resp",
+  "host": "localhost",
+  "port": 6379,
+  "max_capacity_bytes": 10737418240,
+  "eviction": {
+    "eviction_policy": "LRU",
+    "trigger_watermark": 0.8,
+    "eviction_ratio": 0.2
+  }
+}
+```
 
 ## Data Flow: Eviction Cycle
 

--- a/docs/design/l2_adapters/l2_eviction.md
+++ b/docs/design/l2_adapters/l2_eviction.md
@@ -197,14 +197,14 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `MockL2Adapter`            | ✓        | ✓           | stored, deleted     |
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `FSL2Adapter`              | no-op    | `(-1, -1)`  | none                |
-| `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_bytes`) | stored, deleted |
+| `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
 
 **Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:
 
 1. The underlying C++ connector must implement `do_single_delete()` (built-in Redis
    and FS connectors do; third-party plugins may not — in which case `delete()` is a
    no-op).
-2. The adapter must be configured with `max_capacity_bytes > 0` to enable client-side
+2. The adapter must be configured with `max_capacity_gb > 0` to enable client-side
    size tracking for `get_usage()`. Without it, `get_usage()` returns `(-1, -1)` and
    the eviction controller will not trigger.
 
@@ -215,7 +215,7 @@ Example configuration with eviction enabled:
   "type": "resp",
   "host": "localhost",
   "port": 6379,
-  "max_capacity_bytes": 10737418240,
+  "max_capacity_gb": 10,
   "eviction": {
     "eviction_policy": "LRU",
     "trigger_watermark": 0.8,

--- a/docs/source/developer_guide/extending_lmcache/native_connectors.rst
+++ b/docs/source/developer_guide/extending_lmcache/native_connectors.rst
@@ -50,7 +50,8 @@ Step 1: C++ Connector
 ---------------------
 
 Create your connector directory (e.g., ``csrc/storage_backends/mybackend/``) and
-inherit from ``ConnectorBase<YourConnectionType>``. You only need to override 4 methods.
+inherit from ``ConnectorBase<YourConnectionType>``. You need to override 4 required methods
+(and optionally ``do_single_delete`` to support eviction).
 
 **connector.h:**
 
@@ -529,7 +530,7 @@ Step-by-Step: Building an External Native Connector Plugin
 
 2. **Implement the C++ connector** inheriting from ``ConnectorBase<T>`` and override
    the 4 required methods (``create_connection``, ``do_single_get``, ``do_single_set``,
-   ``do_single_exists``).
+   ``do_single_exists``) and optionally ``do_single_delete`` for eviction support.
 
 3. **Create pybind11 bindings** using the ``LMCACHE_BIND_CONNECTOR_METHODS`` macro:
 

--- a/docs/source/developer_guide/extending_lmcache/native_connectors.rst
+++ b/docs/source/developer_guide/extending_lmcache/native_connectors.rst
@@ -262,11 +262,11 @@ Create a new file in the L2 adapters package:
     class MyBackendL2AdapterConfig(L2AdapterConfigBase):
         def __init__(self, host: str, port: int,
                      num_workers: int = 8,
-                     max_capacity_bytes: int = 0):
+                     max_capacity_gb: float = 0):
             self.host = host
             self.port = port
             self.num_workers = num_workers
-            self.max_capacity_bytes = max_capacity_bytes
+            self.max_capacity_gb = max_capacity_gb
 
         @classmethod
         def from_dict(cls, d: dict) -> "MyBackendL2AdapterConfig":
@@ -277,10 +277,10 @@ Create a new file in the L2 adapters package:
             if not isinstance(port, int) or port <= 0:
                 raise ValueError("port must be a positive integer")
             num_workers = d.get("num_workers", 8)
-            max_capacity_bytes = d.get("max_capacity_bytes", 0)
+            max_capacity_gb = d.get("max_capacity_gb", 0)
             return cls(host=host, port=port,
                        num_workers=num_workers,
-                       max_capacity_bytes=max_capacity_bytes)
+                       max_capacity_gb=max_capacity_gb)
 
         @classmethod
         def help(cls) -> str:
@@ -308,7 +308,7 @@ Create a new file in the L2 adapters package:
         )
         return NativeConnectorL2Adapter(
             native_client,
-            max_capacity_bytes=config.max_capacity_bytes,
+            max_capacity_gb=config.max_capacity_gb,
         )
 
 
@@ -478,10 +478,10 @@ Configuration
      - ``dict``
      - no
      - Forwarded as ``**kwargs`` to the connector class constructor.
-   * - ``max_capacity_bytes``
-     - ``int``
+   * - ``max_capacity_gb``
+     - ``float``
      - no
-     - Maximum L2 storage capacity in bytes for client-side usage tracking. Required for L2 eviction. Default 0 (disabled).
+     - Maximum L2 storage capacity in GB for client-side usage tracking. Required for L2 eviction. Default 0 (disabled).
 
 Loading Flow
 ~~~~~~~~~~~~

--- a/docs/source/developer_guide/extending_lmcache/native_connectors.rst
+++ b/docs/source/developer_guide/extending_lmcache/native_connectors.rst
@@ -104,6 +104,12 @@ inherit from ``ConnectorBase<YourConnectionType>``. You only need to override 4 
         // send EXISTS, return true/false
       }
 
+      // 5. DELETE: remove key (optional, has default no-op)
+      bool do_single_delete(MyConn& conn,
+                            const std::string& key) override {
+        // send DELETE, return true if deleted, false if not found
+      }
+
       // Optional: clean shutdown
       void shutdown_connections() override {
         // close sockets, free resources
@@ -136,8 +142,8 @@ inherit from ``ConnectorBase<YourConnectionType>``. You only need to override 4 
 Step 2: Pybind Module
 ---------------------
 
-Use the ``LMCACHE_BIND_CONNECTOR_METHODS`` macro, which binds all 6 methods
-(``event_fd``, ``submit_batch_get/set/exists``, ``drain_completions``, ``close``)
+Use the ``LMCACHE_BIND_CONNECTOR_METHODS`` macro, which binds all 7 methods
+(``event_fd``, ``submit_batch_get/set/exists/delete``, ``drain_completions``, ``close``)
 with proper GIL release and Python buffer protocol handling.
 
 .. code-block:: cpp
@@ -255,10 +261,12 @@ Create a new file in the L2 adapters package:
 
     class MyBackendL2AdapterConfig(L2AdapterConfigBase):
         def __init__(self, host: str, port: int,
-                     num_workers: int = 8):
+                     num_workers: int = 8,
+                     max_capacity_bytes: int = 0):
             self.host = host
             self.port = port
             self.num_workers = num_workers
+            self.max_capacity_bytes = max_capacity_bytes
 
         @classmethod
         def from_dict(cls, d: dict) -> "MyBackendL2AdapterConfig":
@@ -269,8 +277,10 @@ Create a new file in the L2 adapters package:
             if not isinstance(port, int) or port <= 0:
                 raise ValueError("port must be a positive integer")
             num_workers = d.get("num_workers", 8)
+            max_capacity_bytes = d.get("max_capacity_bytes", 0)
             return cls(host=host, port=port,
-                       num_workers=num_workers)
+                       num_workers=num_workers,
+                       max_capacity_bytes=max_capacity_bytes)
 
         @classmethod
         def help(cls) -> str:
@@ -296,7 +306,10 @@ Create a new file in the L2 adapters package:
         native_client = LMCacheMyBackendClient(
             config.host, config.port, config.num_workers
         )
-        return NativeConnectorL2Adapter(native_client)
+        return NativeConnectorL2Adapter(
+            native_client,
+            max_capacity_bytes=config.max_capacity_bytes,
+        )
 
 
     # Self-register -- runs automatically when the module
@@ -417,12 +430,18 @@ pybind ``LMCACHE_BIND_CONNECTOR_METHODS`` contract):
             self,
             keys: list[str],
         ) -> int: ...
+        def submit_batch_delete(
+            self,
+            keys: list[str],
+        ) -> int: ...
         def drain_completions(
             self,
         ) -> list[tuple[int, bool, str, list[bool] | None]]: ...
         def close(self) -> None: ...
 
-The factory validates these methods at creation time and raises ``TypeError`` if any are missing.
+The factory validates the first 6 methods at creation time and raises ``TypeError`` if
+any are missing. ``submit_batch_delete`` is **optional** -- if absent, the adapter's
+``delete()`` method will be a no-op (eviction will not remove keys from the backend).
 
 Configuration
 ~~~~~~~~~~~~~
@@ -459,6 +478,10 @@ Configuration
      - ``dict``
      - no
      - Forwarded as ``**kwargs`` to the connector class constructor.
+   * - ``max_capacity_bytes``
+     - ``int``
+     - no
+     - Maximum L2 storage capacity in bytes for client-side usage tracking. Required for L2 eviction. Default 0 (disabled).
 
 Loading Flow
 ~~~~~~~~~~~~
@@ -583,7 +606,7 @@ Checklist
 
 Use this checklist when adding a new native connector:
 
-1. C++ connector inheriting ``ConnectorBase<T>`` with 4 method overrides
+1. C++ connector inheriting ``ConnectorBase<T>`` with 4 required + 1 optional (``do_single_delete``) method overrides
 2. Pybind module using ``LMCACHE_BIND_CONNECTOR_METHODS``
 3. ``setup.py`` entry for the new ``CppExtension``
 4. Python client inheriting ``ConnectorClientBase`` (non-MP mode)
@@ -594,7 +617,7 @@ Use this checklist when adding a new native connector:
 For **external** native connector plugins (``native_plugin``):
 
 1. Separate pip-installable package with C++ pybind11 extension
-2. Connector class exposing the 6 required methods
+2. Connector class exposing the 6 required methods (+ optional ``submit_batch_delete`` for eviction)
 3. Python factory class for backend selection
 4. ``pip install -e .`` and configure via ``--l2-adapter`` JSON
 5. Unit tests (see ``examples/lmc_external_native_connector/tests/``)

--- a/docs/source/kv_cache/storage_backends/resp.rst
+++ b/docs/source/kv_cache/storage_backends/resp.rst
@@ -281,16 +281,16 @@ The ``--l2-adapter`` JSON accepts these fields:
      - str
      - ``""``
      - Redis AUTH password (leave empty for no auth)
-   * - ``max_capacity_bytes``
-     - int
+   * - ``max_capacity_gb``
+     - float
      - 0
-     - Maximum L2 storage capacity in bytes for client-side usage tracking. Required for L2 eviction. Set to 0 (default) to disable usage tracking.
+     - Maximum L2 storage capacity in GB for client-side usage tracking. Required for L2 eviction. Set to 0 (default) to disable usage tracking.
 
 L2 Eviction
 ~~~~~~~~~~~~
 
 To enable automatic eviction of least-recently-used keys when the Redis backend fills up,
-set ``max_capacity_bytes`` and add an ``"eviction"`` block:
+set ``max_capacity_gb`` and add an ``"eviction"`` block:
 
 .. code-block:: bash
 
@@ -303,7 +303,7 @@ set ``max_capacity_bytes`` and add an ``"eviction"`` block:
             "host": "localhost",
             "port": 6379,
             "num_workers": 8,
-            "max_capacity_bytes": 10737418240,
+            "max_capacity_gb": 10,
             "eviction": {
                 "eviction_policy": "LRU",
                 "trigger_watermark": 0.8,
@@ -317,8 +317,8 @@ the eviction controller will delete the least-recently-used ~20% of stored keys
 (``eviction_ratio``) using the Redis ``DEL`` command.
 
 .. note::
-   ``max_capacity_bytes`` enables **client-side** size tracking. It does not configure
-   the Redis server's ``maxmemory`` setting. You should set ``max_capacity_bytes`` to
+   ``max_capacity_gb`` enables **client-side** size tracking. It does not configure
+   the Redis server's ``maxmemory`` setting. You should set ``max_capacity_gb`` to
    match or be slightly below your Redis server's available memory.
 
 

--- a/docs/source/kv_cache/storage_backends/resp.rst
+++ b/docs/source/kv_cache/storage_backends/resp.rst
@@ -281,6 +281,45 @@ The ``--l2-adapter`` JSON accepts these fields:
      - str
      - ``""``
      - Redis AUTH password (leave empty for no auth)
+   * - ``max_capacity_bytes``
+     - int
+     - 0
+     - Maximum L2 storage capacity in bytes for client-side usage tracking. Required for L2 eviction. Set to 0 (default) to disable usage tracking.
+
+L2 Eviction
+~~~~~~~~~~~~
+
+To enable automatic eviction of least-recently-used keys when the Redis backend fills up,
+set ``max_capacity_bytes`` and add an ``"eviction"`` block:
+
+.. code-block:: bash
+
+    lmcache server \
+        --l1-size-gb 10 \
+        --eviction-policy LRU \
+        --chunk-size 16 \
+        --l2-adapter '{
+            "type": "resp",
+            "host": "localhost",
+            "port": 6379,
+            "num_workers": 8,
+            "max_capacity_bytes": 10737418240,
+            "eviction": {
+                "eviction_policy": "LRU",
+                "trigger_watermark": 0.8,
+                "eviction_ratio": 0.2
+            }
+        }' \
+        --port 6555
+
+This configures a 10 GB capacity limit. When usage exceeds 80% (``trigger_watermark``),
+the eviction controller will delete the least-recently-used ~20% of stored keys
+(``eviction_ratio``) using the Redis ``DEL`` command.
+
+.. note::
+   ``max_capacity_bytes`` enables **client-side** size tracking. It does not configure
+   the Redis server's ``maxmemory`` setting. You should set ``max_capacity_bytes`` to
+   match or be slightly below your Redis server's available memory.
 
 
 Testing the Setup

--- a/examples/kv_cache_reuse/remote_backends/resp/README.md
+++ b/examples/kv_cache_reuse/remote_backends/resp/README.md
@@ -91,6 +91,7 @@ The `--l2-adapter` JSON accepts these fields:
 | `num_workers` | int | 8 | C++ worker threads for parallel I/O |
 | `username` | str | `""` | Redis ACL username |
 | `password` | str | `""` | Redis AUTH password |
+| `max_capacity_bytes` | int | 0 | Max L2 capacity in bytes for usage tracking (required for L2 eviction) |
 
 ### Launch vLLM with LMCache MP Connector
 

--- a/examples/kv_cache_reuse/remote_backends/resp/README.md
+++ b/examples/kv_cache_reuse/remote_backends/resp/README.md
@@ -91,7 +91,7 @@ The `--l2-adapter` JSON accepts these fields:
 | `num_workers` | int | 8 | C++ worker threads for parallel I/O |
 | `username` | str | `""` | Redis ACL username |
 | `password` | str | `""` | Redis AUTH password |
-| `max_capacity_bytes` | int | 0 | Max L2 capacity in bytes for usage tracking (required for L2 eviction) |
+| `max_capacity_gb` | float | 0 | Max L2 capacity in GB for usage tracking (required for L2 eviction) |
 
 ### Launch vLLM with LMCache MP Connector
 

--- a/examples/lmc_external_native_connector/csrc/connector.cpp
+++ b/examples/lmc_external_native_connector/csrc/connector.cpp
@@ -172,6 +172,13 @@ bool ExampleFSConnector::do_single_exists(WorkerFSConn& conn,
   return std::filesystem::exists(path);
 }
 
+bool ExampleFSConnector::do_single_delete(WorkerFSConn& conn,
+                                          const std::string& key) {
+  auto path = conn.base_path / safe_filename(key);
+  std::error_code ec;
+  return std::filesystem::remove(path, ec);
+}
+
 // ---------------------------------------------------------------
 // ExampleMemoryConnector
 // ---------------------------------------------------------------
@@ -218,6 +225,12 @@ bool ExampleMemoryConnector::do_single_exists(WorkerMemConn& conn,
                                               const std::string& key) {
   std::lock_guard<std::mutex> lk(conn.store->mu);
   return conn.store->data.count(key) > 0;
+}
+
+bool ExampleMemoryConnector::do_single_delete(WorkerMemConn& conn,
+                                              const std::string& key) {
+  std::lock_guard<std::mutex> lk(conn.store->mu);
+  return conn.store->data.erase(key) > 0;
 }
 
 }  // namespace example_connector

--- a/examples/lmc_external_native_connector/csrc/connector.h
+++ b/examples/lmc_external_native_connector/csrc/connector.h
@@ -33,6 +33,7 @@ class ExampleFSConnector
   void do_single_set(WorkerFSConn& conn, const std::string& key,
                      const void* buf, size_t len, size_t chunk_size) override;
   bool do_single_exists(WorkerFSConn& conn, const std::string& key) override;
+  bool do_single_delete(WorkerFSConn& conn, const std::string& key) override;
 
  private:
   static std::string safe_filename(const std::string& key);
@@ -71,6 +72,7 @@ class ExampleMemoryConnector
   void do_single_set(WorkerMemConn& conn, const std::string& key,
                      const void* buf, size_t len, size_t chunk_size) override;
   bool do_single_exists(WorkerMemConn& conn, const std::string& key) override;
+  bool do_single_delete(WorkerMemConn& conn, const std::string& key) override;
 
  private:
   std::shared_ptr<SharedMemoryStore> store_;

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -54,12 +54,14 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         relative_tmp_dir: str = "",
         use_odirect: bool = False,
         read_ahead_size: Optional[int] = None,
+        max_capacity_bytes: int = 0,
     ):
         self.base_path = base_path
         self.num_workers = num_workers
         self.relative_tmp_dir = relative_tmp_dir
         self.use_odirect = use_odirect
         self.read_ahead_size = read_ahead_size
+        self.max_capacity_bytes = max_capacity_bytes
 
     @classmethod
     def from_dict(cls, d: dict) -> "FSNativeL2AdapterConfig":
@@ -84,12 +86,17 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             if not isinstance(read_ahead_size, int) or read_ahead_size <= 0:
                 raise ValueError("read_ahead_size must be a positive integer")
 
+        max_capacity_bytes = d.get("max_capacity_bytes", 0)
+        if not isinstance(max_capacity_bytes, int) or max_capacity_bytes < 0:
+            raise ValueError("max_capacity_bytes must be a non-negative integer")
+
         return cls(
             base_path=base_path,
             num_workers=num_workers,
             relative_tmp_dir=str(relative_tmp_dir),
             use_odirect=use_odirect,
             read_ahead_size=read_ahead_size,
+            max_capacity_bytes=max_capacity_bytes,
         )
 
     @classmethod
@@ -148,7 +155,9 @@ def _create_fs_native_l2_adapter(
         config.use_odirect,
         config.read_ahead_size,
     )
-    return NativeConnectorL2Adapter(native_client)
+    return NativeConnectorL2Adapter(
+        native_client, max_capacity_bytes=config.max_capacity_bytes
+    )
 
 
 register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -113,7 +113,10 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             "via O_DIRECT (default false)\n"
             "- read_ahead_size (int): trigger fs "
             "readahead by reading this many bytes "
-            "first (optional)"
+            "first (optional)\n"
+            "- max_capacity_bytes (int): max L2 capacity "
+            "in bytes for usage tracking / eviction "
+            "(default 0 = disabled)"
         )
 
 

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -54,14 +54,14 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         relative_tmp_dir: str = "",
         use_odirect: bool = False,
         read_ahead_size: Optional[int] = None,
-        max_capacity_bytes: int = 0,
+        max_capacity_gb: float = 0,
     ):
         self.base_path = base_path
         self.num_workers = num_workers
         self.relative_tmp_dir = relative_tmp_dir
         self.use_odirect = use_odirect
         self.read_ahead_size = read_ahead_size
-        self.max_capacity_bytes = max_capacity_bytes
+        self.max_capacity_gb = max_capacity_gb
 
     @classmethod
     def from_dict(cls, d: dict) -> "FSNativeL2AdapterConfig":
@@ -86,9 +86,9 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             if not isinstance(read_ahead_size, int) or read_ahead_size <= 0:
                 raise ValueError("read_ahead_size must be a positive integer")
 
-        max_capacity_bytes = d.get("max_capacity_bytes", 0)
-        if not isinstance(max_capacity_bytes, int) or max_capacity_bytes < 0:
-            raise ValueError("max_capacity_bytes must be a non-negative integer")
+        max_capacity_gb = d.get("max_capacity_gb", 0)
+        if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
+            raise ValueError("max_capacity_gb must be a non-negative number")
 
         return cls(
             base_path=base_path,
@@ -96,7 +96,7 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             relative_tmp_dir=str(relative_tmp_dir),
             use_odirect=use_odirect,
             read_ahead_size=read_ahead_size,
-            max_capacity_bytes=max_capacity_bytes,
+            max_capacity_gb=float(max_capacity_gb),
         )
 
     @classmethod
@@ -114,8 +114,8 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             "- read_ahead_size (int): trigger fs "
             "readahead by reading this many bytes "
             "first (optional)\n"
-            "- max_capacity_bytes (int): max L2 capacity "
-            "in bytes for usage tracking / eviction "
+            "- max_capacity_gb (float): max L2 capacity "
+            "in GB for usage tracking / eviction "
             "(default 0 = disabled)"
         )
 
@@ -159,7 +159,7 @@ def _create_fs_native_l2_adapter(
         config.read_ahead_size,
     )
     return NativeConnectorL2Adapter(
-        native_client, max_capacity_bytes=config.max_capacity_bytes
+        native_client, max_capacity_gb=config.max_capacity_gb
     )
 
 

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -240,7 +240,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                 self._OP_LOAD,
                 task_id,
                 len(keys),
-                None,
+                list(keys),
             )
 
         return task_id
@@ -254,6 +254,16 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     # ---------------------------------------------------------------
 
     def delete(self, keys: list[ObjectKey]) -> None:
+        """Delete a batch of keys from the remote backend.
+
+        Submits a batch delete to the native connector and blocks
+        until the demux thread signals completion (up to 30s timeout).
+        Fires ``_notify_keys_deleted`` on success so eviction policy
+        tracking stays in sync.
+
+        No-op if the connector does not expose ``submit_batch_delete``
+        or if the key list is empty.
+        """
         if not keys or not self._has_delete:
             return
 
@@ -273,6 +283,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         # Block until demux thread signals completion
         if not done_event.wait(timeout=30.0):
+            with self._lock:
+                self._pending_delete_events.pop(task_id, None)
+                # Note: _pending_ops entry may already be consumed
+                # by the demux thread; pop is safe either way.
+                for fid, entry in list(self._pending_ops.items()):
+                    if entry[1] == task_id:
+                        self._pending_ops.pop(fid, None)
+                        break
             logger.warning(
                 "delete() timed out after 30s for %d keys",
                 len(keys),
@@ -335,6 +353,11 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             if not completions:
                 continue
 
+            # Collect listener notifications to fire after
+            # releasing the lock.
+            keys_stored: list[ObjectKey] = []
+            keys_accessed: list[ObjectKey] = []
+
             with self._lock:
                 for (
                     future_id,
@@ -368,6 +391,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                 if key not in self._key_sizes:
                                     self._key_sizes[key] = size
                                     self._current_size_bytes += size
+                            keys_stored.extend(store_keys)
                         os.eventfd_write(self._store_efd, 1)
 
                     elif op_type == self._OP_LOOKUP:
@@ -383,15 +407,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
                     elif op_type == self._OP_LOAD:
                         bitmap = Bitmap(num_keys)
+                        loaded_keys: list[ObjectKey] = []
                         if result_bools is not None:
                             for i, loaded in enumerate(result_bools):
                                 if loaded:
                                     bitmap.set(i)
+                                    if lookup_keys is not None:
+                                        loaded_keys.append(lookup_keys[i])
                         elif ok:
                             # Fallback for connectors that
                             # do not report per-key results
                             for i in range(num_keys):
                                 bitmap.set(i)
+                            if lookup_keys is not None:
+                                loaded_keys.extend(lookup_keys)
+                        keys_accessed.extend(loaded_keys)
                         self._completed_loads[task_id] = bitmap
                         os.eventfd_write(self._load_efd, 1)
 
@@ -406,3 +436,9 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         evt = self._pending_delete_events.pop(task_id, None)
                         if evt is not None:
                             evt.set()
+
+            # Fire listener notifications outside the lock
+            if keys_stored:
+                self._notify_keys_stored(keys_stored)
+            if keys_accessed:
+                self._notify_keys_accessed(keys_accessed)

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -79,7 +79,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     _OP_LOAD = "load"
     _OP_DELETE = "delete"
 
-    def __init__(self, native_client, max_capacity_bytes: int = 0):
+    def __init__(self, native_client, max_capacity_gb: float = 0):
         super().__init__()
         self._client = native_client
         self._client_fd: int = int(native_client.event_fd())
@@ -114,7 +114,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
 
         # Client-side size tracking for get_usage()
-        self._max_capacity_bytes = max_capacity_bytes
+        self._max_capacity_bytes = int(max_capacity_gb * (1024**3))
         self._current_size_bytes: int = 0
         self._key_sizes: dict[ObjectKey, int] = {}
         # Pending store sizes: native future_id -> (keys, per_key_sizes)

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -77,8 +77,10 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     _OP_STORE = "store"
     _OP_LOOKUP = "lookup"
     _OP_LOAD = "load"
+    _OP_DELETE = "delete"
 
     def __init__(self, native_client):
+        super().__init__()
         self._client = native_client
         self._client_fd: int = int(native_client.event_fd())
 
@@ -104,6 +106,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         # Client-side lock tracking (refcount per key)
         self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+
+        # Delete capability detection
+        self._has_delete = callable(getattr(native_client, "submit_batch_delete", None))
+
+        # Pending delete events for synchronous delete() calls
+        self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
 
         # Task ID counter
         self._next_task_id: L2TaskId = 0
@@ -237,11 +245,37 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     # ---------------------------------------------------------------
 
     def delete(self, keys: list[ObjectKey]) -> None:
-        # Not implemented for the native connector adapter.
-        pass
+        if not keys or not self._has_delete:
+            return
+
+        key_strings = [_object_key_to_string(k) for k in keys]
+        done_event = threading.Event()
+
+        with self._lock:
+            task_id = self._get_next_task_id()
+            future_id = int(self._client.submit_batch_delete(key_strings))
+            self._pending_ops[future_id] = (
+                self._OP_DELETE,
+                task_id,
+                len(keys),
+                list(keys),
+            )
+            self._pending_delete_events[task_id] = done_event
+
+        # Block until demux thread signals completion
+        if not done_event.wait(timeout=30.0):
+            logger.warning(
+                "delete() timed out after 30s for %d keys",
+                len(keys),
+            )
+            return
+
+        self._notify_keys_deleted(keys)
 
     def get_usage(self) -> tuple[float, float]:
-        # Not implemented for the native connector adapter.
+        # Not yet implemented for the native connector adapter.
+        # Usage-based eviction triggering requires backend-specific
+        # introspection or client-side size tracking (future work).
         return (-1.0, -1.0)
 
     # ---------------------------------------------------------------
@@ -342,3 +376,8 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                 bitmap.set(i)
                         self._completed_loads[task_id] = bitmap
                         os.eventfd_write(self._load_efd, 1)
+
+                    elif op_type == self._OP_DELETE:
+                        evt = self._pending_delete_events.pop(task_id, None)
+                        if evt is not None:
+                            evt.set()

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -79,7 +79,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     _OP_LOAD = "load"
     _OP_DELETE = "delete"
 
-    def __init__(self, native_client):
+    def __init__(self, native_client, max_capacity_bytes: int = 0):
         super().__init__()
         self._client = native_client
         self._client_fd: int = int(native_client.event_fd())
@@ -112,6 +112,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         # Pending delete events for synchronous delete() calls
         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+
+        # Client-side size tracking for get_usage()
+        self._max_capacity_bytes = max_capacity_bytes
+        self._current_size_bytes: int = 0
+        self._key_sizes: dict[ObjectKey, int] = {}
+        # Pending store sizes: native future_id -> (keys, per_key_sizes)
+        self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
 
         # Task ID counter
         self._next_task_id: L2TaskId = 0
@@ -152,6 +159,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     ) -> L2TaskId:
         key_strings = [_object_key_to_string(k) for k in keys]
         memviews = [_obj_to_memoryview(obj) for obj in objects]
+        per_key_sizes = [obj.get_size() for obj in objects]
 
         # Register pending op BEFORE submit to avoid race
         # with demux thread. The native submit is
@@ -165,6 +173,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                 len(keys),
                 None,
             )
+            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
 
         return task_id
 
@@ -273,10 +282,11 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         self._notify_keys_deleted(keys)
 
     def get_usage(self) -> tuple[float, float]:
-        # Not yet implemented for the native connector adapter.
-        # Usage-based eviction triggering requires backend-specific
-        # introspection or client-side size tracking (future work).
-        return (-1.0, -1.0)
+        if self._max_capacity_bytes <= 0:
+            return (-1.0, -1.0)
+        with self._lock:
+            usage = self._current_size_bytes / self._max_capacity_bytes
+            return (usage, usage)
 
     # ---------------------------------------------------------------
     # Cleanup
@@ -350,6 +360,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
                     if op_type == self._OP_STORE:
                         self._completed_stores[task_id] = ok
+                        # Update size tracking on success
+                        store_info = self._pending_store_sizes.pop(fid, None)
+                        if ok and store_info is not None:
+                            store_keys, sizes = store_info
+                            for key, size in zip(store_keys, sizes, strict=False):
+                                if key not in self._key_sizes:
+                                    self._key_sizes[key] = size
+                                    self._current_size_bytes += size
                         os.eventfd_write(self._store_efd, 1)
 
                     elif op_type == self._OP_LOOKUP:
@@ -378,6 +396,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         os.eventfd_write(self._load_efd, 1)
 
                     elif op_type == self._OP_DELETE:
+                        # Decrement sizes for successfully deleted keys
+                        if result_bools is not None and lookup_keys is not None:
+                            for i, deleted in enumerate(result_bools):
+                                if deleted:
+                                    key = lookup_keys[i]
+                                    size = self._key_sizes.pop(key, 0)
+                                    self._current_size_bytes -= size
                         evt = self._pending_delete_events.pop(task_id, None)
                         if evt is not None:
                             evt.set()

--- a/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
@@ -105,7 +105,10 @@ class NativePluginL2AdapterConfig(L2AdapterConfigBase):
             '"module_path": "my_ext.connector", '
             '"class_name": "MyConnectorClient", '
             '"adapter_params": '
-            '{"host": "localhost", "port": 1234}}'
+            '{"host": "localhost", "port": 1234}}\n'
+            "- max_capacity_bytes (int): max L2 capacity "
+            "in bytes for usage tracking / eviction "
+            "(default 0 = disabled)"
         )
 
 

--- a/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
@@ -166,6 +166,14 @@ def _create_native_plugin_l2_adapter(
             native_client.close()
         raise
 
+    if not callable(getattr(native_client, "submit_batch_delete", None)):
+        logger.warning(
+            "%s.%s does not expose submit_batch_delete; "
+            "L2 eviction delete will be a no-op.",
+            config.module_path,
+            config.class_name,
+        )
+
     logger.info(
         "Created native plugin L2 adapter: %s.%s (params=%s)",
         config.module_path,

--- a/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
@@ -55,12 +55,12 @@ class NativePluginL2AdapterConfig(L2AdapterConfigBase):
         module_path: str,
         class_name: str,
         adapter_params: dict[str, Any] | None = None,
-        max_capacity_bytes: int = 0,
+        max_capacity_gb: float = 0,
     ):
         self.module_path = module_path
         self.class_name = class_name
         self.adapter_params = adapter_params or {}
-        self.max_capacity_bytes = max_capacity_bytes
+        self.max_capacity_gb = max_capacity_gb
 
     @classmethod
     def from_dict(cls, d: dict) -> "NativePluginL2AdapterConfig":
@@ -76,15 +76,15 @@ class NativePluginL2AdapterConfig(L2AdapterConfigBase):
         if not isinstance(adapter_params, dict):
             raise ValueError("adapter_params must be a dict")
 
-        max_capacity_bytes = d.get("max_capacity_bytes", 0)
-        if not isinstance(max_capacity_bytes, int) or max_capacity_bytes < 0:
-            raise ValueError("max_capacity_bytes must be a non-negative integer")
+        max_capacity_gb = d.get("max_capacity_gb", 0)
+        if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
+            raise ValueError("max_capacity_gb must be a non-negative number")
 
         return cls(
             module_path=module_path,
             class_name=class_name,
             adapter_params=adapter_params,
-            max_capacity_bytes=max_capacity_bytes,
+            max_capacity_gb=float(max_capacity_gb),
         )
 
     @classmethod
@@ -106,8 +106,8 @@ class NativePluginL2AdapterConfig(L2AdapterConfigBase):
             '"class_name": "MyConnectorClient", '
             '"adapter_params": '
             '{"host": "localhost", "port": 1234}}\n'
-            "- max_capacity_bytes (int): max L2 capacity "
-            "in bytes for usage tracking / eviction "
+            "- max_capacity_gb (float): max L2 capacity "
+            "in GB for usage tracking / eviction "
             "(default 0 = disabled)"
         )
 
@@ -191,7 +191,7 @@ def _create_native_plugin_l2_adapter(
         config.adapter_params,
     )
     return NativeConnectorL2Adapter(
-        native_client, max_capacity_bytes=config.max_capacity_bytes
+        native_client, max_capacity_gb=config.max_capacity_gb
     )
 
 

--- a/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
@@ -55,10 +55,12 @@ class NativePluginL2AdapterConfig(L2AdapterConfigBase):
         module_path: str,
         class_name: str,
         adapter_params: dict[str, Any] | None = None,
+        max_capacity_bytes: int = 0,
     ):
         self.module_path = module_path
         self.class_name = class_name
         self.adapter_params = adapter_params or {}
+        self.max_capacity_bytes = max_capacity_bytes
 
     @classmethod
     def from_dict(cls, d: dict) -> "NativePluginL2AdapterConfig":
@@ -74,10 +76,15 @@ class NativePluginL2AdapterConfig(L2AdapterConfigBase):
         if not isinstance(adapter_params, dict):
             raise ValueError("adapter_params must be a dict")
 
+        max_capacity_bytes = d.get("max_capacity_bytes", 0)
+        if not isinstance(max_capacity_bytes, int) or max_capacity_bytes < 0:
+            raise ValueError("max_capacity_bytes must be a non-negative integer")
+
         return cls(
             module_path=module_path,
             class_name=class_name,
             adapter_params=adapter_params,
+            max_capacity_bytes=max_capacity_bytes,
         )
 
     @classmethod
@@ -180,7 +187,9 @@ def _create_native_plugin_l2_adapter(
         config.class_name,
         config.adapter_params,
     )
-    return NativeConnectorL2Adapter(native_client)
+    return NativeConnectorL2Adapter(
+        native_client, max_capacity_bytes=config.max_capacity_bytes
+    )
 
 
 register_l2_adapter_type("native_plugin", NativePluginL2AdapterConfig)

--- a/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
@@ -53,6 +53,7 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
         num_workers: int = 8,
         username: str = "",
         password: str = "",
+        max_capacity_bytes: int = 0,
     ):
         super().__init__()
         self.host = host
@@ -60,6 +61,7 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
         self.num_workers = num_workers
         self.username = username
         self.password = password
+        self.max_capacity_bytes = max_capacity_bytes
 
     @classmethod
     def from_dict(cls, d: dict) -> "RESPL2AdapterConfig":
@@ -78,12 +80,17 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
         username = d.get("username", "")
         password = d.get("password", "")
 
+        max_capacity_bytes = d.get("max_capacity_bytes", 0)
+        if not isinstance(max_capacity_bytes, int) or max_capacity_bytes < 0:
+            raise ValueError("max_capacity_bytes must be a non-negative integer")
+
         return cls(
             host=host,
             port=port,
             num_workers=num_workers,
             username=str(username),
             password=str(password),
+            max_capacity_bytes=max_capacity_bytes,
         )
 
     @classmethod
@@ -139,7 +146,9 @@ def _create_resp_l2_adapter(
         config.port,
         config.num_workers,
     )
-    return NativeConnectorL2Adapter(native_client)
+    return NativeConnectorL2Adapter(
+        native_client, max_capacity_bytes=config.max_capacity_bytes
+    )
 
 
 # Self-register config type and adapter factory

--- a/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
@@ -105,7 +105,10 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
             "- username (str): auth username "
             "(default empty)\n"
             "- password (str): auth password "
-            "(default empty)"
+            "(default empty)\n"
+            "- max_capacity_bytes (int): max L2 capacity "
+            "in bytes for usage tracking / eviction "
+            "(default 0 = disabled)"
         )
 
 

--- a/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
@@ -53,7 +53,7 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
         num_workers: int = 8,
         username: str = "",
         password: str = "",
-        max_capacity_bytes: int = 0,
+        max_capacity_gb: float = 0,
     ):
         super().__init__()
         self.host = host
@@ -61,7 +61,7 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
         self.num_workers = num_workers
         self.username = username
         self.password = password
-        self.max_capacity_bytes = max_capacity_bytes
+        self.max_capacity_gb = max_capacity_gb
 
     @classmethod
     def from_dict(cls, d: dict) -> "RESPL2AdapterConfig":
@@ -80,9 +80,9 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
         username = d.get("username", "")
         password = d.get("password", "")
 
-        max_capacity_bytes = d.get("max_capacity_bytes", 0)
-        if not isinstance(max_capacity_bytes, int) or max_capacity_bytes < 0:
-            raise ValueError("max_capacity_bytes must be a non-negative integer")
+        max_capacity_gb = d.get("max_capacity_gb", 0)
+        if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
+            raise ValueError("max_capacity_gb must be a non-negative number")
 
         return cls(
             host=host,
@@ -90,7 +90,7 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
             num_workers=num_workers,
             username=str(username),
             password=str(password),
-            max_capacity_bytes=max_capacity_bytes,
+            max_capacity_gb=float(max_capacity_gb),
         )
 
     @classmethod
@@ -106,8 +106,8 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
             "(default empty)\n"
             "- password (str): auth password "
             "(default empty)\n"
-            "- max_capacity_bytes (int): max L2 capacity "
-            "in bytes for usage tracking / eviction "
+            "- max_capacity_gb (float): max L2 capacity "
+            "in GB for usage tracking / eviction "
             "(default 0 = disabled)"
         )
 
@@ -150,7 +150,7 @@ def _create_resp_l2_adapter(
         config.num_workers,
     )
     return NativeConnectorL2Adapter(
-        native_client, max_capacity_bytes=config.max_capacity_bytes
+        native_client, max_capacity_gb=config.max_capacity_gb
     )
 
 

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -1072,3 +1072,104 @@ class TestDeleteBackwardCompatibility:
             adp.delete([key])  # should not raise, just no-op
         finally:
             adp.close()
+
+
+# =============================================================================
+# Usage Tracking Tests
+# =============================================================================
+
+
+@pytest.fixture
+def adapter_with_capacity():
+    """Adapter with max_capacity_bytes set for usage tracking tests."""
+    mock_client = MockNativeConnector()
+    # 100 floats * 4 bytes = 400 bytes per obj; set capacity to 2000 bytes (5 objects)
+    adp = NativeConnectorL2Adapter(mock_client, max_capacity_bytes=2000)
+    yield adp
+    adp.close()
+
+
+class TestUsageTracking:
+    def test_get_usage_without_capacity(self, adapter):
+        """Without max_capacity_bytes, get_usage returns (-1, -1)."""
+        usage = adapter.get_usage()
+        assert usage == (-1.0, -1.0)
+
+    def test_get_usage_starts_at_zero(self, adapter_with_capacity):
+        usage, _ = adapter_with_capacity.get_usage()
+        assert usage == 0.0
+
+    def test_get_usage_after_store(self, adapter_with_capacity):
+        adp = adapter_with_capacity
+        store_fd = adp.get_store_event_fd()
+
+        key = create_object_key(1)
+        obj = create_memory_obj(size=100, fill_value=1.0)  # 100 floats = 400 bytes
+
+        adp.submit_store_task([key], [obj])
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adp.pop_completed_store_tasks()
+
+        usage, _ = adp.get_usage()
+        # 400 bytes / 2000 bytes = 0.2
+        assert usage == pytest.approx(0.2)
+
+    def test_get_usage_after_delete(self, adapter_with_capacity):
+        adp = adapter_with_capacity
+        store_fd = adp.get_store_event_fd()
+
+        key = create_object_key(1)
+        obj = create_memory_obj(size=100, fill_value=1.0)
+
+        # Store
+        adp.submit_store_task([key], [obj])
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adp.pop_completed_store_tasks()
+
+        assert adp.get_usage()[0] == pytest.approx(0.2)
+
+        # Delete
+        adp.delete([key])
+
+        assert adp.get_usage()[0] == pytest.approx(0.0)
+
+    def test_get_usage_store_delete_cycle(self, adapter_with_capacity):
+        adp = adapter_with_capacity
+        store_fd = adp.get_store_event_fd()
+
+        # Store 3 objects (3 * 400 = 1200 bytes)
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(size=100, fill_value=float(i)) for i in range(3)]
+
+        adp.submit_store_task(keys, objs)
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adp.pop_completed_store_tasks()
+
+        usage, _ = adp.get_usage()
+        assert usage == pytest.approx(1200 / 2000)
+
+        # Delete 2
+        adp.delete(keys[:2])
+
+        usage, _ = adp.get_usage()
+        assert usage == pytest.approx(400 / 2000)
+
+    def test_idempotent_store_no_double_count(self, adapter_with_capacity):
+        adp = adapter_with_capacity
+        store_fd = adp.get_store_event_fd()
+
+        key = create_object_key(1)
+        obj = create_memory_obj(size=100, fill_value=1.0)
+
+        # Store same key twice
+        adp.submit_store_task([key], [obj])
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adp.pop_completed_store_tasks()
+
+        adp.submit_store_task([key], [obj])
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adp.pop_completed_store_tasks()
+
+        # Should only count once
+        usage, _ = adp.get_usage()
+        assert usage == pytest.approx(0.2)

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -108,6 +108,22 @@ class MockNativeConnector:
 
         return fid
 
+    def submit_batch_delete(self, keys: list[str]) -> int:
+        with self._lock:
+            fid = self._next_id
+            self._next_id += 1
+
+        results = []
+        for key in keys:
+            if key in self._store:
+                del self._store[key]
+                results.append(True)
+            else:
+                results.append(False)
+        self._push_completion(fid, True, "", results)
+
+        return fid
+
     def drain_completions(self) -> list[tuple[int, bool, str, list[bool] | None]]:
         # Drain the eventfd
         try:
@@ -946,3 +962,113 @@ class TestFSNativeL2AdapterConfig:
             base_path="/tmp/test",
         )
         assert get_type_name_for_config(cfg) == "fs_native"
+
+
+# =============================================================================
+# Delete Interface Tests
+# =============================================================================
+
+
+class TestDeleteInterface:
+    def test_delete_existing_key(self, adapter):
+        key = create_object_key(1)
+        obj = create_memory_obj()
+        store_fd = adapter.get_store_event_fd()
+        lookup_fd = adapter.get_lookup_and_lock_event_fd()
+
+        # Store
+        adapter.submit_store_task([key], [obj])
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adapter.pop_completed_store_tasks()
+
+        # Verify exists
+        task_id = adapter.submit_lookup_and_lock_task([key])
+        wait_for_event_fd(lookup_fd, timeout=5.0)
+        bitmap = adapter.query_lookup_and_lock_result(task_id)
+        assert bitmap.test(0) is True
+        adapter.submit_unlock([key])
+
+        # Delete (synchronous)
+        adapter.delete([key])
+
+        # Verify gone
+        task_id = adapter.submit_lookup_and_lock_task([key])
+        wait_for_event_fd(lookup_fd, timeout=5.0)
+        bitmap = adapter.query_lookup_and_lock_result(task_id)
+        assert bitmap.test(0) is False
+
+    def test_delete_nonexistent_key(self, adapter):
+        key = create_object_key(999)
+        adapter.delete([key])  # should not raise
+
+    def test_delete_empty_keys(self, adapter):
+        adapter.delete([])  # should not raise
+
+    def test_delete_batch(self, adapter):
+        keys = [create_object_key(i) for i in range(5)]
+        objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+        store_fd = adapter.get_store_event_fd()
+        lookup_fd = adapter.get_lookup_and_lock_event_fd()
+
+        # Store all
+        adapter.submit_store_task(keys, objs)
+        wait_for_event_fd(store_fd, timeout=5.0)
+        adapter.pop_completed_store_tasks()
+
+        # Delete first 3
+        adapter.delete(keys[:3])
+
+        # Verify: first 3 gone, last 2 remain
+        task_id = adapter.submit_lookup_and_lock_task(keys)
+        wait_for_event_fd(lookup_fd, timeout=5.0)
+        bitmap = adapter.query_lookup_and_lock_result(task_id)
+        for i in range(3):
+            assert bitmap.test(i) is False
+        for i in range(3, 5):
+            assert bitmap.test(i) is True
+        adapter.submit_unlock(keys[3:])
+
+
+# =============================================================================
+# Delete Backward Compatibility Tests
+# =============================================================================
+
+
+class TestDeleteBackwardCompatibility:
+    def test_delete_noop_without_submit_batch_delete(self):
+        """Connector without submit_batch_delete => delete is no-op."""
+
+        class NoDeleteConnector:
+            """Mock connector that only has the 6 original methods."""
+
+            def __init__(self):
+                self._efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+                self._closed = False
+
+            def event_fd(self) -> int:
+                return self._efd
+
+            def submit_batch_get(self, keys, memoryviews):
+                return 0
+
+            def submit_batch_set(self, keys, memoryviews):
+                return 0
+
+            def submit_batch_exists(self, keys):
+                return 0
+
+            def drain_completions(self):
+                return []
+
+            def close(self):
+                if not self._closed:
+                    self._closed = True
+                    os.close(self._efd)
+
+        client = NoDeleteConnector()
+        adp = NativeConnectorL2Adapter(client)
+        try:
+            key = create_object_key(1)
+            adp.delete([key])  # should not raise, just no-op
+        finally:
+            adp.close()

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -1081,10 +1081,10 @@ class TestDeleteBackwardCompatibility:
 
 @pytest.fixture
 def adapter_with_capacity():
-    """Adapter with max_capacity_bytes set for usage tracking tests."""
+    """Adapter with max_capacity_gb set for usage tracking tests."""
     mock_client = MockNativeConnector()
-    # 100 floats * 4 bytes = 400 bytes per obj; set capacity to 2000 bytes (5 objects)
-    adp = NativeConnectorL2Adapter(mock_client, max_capacity_bytes=2000)
+    # 100 floats * 4 bytes = 400 bytes per obj; capacity = 2000 bytes = 2000/1024^3 GB
+    adp = NativeConnectorL2Adapter(mock_client, max_capacity_gb=2000 / (1024**3))
     yield adp
     adp.close()
 


### PR DESCRIPTION
Adds a DELETE operation through all layers of the native connector framework and hooks into the the existing eviction controller.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds deletion and capacity tracking paths to the native connector stack and wires them into MP-mode eviction, which can remove backend data and introduces new cross-thread accounting/timeout behavior.
> 
> **Overview**
> Enables L2 eviction for native backends by adding a new batched `DELETE` operation end-to-end: `IStorageConnector`/`ConnectorBase` gain `submit_batch_delete`, pybind exposes it, and built-in Redis/FS (plus the external connector example) implement `do_single_delete`.
> 
> Updates `NativeConnectorL2Adapter` to (a) synchronously delete keys via `submit_batch_delete` when available (otherwise no-op for backward compatibility), (b) emit eviction listener events (`_notify_keys_stored/accessed/deleted`) from the demux thread, and (c) optionally report `get_usage()` using client-side size tracking gated by new `max_capacity_gb` config passed through `resp`, `fs_native`, and `native_plugin` adapters.
> 
> Adds docs and tests covering delete behavior, backward compatibility when `submit_batch_delete` is missing, and usage accounting across store/delete cycles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01612059ad43e1b20f9f887fc8d68c1dec97333d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->