### PR TITLE
[BugFix] Fix deadlock + silent data corruption in storage backends (fixes #2942, fixes #3022)

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -589,6 +589,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_obj is not None or not eviction:
             return memory_obj
 
+        # When use_hot=False, hot_cache is always empty (batched_submit_put_task
+        # returns early without inserting into hot_cache), so eviction is
+        # structurally impossible. Busy-looping would spin forever; override to
+        # fail-fast so callers can handle the None return gracefully.
+        if not self.use_hot:
+            busy_loop = False
+
         evict_keys_count = 0
         num_attempts = 0
         while True:
@@ -698,6 +705,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
             return memory_objs
 
         assert isinstance(self.memory_allocator, MixedMemoryAllocator)
+
+        # When use_hot=False, hot_cache is always empty (batched_submit_put_task
+        # returns early without inserting into hot_cache), so eviction is
+        # structurally impossible. Busy-looping would spin forever; override to
+        # fail-fast so callers can handle the None return gracefully.
+        if not self.use_hot:
+            busy_loop = False
 
         evict_keys_count = 0
         num_attempts = 0

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -528,6 +528,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_obj is not None or not eviction:
             return memory_obj
 
+        # When use_hot=False, hot_cache is always empty (batched_submit_put_task
+        # returns early without inserting into hot_cache), so eviction is
+        # structurally impossible. Busy-looping would spin forever; override to
+        # fail-fast so callers can handle the None return gracefully.
+        if not self.use_hot:
+            busy_loop = False
+
         evict_keys_count = 0
         num_attempts = 0
         while True:
@@ -637,6 +644,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
             return memory_objs
 
         assert isinstance(self.memory_allocator, MixedMemoryAllocator)
+
+        # When use_hot=False, hot_cache is always empty (batched_submit_put_task
+        # returns early without inserting into hot_cache), so eviction is
+        # structurally impossible. Busy-looping would spin forever; override to
+        # fail-fast so callers can handle the None return gracefully.
+        if not self.use_hot:
+            busy_loop = False
 
         evict_keys_count = 0
         num_attempts = 0

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -463,13 +463,15 @@ class LocalDiskBackend(StorageBackendInterface):
                 # NOT run, so any returned mem_objs would contain stale
                 # memory — not valid KV cache data.  Clean up and return
                 # empty to avoid silent data corruption.
-                for prev_obj in mem_objs:
-                    prev_obj.unpin()
-                    prev_obj.ref_count_down()
-                for prev_key in keys[: len(mem_objs)]:
-                    if prev_key in self.dict:
-                        self.dict[prev_key].unpin()
-                self.disk_lock.release()
+                try:
+                    for prev_obj in mem_objs:
+                        prev_obj.unpin()
+                        prev_obj.ref_count_down()
+                    for prev_key in keys[: len(mem_objs)]:
+                        if prev_key in self.dict:
+                            self.dict[prev_key].unpin()
+                finally:
+                    self.disk_lock.release()
                 return []
 
             self.dict[key].pin()

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -589,7 +589,7 @@ class LocalDiskBackend(StorageBackendInterface):
         Load bytearray from disk.
         """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt, busy_loop=False)
+        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
         if memory_obj is None:
             logger.warning(
                 "LocalDiskBackend: CPU staging pool exhausted while loading "

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -589,7 +589,13 @@ class LocalDiskBackend(StorageBackendInterface):
         """
 
         memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
-        assert memory_obj is not None, "Memory allocation failed during disk load."
+        if memory_obj is None:
+            logger.warning(
+                "LocalDiskBackend: CPU staging pool exhausted while loading "
+                "key %s from disk. Returning cache miss.",
+                key,
+            )
+            return None
 
         buffer = memory_obj.byte_array
         self.read_file(key, buffer, path)

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -427,6 +427,7 @@ class LocalDiskBackend(StorageBackendInterface):
     ) -> list[MemoryObj]:
         mem_objs: list[MemoryObj] = []
         paths: list[str] = []
+        hit_keys: list[CacheEngineKey] = []
 
         logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
         for key in keys:
@@ -475,16 +476,20 @@ class LocalDiskBackend(StorageBackendInterface):
                 return []
 
             self.dict[key].pin()
-
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
+            hit_keys.append(key)
 
             self.disk_lock.release()
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)
             paths.append(path)
+
+        # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+        # Only record those hits after the whole batch is staged to avoid
+        # phantom cache-policy updates on partial-allocation failure.
+        with self.disk_lock:
+            for key in hit_keys:
+                self.cache_policy.update_on_hit(key, self.dict)
 
         return await self.disk_worker.submit_task(
             "prefetch",

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -458,6 +458,7 @@ class LocalDiskBackend(StorageBackendInterface):
                     "a previous retrieve). Returning partial results.",
                     key,
                 )
+                self.disk_lock.release()
                 return mem_objs
 
             self.dict[key].pin()
