### PR TITLE
[MP][Bugfix] Fix deadlock caused by cuda launch host func

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -50,3 +50,10 @@ steps:
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
+
+      - label: ":compression: deadlock"
+        command: .buildkite/k3_tests/multiprocess/run.sh deadlock
+        timeout_in_minutes: 30
+        agents: { queue: "k8s" }
+        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
+        artifact_paths: ["*.log"]

--- a/.buildkite/k3_tests/multiprocess/run.sh
+++ b/.buildkite/k3_tests/multiprocess/run.sh
@@ -6,7 +6,7 @@
 # No Docker -- all processes run natively in the pod.
 set -euo pipefail
 
-TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance)}"
+TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-deadlock.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-deadlock.sh
@@ -23,6 +23,29 @@ BUILD_ID="${BUILD_ID:-local_$$}"
 PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"
 TIMEOUT_SECONDS=180   # 3 minutes
 
+# ── Install py-spy for deadlock diagnosis ──────────────────
+echo "=== Installing py-spy ==="
+uv pip install py-spy
+PY_SPY="$(which py-spy)"
+echo "py-spy installed at: $PY_SPY"
+
+PYSPY_LOG="/tmp/build_${BUILD_ID}_pyspy.log"
+
+# ── Helper: dump stacks of server processes via py-spy ─────
+dump_stacks() {
+    echo "" | tee -a "$PYSPY_LOG"
+    echo "=== py-spy stack dump (native + Python) ===" | tee -a "$PYSPY_LOG"
+
+    if kill -0 "$LMCACHE_PID" 2>/dev/null; then
+        echo "" | tee -a "$PYSPY_LOG"
+        echo "--- LMCache server (PID=$LMCACHE_PID) ---" | tee -a "$PYSPY_LOG"
+        sudo "$PY_SPY" dump --pid "$LMCACHE_PID" --native 2>&1 | tee -a "$PYSPY_LOG" || true
+    fi
+
+    # Copy to repo root so cleanup.sh collects it as a Buildkite artifact
+    cp "$PYSPY_LOG" "${REPO_ROOT}/build_${BUILD_ID}_pyspy.log" 2>/dev/null || true
+}
+
 # ── 1. Launch LMCache server ───────────────────────────────
 echo "=== Launching LMCache server ==="
 echo "Port: $LMCACHE_PORT"
@@ -68,6 +91,7 @@ vllm serve "$MODEL" \
     --max-num-batched-tokens 16000 \
     --scheduling-policy fcfs \
     --port "$SAVED_VLLM_PORT" \
