### PR TITLE
[Chore] Add CODEOWNERS for automated PR review assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,95 @@
+# LMCache CODEOWNERS
+
+# Core engine
+/lmcache/v1/cache_engine.py            @ApostaC @YaoJiayi @sammshen
+/lmcache/v1/cache_controller/          @maobaolong @YaoJiayi @chunxiaozheng
+/lmcache/v1/offload_server/            @maobaolong @YaoJiayi
+
+# Memory management
+/lmcache/v1/memory_management.py       @sammshen @deng451e @chunxiaozheng @DongDongJu @ApostaC
+
+# Multiprocess
+/lmcache/v1/multiprocess/              @ApostaC
+/lmcache/v1/multiprocess/protocols/observability.py  @royyhuang @ApostaC
+/lmcache/v1/multiprocess/http_server.py              @royyhuang @ApostaC
+
+# Distributed / L2
+/lmcache/v1/distributed/               @ApostaC @maobaolong @chunxiaozheng
+/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py  @maobaolong
+
+# GPU connector
+/lmcache/v1/gpu_connector/             @sammshen @ApostaC
+
+# Lookup client
+/lmcache/v1/lookup_client/             @maobaolong @YaoJiayi @sammshen
+/lmcache/v1/lookup_client/mooncake_lookup_client.py  @maobaolong
+
+# Storage backends
+/lmcache/v1/storage_backend/           @maobaolong @sammshen @chunxiaozheng @DongDongJu
+/lmcache/v1/storage_backend/connector/base_connector.py        @sammshen @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/instrumented_connector.py @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/s3_connector.py          @sammshen @YaoJiayi
+/lmcache/v1/storage_backend/connector/s3_adapter.py            @sammshen @YaoJiayi
+/lmcache/v1/storage_backend/connector/mooncakestore_connector.py @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/mooncakestore_adapter.py  @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/fs_connector.py          @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/fs_adapter.py            @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/audit_connector.py       @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/audit_adapter.py         @maobaolong @chunxiaozheng
+/lmcache/v1/storage_backend/connector/redis_connector.py      @sammshen
+/lmcache/v1/storage_backend/connector/redis_adapter.py        @sammshen
+/lmcache/v1/storage_backend/connector/lm_connector.py         @sammshen
+/lmcache/v1/storage_backend/connector/lm_adapter.py           @sammshen
+
+# Integration
+/lmcache/integration/vllm/             @sammshen @maobaolong @YaoJiayi @deng451e
+/lmcache/integration/sglang/           @OasisGit @DongDongJu @sammshen
+/lmcache/integration/tensorrt_llm/     @sammshen
+
+# Non-CUDA equivalents
+/lmcache/non_cuda_equivalents.py       @hlin99 @hickeyma
+
+# C extensions
+/csrc/                                 @ApostaC @YaoJiayi @sammshen
+
+# Tests
+/tests/                                @hickeyma @sammshen @ApostaC @deng451e
+
+# CLI
+/lmcache/cli/                          @KuntaiDu @deng451e @royyhuang @ApostaC @sammshen
+
+# Server
+/lmcache/server/                       @ApostaC @YaoJiayi @KuntaiDu
+
+# Documentation
+/docs/source/mp/                       @ApostaC @YaoJiayi @KuntaiDu @royyhuang
+/docs/source/kv_cache/                 @sammshen @ApostaC
+/docs/source/kv_cache_optimizations/   @ApostaC @YaoJiayi
+/docs/source/getting_started/          @sammshen @deng451e
+/docs/source/developer_guide/          @sammshen @deng451e
+/docs/source/production/               @maobaolong @chunxiaozheng
+/docs/source/production/kv_cache_events.rst  @hickeyma
+/docs/                                 @sammshen @ApostaC @deng451e
+
+# Examples
+/examples/                             @sammshen @deng451e
+
+# CI / Infrastructure
+/.github/                              @hickeyma @sammshen @ApostaC @deng451e
+/.buildkite/                           @sammshen @ApostaC @deng451e @hickeyma
+
+# Operator
+/operator/                             @royyhuang
+
+# Rust
+/rust/                                 @DongDongJu
+
+# CXL / Maru / DAX
+/lmcache/v1/storage_backend/maru_backend.py            @DongDongJu
+/lmcache/v1/storage_backend/plugins/dax_backend.py     @DongDongJu
+/docs/source/kv_cache/storage_backends/maru.rst        @DongDongJu
+/docs/source/kv_cache/storage_backends/dax.rst         @DongDongJu
+
+# Packaging
+pyproject.toml                         @sammshen @ApostaC @deng451e @hickeyma
+setup.py                               @sammshen @ApostaC @deng451e @hickeyma

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,9 @@
 
 # Distributed / L2
 /lmcache/v1/distributed/               @ApostaC @maobaolong @chunxiaozheng
+/lmcache/v1/distributed/eviction.py                              @YaoJiayi
+/lmcache/v1/distributed/eviction_policy/                         @YaoJiayi
+/lmcache/v1/distributed/storage_controllers/eviction_controller.py @YaoJiayi
 /lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py  @maobaolong
 /lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py           @sammshen
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,9 @@
 /lmcache/v1/memory_management.py       @sammshen @deng451e @chunxiaozheng @DongDongJu @ApostaC
 
 # Multiprocess
-/lmcache/v1/multiprocess/              @ApostaC
+/lmcache/v1/multiprocess/              @ApostaC @OasisGit
 /lmcache/v1/multiprocess/protocols/observability.py  @royyhuang @ApostaC
-/lmcache/v1/multiprocess/http_server.py              @royyhuang @ApostaC
+/lmcache/v1/multiprocess/http_server.py              @royyhuang @ApostaC @OasisGit
 
 # Distributed / L2
 /lmcache/v1/distributed/               @ApostaC @maobaolong @chunxiaozheng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,12 @@
 
 # C extensions
 /csrc/                                 @ApostaC @YaoJiayi @sammshen
+/csrc/storage_backends/                @sammshen
+
+# Native connector L2 adapters
+/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py  @sammshen
+/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py     @sammshen
+/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py         @sammshen
 
 # Tests
 /tests/                                @hickeyma @sammshen @ApostaC @deng451e

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 # Distributed / L2
 /lmcache/v1/distributed/               @ApostaC @maobaolong @chunxiaozheng
 /lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py  @maobaolong
+/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py           @sammshen
 
 # GPU connector
 /lmcache/v1/gpu_connector/             @sammshen @ApostaC


### PR DESCRIPTION
Adds .github/CODEOWNERS to automatically request reviews from the appropriate maintainers when PRs touch specific areas of the codebase.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a `.github/CODEOWNERS` file only; no runtime or library behavior changes, with risk limited to potential misrouting of review requests.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file mapping key LMCache areas (engine, multiprocess, distributed/L2, storage backends, integrations, docs, CI, etc.) to specific maintainers so GitHub can automatically request reviews when matching paths change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa6106333469d11ce0cf7afcd32776ee0135d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->