### PR TITLE
[Feat][RawBlock] Add TP>1 support and compact batched retrieval path

### DIFF
--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -55,6 +55,11 @@ def _validate_per_tp_device_paths(per_tp_devices: PerTPDevicePaths) -> None:
 def _get_per_tp_device_path(
     per_tp_devices: PerTPDevicePaths, tp_rank: int
 ) -> Optional[str]:
+    """Return the configured device path for a TP rank.
+
+    Looks up both string and integer forms of ``tp_rank`` so YAML mappings
+    with either quoted or unquoted numeric keys are accepted.
+    """
     return per_tp_devices.get(str(tp_rank), per_tp_devices.get(tp_rank))
 
 

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -789,6 +789,12 @@ class RustRawBlockBackend(StoragePluginInterface):
 
                 loaded.append(memory_obj)
                 touched.append(key)
+        except Exception:
+            for memory_obj in loaded:
+                memory_obj.ref_count_down()
+            loaded.clear()
+            touched.clear()
+            raise
         finally:
             with self._lock:
                 for key in touched:

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -712,10 +712,10 @@ class RustRawBlockBackend(StoragePluginInterface):
                 return []
             self._inflight_io_count += 1
 
-        raw_dev = self._rawdev()
         loaded: list[MemoryObj] = []
         touched: list[CacheEngineKey] = []
         try:
+            raw_dev = self._rawdev()
             for key, entry in items:
                 meta = entry.meta
                 assert meta.shape is not None and meta.dtype is not None
@@ -723,38 +723,43 @@ class RustRawBlockBackend(StoragePluginInterface):
                 memory_obj = self.local_cpu_backend.allocate(
                     meta.shape, meta.dtype, meta.fmt
                 )
-                assert memory_obj is not None
+                if memory_obj is None:
+                    logger.error(
+                        "Failed to allocate memory for key %s",
+                        self._dbg_key_short(key),
+                    )
+                    break
 
-                payload_len = int(meta.size)
-                total_len = (
-                    _round_up(payload_len, self.block_align)
-                    if self.use_odirect
-                    else payload_len
-                )
-                if logger.isEnabledFor(10):
-                    self._dbg_get_calls += 1
-                    self._dbg_get_bytes += payload_len
-                    if self._dbg_should_log(self._dbg_get_calls):
-                        logger.debug(
-                            "RustRawBlockBackend GET: %s offset=%d size=%d",
-                            self._dbg_key_short(key),
-                            int(entry.offset),
-                            payload_len,
-                        )
+                try:
+                    payload_len = int(meta.size)
+                    total_len = (
+                        _round_up(payload_len, self.block_align)
+                        if self.use_odirect
+                        else payload_len
+                    )
+                    if logger.isEnabledFor(10):
+                        self._dbg_get_calls += 1
+                        self._dbg_get_bytes += payload_len
+                        if self._dbg_should_log(self._dbg_get_calls):
+                            logger.debug(
+                                "RustRawBlockBackend GET: %s offset=%d size=%d",
+                                self._dbg_key_short(key),
+                                int(entry.offset),
+                                payload_len,
+                            )
 
-                buf = memory_obj.byte_array
-                try:
-                    buf = buf.cast("B")
-                except Exception:
-                    pass
-                direct_view = self._build_direct_odirect_view(
-                    memory_obj=memory_obj,
-                    payload_len=payload_len,
-                    total_len=total_len,
-                    buffer_len=len(buf),
-                    zero_tail=False,
-                )
-                try:
+                    buf = memory_obj.byte_array
+                    try:
+                        buf = buf.cast("B")
+                    except Exception:
+                        pass
+                    direct_view = self._build_direct_odirect_view(
+                        memory_obj=memory_obj,
+                        payload_len=payload_len,
+                        total_len=total_len,
+                        buffer_len=len(buf),
+                        zero_tail=False,
+                    )
                     if direct_view is not None:
                         raw_dev.pread_into(
                             entry.offset + self.header_bytes,
@@ -769,6 +774,8 @@ class RustRawBlockBackend(StoragePluginInterface):
                             payload_len,
                             total_len,
                         )
+
+                    memory_obj.metadata.cached_positions = meta.cached_positions
                 except Exception as e:
                     memory_obj.ref_count_down()
                     logger.error(
@@ -776,7 +783,6 @@ class RustRawBlockBackend(StoragePluginInterface):
                     )
                     break
 
-                memory_obj.metadata.cached_positions = meta.cached_positions
                 loaded.append(memory_obj)
                 touched.append(key)
         finally:

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 # Standard
 from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Sequence
 import asyncio
@@ -33,6 +34,8 @@ logger = init_logger(__name__)
 _DEFAULT_META_MAGIC = b"LMCIDX01"
 _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
+TPRankKey = int | str
+PerTPDevicePaths = Mapping[TPRankKey, str]
 
 
 def _round_up(x: int, align: int) -> int:
@@ -40,7 +43,7 @@ def _round_up(x: int, align: int) -> int:
     return ((x + align - 1) // align) * align
 
 
-def _validate_per_tp_device_paths(per_tp_devices: Any) -> None:
+def _validate_per_tp_device_paths(per_tp_devices: PerTPDevicePaths) -> None:
     """Validate per-TP device mapping and enforce unique paths."""
     values = list(per_tp_devices.values())
     if len(values) != len(set(values)):
@@ -49,7 +52,9 @@ def _validate_per_tp_device_paths(per_tp_devices: Any) -> None:
         )
 
 
-def _get_per_tp_device_path(per_tp_devices: dict[Any, Any], tp_rank: int) -> Any:
+def _get_per_tp_device_path(
+    per_tp_devices: PerTPDevicePaths, tp_rank: int
+) -> Optional[str]:
     return per_tp_devices.get(str(tp_rank), per_tp_devices.get(tp_rank))
 
 
@@ -129,6 +134,11 @@ class RustRawBlockBackend(StoragePluginInterface):
         if self.metadata is not None and self.metadata.world_size > 1:
             tp_rank = self.metadata.worker_id
             per_tp_devices = extra.get("rust_raw_block.per_tp_device_paths", {})
