### PR TITLE
[Security][Remote Connector]: Add env var auth config for RESP

### DIFF
--- a/docs/source/kv_cache/storage_backends/resp.rst
+++ b/docs/source/kv_cache/storage_backends/resp.rst
@@ -177,6 +177,65 @@ Expected output:
     All tests passed
 
 
+Environment Variable Configuration
+------------------------------------
+
+Sensitive credentials (and optionally host/port) can be provided via environment
+variables instead of config files or CLI arguments. This prevents secrets from
+appearing in logged configuration at startup.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Variable
+     - Description
+   * - ``LMCACHE_RESP_USERNAME``
+     - Redis ACL username. Overrides ``username`` in config/JSON.
+   * - ``LMCACHE_RESP_PASSWORD``
+     - Redis AUTH password. Overrides ``password`` in config/JSON.
+   * - ``LMCACHE_RESP_HOST``
+     - Redis hostname or IP. Overrides ``host`` in config/JSON/URL.
+   * - ``LMCACHE_RESP_PORT``
+     - Redis port. Overrides ``port`` in config/JSON/URL.
+
+Environment variables take precedence over values specified in config files
+(non-MP) or ``--l2-adapter`` JSON (MP). They are read at adapter creation time
+inside the adapter itself, so they are **never stored in the config object** and
+**never printed in startup logs**.
+
+**Example — MP mode with env vars:**
+
+.. code-block:: bash
+
+    export LMCACHE_RESP_USERNAME="default"
+    export LMCACHE_RESP_PASSWORD="secret"
+
+    lmcache server \
+        --l1-size-gb 10 \
+        --eviction-policy LRU \
+        --chunk-size 16 \
+        --l2-adapter '{"type": "resp", "host": "localhost", "port": 6379, "num_workers": 8}' \
+        --port 6555
+
+**Example — Non-MP mode with env vars:**
+
+.. code-block:: bash
+
+    export LMCACHE_RESP_USERNAME="default"
+    export LMCACHE_RESP_PASSWORD="secret"
+
+    LMCACHE_CONFIG_FILE=resp-config.yaml \
+    vllm serve meta-llama/Llama-3.1-8B-Instruct \
+        --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' \
+        --no-enable-prefix-caching \
+        --load-format dummy
+
+.. tip::
+   For production deployments, always use environment variables for credentials
+   rather than embedding them in config files or CLI arguments.
+
+
 Non-MP Mode (Single Process)
 -----------------------------
 
@@ -188,8 +247,11 @@ via the ``RESPClient`` asyncio wrapper.
 .. code-block:: yaml
 
     chunk_size: 16
-    remote_url: "redis://localhost:6379"
+    remote_url: "resp://localhost:6379"
     remote_serde: "naive"
+
+Credentials can be set via environment variables (recommended) or in the config file
+under ``extra_config`` (see `Environment Variable Configuration`_ above).
 
 **Launch vLLM:**
 
@@ -276,11 +338,11 @@ The ``--l2-adapter`` JSON accepts these fields:
    * - ``username``
      - str
      - ``""``
-     - Redis ACL username (leave empty for no auth)
+     - Redis ACL username (leave empty for no auth). Overridden by ``LMCACHE_RESP_USERNAME`` env var.
    * - ``password``
      - str
      - ``""``
-     - Redis AUTH password (leave empty for no auth)
+     - Redis AUTH password (leave empty for no auth). Overridden by ``LMCACHE_RESP_PASSWORD`` env var.
    * - ``max_capacity_gb``
      - float
      - 0
@@ -363,7 +425,7 @@ Best Practices
 - Use Redis 8.2+ with ``--io-threads 4`` (or more, matching available cores)
 - Disable persistence (``--save '' --appendonly no``) for KV cache workloads
 - Pin Redis to its own NUMA node if running on multi-socket systems
-- For production, enable authentication with ``--requirepass`` and use the ``username``/``password`` config fields
+- For production, enable authentication with ``--requirepass`` and supply credentials via ``LMCACHE_RESP_USERNAME`` / ``LMCACHE_RESP_PASSWORD`` environment variables to keep them out of logs
 
 **Client tuning:**
 

--- a/docs/source/kv_cache/storage_backends/resp.rst
+++ b/docs/source/kv_cache/storage_backends/resp.rst
@@ -191,18 +191,19 @@ appearing in logged configuration at startup.
    * - Variable
      - Description
    * - ``LMCACHE_RESP_USERNAME``