+    --enforce-eager \
     --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 60}}" \
     > "/tmp/build_${BUILD_ID}_vllm.log" 2>&1 &
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-deadlock.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-deadlock.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Self-contained deadlock regression test.
+#
+# Launches DeepSeek-V2-Lite-Chat with TP=2 (both GPUs) + LMCache server,
+# sends 50 requests with ~30K token prefixes, and verifies they all
+# complete within 3 minutes.  A CUDA-driver/GIL deadlock would cause
+# requests to hang indefinitely, failing the timeout.
+#
+# This test is self-contained: it handles its own server lifecycle
+# instead of using the standard launch-processes.sh / wait-for-servers.sh.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+
+# ── Configuration ───────────────────────────────────────────
+MODEL="deepseek-ai/DeepSeek-V2-Lite-Chat"
+LMCACHE_PORT="${LMCACHE_PORT:-15554}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+BUILD_ID="${BUILD_ID:-local_$$}"
+PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"
+TIMEOUT_SECONDS=180   # 3 minutes
+
+# ── 1. Launch LMCache server ───────────────────────────────
+echo "=== Launching LMCache server ==="
+echo "Port: $LMCACHE_PORT"
+
+lmcache server \
+    --host localhost \
+    --port "$LMCACHE_PORT" \
+    --chunk-size 256 \
+    --l1-size-gb 50 \
+    --eviction-policy LRU \
+    --max-workers 2 \
+    > "/tmp/build_${BUILD_ID}_lmcache.log" 2>&1 &
+
+LMCACHE_PID=$!
+echo "$LMCACHE_PID" >> "$PID_FILE"
+echo "LMCache server started (PID=$LMCACHE_PID)"
+sleep 10
+
+# ── 2. Launch vLLM with DeepSeek TP=2 ─────────────────────
+echo "=== Launching vLLM (DeepSeek TP=2) ==="
+echo "Model: $MODEL"
+echo "Port: $VLLM_PORT"
+
+# Save VLLM_PORT before unsetting — vLLM's internal get_open_port()
+# would otherwise collide with the serving port for torch.distributed.
+SAVED_VLLM_PORT="$VLLM_PORT"
+unset VLLM_PORT
+
+FLASHINFER_DISABLE_VERSION_CHECK=1 \
+VLLM_SERVER_DEV_MODE=1 \
+vllm serve "$MODEL" \
+    --tensor-parallel-size 2 \
+    --distributed-executor-backend mp \
+    --block-size 64 \
+    --trust-remote-code \
+    --load-format dummy \
+    --enable-prefix-caching \
+    --enable-chunked-prefill \
+    --gpu-memory-utilization 0.8 \
+    --max-model-len 65536 \
+    --hf-overrides '{"max_position_embeddings":65536}' \
+    --max-num-seqs 32 \
+    --max-num-batched-tokens 16000 \
+    --scheduling-policy fcfs \
+    --port "$SAVED_VLLM_PORT" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 60}}" \
+    > "/tmp/build_${BUILD_ID}_vllm.log" 2>&1 &
+
+VLLM_PID=$!
+echo "$VLLM_PID" >> "$PID_FILE"
+echo "vLLM started (PID=$VLLM_PID)"
+
+VLLM_PORT="$SAVED_VLLM_PORT"
+
+# ── 3. Wait for vLLM to be ready ──────────────────────────
+echo "=== Waiting for vLLM to be ready ==="
+if ! wait_for_server "$VLLM_PORT" 600; then
+    echo "vLLM failed to start. Last 100 lines of log:"
+    tail -100 "/tmp/build_${BUILD_ID}_vllm.log" 2>/dev/null || true
+    exit 1
+fi
+
+# ── 4. Run benchmark with timeout ─────────────────────────
+echo "=== Running lmcache bench engine (random-prefill, 50 reqs, ~30K tokens) ==="
+echo "Timeout: ${TIMEOUT_SECONDS}s"
+
+if ! timeout "$TIMEOUT_SECONDS" lmcache bench engine \
+        --engine-url "http://localhost:${VLLM_PORT}" \
+        --workload random-prefill \
+        --tokens-per-gb-kvcache 6000 \
+        --rp-request-length 30000 \
+        --rp-num-requests 50 \
+        --no-interactive \
+        --no-csv \
+        -q; then
+    echo "FAIL: Benchmark failed or timed out (possible deadlock)"
+    echo ""
+    echo "=== LMCache log (last 50 lines) ==="
+    tail -50 "/tmp/build_${BUILD_ID}_lmcache.log" 2>/dev/null || true
+    echo ""
+    echo "=== vLLM log (last 50 lines) ==="
+    tail -50 "/tmp/build_${BUILD_ID}_vllm.log" 2>/dev/null || true
+    exit 1
+fi
+
+echo ""
+echo "=== Benchmark completed within ${TIMEOUT_SECONDS}s ==="
+echo "PASS: No deadlock detected"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -42,25 +42,30 @@ echo "vLLM baseline port: $VLLM_BASELINE_PORT"
 echo "Results dir: $RESULTS_DIR"
 echo ""
 
-# ── Step 1: Launch native processes ──────────────────────────
-echo "============================================"
-echo "=== Launching native processes ==="
-echo "============================================"
-if ! "${SCRIPT_DIR}/launch-processes.sh"; then
-    echo "Failed to launch processes"
-    exit 1
-fi
-echo ""
+# Tests that handle their own server lifecycle (different GPU/model config)
+SELF_CONTAINED_TESTS=" deadlock "
 
