### PR TITLE
[BugFix] fix sha256_cbor + async_loading type mismatch in _hash_tokens

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -30,6 +30,32 @@ logger = init_logger(__name__)
 
 NONE_HASH = 0
 
+
+def _normalize_hash_to_int(hash_value: Union[int, bytes]) -> int:
+    """Normalize hash outputs to LMCache's int chunk-hash representation.
+
+    This function is triggered when vLLM's ``sha256_cbor`` hash function is
+    used because it returns a 32-byte digest. vLLM's
+    ``kv_cache_utils.init_none_hash`` can therefore initialize ``NONE_HASH`` as
+    bytes, and direct hash calls for token chunks can also return bytes.
+
+    LMCache stores chunk hashes in ``CacheEngineKey`` and serializes them with
+    msgpack, so byte digests must be folded into uint64-compatible ints before
+    they enter the prefix hash chain. This also keeps ``NONE_HASH`` and later
+    prefix hashes using the same structural type for CBOR hashing.
+
+    Args:
+        hash_value: Hash output from vLLM or Python's builtin hash.
+
+    Returns:
+        The original int hash value, or the first eight bytes of a digest as a
+        big-endian int.
+    """
+    if isinstance(hash_value, bytes):
+        return int.from_bytes(hash_value[:8], "big")
+    return hash_value
+
+
 # Type alias for process_tokens return value
 # (start_index, end_index, cache_engine_key｜hash)
 ProcessTokensResult = Tuple[int, int, Union[CacheEngineKey, int]]
@@ -70,11 +96,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
             if hasattr(kv_cache_utils, "init_none_hash"):
                 kv_cache_utils.init_none_hash(self.hash_func)
-                NONE_HASH = kv_cache_utils.NONE_HASH
-                # sha256_cbor returns bytes; fold to uint64 so the entire
-                # prefix chain uses a consistent int type.
-                if isinstance(NONE_HASH, bytes):
-                    NONE_HASH = int.from_bytes(NONE_HASH[:8], "big")
+                NONE_HASH = _normalize_hash_to_int(kv_cache_utils.NONE_HASH)
                 logger.info(
                     f"Initialized NONE_HASH={NONE_HASH} from vLLM (>= PR#20511)"
                 )
@@ -267,13 +289,9 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             prefix_hash, tokens_tuple, extra_keys
         )
 
-        result = self.hash_func((canon_prefix, canon_tokens, canon_extra))
-        # sha256_cbor returns a 32-byte digest; fold it into a uint64 so that
-        # downstream code (msgpack serialisation, CacheEngineKey) always works
-        # with plain ints regardless of the configured hash algorithm.
-        if isinstance(result, bytes):
-            result = int.from_bytes(result[:8], "big")
-        return result
+        return _normalize_hash_to_int(
+            self.hash_func((canon_prefix, canon_tokens, canon_extra))
+        )
 
 
 class ChunkedTokenDatabase(TokenDatabase):

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -263,7 +263,13 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             prefix_hash, tokens_tuple, extra_keys
         )
 
-        return self.hash_func((canon_prefix, canon_tokens, canon_extra))
+        result = self.hash_func((canon_prefix, canon_tokens, canon_extra))
+        # sha256_cbor returns a 32-byte digest; fold it into a uint64 so that
+        # downstream code (msgpack serialisation, CacheEngineKey) always works
+        # with plain ints regardless of the configured hash algorithm.
+        if isinstance(result, bytes):
+            result = int.from_bytes(result[:8], "big")
+        return result
 
 
 class ChunkedTokenDatabase(TokenDatabase):

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -71,6 +71,10 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             if hasattr(kv_cache_utils, "init_none_hash"):
                 kv_cache_utils.init_none_hash(self.hash_func)
                 NONE_HASH = kv_cache_utils.NONE_HASH
