### PR TITLE
[Chore][CI] Upgrade CI base image to CUDA 13.0

### DIFF
--- a/.buildkite/k3_harness/ci-base.Dockerfile
+++ b/.buildkite/k3_harness/ci-base.Dockerfile
@@ -4,7 +4,7 @@
 # Built automatically by setup-cluster.sh and imported into K3s containerd.
 # Rebuild when requirements/*.txt changes.
 
-FROM nvcr.io/nvidia/cuda-dl-base:25.04-cuda12.9-devel-ubuntu24.04
+FROM nvidia/cuda:13.0.2-devel-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/venv/bin:${PATH}"
@@ -15,7 +15,8 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && apt-get install -y --no-install-recommends \
         ccache software-properties-common git curl sudo jq lsof \
         python3 python3-dev python3-venv python3-pip tzdata libxcb1-dev \
-    && ldconfig /usr/local/cuda-12.9/compat/ \
+        libcudart12 \
+    && ldconfig \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv ~/.local/bin/uv /usr/local/bin/ \
     && mv ~/.local/bin/uvx /usr/local/bin/ \


### PR DESCRIPTION
vLLM nightly now requires PyTorch 2.11.0 which is built against CUDA 13.0. Update the CI base image to match.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the CUDA base image and runtime libraries used by CI pods, which can break GPU-dependent builds/tests if the new CUDA 13 environment differs from previous images.
> 
> **Overview**
> Updates the K3s Buildkite harness CI base image to CUDA 13 by switching the Docker base from NVIDIA’s CUDA DL image to `nvidia/cuda:13.0.2-devel-ubuntu24.04`.
> 
> Adjusts image setup to install `libcudart12` and run a generic `ldconfig` (removing the prior CUDA 12.9 compat path), aligning the CI environment with newer CUDA/PyTorch requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcf764cf05d8b8a1e628e9c91ed826fe254f51d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->