### PR TITLE
[CI] Pin cu128 nightly wheel for blend ci test 

### DIFF
--- a/.buildkite/k3_harness/setup-blend-env.sh
+++ b/.buildkite/k3_harness/setup-blend-env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Per-job environment setup: installs vLLM nightly + LMCache from source.
+# Per-job environment setup: installs vLLM (pinned) + LMCache from source.
 # Called at the start of every CI job.
 set -euo pipefail
 
@@ -17,7 +17,8 @@ fi
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
 
-echo "--- :python: Installing vLLM nightly"
+VLLM_VERSION="${VLLM_VERSION:-0.18.0}"
+echo "--- :python: Installing vLLM ${VLLM_VERSION}"
 
 
 DEFAULT_VENV_BIN="/opt/venv/bin"
@@ -51,29 +52,11 @@ else
 fi
 TEST_VENV_BIN="/workspace/.venv/bin"
 
-# Resolve the latest nightly wheel URL directly from the nightly index.
-# PEP 440 ranks stable releases (0.17.0) above pre-release nightlies
-# (0.17.0rc1.devN), so pip/uv always picks the stable version when both
-# indexes are available. We work around this by parsing the nightly index
-# page and installing the wheel by URL.
-ARCH=$(uname -m)  # x86_64 or aarch64
-VLLM_NIGHTLY_INDEX="https://wheels.vllm.ai/nightly/vllm/"
-INDEX_HTML=$(curl -sfL "$VLLM_NIGHTLY_INDEX" 2>&1) || true
-VLLM_NIGHTLY_URL=$(echo "$INDEX_HTML" \
-    | grep -oP 'href="\K[^"]+'"${ARCH}"'\.whl' \
-    | head -1) || true
-if [[ -z "$VLLM_NIGHTLY_URL" ]]; then
-    echo "WARNING: Could not find vLLM nightly wheel for ${ARCH} — falling back to latest stable" >&2
-    "${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" "vllm[runai,tensorizer,flashinfer]"
-else
-    # href is relative (../../<commit>/vllm-....whl), resolve to absolute URL
-    VLLM_WHEEL_URL="https://wheels.vllm.ai/nightly/vllm/${VLLM_NIGHTLY_URL}"
-    echo "Resolved nightly wheel: $VLLM_WHEEL_URL"
-    "${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" --prerelease=allow \
-        "${VLLM_WHEEL_URL}[runai,tensorizer,flashinfer]" \
-        --extra-index-url https://pypi.org/simple \
-        --index-strategy unsafe-best-match
-fi
+# When flashinfer and flashinfer-cubin resolve to different patch versions, skip strict check.
+export FLASHINFER_DISABLE_VERSION_CHECK=1
+
+"${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" \
+    "vllm==${VLLM_VERSION}"
 
 # install LMCache from source twice as two torch version might be different
 echo "--- :python: Installing LMCache from source"

--- a/.buildkite/k3_harness/setup-blend-env.sh
+++ b/.buildkite/k3_harness/setup-blend-env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Per-job environment setup: installs vLLM (pinned) + LMCache from source.
+# Per-job environment setup: installs vLLM (nightly cu128 wheels) + LMCache from source.
 # Called at the start of every CI job.
 set -euo pipefail
 
@@ -17,8 +17,7 @@ fi
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
 
-VLLM_VERSION="${VLLM_VERSION:-0.18.0}"
-echo "--- :python: Installing vLLM ${VLLM_VERSION}"
+echo "--- :python: Installing vLLM (nightly cu128 wheels)"
 
 
 DEFAULT_VENV_BIN="/opt/venv/bin"
@@ -55,14 +54,22 @@ TEST_VENV_BIN="/workspace/.venv/bin"
 # When flashinfer and flashinfer-cubin resolve to different patch versions, skip strict check.
 export FLASHINFER_DISABLE_VERSION_CHECK=1
 