@@ -588,7 +589,7 @@ class LocalDiskBackend(StorageBackendInterface):
         Load bytearray from disk.
         """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
+        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt, busy_loop=False)
         if memory_obj is None:
             logger.warning(
                 "LocalDiskBackend: CPU staging pool exhausted while loading "

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -455,11 +455,22 @@ class LocalDiskBackend(StorageBackendInterface):
                 logger.error(
                     "Memory allocation failed during async disk load for key %s. "
                     "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
+                    "a previous retrieve). Dropping all partial results.",
                     key,
                 )
+                # Undo side effects for already-processed keys: the
+                # disk_worker.submit_task (which loads data from disk) will
+                # NOT run, so any returned mem_objs would contain stale
+                # memory — not valid KV cache data.  Clean up and return
+                # empty to avoid silent data corruption.
+                for prev_obj in mem_objs:
+                    prev_obj.unpin()
+                    prev_obj.ref_count_down()
+                for prev_key in keys[: len(mem_objs)]:
+                    if prev_key in self.dict:
+                        self.dict[prev_key].unpin()
                 self.disk_lock.release()
-                return mem_objs
+                return []
 
             self.dict[key].pin()
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -603,7 +603,7 @@ class LocalDiskBackend(StorageBackendInterface):
         Load bytearray from disk.
         """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt, busy_loop=False)
+        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
         if memory_obj is None:
             logger.warning(
                 "LocalDiskBackend: CPU staging pool exhausted while loading "

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -477,13 +477,15 @@ class LocalDiskBackend(StorageBackendInterface):
                 # NOT run, so any returned mem_objs would contain stale
                 # memory — not valid KV cache data.  Clean up and return
                 # empty to avoid silent data corruption.
-                for prev_obj in mem_objs:
-                    prev_obj.unpin()
-                    prev_obj.ref_count_down()
-                for prev_key in keys[: len(mem_objs)]:
-                    if prev_key in self.dict:
-                        self.dict[prev_key].unpin()
-                self.disk_lock.release()
+                try:
+                    for prev_obj in mem_objs:
+                        prev_obj.unpin()
+                        prev_obj.ref_count_down()
+                    for prev_key in keys[: len(mem_objs)]:
+                        if prev_key in self.dict:
+                            self.dict[prev_key].unpin()
+                finally:
+                    self.disk_lock.release()
                 return []
 
             self.dict[key].pin()

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -472,6 +472,7 @@ class LocalDiskBackend(StorageBackendInterface):
                     "a previous retrieve). Returning partial results.",
                     key,
                 )
+                self.disk_lock.release()
                 return mem_objs
 
             self.dict[key].pin()
@@ -602,7 +603,7 @@ class LocalDiskBackend(StorageBackendInterface):
         Load bytearray from disk.
         """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
+        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt, busy_loop=False)
         if memory_obj is None:
             logger.warning(
                 "LocalDiskBackend: CPU staging pool exhausted while loading "

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -603,7 +603,13 @@ class LocalDiskBackend(StorageBackendInterface):
         """
 
         memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
-        assert memory_obj is not None, "Memory allocation failed during disk load."
+        if memory_obj is None:
+            logger.warning(
+                "LocalDiskBackend: CPU staging pool exhausted while loading "
+                "key %s from disk. Returning cache miss.",
+                key,
+            )
+            return None
 
         buffer = memory_obj.byte_array
         self.read_file(key, buffer, path)

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -469,11 +469,22 @@ class LocalDiskBackend(StorageBackendInterface):
                 logger.error(
                     "Memory allocation failed during async disk load for key %s. "
                     "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
+                    "a previous retrieve). Dropping all partial results.",
                     key,
                 )
+                # Undo side effects for already-processed keys: the
+                # disk_worker.submit_task (which loads data from disk) will
+                # NOT run, so any returned mem_objs would contain stale
+                # memory — not valid KV cache data.  Clean up and return
+                # empty to avoid silent data corruption.
+                for prev_obj in mem_objs:
+                    prev_obj.unpin()
+                    prev_obj.ref_count_down()
+                for prev_key in keys[: len(mem_objs)]:
+                    if prev_key in self.dict:
+                        self.dict[prev_key].unpin()
                 self.disk_lock.release()
-                return mem_objs
+                return []
 
             self.dict[key].pin()
 

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -613,3 +613,65 @@ class TestLocalCPUBackendAllocatorAlignment:
             assert kwargs.get("align_bytes") == 4096
         finally:
             backend.memory_allocator.close()
