### PR TITLE
[Bugfix]: fix get_num_heads for MLA format

### DIFF
--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -561,7 +561,8 @@ def get_num_heads(kv_caches: Any, gpu_kv_format: "lmc_ops.GPUKVFormat") -> int:
         # HND: [..., NH, BS, HS] — num_heads at shape[2]
         return kv_caches[0].shape[2]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
-        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=gpu_kv_format))
+        # MLA: heads are absorbed into hidden dim, so num_heads = 1
+        return 1
     elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         return kv_caches[0][0].shape[1]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:


### PR DESCRIPTION
MLA format (NL_X_NB_BS_HS) absorbs heads into the hidden dim, so get_num_heads should return 1 instead of raising ValueError. This was preventing all MLA models (e.g. DeepSeek-V2-Lite) from launching. 

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single helper to stop raising and to return a constant for the `NL_X_NB_BS_HS` (MLA) KV format, affecting only head-count introspection for MLA models.
> 
> **Overview**
> Fixes `get_num_heads` to handle the MLA KV cache format (`GPUKVFormat.NL_X_NB_BS_HS`) by returning `1` (heads folded into hidden dim) instead of raising `ValueError`, unblocking MLA-based model startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b7449640184706368e43cf6c478c4a1aee2e2c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->