### PR TITLE
[Bugfix] Fix double unpin of LocalCPU objects in retrieve_layer() (#2954)

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1037,8 +1037,13 @@ class LMCacheEngine:
         # has been enqueued (mem_obj_consumer advanced past its sync point).
         # Without this, pin_count stays at 1 forever and the CPU staging pool
         # fills up, causing the next retrieve to deadlock inside allocate().
+        # NOTE: Skip LocalCPUBackend objects — they are pinned by lookup() and
+        # will be unpinned later by lookup_unpin() in wait_for_save(). Unpinning
+        # them here causes a double unpin (pin_count goes negative) because
+        # batched_get_non_blocking() returns the same Python object that
+        # lookup(pin=True) pinned, not a freshly-allocated staging buffer.
         for mem_obj in to_count_down:
-            if mem_obj.is_pinned:
+            if mem_obj.is_pinned and location != "LocalCPUBackend":
                 mem_obj.unpin()
 
         retrieved_tokens = torch.sum(ret_mask)

--- a/tests/v1/test_retrieve_layer_double_unpin.py
+++ b/tests/v1/test_retrieve_layer_double_unpin.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #2954: double unpin of LocalCPU objects
+in retrieve_layer().
+
+The bug: retrieve_layer() and lookup_unpin() both called unpin() on the
+same MemoryObj when using LocalCPUBackend.  LocalCPU's
+batched_get_non_blocking() returns the *same* Python object that
+lookup(pin=True) pinned (unlike LocalDisk which allocates a new staging
+buffer).  The second unpin drove pin_count negative, triggering a
+premature free().
+
+The fix: retrieve_layer() skips the unpin when
+``location == "LocalCPUBackend"`` so that lookup_unpin() is the sole
+unpin path.
+
+This test verifies the pin-count invariant at the MemoryObj level,
+exercising the exact sequence that occurs in production without
+requiring CUDA.
+"""
+
+# Standard
+import logging
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.pin_monitor import PinMonitor
+
+
+@pytest.fixture(autouse=True)
+def _init_pin_monitor():
+    """Initialize and tear down PinMonitor for each test.
+
+    TensorMemoryObj.pin()/unpin() call PinMonitor.GetOrCreate() internally,
+    so the singleton must exist before any pin operation.
+    """
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        local_cpu=True,
+    )
+    PinMonitor.GetOrCreate(config)
+    yield
+    PinMonitor.DestroyInstance()
+
+
+def _make_mem_obj() -> TensorMemoryObj:
+    """Create a TensorMemoryObj backed by a small CPU tensor.
+
+    Uses ``parent_allocator=None`` so that free() is a no-op, which lets
+    us inspect pin_count without side effects.
+    """
+    size = 1024
+    buf = torch.empty(size, dtype=torch.uint8)
+    meta = MemoryObjMetadata(
+        shape=torch.Size([1, 2, 4, 8, 16]),
+        dtype=torch.bfloat16,
+        address=buf.data_ptr(),
+        phy_size=size,
+        ref_count=0,
+        pin_count=0,
+        fmt=MemoryFormat.KV_2LTD,
+    )
+    return TensorMemoryObj(raw_data=buf, metadata=meta, parent_allocator=None)
+
+
+class TestRetrieveLayerDoubleUnpin:
+    """Pin-count lifecycle tests mirroring the retrieve_layer() flow."""
+
+    def test_localcpu_no_double_unpin(self, caplog):
+        """With the fix, LocalCPU objects skip unpin in retrieve_layer(),
+        so lookup_unpin() is the single unpin path.
+
+        Sequence (matches PR description table):
+          1. lookup(pin=True)      -> pin_count = 1
+          2. batched_get -> ref_count_up()  -> ref_count = 1
+          3. ref_count_down()               -> ref_count = 0
+          4. retrieve_layer: is_pinned AND location != "LocalCPUBackend"
+                             -> SKIPPED (location IS LocalCPUBackend)
+          5. lookup_unpin()  -> unpin()     -> pin_count = 0, free()
+        """
+        mem_obj = _make_mem_obj()
+
+        # Step 1: lookup(pin=True)
+        mem_obj.pin()
+        assert mem_obj.metadata.pin_count == 1
+
+        # Step 2: batched_get_non_blocking -> ref_count_up
+        mem_obj.ref_count_up()
+        assert mem_obj.get_ref_count() == 1
+
+        # Step 3: ref_count_down (after device copy enqueued)
+        mem_obj.ref_count_down()
+        assert mem_obj.get_ref_count() == 0
+
+        # Step 4: retrieve_layer unpin guard — simulating the fix
+        location = "LocalCPUBackend"
+        if mem_obj.is_pinned and location != "LocalCPUBackend":
+            mem_obj.unpin()
+        # pin_count should still be 1 (unpin was skipped)
+        assert mem_obj.metadata.pin_count == 1
+
+        # Step 5: lookup_unpin -> unpin
+        logger = logging.getLogger("lmcache.v1.memory_management")
+        old_propagate = logger.propagate
+        logger.propagate = True
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="lmcache.v1.memory_management"
+            ):
+                mem_obj.unpin()
+        finally:
+            logger.propagate = old_propagate
+
+        assert mem_obj.metadata.pin_count == 0, (
+            "pin_count should be exactly 0 after single unpin"
+        )
+        # No "Double unpin" warning should have been logged
+        double_unpin_msgs = [
+            r.message for r in caplog.records if "Double unpin" in r.message
+        ]
+        assert double_unpin_msgs == [], (
+            f"Unexpected double-unpin warning: {double_unpin_msgs}"
+        )
+
+    def test_localcpu_double_unpin_without_guard(self, caplog):
+        """Without the fix (no location guard), LocalCPU objects would be
+        unpinned twice.  This test documents the bug and verifies that
+        the warning fires when the guard is absent.
+        """
+        mem_obj = _make_mem_obj()
+
+        # Step 1: lookup(pin=True)
+        mem_obj.pin()
+
+        # Step 2-3: batched_get ref-count cycle
+        mem_obj.ref_count_up()
+        mem_obj.ref_count_down()
+
+        # Simulate the OLD code (no guard): unconditional unpin
+        if mem_obj.is_pinned:
+            mem_obj.unpin()
+        assert mem_obj.metadata.pin_count == 0
+
+        # Second unpin (from lookup_unpin) — this is the double unpin.
+        # Enable propagation so caplog can capture the warning from
+        # the lmcache logger (which sets propagate=False by default).
+        logger = logging.getLogger("lmcache.v1.memory_management")
+        old_propagate = logger.propagate
+        logger.propagate = True
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="lmcache.v1.memory_management"
+            ):
+                mem_obj.unpin()
+        finally:
+            logger.propagate = old_propagate
+
+        # The safeguard in TensorMemoryObj.unpin() resets pin_count to 0
+        # after logging a warning
+        assert mem_obj.metadata.pin_count == 0, (
+            "Safeguard should have reset pin_count to 0"
+        )
+        double_unpin_msgs = [
+            r.message for r in caplog.records if "Double unpin" in r.message
+        ]
+        assert len(double_unpin_msgs) > 0, (
+            "Without the guard, a double-unpin warning must be raised"
+        )
+
+    def test_localdisk_unpin_both_paths_ok(self, caplog):
+        """For LocalDisk, batched_get_non_blocking() returns a *different*
+        staging MemoryObj, so both unpin paths operate on separate objects
+        and neither hits a double unpin.
+        """
+        lookup_obj = _make_mem_obj()  # pinned by lookup
+        staging_obj = _make_mem_obj()  # returned by batched_get
+
+        # Step 1: lookup pins the lookup_obj
+        lookup_obj.pin()
+        assert lookup_obj.metadata.pin_count == 1
+
+        # Step 2-3: staging_obj goes through ref-count cycle
+        # (LocalDisk staging objects may also be pinned by the allocator)
+        staging_obj.pin()
+        staging_obj.ref_count_up()
+        staging_obj.ref_count_down()
+
+        # Step 4: retrieve_layer unpins the staging_obj (different object)
+        location = "LocalDiskBackend"
+        if staging_obj.is_pinned and location != "LocalCPUBackend":
+            staging_obj.unpin()
+        assert staging_obj.metadata.pin_count == 0
+
+        # Step 5: lookup_unpin unpins the lookup_obj
+        logger = logging.getLogger("lmcache.v1.memory_management")
+        old_propagate = logger.propagate
+        logger.propagate = True
+        try:
+            with caplog.at_level(
+                logging.WARNING, logger="lmcache.v1.memory_management"
+            ):
+                lookup_obj.unpin()
+        finally:
+            logger.propagate = old_propagate
+
+        assert lookup_obj.metadata.pin_count == 0
+        double_unpin_msgs = [
+            r.message for r in caplog.records if "Double unpin" in r.message
+        ]
+        assert double_unpin_msgs == [], (
+            f"LocalDisk should never trigger double-unpin: {double_unpin_msgs}"
+        )


### PR DESCRIPTION
## Summary

Fixes #2954

## Root Cause

This bug is introduced by the combination of two individually correct PRs:

- **#2611** added `if mem_obj.is_pinned: mem_obj.unpin()` in `retrieve_layer()` to release disk-loaded staging objects after the device-side copy completes.
- **#2786** added `lookup_unpin()` in `wait_for_save()` to release objects that were pinned by `lookup(pin=True)`.

These two unpin operations conflict for **LocalCPU backend** because `LocalCPUBackend.batched_get_non_blocking()` returns the **same Python object** from `hot_cache` that `lookup(pin=True)` pinned. Both code paths end up calling `unpin()` on the same object, driving `pin_count` to -1.

For **LocalDisk** there is no conflict: `lookup()` pins a `DiskCacheMetadata` object, while `batched_get_non_blocking()` allocates a **new** staging `MemoryObj` — different objects, no aliasing.

**This is more severe than just the warning.** `TensorMemoryObj.unpin()` calls `free(self)` when both `pin_count <= 0` and `ref_count <= 0`. After the 1st unpin (`retrieve_layer`), pin_count=0 and ref_count=0 (ref_count was decremented to 0 at line 1024), so `free()` is called prematurely. The 2nd unpin (`lookup_unpin`) then tries to free an already-freed object. The safeguard at `memory_management.py:617-624` resets `pin_count` to 0, but only *after* the premature free has already occurred.

## Fix

Add a `location != "LocalCPUBackend"` guard to the unpin loop in `retrieve_layer()`. LocalCPU objects retain their pin until `lookup_unpin()` releases them in `wait_for_save()`, which is the correct single-free path.

```python
# Before
for mem_obj in to_count_down:
    if mem_obj.is_pinned:
        mem_obj.unpin()

# After
for mem_obj in to_count_down:
    if mem_obj.is_pinned and location != "LocalCPUBackend":
        mem_obj.unpin()
```

The `location` variable is already in scope (set at line 960, guaranteed non-None when `to_count_down` is non-empty). The string `"LocalCPUBackend"` is `LocalCPUBackend.__str__()` = `__class__.__name__`, used as a dict key in 20+ places across `storage_manager.py`.

## Pin count lifecycle after fix (LocalCPU)

| Step | Operation | pin_count | ref_count |
|------|-----------|:---------:|:---------:|
| 1 | `lookup(pin=True)` → `contains(pin=True)` → `pin()` | **1** | 0 |
| 2 | `batched_get_non_blocking()` → `ref_count_up()` | 1 | **1** |
| 3 | `ref_count_down()` | 1 | **0** |
| 4 | `if is_pinned and location != "LocalCPUBackend"` → **skipped** | 1 | 0 |
| 5 | `lookup_unpin()` → `unpin()` → pin_count=0, ref_count=0 → `free()` ✅ | **0** | 0 |

## Affected scenarios

| Scenario | Before | After |
|----------|--------|-------|
| Layerwise + LocalCPU (CacheBlend) | ❌ double unpin + premature free | ✅ fixed |
| Layerwise + LocalCPU (non-CacheBlend) | ❌ double unpin + premature free | ✅ fixed |
| Layerwise + LocalDisk | ✅ unaffected | ✅ still correct |
| Non-layerwise (any backend) | ✅ unaffected | ✅ unaffected |
| Redis / PD | ✅ unaffected | ✅ unaffected |

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches memory-object lifecycle in `retrieve_layer()`, so mistakes could cause leaks or premature frees, but the change is narrowly scoped and covered by a new regression test.
> 
> **Overview**
> Fixes a layerwise retrieval bug where `retrieve_layer()` could **unpin the same `MemoryObj` twice** when retrieving from `LocalCPUBackend`, driving `pin_count` negative and potentially triggering premature frees.
> 
> `retrieve_layer()` now skips the post-sync unpin step for `LocalCPUBackend` objects (leaving `lookup_unpin()` as the sole unpin path), and adds a regression test that exercises the pin/ref-count sequence for LocalCPU (fixed) and LocalDisk (unchanged) behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9da68b5f470990a243a40b610e110c785e10fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->