### PR TITLE
[step3] remove unnecessary code in mp adapter

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 import os
 import threading
 
@@ -209,19 +209,14 @@ RetrieveResult = bool
 LookupResult = int
 
 
-# TODO(chunxiaozheng): To be compatible with older `lmcache_mp_connector`,
-#  world_size, kv_rank, tp_size are saved, use parallel_strategy instead
 class LMCacheMPSchedulerAdapter:
     def __init__(
         self,
         server_url: str,
         context: zmq.Context,
         model_name: str,
-        world_size: int = 1,
-        kv_rank: int = 0,
-        vllm_block_size: int = 16,
-        tp_size: int = 1,
-        parallel_strategy: Optional[ParallelStrategy] = None,
+        vllm_block_size: int,
+        parallel_strategy: ParallelStrategy,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
@@ -230,11 +225,7 @@ class LMCacheMPSchedulerAdapter:
             server_url: The server URL for the LMCache message queue
             context: The ZMQ context
             model_name: The model name used for LMCache keys
-            world_size: The world size used for LMCache keys
-            kv_rank: The kv rank used for LMCache keys
             vllm_block_size: The block size used in vLLM
-            tp_size: Tensor-parallel size for MLA
-                multi-reader locking (default 1).
             parallel_strategy:
                 The parallel strategy, which includes `use_mla`,
                 `kv_world_size`, `kv_worker_id` and so on
@@ -254,8 +245,6 @@ class LMCacheMPSchedulerAdapter:
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
-        self._world_size = world_size
-        self._tp_size = tp_size
 
         # Read chunk size from lmcache
         try:
@@ -285,20 +274,12 @@ class LMCacheMPSchedulerAdapter:
     @property
     def world_size(self) -> int:
         """Get the kv world size."""
-        return (
-            self._world_size
-            if self.parallel_strategy is None
-            else self.parallel_strategy.kv_world_size
-        )
+        return self.parallel_strategy.kv_world_size
 
     @property
     def tp_size(self) -> int:
         """The tensor parallel size."""
-        return (
-            self._tp_size
-            if self.parallel_strategy is None
-            else self.parallel_strategy.tp_size
-        )
+        return self.parallel_strategy.tp_size
 
     @property
     def is_healthy(self) -> bool:
@@ -577,10 +558,8 @@ class LMCacheMPWorkerAdapter:
         server_url: str,
         context: zmq.Context,
         model_name: str,
-        world_size: int = 1,
-        kv_rank: int = 0,
-        vllm_block_size: int = 16,
-        parallel_strategy: Optional[ParallelStrategy] = None,
+        vllm_block_size: int,
+        parallel_strategy: ParallelStrategy,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
@@ -614,8 +593,6 @@ class LMCacheMPWorkerAdapter:
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
-        self._world_size = world_size
-        self._worker_id = kv_rank
 
         # Read chunk size from lmcache
         try:
@@ -664,38 +641,21 @@ class LMCacheMPWorkerAdapter:
     @property
     def world_size(self) -> int:
         """Get the kv world size."""
-        return (
-            self._world_size
-            if self.parallel_strategy is None
-            else self.parallel_strategy.kv_world_size
-        )
+        return self.parallel_strategy.kv_world_size
 
     @property
     def worker_id(self) -> int:
         """Get the kv worker id."""
-        return (
-            self._worker_id
-            if self.parallel_strategy is None
-            else self.parallel_strategy.kv_worker_id
-        )
+        return self.parallel_strategy.kv_worker_id
 
     @property
     def use_mla(self) -> bool:
         """Whether to use MLA."""
-        # NOTE: use_mla only used in the latest `lmcache_mp_connector`,
-        # and the latest `lmcache_mp_connector` will set the parallel_strategy
-        if self.parallel_strategy is None:
-            raise RuntimeError("parallel_strategy is not set")
         return self.parallel_strategy.use_mla
 
     @property
     def is_first_rank_of_pp_group(self) -> bool:
         """Is the first rank of the pipeline parallel group."""
-        # NOTE: is_first_rank_of_pp_group only used in the latest
-        # `lmcache_mp_connector`, and the latest `lmcache_mp_connector`
-        # will set the parallel_strategy
-        if self.parallel_strategy is None:
-            raise RuntimeError("parallel_strategy is not set")
         return (
             self.parallel_strategy.actual_worker_id % self.parallel_strategy.tp_size
             == 0


### PR DESCRIPTION
step1: https://github.com/LMCache/LMCache/pull/2935
step2: https://github.com/vllm-project/vllm/pull/38810
step3: must merge after step2


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes constructor signatures and removes legacy fallback fields (`world_size`, `kv_rank`, `tp_size`), which can break callers if not updated. Runtime behavior is mostly the same but now assumes `parallel_strategy` is always provided for keying and MLA/PP-group logic.
> 
> **Overview**
> Simplifies the vLLM multiprocess adapter by **removing backwards-compatibility paths** that allowed `parallel_strategy` to be optional.
> 
> `LMCacheMPSchedulerAdapter` and `LMCacheMPWorkerAdapter` now **require** `vllm_block_size` and a non-optional `ParallelStrategy`, and all `world_size`/`tp_size`/`worker_id` accessors and MLA-related checks unconditionally derive from that strategy (dropping stored `world_size`, `kv_rank`, and `tp_size` defaults).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67aca0e119b3f62482bd3adc1ce59adb6a2fdb57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->