### PR TITLE
[fix] Limit proxy in-flight requests to prevent PD buffer deadlock

### DIFF
--- a/examples/disagg_prefill/1p1d/disagg_example_1p1d.sh
+++ b/examples/disagg_prefill/1p1d/disagg_example_1p1d.sh
@@ -100,6 +100,10 @@ wait_for_server() {
 
 
 main() {
+    # kv_bytes_per_token = num_layers * 2 * num_kv_heads * head_size * dtype_bytes
+    # Default: Llama-3.1-8B bf16 (32*2*8*128*2). Override via first argument.
+    KV_BYTES_PER_TOKEN=${1:-131072}
+
     check_hf_token
     check_num_gpus
     ensure_python_library_installed lmcache
@@ -115,6 +119,9 @@ main() {
     echo "Launching prefiller, decoder and proxy..."
     echo "Please check prefiller.log, decoder.log and proxy.log for logs."
 
+    # Read pd_buffer_size from decoder config (single source of truth).
+    PD_BUFFER_SIZE_BYTES=$(grep 'pd_buffer_size' configs/lmcache-decoder-config.yaml | awk '{print $2}')
+
     # Launch the proxy first
     python3 ../disagg_proxy_server.py \
         --host localhost \
@@ -129,6 +136,8 @@ main() {
         --proxy-host localhost \
         --proxy-port 7500 \
         --num-decoders 1 \
+        --pd-buffer-size $PD_BUFFER_SIZE_BYTES \
+        --kv-bytes-per-token $KV_BYTES_PER_TOKEN \
         > >(tee proxy.log)    2>&1 &
     proxy_pid=$!
     PIDS+=($proxy_pid)

--- a/examples/disagg_prefill/1p1d/disagg_example_1p1d.sh
+++ b/examples/disagg_prefill/1p1d/disagg_example_1p1d.sh
@@ -100,10 +100,10 @@ wait_for_server() {
 
 
 main() {
-    # Max in-flight tokens: limits concurrent PD buffer usage to prevent deadlocks.
-    # Default (16384) suits Llama-3.1-8B on a 2 GB PD buffer (2GB / 131072 B/tok).
-    # Pass as the first argument to override for other models or buffer sizes.
-    MAX_INFLIGHT_TOKENS=${1:-16384}
+    # Usage: main [model] [pd_buffer_size_bytes]
+    # Defaults: meta-llama/Llama-3.1-8B-Instruct, 2147483648 (2 GB)
+    MODEL=${1:-meta-llama/Llama-3.1-8B-Instruct}
+    PD_BUFFER_SIZE=${2:-2147483648}
 
     check_hf_token
     check_num_gpus
@@ -117,6 +117,8 @@ main() {
     trap cleanup USR1
     trap cleanup TERM
 
+    echo "Model: $MODEL"
+    echo "PD buffer size: $PD_BUFFER_SIZE bytes"
     echo "Launching prefiller, decoder and proxy..."
     echo "Please check prefiller.log, decoder.log and proxy.log for logs."
 
@@ -134,21 +136,22 @@ main() {
         --proxy-host localhost \
         --proxy-port 7500 \
         --num-decoders 1 \
-        --max-inflight-tokens $MAX_INFLIGHT_TOKENS \
+        --model "$MODEL" \
+        --pd-buffer-size "$PD_BUFFER_SIZE" \
         > >(tee proxy.log)    2>&1 &
     proxy_pid=$!
     PIDS+=($proxy_pid)
 
 
     # Launch the decoder
-    bash disagg_vllm_launcher.sh decoder  \
+    bash disagg_vllm_launcher.sh decoder "$MODEL" \
         > >(tee decoder.log)  2>&1 &
     decoder_pid=$!
     PIDS+=($decoder_pid)
 
 
     # Launch the prefiller next
-    bash disagg_vllm_launcher.sh prefiller \
+    bash disagg_vllm_launcher.sh prefiller "$MODEL" \
         > >(tee prefiller.log) 2>&1 &
     prefiller_pid=$!
     PIDS+=($prefiller_pid)
@@ -170,4 +173,4 @@ main() {
     done
 }
 
-main
+main "$@"

--- a/examples/disagg_prefill/1p1d/disagg_example_1p1d.sh
+++ b/examples/disagg_prefill/1p1d/disagg_example_1p1d.sh
@@ -100,9 +100,10 @@ wait_for_server() {
 
 
 main() {
-    # kv_bytes_per_token = num_layers * 2 * num_kv_heads * head_size * dtype_bytes
-    # Default: Llama-3.1-8B bf16 (32*2*8*128*2). Override via first argument.
-    KV_BYTES_PER_TOKEN=${1:-131072}
+    # Max in-flight tokens: limits concurrent PD buffer usage to prevent deadlocks.
+    # Default (16384) suits Llama-3.1-8B on a 2 GB PD buffer (2GB / 131072 B/tok).
+    # Pass as the first argument to override for other models or buffer sizes.
+    MAX_INFLIGHT_TOKENS=${1:-16384}
 
     check_hf_token
     check_num_gpus
@@ -119,9 +120,6 @@ main() {
     echo "Launching prefiller, decoder and proxy..."
     echo "Please check prefiller.log, decoder.log and proxy.log for logs."
 
-    # Read pd_buffer_size from decoder config (single source of truth).
-    PD_BUFFER_SIZE_BYTES=$(grep 'pd_buffer_size' configs/lmcache-decoder-config.yaml | awk '{print $2}')
-
     # Launch the proxy first
     python3 ../disagg_proxy_server.py \
         --host localhost \
@@ -136,8 +134,7 @@ main() {
         --proxy-host localhost \
         --proxy-port 7500 \
         --num-decoders 1 \
-        --pd-buffer-size $PD_BUFFER_SIZE_BYTES \
-        --kv-bytes-per-token $KV_BYTES_PER_TOKEN \
+        --max-inflight-tokens $MAX_INFLIGHT_TOKENS \
         > >(tee proxy.log)    2>&1 &
     proxy_pid=$!
     PIDS+=($proxy_pid)

--- a/examples/disagg_prefill/1p1d/disagg_vllm_launcher.sh
+++ b/examples/disagg_prefill/1p1d/disagg_vllm_launcher.sh
@@ -30,7 +30,6 @@ if [[ $1 == "prefiller" ]]; then
         CUDA_VISIBLE_DEVICES=${PREFILLER_DEVICE_ID:-0} \
         vllm serve $MODEL \
         --port 7100 \
-        --disable-log-requests \
         --enforce-eager \
         --no-enable-prefix-caching \
         --kv-transfer-config \
@@ -50,7 +49,6 @@ elif [[ $1 == "decoder" ]]; then
         CUDA_VISIBLE_DEVICES=${DECODER_DEVICE_ID:-1} \
         vllm serve $MODEL \
         --port 7200 \
-        --disable-log-requests \
         --enforce-eager \
         --no-enable-prefix-caching \
         --kv-transfer-config \

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -8,6 +8,7 @@ import argparse
 import asyncio
 import itertools
 import json
+import math
 import os
 import time
 
@@ -28,6 +29,36 @@ from lmcache.v1.storage_backend.pd_backend import (
 )
 
 logger = init_logger(__name__)
+
+
+class WeightedSemaphore:
+    """Async semaphore with variable-weight acquire.
+
+    Limits decoder PD buffer usage: each request holds ceil(L/chunk_size)
+    slots until decoding starts, preventing buffer exhaustion deadlocks.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        self._capacity = capacity
+        self._available = capacity
+        self._lock = asyncio.Condition()
+
+    async def acquire(self, slots: int) -> None:
+        async with self._lock:
+            await self._lock.wait_for(lambda: self._available >= slots)
+            self._available -= slots
+
+    def release(self, slots: int) -> None:
+        async def _release():
+            async with self._lock:
+                self._available += slots
+                self._lock.notify_all()
+
+        asyncio.get_event_loop().create_task(_release())
+
+    @property
+    def available(self) -> int:
+        return self._available
 
 
 @asynccontextmanager
@@ -199,6 +230,30 @@ def parse_args():
     parser.add_argument("--proxy-host", type=str, default="localhost")
     parser.add_argument("--proxy-port", type=int, default=8500)
 
+    # PD buffer concurrency limiting (optional). When both are set, a weighted
+    # semaphore caps in-flight requests to prevent decoder PD buffer deadlocks.
+    # capacity = pd_buffer_size // (chunk_size * kv_bytes_per_token)
+    # kv_bytes_per_token = num_layers * 2 * num_kv_heads * head_size * dtype_bytes
+    parser.add_argument(
+        "--pd-buffer-size",
+        type=int,
+        default=None,
+        help="Decoder PD buffer bytes (matches pd_buffer_size in LMCache config).",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=256,
+        help="LMCache chunk size in tokens.",
+    )
+    parser.add_argument(
+        "--kv-bytes-per-token",
+        type=int,
+        default=None,
+        help="KV bytes per token: num_layers*2*num_kv_heads*head_size*dtype_bytes."
+        " e.g. Llama-3.1-8B bf16=131072.",
+    )
+
     args = parser.parse_args()
     return args
 
@@ -225,6 +280,9 @@ app.state.bound_clients = {}
 
 # Keep finished reqs
 app.state.finished_reqs = defaultdict(int)
+
+# None when --pd-buffer-size / --kv-bytes-per-token are not provided (unlimited).
+pd_buffer_semaphore = None
 
 
 zmq_ctx = zmq.asyncio.Context()
@@ -357,6 +415,7 @@ async def handle_completions(request: Request):
     req_id = str(counter)  # we use counter as req_id
 
     st = time.time()
+    slots = 0  # 0 until tokenization; guards error-path release
     try:
         req_data = await request.json()
 
@@ -371,6 +430,11 @@ async def handle_completions(request: Request):
         org_max_tokens = req_data["max_tokens"]
         req_data["prompt"] = tokenize_output["tokens"]
         req_data["max_tokens"] = 1
+
+        # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
+        slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
+        if pd_buffer_semaphore is not None:
+            await pd_buffer_semaphore.acquire(slots)
 
         disagg_spec = {
             "req_id": req_id,
@@ -427,8 +491,9 @@ async def handle_completions(request: Request):
                 "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
             ).encode()
 
-            # Wait until decode node signals that kv is ready
             await wait_decode_kv_ready(req_id, num_tp_rank)
+            if pd_buffer_semaphore is not None:
+                pd_buffer_semaphore.release(slots)
 
             async for chunk in stream_service_response(
                 decode_client.client, "/v1/completions", req_data
@@ -438,6 +503,8 @@ async def handle_completions(request: Request):
         return StreamingResponse(generate_stream(), media_type="application/json")
 
     except Exception as e:
+        if pd_buffer_semaphore is not None:
+            pd_buffer_semaphore.release(slots)
         # Standard
         import sys
         import traceback
@@ -456,6 +523,7 @@ async def handle_chat_completions(request: Request):
     req_id = str(counter)
 
     st = time.time()
+    slots = 0  # slots acquired from pd_buffer_semaphore; 0 until tokenization
     try:
         req_data = await request.json()
 
@@ -476,6 +544,11 @@ async def handle_chat_completions(request: Request):
         if "max_completion_tokens" in req_data:
             org_max_completion_tokens = req_data["max_completion_tokens"]
             req_data["max_completion_tokens"] = 1
+
+        # Acquire ceil(L/chunk_size) PD buffer slots before prefill.
+        slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
+        if pd_buffer_semaphore is not None:
+            await pd_buffer_semaphore.acquire(slots)
 
         disagg_spec = {
             "req_id": req_id,
@@ -555,6 +628,8 @@ async def handle_chat_completions(request: Request):
             ).encode()
 
             await wait_decode_kv_ready(req_id, num_tp_rank)
+            if pd_buffer_semaphore is not None:
+                pd_buffer_semaphore.release(slots)
 
             # Stream and convert completion format chunks to chat completion format
             async for chunk in stream_service_response(
@@ -606,6 +681,8 @@ async def handle_chat_completions(request: Request):
         return StreamingResponse(generate_stream(), media_type="application/json")
 
     except Exception as e:
+        if pd_buffer_semaphore is not None:
+            pd_buffer_semaphore.release(slots)
         # Standard
         import sys
         import traceback
@@ -622,6 +699,24 @@ async def handle_chat_completions(request: Request):
 if __name__ == "__main__":
     global global_args
     global_args = parse_args()
+
+    if (
+        global_args.pd_buffer_size is not None
+        and global_args.kv_bytes_per_token is not None
+    ):
+        capacity_slots = global_args.pd_buffer_size // (
+            global_args.chunk_size * global_args.kv_bytes_per_token
+        )
+        pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
+        logger.info("PD buffer semaphore: capacity=%d slots.", capacity_slots)
+    elif (
+        global_args.pd_buffer_size is not None
+        or global_args.kv_bytes_per_token is not None
+    ):
+        logger.warning(
+            "Both --pd-buffer-size and --kv-bytes-per-token required."
+            " Running unlimited."
+        )
 
     # Third Party
     import uvicorn

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -44,17 +44,20 @@ class WeightedSemaphore:
         self._lock = asyncio.Condition()
 
     async def acquire(self, slots: int) -> None:
+        if slots > self._capacity:
+            raise ValueError(
+                f"Requested {slots} slots exceeds total capacity {self._capacity}"
+            )
         async with self._lock:
             await self._lock.wait_for(lambda: self._available >= slots)
             self._available -= slots
 
-    def release(self, slots: int) -> None:
-        async def _release():
-            async with self._lock:
-                self._available += slots
-                self._lock.notify_all()
-
-        asyncio.get_event_loop().create_task(_release())
+    async def release(self, slots: int) -> None:
+        if slots <= 0:
+            return
+        async with self._lock:
+            self._available += slots
+            self._lock.notify_all()
 
     @property
     def available(self) -> int:
@@ -155,6 +158,25 @@ async def lifespan(app: FastAPI):
     app.state.total_clients = app.state.prefill_clients + app.state.decode_clients
 
     app.state.zmq_task = asyncio.create_task(zmq_pull_server())
+
+    global pd_buffer_semaphore
+    if (
+        global_args.pd_buffer_size is not None
+        and global_args.kv_bytes_per_token is not None
+    ):
+        capacity_slots = global_args.pd_buffer_size // (
+            global_args.chunk_size * global_args.kv_bytes_per_token
+        )
+        pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
+        logger.info("PD buffer semaphore: capacity=%d slots.", capacity_slots)
+    elif (
+        global_args.pd_buffer_size is not None
+        or global_args.kv_bytes_per_token is not None
+    ):
+        logger.warning(
+            "Both --pd-buffer-size and --kv-bytes-per-token required."
+            " Running unlimited."
+        )
 
     yield
 
@@ -282,7 +304,7 @@ app.state.bound_clients = {}
 app.state.finished_reqs = defaultdict(int)
 
 # None when --pd-buffer-size / --kv-bytes-per-token are not provided (unlimited).
-pd_buffer_semaphore = None
+pd_buffer_semaphore: Optional[WeightedSemaphore] = None
 
 
 zmq_ctx = zmq.asyncio.Context()
@@ -491,9 +513,11 @@ async def handle_completions(request: Request):
                 "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
             ).encode()
 
-            await wait_decode_kv_ready(req_id, num_tp_rank)
-            if pd_buffer_semaphore is not None:
-                pd_buffer_semaphore.release(slots)
+            try:
+                await wait_decode_kv_ready(req_id, num_tp_rank)
+            finally:
+                if pd_buffer_semaphore is not None:
+                    await pd_buffer_semaphore.release(slots)
 
             async for chunk in stream_service_response(
                 decode_client.client, "/v1/completions", req_data
@@ -504,7 +528,7 @@ async def handle_completions(request: Request):
 
     except Exception as e:
         if pd_buffer_semaphore is not None:
-            pd_buffer_semaphore.release(slots)
+            await pd_buffer_semaphore.release(slots)
         # Standard
         import sys
         import traceback
@@ -627,9 +651,11 @@ async def handle_chat_completions(request: Request):
                 "data: " + json.dumps(head_chunk, separators=(",", ":")) + "\n\n"
             ).encode()
 
-            await wait_decode_kv_ready(req_id, num_tp_rank)
-            if pd_buffer_semaphore is not None:
-                pd_buffer_semaphore.release(slots)
+            try:
+                await wait_decode_kv_ready(req_id, num_tp_rank)
+            finally:
+                if pd_buffer_semaphore is not None:
+                    await pd_buffer_semaphore.release(slots)
 
             # Stream and convert completion format chunks to chat completion format
             async for chunk in stream_service_response(
@@ -682,7 +708,7 @@ async def handle_chat_completions(request: Request):
 
     except Exception as e:
         if pd_buffer_semaphore is not None:
-            pd_buffer_semaphore.release(slots)
+            await pd_buffer_semaphore.release(slots)
         # Standard
         import sys
         import traceback
@@ -699,24 +725,6 @@ async def handle_chat_completions(request: Request):
 if __name__ == "__main__":
     global global_args
     global_args = parse_args()
-
-    if (
-        global_args.pd_buffer_size is not None
-        and global_args.kv_bytes_per_token is not None
-    ):
-        capacity_slots = global_args.pd_buffer_size // (
-            global_args.chunk_size * global_args.kv_bytes_per_token
-        )
-        pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
-        logger.info("PD buffer semaphore: capacity=%d slots.", capacity_slots)
-    elif (
-        global_args.pd_buffer_size is not None
-        or global_args.kv_bytes_per_token is not None
-    ):
-        logger.warning(
-            "Both --pd-buffer-size and --kv-bytes-per-token required."
-            " Running unlimited."
-        )
 
     # Third Party
     import uvicorn

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -34,8 +34,8 @@ logger = init_logger(__name__)
 class WeightedSemaphore:
     """Async semaphore with variable-weight acquire.
 
-    Limits decoder PD buffer usage: each request holds ceil(L/chunk_size)
-    slots until decoding starts, preventing buffer exhaustion deadlocks.
+    Limits in-flight PD token usage: each request holds ceil(L/chunk_size)
+    slots until decoding starts, preventing decoder buffer exhaustion deadlocks.
     """
 
     def __init__(self, capacity: int) -> None:
@@ -44,6 +44,14 @@ class WeightedSemaphore:
         self._lock = asyncio.Condition()
 
     async def acquire(self, slots: int) -> None:
+        """Acquire *slots* from the semaphore, blocking until available.
+
+        Args:
+            slots: Number of slots to acquire (must be <= capacity).
+
+        Raises:
+            ValueError: If slots exceeds total capacity (would block forever).
+        """
         if slots > self._capacity:
             raise ValueError(
                 f"Requested {slots} slots exceeds total capacity {self._capacity}"
@@ -53,6 +61,11 @@ class WeightedSemaphore:
             self._available -= slots
 
     async def release(self, slots: int) -> None:
+        """Return *slots* to the semaphore and wake waiting acquirers.
+
+        Args:
+            slots: Number of slots to release. No-op if <= 0.
+        """
         if slots <= 0:
             return
         async with self._lock:
@@ -61,6 +74,7 @@ class WeightedSemaphore:
 
     @property
     def available(self) -> int:
+        """Number of slots currently available."""
         return self._available
 
 
@@ -160,22 +174,14 @@ async def lifespan(app: FastAPI):
     app.state.zmq_task = asyncio.create_task(zmq_pull_server())
 
     global pd_buffer_semaphore
-    if (
-        global_args.pd_buffer_size is not None
-        and global_args.kv_bytes_per_token is not None
-    ):
-        capacity_slots = global_args.pd_buffer_size // (
-            global_args.chunk_size * global_args.kv_bytes_per_token
-        )
+    if global_args.max_inflight_tokens is not None:
+        capacity_slots = global_args.max_inflight_tokens // global_args.chunk_size
         pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
-        logger.info("PD buffer semaphore: capacity=%d slots.", capacity_slots)
-    elif (
-        global_args.pd_buffer_size is not None
-        or global_args.kv_bytes_per_token is not None
-    ):
-        logger.warning(
-            "Both --pd-buffer-size and --kv-bytes-per-token required."
-            " Running unlimited."
+        logger.info(
+            "PD buffer semaphore: capacity=%d slots (%d tokens / %d chunk_size).",
+            capacity_slots,
+            global_args.max_inflight_tokens,
+            global_args.chunk_size,
         )
 
     yield
@@ -252,28 +258,25 @@ def parse_args():
     parser.add_argument("--proxy-host", type=str, default="localhost")
     parser.add_argument("--proxy-port", type=int, default=8500)
 
-    # PD buffer concurrency limiting (optional). When both are set, a weighted
-    # semaphore caps in-flight requests to prevent decoder PD buffer deadlocks.
-    # capacity = pd_buffer_size // (chunk_size * kv_bytes_per_token)
-    # kv_bytes_per_token = num_layers * 2 * num_kv_heads * head_size * dtype_bytes
+    # PD buffer concurrency limiting (optional). When set, a weighted semaphore
+    # caps in-flight token usage to prevent decoder buffer exhaustion deadlocks.
+    # capacity_slots = max_inflight_tokens // chunk_size
     parser.add_argument(
-        "--pd-buffer-size",
+        "--max-inflight-tokens",
         type=int,
         default=None,
-        help="Decoder PD buffer bytes (matches pd_buffer_size in LMCache config).",
+        help=(
+            "Maximum total prompt tokens allowed in flight across all requests."
+            " Each request occupies ceil(prompt_tokens / chunk_size) slots."
+            " Set to roughly pd_buffer_size / kv_bytes_per_token to match the"
+            " decoder buffer capacity. Disabled (unlimited) when not provided."
+        ),
     )
     parser.add_argument(
         "--chunk-size",
         type=int,
         default=256,
-        help="LMCache chunk size in tokens.",
-    )
-    parser.add_argument(
-        "--kv-bytes-per-token",
-        type=int,
-        default=None,
-        help="KV bytes per token: num_layers*2*num_kv_heads*head_size*dtype_bytes."
-        " e.g. Llama-3.1-8B bf16=131072.",
+        help="LMCache chunk size in tokens (must match the LMCache config).",
     )
 
     args = parser.parse_args()
@@ -303,7 +306,7 @@ app.state.bound_clients = {}
 # Keep finished reqs
 app.state.finished_reqs = defaultdict(int)
 
-# None when --pd-buffer-size / --kv-bytes-per-token are not provided (unlimited).
+# None when --max-inflight-tokens is not provided (unlimited).
 pd_buffer_semaphore: Optional[WeightedSemaphore] = None
 
 
@@ -437,7 +440,8 @@ async def handle_completions(request: Request):
     req_id = str(counter)  # we use counter as req_id
 
     st = time.time()
-    slots = 0  # 0 until tokenization; guards error-path release
+    slots = 0  # slots to release on error; set after successful acquire only
+    acquired = False
     try:
         req_data = await request.json()
 
@@ -457,6 +461,7 @@ async def handle_completions(request: Request):
         slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
         if pd_buffer_semaphore is not None:
             await pd_buffer_semaphore.acquire(slots)
+            acquired = True
 
         disagg_spec = {
             "req_id": req_id,
@@ -527,7 +532,7 @@ async def handle_completions(request: Request):
         return StreamingResponse(generate_stream(), media_type="application/json")
 
     except Exception as e:
-        if pd_buffer_semaphore is not None:
+        if pd_buffer_semaphore is not None and acquired:
             await pd_buffer_semaphore.release(slots)
         # Standard
         import sys
@@ -547,7 +552,8 @@ async def handle_chat_completions(request: Request):
     req_id = str(counter)
 
     st = time.time()
-    slots = 0  # slots acquired from pd_buffer_semaphore; 0 until tokenization
+    slots = 0  # slots to release on error; set after successful acquire only
+    acquired = False
     try:
         req_data = await request.json()
 
@@ -573,6 +579,7 @@ async def handle_chat_completions(request: Request):
         slots = math.ceil(len(tokenize_output["tokens"]) / global_args.chunk_size)
         if pd_buffer_semaphore is not None:
             await pd_buffer_semaphore.acquire(slots)
+            acquired = True
 
         disagg_spec = {
             "req_id": req_id,
@@ -707,7 +714,7 @@ async def handle_chat_completions(request: Request):
         return StreamingResponse(generate_stream(), media_type="application/json")
 
     except Exception as e:
-        if pd_buffer_semaphore is not None:
+        if pd_buffer_semaphore is not None and acquired:
             await pd_buffer_semaphore.release(slots)
         # Standard
         import sys

--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -174,15 +174,20 @@ async def lifespan(app: FastAPI):
     app.state.zmq_task = asyncio.create_task(zmq_pull_server())
 
     global pd_buffer_semaphore
-    if global_args.max_inflight_tokens is not None:
-        capacity_slots = global_args.max_inflight_tokens // global_args.chunk_size
-        pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
-        logger.info(
-            "PD buffer semaphore: capacity=%d slots (%d tokens / %d chunk_size).",
-            capacity_slots,
-            global_args.max_inflight_tokens,
-            global_args.chunk_size,
-        )
+    kv_bytes_per_token = compute_kv_bytes_per_token(global_args.model)
+    capacity_slots = global_args.pd_buffer_size // (
+        kv_bytes_per_token * global_args.chunk_size
+    )
+    pd_buffer_semaphore = WeightedSemaphore(capacity_slots)
+    logger.info(
+        "PD buffer semaphore: capacity=%d slots"
+        " (%d bytes / (%d bytes/tok * %d chunk_size)) for model %s.",
+        capacity_slots,
+        global_args.pd_buffer_size,
+        kv_bytes_per_token,
+        global_args.chunk_size,
+        global_args.model,
+    )
 
     yield
 
@@ -241,6 +246,31 @@ def csv_strs(s):
     return [x.strip() for x in s.split(",")]
 
 
+def compute_kv_bytes_per_token(model_name: str) -> int:
+    """Return the number of KV cache bytes per token for *model_name*.
+
+    Reads num_hidden_layers, num_key_value_heads, head_dim, and torch_dtype
+    from the HuggingFace config without downloading model weights.
+
+    Args:
+        model_name: HuggingFace model id or local path.
+
+    Returns:
+        Bytes per token across all layers and both K/V tensors.
+    """
+    # Third Party
+    from transformers import AutoConfig
+
+    cfg = AutoConfig.from_pretrained(model_name)
+    num_layers: int = cfg.num_hidden_layers
+    num_kv_heads: int = getattr(cfg, "num_key_value_heads", cfg.num_attention_heads)
+    head_dim: int = getattr(cfg, "head_dim", cfg.hidden_size // cfg.num_attention_heads)
+    # 4 bytes for float32, 2 bytes for float16/bfloat16 (the common default)
+    torch_dtype = str(getattr(cfg, "torch_dtype", "bfloat16"))
+    dtype_bytes = 4 if "float32" in torch_dtype else 2
+    return 2 * num_layers * num_kv_heads * head_dim * dtype_bytes
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
 
@@ -258,18 +288,27 @@ def parse_args():
     parser.add_argument("--proxy-host", type=str, default="localhost")
     parser.add_argument("--proxy-port", type=int, default=8500)
 
-    # PD buffer concurrency limiting (optional). When set, a weighted semaphore
-    # caps in-flight token usage to prevent decoder buffer exhaustion deadlocks.
-    # capacity_slots = max_inflight_tokens // chunk_size
+    # PD buffer concurrency limiting. A weighted semaphore caps in-flight
+    # chunk slots to prevent decoder buffer exhaustion deadlocks.
+    # capacity_slots = pd_buffer_size // (kv_bytes_per_token * chunk_size)
+    # kv_bytes_per_token is derived from the model config automatically.
     parser.add_argument(
-        "--max-inflight-tokens",
-        type=int,
-        default=None,
+        "--model",
+        type=str,
+        default="meta-llama/Llama-3.1-8B-Instruct",
         help=(
-            "Maximum total prompt tokens allowed in flight across all requests."
-            " Each request occupies ceil(prompt_tokens / chunk_size) slots."
-            " Set to roughly pd_buffer_size / kv_bytes_per_token to match the"
-            " decoder buffer capacity. Disabled (unlimited) when not provided."
+            "HuggingFace model name or local path. Used to derive"
+            " kv_bytes_per_token for the PD buffer semaphore capacity."
+        ),
+    )
+    parser.add_argument(
+        "--pd-buffer-size",
+        type=int,
+        default=2 * 1024 * 1024 * 1024,  # 2 GB
+        help=(
+            "PD transfer buffer size in bytes (must match the decoder's"
+            " LMCache config). Used to derive the in-flight slot capacity."
+            " Default: 2 GB."
         ),
     )
     parser.add_argument(
@@ -306,7 +345,6 @@ app.state.bound_clients = {}
 # Keep finished reqs
 app.state.finished_reqs = defaultdict(int)
 
-# None when --max-inflight-tokens is not provided (unlimited).
 pd_buffer_semaphore: Optional[WeightedSemaphore] = None
 
 


### PR DESCRIPTION
Problem

Under high concurrency, the decoder PD buffer can fill up with partial KV chunks from multiple in-flight requests. Since the
proxy only dispatches a decode request after receiving the full KV completion signal, a deadlock forms: the prefiller cannot send remaining chunks (decoder buffer full), and the decoder never starts (proxy never signals ready).

Temp Fix for in-process mode PD

Add a WeightedSemaphore to the proxy that caps total in-flight PD buffer usage. Each request acquires ⌈L / chunk_size⌉ slots before prefill and releases them after wait_decode_kv_ready when proxy forward request to decoder after all kv sent by prefiller .

capacity_slots = pd_buffer_size_bytes // (chunk_size × kv_bytes_per_token)

New proxy args:

- -pd-buffer-size: decoder PD buffer bytes (matches pd_buffer_size in LMCache config)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new concurrency limiting in the disaggregated prefill proxy that can affect request scheduling/throughput and relies on model config-derived sizing; misconfiguration could cause unexpected blocking or reduced concurrency.
> 
> **Overview**
> Prevents PD-buffer deadlocks under high concurrency by adding a **weighted in-flight limiter** in `disagg_proxy_server.py`: each request acquires `ceil(prompt_tokens / chunk_size)` slots before prefill and releases them once the decoder signals KV readiness.
> 
> Adds proxy CLI flags `--model`, `--pd-buffer-size`, and `--chunk-size` and derives semaphore capacity from HuggingFace model config (`compute_kv_bytes_per_token`) to approximate KV bytes per token.
> 
> Updates the 1p1d example scripts to accept a model and PD buffer size, pass them through to the proxy/launchers, and removes `--disable-log-requests` from the vLLM launcher invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1888a966caab03c91877c56f3db1d11bab2e8254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->