### PR TITLE
[BugFix] Fix GDS thread-pool device mismatch on multi-GPU ROCm/HipFile

### DIFF
--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -198,6 +198,7 @@ class GdsBackend(AllocatorBackendInterface):
             if ":" in dst_device
             else torch.cuda.current_device()
         )
+        self.device_id = device_id
 
         assert config.gds_path is not None, "Need to specify gds_path for GdsBackend"
 
@@ -931,6 +932,7 @@ class GdsBackend(AllocatorBackendInterface):
         base_pointer: int,
         device_offset: int,
     ):
+        self._set_device()
         if base_pointer is None:
             addr = ctypes.c_void_p(kv_chunk.data_ptr())
             dev_offset = 0
@@ -994,7 +996,8 @@ class GdsBackend(AllocatorBackendInterface):
         size_in_bytes: int,
         dev_offset: int,
     ) -> int:
-        """Read data from disk into a GPU buffer"""
+        """Read data from disk into a GPU buffer."""
+        self._set_device()
         try:
             if self.cufile:
                 with self.cufile.CuFile(
@@ -1183,6 +1186,15 @@ class GdsBackend(AllocatorBackendInterface):
 
     def get_memory_allocator(self):
         return self.memory_allocator
+
+    def _set_device(self) -> None:
+        """Ensure the correct HIP/CUDA device is active in this thread.
+
+        ``asyncio.to_thread()`` dispatches to a pool thread whose default
+        device may differ from the worker's assigned GPU, causing GDS
+        reads/writes to fail with a device mismatch error.
+        """
+        torch.cuda.set_device(self.device_id)
 
     def close(self) -> None:
         # Wait for initial metadata scan to complete


### PR DESCRIPTION
What this PR does / why we need it:

asyncio.to_thread() dispatches _save_gds and _load_gds to pool threads whose default CUDA/HIP device may differ from the worker's assigned GPU. On ROCm with HipFile, this causes hipAmdFileWrite /
hipAmdFileRead to fail with hipErrorInvalidDevice.

This PR stores the resolved device_id on the GdsBackend instance and calls torch.cuda.set_device(self.device_id) at the top of both _save_gds and _load_gds so the correct device is always active in the
executing thread.

Changes:

  • Store self.device_id during GdsBackend.__init__
  • Add torch.cuda.set_device(self.device_id) at the entry of _save_gds and _load_gds

Special notes for your reviewers:

This bug is specifically triggered on multi-GPU ROCm/HIP setups using the HipFile backend, where thread pool workers default to device 0 instead of the worker's assigned GPU. The fix is also safe for CUDA/
cuFile paths — torch.cuda.set_device() is a no-op when the device is already correct.

If applicable:

  • [ ] this PR contains user facing changes - docs added
  • [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level GPU disk I/O paths (`_save_gds`/`_load_gds`) and changes per-thread device selection, which could impact multi-GPU correctness if misconfigured, but the change is small and localized.
> 
> **Overview**
> Fixes multi-GPU GDS failures when I/O runs in `asyncio.to_thread()`/thread-pool workers by **persisting the resolved `device_id` on `GdsBackend` and explicitly activating it** before GDS reads/writes.
> 
> Adds a `_set_device()` helper (calling `torch.cuda.set_device(self.device_id)`) and invokes it at the start of `_save_gds` and `_load_gds`, ensuring cuFile/hipFile operations run on the intended GPU.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a531a934e5a02d8bb8b530177517c3ddbb9074a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->