-# ── Step 2: Wait for vLLM to be ready ───────────────────────
-echo "============================================"
-echo "=== Waiting for vLLM to be ready ==="
-echo "============================================"
-if ! "${SCRIPT_DIR}/wait-for-servers.sh"; then
-    echo "vLLM failed to become ready"
-    exit 1
+if [[ "$SELF_CONTAINED_TESTS" != *" $TEST_NAME "* ]]; then
+    # ── Step 1: Launch native processes ──────────────────────────
+    echo "============================================"
+    echo "=== Launching native processes ==="
+    echo "============================================"
+    if ! "${SCRIPT_DIR}/launch-processes.sh"; then
+        echo "Failed to launch processes"
+        exit 1
+    fi
+    echo ""
+
+    # ── Step 2: Wait for vLLM to be ready ───────────────────────
+    echo "============================================"
+    echo "=== Waiting for vLLM to be ready ==="
+    echo "============================================"
+    if ! "${SCRIPT_DIR}/wait-for-servers.sh"; then
+        echo "vLLM failed to become ready"
+        exit 1
+    fi
+    echo ""
 fi
-echo ""
 
 # ── Step 3: Run the requested test ──────────────────────────
 echo "============================================"
@@ -83,9 +88,12 @@ case "$TEST_NAME" in
     fault_tolerance)
         exec_script="${SCRIPT_DIR}/run-fault-tolerance.sh"
         ;;
+    deadlock)
+        exec_script="${SCRIPT_DIR}/run-deadlock.sh"
+        ;;
     *)
         echo "Unknown test: $TEST_NAME"
-        echo "Valid tests: lm_eval, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance"
+        echo "Valid tests: lm_eval, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock"
         exit 1
         ;;
 esac

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,7 @@ steps:
           --ignore=tests/v1/test_nixl_storage.py \
           --ignore=tests/skipped \
           --ignore=tests/v1/multiprocess \
+          --ignore=tests/v1/mp_observability/test_event_recorder.py \
           --ignore=tests/v1/storage_backend/test_eic.py
       fi
 

--- a/csrc/event_recorder.cpp
+++ b/csrc/event_recorder.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "event_recorder.h"
+
+#include <chrono>
+#include <utility>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static double wall_clock_time() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration<double>(now.time_since_epoch()).count();
+}
+
+// ---------------------------------------------------------------------------
+// EventRecorder
+// ---------------------------------------------------------------------------
+
+EventRecorder& EventRecorder::instance() {
+  static EventRecorder recorder;
+  return recorder;
+}
+
+void EventRecorder::push(PendingEvent* event) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffer_.push_back(std::move(*event));
+  }
+  delete event;
+}
+
+std::vector<PendingEvent> EventRecorder::drain() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<PendingEvent> result;
+  result.swap(buffer_);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// CUDA host callback — runs on a CUDA driver thread, no GIL.
+// ---------------------------------------------------------------------------
+
+static void
+#ifndef USE_ROCM
+    CUDART_CB
+#endif
+    event_host_callback(void* data) {
+  auto* event = static_cast<PendingEvent*>(data);
+  event->timestamp = wall_clock_time();
+  EventRecorder::instance().push(event);
+}
+
+// ---------------------------------------------------------------------------
+// Free functions for pybind11
+// ---------------------------------------------------------------------------
+
+void record_event_on_stream(
+    int64_t cuda_stream_ptr, const std::string& event_type_name,
+    const std::string& session_id,
+    const std::unordered_map<std::string, std::string>& str_metadata,
+    const std::unordered_map<std::string, int64_t>& int_metadata) {
+  auto* event = new PendingEvent{
+      event_type_name, session_id, 0.0, str_metadata, int_metadata,
+  };
+
+  auto stream = reinterpret_cast<lmcache_stream_t>(
+      static_cast<uintptr_t>(cuda_stream_ptr));
+  LMCACHE_LAUNCH_HOST_FUNC(stream, event_host_callback, event);
+}
+
+DrainResult drain_recorded_events() {
+  auto events = EventRecorder::instance().drain();
+  DrainResult result;
+  result.reserve(events.size());
+  for (auto& e : events) {
+    result.emplace_back(std::move(e.event_type_name), std::move(e.session_id),
+                        e.timestamp, std::move(e.str_metadata),
+                        std::move(e.int_metadata));
+  }
+  return result;
+}

