### PR TITLE
[Chore][CI]: K3 base CI image 12.9 CUDA

### DIFF
--- a/.buildkite/k3_harness/ci-base.Dockerfile
+++ b/.buildkite/k3_harness/ci-base.Dockerfile
@@ -4,7 +4,7 @@
 # Built automatically by setup-cluster.sh and imported into K3s containerd.
 # Rebuild when requirements/*.txt changes.
 
-FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda12.8-devel-ubuntu24.04
+FROM nvcr.io/nvidia/cuda-dl-base:25.04-cuda12.9-devel-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/venv/bin:${PATH}"
@@ -15,7 +15,7 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && apt-get install -y --no-install-recommends \
         ccache software-properties-common git curl sudo jq lsof \
         python3 python3-dev python3-venv python3-pip tzdata libxcb1-dev \
-    && ldconfig /usr/local/cuda-12.8/compat/ \
+    && ldconfig /usr/local/cuda-12.9/compat/ \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv ~/.local/bin/uv /usr/local/bin/ \
     && mv ~/.local/bin/uvx /usr/local/bin/ \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the underlying CUDA/toolchain version used across CI jobs, which can surface driver/library compatibility issues or alter build outputs.
> 
> **Overview**
> Updates the K3 harness CI base Dockerfile to use `nvcr.io/nvidia/cuda-dl-base:25.04-cuda12.9-devel-ubuntu24.04` (from CUDA 12.8) and switches the `ldconfig` compat path to `/usr/local/cuda-12.9/compat/`, effectively moving CI runs to a CUDA 12.9 environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc9ba60d721d8c91f25faaf145b3d5f1a783e86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->