+            if not isinstance(per_tp_devices, Mapping):
+                raise ValueError(
+                    "rust_raw_block.per_tp_device_paths must be a mapping from "
+                    "TP rank to device path"
+                )
 
             if not per_tp_devices:
                 raise ValueError(
@@ -138,12 +148,13 @@ class RustRawBlockBackend(StoragePluginInterface):
             _validate_per_tp_device_paths(per_tp_devices)
 
             tp_rank_str = str(tp_rank)
-            self.device_path = _get_per_tp_device_path(per_tp_devices, tp_rank)
-            if not self.device_path:
+            device_path = _get_per_tp_device_path(per_tp_devices, tp_rank)
+            if not device_path:
                 raise ValueError(
                     f"No device path configured for TP rank {tp_rank_str}. "
                     f"Available ranks: {list(per_tp_devices.keys())}"
                 )
+            self.device_path = device_path
             logger.info(
                 f"RustRawBlockBackend: TP={self.metadata.world_size} mode, "
                 f"using explicit device path for rank {tp_rank}: {self.device_path}"

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -49,6 +49,10 @@ def _validate_per_tp_device_paths(per_tp_devices: Any) -> None:
         )
 
 
+def _get_per_tp_device_path(per_tp_devices: dict[Any, Any], tp_rank: int) -> Any:
+    return per_tp_devices.get(str(tp_rank), per_tp_devices.get(tp_rank))
+
+
 @dataclass
 class _Entry:
     """In-memory index entry for a stored chunk."""
@@ -134,7 +138,7 @@ class RustRawBlockBackend(StoragePluginInterface):
             _validate_per_tp_device_paths(per_tp_devices)
 
             tp_rank_str = str(tp_rank)
-            self.device_path = per_tp_devices.get(tp_rank_str)
+            self.device_path = _get_per_tp_device_path(per_tp_devices, tp_rank)
             if not self.device_path:
                 raise ValueError(
                     f"No device path configured for TP rank {tp_rank_str}. "
@@ -781,7 +785,7 @@ class RustRawBlockBackend(StoragePluginInterface):
                     logger.error(
                         "Read failed for key %s: %s", self._dbg_key_short(key), e
                     )
-                    break
+                    raise
 
                 loaded.append(memory_obj)
                 touched.append(key)
@@ -802,15 +806,14 @@ class RustRawBlockBackend(StoragePluginInterface):
         keys: List[CacheEngineKey],
     ) -> List[Optional[MemoryObj]]:
         """
-        Get a batch of cache entries until the first miss or read failure.
+        Get a batch of cache entries until the first miss.
 
         :param List[CacheEngineKey] keys: Ordered keys to retrieve.
 
         :return: A list aligned to ``keys`` where the successful prefix contains
             loaded memory objects and the remaining suffix is ``None``.
 
-        :raises Exception: Propagates raw-device initialization failures before
-            any batched reads begin.
+        :raises Exception: Propagates raw-device initialization or read failures.
         """
         if not keys:
             return []
@@ -842,8 +845,7 @@ class RustRawBlockBackend(StoragePluginInterface):
         transfer_spec: Any = None,
     ) -> list[MemoryObj]:
         """
-        Asynchronously get a batch of cache entries until the first miss or read
-        failure.
+        Asynchronously get a batch of cache entries until the first miss.
 
         :param str lookup_id: Lookup identifier used by the storage manager.
         :param list[CacheEngineKey] keys: Ordered keys to retrieve.
@@ -851,8 +853,7 @@ class RustRawBlockBackend(StoragePluginInterface):
 
         :return: The successfully loaded prefix of ``keys`` in input order.
 
-        :raises Exception: Propagates raw-device initialization failures before
-            the background batched read starts.
+        :raises Exception: Propagates raw-device initialization or read failures.
         """
         del lookup_id, transfer_spec
         return await asyncio.to_thread(self._batched_get_prefix, keys)

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -801,6 +801,17 @@ class RustRawBlockBackend(StoragePluginInterface):
         self,
         keys: List[CacheEngineKey],
     ) -> List[Optional[MemoryObj]]:
+        """
+        Get a batch of cache entries until the first miss or read failure.
+
+        :param List[CacheEngineKey] keys: Ordered keys to retrieve.
+
+        :return: A list aligned to ``keys`` where the successful prefix contains
+            loaded memory objects and the remaining suffix is ``None``.
+
+        :raises Exception: Propagates raw-device initialization failures before
+            any batched reads begin.
+        """
         if not keys:
             return []
 
@@ -830,6 +841,19 @@ class RustRawBlockBackend(StoragePluginInterface):
         keys: list[CacheEngineKey],
         transfer_spec: Any = None,
     ) -> list[MemoryObj]:
+        """
+        Asynchronously get a batch of cache entries until the first miss or read
+        failure.
+
+        :param str lookup_id: Lookup identifier used by the storage manager.
+        :param list[CacheEngineKey] keys: Ordered keys to retrieve.
+        :param Any transfer_spec: Unused transfer hint for API compatibility.
+
+        :return: The successfully loaded prefix of ``keys`` in input order.
+
+        :raises Exception: Propagates raw-device initialization failures before
+            the background batched read starts.
+        """
         del lookup_id, transfer_spec
         return await asyncio.to_thread(self._batched_get_prefix, keys)
 

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -67,8 +67,23 @@ class RustRawBlockBackend(StoragePluginInterface):
     - On-device metadata checkpoint for restart recovery
     - Efficient buffer operations via Rust extension
 
