### PR TITLE
[MP][Optimize] Skip locked keys during LRU eviction to improve eviction efficiency

### DIFF
--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -5,6 +5,7 @@ Eviction module to determine what to evict from L1 and L2 caches.
 
 # Standard
 from abc import abstractmethod
+from collections.abc import Callable
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
@@ -68,7 +69,11 @@ class EvictionPolicy:
         pass
 
     @abstractmethod
-    def get_eviction_actions(self, expected_ratio: float) -> list[EvictionAction]:
+    def get_eviction_actions(
+        self,
+        expected_ratio: float,
+        key_filter: Callable[[ObjectKey], bool] | None = None,
+    ) -> list[EvictionAction]:
         """
         Get the eviction actions to evict objects from cache.
 
@@ -78,6 +83,11 @@ class EvictionPolicy:
                 in range [0.0, 1.0]. For example, 0.1 means roughly 10% of
                 keys should be evicted. This is a hint and the policy may
                 return more or fewer keys.
+            key_filter: An optional callable that takes an ObjectKey and
+                returns True if the key is eligible for eviction. When
+                provided, keys for which the filter returns False will be
+                skipped. This is useful for skipping locked keys that
+                cannot be deleted.
 
         Returns:
             list[EvictionAction]: The eviction actions to perform. Each

--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -72,7 +72,7 @@ class EvictionPolicy:
     def get_eviction_actions(
         self,
         expected_ratio: float,
-        key_filter: Callable[[ObjectKey], bool] | None = None,
+        key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
     ) -> list[EvictionAction]:
         """
         Get the eviction actions to evict objects from cache.
@@ -83,8 +83,8 @@ class EvictionPolicy:
                 in range [0.0, 1.0]. For example, 0.1 means roughly 10% of
                 keys should be evicted. This is a hint and the policy may
                 return more or fewer keys.
-            key_filter: An optional callable that takes an ObjectKey and
-                returns True if the key is eligible for eviction. When
+            key_eligible_filter: An optional callable that takes an ObjectKey
+                and returns True if the key is eligible for eviction. When
                 provided, keys for which the filter returns False will be
                 skipped. This is useful for skipping locked keys that
                 cannot be deleted.

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -122,7 +122,7 @@ class LRUEvictionPolicy(EvictionPolicy):
     def get_eviction_actions(
         self,
         expected_ratio: float,
-        key_filter: Callable[[ObjectKey], bool] | None = None,
+        key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
     ) -> list[EvictionAction]:
         """
         Get the eviction actions to evict objects from L1 cache.
@@ -132,8 +132,8 @@ class LRUEvictionPolicy(EvictionPolicy):
             expected_ratio (float): A hint indicating approximately what fraction
                 of tracked keys should be evicted. Value should be in range [0.0, 1.0].
                 For example, 0.1 means roughly 10% of keys should be evicted.
-            key_filter: An optional callable that takes an ObjectKey and
-                returns True if the key is eligible for eviction. When
+            key_eligible_filter: An optional callable that takes an ObjectKey
+                and returns True if the key is eligible for eviction. When
                 provided, keys for which the filter returns False will be
                 skipped. This is useful for skipping locked keys that
                 cannot be deleted.
@@ -171,7 +171,7 @@ class LRUEvictionPolicy(EvictionPolicy):
             keys_to_evict: list[ObjectKey] = []
 
             for key in self._order:
-                if key_filter is not None and not key_filter(key):
+                if key_eligible_filter is not None and not key_eligible_filter(key):
                     # Skip keys that are not eligible for eviction
                     # (e.g. currently locked by read/write operations)
                     continue

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -5,6 +5,7 @@ LRU (Least Recently Used) eviction policy implementation
 
 # Standard
 from collections import OrderedDict
+from collections.abc import Callable
 import threading
 
 # First Party
@@ -118,7 +119,11 @@ class LRUEvictionPolicy(EvictionPolicy):
                 if key in self._order:
                     del self._order[key]
 
-    def get_eviction_actions(self, expected_ratio: float) -> list[EvictionAction]:
+    def get_eviction_actions(
+        self,
+        expected_ratio: float,
+        key_filter: Callable[[ObjectKey], bool] | None = None,
+    ) -> list[EvictionAction]:
         """
         Get the eviction actions to evict objects from L1 cache.
         Returns keys in LRU order (least recently used first).
