### PR TITLE
fix: use unique device_id per OBJ register/deregister cycle

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,6 +39,7 @@ steps:
         --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
         --ignore=tests/v1/test_nixl_storage.py \
         --ignore=tests/v1/test_nixl_batched_contains.py \
+        --ignore=tests/v1/test_device_id_race.py \
         --ignore=tests/skipped \
         --ignore=tests/v1/storage_backend/test_eic.py
 

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -1095,6 +1095,13 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         self.meta_fmt: Optional[MemoryFormat] = None
         self.init_chunk_meta(metadata)
 
+        # Monotonically increasing counter for OBJ device_id values.
+        # Each register/deregister cycle must use globally unique IDs to
+        # avoid a race where an async PUT deregister erases a concurrent
+        # GET registration in NIXL's devIdToObjKey_ map.
+        self._device_id_counter = 0
+        self._device_id_lock = threading.Lock()
+
         self.agent = NixlDynamicStorageAgent(
             self.memory_allocator,
             nixl_config.buffer_device,
@@ -1108,6 +1115,22 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         """Configure a custom cache policy for key presence tracking."""
         if self.enable_presence_cache:
             self.key_presence_cache = cache
+
+    def _alloc_device_ids(self, count: int) -> list[int]:
+        """Allocate ``count`` globally unique OBJ device_id values.
+
+        The NIXL OBJ backend indexes registrations by device_id in a flat
+        unordered_map with no reference counting.  If two concurrent
+        operations (e.g. async PUT cleanup + sync GET) use the same
+        device_id sequence (0, 1, 2, ...), the PUT deregister can erase
+        the GET entry and cause ``prepXfer``/``postXfer`` to fail with
+        NIXL_ERR_INVALID_PARAM.  Using a monotonic counter ensures every
+        register/deregister cycle gets its own ID range.
+        """
+        with self._device_id_lock:
+            start = self._device_id_counter
+            self._device_id_counter += count
+        return list(range(start, start + count))
 
     def _cache_contains(self, chunk_hash: int) -> bool:
         if not self.enable_presence_cache or self.key_presence_cache is None:
@@ -1210,9 +1233,10 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
             storage_indices.append(idx)
 
         if self.agent.mem_type == "OBJ":
+            device_ids = self._alloc_device_ids(len(keys))
             for idx in range(len(keys)):
                 object_key = self._format_object_key(keys[idx])
-                descs.append(NixlDesc(device_id=idx, meta_info=object_key))
+                descs.append(NixlDesc(device_id=device_ids[idx], meta_info=object_key))
         else:
             # Already validated in validate_nixl_backend
             raise ValueError(f"unexpected mem_type: {self.agent.mem_type}")
@@ -1305,9 +1329,10 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         descs = []
 
         if self.agent.mem_type == "OBJ":
+            device_ids = self._alloc_device_ids(len(keys))
             for idx in range(len(keys)):
                 object_key = self._format_object_key(keys[idx])
-                descs.append(NixlDesc(device_id=idx, meta_info=object_key))
+                descs.append(NixlDesc(device_id=device_ids[idx], meta_info=object_key))
         else:
             # Already validated in validate_nixl_backend
             raise ValueError(f"unexpected mem_type: {self.agent.mem_type}")

--- a/tests/v1/test_device_id_race.py
+++ b/tests/v1/test_device_id_race.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for NixlDynamicStorageBackend._alloc_device_ids.
+
+These tests verify the fix for the NIXL OBJ devIdToObjKey_ race condition
+(https://github.com/LMCache/LMCache/issues/2983).  When nixl_async_put is
+enabled, async PUT cleanup and sync GET run concurrently.  Both previously
+used device_id = 0, 1, 2, ... for every call, causing the PUT's
+deregister to erase the GET registration in NIXL's flat map.
+
+The fix uses a monotonically increasing counter so each register/deregister
+cycle gets globally unique device_ids.  These tests validate correctness
+and thread safety of that counter without requiring NIXL or CUDA hardware.
+"""
+
+# Standard
+import threading
+
+# Third Party
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal NixlDynamicStorageBackend with only the fields
+# needed by _alloc_device_ids, bypassing __init__'s heavy dependencies.
+# ---------------------------------------------------------------------------
+def _make_stub_backend():
+    """Return a NixlDynamicStorageBackend instance with __init__ bypassed."""
+    # Import inside function so the test file can be collected even when
+    # nixl is not installed (the importorskip below handles the skip).
+    # First Party
+    from lmcache.v1.storage_backend.nixl_storage_backend import (
+        NixlDynamicStorageBackend,
+    )
+
+    obj = object.__new__(NixlDynamicStorageBackend)
+    obj._device_id_counter = 0
+    obj._device_id_lock = threading.Lock()
+    return obj
+
+
+# Skip the entire module if nixl is not importable (mirrors existing tests)
+pytest.importorskip("nixl", reason="nixl package is required for nixl tests")
+
+
+# ---- Basic correctness ----------------------------------------------------
+
+
+class TestAllocDeviceIds:
+    """Tests for _alloc_device_ids correctness."""
+
+    def test_single_alloc_returns_sequential_range(self):
+        backend = _make_stub_backend()
+        ids = backend._alloc_device_ids(5)
+        assert ids == [0, 1, 2, 3, 4]
+
+    def test_successive_allocs_are_non_overlapping(self):
+        backend = _make_stub_backend()
+        first = backend._alloc_device_ids(3)
+        second = backend._alloc_device_ids(4)
+        third = backend._alloc_device_ids(2)
+        assert first == [0, 1, 2]
+        assert second == [3, 4, 5, 6]
+        assert third == [7, 8]
+
+    def test_alloc_zero_returns_empty(self):
+        backend = _make_stub_backend()
+        ids = backend._alloc_device_ids(0)
+        assert ids == []
+        # Counter should not advance
+        assert backend._device_id_counter == 0
+
+    def test_alloc_one_returns_single_element(self):
+        backend = _make_stub_backend()
+        ids = backend._alloc_device_ids(1)
+        assert ids == [0]
+        assert backend._device_id_counter == 1
+
+    def test_counter_advances_correctly(self):
+        backend = _make_stub_backend()
+        backend._alloc_device_ids(10)
+        assert backend._device_id_counter == 10
+        backend._alloc_device_ids(5)
+        assert backend._device_id_counter == 15
+
+    def test_all_ids_globally_unique_across_many_allocs(self):
+        backend = _make_stub_backend()
+        all_ids = []
+        for n in [1, 3, 7, 2, 10, 5]:
+            all_ids.extend(backend._alloc_device_ids(n))
+        assert len(all_ids) == len(set(all_ids)), "duplicate device_ids found"
+        assert all_ids == list(range(28))
+
+
+# ---- Thread safety ---------------------------------------------------------
+
+
+class TestAllocDeviceIdsThreadSafety:
+    """Verify no duplicate IDs under concurrent access."""
+
+    def test_concurrent_allocs_produce_unique_ids(self):
+        """Simulate the race: multiple threads calling _alloc_device_ids
+        concurrently, as happens when async PUT cleanup and sync GET
+        overlap."""
+        backend = _make_stub_backend()
+        num_threads = 16
+        allocs_per_thread = 200
+        batch_size = 5  # typical: one device_id per key in a batch
+        results: list[list[int]] = [[] for _ in range(num_threads)]
+
+        barrier = threading.Barrier(num_threads)
+
+        def worker(thread_idx):
+            barrier.wait()  # maximize contention
+            for _ in range(allocs_per_thread):
+                ids = backend._alloc_device_ids(batch_size)
+                results[thread_idx].extend(ids)
+
+        threads = [
+            threading.Thread(target=worker, args=(i,)) for i in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        all_ids = []
+        for r in results:
+            all_ids.extend(r)
+
+        expected_total = num_threads * allocs_per_thread * batch_size
+        assert len(all_ids) == expected_total
+        assert len(set(all_ids)) == expected_total, (
+            f"found {expected_total - len(set(all_ids))} duplicate device_ids "
+            f"under concurrent access"
+        )
+
+    def test_interleaved_put_get_simulation(self):
+        """Simulate interleaved PUT (async cleanup) and GET (sync worker)
+        operations to verify the fix prevents the exact race from #44."""
+        backend = _make_stub_backend()
+        put_ids: list[list[int]] = []
+        get_ids: list[list[int]] = []
+        barrier = threading.Barrier(2)
+
+        def put_worker():
+            """Simulates async PUT: register → transfer → deregister."""
+            barrier.wait()
+            for _ in range(100):
+                ids = backend._alloc_device_ids(3)
+                put_ids.append(ids)
+
+        def get_worker():
+            """Simulates sync GET: register → prepXfer → postXfer → deregister."""
+            barrier.wait()
+            for _ in range(100):
+                ids = backend._alloc_device_ids(3)
+                get_ids.append(ids)
+
+        t_put = threading.Thread(target=put_worker)
+        t_get = threading.Thread(target=get_worker)
+        t_put.start()
+        t_get.start()
+        t_put.join()
+        t_get.join()
+
+        # Flatten and check uniqueness
+        all_put = [id_ for batch in put_ids for id_ in batch]
+        all_get = [id_ for batch in get_ids for id_ in batch]
+
+        # No overlap between PUT and GET id ranges
+        overlap = set(all_put) & set(all_get)
+        assert len(overlap) == 0, (
+            f"PUT and GET device_ids overlap: {sorted(list(overlap))[:10]}..."
+        )
+
+        # All IDs globally unique
+        combined = all_put + all_get
+        assert len(combined) == len(set(combined))


### PR DESCRIPTION
When nixl_async_put is enabled, the async PUT cleanup thread (deregister_memory) and the sync GET worker thread (register_memory + prepXfer) both use device_id = 0, 1, 2, ... for every call.  NIXL's OBJ backend tracks registrations in a flat unordered_map<uint64, string> keyed by devId with no reference counting.  The PUT's deregister erases devId=0, which deletes the GET's registration, causing postXfer to fail with NIXL_ERR_INVALID_PARAM and crashing the EngineCore.

Fix: replace the per-call sequential device_id (idx) with a monotonically increasing counter protected by a threading.Lock.  Each register/deregister cycle now gets globally unique IDs, so concurrent operations never collide in devIdToObjKey_.

Fixes https://github.com/LMCache/LMCache/issues/2983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NIXL dynamic storage transfer registration logic and introduces new cross-call device_id allocation, which could affect correctness/performance under concurrent PUT/GET. The change is localized but concurrency-related and may be hard to fully validate in CI since the new race test is currently skipped in the Buildkite pipeline.
> 
> **Overview**
> Prevents a concurrency race in NIXL OBJ dynamic storage by switching per-batch `device_id` assignment from `0..n` to a process-wide monotonic allocator (`_alloc_device_ids`) guarded by a lock, and using those IDs in both `storage_to_mem` and `mem_to_storage` registrations.
> 
> Adds a new unit test module `tests/v1/test_device_id_race.py` that stress-tests uniqueness and thread safety of the allocator (skipped if `nixl` isn’t installed), and updates CI to `--ignore` this new test for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9ee0bc64d3944f049e02ab35200d4c64696753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->