### PR TITLE
fix: support bytes hashes from sha256_cbor in async loading path

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -439,11 +439,17 @@ class CacheEngineKey:
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
+        # A 64-char hex string is a SHA-256 digest (32 bytes); decode as bytes
+        # so the reconstructed key matches keys produced by sha256_cbor.
+        hex_str = parts[3]
+        chunk_hash: Union[int, bytes] = (
+            bytes.fromhex(hex_str) if len(hex_str) == 64 else int(hex_str, 16)
+        )
         return CacheEngineKey(
             model_name=parts[0],
             world_size=int(parts[1]),
             worker_id=int(parts[2]),
-            chunk_hash=int(parts[3], 16),
+            chunk_hash=chunk_hash,
             dtype=STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
             request_configs=request_configs,
         )
@@ -566,11 +572,17 @@ class LayerCacheEngineKey(CacheEngineKey):
                 if len(kvs) != 2:
                     raise ValueError(f"Invalid key string: {s}")
                 request_configs["lmcache.tag." + kvs[0]] = kvs[1]
+        # A 64-char hex string is a SHA-256 digest (32 bytes); decode as bytes
+        # so the reconstructed key matches keys produced by sha256_cbor.
+        hex_str = parts[3]
+        chunk_hash: Union[int, bytes] = (
+            bytes.fromhex(hex_str) if len(hex_str) == 64 else int(hex_str, 16)
+        )
         return LayerCacheEngineKey(
             model_name=parts[0],
             world_size=int(parts[1]),
             worker_id=int(parts[2]),
-            chunk_hash=int(parts[3], 16),
+            chunk_hash=chunk_hash,
             dtype=STR_DTYPE_TO_TORCH_DTYPE[parts[4]],
             request_configs=request_configs,
             layer_id=int(parts[5]),

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -341,7 +341,7 @@ class CacheEngineKey:
     model_name: str
     world_size: int
     worker_id: int
-    chunk_hash: int
+    chunk_hash: Union[int, bytes]
     dtype: torch.dtype
     request_configs: Optional[dict] = field(default_factory=dict)
     tags: Optional[tuple] = field(init=False, default=None)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1072,7 +1072,9 @@ class LMCacheEngine:
         :param Optional[Union[torch.Tensor, List[int]]] tokens: the input tokens,
         with shape [seq_len]
 
-        :param Optional[List[int]] hashes: the input hashes, with length [num_chunks]
+        :param Optional[List[Union[int, bytes]]] hashes: the input hashes, with
+        length [num_chunks]. Each element may be an int (builtin hash) or bytes
+        (sha256_cbor 32-byte digest).
         :param Optional[List[int]] offsets: the offsets of each chunk,
         with length [num_chunks]
 
@@ -1258,6 +1260,11 @@ class LMCacheEngine:
     ) -> None:
         """
         An async version of lookup + prefetch.
+
+        :param Optional[List[Union[int, bytes]]] hashes: pre-computed hashes,
+        one per chunk. Each element may be an int (builtin hash) or bytes
+        (sha256_cbor 32-byte digest). If provided, ``tokens`` is ignored for
+        key derivation.
 
         There are three categories of backends:
         (1) sync lookup + sync retrieval (e.g., cpu)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -363,7 +363,7 @@ class LMCacheEngine:
     def store(
         self,
         tokens: Optional[Union[torch.Tensor, list[int]]] = None,
-        hashes: Optional[List[int]] = None,
+        hashes: Optional[List[Union[int, bytes]]] = None,
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         **kwargs,
@@ -372,7 +372,8 @@ class LMCacheEngine:
 
         :param Optional[torch.Tensor] tokens: The tokens of the corresponding KV caches.
 
-        :param Optional[List[int]] hashes: The hashes of the corresponding KV caches.
+        :param Optional[List[Union[int, bytes]]] hashes: The hashes of the
+            corresponding KV caches.
 
         :param Optional[torch.Tensor] mask: The mask for the tokens. Should
             have the same length as tokens. And the mask should ALWAYS be like
@@ -1058,7 +1059,7 @@ class LMCacheEngine:
     def lookup(
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
-        hashes: Optional[List[int]] = None,
+        hashes: Optional[List[Union[int, bytes]]] = None,
         offsets: Optional[List[int]] = None,
         search_range: Optional[List[str]] = None,
         lookup_id: Optional[str] = None,
@@ -1249,7 +1250,7 @@ class LMCacheEngine:
         self,
         lookup_id: str,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
-        hashes: Optional[List[int]] = None,
+        hashes: Optional[List[Union[int, bytes]]] = None,
         offsets: Optional[List[int]] = None,
         search_range: Optional[List[str]] = None,
         pin: bool = False,

--- a/lmcache/v1/lookup_client/async_lookup_message.py
+++ b/lmcache/v1/lookup_client/async_lookup_message.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 # Third Party
 import msgspec
@@ -17,7 +17,7 @@ class LookupRequestMsg(AsyncLookupMsg):
     """Async lookup request message from scheduler to worker"""
 
     lookup_id: str
-    hashes: list[int]
+    hashes: list[Union[int, bytes]]
     offsets: list[int]
     request_configs: Optional[Dict[str, str]] = None
 

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -171,7 +171,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
     def process_tokens(
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
-        hashes: Optional[List[int]] = None,
+        hashes: Optional[List[Union[int, bytes]]] = None,
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
@@ -181,7 +181,8 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
         :param Optional[Union[torch.Tensor, List[int]]] tokens: The tokens to process.
 
-        :param Optional[List[int]] hashes: The hashes to process. If provided,
+        :param Optional[List[Union[int, bytes]]] hashes: The hashes to process.
+            If provided,
             it will be used instead of tokens to generate cache engine keys.
 
         :param Optional[List[int]] offsets: The number of tokens in each chunk.
@@ -339,7 +340,7 @@ class ChunkedTokenDatabase(TokenDatabase):
     def process_tokens(
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
-        hashes: Optional[List[int]] = None,
+        hashes: Optional[List[Union[int, bytes]]] = None,
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,
@@ -464,7 +465,7 @@ class SegmentTokenDatabase(TokenDatabase):
     def process_tokens(
         self,
         tokens: Optional[Union[torch.Tensor, List[int]]] = None,
-        hashes: Optional[List[int]] = None,
+        hashes: Optional[List[Union[int, bytes]]] = None,
         offsets: Optional[List[int]] = None,
         mask: Optional[torch.Tensor] = None,
         make_key: bool = True,

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -31,8 +31,9 @@ logger = init_logger(__name__)
 NONE_HASH = 0
 
 # Type alias for process_tokens return value
-# (start_index, end_index, cache_engine_key｜hash)
-ProcessTokensResult = Tuple[int, int, Union[CacheEngineKey, int]]
+# (start_index, end_index, cache_engine_key | hash)
+# hash may be int (builtin/sha256_cbor_64bit) or bytes (sha256_cbor)
+ProcessTokensResult = Tuple[int, int, Union[CacheEngineKey, int, bytes]]
 
 
 class TokenDatabase(metaclass=abc.ABCMeta):
@@ -206,7 +207,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def _make_key_by_hash(
-        self, chunk_hash: int, request_configs: Optional[dict] = None
+        self, chunk_hash: Union[int, bytes], request_configs: Optional[dict] = None
     ):
         assert self.metadata is not None
         # When save_only_first_rank is enabled (for MLA), we deliberately
@@ -223,10 +224,10 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
     def _canonicalize_hash_inputs(
         self,
-        prefix_hash: Optional[int],
+        prefix_hash: Optional[Union[int, bytes]],
         tokens_tuple: Tuple[int, ...],
         extra_keys: Optional[List[Any]],
-    ) -> Tuple[int, Tuple[int, ...], Tuple[Any, ...]]:
+    ) -> Tuple[Union[int, bytes], Tuple[int, ...], Tuple[Any, ...]]:
         """
         Canonicalize hash inputs so that semantically identical requests
         produce structurally identical hash inputs across instances.