-    .. warning::
-       **This backend currently only supports TP=1 (single GPU) deployments.**
+    - TP > 1 support via per-TP partitions
+
+    TP > 1 Support:
+    ----------------
+    When using Tensor Parallelism (TP > 1), each TP worker must use a
+    separate partition to avoid metadata conflicts and data corruption.
+
+    Configuration:
+    For TP > 1, you must explicitly configure device paths for each TP worker:
+       extra_config:
+         rust_raw_block.per_tp_device_paths:
+           "0": "/dev/nvme0n1p1"
+           "1": "/dev/nvme0n1p2"
+           "2": "/dev/nvme0n1p3"
+           "3": "/dev/nvme0n1p4"
+
+    Note: Partitions must be pre-created on the device before use.
     """
 
     def __init__(
@@ -93,17 +108,37 @@ class RustRawBlockBackend(StoragePluginInterface):
         if self.config is None:
             raise ValueError("RustRawBlockBackend requires config")
 
-        if self.metadata is not None and self.metadata.world_size != 1:
-            raise ValueError(
-                "RustRawBlockBackend currently only supports TP=1 "
-                "(single GPU) deployments. "
-                f"Current world_size={self.metadata.world_size}."
-            )
-
         extra = self.config.extra_config or {}
-        self.device_path: str = extra.get("rust_raw_block.device_path", "")
-        if not self.device_path:
-            raise ValueError("extra_config['rust_raw_block.device_path'] is required")
+
+        # Support TP > 1 via per-TP device paths.
+        # Each TP worker uses its own partition to avoid conflicts.
+        if self.metadata is not None and self.metadata.world_size > 1:
+            tp_rank = self.metadata.worker_id
+            per_tp_devices = extra.get("rust_raw_block.per_tp_device_paths", {})
+
+            if not per_tp_devices:
+                raise ValueError(
+                    "For TP > 1, rust_raw_block.per_tp_device_paths is required. "
+                    "Each TP worker must have an explicit device path configured."
+                )
+
+            tp_rank_str = str(tp_rank)
+            self.device_path = per_tp_devices.get(tp_rank_str)
+            if not self.device_path:
+                raise ValueError(
+                    f"No device path configured for TP rank {tp_rank_str}. "
+                    f"Available ranks: {list(per_tp_devices.keys())}"
+                )
+            logger.info(
+                f"RustRawBlockBackend: TP={self.metadata.world_size} mode, "
+                f"using explicit device path for rank {tp_rank}: {self.device_path}"
+            )
+        else:
+            self.device_path: str = extra.get("rust_raw_block.device_path", "")
+            if not self.device_path:
+                raise ValueError(
+                    "extra_config['rust_raw_block.device_path'] is required"
+                )
 
         self.capacity_bytes: int = int(extra.get("rust_raw_block.capacity_bytes", 0))
         self.block_align: int = int(extra.get("rust_raw_block.block_align", 4096))

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -1158,6 +1158,21 @@ class RustRawBlockBackend(StoragePluginInterface):
                     )
                     self._index[key] = _Entry(offset=offset, size=size, meta=meta)
 
+            if self.metadata is not None and self._index:
+                first_loaded_key = next(iter(self._index))
+                expected_worker_id = int(self.metadata.worker_id)
+                loaded_worker_id = int(first_loaded_key.worker_id)
+                if loaded_worker_id != expected_worker_id:
+                    logger.warning(
+                        "RustRawBlockBackend: loaded metadata may belong to another "
+                        "worker (device=%s, current_worker_id=%d, "
+                        "first_entry_worker_id=%d, first_entry_key=%s)",
+                        self.device_path,
+                        expected_worker_id,
+                        loaded_worker_id,
+                        first_loaded_key.to_string(),
+                    )
+
             # Remove free-slot entries that overlap with loaded index slots.
             used_slots = {
                 self._offset_to_slot(int(entry.offset))

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -40,6 +40,15 @@ def _round_up(x: int, align: int) -> int:
     return ((x + align - 1) // align) * align
 
 
+def _validate_per_tp_device_paths(per_tp_devices: Any) -> None:
+    """Validate per-TP device mapping and enforce unique paths."""
+    values = list(per_tp_devices.values())
+    if len(values) != len(set(values)):
+        raise ValueError(
+            "Duplicate device path configured in rust_raw_block.per_tp_device_paths"
+        )
+
+
 @dataclass
 class _Entry:
     """In-memory index entry for a stored chunk."""
@@ -121,6 +130,7 @@ class RustRawBlockBackend(StoragePluginInterface):
                     "For TP > 1, rust_raw_block.per_tp_device_paths is required. "
                     "Each TP worker must have an explicit device path configured."
                 )
+            _validate_per_tp_device_paths(per_tp_devices)
 
             tp_rank_str = str(tp_rank)
             self.device_path = per_tp_devices.get(tp_rank_str)

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -121,6 +121,7 @@ class RustRawBlockBackend(StoragePluginInterface):
 
         # Support TP > 1 via per-TP device paths.
         # Each TP worker uses its own partition to avoid conflicts.
+        self.device_path: str
         if self.metadata is not None and self.metadata.world_size > 1:
             tp_rank = self.metadata.worker_id
             per_tp_devices = extra.get("rust_raw_block.per_tp_device_paths", {})
@@ -144,7 +145,7 @@ class RustRawBlockBackend(StoragePluginInterface):
                 f"using explicit device path for rank {tp_rank}: {self.device_path}"
             )
         else:
-            self.device_path: str = extra.get("rust_raw_block.device_path", "")
+            self.device_path = extra.get("rust_raw_block.device_path", "")
             if not self.device_path:
                 raise ValueError(
                     "extra_config['rust_raw_block.device_path'] is required"
@@ -696,81 +697,109 @@ class RustRawBlockBackend(StoragePluginInterface):
                 self._inflight_io_count -= 1
                 self._last_io_ts = time.monotonic()
 
-    def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        if logger.isEnabledFor(10):
-            self._dbg_get_calls += 1
+    def _batched_get_prefix(self, keys: Sequence[CacheEngineKey]) -> list[MemoryObj]:
+        if not keys:
+            return []
+
+        items: list[tuple[CacheEngineKey, _Entry]] = []
         with self._lock:
-            entry = self._index.get(key)
-        if entry is None:
-            return None
+            for key in keys:
+                entry = self._index.get(key)
+                if entry is None:
+                    break
+                items.append((key, entry))
+            if not items:
+                return []
+            self._inflight_io_count += 1
 
-        meta = entry.meta
-        assert meta.shape is not None and meta.dtype is not None
-        payload_len = int(meta.size)
-        total_len = (
-            _round_up(payload_len, self.block_align)
-            if self.use_odirect
-            else payload_len
-        )
-
-        if logger.isEnabledFor(10):
-            self._dbg_get_bytes += int(payload_len)
-            if self._dbg_should_log(self._dbg_get_calls):
-                logger.debug(
-                    "RustRawBlockBackend GET: %s offset=%d size=%d",
-                    self._dbg_key_short(key),
-                    int(entry.offset),
-                    int(payload_len),
-                )
-
-        assert self.local_cpu_backend is not None
-        memory_obj = self.local_cpu_backend.allocate(meta.shape, meta.dtype, meta.fmt)
-        assert memory_obj is not None
-        buf = memory_obj.byte_array
+        raw_dev = self._rawdev()
+        loaded: list[MemoryObj] = []
+        touched: list[CacheEngineKey] = []
         try:
-            buf = buf.cast("B")
-        except Exception:
-            pass
+            for key, entry in items:
+                meta = entry.meta
+                assert meta.shape is not None and meta.dtype is not None
+                assert self.local_cpu_backend is not None
+                memory_obj = self.local_cpu_backend.allocate(
+                    meta.shape, meta.dtype, meta.fmt
+                )
+                assert memory_obj is not None
 
-        try:
-            direct_view = self._build_direct_odirect_view(
-                memory_obj=memory_obj,
-                payload_len=payload_len,
-                total_len=total_len,
-                buffer_len=len(buf),
-                zero_tail=False,
-            )
-            with self._lock:
-                self._inflight_io_count += 1
-            if direct_view is not None:
-                read_payload_len = (
-                    total_len if len(direct_view) >= total_len else payload_len
+                payload_len = int(meta.size)
+                total_len = (
+                    _round_up(payload_len, self.block_align)
+                    if self.use_odirect
+                    else payload_len
                 )
-                self._rawdev().pread_into(
-                    entry.offset + self.header_bytes,
-                    direct_view,
-                    read_payload_len,
-                    total_len,
+                if logger.isEnabledFor(10):
+                    self._dbg_get_calls += 1
+                    self._dbg_get_bytes += payload_len
+                    if self._dbg_should_log(self._dbg_get_calls):
+                        logger.debug(
+                            "RustRawBlockBackend GET: %s offset=%d size=%d",
+                            self._dbg_key_short(key),
+                            int(entry.offset),
+                            payload_len,
+                        )
+
+                buf = memory_obj.byte_array
+                try:
+                    buf = buf.cast("B")
+                except Exception:
+                    pass
+                direct_view = self._build_direct_odirect_view(
+                    memory_obj=memory_obj,
+                    payload_len=payload_len,
+                    total_len=total_len,
+                    buffer_len=len(buf),
+                    zero_tail=False,
                 )
-            else:
-                self._rawdev().pread_into(
-                    entry.offset + self.header_bytes,
-                    buf,
-                    payload_len,
-                    total_len,
-                )
-        except Exception as e:
-            logger.error(f"Read failed for key {self._dbg_key_short(key)}: {e}")
-            raise
+                try:
+                    if direct_view is not None:
+                        raw_dev.pread_into(
+                            entry.offset + self.header_bytes,
+                            direct_view,
+                            total_len if len(direct_view) >= total_len else payload_len,
+                            total_len,
+                        )
+                    else:
+                        raw_dev.pread_into(
+                            entry.offset + self.header_bytes,
+                            buf,
+                            payload_len,
+                            total_len,
+                        )
+                except Exception as e:
+                    memory_obj.ref_count_down()
+                    logger.error(
+                        "Read failed for key %s: %s", self._dbg_key_short(key), e
+                    )
+                    break
+
+                memory_obj.metadata.cached_positions = meta.cached_positions
+                loaded.append(memory_obj)
+                touched.append(key)
         finally:
             with self._lock:
+                for key in touched:
+                    self._touch(key)
                 self._inflight_io_count -= 1
                 self._last_io_ts = time.monotonic()
+        return loaded
 
-        memory_obj.metadata.cached_positions = meta.cached_positions
-        with self._lock:
-            self._touch(key)
-        return memory_obj
+    def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
+        loaded = self._batched_get_prefix([key])
+        return loaded[0] if loaded else None
+
+    def batched_get_blocking(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> List[Optional[MemoryObj]]:
+        if not keys:
+            return []
+
+        loaded = self._batched_get_prefix(keys)
+        return [*loaded, *([None] * (len(keys) - len(loaded)))]
 
     async def batched_async_contains(
         self,
@@ -778,6 +807,7 @@ class RustRawBlockBackend(StoragePluginInterface):
         keys: list[CacheEngineKey],
         pin: bool = False,
     ) -> int:
+        del lookup_id
         hit = 0
         with self._lock:
             for k in keys:
@@ -787,6 +817,15 @@ class RustRawBlockBackend(StoragePluginInterface):
                     self._pinned.add(k)
                 hit += 1
         return hit
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: list[CacheEngineKey],
+        transfer_spec: Any = None,
+    ) -> list[MemoryObj]:
+        del lookup_id, transfer_spec
+        return await asyncio.to_thread(self._batched_get_prefix, keys)
 
     def get_allocator_backend(self) -> "AllocatorBackendInterface":
         assert self.local_cpu_backend is not None

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -742,3 +742,54 @@ def test_rust_raw_block_backend_tp4_comprehensive_io(memory_allocator, loop_in_t
         finally:
             for backend in backends:
                 backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_tp_paths_must_be_unique(
+    memory_allocator, loop_in_thread
+):
+    """Reject TP config when multiple ranks point to the same partition."""
+    with tempfile.TemporaryDirectory() as td:
+        shared_dev = os.path.join(td, "shared.bin")
+        with open(shared_dev, "wb") as f:
+            f.truncate(512 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_tp_dupe_paths",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.per_tp_device_paths": {"0": shared_dev, "1": shared_dev},
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test-model",
+            world_size=2,
+            local_world_size=2,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(32, 2, 256, 32, 128),
+        )
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        with pytest.raises(ValueError, match="Duplicate device path configured"):
+            RustRawBlockBackend(
+                config=config,
+                metadata=metadata,
+                local_cpu_backend=local_cpu,
+                loop=loop_in_thread,
+                dst_device="cpu",
+            )

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -388,7 +388,7 @@ def test_rust_raw_block_backend_batched_get_handles_allocator_exhaustion(
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
-def test_rust_raw_block_backend_batched_get_releases_failed_allocation(
+def test_rust_raw_block_backend_batched_get_releases_allocation_on_read_error(
     memory_allocator, loop_in_thread
 ):
     with tempfile.TemporaryDirectory() as td:
@@ -459,7 +459,8 @@ def test_rust_raw_block_backend_batched_get_releases_failed_allocation(
             raw_dev.pread_into.side_effect = OSError("read failed")
             with patch.object(local_cpu, "allocate", return_value=leaked_obj):
                 with patch.object(backend, "_rawdev", return_value=raw_dev):
-                    assert backend.get_blocking(key) is None
+                    with pytest.raises(OSError, match="read failed"):
+                        backend.get_blocking(key)
 
             assert leaked_obj.get_ref_count() == 0
             assert backend._inflight_io_count == 0
@@ -954,6 +955,69 @@ def test_rust_raw_block_backend_tp4_initialization(memory_allocator, loop_in_thr
                 backends.append(be)
                 assert be.device_path == device_paths[i]
             assert len({b.device_path for b in backends}) == TP
+        finally:
+            for backend in backends:
+                backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_tp4_initialization_accepts_integer_yaml_keys(
+    memory_allocator, loop_in_thread
+):
+    """Accept integer per-TP YAML keys in addition to quoted string keys."""
+    TP = 4
+    with tempfile.TemporaryDirectory() as td:
+        device_paths = [os.path.join(td, f"device{i}.bin") for i in range(TP)]
+        for p in device_paths:
+            with open(p, "wb") as f:
+                f.truncate(256 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_tp4_init_int_keys",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.per_tp_device_paths": {
+                i: device_paths[i] for i in range(TP)
+            },
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+
+        backends = []
+        try:
+            for i in range(TP):
+                metadata = LMCacheMetadata(
+                    model_name="test-model",
+                    world_size=TP,
+                    local_world_size=TP,
+                    worker_id=i,
+                    local_worker_id=i,
+                    kv_dtype=torch.bfloat16,
+                    kv_shape=(32, 2, 256, 32, 128),
+                )
+                local_cpu = LocalCPUBackend(
+                    config=config,
+                    metadata=metadata,
+                    dst_device="cpu",
+                    memory_allocator=memory_allocator,
+                )
+                be = RustRawBlockBackend(
+                    config=config,
+                    metadata=metadata,
+                    local_cpu_backend=local_cpu,
+                    loop=loop_in_thread,
+                    dst_device="cpu",
+                )
+                backends.append(be)
+                assert be.device_path == device_paths[i]
         finally:
             for backend in backends:
                 backend.close()

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -550,3 +550,195 @@ def test_rust_raw_block_backend_skips_invalid_checkpoint_entries(
             assert backend._index == {}
         finally:
             backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_tp4_initialization(memory_allocator, loop_in_thread):
+    """Test TP=4 initialization with per-TP device paths."""
+    TP = 4
+    with tempfile.TemporaryDirectory() as td:
+        device_paths = [os.path.join(td, f"device{i}.bin") for i in range(TP)]
+        for p in device_paths:
+            with open(p, "wb") as f:
+                f.truncate(256 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_tp4_init",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.per_tp_device_paths": {
+                str(i): device_paths[i] for i in range(TP)
+            },
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+
+        backends = []
+        try:
+            for i in range(TP):
+                metadata = LMCacheMetadata(
+                    model_name="test-model",
+                    world_size=TP,
+                    local_world_size=TP,
+                    worker_id=i,
+                    local_worker_id=i,
+                    kv_dtype=torch.bfloat16,
+                    kv_shape=(32, 2, 256, 32, 128),
+                )
+                local_cpu = LocalCPUBackend(
+                    config=config,
+                    metadata=metadata,
+                    dst_device="cpu",
+                    memory_allocator=memory_allocator,
+                )
+                be = RustRawBlockBackend(
+                    config=config,
+                    metadata=metadata,
+                    local_cpu_backend=local_cpu,
+                    loop=loop_in_thread,
+                    dst_device="cpu",
+                )
+                backends.append(be)
+                assert be.device_path == device_paths[i]
+            assert len({b.device_path for b in backends}) == TP
+        finally:
+            for backend in backends:
+                backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_tp4_comprehensive_io(memory_allocator, loop_in_thread):
+    """Comprehensive TP=4 I/O test covering roundtrip, multiple ops, and isolation."""
+    TP = 4
+    with tempfile.TemporaryDirectory() as td:
+        device_paths = [os.path.join(td, f"device{i}.bin") for i in range(TP)]
+        for p in device_paths:
+            with open(p, "wb") as f:
+                f.truncate(512 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_tp4_io",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.per_tp_device_paths": {
+                str(i): device_paths[i] for i in range(TP)
+            },
+            "rust_raw_block.capacity_bytes": 0,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+
+        backends = []
+        try:
+            for i in range(TP):
+                metadata = LMCacheMetadata(
+                    model_name="test-model",
+                    world_size=TP,
+                    local_world_size=TP,
+                    worker_id=i,
+                    local_worker_id=i,
+                    kv_dtype=torch.bfloat16,
+                    kv_shape=(32, 2, 256, 32, 128),
+                )
+                local_cpu = LocalCPUBackend(
+                    config=config,
+                    metadata=metadata,
+                    dst_device="cpu",
+                    memory_allocator=memory_allocator,
+                )
+                be = RustRawBlockBackend(
+                    config=config,
+                    metadata=metadata,
+                    local_cpu_backend=local_cpu,
+                    loop=loop_in_thread,
+                    dst_device="cpu",
+                )
+                backends.append(be)
+
+            allocator = AdHocMemoryAllocator(device="cpu")
+            for tp in range(TP):
+                backend = backends[tp]
+                key = CacheEngineKey("test-model", TP, tp, 1000 + tp, torch.bfloat16)
+                obj = allocator.allocate(
+                    [torch.Size([2, 16, 8, 128])],
+                    [torch.bfloat16],
+                    fmt=MemoryFormat.KV_T2D,
+                )
+                assert obj is not None
+                assert obj.tensor is not None
+                obj.tensor.fill_(tp * 10)
+                expected = bytes(obj.byte_array)
+
+                futs = backend.batched_submit_put_task([key], [obj])
+                assert futs is not None
+                futs[0].result(timeout=10)
+                obj.ref_count_down()
+
+                out = backend.get_blocking(key)
+                assert out is not None
+                assert bytes(out.byte_array) == expected
+                out.ref_count_down()
+
+                for other in range(TP):
+                    if other == tp:
+                        continue
+                    other_key = CacheEngineKey(
+                        "test-model", TP, other, 1000 + other, torch.bfloat16
+                    )
+                    assert backend.get_blocking(other_key) is None
+
+            all_keys = []
+            for tp in range(TP):
+                keys = []
+                for i in range(TP - 1):
+                    allocator = AdHocMemoryAllocator(device="cpu")
+                    obj = allocator.allocate(
+                        [torch.Size([2, 16, 8, 128])],
+                        [torch.bfloat16],
+                        fmt=MemoryFormat.KV_T2D,
+                    )
+                    assert obj is not None
+                    assert obj.tensor is not None
+                    obj.tensor.fill_(tp * 100 + i)
+                    key = CacheEngineKey(
+                        "test-model", TP, tp, tp * 100 + i, torch.bfloat16
+                    )
+                    keys.append(key)
+                    futs = backends[tp].batched_submit_put_task([key], [obj])
+                    assert futs is not None
+                    futs[0].result(timeout=10)
+                    obj.ref_count_down()
+                all_keys.append(keys)
+
+            for tp in range(TP):
+                for key in all_keys[tp]:
+                    out = backends[tp].get_blocking(key)
+                    assert out is not None
+                    assert out.tensor is not None
+                    out.ref_count_down()
+
+            for tp in range(TP):
+                for other in range(TP):
+                    if other == tp:
+                        continue
+                    for key in all_keys[other]:
+                        assert backends[tp].get_blocking(key) is None
+        finally:
+            for backend in backends:
+                backend.close()

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 # Standard
 from concurrent.futures import Future
+from unittest.mock import patch
 import asyncio
 import os
 import struct
@@ -793,3 +794,128 @@ def test_rust_raw_block_backend_tp_paths_must_be_unique(
                 loop=loop_in_thread,
                 dst_device="cpu",
             )
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_warns_on_cross_rank_metadata_load(
+    memory_allocator, loop_in_thread
+):
+    """Warn when loading metadata whose first entry belongs to another worker."""
+    with tempfile.TemporaryDirectory() as td:
+        device0 = os.path.join(td, "device0.bin")
+        device1 = os.path.join(td, "device1.bin")
+        for p in [device0, device1]:
+            with open(p, "wb") as f:
+                f.truncate(512 * 1024 * 1024)
+
+        base_extra = {
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+
+        config_tp0 = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_cross_rank_warn_tp0",
+        )
+        config_tp0.storage_plugins = []
+        config_tp0.extra_config = {
+            **base_extra,
+            "rust_raw_block.per_tp_device_paths": {"0": device0, "1": device1},
+        }
+        metadata_tp0 = LMCacheMetadata(
+            model_name="test-model",
+            world_size=2,
+            local_world_size=2,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(32, 2, 256, 32, 128),
+        )
+        local_cpu_tp0 = LocalCPUBackend(
+            config=config_tp0,
+            metadata=metadata_tp0,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend_tp0 = RustRawBlockBackend(
+            config=config_tp0,
+            metadata=metadata_tp0,
+            local_cpu_backend=local_cpu_tp0,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        key_tp0 = CacheEngineKey("test-model", 2, 0, 31337, torch.bfloat16)
+        allocator = AdHocMemoryAllocator(device="cpu")
+        obj = allocator.allocate(
+            [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+        )
+        assert obj is not None
+        assert obj.tensor is not None
+        obj.tensor.fill_(9)
+        try:
+            futs = backend_tp0.batched_submit_put_task([key_tp0], [obj])
+            assert futs is not None
+            futs[0].result(timeout=10)
+            obj.ref_count_down()
+        finally:
+            backend_tp0.close()
+
+        config_tp1_mis = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_cross_rank_warn_tp1",
+        )
+        config_tp1_mis.storage_plugins = []
+        config_tp1_mis.extra_config = {
+            **base_extra,
+            "rust_raw_block.per_tp_device_paths": {"1": device0},
+        }
+        metadata_tp1 = LMCacheMetadata(
+            model_name="test-model",
+            world_size=2,
+            local_world_size=2,
+            worker_id=1,
+            local_worker_id=1,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(32, 2, 256, 32, 128),
+        )
+        local_cpu_tp1 = LocalCPUBackend(
+            config=config_tp1_mis,
+            metadata=metadata_tp1,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+
+        with patch(
+            "lmcache.v1.storage_backend.plugins.rust_raw_block_backend.logger.warning"
+        ) as mock_warning:
+            backend_tp1 = RustRawBlockBackend(
+                config=config_tp1_mis,
+                metadata=metadata_tp1,
+                local_cpu_backend=local_cpu_tp1,
+                loop=loop_in_thread,
+                dst_device="cpu",
+            )
+        try:
+            matched = False
+            for call in mock_warning.call_args_list:
+                call_args = call.args
+                if not call_args:
+                    continue
+                fmt = call_args[0]
+                if "loaded metadata may belong to another worker" not in str(fmt):
+                    continue
+                assert int(call_args[2]) == 1
+                assert int(call_args[3]) == 0
+                matched = True
+                break
+            assert matched, "Expected cross-rank metadata warning was not emitted"
+        finally:
+            backend_tp1.close()

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -52,6 +52,108 @@ def loop_in_thread():
         loop.close()
 
 
+def _run_batched_get_prefix_stop(
+    memory_allocator,
+    loop_in_thread,
+    *,
+    async_get: bool,
+) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_batched_get",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = AdHocMemoryAllocator(device="cpu")
+            key1 = CacheEngineKey("test_model", 1, 0, 1001, torch.bfloat16)
+            key_miss = CacheEngineKey("test_model", 1, 0, 1002, torch.bfloat16)
+            key3 = CacheEngineKey("test_model", 1, 0, 1003, torch.bfloat16)
+
+            obj1 = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            obj3 = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            assert obj1 is not None and obj1.tensor is not None
+            assert obj3 is not None and obj3.tensor is not None
+            obj1.tensor.fill_(1)
+            obj3.tensor.fill_(3)
+            expected1 = bytes(obj1.byte_array)
+            expected3 = bytes(obj3.byte_array)
+
+            for key, obj in ((key1, obj1), (key3, obj3)):
+                futs = backend.batched_submit_put_task([key], [obj])
+                assert futs is not None
+                futs[0].result(timeout=10)
+                obj.ref_count_down()
+
+            if async_get:
+                future = asyncio.run_coroutine_threadsafe(
+                    backend.batched_get_non_blocking(
+                        "lookup-rawblock", [key1, key_miss, key3]
+                    ),
+                    loop_in_thread,
+                )
+                async_results = future.result(timeout=10)
+                assert len(async_results) == 1
+                assert bytes(async_results[0].byte_array) == expected1
+                async_results[0].ref_count_down()
+            else:
+                blocking_results = backend.batched_get_blocking([key1, key_miss, key3])
+                assert len(blocking_results) == 3
+                assert blocking_results[0] is not None
+                assert bytes(blocking_results[0].byte_array) == expected1
+                assert blocking_results[1] is None
+                assert blocking_results[2] is None
+                blocking_results[0].ref_count_down()
+
+            out3 = backend.get_blocking(key3)
+            assert out3 is not None
+            assert bytes(out3.byte_array) == expected3
+            out3.ref_count_down()
+        finally:
+            backend.close()
+
+
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
@@ -121,6 +223,26 @@ def test_rust_raw_block_backend_put_get_roundtrip(memory_allocator, loop_in_thre
             assert bytes(out.byte_array) == expected
         finally:
             backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_batched_get_blocking_prefix_stop(
+    memory_allocator, loop_in_thread
+):
+    """Batched blocking get should stop at the first miss and preserve order."""
+    _run_batched_get_prefix_stop(memory_allocator, loop_in_thread, async_get=False)
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_batched_get_non_blocking_prefix_stop(
+    memory_allocator, loop_in_thread
+):
+    """Async batched get should return only the successful prefix."""
+    _run_batched_get_prefix_stop(memory_allocator, loop_in_thread, async_get=True)
 
 
 @pytest.mark.skipif(

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 # Standard
 from concurrent.futures import Future
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import struct
@@ -243,6 +243,228 @@ def test_rust_raw_block_backend_batched_get_non_blocking_prefix_stop(
 ):
     """Async batched get should return only the successful prefix."""
     _run_batched_get_prefix_stop(memory_allocator, loop_in_thread, async_get=True)
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_batched_get_resets_inflight_on_rawdev_error(
+    memory_allocator, loop_in_thread
+):
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_rawdev_error",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = AdHocMemoryAllocator(device="cpu")
+            key = CacheEngineKey("test_model", 1, 0, 3001, torch.bfloat16)
+            obj = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            assert obj is not None and obj.tensor is not None
+            obj.tensor.fill_(31)
+            futs = backend.batched_submit_put_task([key], [obj])
+            assert futs is not None
+            futs[0].result(timeout=10)
+            obj.ref_count_down()
+
+            with patch.object(backend, "_rawdev", side_effect=RuntimeError("boom")):
+                with pytest.raises(RuntimeError, match="boom"):
+                    backend.get_blocking(key)
+            assert backend._inflight_io_count == 0
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_batched_get_handles_allocator_exhaustion(
+    memory_allocator, loop_in_thread
+):
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_allocator_exhaustion",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = AdHocMemoryAllocator(device="cpu")
+            key = CacheEngineKey("test_model", 1, 0, 3002, torch.bfloat16)
+            obj = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            assert obj is not None and obj.tensor is not None
+            obj.tensor.fill_(32)
+            futs = backend.batched_submit_put_task([key], [obj])
+            assert futs is not None
+            futs[0].result(timeout=10)
+            obj.ref_count_down()
+
+            with patch.object(local_cpu, "allocate", return_value=None):
+                assert backend.get_blocking(key) is None
+                assert backend.batched_get_blocking([key]) == [None]
+            assert backend._inflight_io_count == 0
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_batched_get_releases_failed_allocation(
+    memory_allocator, loop_in_thread
+):
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_release_failed_get",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = AdHocMemoryAllocator(device="cpu")
+            key = CacheEngineKey("test_model", 1, 0, 3003, torch.bfloat16)
+            obj = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            assert obj is not None and obj.tensor is not None
+            obj.tensor.fill_(33)
+            futs = backend.batched_submit_put_task([key], [obj])
+            assert futs is not None
+            futs[0].result(timeout=10)
+            obj.ref_count_down()
+
+            leaked_obj = local_cpu.allocate(
+                torch.Size([2, 16, 8, 128]),
+                torch.bfloat16,
+                MemoryFormat.KV_T2D,
+            )
+            assert leaked_obj is not None
+            assert leaked_obj.get_ref_count() == 1
+
+            raw_dev = MagicMock()
+            raw_dev.pread_into.side_effect = OSError("read failed")
+            with patch.object(local_cpu, "allocate", return_value=leaked_obj):
+                with patch.object(backend, "_rawdev", return_value=raw_dev):
+                    assert backend.get_blocking(key) is None
+
+            assert leaked_obj.get_ref_count() == 0
+            assert backend._inflight_io_count == 0
+        finally:
+            backend.close()
 
 
 @pytest.mark.skipif(

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -471,6 +471,103 @@ def test_rust_raw_block_backend_batched_get_releases_allocation_on_read_error(
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
+def test_rust_raw_block_backend_batched_get_releases_loaded_prefix_on_read_error(
+    memory_allocator, loop_in_thread
+):
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_release_prefix_get",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            allocator = AdHocMemoryAllocator(device="cpu")
+            key1 = CacheEngineKey("test_model", 1, 0, 3004, torch.bfloat16)
+            key2 = CacheEngineKey("test_model", 1, 0, 3005, torch.bfloat16)
+            for key, fill in ((key1, 34), (key2, 35)):
+                obj = allocator.allocate(
+                    [torch.Size([2, 16, 8, 128])],
+                    [torch.bfloat16],
+                    fmt=MemoryFormat.KV_T2D,
+                )
+                assert obj is not None and obj.tensor is not None
+                obj.tensor.fill_(fill)
+                futs = backend.batched_submit_put_task([key], [obj])
+                assert futs is not None
+                futs[0].result(timeout=10)
+                obj.ref_count_down()
+
+            loaded_obj = local_cpu.allocate(
+                torch.Size([2, 16, 8, 128]),
+                torch.bfloat16,
+                MemoryFormat.KV_T2D,
+            )
+            failed_obj = local_cpu.allocate(
+                torch.Size([2, 16, 8, 128]),
+                torch.bfloat16,
+                MemoryFormat.KV_T2D,
+            )
+            assert loaded_obj is not None
+            assert failed_obj is not None
+            assert loaded_obj.get_ref_count() == 1
+            assert failed_obj.get_ref_count() == 1
+
+            raw_dev = MagicMock()
+            raw_dev.pread_into.side_effect = [None, OSError("read failed")]
+            with patch.object(
+                local_cpu, "allocate", side_effect=[loaded_obj, failed_obj]
+            ):
+                with patch.object(backend, "_rawdev", return_value=raw_dev):
+                    with pytest.raises(OSError, match="read failed"):
+                        backend.batched_get_blocking([key1, key2])
+
+            assert loaded_obj.get_ref_count() == 0
+            assert failed_obj.get_ref_count() == 0
+            assert backend._inflight_io_count == 0
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
 def test_rust_raw_block_backend_eviction_lru(memory_allocator, loop_in_thread):
     """Test LRU eviction when capacity is exceeded."""
     with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
**What this PR does / why we need it**:
  - Add `RustRawBlockBackend` support for `TP > 1` by allowing explicit per-TP raw block device mapping via `extra_config["rust_raw_block.per_tp_device_paths"]`.
  - Fail fast if multiple TP ranks are configured to use the same raw block device path.
  - Warn when restored on-device metadata appears to belong to a different TP worker.
  - Add a compact backend-native batched retrieval path so `get_blocking`, `batched_get_blocking`, and `batched_get_non_blocking` share the same raw-block prefix-read behavior.
  - including tp4 unit test. (do not require gpus)

  **Special notes for your reviewers**:
  - This PR is mainly about higher-TP support and correctness for the raw block backend.
  - For `TP > 1`, each TP worker must be mapped to a distinct raw block partition.
  - The batched retrieval cleanup is intentionally compact: one shared prefix-read path backs the blocking and async raw-block get paths.
  - Validation included TP4 runs with vLLM + LMCache + `uv` + `aiperf`, plus LMCache `long_doc_qa`, on `/dev/nvme4n1p1-4`.

  **Validation / test results**:
  TP4 `aiperf` fair comparison:
  - LMCache + LocalCPU: `10.82 req/s`, `723.06 ms`
  - LMCache + LocalDisk buffered: `8.55 req/s`, `930.88 ms`
  - LMCache + rust_raw_block: `7.17 req/s`, `1110.23 ms`
  - LMCache + LocalDisk `O_DIRECT`: `1.95 req/s`, `4095.91 ms`

  TP4 `long_doc_qa` comparison:
  - LMCache + LocalCPU: `0.145 s`, `0.256 s`
  - LMCache + LocalDisk buffered: `0.350 s`, `0.328 s`
  - LMCache + rust_raw_block: `0.438 s`, `0.343 s`
  - LMCache + LocalDisk `O_DIRECT`: `1.933 s`, `0.885 s`
  Correctness check:
  - Raw block vs vanilla vLLM constrained-output comparison: `6/6` exact matches on
  `content`, `finish_reason`, and `usage`

  **Reproduction scripts**:

  1. unit tests
  ```bash
  cd LMCache

  ./[your venv]/bin/pytest -q \
    tests/v1/storage_backend/test_rust_raw_block_backend.py

  2. TP4 raw-block config

  # /tmp/lmcache_rawblock_tp4.yaml
  chunk_size: 256
  local_cpu: false
  max_local_cpu_size: 10.0
  lmcache_instance_id: "tp4_rawblock"
  storage_plugins:
    - rust_raw_block
  store_location: "rust_raw_block"
  retrieve_locations:
    - "rust_raw_block"
  extra_config:
    storage_plugin.rust_raw_block.module_path:
  lmcache.v1.storage_backend.plugins.rust_raw_block_backend
    storage_plugin.rust_raw_block.class_name: RustRawBlockBackend
    rust_raw_block.per_tp_device_paths:
      "0": "/dev/nvme4n1p1"
      "1": "/dev/nvme4n1p2"
      "2": "/dev/nvme4n1p3"
      "3": "/dev/nvme4n1p4"
    rust_raw_block.block_align: 4096
    rust_raw_block.header_bytes: 4096
    rust_raw_block.meta_total_bytes: 4194304
    rust_raw_block.meta_enable_periodic: false
    rust_raw_block.use_odirect: true
    rust_raw_block.align_local_cpu_allocator: true

  3. TP4 vLLM server

  export PYTHONHASHSEED=0
  MODEL=/path/to/Qwen2.5-14B-Instruct
  for dev in /dev/nvme4n1p1 /dev/nvme4n1p2 /dev/nvme4n1p3 /dev/nvme4n1p4; do
    sudo dd if=/dev/zero of="$dev" bs=1M count=16 conv=fsync status=none
  done

  LMCACHE_CONFIG_FILE=/tmp/lmcache_rawblock_tp4.yaml \
  ./.venv-raw-block-tp4/bin/vllm serve "$MODEL" \
    --served-model-name qwen2.5-14b-local \
    --tensor-parallel-size 4 \
    --gpu-memory-utilization 0.70 \
    --max-model-len 8192 \
    --trust-remote-code \
    --enforce-eager \
    --no-enable-prefix-caching \
    --port 18115 \
    --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'

  4. aiperf repeated-prefix dataset + run

  python3 - <<'PY'
  import json
  prefix = " ".join(["hi"] * 3584)
  with open("/tmp/repeated_prefix_single_turn.jsonl", "w") as f:
      for i in range(64):
          req = {
              "messages": [
                  {"role": "user", "content": f"{prefix} unique_suffix_{i}"}
              ]
          }
          f.write(json.dumps(req) + "\n")
  PY

  PYTHONHASHSEED=0 uv run --directory ../aiperf aiperf \
    profile qwen2.5-14b-local \
    --tokenizer "$MODEL" \
    --endpoint-type chat \
    --custom-dataset-type single-turn \
    --input-file /tmp/repeated_prefix_single_turn.jsonl \
    --dataset-sampling-strategy sequential \
    --request-count 64 \
    --warmup-request-count 8 \
    --concurrency 8 \
    --output-tokens-mean 32 \
    --output-tokens-stddev 0 \
    --use-legacy-max-tokens \
    --ui-type none \
    --no-gpu-telemetry \
    --url http://127.0.0.1:18115 \
    --output-artifact-dir /tmp/aiperf_rawblock_tp4

  5. long_doc_qa

  PYTHONHASHSEED=0 python3 benchmarks/long_doc_qa/long_doc_qa.py \
    --port 18115 \
    --model qwen2.5-14b-local \
    --document-length 6000 \
    --num-documents 12 \
    --output-len 64 \
    --repeat-count 2 \
    --repeat-mode tile \
    --max-inflight-requests 4 \
    --json-output

  If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a storage backend’s device selection and read path; misconfiguration or subtle ordering/error-handling bugs could lead to cross-rank data corruption or retrieval failures, though guarded by validation and extensive tests.
> 
> **Overview**
> Adds **TP>1 support** to `RustRawBlockBackend` by selecting a per-rank raw block `device_path` from `extra_config["rust_raw_block.per_tp_device_paths"]`, accepting both int/string YAML keys, and **failing fast** on duplicate device paths.
> 
> Refactors retrieval to a shared `_batched_get_prefix` implementation backing `get_blocking`, `batched_get_blocking`, and new async `batched_get_non_blocking`, with consistent “stop at first miss” semantics and improved cleanup (refcount release, `_inflight_io_count` reset, LRU touch) on allocation/read errors.
> 
> On restart metadata load, emits a **warning** when the restored index appears to belong to a different TP worker/device mapping, and adds comprehensive unit coverage for TP=4 init/I/O isolation and new batched-get error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf276b0b89b7ec7d9e82a7e574b3a3233aec280a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->