### PR TITLE
[Chore][Docs] Clarify raw block plugin name in LMCache YAML

### DIFF
--- a/docs/source/kv_cache/storage_backends/index.rst
+++ b/docs/source/kv_cache/storage_backends/index.rst
@@ -16,6 +16,7 @@ Supported Backends
    gds
    infinistore
    local_storage
+   raw_block
    maru
    mock
    mooncake

--- a/docs/source/kv_cache/storage_backends/raw_block.rst
+++ b/docs/source/kv_cache/storage_backends/raw_block.rst
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+Raw Block Backend
+=================
+
+.. _raw-block-overview:
+
+Overview
+--------
+
+The raw block backend is an LMCache storage plugin that stores KV cache chunks
+directly on a raw block device or file through the Rust
+``lmcache_rust_raw_block_io`` extension.
+
+This backend is intended for device-backed local storage where you want LMCache
+to issue raw block reads and writes instead of storing chunk files in a
+filesystem directory.
+
+
+Configuration
+-------------
+
+Use the plugin name ``raw_block`` in LMCache YAML for backend selection. Do not
+use ``RustRawBlockBackend`` for ``store_location`` or
+``retrieve_locations``.
+
+.. code-block:: yaml
+
+   chunk_size: 256
+   local_cpu: true
+   max_local_cpu_size: 5
+
+   storage_plugins: ["raw_block"]
+   store_location: "raw_block"
+   retrieve_locations: ["raw_block"]
+
+   extra_config:
+     storage_plugin.raw_block.module_path: lmcache.v1.storage_backend.plugins.rust_raw_block_backend
+     storage_plugin.raw_block.class_name: RustRawBlockBackend
+
+     rust_raw_block.device_path: "/dev/nvme0n1"
+     rust_raw_block.use_odirect: true
+
+If ``rust_raw_block.use_odirect`` is enabled, LMCache can automatically align
+the local CPU allocator to ``rust_raw_block.block_align`` when
+``rust_raw_block.align_local_cpu_allocator`` is left at its default value.
+
+
+Runtime Requirements
+--------------------
+
+- ``extra_config['rust_raw_block.device_path']`` is required and must point to
+  a readable and writable block device or file.
+- ``LocalCPUBackend`` must be enabled because the raw block backend reads into
+  CPU-backed memory objects.
+
+
+Build the Extension
+-------------------
+
+Build and install the Rust extension before starting LMCache:
+
+.. code-block:: bash
+
+   cd rust/raw_block
+   pip install maturin
+   maturin develop --release
+
+
+Validation and Current Limits
+-----------------------------
+
+- Linux only.
+- Tensor parallelism is currently limited to TP=1
+  (``metadata.world_size == 1``).
+- The backend requires read-write access to the configured device path.
+- ``RustRawBlockBackend`` is the plugin class name, but the LMCache YAML
+  backend selector remains ``raw_block``.

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -49,8 +49,9 @@ No fixed numbers are included here because results are host/device/workload depe
 
 ## LMCache Configuration
 
-In LMCache YAML, use the plugin name `raw_block` for `store_location` and
-`retrieve_locations`. Do not use `RustRawBlockBackend` there.
+For end-user LMCache YAML configuration, see
+[`docs/source/kv_cache/storage_backends/raw_block.rst`](../../docs/source/kv_cache/storage_backends/raw_block.rst).
+LMCache selects this backend by the plugin name `raw_block`.
 
 ## Limitations
 

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -47,6 +47,11 @@ Use the benchmark commands in:
 
 No fixed numbers are included here because results are host/device/workload dependent.
 
+## LMCache Configuration
+
+In LMCache YAML, use the plugin name `raw_block` for `store_location` and
+`retrieve_locations`. Do not use `RustRawBlockBackend` there.
+
 ## Limitations
 
 - Linux only (`pread` / `pwrite`, O_DIRECT semantics).


### PR DESCRIPTION
**What this PR does / why we need it**:

  This PR adds a small documentation clarification for the raw block backend.

  In LMCache YAML, dynamic storage backends are selected by plugin name. For the raw block backend, `store_location` and `retrieve_locations` should use `raw_block`, not `RustRawBlockBackend`.

  This came up while validating the raw block backend because using the class name in config resulted in the backend not being selected, which looked like a runtime issue even though the backend itself was working correctly.

I will refactor the name into "raw_block" for everything when its functional work is done which expect by end of Q2.

  **Special notes for your reviewers**:

  This is a docs-only change. No runtime behavior or benchmark code was changed.

  **If applicable**:

  - [x] this PR contains user facing changes - docs added
  - [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify configuration keys and add a new backend doc page; no runtime or API behavior changes.
> 
> **Overview**
> Adds documentation for the `raw_block` KV-cache storage backend and clarifies that LMCache YAML must select it via the plugin name `raw_block` (not the class name `RustRawBlockBackend`).
> 
> Updates the storage backend docs index to include the new `raw_block` page and links the Rust raw-block crate README to that end-user configuration guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 203484b41ec4aa9fb5605dcb884bb110bfaca2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->