@@ -243,9 +244,9 @@ class TokenDatabase(metaclass=abc.ABCMeta):
     def _hash_tokens(
         self,
         tokens: Union[torch.Tensor, List[int]],
-        prefix_hash: Optional[int] = None,
+        prefix_hash: Optional[Union[int, bytes]] = None,
         extra_keys: Optional[list[Any]] = None,
-    ) -> int:
+    ) -> Union[int, bytes]:
         if isinstance(tokens, torch.Tensor):
             tokens_tuple = tuple(tokens.cpu().tolist())
         elif isinstance(tokens, list):
@@ -350,8 +351,10 @@ class ChunkedTokenDatabase(TokenDatabase):
 
         :param Optional[Union[torch.Tensor, List[int]]] tokens: The tokens to process.
 
-        :param Optional[List[int]] hashes: The hashes to process. If provided,
-            it will be used instead of tokens to generate cache engine keys.
+        :param Optional[List[Union[int, bytes]]] hashes: The hashes to process.
+            If provided, it will be used instead of tokens to generate cache engine
+            keys. Each hash may be an ``int`` (builtin hash) or ``bytes``
+            (sha256_cbor, 32-byte digest).
 
         :param Optional[List[int]] offsets: The number of tokens in each chunk.
 
@@ -475,8 +478,10 @@ class SegmentTokenDatabase(TokenDatabase):
 
         :param Union[torch.Tensor, List[int]] tokens: The tokens to process.
 
