### PR TITLE
refactor: extract PathSharder module for shared multi-path selection

### DIFF
--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -31,6 +31,7 @@ from lmcache.v1.memory_management import (
 )
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
+from lmcache.v1.storage_backend.path_sharder import PathSharder
 
 logger = init_logger(__name__)
 
@@ -192,33 +193,22 @@ class GdsBackend(AllocatorBackendInterface):
         self.loop = loop
         self.dst_device = dst_device
 
-        # Extract device index from self.dst_device (e.g. "cuda:2" -> 2)
-        device_id = (
-            int(dst_device.split(":")[1])
-            if ":" in dst_device
-            else torch.cuda.current_device()
-        )
-
         assert config.gds_path is not None, "Need to specify gds_path for GdsBackend"
 
-        # Multi-path support: parse comma-separated paths and select one
-        # based on the configured sharding strategy.
-        self.gds_paths = [p.strip() for p in config.gds_path.split(",") if p.strip()]
-        assert len(self.gds_paths) > 0, "gds_path cannot be empty"
-
-        self.gds_path_sharding = config.gds_path_sharding
-        assert self.gds_path_sharding == "by_gpu", (
-            f"Unsupported gds_path_sharding '{self.gds_path_sharding}'. "
-            "Only 'by_gpu' is supported currently."
+        sharder = PathSharder(
+            raw_csv=config.gds_path,
+            strategy=config.gds_path_sharding,
+            dst_device=dst_device,
         )
-        self.gds_path = self.gds_paths[device_id % len(self.gds_paths)]
+        self.gds_paths = sharder.all_paths
+        self.gds_path = sharder.selected
         self.fstype = get_fstype(self.gds_path)
 
         # Log the fstype - this is useful in reports and varying optimizations
         # based on the kind of fstype used.
         logger.info(
             f"GDS backend using fstype '{self.fstype}' on path '{self.gds_path}'"
-            f" (device {device_id}, {len(self.gds_paths)} path(s) configured)"
+            f" ({len(self.gds_paths)} path(s) configured)"
         )
 
         # Initialize use_cufile and use_hipfile before creating the memory allocator

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -25,6 +25,7 @@ from lmcache.v1.storage_backend.job_executor.pq_executor import (
     AsyncPQThreadPoolExecutor,
 )
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.path_sharder import PathSharder
 
 if TYPE_CHECKING:
     # First Party
@@ -120,34 +121,19 @@ class LocalDiskBackend(StorageBackendInterface):
 
         assert config.local_disk is not None
 
-        # Multi-path support: parse comma-separated paths and select one
-        # based on the configured sharding strategy.
-        paths = [p.strip() for p in config.local_disk.split(",") if p.strip()]
-        assert len(paths) > 0, "At least one disk path must be provided"
-
-        self.local_disk_path_sharding = config.local_disk_path_sharding
-        assert self.local_disk_path_sharding == "by_gpu", (
-            f"Unsupported local_disk_path_sharding "
-            f"'{self.local_disk_path_sharding}'. "
-            "Only 'by_gpu' is supported currently."
+        sharder = PathSharder(
+            raw_csv=config.local_disk,
+            strategy=config.local_disk_path_sharding,
+            dst_device=dst_device,
+            create_dirs=True,
         )
+        self.path: str = sharder.selected
 
-        # Extract device index from dst_device (e.g. "cuda:2" -> 2)
-        device_id = (
-            int(dst_device.split(":")[1])
-            if ":" in dst_device
-            else (torch.cuda.current_device() if torch.cuda.is_available() else 0)
-        )
-        self.path: str = paths[device_id % len(paths)]
-
-        # Create all directories (not just the selected one)
-        for p in paths:
-            os.makedirs(p, exist_ok=True)
         logger.info(
             "Local disk cache path: %s (device %s, %d path(s) configured)",
             self.path,
             dst_device,
-            len(paths),
+            len(sharder.all_paths),
         )
 
         self.loop = loop

--- a/lmcache/v1/storage_backend/path_sharder.py
+++ b/lmcache/v1/storage_backend/path_sharder.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared path-sharding logic for multi-path storage backends.
+
+A :class:`PathSharder` takes a comma-separated list of directory paths
+and a sharding strategy, then selects a single path for the current
+worker.  Both :class:`LocalDiskBackend` and :class:`GdsBackend` delegate
+path selection to this module so the policy lives in one place.
+"""
+
+# Standard
+from typing import List
+import os
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+def _resolve_device_id(dst_device: str) -> int:
+    """Derive an integer device index from *dst_device*.
+
+    Args:
+        dst_device: Device string such as ``"cuda:2"``, ``"cuda"``,
+            or ``"cpu"``.
+
+    Returns:
+        Integer device index.  Falls back to
+        :func:`torch.cuda.current_device` when the string carries no
+        explicit index, or ``0`` when CUDA is unavailable.
+    """
+    if ":" in dst_device:
+        try:
+            return int(dst_device.split(":", 1)[1])
+        except ValueError:
+            logger.warning(f"Invalid device index in '{dst_device}', falling back.")
+    if "cuda" in dst_device and torch.cuda.is_available():
+        return torch.cuda.current_device()
+    return 0
+
+
+class PathSharder:
+    """Select one path from a comma-separated list using a sharding policy.
+
+    Args:
+        raw_csv: Comma-separated directory paths (e.g.
+            ``"/mnt/nvme0/cache,/mnt/nvme1/cache"``).
+        strategy: Sharding strategy name.  Currently only ``"by_gpu"``
+            is supported, which selects ``paths[device_id % len(paths)]``.
+        dst_device: Device string used to derive the worker index
+            (e.g. ``"cuda:0"``, ``"cuda"``, ``"cpu"``).
+        create_dirs: If ``True``, create **all** directories in the
+            list at construction time (not just the selected one).
+
+    Raises:
+        ValueError: If *raw_csv* is empty or contains no valid paths.
+        ValueError: If *strategy* is not a supported sharding mode.
+
+    Example::
+
+        sharder = PathSharder(
+            "/mnt/nvme0/cache,/mnt/nvme1/cache",
+            strategy="by_gpu",
+            dst_device="cuda:1",
+        )
+        sharder.selected   # "/mnt/nvme1/cache"
+        sharder.all_paths  # ["/mnt/nvme0/cache", "/mnt/nvme1/cache"]
+    """
+
+    _SUPPORTED_STRATEGIES = ("by_gpu",)
+
+    def __init__(
+        self,
+        raw_csv: str,
+        strategy: str,
+        dst_device: str,
+        create_dirs: bool = False,
+    ) -> None:
+        paths = [p.strip() for p in raw_csv.split(",") if p.strip()]
+        if not paths:
+            raise ValueError("At least one path must be provided")
+
+        if strategy not in self._SUPPORTED_STRATEGIES:
+            raise ValueError(
+                f"Unsupported path sharding strategy '{strategy}'. "
+                f"Supported: {', '.join(self._SUPPORTED_STRATEGIES)}"
+            )
+
+        device_id = _resolve_device_id(dst_device)
+
+        self._all_paths: List[str] = paths
+        self._strategy: str = strategy
+        self._selected: str = paths[device_id % len(paths)]
+
+        if create_dirs:
+            for p in paths:
+                os.makedirs(p, exist_ok=True)
+
+    # -- public read-only properties -----------------------------------------
+
+    @property
+    def selected(self) -> str:
+        """The single path chosen for this worker."""
+        return self._selected
+
+    @property
+    def all_paths(self) -> List[str]:
+        """All configured paths (unmodified order)."""
+        return list(self._all_paths)
+
+    @property
+    def strategy(self) -> str:
+        """Name of the active sharding strategy."""
+        return self._strategy

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -763,10 +763,10 @@ class TestGdsMultiPath:
                 shutil.rmtree(p, ignore_errors=True)
 
     def test_gds_path_sharding_default(self, temp_gds_path, async_loop):
-        """Default gds_path_sharding is 'by_gpu'."""
+        """Default gds_path_sharding is 'by_gpu' (backend inits OK)."""
         backend = self._make_backend(temp_gds_path, "cuda:0", async_loop)
         try:
-            assert backend.gds_path_sharding == "by_gpu"
+            assert backend.gds_path == temp_gds_path
         finally:
             backend.close()
 
@@ -779,13 +779,13 @@ class TestGdsMultiPath:
             gds_path_sharding="by_gpu",
         )
         try:
-            assert backend.gds_path_sharding == "by_gpu"
+            assert backend.gds_path == temp_gds_path
         finally:
             backend.close()
 
     def test_gds_path_sharding_unsupported_raises(self, temp_gds_path, async_loop):
-        """Unsupported gds_path_sharding value raises AssertionError."""
-        with pytest.raises(AssertionError, match="Unsupported gds_path_sharding"):
+        """Unsupported gds_path_sharding value raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported path sharding strategy"):
             self._make_backend(
                 temp_gds_path,
                 "cuda:0",

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -283,7 +283,7 @@ class TestMultiPathDiskBackend:
         local_cpu_backend.memory_allocator.close()
 
     def test_path_sharding_default(self, temp_disk_path, async_loop, local_cpu_backend):
-        """Default local_disk_path_sharding is 'by_gpu'."""
+        """Default local_disk_path_sharding is 'by_gpu' (backend inits OK)."""
         config = create_test_config(temp_disk_path)
         backend = LocalDiskBackend(
             config=config,
@@ -291,7 +291,7 @@ class TestMultiPathDiskBackend:
             local_cpu_backend=local_cpu_backend,
             dst_device="cuda:0",
         )
-        assert backend.local_disk_path_sharding == "by_gpu"
+        assert backend.path == temp_disk_path
         local_cpu_backend.memory_allocator.close()
 
     def test_path_sharding_explicit_by_gpu(
@@ -305,19 +305,17 @@ class TestMultiPathDiskBackend:
             local_cpu_backend=local_cpu_backend,
             dst_device="cuda:0",
         )
-        assert backend.local_disk_path_sharding == "by_gpu"
+        assert backend.path == temp_disk_path
         local_cpu_backend.memory_allocator.close()
 
     def test_path_sharding_unsupported_raises(
         self, temp_disk_path, async_loop, local_cpu_backend
     ):
-        """Unsupported local_disk_path_sharding raises AssertionError."""
+        """Unsupported local_disk_path_sharding raises ValueError."""
         config = create_test_config(
             temp_disk_path, local_disk_path_sharding="round_robin"
         )
-        with pytest.raises(
-            AssertionError, match="Unsupported local_disk_path_sharding"
-        ):
+        with pytest.raises(ValueError, match="Unsupported path sharding strategy"):
             LocalDiskBackend(
                 config=config,
                 loop=async_loop,

--- a/tests/v1/storage_backend/test_path_sharder.py
+++ b/tests/v1/storage_backend/test_path_sharder.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :mod:`lmcache.v1.storage_backend.path_sharder`."""
+
+# Standard
+from unittest.mock import patch
+import os
+import shutil
+import tempfile
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.path_sharder import PathSharder
+
+
+class TestPathSharder:
+    """Tests for PathSharder class."""
+
+    def test_single_path(self):
+        d = tempfile.mkdtemp()
+        try:
+            s = PathSharder(d, strategy="by_gpu", dst_device="cuda:0")
+            assert s.selected == d
+            assert s.all_paths == [d]
+            assert s.strategy == "by_gpu"
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_multi_path_selects_by_device_id(self):
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            for i, d in enumerate(dirs):
+                s = PathSharder(csv, strategy="by_gpu", dst_device=f"cuda:{i}")
+                assert s.selected == d
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_modulo_wraps(self):
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:4")
+            # 4 % 2 == 0
+            assert s.selected == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_create_dirs(self):
+        base = tempfile.mkdtemp()
+        try:
+            paths = [os.path.join(base, f"nvme{i}") for i in range(3)]
+            csv = ",".join(paths)
+            PathSharder(csv, strategy="by_gpu", dst_device="cuda:0", create_dirs=True)
+            for p in paths:
+                assert os.path.isdir(p)
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+
+    def test_no_create_dirs_by_default(self):
+        base = tempfile.mkdtemp()
+        try:
+            new_dir = os.path.join(base, "should_not_exist")
+            PathSharder(new_dir, strategy="by_gpu", dst_device="cuda:0")
+            assert not os.path.exists(new_dir)
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
+
+    def test_empty_csv_raises(self):
+        with pytest.raises(ValueError, match="At least one path"):
+            PathSharder("", strategy="by_gpu", dst_device="cuda:0")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="At least one path"):
+            PathSharder("  , ,  ", strategy="by_gpu", dst_device="cuda:0")
+
+    def test_unsupported_strategy_raises(self):
+        d = tempfile.mkdtemp()
+        try:
+            with pytest.raises(ValueError, match="Unsupported path sharding"):
+                PathSharder(d, strategy="round_robin", dst_device="cuda:0")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_strips_whitespace(self):
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = f"  {dirs[0]}  ,  {dirs[1]}  "
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:0")
+            assert s.all_paths == dirs
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    @patch("torch.cuda.is_available", return_value=False)
+    def test_cpu_device_selects_first_path(self, _avail):
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cpu")
+            assert s.selected == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_all_paths_returns_copy(self):
+        d = tempfile.mkdtemp()
+        try:
+            s = PathSharder(d, strategy="by_gpu", dst_device="cuda:0")
+            paths = s.all_paths
+            paths.append("/rogue")
+            assert "/rogue" not in s.all_paths
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    # -- device-resolution edge cases (exercised via public API) -----------
+
+    @patch("torch.cuda.is_available", return_value=True)
+    @patch("torch.cuda.current_device", return_value=1)
+    def test_bare_cuda_uses_current_device(self, _cur, _avail):
+        """Bare 'cuda' resolves to torch.cuda.current_device()."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda")
+            assert s.selected == dirs[1]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    @patch("torch.cuda.is_available", return_value=False)
+    def test_bare_cuda_no_gpu_selects_first(self, _avail):
+        """Bare 'cuda' with no GPU falls back to device 0."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda")
+            assert s.selected == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    @patch("torch.cuda.is_available", return_value=True)
+    @patch("torch.cuda.current_device", return_value=2)
+    def test_cpu_device_always_selects_first(self, _cur, _avail):
+        """'cpu' always resolves to index 0, even when CUDA is available."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cpu")
+            assert s.selected == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    @patch("torch.cuda.is_available", return_value=True)
+    @patch("torch.cuda.current_device", return_value=2)
+    def test_malformed_device_empty_index_falls_back(self, _cur, _avail):
+        """'cuda:' (no int) falls back to current_device."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:")
+            assert s.selected == dirs[2]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    @patch("torch.cuda.is_available", return_value=False)
+    def test_malformed_device_non_numeric_falls_back(self, _avail):
+        """'cuda:foo' falls back to 0 when CUDA is unavailable."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:foo")
+            assert s.selected == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
Move the duplicated path-sharding logic (CSV parsing, device ID extraction, by_gpu strategy) from LocalDiskBackend and GdsBackend into a new PathSharder class in path_sharder.py.

Both backends now delegate to PathSharder, keeping the policy in one place.  The _resolve_device_id helper handles cuda:N, bare cuda, and cpu devices gracefully.

Generated with [Devin](https://cli.devin.ai/docs)

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches storage backend initialization and path selection logic for both `LocalDiskBackend` and `GdsBackend`, which could change which directory is used (and how invalid configs fail) in multi-GPU/multi-path deployments.
> 
> **Overview**
> Refactors multi-path cache directory selection by extracting the shared CSV parsing + *by-GPU* sharding logic into a new `PathSharder` utility and switching both `GdsBackend` and `LocalDiskBackend` to use it.
> 
> Standardizes device-id resolution (handles `cuda:N`, bare `cuda`, and `cpu`) and changes unsupported sharding configuration failures from `AssertionError` to `ValueError`, with updated/new unit tests covering selection, directory creation, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192341413dca14d16fb3a44e510d65d2961f78cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->