### PR TITLE
fix[mooncake]: use batch_is_exist for batched contains operations

### DIFF
--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -270,6 +270,17 @@ class MooncakestoreConnector(RemoteConnector):
     def exists_sync(self, key: CacheEngineKey) -> bool:
         return self.store.is_exist(key.to_string())
 
+    def support_batched_contains(self) -> bool:
+        return True
+
+    def batched_contains(self, keys: List[CacheEngineKey]) -> int:
+        key_strings = [key.to_string() for key in keys]
+        rets = self.store.batch_is_exist(key_strings)
+        for i, ret in enumerate(rets):
+            if ret != 1:
+                return i
+        return len(keys)
+
     async def batched_get(
         self, keys: List[CacheEngineKey]
     ) -> List[Optional[MemoryObj]]:
@@ -297,12 +308,12 @@ class MooncakestoreConnector(RemoteConnector):
         keys: List[CacheEngineKey],
         pin: bool = False,
     ) -> int:
-        num_hit_counts = 0
-        for key in keys:
-            if not self.store.is_exist(key.to_string()):
-                break
-            num_hit_counts += 1
-        return num_hit_counts
+        key_strings = [key.to_string() for key in keys]
+        rets = self.store.batch_is_exist(key_strings)
+        for i, ret in enumerate(rets):
+            if ret != 1:
+                return i
+        return len(keys)
 
     async def _batch_get_into(
         self, keys: List[CacheEngineKey]

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -271,9 +271,24 @@ class MooncakestoreConnector(RemoteConnector):
         return self.store.is_exist(key.to_string())
 
     def support_batched_contains(self) -> bool:
+        """
+        Check if the connector supports batched contains
+
+        Returns:
+            True if batched contains is supported, False otherwise
+        """
         return True
 
     def batched_contains(self, keys: List[CacheEngineKey]) -> int:
+        """
+        Check how many keys exist in the remote store in batch (sync).
+
+        Args:
+            keys: List of keys to check.
+
+        Returns:
+            Number of consecutive keys that exist, starting from the first key.
+        """
         key_strings = [key.to_string() for key in keys]
         rets = self.store.batch_is_exist(key_strings)
         for i, ret in enumerate(rets):
@@ -309,7 +324,7 @@ class MooncakestoreConnector(RemoteConnector):
         pin: bool = False,
     ) -> int:
         key_strings = [key.to_string() for key in keys]
-        rets = self.store.batch_is_exist(key_strings)
+        rets = await asyncio.to_thread(self.store.batch_is_exist, key_strings)
         for i, ret in enumerate(rets):
             if ret != 1:
                 return i


### PR DESCRIPTION
## Problem
MooncakestoreConnector.batched_async_contains() calls self.store.is_exist() sequentially per key in a loop, resulting in O(N) individual RPCs to the Mooncake metadata server. The sync path (batched_contains) doesn't exist at all, so RemoteBackend falls back to per-key exists_sync() calls — also O(N) RPCs.

For a typical 30K-token input with chunk_size=512, that's ~58 keys checked per request, meaning 58 sequential round-trips on every prefix cache lookup.

## Fix
batched_async_contains(): Replace the sequential is_exist loop with a single self.store.batch_is_exist(key_strings) call.
support_batched_contains() + batched_contains(): Add new methods to enable the sync lookup path to use the same batched operation, instead of falling back to per-key contains().
## Impact
O(N) → O(1) RPCs for prefix cache existence checks on both async and sync code paths. Validated on disaggregated vLLM serving (Llama 4) with Mooncake DRAM KV cache at concurrencies up to c=64.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization limited to Mooncake connector existence checks, but it changes how prefix-hit counts are computed based on `batch_is_exist` return values.
> 
> **Overview**
> Reduces Mooncake metadata-server round trips during prefix-cache lookups by switching `batched_async_contains` from per-key `is_exist` calls to a single `batch_is_exist` call executed via `asyncio.to_thread`.
> 
> Adds sync-path support for prefix existence checks by implementing `support_batched_contains` and `batched_contains`, also backed by `batch_is_exist`, so callers no longer fall back to per-key `exists_sync` RPCs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349967b91ded733e4290f206333c788150acb1ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->