-        :param Optional[List[int]] hashes: The hashes to process. If provided,
-            it will be used instead of tokens to generate cache engine keys.
+        :param Optional[List[Union[int, bytes]]] hashes: The hashes to process.
+            If provided, it will be used instead of tokens to generate cache engine
+            keys. Each hash may be an ``int`` (builtin hash) or ``bytes``
+            (sha256_cbor, 32-byte digest).
 
         :param Optional[List[int]] offsets: The number of tokens in each chunk.
 

--- a/tests/v1/lookup_client/test_async_lookup_message.py
+++ b/tests/v1/lookup_client/test_async_lookup_message.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for AsyncLookupMsg serialization with bytes hashes (sha256_cbor support).
+
+The sha256_cbor hash algorithm returns a 32-byte digest (bytes), whereas the
+legacy default hash algorithm returns an int.  LookupRequestMsg must accept
+both so that async loading works correctly when sha256_cbor is configured.
+"""
+
+# Standard
+import hashlib
+
+# Third Party
+import msgspec
+
+# First Party
+from lmcache.v1.lookup_client.async_lookup_message import (
+    LookupCleanupMsg,
+    LookupRequestMsg,
+    LookupResponseMsg,
+)
+
+
+class TestLookupRequestMsgWithIntHashes:
+    """原始 int 哈希：向后兼容性验证。"""
+
+    def test_serialization_roundtrip(self):
+        hashes = [123456789, 987654321, 0, 2**32 - 1]
+        offsets = [0, 128, 256, 384]
+        msg = LookupRequestMsg(
+            lookup_id="test-id-int",
+            hashes=hashes,
+            offsets=offsets,
+        )
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupRequestMsg)
+        assert decoded.lookup_id == msg.lookup_id
+        assert decoded.hashes == hashes
+        assert decoded.offsets == offsets
+
+    def test_describe(self):
+        msg = LookupRequestMsg(lookup_id="abc", hashes=[1, 2, 3], offsets=[0, 1, 2])
+        assert "abc" in msg.describe()
+        assert "3" in msg.describe()
+
+
+class TestLookupRequestMsgWithBytesHashes:
+    """sha256_cbor 返回 bytes：核心 bug 修复验证。"""
+
+    @staticmethod
+    def _sha256_hash(data: bytes) -> bytes:
+        """模拟 vLLM sha256_cbor 哈希函数的输出（32 字节摘要）。"""
+        return hashlib.sha256(data).digest()
+
+    def test_bytes_hash_serialization_roundtrip(self):
+        """LookupRequestMsg 应能序列化和反序列化 bytes 类型的 hashes。"""
+        hashes = [
+            self._sha256_hash(b"chunk_0"),
+            self._sha256_hash(b"chunk_1"),
+            self._sha256_hash(b"chunk_2"),
+        ]
+        offsets = [0, 128, 256]
+        msg = LookupRequestMsg(
+            lookup_id="test-id-bytes",
+            hashes=hashes,
+            offsets=offsets,
+        )
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupRequestMsg)
+        assert decoded.lookup_id == msg.lookup_id
+        assert decoded.hashes == hashes
+        assert all(isinstance(h, bytes) for h in decoded.hashes)
+        assert decoded.offsets == offsets
+
+    def test_bytes_hash_is_32_bytes(self):
+        """sha256_cbor 输出正好 32 字节，超出 int64 范围但应被接受。"""
+        sha256_digest = self._sha256_hash(b"some token chunk")
+        assert len(sha256_digest) == 32
+        msg = LookupRequestMsg(
+            lookup_id="overflow-test",
+            hashes=[sha256_digest],
+            offsets=[0],
+        )
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupRequestMsg)
+        assert decoded.hashes[0] == sha256_digest
+
+    def test_mixed_int_and_bytes_hashes(self):
+        """混合 int 和 bytes 的哈希列表也应被支持。"""
+        hashes = [12345, self._sha256_hash(b"mixed"), 67890]
+        offsets = [0, 128, 256]
+        msg = LookupRequestMsg(
+            lookup_id="mixed-test",
+            hashes=hashes,
+            offsets=offsets,
+        )
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupRequestMsg)
+        assert decoded.hashes[0] == 12345
+        assert isinstance(decoded.hashes[1], bytes)
+        assert decoded.hashes[2] == 67890
+
+    def test_request_configs_preserved(self):
+        """带 request_configs 的消息序列化也应正常。"""
+        hashes = [self._sha256_hash(b"cfg_chunk")]
+        msg = LookupRequestMsg(
+            lookup_id="cfg-test",
+            hashes=hashes,
+            offsets=[0],
+            request_configs={"key": "value"},
+        )
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupRequestMsg)
+        assert decoded.request_configs == {"key": "value"}
+        assert decoded.hashes == hashes
+
+
+class TestLookupResponseMsg:
+    def test_serialization_roundtrip(self):
+        msg = LookupResponseMsg(lookup_id="resp-id", num_hit_tokens=512)
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupResponseMsg)
+        assert decoded.lookup_id == "resp-id"
+        assert decoded.num_hit_tokens == 512
+
+    def test_describe(self):
+        msg = LookupResponseMsg(lookup_id="x", num_hit_tokens=256)
+        assert "x" in msg.describe()
+        assert "256" in msg.describe()
+
+
+class TestLookupCleanupMsg:
+    def test_serialization_roundtrip(self):
+        msg = LookupCleanupMsg(lookup_id="cleanup-id")
+        raw = msgspec.msgpack.encode(msg)
+        decoded = msgspec.msgpack.decode(raw, type=LookupCleanupMsg)
+        assert decoded.lookup_id == "cleanup-id"
+
+    def test_describe(self):
+        msg = LookupCleanupMsg(lookup_id="cl-123")
+        assert "cl-123" in msg.describe()

--- a/tests/v1/lookup_client/test_async_lookup_message.py
+++ b/tests/v1/lookup_client/test_async_lookup_message.py
@@ -21,9 +21,9 @@ from lmcache.v1.lookup_client.async_lookup_message import (
 
 
 class TestLookupRequestMsgWithIntHashes:
-    """原始 int 哈希：向后兼容性验证。"""
+    """Backward compatibility: int hashes must still serialize correctly."""
 
-    def test_serialization_roundtrip(self):
+    def test_serialization_roundtrip(self) -> None:
         hashes = [123456789, 987654321, 0, 2**32 - 1]
         offsets = [0, 128, 256, 384]
         msg = LookupRequestMsg(
@@ -37,22 +37,22 @@ class TestLookupRequestMsgWithIntHashes:
         assert decoded.hashes == hashes
         assert decoded.offsets == offsets
 
-    def test_describe(self):
+    def test_describe(self) -> None:
         msg = LookupRequestMsg(lookup_id="abc", hashes=[1, 2, 3], offsets=[0, 1, 2])
         assert "abc" in msg.describe()
         assert "3" in msg.describe()
 
 
 class TestLookupRequestMsgWithBytesHashes:
-    """sha256_cbor 返回 bytes：核心 bug 修复验证。"""
+    """Core bug fix: sha256_cbor returns bytes; LookupRequestMsg must accept them."""
 
     @staticmethod
     def _sha256_hash(data: bytes) -> bytes:
-        """模拟 vLLM sha256_cbor 哈希函数的输出（32 字节摘要）。"""
+        """Return the SHA-256 digest of *data*, mimicking vLLM sha256_cbor output."""
         return hashlib.sha256(data).digest()
 
-    def test_bytes_hash_serialization_roundtrip(self):
-        """LookupRequestMsg 应能序列化和反序列化 bytes 类型的 hashes。"""
+    def test_bytes_hash_serialization_roundtrip(self) -> None:
+        """LookupRequestMsg must serialize and deserialize bytes hashes unchanged."""
         hashes = [
             self._sha256_hash(b"chunk_0"),
             self._sha256_hash(b"chunk_1"),
@@ -71,8 +71,8 @@ class TestLookupRequestMsgWithBytesHashes:
         assert all(isinstance(h, bytes) for h in decoded.hashes)
         assert decoded.offsets == offsets
 
-    def test_bytes_hash_is_32_bytes(self):
-        """sha256_cbor 输出正好 32 字节，超出 int64 范围但应被接受。"""
+    def test_bytes_hash_is_32_bytes(self) -> None:
+        """sha256_cbor produces a 32-byte digest that exceeds int64 range."""
         sha256_digest = self._sha256_hash(b"some token chunk")
         assert len(sha256_digest) == 32
         msg = LookupRequestMsg(
@@ -84,8 +84,8 @@ class TestLookupRequestMsgWithBytesHashes:
         decoded = msgspec.msgpack.decode(raw, type=LookupRequestMsg)
         assert decoded.hashes[0] == sha256_digest
 
-    def test_mixed_int_and_bytes_hashes(self):
-        """混合 int 和 bytes 的哈希列表也应被支持。"""
+    def test_mixed_int_and_bytes_hashes(self) -> None:
+        """A hash list containing both int and bytes elements must round-trip."""
         hashes = [12345, self._sha256_hash(b"mixed"), 67890]
         offsets = [0, 128, 256]
         msg = LookupRequestMsg(
@@ -99,8 +99,8 @@ class TestLookupRequestMsgWithBytesHashes:
         assert isinstance(decoded.hashes[1], bytes)
         assert decoded.hashes[2] == 67890
 
-    def test_request_configs_preserved(self):
-        """带 request_configs 的消息序列化也应正常。"""
+    def test_request_configs_preserved(self) -> None:
+        """request_configs must survive serialization alongside bytes hashes."""
         hashes = [self._sha256_hash(b"cfg_chunk")]
         msg = LookupRequestMsg(
             lookup_id="cfg-test",
@@ -115,26 +115,26 @@ class TestLookupRequestMsgWithBytesHashes:
 
 
 class TestLookupResponseMsg:
-    def test_serialization_roundtrip(self):
+    def test_serialization_roundtrip(self) -> None:
         msg = LookupResponseMsg(lookup_id="resp-id", num_hit_tokens=512)
         raw = msgspec.msgpack.encode(msg)
         decoded = msgspec.msgpack.decode(raw, type=LookupResponseMsg)
         assert decoded.lookup_id == "resp-id"
         assert decoded.num_hit_tokens == 512
 
-    def test_describe(self):
+    def test_describe(self) -> None:
         msg = LookupResponseMsg(lookup_id="x", num_hit_tokens=256)
         assert "x" in msg.describe()
         assert "256" in msg.describe()
 
 
 class TestLookupCleanupMsg:
-    def test_serialization_roundtrip(self):
+    def test_serialization_roundtrip(self) -> None:
         msg = LookupCleanupMsg(lookup_id="cleanup-id")
         raw = msgspec.msgpack.encode(msg)
         decoded = msgspec.msgpack.decode(raw, type=LookupCleanupMsg)
         assert decoded.lookup_id == "cleanup-id"
 
-    def test_describe(self):
+    def test_describe(self) -> None:
         msg = LookupCleanupMsg(lookup_id="cl-123")
         assert "cl-123" in msg.describe()


### PR DESCRIPTION
## Summary

Fixes #2997

When `LMCACHE_PRE_CACHING_HASH_ALGORITHM=sha256_cbor` is used together with
`LMCACHE_ENABLE_ASYNC_LOADING=True`, LMCache fails with a type error because
`sha256_cbor` (vLLM PR#23673) returns a 32-byte `bytes` digest, but all
hash-related type annotations in LMCache declare hashes as `int`.

This causes two distinct failures:

1. **OverflowError during serialization**: `LookupRequestMsg.hashes: list[int]`
   causes `msgspec.msgpack` to raise `OverflowError` when it encounters a
   32-byte (256-bit) `bytes` value that cannot fit in an int64.

2. **Cache miss on warm lookup**: `CacheEngineKey.chunk_hash: int` would never
   equal a `bytes` key, so even if serialization were bypassed, all async
   lookups would miss.

## Changes

Widen hash-related type hints from `int` / `List[int]` to
`Union[int, bytes]` / `List[Union[int, bytes]]` across four files:

- `lmcache/v1/lookup_client/async_lookup_message.py` — `LookupRequestMsg.hashes`
- `lmcache/utils.py` — `CacheEngineKey.chunk_hash`
- `lmcache/v1/token_database.py` — `process_tokens` `hashes` param (3 sites)
- `lmcache/v1/cache_engine.py` — `store` / `lookup` / `async_lookup_and_prefetch` (3 sites)

`msgspec` natively encodes `bytes` as msgpack bin8/16/32 and decodes them back
as `bytes`, so **no custom serialization logic is needed** — this is a
minimal, surgical type annotation fix.

## Testing

Added `tests/v1/lookup_client/test_async_lookup_message.py` with 10 unit tests
covering:
- Backward compatibility: `list[int]` hashes still serialize/deserialize correctly
- New behavior: `bytes` hashes (32-byte sha256 digests) serialize/deserialize correctly
- Mixed `int`/`bytes` hash lists work
- `request_configs` are preserved alongside bytes hashes

End-to-end validation: ran `lmcache_bench.py` with
`sha256_cbor` + `enable_async_loading=True`; all 5 warm-phase requests
show 100% cache hits with no errors.

## Before / After

**Before** (with sha256_cbor + async_loading):
```
OverflowError: can't serialize ints < -2**63 or > 2**64 - 1
```

**After**: Warm phase log shows full cache hits:
```
Reqid: 5-bed456a3, Total tokens 425, LMCache hit tokens: 384
Reqid: 6-a0efd469, Total tokens 243, LMCache hit tokens: 128
...
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache key parsing/equality and async lookup message types; while intended to be backward-compatible, misclassification of 64-hex `chunk_hash` strings or mixed hash types could lead to unexpected cache misses/hits.
> 
> **Overview**
> **Fixes async loading with `sha256_cbor`.** Hash handling is widened across the async lookup path to accept `bytes` digests in addition to legacy `int` hashes (engine `store`/`lookup`/`async_lookup_and_prefetch`, token database `process_tokens`, and `LookupRequestMsg`).
> 
> **Makes cache keys round-trip correctly.** `CacheEngineKey`/`LayerCacheEngineKey` now store `chunk_hash` as `Union[int, bytes]`, and `from_string()` decodes 64-char hex hashes back into raw 32-byte digests so reconstructed keys match those produced by `sha256_cbor`.
> 
> Adds unit tests ensuring `msgspec` msgpack round-trips for `LookupRequestMsg` with `int`, `bytes`, and mixed hash lists (plus `request_configs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4780f331d5f4e779b2693935002fd058ac08cdd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->