### PR TITLE
[MP] Lazy start heartbeat thread when first req coming

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -532,8 +532,8 @@ class LMCacheMPWorkerAdapter:
         self._health_event.set()
 
         # Heartbeat thread is created but NOT started yet.
-        # It will be lazily started on the first get_finished()
-        # call, by which time vLLM is fully ready (model loaded,
+        # It will be lazily started on the first store or retrieve
+        # request, by which time vLLM is fully ready (model loaded,
         # KV caches allocated, warmup & CUDA graph capture done).
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -532,8 +532,9 @@ class LMCacheMPWorkerAdapter:
         self._health_event.set()
 
         # Heartbeat thread is created but NOT started yet.
-        # It will be started after register_kv_caches()
-        # completes, i.e. after vLLM is fully ready.
+        # It will be lazily started on the first get_finished()
+        # call, by which time vLLM is fully ready (model loaded,
+        # KV caches allocated, warmup & CUDA graph capture done).
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None
         self._heartbeat_lock = threading.Lock()
@@ -600,12 +601,8 @@ class LMCacheMPWorkerAdapter:
                 f"{self._mq_timeout}s. Is the server running?"
             ) from None
 
-        # Start heartbeat only after vLLM is fully ready
-        # (model loaded, KV caches allocated, warmup done).
-        self._start_heartbeat()
-
-    def _start_heartbeat(self) -> None:
-        """Start the heartbeat thread (idempotent)."""
+    def _ensure_heartbeat_started(self) -> None:
+        """Lazily start the heartbeat thread on first use."""
         if self._heartbeat is not None:
             return
         with self._heartbeat_lock:
@@ -631,6 +628,8 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
         """
+        self._ensure_heartbeat_started()
+
         if not self.is_healthy:
             return
 
@@ -656,6 +655,8 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
         """
+        self._ensure_heartbeat_started()
+
         if not self.is_healthy:
             self.error_block_ids.update(op.block_ids)
             return


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

I'm sorry #2798 is not good enough, the current PR make it lazy start heartbeat thread when first req coming.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing of heartbeat thread startup in the vLLM multiprocess adapter, which can affect health detection and degraded-mode behavior during startup and early requests. Concurrency/thread-lifecycle adjustments may introduce subtle race or ordering issues.
> 
> **Overview**
> Defers starting the LMCache `HeartbeatThread` in `LMCacheMPWorkerAdapter` until the first `submit_store_request` or `submit_retrieve_request`, instead of starting it immediately after `register_kv_caches` completes.
> 
> Replaces the eager `_start_heartbeat` call with an idempotent `_ensure_heartbeat_started` helper and updates comments to clarify the new “start on first use” behavior once vLLM initialization (model load, KV allocation, warmup/CUDA graph capture) is complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2775a487d537b3505293e9ef68a9ba046b9179aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->