-"${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" \
-    "vllm==${VLLM_VERSION}"
+"${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" -U vllm "torch==2.10.0+cu128" --pre \
+    --extra-index-url https://wheels.vllm.ai/nightly/cu128 \
+    --extra-index-url https://download.pytorch.org/whl/cu128 \
+    --index-strategy unsafe-best-match
+
 
 # install LMCache from source twice as two torch version might be different
+ 
+"${DEFAULT_VENV_BIN}/python" -c 'import vllm; print(f"default venv vllm={vllm.__version__}")' 
+"${TEST_VENV_BIN}/python" -c 'import vllm; print(f"test venv vllm={vllm.__version__}")'
+"${DEFAULT_VENV_BIN}/python" -c 'import torch; print(f"default venv torch={torch.__version__}, torch.version.cuda={torch.version.cuda}")' 
+"${TEST_VENV_BIN}/python" -c 'import torch; print(f"test venv torch={torch.__version__}, torch.version.cuda={torch.version.cuda}")'
+
 echo "--- :python: Installing LMCache from source"
 "${UV_BIN}" pip install -p "${DEFAULT_VENV_BIN}/python" -e . --no-build-isolation
 "${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" -e . --no-build-isolation
-
 # Work around openai_harmony vocab download/load issues for GPT-OSS (vLLM recipes troubleshooting).
 # related github issue: https://github.com/openai/harmony/pull/41
 TIKTOKEN_ENCODINGS_DIR="${REPO_ROOT}/tiktoken_encodings"
@@ -77,8 +84,11 @@ fi
 if [[ ! -s "${TIKTOKEN_ENCODINGS_DIR}/cl100k_base.tiktoken" ]]; then
   curl -fsSL "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken" -o "${TIKTOKEN_ENCODINGS_DIR}/cl100k_base.tiktoken"
 fi
+
+
 export TIKTOKEN_ENCODINGS_BASE="${TIKTOKEN_ENCODINGS_DIR}"
 echo "Using TIKTOKEN_ENCODINGS_BASE=${TIKTOKEN_ENCODINGS_BASE}"
+
 
 echo "--- :white_check_mark: Environment ready"
 "${DEFAULT_VENV_BIN}/python" -c "import vllm; import lmcache; print(f'vLLM={vllm.__version__}, LMCache installed from source with no build isolation in default venv')"

--- a/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
+++ b/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
@@ -30,14 +30,16 @@ SERVER_WAIT_TIMEOUT="${SERVER_WAIT_TIMEOUT:-400}"
 
 BUILD_ID="${BUILDKITE_BUILD_ID:-local_$$}"
 WORK_LOG="/tmp/build_${BUILD_ID}_blend.log" 
-# Blend server, vLLM prefiller/decoder, and proxy stdout/stderr (main script uses WORK_LOG via tee).
-VLLM_LOG="/tmp/build_${BUILD_ID}_vllm.log"
+# Proxy stdout/stderr. Blend server/prefiller/decoder each get their own _blend_server/_prefiller_PORT/_decoder_PORT logs.
+VLLM_LOG="/tmp/build_${BUILD_ID}_proxy.log"
+BLEND_SERVER_LOG="/tmp/build_${BUILD_ID}_blend_server.log"
 ARTIFACT="build_${BUILD_ID}.log"
 # Benchmark wall-clock limit (seconds). Exit 124 from `timeout` => failure. Default stays under blend pipeline 90m.
 BENCHMARK_TIMEOUT_SEC="${BENCHMARK_TIMEOUT_SEC:-4800}"
 
 : > "${WORK_LOG}"
 : > "${VLLM_LOG}"
+: > "${BLEND_SERVER_LOG}"
 
 declare -A RESERVED_PORTS=()
 