+
+
+@pytest.mark.no_shared_allocator
+def test_allocate_no_deadlock_use_hot_false():
+    """Regression test for #2942: allocate(busy_loop=True) must not hang
+    when use_hot=False and the memory pool is exhausted.
+
+    Before the fix, the while-loop in allocate() would spin forever because
+    hot_cache was always empty (no eviction candidates) yet busy_loop was
+    True.  The fix forces busy_loop=False when use_hot=False so allocate()
+    returns None instead of deadlocking.
+    """
+    # Standard
+    from concurrent.futures import ThreadPoolExecutor, TimeoutError
+
+    # First Party
+    from lmcache.v1.memory_management import MixedMemoryAllocator
+
+    # --- setup -----------------------------------------------------------
+    # Small pool: 3 MB – easy to exhaust with a few allocations.
+    pool_bytes = 3 * 1024 * 1024
+    allocator = MixedMemoryAllocator(pool_bytes)
+
+    config = create_test_config(local_cpu=False)  # use_hot = False
+    PinMonitor.GetOrCreate(config)
+
+    backend = LocalCPUBackend(
+        config=config, memory_allocator=allocator, dst_device="cpu"
+    )
+    assert backend.use_hot is False
+
+    shape = torch.Size([2, 16, 8, 128])
+    dtype = torch.bfloat16
+    fmt = MemoryFormat.KV_T2D
+
+    # --- exhaust the pool ------------------------------------------------
+    held_objs = []
+    while True:
+        obj = allocator.allocate([shape], [dtype], fmt)
+        if obj is None:
+            break
+        held_objs.append(obj)
+    assert len(held_objs) > 0, "Pool should have held at least one object"
+
+    # --- the actual regression check -------------------------------------
+    # allocate() with busy_loop=True must return None (not hang).
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(backend.allocate, shape, dtype, fmt, True, True)
+        try:
+            result = future.result(timeout=5)
+        except TimeoutError:
+            pytest.fail(
+                "allocate(busy_loop=True) deadlocked with use_hot=False (issue #2942)"
+            )
+
+    assert result is None, "Expected None when pool is exhausted with use_hot=False"
+
+    # --- cleanup ---------------------------------------------------------
+    for obj in held_objs:
+        obj.ref_count_down()
+    allocator.close()
+    PinMonitor.DestroyInstance()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -386,7 +386,7 @@ class TestPoolExhaustionHandling:
     pool is exhausted during disk I/O."""
 
     def test_load_bytes_from_disk_returns_none_on_pool_exhaustion(
-        self, local_disk_backend, capsys
+        self, local_disk_backend, capfd
     ):
         """load_bytes_from_disk must return None (not crash) when allocate
         returns None, and emit a warning log."""
@@ -407,8 +407,8 @@ class TestPoolExhaustionHandling:
             "Expected None when staging pool is exhausted, not an assertion error"
         )
         # LMCache uses its own logger that writes to stderr, not stdlib
-        # logging handlers, so we check capsys instead of caplog.
-        captured = capsys.readouterr()
+        # logging handlers, so we use capfd (fd-level capture) instead of caplog.
+        captured = capfd.readouterr()
         assert "CPU staging pool exhausted" in captured.err, (
             "Expected a warning about CPU staging pool exhaustion in stderr"
         )

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import patch
 import asyncio
+import logging
 import os
 import shutil
 import tempfile
@@ -10,9 +12,10 @@ import pytest
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import CacheEngineKey, DiskCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
+from lmcache.v1.memory_management import MemoryFormat
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -377,3 +380,109 @@ class TestParseLocalDisk:
 
     def test_empty_string(self):
         assert _parse_local_disk("") is None
+
+
+class TestPoolExhaustionHandling:
+    """Regression tests for issue #2942: graceful handling when CPU staging
+    pool is exhausted during disk I/O."""
+
+    def test_load_bytes_from_disk_returns_none_on_pool_exhaustion(
+        self, local_disk_backend, caplog
+    ):
+        """load_bytes_from_disk must return None (not crash) when allocate
+        returns None, and emit a warning log."""
+        key = create_test_key(100)
+        path = local_disk_backend._key_to_path(key)
+        dtype = torch.bfloat16
+        shape = torch.Size([2, 28, 256, 8, 128])
+        fmt = MemoryFormat.KV_2LTD
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            with caplog.at_level(logging.WARNING):
+                result = local_disk_backend.load_bytes_from_disk(
+                    key, path, dtype, shape, fmt
+                )
+
+        assert result is None, (
+            "Expected None when staging pool is exhausted, not an assertion error"
+        )
+        assert any(
+            "CPU staging pool exhausted" in record.message for record in caplog.records
+        ), "Expected a warning about CPU staging pool exhaustion"
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_batched_get_non_blocking_releases_lock_on_alloc_failure(
+        self, local_disk_backend, async_loop
+    ):
+        """batched_get_non_blocking must release disk_lock even when allocate
+        returns None (issue #2942 lock leak)."""
+        key = create_test_key(200)
+        path = local_disk_backend._key_to_path(key)
+
+        # Insert a fake entry so the key lookup succeeds inside the method.
+        local_disk_backend.dict[key] = DiskCacheMetadata(
+            path=path,
+            size=1024,
+            shape=torch.Size([2, 28, 256, 8, 128]),
+            dtype=torch.bfloat16,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test", keys=[key]
+                )
+            )
+
+        # The method should return an empty list (partial results before the
+        # failing key) rather than raising.
+        assert result == []
+
+        # The critical check: disk_lock must be released after the early
+        # return, so acquiring it here must succeed immediately.
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock was NOT released after alloc failure — lock leak!"
+        local_disk_backend.disk_lock.release()
+
+        # pin() should NOT have been called on the metadata — the early
+        # return happens before the pin() call.
+        assert local_disk_backend.dict[key].pin_count == 0, (
+            "pin_count should be 0 — alloc failed before pin()"
+        )
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_get_blocking_returns_none_on_pool_exhaustion(
+        self, local_disk_backend, caplog
+    ):
+        """get_blocking must return None when load_bytes_from_disk returns
+        None due to pool exhaustion (issue #2942 synchronous path)."""
+        key = create_test_key(300)
+        path = local_disk_backend._key_to_path(key)
+
+        # Insert a fake entry so the key lookup succeeds.
+        local_disk_backend.dict[key] = DiskCacheMetadata(
+            path=path,
+            size=1024,
+            shape=torch.Size([2, 28, 256, 8, 128]),
+            dtype=torch.bfloat16,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            with caplog.at_level(logging.WARNING):
+                result = local_disk_backend.get_blocking(key)
+
+        assert result is None, (
+            "get_blocking should return None when staging pool is exhausted"
+        )
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import shutil
@@ -456,6 +456,216 @@ class TestPoolExhaustionHandling:
         assert local_disk_backend.dict[key].pin_count == 0, (
             "pin_count should be 0 — alloc failed before pin()"
         )
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    # ------------------------------------------------------------------
+    # Partial-alloc failure tests (issue #3022)
+    # ------------------------------------------------------------------
+
+    def _insert_fake_entries(self, backend, keys):
+        """Insert fake DiskCacheMetadata for each key so lookups succeed."""
+        for key in keys:
+            path = backend._key_to_path(key)
+            backend.dict[key] = DiskCacheMetadata(
+                path=path,
+                size=1024,
+                shape=torch.Size([2, 28, 256, 8, 128]),
+                dtype=torch.bfloat16,
+                fmt=MemoryFormat.KV_2LTD,
+            )
+
+    def test_partial_alloc_cleanup_on_multi_key_failure(
+        self, local_disk_backend, async_loop
+    ):
+        """Issue #3022: When allocate fails on key 2 of 3, all side
+        effects from keys 0 and 1 (DiskCacheMetadata pins, MemoryObj
+        pins/refs) must be fully rolled back, and result must be []."""
+        keys = [create_test_key(400 + i) for i in range(3)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(2)]
+        allocate_returns = iter([mock_objs[0], mock_objs[1], None])
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            side_effect=lambda *a, **kw: next(allocate_returns),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_multi", keys=keys
+                )
+            )
+
+        # Must return empty — no partial results
+        assert result == []
+
+        # DiskCacheMetadata pin_count must be 0 for ALL keys
+        for i, key in enumerate(keys):
+            assert local_disk_backend.dict[key].pin_count == 0, (
+                f"key {i}: pin_count should be 0 after rollback"
+            )
+
+        # MemoryObj cleanup: unpin + ref_count_down called on both
+        for i, obj in enumerate(mock_objs):
+            obj.unpin.assert_called_once()
+            obj.ref_count_down.assert_called_once()
+
+        # disk_lock must be released
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock NOT released after partial alloc failure"
+        local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_partial_alloc_no_stale_data_returned(self, local_disk_backend, async_loop):
+        """CRITICAL (issue #3022): When first allocation succeeds but
+        second fails, the returned list must be empty — NOT contain the
+        first allocated-but-unloaded MemoryObj (stale/corrupt data)."""
+        keys = [create_test_key(500 + i) for i in range(2)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        stale_obj = MagicMock(name="stale_MemoryObj")
+        allocate_returns = iter([stale_obj, None])
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            side_effect=lambda *a, **kw: next(allocate_returns),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_stale", keys=keys
+                )
+            )
+
+        # THE critical assertion: empty list, not [stale_obj]
+        assert len(result) == 0, (
+            f"Expected 0 items but got {len(result)} — "
+            "allocated-but-unloaded MemoryObj would be stale/corrupt data"
+        )
+        assert stale_obj not in result
+
+        # Verify stale_obj was properly cleaned up
+        stale_obj.unpin.assert_called_once()
+        stale_obj.ref_count_down.assert_called_once()
+
+        # pin_count check
+        for key in keys:
+            assert local_disk_backend.dict[key].pin_count == 0
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_first_key_alloc_failure_multi_key_batch(
+        self, local_disk_backend, async_loop
+    ):
+        """First-key failure in a multi-key batch: no side effects on
+        any key, consistent with the single-key test above."""
+        keys = [create_test_key(700 + i) for i in range(3)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            return_value=None,
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_first_fail", keys=keys
+                )
+            )
+
+        assert result == []
+        for key in keys:
+            assert local_disk_backend.dict[key].pin_count == 0
+
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock NOT released after first-key failure"
+        local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_last_key_in_large_batch_fails(self, local_disk_backend, async_loop):
+        """Edge case: last key (of 5) fails — all 4 successful
+        allocations must be fully rolled back."""
+        n_keys = 5
+        keys = [create_test_key(800 + i) for i in range(n_keys)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(n_keys - 1)]
+        returns = mock_objs + [None]  # last one fails
+        allocate_returns = iter(returns)
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            side_effect=lambda *a, **kw: next(allocate_returns),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_last_fail", keys=keys
+                )
+            )
+
+        assert result == []
+
+        for i, key in enumerate(keys):
+            assert local_disk_backend.dict[key].pin_count == 0, (
+                f"key {i}: pin_count should be 0 after rollback"
+            )
+
+        for obj in mock_objs:
+            obj.unpin.assert_called_once()
+            obj.ref_count_down.assert_called_once()
+
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock NOT released after last-key failure"
+        local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_all_keys_succeed_returns_full_batch(self, local_disk_backend, async_loop):
+        """Happy path: all allocations succeed → result contains
+        exactly len(keys) items with all pins intact."""
+        keys = [create_test_key(600 + i) for i in range(3)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(3)]
+        allocate_returns = iter(mock_objs)
+
+        async def fake_submit_task(*args, **kwargs):
+            return kwargs.get("memory_objs", [])
+
+        with (
+            patch.object(
+                local_disk_backend.local_cpu_backend,
+                "allocate",
+                side_effect=lambda *a, **kw: next(allocate_returns),
+            ),
+            patch.object(
+                local_disk_backend.disk_worker,
+                "submit_task",
+                side_effect=fake_submit_task,
+            ),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_happy", keys=keys
+                )
+            )
+
+        assert len(result) == len(keys), (
+            f"Expected {len(keys)} items but got {len(result)}"
+        )
+
+        # DiskCacheMetadata should stay pinned (pin_count == 1)
+        for key in keys:
+            assert local_disk_backend.dict[key].pin_count == 1
+
+        # Each MemoryObj should have been pinned once
+        for obj in mock_objs:
+            obj.pin.assert_called_once()
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -483,6 +483,7 @@ class TestPoolExhaustionHandling:
         pins/refs) must be fully rolled back, and result must be []."""
         keys = [create_test_key(400 + i) for i in range(3)]
         self._insert_fake_entries(local_disk_backend, keys)
+        original_order = list(local_disk_backend.dict.keys())
 
         mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(2)]
         allocate_returns = iter([mock_objs[0], mock_objs[1], None])
@@ -511,6 +512,9 @@ class TestPoolExhaustionHandling:
         for i, obj in enumerate(mock_objs):
             obj.unpin.assert_called_once()
             obj.ref_count_down.assert_called_once()
+
+        # Cache policy state must also roll back on failed batch prefetch.
+        assert list(local_disk_backend.dict.keys()) == original_order
 
         # disk_lock must be released
         acquired = local_disk_backend.disk_lock.acquire(timeout=1)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -2,7 +2,6 @@
 # Standard
 from unittest.mock import patch
 import asyncio
-import logging
 import os
 import shutil
 import tempfile
@@ -387,7 +386,7 @@ class TestPoolExhaustionHandling:
     pool is exhausted during disk I/O."""
 
     def test_load_bytes_from_disk_returns_none_on_pool_exhaustion(
-        self, local_disk_backend, caplog
+        self, local_disk_backend, capsys
     ):
         """load_bytes_from_disk must return None (not crash) when allocate
         returns None, and emit a warning log."""