--- a/csrc/event_recorder.h
+++ b/csrc/event_recorder.h
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+// CUDA / HIP runtime
+#ifdef USE_ROCM
+  #include <hip/hip_runtime.h>
+using lmcache_stream_t = hipStream_t;
+  #define LMCACHE_LAUNCH_HOST_FUNC hipLaunchHostFunc
+#else
+  #include <cuda_runtime.h>
+using lmcache_stream_t = cudaStream_t;
+  #define LMCACHE_LAUNCH_HOST_FUNC cudaLaunchHostFunc
+#endif
+
+// ---------------------------------------------------------------------------
+// PendingEvent — lightweight struct held in a lock-free-ish buffer.
+// All fields are pure C++ (no Python objects) so the CUDA host callback
+// can write the timestamp without touching the GIL.
+// ---------------------------------------------------------------------------
+
+struct PendingEvent {
+  std::string event_type_name;  // e.g. "mp.store.start"
+  std::string session_id;
+  double timestamp;  // wall-clock, set by host callback
+  std::unordered_map<std::string, std::string> str_metadata;
+  std::unordered_map<std::string, int64_t> int_metadata;
+};
+
+// ---------------------------------------------------------------------------
+// EventRecorder — global singleton that buffers events from CUDA callbacks.
+// ---------------------------------------------------------------------------
+
+class EventRecorder {
+ public:
+  static EventRecorder& instance();
+
+  // Called from the CUDA host callback (no GIL held).
+  // Takes ownership of *event, moves it into the buffer, then deletes it.
+  void push(PendingEvent* event);
+
+  // Called from Python (GIL held) to drain all buffered events.
+  std::vector<PendingEvent> drain();
+
+ private:
+  EventRecorder() = default;
+  std::mutex mutex_;
+  std::vector<PendingEvent> buffer_;
+};
+
+// ---------------------------------------------------------------------------
+// Free functions exposed via pybind11
+// ---------------------------------------------------------------------------
+
+// Schedule an event recording on a CUDA stream.  The host callback stamps
+// the wall-clock time and pushes to the global EventRecorder.
+// Called WITHOUT the GIL (py::call_guard<py::gil_scoped_release>).
+void record_event_on_stream(
+    int64_t cuda_stream_ptr, const std::string& event_type_name,
+    const std::string& session_id,
+    const std::unordered_map<std::string, std::string>& str_metadata,
+    const std::unordered_map<std::string, int64_t>& int_metadata);
+
+// Drain all buffered events.  Returns a list of tuples:
+//   (event_type_name, session_id, timestamp, str_metadata, int_metadata)
+using DrainResult =
+    std::vector<std::tuple<std::string, std::string, double,
+                           std::unordered_map<std::string, std::string>,
+                           std::unordered_map<std::string, int64_t>>>;
+
+DrainResult drain_recorded_events();

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -8,6 +8,7 @@
 #include "pos_kernels.cuh"
 #include "mem_alloc.h"
 #include "utils.h"
+#include "event_recorder.h"
 #include <torch/torch.h>
 #include <torch/extension.h>
 #include <iostream>
@@ -84,4 +85,9 @@ PYBIND11_MODULE(c_ops, m) {
       .def_readwrite("nh", &PageBufferShapeDesc::nh)
       .def_readwrite("hs", &PageBufferShapeDesc::hs)
       .def_readwrite("element_size", &PageBufferShapeDesc::element_size);
+  m.def("record_event_on_stream", &record_event_on_stream,
+        py::arg("cuda_stream_ptr"), py::arg("event_type_name"),
+        py::arg("session_id"), py::arg("str_metadata"), py::arg("int_metadata"),
+        py::call_guard<py::gil_scoped_release>());
+  m.def("drain_recorded_events", &drain_recorded_events);
 }