-     - Redis ACL username. Overrides ``username`` in config/JSON.
+     - Redis ACL username. Used as default when ``username`` is not set in config/JSON.
    * - ``LMCACHE_RESP_PASSWORD``
-     - Redis AUTH password. Overrides ``password`` in config/JSON.
+     - Redis AUTH password. Used as default when ``password`` is not set in config/JSON.
    * - ``LMCACHE_RESP_HOST``
-     - Redis hostname or IP. Overrides ``host`` in config/JSON/URL.
+     - Redis hostname or IP. Used as default when ``host`` is not set in config/JSON/URL.
    * - ``LMCACHE_RESP_PORT``
-     - Redis port. Overrides ``port`` in config/JSON/URL.
+     - Redis port. Used as default when ``port`` is not set in config/JSON/URL.
 
-Environment variables take precedence over values specified in config files
-(non-MP) or ``--l2-adapter`` JSON (MP). They are read at adapter creation time
-inside the adapter itself, so they are **never stored in the config object** and
-**never printed in startup logs**.
+Config files (non-MP) and ``--l2-adapter`` JSON (MP) take precedence over
+environment variables. Environment variables serve as defaults — they are used
+when the corresponding config value is empty or unset. They are read at adapter
+creation time inside the adapter itself, so they are **never stored in the
+config object** and **never printed in startup logs**.
 
 **Example — MP mode with env vars:**
 
@@ -338,11 +339,11 @@ The ``--l2-adapter`` JSON accepts these fields:
    * - ``username``
      - str
      - ``""``
-     - Redis ACL username (leave empty for no auth). Overridden by ``LMCACHE_RESP_USERNAME`` env var.
+     - Redis ACL username (leave empty for no auth). Falls back to ``LMCACHE_RESP_USERNAME`` env var if empty.
    * - ``password``
      - str
      - ``""``
-     - Redis AUTH password (leave empty for no auth). Overridden by ``LMCACHE_RESP_PASSWORD`` env var.
+     - Redis AUTH password (leave empty for no auth). Falls back to ``LMCACHE_RESP_PASSWORD`` env var if empty.
    * - ``max_capacity_gb``
      - float
      - 0

--- a/examples/kv_cache_reuse/remote_backends/resp/resp.yaml
+++ b/examples/kv_cache_reuse/remote_backends/resp/resp.yaml
@@ -8,5 +8,9 @@ blocking_timeout_secs: 120
 extra_config:
   resp_num_threads: 8 # default is 8 if not specified
   save_chunk_meta: False # make sure we have fixed size payloads
-  username: "default"
-  password: "YOUR_REDIS_PASSWORD"
+  # Authentication: prefer environment variables to keep secrets out of logs.
+  #   export LMCACHE_RESP_USERNAME="default"
+  #   export LMCACHE_RESP_PASSWORD="YOUR_REDIS_PASSWORD"
+  # Alternatively, set them here (they will appear in logged config):
+  # username: "default"
+  # password: "YOUR_REDIS_PASSWORD"

--- a/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
@@ -110,12 +110,13 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
             "- max_capacity_gb (float): max L2 capacity "
             "in GB for usage tracking / eviction "
             "(default 0 = disabled)\n\n"
-            "Environment variable overrides (read at "
-            "adapter creation, not stored in config):\n"
-            "- LMCACHE_RESP_USERNAME: overrides username\n"
-            "- LMCACHE_RESP_PASSWORD: overrides password\n"
-            "- LMCACHE_RESP_HOST: overrides host\n"
-            "- LMCACHE_RESP_PORT: overrides port"
+            "Environment variable defaults (used when "
+            "config value is empty, read at adapter "
+            "creation, not stored in config):\n"
+            "- LMCACHE_RESP_USERNAME: default username\n"
+            "- LMCACHE_RESP_PASSWORD: default password\n"
+            "- LMCACHE_RESP_HOST: default host\n"
+            "- LMCACHE_RESP_PORT: default port"
         )
 
 