@@ -400,17 +399,19 @@ class TestPoolExhaustionHandling:
         with patch.object(
             local_disk_backend.local_cpu_backend, "allocate", return_value=None
         ):
-            with caplog.at_level(logging.WARNING):
-                result = local_disk_backend.load_bytes_from_disk(
-                    key, path, dtype, shape, fmt
-                )
+            result = local_disk_backend.load_bytes_from_disk(
+                key, path, dtype, shape, fmt
+            )
 
         assert result is None, (
             "Expected None when staging pool is exhausted, not an assertion error"
         )
-        assert any(
-            "CPU staging pool exhausted" in record.message for record in caplog.records
-        ), "Expected a warning about CPU staging pool exhaustion"
+        # LMCache uses its own logger that writes to stderr, not stdlib
+        # logging handlers, so we check capsys instead of caplog.
+        captured = capsys.readouterr()
+        assert "CPU staging pool exhausted" in captured.err, (
+            "Expected a warning about CPU staging pool exhaustion in stderr"
+        )
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
@@ -458,9 +459,7 @@ class TestPoolExhaustionHandling:
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
-    def test_get_blocking_returns_none_on_pool_exhaustion(
-        self, local_disk_backend, caplog
-    ):
+    def test_get_blocking_returns_none_on_pool_exhaustion(self, local_disk_backend):
         """get_blocking must return None when load_bytes_from_disk returns
         None due to pool exhaustion (issue #2942 synchronous path)."""
         key = create_test_key(300)