--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -18,6 +18,17 @@ import time
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.event import Event, EventType
 
+try:
+    # Third Party
+    import torch  # noqa: F401 — must be imported before lmcache.c_ops
+
+    # First Party
+    import lmcache.c_ops as _lmc_ops
+
+    _has_native_recorder = hasattr(_lmc_ops, "record_event_on_stream")
+except ImportError:
+    _has_native_recorder = False
+
 logger = init_logger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -120,14 +131,33 @@ class EventBus:
             self._registered_subscribers.append(subscriber)
 
     def publish_on_stream(self, stream: Any, event: Event) -> None:
-        """Schedule :meth:`publish` as a CUDA host function on *stream*.
+        """Schedule event recording as a CUDA host function on *stream*.
+
+        Uses a C++ callback via ``cudaLaunchHostFunc`` so the callback
+        never touches the GIL, avoiding the CUDA-driver/GIL deadlock.
 
         No-op when the EventBus is disabled, avoiding the overhead of
         scheduling a host function on the CUDA stream entirely.
         """
         if not self._config.enabled:
             return
-        stream.launch_host_func(self.publish, event)
+        if _has_native_recorder:
+            str_metadata: dict[str, str] = {}
+            int_metadata: dict[str, int] = {}
+            for k, v in event.metadata.items():
+                if isinstance(v, int):
+                    int_metadata[k] = v
+                else:
+                    str_metadata[k] = str(v)
+            _lmc_ops.record_event_on_stream(
+                stream.ptr,
+                event.event_type.value,
+                event.session_id,
+                str_metadata,
+                int_metadata,
+            )
+        else:
+            stream.launch_host_func(self.publish, event)
 
     def publish(self, event: Event) -> None:
         """Submit an event (hot path — non-blocking).
@@ -207,6 +237,20 @@ class EventBus:
 
     def _drain_all(self) -> None:
         """Pop all queued events and dispatch to subscribers."""
+        # Drain events buffered on the C++ side (from CUDA host callbacks)
+        if _has_native_recorder:
+            for name, sid, ts, str_meta, int_meta in _lmc_ops.drain_recorded_events():
+                metadata: dict[str, Any] = dict(str_meta)
+                metadata.update(int_meta)
+                self._queue.append(
+                    Event(
+                        event_type=EventType(name),
+                        session_id=sid,
+                        timestamp=ts,
+                        metadata=metadata,
+                    )
+                )
+
         with self._lock:
             snapshot = dict(self._subscribers)
 

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ def cuda_extension() -> tuple[list, dict]:
         "csrc/pos_kernels.cu",
         "csrc/mem_alloc.cpp",
         "csrc/utils.cpp",
