### PR TITLE
[BugFix]: Fix typo bug

### DIFF
--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -212,7 +212,7 @@ class KVCacheDescriber:
             )
             sec.add("num_layers", "Num layers", layout["num_layers"])
             sec.add("block_size", "Block size", layout["block_size"])
-            sec.add("hidden_dim_size", "Hidden dim size", layout["hidden_dim_size"])
+            sec.add("hidden_dim_sizes", "Hidden dim sizes", layout["hidden_dim_sizes"])
             sec.add("dtype", "Dtype", layout["dtype"])
             sec.add("is_mla", "MLA", layout["is_mla"])
             sec.add("num_blocks", "Num blocks", layout["num_blocks"])

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -814,7 +814,7 @@ class MPCacheEngine:
                 entry["kv_cache_layout"] = {
                     "num_layers": ctx.num_layers,
                     "block_size": ctx.block_size,
-                    "hidden_dim_sizes": str(ctx.hidden_dim_sizes),
+                    "hidden_dim_size": str(ctx.hidden_dim_sizes),
                     "dtype": str(ctx.dtype),
                     "is_mla": ctx.is_mla,
                     "num_blocks": ctx.num_blocks,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -814,7 +814,7 @@ class MPCacheEngine:
                 entry["kv_cache_layout"] = {
                     "num_layers": ctx.num_layers,
                     "block_size": ctx.block_size,
-                    "hidden_dim_size": str(ctx.hidden_dim_sizes),
+                    "hidden_dim_sizes": str(ctx.hidden_dim_sizes),
                     "dtype": str(ctx.dtype),
                     "is_mla": ctx.is_mla,
                     "num_blocks": ctx.num_blocks,

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -36,7 +36,7 @@ SAMPLE_STATUS = {
             "kv_cache_layout": {
                 "num_layers": 32,
                 "block_size": 16,
-                "hidden_dim_size": 128,
+                "hidden_dim_sizes": 128,
                 "dtype": "torch.float16",
                 "is_mla": False,
                 "num_blocks": 2048,
@@ -181,7 +181,7 @@ class TestDescribeKvcacheFields:
         assert model["gpu_ids"] == "0"
         assert model["num_layers"] == 32
         assert model["block_size"] == 16
-        assert model["hidden_dim_size"] == 128
+        assert model["hidden_dim_sizes"] == 128
         assert model["dtype"] == "torch.float16"
         assert model["is_mla"] is False
         assert model["num_blocks"] == 2048


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
I noticed we use `hidden_dim_sizes` instead of `hidden_dim_size`, when I run 
```
lmcache describe kvcache --url http://localhost:7555
```
, I got an error:

```
[2026-04-08 07:54:07,817] LMCache ERROR: Command failed (main.py:41:lmcache.cli.main)
Traceback (most recent call last):
  File "/proj-tango-pvc/users/zhipeng.wang/workspace/LMCache/lmcache/cli/main.py", line 37, in main
    args.func(args)
  File "/proj-tango-pvc/users/zhipeng.wang/workspace/LMCache/lmcache/cli/commands/describe.py", line 299, in execute
    self._describe_kvcache(args)
  File "/proj-tango-pvc/users/zhipeng.wang/workspace/LMCache/lmcache/cli/commands/describe.py", line 310, in _describe_kvcache
    KVCacheDescriber(metrics, data, base_url).describe()
  File "/proj-tango-pvc/users/zhipeng.wang/workspace/LMCache/lmcache/cli/commands/describe.py", line 114, in describe
    self.add_models()
  File "/proj-tango-pvc/users/zhipeng.wang/workspace/LMCache/lmcache/cli/commands/describe.py", line 215, in add_models
    sec.add("hidden_dim_size", "Hidden dim size", layout["hidden_dim_size"])
                                                  ~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'hidden_dim_size'
```

After this typo fix, you can got the expect result:
```
============ LMCache KV Cache Service ============
Health:                                         OK
URL:                         http://localhost:7555
Engine type:                         MPCacheEngine
Chunk size:                                    256
L1 capacity (GB):                           200.00
L1 used (GB):                        31.66 (15.8%)
Eviction policy:                               N/A
Cached objects:                               1309
Active sessions:                                 3
------------- Model: /tmp/GLM-5-FP8 --------------
Model:                              /tmp/GLM-5-FP8
World size:                                      1
GPU IDs: 623435, 623211, 623775, 623672, 623531, 623280, 623352, 623921
Attention backend:                        vLLM MLA
GPU KV shape:                    NL x [NB, BS, HS]
GPU KV tensor shape:          158 x [918, 64, 132]
Num layers:                                    158
Block size:                                     64
Hidden dim size:                        [132, 576]
Dtype:                                 torch.uint8
MLA:                                          True
Num blocks:                                    918
Cache size per token (bytes):               101436
==================================================
```

BTW, I noticed a lot of `hidden_dim_sizes`😂

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI-only typo fix with corresponding test updates; minimal impact beyond correcting field extraction and output.
> 
> **Overview**
> Fixes a `KeyError` in `lmcache describe kvcache` by changing the per-model KV cache layout field from `hidden_dim_size` to the correct `hidden_dim_sizes` key, so `describe` works with the service’s `/api/status` payload.
> 
> Updates the CLI integration test fixture and assertions to expect `hidden_dim_sizes` instead of `hidden_dim_size`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf63af41c4dea952ef14a185051163fb0029fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->