+                # sha256_cbor returns bytes; fold to uint64 so the entire
+                # prefix chain uses a consistent int type.
+                if isinstance(NONE_HASH, bytes):
+                    NONE_HASH = int.from_bytes(NONE_HASH[:8], "big")
                 logger.info(
                     f"Initialized NONE_HASH={NONE_HASH} from vLLM (>= PR#20511)"
                 )

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -134,10 +134,10 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         # print(ed, ends[i])
 
 
-def test_hash_tokens_returns_int_for_bytes_hash_func() -> None:
-    """_hash_tokens must return int even when the underlying hash function
-    returns bytes (e.g. sha256_cbor). This ensures downstream code such as
-    msgpack serialisation and CacheEngineKey always receives plain ints.
+def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:
+    """process_tokens must produce int chunk_hash keys even when the underlying
+    hash function returns bytes (e.g. sha256_cbor). This ensures downstream
+    code such as msgpack serialisation always receives plain ints.
     """
     import hashlib
 
@@ -145,17 +145,14 @@ def test_hash_tokens_returns_int_for_bytes_hash_func() -> None:
     metadata = dumb_metadata()
     db = ChunkedTokenDatabase(cfg, metadata)
 
-    # Replace hash_func with a bytes-returning stub that mimics sha256_cbor.
-    def _bytes_hash(x) -> bytes:
-        import cbor2
-
-        return hashlib.sha256(cbor2.dumps(x)).digest()
-
-    db.hash_func = _bytes_hash
+    # Stub that returns bytes, mimicking sha256_cbor without requiring cbor2.
+    db.hash_func = lambda x: hashlib.sha256(str(x).encode()).digest()
 
     tokens = generate_tokens(32, "cpu")
-    result = db._hash_tokens(tokens[:16])
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
 
-    assert isinstance(result, int), f"Expected int, got {type(result)}"
-    # Must fit in uint64 (msgpack range)
-    assert 0 <= result <= 2**64 - 1
+    assert len(results) > 0
+    for _, _, hash_val in results:
+        assert isinstance(hash_val, int), f"Expected int, got {type(hash_val)}"
+        # Must fit in uint64 (msgpack range: 0 to 2**64 - 1)
+        assert 0 <= hash_val <= 2**64 - 1

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -132,3 +132,30 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         assert key.chunk_hash == hashes[i]
         # print(st, starts[i])
         # print(ed, ends[i])
+
+
+def test_hash_tokens_returns_int_for_bytes_hash_func() -> None:
+    """_hash_tokens must return int even when the underlying hash function
+    returns bytes (e.g. sha256_cbor). This ensures downstream code such as
+    msgpack serialisation and CacheEngineKey always receives plain ints.
+    """
+    import hashlib
+
+    cfg = LMCacheEngineConfig.from_legacy(chunk_size=16, backend="cpu")
+    metadata = dumb_metadata()
+    db = ChunkedTokenDatabase(cfg, metadata)
+
+    # Replace hash_func with a bytes-returning stub that mimics sha256_cbor.
+    def _bytes_hash(x) -> bytes:
+        import cbor2
+
+        return hashlib.sha256(cbor2.dumps(x)).digest()
+
+    db.hash_func = _bytes_hash
+
+    tokens = generate_tokens(32, "cpu")
+    result = db._hash_tokens(tokens[:16])
+
+    assert isinstance(result, int), f"Expected int, got {type(result)}"
+    # Must fit in uint64 (msgpack range)
+    assert 0 <= result <= 2**64 - 1

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import hashlib
 import os
 
 # Third Party
@@ -139,8 +140,6 @@ def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:
     hash function returns bytes (e.g. sha256_cbor). This ensures downstream
     code such as msgpack serialisation always receives plain ints.
     """
-    import hashlib
-
     cfg = LMCacheEngineConfig.from_legacy(chunk_size=16, backend="cpu")
     metadata = dumb_metadata()
     db = ChunkedTokenDatabase(cfg, metadata)


### PR DESCRIPTION
## Summary

Fixes #2997

When `LMCACHE_PRE_CACHING_HASH_ALGORITHM=sha256_cbor` is combined with
`LMCACHE_ENABLE_ASYNC_LOADING=True`, LMCache raises:

```
OverflowError: can't serialize ints < -2**63 or > 2**64 - 1
```

**Root cause**: `sha256_cbor` (vLLM PR#23673) returns a 32-byte `bytes`
digest.  `_hash_tokens` returns this value directly, which then lands in
`LookupRequestMsg.hashes` — a field that msgpack encodes as integer.
A 256-bit value cannot fit in any integer msgpack type, causing the overflow.

**Fix**: one-line guard in `_hash_tokens` — after calling `hash_func`, if
the result is `bytes`, fold the first 8 bytes into a `uint64` int:

```python
result = self.hash_func((canon_prefix, canon_tokens, canon_extra))
if isinstance(result, bytes):
    result = int.from_bytes(result[:8], "big")
return result
```

Both the store path (`store(token_ids, ...)`) and the async lookup path
(`process_tokens(token_ids, make_key=False)`) go through `_hash_tokens`,
so the int keys they produce are always consistent with each other.
No type annotations elsewhere need to change.

## Testing

Added `test_hash_tokens_returns_int_for_bytes_hash_func` to
`tests/v1/test_token_database.py`: patches `hash_func` with a
bytes-returning sha256 stub and asserts that `_hash_tokens` returns a
`uint64` int.

End-to-end: ran `lmcache_bench.py` with sha256_cbor + async_loading; warm
phase shows 100% cache hits with no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache key hashing behavior by folding `bytes` digests into `uint64` ints, which can affect cache key compatibility/hit rates for users on bytes-returning hash functions. Scope is small and guarded, but it touches core hashing used in cache lookup/serialization paths.
> 
> **Overview**
> Fixes a type/serialization mismatch when using bytes-returning hash algorithms (e.g. vLLM `sha256_cbor`) by **normalizing all hash outputs to `uint64` ints**.
> 
> `TokenDatabase` now folds `NONE_HASH` and `_hash_tokens()` results from `bytes` to an 8-byte `int`, ensuring prefix chaining and downstream msgpack/`CacheEngineKey` usage always sees plain integers. Adds a regression test asserting `process_tokens(..., make_key=False)` returns `int` hashes when `hash_func` returns `bytes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539a8eba5131666278daaa851939eb67359bc3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->