### PR TITLE
[hotfix] fix prometheus version for UT failure

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,7 +17,7 @@ opentelemetry-api >= 1.20.0
 opentelemetry-sdk >= 1.20.0
 opentelemetry-exporter-otlp >= 1.20.0
 opentelemetry-exporter-prometheus >= 0.50b0
-prometheus_client >= 0.18.0
+prometheus_client >= 0.18.0, <= 0.24.1
 psutil
 py-cpuinfo
 pyyaml

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -13,10 +13,10 @@ nixl; python_version < "3.13"
 numpy<=2.2.6
 numba
 nvtx
-opentelemetry-api >= 1.20.0
+opentelemetry-api >= 1.20.0, <= 1.40.0
 opentelemetry-sdk >= 1.20.0
 opentelemetry-exporter-otlp >= 1.20.0
-opentelemetry-exporter-prometheus >= 0.50b0
+opentelemetry-exporter-prometheus >= 0.50b0, <= 0.61b0
 prometheus_client >= 0.18.0, <= 0.24.1
 psutil
 py-cpuinfo


### PR DESCRIPTION
**What this PR does / why we need it**:

Pin `prometheus_client` to `<= 0.24.1` to fix unit test failures caused by
a breaking change in newer versions of the library.

**Special notes for your reviewers**:

One-line change in `requirements/common.txt`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main impact is constraining versions for observability libraries, which could affect compatibility if newer versions are required elsewhere.
> 
> **Overview**
> Pins observability dependencies in `requirements/common.txt` by adding upper bounds to `prometheus_client`, `opentelemetry-exporter-prometheus`, and `opentelemetry-api` to avoid breakages from newer releases (notably unit test failures with newer `prometheus_client`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def00c63730e859f3503f66731cab5fc2be5d4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->