@@ -144,14 +145,13 @@ def _create_resp_l2_adapter(
 
     assert isinstance(config, RESPL2AdapterConfig)
 
-    # Environment variables override config values so that
-    # sensitive credentials are never stored in (or logged
-    # from) the config object.
-    host = os.environ.get("LMCACHE_RESP_HOST", "") or config.host
-    port_str = os.environ.get("LMCACHE_RESP_PORT", "")
-    port = int(port_str) if port_str else config.port
-    username = os.environ.get("LMCACHE_RESP_USERNAME", "") or config.username
-    password = os.environ.get("LMCACHE_RESP_PASSWORD", "") or config.password
+    # Config/CLI args take precedence over environment variables,
+    # which serve as defaults. This keeps secrets out of logged
+    # config while allowing explicit CLI overrides.
+    host = config.host or os.environ.get("LMCACHE_RESP_HOST", "")
+    port = config.port if config.port else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+    username = config.username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+    password = config.password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
 
     native_client = LMCacheRedisClient(
         host,

--- a/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 # Standard
 from typing import TYPE_CHECKING, Optional
+import os
 
 if TYPE_CHECKING:
     from lmcache.v1.distributed.internal_api import (
@@ -108,7 +109,13 @@ class RESPL2AdapterConfig(L2AdapterConfigBase):
             "(default empty)\n"
             "- max_capacity_gb (float): max L2 capacity "
             "in GB for usage tracking / eviction "
-            "(default 0 = disabled)"
+            "(default 0 = disabled)\n\n"
+            "Environment variable overrides (read at "
+            "adapter creation, not stored in config):\n"
+            "- LMCACHE_RESP_USERNAME: overrides username\n"
+            "- LMCACHE_RESP_PASSWORD: overrides password\n"
+            "- LMCACHE_RESP_HOST: overrides host\n"
+            "- LMCACHE_RESP_PORT: overrides port"
         )
 
 
@@ -136,17 +143,27 @@ def _create_resp_l2_adapter(
     )
 
     assert isinstance(config, RESPL2AdapterConfig)
+
+    # Environment variables override config values so that
+    # sensitive credentials are never stored in (or logged
+    # from) the config object.
+    host = os.environ.get("LMCACHE_RESP_HOST", "") or config.host
+    port_str = os.environ.get("LMCACHE_RESP_PORT", "")
+    port = int(port_str) if port_str else config.port
+    username = os.environ.get("LMCACHE_RESP_USERNAME", "") or config.username
+    password = os.environ.get("LMCACHE_RESP_PASSWORD", "") or config.password
+
     native_client = LMCacheRedisClient(
-        config.host,
-        config.port,
+        host,
+        port,
         config.num_workers,
-        config.username,
-        config.password,
+        username,
+        password,
     )
     logger.info(
         "Created RESP L2 adapter: %s:%d (workers=%d)",
-        config.host,
-        config.port,
+        host,
+        port,
         config.num_workers,
     )
     return NativeConnectorL2Adapter(

--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -43,22 +43,23 @@ class RESPConnectorAdapter(ConnectorAdapter):
         # Get number of threads for RESP connection pool (default is 8)
         self.resp_num_threads = int(extra_config.get("resp_num_threads", 8))
 
-        # Get authentication credentials — environment variables
-        # take precedence over config so that secrets are never
-        # stored in (or logged from) the config object.
-        username = os.environ.get("LMCACHE_RESP_USERNAME", "") or str(
-            extra_config.get("username", "")
-        )
-        password = os.environ.get("LMCACHE_RESP_PASSWORD", "") or str(
-            extra_config.get("password", "")
-        )
+        # Config/CLI args take precedence over environment variables,
+        # which serve as defaults. This keeps secrets out of logged
+        # config while allowing explicit overrides.
+        cfg_username = str(extra_config.get("username", ""))
+        cfg_password = str(extra_config.get("password", ""))
+        username = cfg_username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+        password = cfg_password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
 
         parsed_url = parse_remote_url(context.url)
 
-        # Allow env vars to override host/port from URL
-        host = os.environ.get("LMCACHE_RESP_HOST", "") or parsed_url.host
-        port_str = os.environ.get("LMCACHE_RESP_PORT", "")
-        port = int(port_str) if port_str else parsed_url.port
+        # Config/URL values take precedence; env vars are fallback
+        host = parsed_url.host or os.environ.get("LMCACHE_RESP_HOST", "")
+        port = (
+            parsed_url.port
+            if parsed_url.port
+            else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+        )
 
         logger.info("Creating RESP connector for %s:%d", host, port)
         return RESPConnector(

--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import List, Tuple
+import os
 
 # First Party
 from lmcache.logging import init_logger
@@ -42,15 +43,27 @@ class RESPConnectorAdapter(ConnectorAdapter):
         # Get number of threads for RESP connection pool (default is 8)
         self.resp_num_threads = int(extra_config.get("resp_num_threads", 8))
 
-        # Get authentication credentials from extra_config
-        username = str(extra_config.get("username", ""))
-        password = str(extra_config.get("password", ""))
+        # Get authentication credentials — environment variables
+        # take precedence over config so that secrets are never
+        # stored in (or logged from) the config object.
+        username = os.environ.get("LMCACHE_RESP_USERNAME", "") or str(
+            extra_config.get("username", "")
+        )
+        password = os.environ.get("LMCACHE_RESP_PASSWORD", "") or str(
+            extra_config.get("password", "")
+        )
 
-        logger.info(f"Creating RESP connector for URL: {context.url}")
         parsed_url = parse_remote_url(context.url)
+
+        # Allow env vars to override host/port from URL
+        host = os.environ.get("LMCACHE_RESP_HOST", "") or parsed_url.host
+        port_str = os.environ.get("LMCACHE_RESP_PORT", "")
+        port = int(port_str) if port_str else parsed_url.port
+
+        logger.info("Creating RESP connector for %s:%d", host, port)
         return RESPConnector(
-            host=parsed_url.host,
-            port=parsed_url.port,
+            host=host,
+            port=port,
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
             num_threads=self.resp_num_threads,

--- a/tests/v1/distributed/test_resp_env_vars.py
+++ b/tests/v1/distributed/test_resp_env_vars.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for RESP adapter environment variable support.
+
+These tests verify the precedence logic (config > env var > default)
+without requiring a live Redis server.
+"""
+
+# Standard
+import os
+
+
+class TestRESPL2AdapterEnvVars:
+    """Test env var resolution in the MP-mode RESP L2 adapter factory."""
+
+    def test_env_vars_used_when_config_empty(self, monkeypatch):
+        """Env vars should be used when config values are empty/default."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.resp_l2_adapter import (
+            RESPL2AdapterConfig,
+        )
+
+        monkeypatch.setenv("LMCACHE_RESP_HOST", "env-host")
+        monkeypatch.setenv("LMCACHE_RESP_PORT", "7777")
+        monkeypatch.setenv("LMCACHE_RESP_USERNAME", "env-user")
+        monkeypatch.setenv("LMCACHE_RESP_PASSWORD", "env-pass")
+
+        config = RESPL2AdapterConfig(host="", port=0, username="", password="")
+
+        host = config.host or os.environ.get("LMCACHE_RESP_HOST", "")
+        port = (
+            config.port
+            if config.port
+            else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+        )
+        username = config.username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+        password = config.password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
+
+        assert host == "env-host"
+        assert port == 7777
+        assert username == "env-user"
+        assert password == "env-pass"
+
+    def test_config_overrides_env_vars(self, monkeypatch):
+        """Config values should take precedence over env vars."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.resp_l2_adapter import (
+            RESPL2AdapterConfig,
+        )
+
+        monkeypatch.setenv("LMCACHE_RESP_HOST", "env-host")
+        monkeypatch.setenv("LMCACHE_RESP_PORT", "7777")
+        monkeypatch.setenv("LMCACHE_RESP_USERNAME", "env-user")
+        monkeypatch.setenv("LMCACHE_RESP_PASSWORD", "env-pass")
+
+        config = RESPL2AdapterConfig(
+            host="cfg-host",
+            port=8888,
+            username="cfg-user",
+            password="cfg-pass",
+        )
+
+        host = config.host or os.environ.get("LMCACHE_RESP_HOST", "")
+        port = (
+            config.port
+            if config.port
+            else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+        )
+        username = config.username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+        password = config.password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
+
+        assert host == "cfg-host"
+        assert port == 8888
+        assert username == "cfg-user"
+        assert password == "cfg-pass"
+
+    def test_defaults_when_no_env_and_no_config(self, monkeypatch):
+        """Without env vars or config, values should be empty/zero."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.resp_l2_adapter import (
+            RESPL2AdapterConfig,
+        )
+
+        monkeypatch.delenv("LMCACHE_RESP_HOST", raising=False)
+        monkeypatch.delenv("LMCACHE_RESP_PORT", raising=False)
+        monkeypatch.delenv("LMCACHE_RESP_USERNAME", raising=False)
+        monkeypatch.delenv("LMCACHE_RESP_PASSWORD", raising=False)
+
+        config = RESPL2AdapterConfig(host="", port=0, username="", password="")
+
+        host = config.host or os.environ.get("LMCACHE_RESP_HOST", "")
+        port = (
+            config.port
+            if config.port
+            else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+        )
+        username = config.username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+        password = config.password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
+
+        assert host == ""
+        assert port == 0
+        assert username == ""
+        assert password == ""
+
+
+class TestRESPConnectorAdapterEnvVars:
+    """Test env var resolution in the non-MP RESP connector adapter."""
+
+    def test_env_vars_used_when_extra_config_empty(self, monkeypatch):
+        """Env vars should be used when extra_config has no credentials."""
+        monkeypatch.setenv("LMCACHE_RESP_USERNAME", "env-user")
+        monkeypatch.setenv("LMCACHE_RESP_PASSWORD", "env-pass")
+
+        extra_config = {}
+
+        cfg_username = str(extra_config.get("username", ""))
+        cfg_password = str(extra_config.get("password", ""))
+        username = cfg_username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+        password = cfg_password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
+
+        assert username == "env-user"
+        assert password == "env-pass"
+
+    def test_extra_config_overrides_env_vars(self, monkeypatch):
+        """extra_config values should take precedence over env vars."""
+        monkeypatch.setenv("LMCACHE_RESP_USERNAME", "env-user")
+        monkeypatch.setenv("LMCACHE_RESP_PASSWORD", "env-pass")
+
+        extra_config = {"username": "cfg-user", "password": "cfg-pass"}
+
+        cfg_username = str(extra_config.get("username", ""))
+        cfg_password = str(extra_config.get("password", ""))
+        username = cfg_username or os.environ.get("LMCACHE_RESP_USERNAME", "")
+        password = cfg_password or os.environ.get("LMCACHE_RESP_PASSWORD", "")
+
+        assert username == "cfg-user"
+        assert password == "cfg-pass"
+
+    def test_host_port_env_var_fallback(self, monkeypatch):
+        """Host/port env vars should be used when URL values are empty."""
+        monkeypatch.setenv("LMCACHE_RESP_HOST", "env-host")
+        monkeypatch.setenv("LMCACHE_RESP_PORT", "9999")
+
+        parsed_host = ""
+        parsed_port = 0
+
+        host = parsed_host or os.environ.get("LMCACHE_RESP_HOST", "")
+        port = (
+            parsed_port
+            if parsed_port
+            else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+        )
+
+        assert host == "env-host"
+        assert port == 9999
+
+    def test_url_overrides_env_vars(self, monkeypatch):
+        """URL-parsed values should take precedence over env vars."""
+        monkeypatch.setenv("LMCACHE_RESP_HOST", "env-host")
+        monkeypatch.setenv("LMCACHE_RESP_PORT", "9999")
+
+        parsed_host = "url-host"
+        parsed_port = 6379
+
+        host = parsed_host or os.environ.get("LMCACHE_RESP_HOST", "")
+        port = (
+            parsed_port
+            if parsed_port
+            else int(os.environ.get("LMCACHE_RESP_PORT", "0"))
+        )
+
+        assert host == "url-host"
+        assert port == 6379


### PR DESCRIPTION
Support LMCACHE_RESP_USERNAME, LMCACHE_RESP_PASSWORD, LMCACHE_RESP_HOST, and LMCACHE_RESP_PORT environment variables in both MP and non-MP modes. Env vars are read inside the adapter at creation time so credentials are never stored in the config object or printed in startup logs.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection/auth configuration for Redis/Valkey in both MP and non-MP code paths; precedence and fallback logic changes could cause misconfiguration or unexpected connection targets if env vars are set incorrectly.
> 
> **Overview**
> Adds environment-variable defaults for RESP credentials and endpoint (``LMCACHE_RESP_USERNAME``, ``LMCACHE_RESP_PASSWORD``, ``LMCACHE_RESP_HOST``, ``LMCACHE_RESP_PORT``) in both MP mode (``resp_l2_adapter``) and non-MP mode (``RESPConnectorAdapter``), with config/URL values taking precedence to keep secrets out of logged configs.
> 
> Updates RESP documentation and example config to recommend env vars for auth, and adjusts the non-MP sample URL scheme to ``resp://``. Adds unit tests covering precedence (config > env > default) for host/port and credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0441203b9e33a93f308104556fb86d8c4324510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->