### PR TITLE
fix(agents): fix 4 bugs in prefix_analysis.py causing incorrect hit rate simulation

### DIFF
--- a/examples/agents/prefix_analysis.py
+++ b/examples/agents/prefix_analysis.py
@@ -17,6 +17,9 @@ import torch
 DEFAULT_TOKENIZER = "meta-llama/Llama-3.1-8B"
 DEFAULT_TOKENS_PER_GB = 8200  # Default for Llama-3.1; More details here: https://docs.lmcache.ai/getting_started/kv_cache_calculator.html
 DEFAULT_POOL_SIZES_GB: List[Union[int, float, str]] = [
+    0.1,
+    0.2,
+    0.4,
     1,
     2,
     4,
@@ -125,6 +128,12 @@ class LRUTokenPool:
         """
         Add a request to the pool, evicting LRU entries if necessary.
         """
+        # Trim tokens that exceed pool capacity to prevent current_tokens > max_tokens
+        capacity = int(self.max_tokens) if self.max_tokens != float("inf") else len(tokens)
+        tokens = tokens[:capacity]
+        if token_tensor is not None and capacity < token_tensor.size(1):
+            token_tensor[request_id, capacity:] = 0
+
         # Evict until we have space
         while self.current_tokens + len(tokens) > self.max_tokens and self.requests:
             old_id, old_tokens = self.requests.popitem(last=False)
@@ -252,7 +261,7 @@ def analyze_hit_rates_across_pool_sizes(
             token_desc = ""
         else:
             size_tokens = int(size_gb * tokens_per_gb)
-            x_labels.append(str(int(size_gb)))
+            x_labels.append(str(size_gb))
             pool_desc = f"{size_gb}GB"
             token_desc = f" ({size_tokens:,} tokens)"
 


### PR DESCRIPTION
## Summary

Fixes 4 bugs in `examples/agents/prefix_analysis.py` that caused the hit rate analysis to report incorrect numbers, especially at small pool sizes.

---

### Bug 1  LRU pool capacity overflow (most critical)

**Problem:** When a single request's token list is longer than the pool's total capacity, `current_tokens` grows beyond `max_tokens`, permanently breaking the pool invariant. All subsequent hit rate numbers are wrong.

**Fix:** Trim the token list to `tokens[:capacity]` before inserting. We keep the *head* (not tail) because `longest_prefix_len()` matches from index 0  preserving the prefix is what matters for cache hit simulation.

---

### Bug 2  Ghost tokens inflate substring (CacheBlend) hit rate

**Problem:** After trimming `tokens` to `[:capacity]`, the corresponding `token_tensor` row still held the full untrimmed token sequence. The substring matcher (`torch.unfold`) scanned this ghost data and reported hits against tokens that were never actually stored in the cache pool.

**Fix:** Zero out the excess after trimming: `token_tensor[request_id, capacity:] = 0`. This mirrors the existing eviction pattern at line 141.

---

### Bug 3  X-axis labels show "0" for sub-1GB pool sizes

**Problem:** `str(int(0.1))`  `str(0)`  `"0"`. Any pool size < 1 GB displayed as "0" on the plot x-axis.

**Fix:** `str(size_gb)` directly  Python's `str()` on `0.1`/`0.2`/`0.4` produces clean labels.

---

### Bug 4  Default pool sizes start at 1 GB (too coarse)

**Problem:** The analysis skipped the 01 GB range entirely, hiding the behaviour of small caches (e.g., spare GPU VRAM after model load).

**Fix:** Added `0.1`, `0.2`, `0.4` GB to `DEFAULT_POOL_SIZES_GB`. As a side effect, these small pool sizes make Bugs 1 & 2 trigger much more frequently (every request), making the fixes above critical.

---

## Credit

Bug 1 was originally identified by @yamazakihirofumi in #1918, which was stale-closed before merging. This PR re-applies and extends that fix.

Closes #1826 (partial  analysis tooling fixes only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core hit-rate simulation behavior (token trimming and tensor zeroing), which will materially alter reported metrics and could affect downstream analysis assumptions.
> 
> **Overview**
> Fixes hit-rate simulation in `examples/agents/prefix_analysis.py` by **capping per-request tokens to the pool capacity** so the LRU pool can’t exceed `max_tokens`, and by **zeroing trimmed tensor slots** to avoid substring matching against non-existent “ghost” tokens.
> 
> Improves analysis ergonomics by **testing smaller default pool sizes** (`0.1/0.2/0.4` GB) and **fixing plot x-axis labels** to correctly display sub-1GB sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bba90c527a216e1e36b6d5904522fdb7ed2a7ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->