@@ -127,6 +132,11 @@ class LRUEvictionPolicy(EvictionPolicy):
             expected_ratio (float): A hint indicating approximately what fraction
                 of tracked keys should be evicted. Value should be in range [0.0, 1.0].
                 For example, 0.1 means roughly 10% of keys should be evicted.
+            key_filter: An optional callable that takes an ObjectKey and
+                returns True if the key is eligible for eviction. When
+                provided, keys for which the filter returns False will be
+                skipped. This is useful for skipping locked keys that
+                cannot be deleted.
 
         Returns:
             list[EvictionAction]: The eviction actions to perform. Each
@@ -156,10 +166,15 @@ class LRUEvictionPolicy(EvictionPolicy):
             if target_count == 0:
                 return []
 
-            # Get keys in LRU order (from beginning - least recently used)
+            # Get keys in LRU order (from beginning - least recently used),
+            # skipping keys that fail the filter (e.g. locked keys).
             keys_to_evict: list[ObjectKey] = []
 
             for key in self._order:
+                if key_filter is not None and not key_filter(key):
+                    # Skip keys that are not eligible for eviction
+                    # (e.g. currently locked by read/write operations)
+                    continue
                 keys_to_evict.append(key)
                 if len(keys_to_evict) >= target_count:
                     break

--- a/lmcache/v1/distributed/eviction_policy/noop.py
+++ b/lmcache/v1/distributed/eviction_policy/noop.py
@@ -7,6 +7,9 @@ immediately after being stored to L2 by the StoreController), there
 is no need for the eviction policy to track keys at all.
 """
 
+# Standard
+from collections.abc import Callable
+
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.eviction import EvictionPolicy
@@ -38,5 +41,9 @@ class NoOpEvictionPolicy(EvictionPolicy):
     def on_keys_removed(self, keys: list[ObjectKey]):
         pass
 
-    def get_eviction_actions(self, expected_ratio: float) -> list[EvictionAction]:
+    def get_eviction_actions(
+        self,
+        expected_ratio: float,
+        key_filter: Callable[[ObjectKey], bool] | None = None,
+    ) -> list[EvictionAction]:
         return []

--- a/lmcache/v1/distributed/eviction_policy/noop.py
+++ b/lmcache/v1/distributed/eviction_policy/noop.py
@@ -44,6 +44,6 @@ class NoOpEvictionPolicy(EvictionPolicy):
     def get_eviction_actions(
         self,
         expected_ratio: float,
-        key_filter: Callable[[ObjectKey], bool] | None = None,
+        key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
     ) -> list[EvictionAction]:
         return []

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -733,11 +733,6 @@ class L1Manager:
         """
         entry = self._objects.get(key, None)
         if entry is None:
-            logger.warning(
-                "object key %s not found in L1Manager check evictable, "
-                "this should not happen",
-                key,
-            )
             return False
         return not entry.read_lock.is_locked() and not entry.write_lock.is_locked()
 

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -717,6 +717,30 @@ class L1Manager:
             locked_count,
         )
 