@@ -89,7 +91,7 @@ resolve_port_csv() {
 
 collect_artifact() {
   echo "[INFO] Collecting logs into ${ARTIFACT}"
-  cat "${WORK_LOG}" "${VLLM_LOG}" > "${ARTIFACT}" 2>/dev/null || true
+  cat /tmp/build_"${BUILD_ID}"_*.log > "${ARTIFACT}" 2>/dev/null || true
 }
 
 finalize() {
@@ -198,7 +200,7 @@ export LD_LIBRARY_PATH=/opt/nvidia/nsight-compute/2025.1.0/host/linux-desktop-gl
   --eviction-policy LRU \
   --chunk-size 1024 \
   --l1-align-bytes 16777216 \
-  >>"${VLLM_LOG}" 2>&1 &
+  >>"${BLEND_SERVER_LOG}" 2>&1 &
 TRACKED_PIDS+=($!)
 
 sleep 10
@@ -209,6 +211,8 @@ GPU_IDX=0
 for port in "${PREFILLER_PORTS[@]}"; do
   GPU_END=$((GPU_IDX + TENSOR_PARALLEL - 1))
   CUDA_DEVS=$(seq -s, "$GPU_IDX" "$GPU_END")
+  PREFILLER_LOG="/tmp/build_${BUILD_ID}_prefiller_${port}.log"
+  : > "${PREFILLER_LOG}"
   echo "Starting prefiller on GPUs ${CUDA_DEVS}, port ${port}"
   CUDA_VISIBLE_DEVICES=$CUDA_DEVS \
     LMCACHE_REQUEST_TELEMETRY_TYPE=fastapi \
@@ -226,7 +230,7 @@ for port in "${PREFILLER_PORTS[@]}"; do
     --gpu-memory-utilization "$GPU_MEM_UTIL" \
     --kv-transfer-config \
       "{\"kv_connector\":\"LMCacheMPCBConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":${LMCACHE_MP_PORT}}}" \
-    >>"${VLLM_LOG}" 2>&1 &
+    >>"${PREFILLER_LOG}" 2>&1 &
   TRACKED_PIDS+=($!)
   GPU_IDX=$((GPU_IDX + TENSOR_PARALLEL))
 done
@@ -238,6 +242,8 @@ done
 for port in "${DECODER_PORTS[@]}"; do
   GPU_END=$((GPU_IDX + TENSOR_PARALLEL - 1))
   CUDA_DEVS=$(seq -s, "$GPU_IDX" "$GPU_END")
+  DECODER_LOG="/tmp/build_${BUILD_ID}_decoder_${port}.log"
+  : > "${DECODER_LOG}"
   echo "Starting decoder on GPUs ${CUDA_DEVS}, port ${port}"
   CUDA_VISIBLE_DEVICES=$CUDA_DEVS \
     VLLM_USE_FLASHINFER_MOE_FP8=0 \
@@ -252,7 +258,7 @@ for port in "${DECODER_PORTS[@]}"; do
     --gpu-memory-utilization "$GPU_MEM_UTIL" \
     --kv-transfer-config \
       "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":${LMCACHE_MP_PORT}}}" \
-    >>"${VLLM_LOG}" 2>&1 &
+    >>"${DECODER_LOG}" 2>&1 &
   TRACKED_PIDS+=($!)
   GPU_IDX=$((GPU_IDX + TENSOR_PARALLEL))
 done


### PR DESCRIPTION
 
**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI dependency resolution (nightly wheel sources + pinned CUDA torch), which may introduce new incompatibilities or flakiness in GPU runs; functional code paths are otherwise unaffected.
> 
> **Overview**
> Switches Blend CI environment setup to install `vllm` from the nightly *cu128* wheel index and pins `torch==2.10.0+cu128`, including a `FLASHINFER_DISABLE_VERSION_CHECK` workaround and extra version diagnostics.
> 
> Updates the Blend integration test runner to split logs per process (blend server/prefillers/decoders/proxy) and bundle all `/tmp/build_${BUILD_ID}_*.log` files into the final artifact for easier debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbead04692e69e7fcdcc33c12f86eab2e9212480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->