### PR TITLE
fix: add controller config validation and clear error messages (#2907)

### DIFF
--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -79,7 +79,10 @@ class LMCacheWorker:
         # Please consider removing it.
         self.config = config
         self.lmcache_instance_id = config.lmcache_instance_id
-        assert self.lmcache_instance_id is not None
+        if self.lmcache_instance_id is None:
+            raise ValueError(
+                "lmcache_instance_id is required when enable_controller=True"
+            )
         self.lmcache_engine = lmcache_engine
         self.worker_id = metadata.worker_id
 
@@ -93,7 +96,10 @@ class LMCacheWorker:
             "worker_socket_send_timeout_ms", DEFAULT_SOCKET_SEND_TIMEOUT_MS
         )
 
-        assert config.controller_pull_url is not None
+        if config.controller_pull_url is None:
+            raise ValueError(
+                "controller_pull_url is required when enable_controller=True"
+            )
 
         controller_pull_url = config.controller_pull_url
         self.push_socket = get_zmq_socket(
@@ -131,12 +137,22 @@ class LMCacheWorker:
         if not lmcache_worker_ids:
             # start lmcache worker on all ranks;
             # need at least one port per rank (world_size)
-            assert len(config.lmcache_worker_ports) >= metadata.world_size
+            if len(config.lmcache_worker_ports) < metadata.world_size:
+                raise ValueError(
+                    f"lmcache_worker_ports must have at least {metadata.world_size} "
+                    f"port(s) (world_size), got {len(config.lmcache_worker_ports)}"
+                )
             lmcache_worker_port = config.lmcache_worker_ports[self.worker_id]
         else:
             # start lmcache worker on given worker ids;
             # need at least one port per explicitly listed worker
-            assert len(config.lmcache_worker_ports) >= len(lmcache_worker_ids)
+            if len(config.lmcache_worker_ports) < len(lmcache_worker_ids):
+                raise ValueError(
+                    f"lmcache_worker_ports must have at least "
+                    f"{len(lmcache_worker_ids)} "
+                    f"port(s) (one per lmcache worker), "
+                    f"got {len(config.lmcache_worker_ports)}"
+                )
             index = lmcache_worker_ids.index(self.worker_id)
             lmcache_worker_port = config.lmcache_worker_ports[index]
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -269,11 +269,9 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     "extra_config": {
         "type": Optional[dict],
         "default": None,
-        "env_converter": lambda x: x
-        if isinstance(x, dict)
-        else json.loads(x)
-        if x
-        else None,
+        "env_converter": lambda x: (
+            x if isinstance(x, dict) else json.loads(x) if x else None
+        ),
     },
     "save_unfull_chunk": {
         "type": bool,
@@ -545,6 +543,25 @@ def _validate_config(self):
                 "enable_blending=True"
             )
             self.save_unfull_chunk = True
+
+    if self.enable_controller:
+        if self.lmcache_instance_id is None:
+            raise ValueError(
+                "lmcache_instance_id is required when enable_controller=True"
+            )
+        if self.controller_pull_url is None:
+            raise ValueError(
+                "controller_pull_url is required when enable_controller=True"
+            )
+        if self.controller_reply_url is None:
+            raise ValueError(
+                "controller_reply_url is required when enable_controller=True"
+            )
+        if not self.lmcache_worker_ports:
+            raise ValueError(
+                "lmcache_worker_ports is required and cannot be "
+                "empty when enable_controller=True"
+            )
 
     if self.enable_p2p:
         assert self.enable_controller

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -715,3 +715,64 @@ def test_update_config_from_env_calls_validate():
         del os.environ["LMCACHE_PD_BUFFER_SIZE"]
         del os.environ["LMCACHE_PD_BUFFER_DEVICE"]
         del os.environ["LMCACHE_SAVE_UNFULL_CHUNK"]
+
+
+class TestControllerConfigValidation:
+    """Test validation of required controller fields when enable_controller=True."""
+
+    def _make_controller_config(self, **overrides):
+        """Create a config with controller enabled and all required fields set.
+
+        Override specific fields to None to test individual validation checks.
+        Note: lmcache_instance_id is auto-generated in __post_init__ if None,
+        so we set it after construction to test the validation path.
+        """
+        defaults = dict(
+            enable_controller=True,
+            controller_pull_url="tcp://localhost:5555",
+            controller_reply_url="tcp://localhost:5556",
+            lmcache_worker_ports=[8000],
+        )
+        # lmcache_instance_id must be set after construction because
+        # __post_init__ auto-generates it when None
+        instance_id = overrides.pop("lmcache_instance_id", "instance-1")
+        defaults.update(overrides)
+        config = LMCacheEngineConfig.from_defaults(**defaults)
+        config.lmcache_instance_id = instance_id
+        return config
+
+    def test_controller_requires_lmcache_instance_id(self):
+        config = self._make_controller_config(lmcache_instance_id=None)
+        with pytest.raises(ValueError, match="lmcache_instance_id"):
+            config.validate()
+
+    def test_controller_requires_controller_pull_url(self):
+        config = self._make_controller_config(controller_pull_url=None)
+        with pytest.raises(ValueError, match="controller_pull_url"):
+            config.validate()
+
+    def test_controller_requires_controller_reply_url(self):
+        config = self._make_controller_config(controller_reply_url=None)
+        with pytest.raises(ValueError, match="controller_reply_url"):
+            config.validate()
+
+    def test_controller_requires_lmcache_worker_ports(self):
+        config = self._make_controller_config(lmcache_worker_ports=None)
+        with pytest.raises(ValueError, match="lmcache_worker_ports"):
+            config.validate()
+
+    def test_controller_rejects_empty_worker_ports(self):
+        config = self._make_controller_config(lmcache_worker_ports=[])
+        with pytest.raises(ValueError, match="cannot be empty"):
+            config.validate()
+
+    def test_controller_valid_config_no_error(self):
+        config = self._make_controller_config()
+        config.validate()  # Should not raise
+
+    def test_controller_disabled_no_error(self):
+        config = LMCacheEngineConfig.from_defaults(
+            enable_controller=False,
+        )
+        # All controller fields are None by default; should not raise
+        config.validate()


### PR DESCRIPTION
## Summary

Fixes #2907  LMCache emits an empty error message when `enable_controller=True` but required config fields are missing.

## Root Cause

Two interacting bugs:

1. **Missing validation in `_validate_config()`**: When `enable_controller=True`, no validation was performed for required controller fields (`lmcache_instance_id`, `controller_pull_url`, `controller_reply_url`, `lmcache_worker_ports`). Config silently passed with `None` values, causing a runtime failure deep in the worker init.

2. **Bare `assert` statements in `worker.py`**: Checks like `assert config.controller_pull_url is not None` raise `AssertionError` with an **empty string** when they fail, resulting in the confusing `": ."` in the error log.

## Changes

### `lmcache/v1/config.py`
- Added `if self.enable_controller:` validation block in `_validate_config()`
- Each required field is individually checked with `raise ValueError(...)` and a clear message
- `lmcache_worker_ports` also rejects empty lists (not just `None`)
- Follows the existing pattern used for `enable_p2p` validation in the same method

### `lmcache/v1/cache_controller/worker.py`
- Replaced 4 bare `assert` statements with explicit `if/raise ValueError` checks
- Port-count checks now include actual vs expected values in f-strings
- Uses `ValueError` instead of `assert` to ensure validation is not bypassed by `python -O`

### `tests/v1/test_config.py`
- Added 7 test cases covering all controller validation paths:
  - Each required field missing individually  `ValueError`
  - Empty `lmcache_worker_ports` list  `ValueError`
  - Valid config with all fields  no error
  - `enable_controller=False` with missing fields  no error

## Before / After

**Before:**
```
LMCache ERROR: Failed to initialize LMCacheManager components: . System will operate in degraded mode (recompute).
```

**After (at config creation time):**
```
ValueError: controller_pull_url is required when enable_controller=True
```

## Testing

- 7 new unit tests added and passing
- Zero impact on correctly-configured setups (`if self.enable_controller:` block is never entered when `enable_controller=False`)
- No existing tests broken