@@ -478,8 +477,7 @@ class TestPoolExhaustionHandling:
         with patch.object(
             local_disk_backend.local_cpu_backend, "allocate", return_value=None
         ):
-            with caplog.at_level(logging.WARNING):
-                result = local_disk_backend.get_blocking(key)
+            result = local_disk_backend.get_blocking(key)
 
         assert result is None, (
             "get_blocking should return None when staging pool is exhausted"

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import shutil
@@ -458,6 +458,216 @@ class TestPoolExhaustionHandling:
         assert local_disk_backend.dict[key].pin_count == 0, (
             "pin_count should be 0 — alloc failed before pin()"
         )
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    # ------------------------------------------------------------------
+    # Partial-alloc failure tests (issue #3022)
+    # ------------------------------------------------------------------
+
+    def _insert_fake_entries(self, backend, keys):
+        """Insert fake DiskCacheMetadata for each key so lookups succeed."""
+        for key in keys:
+            path = backend._key_to_path(key)
+            backend.dict[key] = DiskCacheMetadata(
+                path=path,
+                size=1024,
+                shape=torch.Size([2, 28, 256, 8, 128]),
+                dtype=torch.bfloat16,
+                fmt=MemoryFormat.KV_2LTD,
+            )
+
+    def test_partial_alloc_cleanup_on_multi_key_failure(
+        self, local_disk_backend, async_loop
+    ):
+        """Issue #3022: When allocate fails on key 2 of 3, all side
+        effects from keys 0 and 1 (DiskCacheMetadata pins, MemoryObj
+        pins/refs) must be fully rolled back, and result must be []."""
+        keys = [create_test_key(400 + i) for i in range(3)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(2)]
+        allocate_returns = iter([mock_objs[0], mock_objs[1], None])
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            side_effect=lambda *a, **kw: next(allocate_returns),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_multi", keys=keys
+                )
+            )
+
+        # Must return empty — no partial results
+        assert result == []
+
+        # DiskCacheMetadata pin_count must be 0 for ALL keys
+        for i, key in enumerate(keys):
+            assert local_disk_backend.dict[key].pin_count == 0, (
+                f"key {i}: pin_count should be 0 after rollback"
+            )
+
+        # MemoryObj cleanup: unpin + ref_count_down called on both
+        for i, obj in enumerate(mock_objs):
+            obj.unpin.assert_called_once()
+            obj.ref_count_down.assert_called_once()
+
+        # disk_lock must be released
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock NOT released after partial alloc failure"
+        local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_partial_alloc_no_stale_data_returned(self, local_disk_backend, async_loop):
+        """CRITICAL (issue #3022): When first allocation succeeds but
+        second fails, the returned list must be empty — NOT contain the
+        first allocated-but-unloaded MemoryObj (stale/corrupt data)."""
+        keys = [create_test_key(500 + i) for i in range(2)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        stale_obj = MagicMock(name="stale_MemoryObj")
+        allocate_returns = iter([stale_obj, None])
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            side_effect=lambda *a, **kw: next(allocate_returns),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_stale", keys=keys
+                )
+            )
+
+        # THE critical assertion: empty list, not [stale_obj]
+        assert len(result) == 0, (
+            f"Expected 0 items but got {len(result)} — "
+            "allocated-but-unloaded MemoryObj would be stale/corrupt data"
+        )
+        assert stale_obj not in result
+
+        # Verify stale_obj was properly cleaned up
+        stale_obj.unpin.assert_called_once()
+        stale_obj.ref_count_down.assert_called_once()
+
+        # pin_count check
+        for key in keys:
+            assert local_disk_backend.dict[key].pin_count == 0
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_first_key_alloc_failure_multi_key_batch(
+        self, local_disk_backend, async_loop
+    ):
+        """First-key failure in a multi-key batch: no side effects on
+        any key, consistent with the single-key test above."""
+        keys = [create_test_key(700 + i) for i in range(3)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            return_value=None,
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_first_fail", keys=keys
+                )
+            )
+
+        assert result == []
+        for key in keys:
+            assert local_disk_backend.dict[key].pin_count == 0
+
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock NOT released after first-key failure"
+        local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_last_key_in_large_batch_fails(self, local_disk_backend, async_loop):
+        """Edge case: last key (of 5) fails — all 4 successful
+        allocations must be fully rolled back."""
+        n_keys = 5
+        keys = [create_test_key(800 + i) for i in range(n_keys)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(n_keys - 1)]
+        returns = mock_objs + [None]  # last one fails
+        allocate_returns = iter(returns)
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            side_effect=lambda *a, **kw: next(allocate_returns),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_last_fail", keys=keys
+                )
+            )
+
+        assert result == []
+
+        for i, key in enumerate(keys):
+            assert local_disk_backend.dict[key].pin_count == 0, (
+                f"key {i}: pin_count should be 0 after rollback"
+            )
+
+        for obj in mock_objs:
+            obj.unpin.assert_called_once()
+            obj.ref_count_down.assert_called_once()
+
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock NOT released after last-key failure"
+        local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_all_keys_succeed_returns_full_batch(self, local_disk_backend, async_loop):
+        """Happy path: all allocations succeed → result contains
+        exactly len(keys) items with all pins intact."""
+        keys = [create_test_key(600 + i) for i in range(3)]
+        self._insert_fake_entries(local_disk_backend, keys)
+
+        mock_objs = [MagicMock(name=f"MemoryObj_{i}") for i in range(3)]
+        allocate_returns = iter(mock_objs)
+
+        async def fake_submit_task(*args, **kwargs):
+            return kwargs.get("memory_objs", [])
+
+        with (
+            patch.object(
+                local_disk_backend.local_cpu_backend,
+                "allocate",
+                side_effect=lambda *a, **kw: next(allocate_returns),
+            ),
+            patch.object(
+                local_disk_backend.disk_worker,
+                "submit_task",
+                side_effect=fake_submit_task,
+            ),
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test_happy", keys=keys
+                )
+            )
+
+        assert len(result) == len(keys), (
+            f"Expected {len(keys)} items but got {len(result)}"
+        )
+
+        # DiskCacheMetadata should stay pinned (pin_count == 1)
+        for key in keys:
+            assert local_disk_backend.dict[key].pin_count == 1
+
+        # Each MemoryObj should have been pinned once
+        for obj in mock_objs:
+            obj.pin.assert_called_once()
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -2,7 +2,6 @@
 # Standard
 from unittest.mock import patch
 import asyncio