+    def is_key_evictable(self, key: ObjectKey) -> bool:
+        """Check if a key is eligible for eviction (not locked).
+
+        This method does NOT acquire the global L1Manager lock.
+        L1Manager.delete() will check again and safely reject a key
+        that became locked between the check and the actual deletion.
+
+        Args:
+            key: The object key to check.
+
+        Returns:
+            True if the key exists and is not locked (neither read-locked
+            nor write-locked), False otherwise.
+        """
+        entry = self._objects.get(key, None)
+        if entry is None:
+            logger.warning(
+                "object key %s not found in L1Manager check evictable, "
+                "this should not happen",
+                key,
+            )
+            return False
+        return not entry.read_lock.is_locked() and not entry.write_lock.is_locked()
+
     def get_memory_usage(self) -> tuple[int, int]:
         """Get the current memory usage of L1 cache.
 

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -124,7 +124,10 @@ class L1EvictionController(EvictionController):
                 usage,
                 watermark,
             )
-            actions = self._eviction_policy.get_eviction_actions(eviction_ratio)
+            actions = self._eviction_policy.get_eviction_actions(
+                eviction_ratio,
+                key_filter=self._l1_manager.is_key_evictable,
+            )
             for action in actions:
                 self.execute_eviction_action(action)
 

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -126,7 +126,7 @@ class L1EvictionController(EvictionController):
             )
             actions = self._eviction_policy.get_eviction_actions(
                 eviction_ratio,
-                key_filter=self._l1_manager.is_key_evictable,
+                key_eligible_filter=self._l1_manager.is_key_evictable,
             )
             for action in actions:
                 self.execute_eviction_action(action)

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -1769,3 +1769,170 @@ class TestThreadSafety:
         assert len(errors) == 0, f"Thread safety errors: {errors}"
 
         manager.close()
+
+
+# =============================================================================
+# Tests for L1Manager.is_key_evictable()
+# =============================================================================
+
+
+class TestIsKeyEvictable:
+    """Tests for L1Manager.is_key_evictable() method."""
+
+    def test_evictable_key_in_ready_state(self, basic_l1_config, basic_layout):
+        """A key that has been written and finished should be evictable."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Write and finish -> key is in ready state
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        assert manager.is_key_evictable(key) is True
+
+        manager.close()
+
+    def test_write_locked_key_is_not_evictable(self, basic_l1_config, basic_layout):
+        """A write-locked key should not be evictable."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Reserve write but don't finish -> key is write-locked
+        manager.reserve_write([key], [False], basic_layout)
+
+        assert manager.is_key_evictable(key) is False
+
+        # Cleanup
+        manager.finish_write([key])
+        manager.close()
+
+    def test_read_locked_key_is_not_evictable(self, basic_l1_config, basic_layout):
+        """A read-locked key should not be evictable."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Write, finish, then reserve read -> key is read-locked
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+        manager.reserve_read([key])
+
+        assert manager.is_key_evictable(key) is False
+
+        # Cleanup
+        manager.finish_read([key])
+        manager.close()
+
+    def test_nonexistent_key_is_not_evictable(self, basic_l1_config):
+        """A key that does not exist should not be evictable."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(999)
+
+        assert manager.is_key_evictable(key) is False
+
+        manager.close()
+
+    def test_key_becomes_evictable_after_read_unlock(
+        self, basic_l1_config, basic_layout
+    ):
+        """A key should become evictable after all read locks are released."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Write and finish
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        # Reserve read -> not evictable
+        manager.reserve_read([key])
+        assert manager.is_key_evictable(key) is False
+
+        # Finish read -> evictable again
+        manager.finish_read([key])
+        assert manager.is_key_evictable(key) is True
+
+        manager.close()
+
+    def test_key_becomes_evictable_after_write_unlock(
+        self, basic_l1_config, basic_layout
+    ):
+        """A key should become evictable after write lock is released."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Reserve write -> not evictable
+        manager.reserve_write([key], [False], basic_layout)
+        assert manager.is_key_evictable(key) is False
+
+        # Finish write -> evictable
+        manager.finish_write([key])
+        assert manager.is_key_evictable(key) is True
+
+        manager.close()
+
+    def test_multiple_keys_mixed_evictability(self, basic_l1_config, basic_layout):
+        """Test evictability with multiple keys in different states."""
+        manager = L1Manager(basic_l1_config)
+        key_ready = make_object_key(1)
+        key_write_locked = make_object_key(2)
+        key_read_locked = make_object_key(3)
+
+        # key_ready: write + finish -> ready state
+        manager.reserve_write([key_ready], [False], basic_layout)
+        manager.finish_write([key_ready])
+
+        # key_write_locked: write only -> write-locked
+        manager.reserve_write([key_write_locked], [False], basic_layout)
+
+        # key_read_locked: write + finish + read -> read-locked
+        manager.reserve_write([key_read_locked], [False], basic_layout)
+        manager.finish_write([key_read_locked])
+        manager.reserve_read([key_read_locked])
+
+        assert manager.is_key_evictable(key_ready) is True
+        assert manager.is_key_evictable(key_write_locked) is False
+        assert manager.is_key_evictable(key_read_locked) is False
+
+        # Cleanup
+        manager.finish_write([key_write_locked])
+        manager.finish_read([key_read_locked])
+        manager.close()
+
+    def test_deleted_key_is_not_evictable(self, basic_l1_config, basic_layout):
+        """A key that has been deleted should not be evictable."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Write, finish, then delete
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+        manager.delete([key])
+
+        assert manager.is_key_evictable(key) is False
+
+        manager.close()
+
+    def test_key_with_multiple_read_locks_not_evictable(
+        self, basic_l1_config, basic_layout
+    ):
+        """A key with extra_count read locks should not be evictable
+        until all locks are released."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(1)
+
+        # Write and finish
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+
+        # Reserve read with extra_count=2 (total 3 locks)
+        manager.reserve_read([key], extra_count=2)
+        assert manager.is_key_evictable(key) is False
+
+        # Release only 1 lock (extra_count=0) -> still locked
+        manager.finish_read([key], extra_count=0)
+        assert manager.is_key_evictable(key) is False
+
+        # Release remaining 2 locks (extra_count=1)
+        manager.finish_read([key], extra_count=1)
+        assert manager.is_key_evictable(key) is True
+
+        manager.close()

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -258,24 +258,26 @@ class TestLRUEvictionPolicyCandidates:
 
 
 # =============================================================================
-# Key Filter Tests
+# Key Eligible Filter Tests
 # =============================================================================
 
 
-class TestLRUEvictionPolicyKeyFilter:
-    """Tests for key_filter parameter in get_eviction_actions."""
+class TestLRUEvictionPolicyKeyEligibleFilter:
+    """Tests for key_eligible_filter parameter in get_eviction_actions."""
 
-    def test_key_filter_skips_filtered_keys(self):
+    def test_key_eligible_filter_skips_filtered_keys(self):
         """Keys that fail the filter should be skipped during eviction."""
         policy = LRUEvictionPolicy()
         keys = [make_key(i) for i in range(5)]
         policy.on_keys_created(keys)
 
         # Filter out keys with even chunk_hash
-        def key_filter(key: ObjectKey) -> bool:
+        def key_eligible_filter(key: ObjectKey) -> bool:
             return ObjectKey.Bytes2IntHash(key.chunk_hash) % 2 != 0
 
-        actions = policy.get_eviction_actions(1.0, key_filter=key_filter)
+        actions = policy.get_eviction_actions(
+            1.0, key_eligible_filter=key_eligible_filter
+        )
         assert len(actions) == 1
         evicted_hashes = {
             ObjectKey.Bytes2IntHash(k.chunk_hash) for k in actions[0].keys
@@ -283,26 +285,26 @@ class TestLRUEvictionPolicyKeyFilter:
         # Only odd keys should be evicted: 1, 3
         assert evicted_hashes == {1, 3}
 
-    def test_key_filter_none_evicts_all(self):
-        """When key_filter is None, all keys should be eligible."""
+    def test_key_eligible_filter_none_evicts_all(self):
+        """When key_eligible_filter is None, all keys should be eligible."""
         policy = LRUEvictionPolicy()
         keys = [make_key(i) for i in range(5)]
         policy.on_keys_created(keys)
 
-        actions = policy.get_eviction_actions(1.0, key_filter=None)
+        actions = policy.get_eviction_actions(1.0, key_eligible_filter=None)
         assert len(actions) == 1
         assert len(actions[0].keys) == 5
 
-    def test_key_filter_rejects_all_returns_empty(self):
+    def test_key_eligible_filter_rejects_all_returns_empty(self):
         """When filter rejects all keys, no eviction actions should be returned."""
         policy = LRUEvictionPolicy()
         keys = [make_key(i) for i in range(5)]
         policy.on_keys_created(keys)
 
-        actions = policy.get_eviction_actions(1.0, key_filter=lambda _: False)
+        actions = policy.get_eviction_actions(1.0, key_eligible_filter=lambda _: False)
         assert actions == []
 
-    def test_key_filter_respects_target_count(self):
+    def test_key_eligible_filter_respects_target_count(self):
         """Filter should stop collecting once target_count is reached."""
         policy = LRUEvictionPolicy()
         # Create 10 keys, all pass filter
@@ -310,11 +312,11 @@ class TestLRUEvictionPolicyKeyFilter:
         policy.on_keys_created(keys)
 
         # Request 50% eviction with a filter that accepts all
-        actions = policy.get_eviction_actions(0.5, key_filter=lambda _: True)
+        actions = policy.get_eviction_actions(0.5, key_eligible_filter=lambda _: True)
         assert len(actions) == 1
         assert len(actions[0].keys) == 5
 
-    def test_key_filter_with_partial_acceptance(self):
+    def test_key_eligible_filter_with_partial_acceptance(self):
         """When filter accepts some keys, only accepted keys up to
         target_count should be evicted."""
         policy = LRUEvictionPolicy()
@@ -323,17 +325,19 @@ class TestLRUEvictionPolicyKeyFilter:
         policy.on_keys_created(keys)
 
         # Filter: only accept keys with hash >= 5
-        def key_filter(key: ObjectKey) -> bool:
+        def key_eligible_filter(key: ObjectKey) -> bool:
             return ObjectKey.Bytes2IntHash(key.chunk_hash) >= 5
 
         # Request 100% eviction -> target_count = 10, but only 5 pass filter
-        actions = policy.get_eviction_actions(1.0, key_filter=key_filter)
+        actions = policy.get_eviction_actions(
+            1.0, key_eligible_filter=key_eligible_filter
+        )
         assert len(actions) == 1
         assert len(actions[0].keys) == 5
         for k in actions[0].keys:
             assert ObjectKey.Bytes2IntHash(k.chunk_hash) >= 5
 
-    def test_key_filter_preserves_lru_order(self):
+    def test_key_eligible_filter_preserves_lru_order(self):
         """Filtered eviction should still respect LRU order."""
         policy = LRUEvictionPolicy()
         # Create keys in order: 1, 2, 3, 4, 5
@@ -344,7 +348,7 @@ class TestLRUEvictionPolicyKeyFilter:
         policy.on_keys_touched([make_key(1)])
 
         # Filter: accept all keys
-        actions = policy.get_eviction_actions(0.6, key_filter=lambda _: True)
+        actions = policy.get_eviction_actions(0.6, key_eligible_filter=lambda _: True)
         assert len(actions) == 1
         evicted_hashes = [
             ObjectKey.Bytes2IntHash(k.chunk_hash) for k in actions[0].keys
@@ -353,7 +357,7 @@ class TestLRUEvictionPolicyKeyFilter:
         # 60% of 5 = 3 keys, should be 2, 3, 4
         assert evicted_hashes == [2, 3, 4]
 
-    def test_key_filter_skips_locked_simulated(self):
+    def test_key_eligible_filter_skips_locked_simulated(self):
         """Simulate the real use case: filter skips 'locked' keys."""
         policy = LRUEvictionPolicy()
         keys = [make_key(i) for i in range(1, 6)]
@@ -362,11 +366,13 @@ class TestLRUEvictionPolicyKeyFilter:
         # Simulate: keys 1 and 3 are "locked" (not evictable)
         locked_hashes = {1, 3}
 
-        def key_filter(key: ObjectKey) -> bool:
+        def key_eligible_filter(key: ObjectKey) -> bool:
             return ObjectKey.Bytes2IntHash(key.chunk_hash) not in locked_hashes
 
         # Request 100% eviction
-        actions = policy.get_eviction_actions(1.0, key_filter=key_filter)
+        actions = policy.get_eviction_actions(
+            1.0, key_eligible_filter=key_eligible_filter
+        )
         assert len(actions) == 1
         evicted_hashes = {
             ObjectKey.Bytes2IntHash(k.chunk_hash) for k in actions[0].keys
@@ -374,7 +380,7 @@ class TestLRUEvictionPolicyKeyFilter:
         # Keys 1 and 3 should be skipped
         assert evicted_hashes == {2, 4, 5}
 
-    def test_key_filter_with_small_ratio_and_many_filtered(self):
+    def test_key_eligible_filter_with_small_ratio_and_many_filtered(self):
         """When many keys are filtered, a small ratio should still
         collect enough eligible keys."""
         policy = LRUEvictionPolicy()
@@ -384,11 +390,13 @@ class TestLRUEvictionPolicyKeyFilter:
 
         # Filter: only accept keys with hash divisible by 5
         # Eligible: 0, 5, 10, 15 (4 keys)
-        def key_filter(key: ObjectKey) -> bool:
+        def key_eligible_filter(key: ObjectKey) -> bool:
             return ObjectKey.Bytes2IntHash(key.chunk_hash) % 5 == 0
 
         # Request 10% eviction -> target_count = 2
-        actions = policy.get_eviction_actions(0.1, key_filter=key_filter)
+        actions = policy.get_eviction_actions(
+            0.1, key_eligible_filter=key_eligible_filter
+        )
         assert len(actions) == 1
         assert len(actions[0].keys) == 2
         for k in actions[0].keys:

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -255,3 +255,141 @@ class TestLRUEvictionPolicyCandidates:
         policy.on_keys_created([make_key(1), make_key(2)])
         candidates = policy.get_eviction_candidates(10)
         assert len(candidates) == 2
+
+
+# =============================================================================
+# Key Filter Tests
+# =============================================================================
+
+
+class TestLRUEvictionPolicyKeyFilter:
+    """Tests for key_filter parameter in get_eviction_actions."""
+
+    def test_key_filter_skips_filtered_keys(self):
+        """Keys that fail the filter should be skipped during eviction."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(5)]
+        policy.on_keys_created(keys)
+
+        # Filter out keys with even chunk_hash
+        def key_filter(key: ObjectKey) -> bool:
+            return ObjectKey.Bytes2IntHash(key.chunk_hash) % 2 != 0
+
+        actions = policy.get_eviction_actions(1.0, key_filter=key_filter)
+        assert len(actions) == 1
+        evicted_hashes = {
+            ObjectKey.Bytes2IntHash(k.chunk_hash) for k in actions[0].keys
+        }
+        # Only odd keys should be evicted: 1, 3
+        assert evicted_hashes == {1, 3}
+
+    def test_key_filter_none_evicts_all(self):
+        """When key_filter is None, all keys should be eligible."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(5)]
+        policy.on_keys_created(keys)
+
+        actions = policy.get_eviction_actions(1.0, key_filter=None)
+        assert len(actions) == 1
+        assert len(actions[0].keys) == 5
+
+    def test_key_filter_rejects_all_returns_empty(self):
+        """When filter rejects all keys, no eviction actions should be returned."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(5)]
+        policy.on_keys_created(keys)
+
+        actions = policy.get_eviction_actions(1.0, key_filter=lambda _: False)
+        assert actions == []
+
+    def test_key_filter_respects_target_count(self):
+        """Filter should stop collecting once target_count is reached."""
+        policy = LRUEvictionPolicy()
+        # Create 10 keys, all pass filter
+        keys = [make_key(i) for i in range(10)]
+        policy.on_keys_created(keys)
+
+        # Request 50% eviction with a filter that accepts all
+        actions = policy.get_eviction_actions(0.5, key_filter=lambda _: True)
+        assert len(actions) == 1
+        assert len(actions[0].keys) == 5
+
+    def test_key_filter_with_partial_acceptance(self):
+        """When filter accepts some keys, only accepted keys up to
+        target_count should be evicted."""
+        policy = LRUEvictionPolicy()
+        # Create 10 keys: 0..9
+        keys = [make_key(i) for i in range(10)]
+        policy.on_keys_created(keys)
+
+        # Filter: only accept keys with hash >= 5
+        def key_filter(key: ObjectKey) -> bool:
+            return ObjectKey.Bytes2IntHash(key.chunk_hash) >= 5
+
+        # Request 100% eviction -> target_count = 10, but only 5 pass filter
+        actions = policy.get_eviction_actions(1.0, key_filter=key_filter)
+        assert len(actions) == 1
+        assert len(actions[0].keys) == 5
+        for k in actions[0].keys:
+            assert ObjectKey.Bytes2IntHash(k.chunk_hash) >= 5
+
+    def test_key_filter_preserves_lru_order(self):
+        """Filtered eviction should still respect LRU order."""
+        policy = LRUEvictionPolicy()
+        # Create keys in order: 1, 2, 3, 4, 5
+        for i in range(1, 6):
+            policy.on_keys_created([make_key(i)])
+
+        # Touch key 1 to make it most recently used
+        policy.on_keys_touched([make_key(1)])
+
+        # Filter: accept all keys
+        actions = policy.get_eviction_actions(0.6, key_filter=lambda _: True)
+        assert len(actions) == 1
+        evicted_hashes = [
+            ObjectKey.Bytes2IntHash(k.chunk_hash) for k in actions[0].keys
+        ]
+        # LRU order after touch: 2, 3, 4, 5, 1
+        # 60% of 5 = 3 keys, should be 2, 3, 4
+        assert evicted_hashes == [2, 3, 4]
+
+    def test_key_filter_skips_locked_simulated(self):
+        """Simulate the real use case: filter skips 'locked' keys."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(1, 6)]
+        policy.on_keys_created(keys)
+
+        # Simulate: keys 1 and 3 are "locked" (not evictable)
+        locked_hashes = {1, 3}
+
+        def key_filter(key: ObjectKey) -> bool:
+            return ObjectKey.Bytes2IntHash(key.chunk_hash) not in locked_hashes
+
+        # Request 100% eviction
+        actions = policy.get_eviction_actions(1.0, key_filter=key_filter)
+        assert len(actions) == 1
+        evicted_hashes = {
+            ObjectKey.Bytes2IntHash(k.chunk_hash) for k in actions[0].keys
+        }
+        # Keys 1 and 3 should be skipped
+        assert evicted_hashes == {2, 4, 5}
+
+    def test_key_filter_with_small_ratio_and_many_filtered(self):
+        """When many keys are filtered, a small ratio should still
+        collect enough eligible keys."""
+        policy = LRUEvictionPolicy()
+        # Create 20 keys: 0..19
+        keys = [make_key(i) for i in range(20)]
+        policy.on_keys_created(keys)
+
+        # Filter: only accept keys with hash divisible by 5
+        # Eligible: 0, 5, 10, 15 (4 keys)
+        def key_filter(key: ObjectKey) -> bool:
+            return ObjectKey.Bytes2IntHash(key.chunk_hash) % 5 == 0
+
+        # Request 10% eviction -> target_count = 2
+        actions = policy.get_eviction_actions(0.1, key_filter=key_filter)
+        assert len(actions) == 1
+        assert len(actions[0].keys) == 2
+        for k in actions[0].keys:
+            assert ObjectKey.Bytes2IntHash(k.chunk_hash) % 5 == 0


### PR DESCRIPTION
In the current LRU eviction implementation, get_eviction_actions blindly selects the first target_count keys from the LRU order without checking whether those keys are actually evictable (i.e., not locked).
For example, if target_count = 10 but 8 out of the first 10 LRU keys are currently read-locked or write-locked, the subsequent delete call can only successfully remove 2 keys. Meanwhile, there may be plenty of unlocked keys further down the LRU order that could have been evicted instead, this leads to extremely low eviction efficiency and prevents memory from being released in a timely manner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eviction selection logic and the `EvictionPolicy.get_eviction_actions` interface, which could affect eviction behavior and call sites; however the change is localized and covered by new unit tests.
> 
> **Overview**
> Improves L1 eviction efficiency by **skipping read/write-locked keys** when choosing LRU eviction candidates.
> 
> This extends `EvictionPolicy.get_eviction_actions` with an optional `key_eligible_filter` callback, implements filtering in `LRUEvictionPolicy`, and wires `L1EvictionController` to pass `L1Manager.is_key_evictable` so eviction avoids non-deletable keys.
> 
> Adds unit tests for `L1Manager.is_key_evictable` and for the new LRU filter behavior (including order/ratio handling and all/none acceptance cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132b18502197846b325601a2f8cb17b77fc255cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->