+        "csrc/event_recorder.cpp",
     ]
     storage_manager_sources = [
         "csrc/storage_manager/bitmap.cpp",
@@ -201,6 +202,7 @@ def rocm_extension() -> tuple[list, dict]:
         "csrc/pos_kernels.hip",
         "csrc/mem_alloc_hip.cpp",
         "csrc/utils_hip.cpp",
+        "csrc/event_recorder.cpp",
     ]
     storage_manager_sources = [
         "csrc/storage_manager/bitmap.cpp",

--- a/tests/v1/mp_observability/test_event_recorder.py
+++ b/tests/v1/mp_observability/test_event_recorder.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the C++ EventRecorder (record_event_on_stream / drain)."""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch required")
+if not torch.cuda.is_available():
+    pytest.skip("CUDA not available", allow_module_level=True)
+
+lmc_ops = pytest.importorskip("lmcache.c_ops", reason="lmcache.c_ops not built")
+if not hasattr(lmc_ops, "record_event_on_stream"):
+    pytest.skip("record_event_on_stream not available", allow_module_level=True)
+
+# Third Party
+import cupy  # noqa: E402
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType  # noqa: E402
+from lmcache.v1.mp_observability.event_bus import (  # noqa: E402
+    EventBus,
+    EventBusConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def stream():
+    """Return a synchronised CuPy external stream."""
+    s = cupy.cuda.Stream()
+    yield s
+    s.synchronize()
+
+
+@pytest.fixture()
+def bus():
+    return EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+
+
+# ---------------------------------------------------------------------------
+# Tests: C++ record / drain API
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAndDrain:
+    """Low-level tests for lmc_ops.record_event_on_stream / drain."""
+
+    def test_drain_empty(self):
+        events = lmc_ops.drain_recorded_events()
+        assert events == []
+
+    def test_single_event(self, stream):
+        lmc_ops.record_event_on_stream(
+            stream.ptr,
+            "mp.store.start",
+            "sess-1",
+            {"device": "cuda:0"},
+            {},
+        )
+        stream.synchronize()
+
+        events = lmc_ops.drain_recorded_events()
+        assert len(events) == 1
+        name, sid, ts, str_meta, int_meta = events[0]
+        assert name == "mp.store.start"
+        assert sid == "sess-1"
+        assert ts > 0.0
+        assert str_meta == {"device": "cuda:0"}
+        assert int_meta == {}
+
+    def test_int_metadata_preserved(self, stream):
+        lmc_ops.record_event_on_stream(
+            stream.ptr,
+            "mp.store.end",
+            "sess-2",
+            {"device": "cuda:0"},
+            {"stored_count": 42},
+        )
+        stream.synchronize()
+
+        events = lmc_ops.drain_recorded_events()
+        assert len(events) == 1
+        _, _, _, str_meta, int_meta = events[0]
+        assert str_meta == {"device": "cuda:0"}
+        assert int_meta == {"stored_count": 42}
+
+    def test_multiple_events_ordered(self, stream):
+        for i in range(5):
+            lmc_ops.record_event_on_stream(
+                stream.ptr,
+                f"mp.test.{i}",
+                f"sess-{i}",
+                {},
+                {"idx": i},
+            )
+        stream.synchronize()
+
+        events = lmc_ops.drain_recorded_events()
+        assert len(events) == 5
+        for i, (name, sid, ts, _, int_meta) in enumerate(events):
+            assert name == f"mp.test.{i}"
+            assert sid == f"sess-{i}"
+            assert int_meta["idx"] == i
+            assert ts > 0.0
+
+    def test_drain_clears_buffer(self, stream):
+        lmc_ops.record_event_on_stream(stream.ptr, "mp.store.start", "s", {}, {})
+        stream.synchronize()
+
+        first = lmc_ops.drain_recorded_events()
+        assert len(first) == 1
+
+        second = lmc_ops.drain_recorded_events()
+        assert second == []
+
+    def test_timestamps_monotonic(self, stream):
+        for _ in range(3):
+            lmc_ops.record_event_on_stream(stream.ptr, "mp.store.start", "s", {}, {})
+        stream.synchronize()
+
+        events = lmc_ops.drain_recorded_events()
+        timestamps = [e[2] for e in events]
+        assert timestamps == sorted(timestamps)
+
+
+# ---------------------------------------------------------------------------
+# Tests: EventBus integration (publish_on_stream -> drain)
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusIntegration:
+    """Verify EventBus.publish_on_stream routes through C++ and events
+    are dispatched to subscribers via the drain thread."""
+
+    def test_publish_on_stream_reaches_subscriber(self, stream, bus):
+        received: list[Event] = []
+        bus.subscribe(EventType.MP_STORE_START, received.append)
+        bus.start()
+
+        bus.publish_on_stream(
+            stream,
+            Event(
+                event_type=EventType.MP_STORE_START,
+                session_id="req-1",
+                metadata={"device": "cuda:0"},
+            ),
+        )
+        stream.synchronize()
+        time.sleep(0.3)
+        bus.stop()
+
+        assert len(received) == 1
+        evt = received[0]
+        assert evt.event_type is EventType.MP_STORE_START
+        assert evt.session_id == "req-1"
+        assert evt.metadata["device"] == "cuda:0"
+        assert evt.timestamp > 0.0
+
+    def test_int_metadata_roundtrip(self, stream, bus):
+        received: list[Event] = []
+        bus.subscribe(EventType.MP_STORE_END, received.append)
+        bus.start()
+
+        bus.publish_on_stream(
+            stream,
+            Event(
+                event_type=EventType.MP_STORE_END,
+                session_id="req-2",
+                metadata={"device": "cuda:0", "stored_count": 10},
+            ),
+        )
+        stream.synchronize()
+        time.sleep(0.3)
+        bus.stop()
+
+        assert len(received) == 1
+        assert received[0].metadata["stored_count"] == 10
+        assert received[0].metadata["device"] == "cuda:0"
+
+    def test_disabled_bus_skips_recording(self, stream):
+        disabled_bus = EventBus(EventBusConfig(enabled=False))
+        disabled_bus.publish_on_stream(
+            stream,
+            Event(
+                event_type=EventType.MP_STORE_START,
+                session_id="req-3",
+                metadata={"device": "cuda:0"},
+            ),
+        )
+        stream.synchronize()
+
+        events = lmc_ops.drain_recorded_events()
+        assert events == []


### PR DESCRIPTION
**What this PR does / why we need it**:

`EventBus.publish_on_stream()` schedules Python callbacks on CUDA streams via
`cupy_stream.launch_host_func(self.publish, event)`. This causes a CUDA
driver / GIL deadlock: the host-function callback holds the CUDA driver lock
and tries to acquire the GIL, while another thread holds the GIL and waits on
the CUDA driver lock.

This PR introduces a C++ `EventRecorder` that calls `cudaLaunchHostFunc`
directly. The callback runs entirely in native code (no GIL), stamps the
wall-clock timestamp, and buffers events in a thread-safe C++ vector. The
EventBus drain thread periodically pulls these buffered events into the Python
dispatch queue via `drain_recorded_events()`.

Changes:
- New `csrc/event_recorder.{h,cpp}`: `EventRecorder` singleton with
  `cudaLaunchHostFunc` callback and `drain()` API
- `csrc/pybind.cpp`: bind `record_event_on_stream` (GIL released) and
  `drain_recorded_events`
- `event_bus.py`: `publish_on_stream` routes through C++ when available;
  `_drain_all` drains the C++ buffer before processing the Python queue
- Fallback to the old Python path when `lmcache.c_ops` is unavailable
- New end to end CI test to prevent deadlock happen again

**Special notes for your reviewers**:

- `record_event_on_stream` releases the GIL via `py::call_guard` to avoid the
  reverse deadlock (Python thread → CUDA driver lock)
- ROCm/HIP supported via `#ifdef USE_ROCM` (maps to `hipLaunchHostFunc`)
- The 4 affected callsites (`MP_STORE_START/END`, `MP_RETRIEVE_START/END`) in
  `server.py` are unchanged — the fix is internal to `EventBus`

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CUDA/HIP host-callback C++ code and pybind APIs on the MP observability hot path; mistakes could cause crashes, leaks, or missing events, but behavior is gated with a Python fallback and covered by new tests.
> 
> **Overview**
> Fixes a multiprocessing observability deadlock by switching `EventBus.publish_on_stream` from scheduling a Python callback on the CUDA stream to scheduling a native `cudaLaunchHostFunc`/`hipLaunchHostFunc` callback that records events without touching the GIL.
> 
> Introduces a C++ `EventRecorder` buffer (`record_event_on_stream` + `drain_recorded_events`) exposed via `lmcache.c_ops`, and updates the EventBus drain loop to pull native-recorded events into the normal Python dispatch queue (falling back to the old Python path when the native API isn’t available).
> 
> Adds CUDA unit/integration tests for the recorder + EventBus routing, updates build configuration to compile the new source, and adds a dedicated Buildkite multiprocess `deadlock` regression step (while skipping the new CUDA-only test on ROCm CI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b6bfd44f8591554225238e0d53c86d3c587f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->