-import logging
 import os
 import shutil
 import tempfile
@@ -389,7 +388,7 @@ class TestPoolExhaustionHandling:
     pool is exhausted during disk I/O."""
 
     def test_load_bytes_from_disk_returns_none_on_pool_exhaustion(
-        self, local_disk_backend, caplog
+        self, local_disk_backend, capsys
     ):
         """load_bytes_from_disk must return None (not crash) when allocate
         returns None, and emit a warning log."""
@@ -402,17 +401,19 @@ class TestPoolExhaustionHandling:
         with patch.object(
             local_disk_backend.local_cpu_backend, "allocate", return_value=None
         ):
-            with caplog.at_level(logging.WARNING):
-                result = local_disk_backend.load_bytes_from_disk(
-                    key, path, dtype, shape, fmt
-                )
+            result = local_disk_backend.load_bytes_from_disk(
+                key, path, dtype, shape, fmt
+            )
 
         assert result is None, (
             "Expected None when staging pool is exhausted, not an assertion error"
         )
-        assert any(
-            "CPU staging pool exhausted" in record.message for record in caplog.records
-        ), "Expected a warning about CPU staging pool exhaustion"
+        # LMCache uses its own logger that writes to stderr, not stdlib
+        # logging handlers, so we check capsys instead of caplog.
+        captured = capsys.readouterr()
+        assert "CPU staging pool exhausted" in captured.err, (
+            "Expected a warning about CPU staging pool exhaustion in stderr"
+        )
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
@@ -460,9 +461,7 @@ class TestPoolExhaustionHandling:
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
-    def test_get_blocking_returns_none_on_pool_exhaustion(
-        self, local_disk_backend, caplog
-    ):
+    def test_get_blocking_returns_none_on_pool_exhaustion(self, local_disk_backend):
         """get_blocking must return None when load_bytes_from_disk returns
         None due to pool exhaustion (issue #2942 synchronous path)."""
         key = create_test_key(300)
@@ -480,8 +479,7 @@ class TestPoolExhaustionHandling:
         with patch.object(
             local_disk_backend.local_cpu_backend, "allocate", return_value=None
         ):
-            with caplog.at_level(logging.WARNING):
-                result = local_disk_backend.get_blocking(key)
+            result = local_disk_backend.get_blocking(key)
 
         assert result is None, (
             "get_blocking should return None when staging pool is exhausted"

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import patch
 import asyncio
+import logging
 import os
 import shutil
 import tempfile
@@ -10,9 +12,10 @@ import pytest
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import CacheEngineKey, DiskCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
+from lmcache.v1.memory_management import MemoryFormat
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -379,3 +382,109 @@ class TestParseLocalDisk:
 
     def test_empty_string(self):
         assert _parse_local_disk("") is None
+
+
+class TestPoolExhaustionHandling:
+    """Regression tests for issue #2942: graceful handling when CPU staging
+    pool is exhausted during disk I/O."""
+
+    def test_load_bytes_from_disk_returns_none_on_pool_exhaustion(
+        self, local_disk_backend, caplog
+    ):
+        """load_bytes_from_disk must return None (not crash) when allocate
+        returns None, and emit a warning log."""
+        key = create_test_key(100)
+        path = local_disk_backend._key_to_path(key)
+        dtype = torch.bfloat16
+        shape = torch.Size([2, 28, 256, 8, 128])
+        fmt = MemoryFormat.KV_2LTD
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            with caplog.at_level(logging.WARNING):
+                result = local_disk_backend.load_bytes_from_disk(
+                    key, path, dtype, shape, fmt
+                )
+
+        assert result is None, (
+            "Expected None when staging pool is exhausted, not an assertion error"
+        )
+        assert any(
+            "CPU staging pool exhausted" in record.message for record in caplog.records
+        ), "Expected a warning about CPU staging pool exhaustion"
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_batched_get_non_blocking_releases_lock_on_alloc_failure(
+        self, local_disk_backend, async_loop
+    ):
+        """batched_get_non_blocking must release disk_lock even when allocate
+        returns None (issue #2942 lock leak)."""
+        key = create_test_key(200)
+        path = local_disk_backend._key_to_path(key)
+
+        # Insert a fake entry so the key lookup succeeds inside the method.
+        local_disk_backend.dict[key] = DiskCacheMetadata(
+            path=path,
+            size=1024,
+            shape=torch.Size([2, 28, 256, 8, 128]),
+            dtype=torch.bfloat16,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            result = async_loop.run_until_complete(
+                local_disk_backend.batched_get_non_blocking(
+                    lookup_id="test", keys=[key]
+                )
+            )
+
+        # The method should return an empty list (partial results before the
+        # failing key) rather than raising.
+        assert result == []
+
+        # The critical check: disk_lock must be released after the early
+        # return, so acquiring it here must succeed immediately.
+        acquired = local_disk_backend.disk_lock.acquire(timeout=1)
+        assert acquired, "disk_lock was NOT released after alloc failure — lock leak!"
+        local_disk_backend.disk_lock.release()
+
+        # pin() should NOT have been called on the metadata — the early
+        # return happens before the pin() call.
+        assert local_disk_backend.dict[key].pin_count == 0, (
+            "pin_count should be 0 — alloc failed before pin()"
+        )
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_get_blocking_returns_none_on_pool_exhaustion(
+        self, local_disk_backend, caplog
+    ):
+        """get_blocking must return None when load_bytes_from_disk returns
+        None due to pool exhaustion (issue #2942 synchronous path)."""
+        key = create_test_key(300)
+        path = local_disk_backend._key_to_path(key)
+
+        # Insert a fake entry so the key lookup succeeds.
+        local_disk_backend.dict[key] = DiskCacheMetadata(
+            path=path,
+            size=1024,
+            shape=torch.Size([2, 28, 256, 8, 128]),
+            dtype=torch.bfloat16,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            with caplog.at_level(logging.WARNING):
+                result = local_disk_backend.get_blocking(key)
+
+        assert result is None, (
+            "get_blocking should return None when staging pool is exhausted"
+        )
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## Summary

Fixes #2942 (deadlock when `use_hot=False` and staging buffer full)
Fixes #3022 (partial alloc failure returns unloaded MemoryObjs  silent data corruption, found by @DongDongJu during review)

## Fix 1: Deadlock prevention (#2942)

### Root Cause
`LocalCPUBackend.allocate()` and `batched_allocate()` enter a `while True:` loop whose only exit (other than success) is inside `if self.use_hot:`. When `use_hot=False`, eviction is structurally impossible  `hot_cache` is always empty. With `busy_loop=True`, the loop spins forever.

### Changes in `local_cpu_backend.py`
Added guard before `while True:` in both `allocate()` and `batched_allocate()`:
```python
if not self.use_hot:
    busy_loop = False
```
Zero impact on `use_hot=True` path.

### Changes in `local_disk_backend.py`
- `load_bytes_from_disk()`: replaced `assert memory_obj is not None` with graceful `return None` + warning log
- `batched_get_non_blocking()`: fixed pre-existing `disk_lock` leak on early return

## Fix 2: Silent data corruption (#3022)

### Root Cause
`batched_get_non_blocking()` returns `mem_objs` on allocation failure mid-batch, but `disk_worker.submit_task` (which reads data from disk into the memory buffers) is completely skipped. The returned `MemoryObj`s contain stale pool memory, not valid KV cache data. No layer in the call chain validates data content  stale memory flows directly to GPU via `batched_to_gpu()`.

Additionally: `DiskCacheMetadata.pin()` and `MemoryObj.pin()` were called but never undone on this path.

### Changes in `local_disk_backend.py`
Early return now cleans up all side effects in a `try/finally` block:
```python
if memory_obj is None:
    try:
        for prev_obj in mem_objs:
            prev_obj.unpin()
            prev_obj.ref_count_down()
        for prev_key in keys[:len(mem_objs)]:
            if prev_key in self.dict:
                self.dict[prev_key].unpin()
    finally:
        self.disk_lock.release()
    return []
```

## Testing

9 regression tests added across both files:
- `test_allocate_no_deadlock_use_hot_false`  core deadlock prevention
- `test_load_bytes_from_disk_returns_none_on_pool_exhaustion`  graceful None
- `test_batched_get_non_blocking_releases_lock_on_alloc_failure`  lock release
- `test_get_blocking_returns_none_on_pool_exhaustion`  sync path
- `test_partial_alloc_cleanup_on_multi_key_failure`  multi-key rollback (#3022)
- `test_partial_alloc_no_stale_data_returned`  **critical**: no stale objects (#3022)
- `test_first_key_alloc_failure_multi_key_batch`  edge case
- `test_last_key_in_large_batch_fails`  5-key edge case
- `test_all_keys_succeed_returns_full_batch`  happy path baseline

All `pre-commit` hooks pass (ruff, mypy, isort, codespell, SPDX).

## Follow-up Issues
- #3015: `get_blocking()` records phantom cache hit when `load_bytes_from_disk()` fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core storage/memory-allocation paths and changes failure semantics (returning `None`/empty batch and rolling back pins), which could impact cache hit behavior under memory pressure despite being well-covered by new regression tests.
> 
> **Overview**
> Prevents a potential infinite busy-loop in `LocalCPUBackend.allocate()`/`batched_allocate()` when `use_hot=False` by forcing `busy_loop=False` in that configuration so allocation fails fast with `None` instead of hanging.
> 
> Hardens `LocalDiskBackend` disk reads/prefetch when the CPU staging pool is exhausted: `load_bytes_from_disk()` now returns `None` with a warning (instead of asserting), and `batched_get_non_blocking()` now drops the entire batch on mid-batch allocation failure while rolling back pins/refcounts, releasing `disk_lock`, and deferring cache-policy hit updates until the whole batch is successfully staged to avoid phantom hits and stale/uninitialized data exposure.
> 
> Adds regression tests covering the deadlock case, lock-release behavior, synchronous/async pool-exhaustion handling, and multi-key partial-allocation rollback to prevent silent data corruption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f719182582650a18b63e7bdc0c077d1479f040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->