### PR TITLE
Fix LocalDiskBackend.close() to drain async writes before disk cleanup

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -670,13 +670,31 @@ class LocalDiskBackend(StorageBackendInterface):
         Ordering is important: ``disk_worker.close()`` must be called before
         the file cleanup so that any in-flight async ``put`` tasks complete and
         all entries are present in ``self.dict`` before we snapshot the keys.
+
+        Note: this only handles graceful shutdown.  On a hard crash (SIGKILL,
+        OOM) files will still be orphaned; cross-restart recovery requires a
+        separate persistent index (see issue #1175 / PR #2734).
         """
-        if self.batched_msg_sender is not None:
-            self.batched_msg_sender.close()
-            self.batched_msg_sender = None
+        try:
+            if self.batched_msg_sender is not None:
+                self.batched_msg_sender.close()
+                self.batched_msg_sender = None
+        except Exception:
+            logger.warning(
+                "LocalDiskBackend.close(): error closing batched_msg_sender",
+                exc_info=True,
+            )
 
         # Drain all queued async disk I/O before snapshotting keys.
-        self.disk_worker.close()
+        # This MUST complete before we iterate self.dict so that any in-flight
+        # put tasks finish writing files and inserting entries.
+        try:
+            self.disk_worker.close()
+        except Exception:
+            logger.warning(
+                "LocalDiskBackend.close(): error draining disk_worker",
+                exc_info=True,
+            )
 
         deleted = 0
         keys = list(self.dict.keys())

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -668,13 +668,25 @@ class LocalDiskBackend(StorageBackendInterface):
         """Shut down the backend and delete all tracked on-disk cache files.
 
         Ordering is important: ``disk_worker.close()`` must be called before
-        the file cleanup so that any in-flight async ``put`` tasks complete and
-        all entries are present in ``self.dict`` before we snapshot the keys.
+        the controller sender is closed or file cleanup begins so that any
+        in-flight async ``put`` tasks complete and all entries are present in
+        ``self.dict`` before we snapshot the keys.
 
         Note: this only handles graceful shutdown.  On a hard crash (SIGKILL,
         OOM) files will still be orphaned; cross-restart recovery requires a
         separate persistent index (see issue #1175 / PR #2734).
         """
+        # Drain all queued async disk I/O before closing the sender or
+        # snapshotting keys. This MUST complete first so that in-flight put
+        # tasks can still report admissions without racing on a cleared sender.
+        try:
+            self.disk_worker.close()
+        except Exception:
+            logger.warning(
+                "LocalDiskBackend.close(): error draining disk_worker",
+                exc_info=True,
+            )
+
         if self.batched_msg_sender is not None:
             try:
                 self.batched_msg_sender.close()
@@ -686,21 +698,13 @@ class LocalDiskBackend(StorageBackendInterface):
             finally:
                 self.batched_msg_sender = None
 
-        # Drain all queued async disk I/O before snapshotting keys.
-        # This MUST complete before we iterate self.dict so that any in-flight
-        # put tasks finish writing files and inserting entries.
-        try:
-            self.disk_worker.close()
-        except Exception:
-            logger.warning(
-                "LocalDiskBackend.close(): error draining disk_worker",
-                exc_info=True,
-            )
-
         deleted = 0
         with self.disk_lock:
             items = list(self.dict.items())
             self.dict.clear()
+            self.usage = 0
+            self.current_cache_size = 0.0
+            self.stats_monitor.update_local_storage_usage(0)
 
         for _, meta in items:
             try:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -675,15 +675,16 @@ class LocalDiskBackend(StorageBackendInterface):
         OOM) files will still be orphaned; cross-restart recovery requires a
         separate persistent index (see issue #1175 / PR #2734).
         """
-        try:
-            if self.batched_msg_sender is not None:
+        if self.batched_msg_sender is not None:
+            try:
                 self.batched_msg_sender.close()
+            except Exception:
+                logger.warning(
+                    "LocalDiskBackend.close(): error closing batched_msg_sender",
+                    exc_info=True,
+                )
+            finally:
                 self.batched_msg_sender = None
-        except Exception:
-            logger.warning(
-                "LocalDiskBackend.close(): error closing batched_msg_sender",
-                exc_info=True,
-            )
 
         # Drain all queued async disk I/O before snapshotting keys.
         # This MUST complete before we iterate self.dict so that any in-flight
@@ -697,11 +698,11 @@ class LocalDiskBackend(StorageBackendInterface):
             )
 
         deleted = 0
-        keys = list(self.dict.keys())
-        for key in keys:
-            meta = self.dict.pop(key, None)
-            if meta is None:
-                continue
+        with self.disk_lock:
+            items = list(self.dict.items())
+            self.dict.clear()
+
+        for _, meta in items:
             try:
                 os.remove(meta.path)
                 deleted += 1

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -665,6 +665,36 @@ class LocalDiskBackend(StorageBackendInterface):
         return self.local_cpu_backend
 
     def close(self) -> None:
+        """Shut down the backend and delete all tracked on-disk cache files.
+
+        Ordering is important: ``disk_worker.close()`` must be called before
+        the file cleanup so that any in-flight async ``put`` tasks complete and
+        all entries are present in ``self.dict`` before we snapshot the keys.
+        """
         if self.batched_msg_sender is not None:
             self.batched_msg_sender.close()
+            self.batched_msg_sender = None
+
+        # Drain all queued async disk I/O before snapshotting keys.
         self.disk_worker.close()
+
+        deleted = 0
+        keys = list(self.dict.keys())
+        for key in keys:
+            meta = self.dict.pop(key, None)
+            if meta is None:
+                continue
+            try:
+                os.remove(meta.path)
+                deleted += 1
+            except OSError as e:
+                logger.warning(
+                    "LocalDiskBackend.close(): failed to remove %s: %s",
+                    meta.path,
+                    e,
+                )
+        logger.info(
+            "LocalDiskBackend.close(): deleted %d cached file(s) from %s",
+            deleted,
+            self.path,
+        )

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import shutil
@@ -10,7 +11,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import CacheEngineKey, DiskCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
 from lmcache.v1.metadata import LMCacheMetadata
@@ -379,3 +380,108 @@ class TestParseLocalDisk:
 
     def test_empty_string(self):
         assert _parse_local_disk("") is None
+
+
+class TestLocalDiskBackendClose:
+    """Test cases for LocalDiskBackend.close() file cleanup (issue #2840)."""
+
+    def _make_backend(self, temp_dir, async_loop, local_cpu_backend):
+        """Create a LocalDiskBackend with os.statvfs mocked for Windows."""
+        config = create_test_config(temp_dir)
+        fake_stat = MagicMock()
+        fake_stat.f_bsize = 4096
+        fake_stat.f_bavail = 1000000
+        with patch("os.statvfs", return_value=fake_stat):
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:0",
+            )
+        return backend
+
+    def test_close_deletes_tracked_files(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """close() should delete every file tracked in backend.dict."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        paths = []
+        for i in range(3):
+            fpath = os.path.join(temp_disk_path, f"cache_{i}.pt")
+            with open(fpath, "wb") as f:
+                f.write(b"\x00" * 1024)
+            paths.append(fpath)
+            key = create_test_key(100 + i)
+            backend.dict[key] = DiskCacheMetadata(path=fpath, size=1024)
+
+        backend.close()
+
+        for fpath in paths:
+            assert not os.path.exists(fpath), f"{fpath} should have been deleted"
+        assert len(backend.dict) == 0
+
+        local_cpu_backend.memory_allocator.close()
+
+    def test_close_preserves_untracked_files(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """close() must not delete files that are not tracked in backend.dict."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        untracked = os.path.join(temp_disk_path, "untracked.txt")
+        with open(untracked, "wb") as f:
+            f.write(b"keep me")
+
+        backend.close()
+
+        assert os.path.exists(untracked), "Untracked file should not be removed"
+        os.remove(untracked)
+
+        local_cpu_backend.memory_allocator.close()
+
+    def test_close_missing_file_no_raise(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """close() should not raise when a tracked path no longer exists."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        key = create_test_key(200)
+        backend.dict[key] = DiskCacheMetadata(
+            path=os.path.join(temp_disk_path, "nonexistent.pt"),
+            size=512,
+        )
+
+        # Must not raise
+        backend.close()
+
+        local_cpu_backend.memory_allocator.close()
+
+    def test_close_idempotent(self, temp_disk_path, async_loop, local_cpu_backend):
+        """Calling close() twice should not raise."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        fpath = os.path.join(temp_disk_path, "idem.pt")
+        with open(fpath, "wb") as f:
+            f.write(b"\x00" * 256)
+        key = create_test_key(300)
+        backend.dict[key] = DiskCacheMetadata(path=fpath, size=256)
+
+        backend.close()
+        backend.close()  # second call must not raise
+
+        assert len(backend.dict) == 0
+
+        local_cpu_backend.memory_allocator.close()
+
+    def test_close_empty_backend(self, temp_disk_path, async_loop, local_cpu_backend):
+        """close() on a backend with no tracked files should not raise."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        assert len(backend.dict) == 0
+
+        backend.close()  # must not raise
+
+        assert len(backend.dict) == 0
+
+        local_cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -543,3 +543,20 @@ class TestLocalDiskBackendClose:
         assert backend.batched_msg_sender is None
 
         local_cpu_backend.memory_allocator.close()
+
+    def test_close_sender_raises_still_cleared(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """batched_msg_sender is set to None even if sender.close() raises."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        mock_sender = MagicMock()
+        mock_sender.close.side_effect = RuntimeError("boom")
+        backend.batched_msg_sender = mock_sender
+
+        backend.close()  # must not raise
+
+        mock_sender.close.assert_called_once()
+        assert backend.batched_msg_sender is None
+
+        local_cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -485,3 +485,61 @@ class TestLocalDiskBackendClose:
         assert len(backend.dict) == 0
 
         local_cpu_backend.memory_allocator.close()
+
+    def test_close_drains_disk_worker_before_file_removal(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """disk_worker.close() MUST be called before os.remove() to prevent
+        in-flight async puts from leaking files (regression test for #2840)."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        call_order: list = []
+        original_disk_worker_close = backend.disk_worker.close
+
+        def recording_disk_worker_close():
+            call_order.append("disk_worker.close")
+            original_disk_worker_close()
+
+        fpath = os.path.join(temp_disk_path, "ordering_test.pt")
+        with open(fpath, "wb") as f:
+            f.write(b"\x00" * 256)
+        key = create_test_key(999)
+        backend.dict[key] = DiskCacheMetadata(path=fpath, size=256)
+
+        original_os_remove = os.remove
+
+        def recording_os_remove(path):
+            call_order.append("os.remove")
+            original_os_remove(path)
+
+        with (
+            patch.object(
+                backend.disk_worker, "close", side_effect=recording_disk_worker_close
+            ),
+            patch("os.remove", side_effect=recording_os_remove),
+        ):
+            backend.close()
+
+        assert call_order[0] == "disk_worker.close", (
+            "disk_worker.close() must be called BEFORE any os.remove() — "
+            f"actual order: {call_order}"
+        )
+        assert "os.remove" in call_order
+
+        local_cpu_backend.memory_allocator.close()
+
+    def test_close_calls_batched_msg_sender_close(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """close() should call batched_msg_sender.close() and set it to None."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        mock_sender = MagicMock()
+        backend.batched_msg_sender = mock_sender
+
+        backend.close()
+
+        mock_sender.close.assert_called_once()
+        assert backend.batched_msg_sender is None
+
+        local_cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -14,6 +14,7 @@ import torch
 from lmcache.utils import CacheEngineKey, DiskCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
+from lmcache.v1.memory_management import MemoryFormat
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -391,13 +392,18 @@ class TestLocalDiskBackendClose:
         fake_stat = MagicMock()
         fake_stat.f_bsize = 4096
         fake_stat.f_bavail = 1000000
-        with patch("os.statvfs", return_value=fake_stat):
+        with patch(
+            "lmcache.v1.storage_backend.local_disk_backend.os.statvfs",
+            return_value=fake_stat,
+            create=True,
+        ):
             backend = LocalDiskBackend(
                 config=config,
                 loop=async_loop,
                 local_cpu_backend=local_cpu_backend,
                 dst_device="cuda:0",
             )
+        backend.disk_worker.close = MagicMock()
         return backend
 
     def test_close_deletes_tracked_files(
@@ -544,6 +550,36 @@ class TestLocalDiskBackendClose:
 
         local_cpu_backend.memory_allocator.close()
 
+    def test_close_keeps_sender_alive_until_disk_worker_drains(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """In-flight put completion must not race on a cleared sender."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        mock_sender = MagicMock()
+        backend.batched_msg_sender = mock_sender
+        late_key = create_test_key(301)
+
+        def recording_disk_worker_close():
+            backend.insert_key(
+                late_key,
+                128,
+                torch.Size([1]),
+                torch.float16,
+                MemoryFormat.UNDEFINED,
+            )
+
+        with patch.object(
+            backend.disk_worker, "close", side_effect=recording_disk_worker_close
+        ):
+            backend.close()
+
+        mock_sender.add_kv_op.assert_called_once()
+        mock_sender.close.assert_called_once()
+        assert backend.batched_msg_sender is None
+
+        local_cpu_backend.memory_allocator.close()
+
     def test_close_sender_raises_still_cleared(
         self, temp_disk_path, async_loop, local_cpu_backend
     ):
@@ -558,5 +594,29 @@ class TestLocalDiskBackendClose:
 
         mock_sender.close.assert_called_once()
         assert backend.batched_msg_sender is None
+
+        local_cpu_backend.memory_allocator.close()
+
+    def test_close_resets_usage_and_metrics_under_lock(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """close() should leave cache bookkeeping in a consistent empty state."""
+        backend = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+
+        fpath = os.path.join(temp_disk_path, "usage_reset.pt")
+        with open(fpath, "wb") as f:
+            f.write(b"\x00" * 64)
+
+        key = create_test_key(302)
+        backend.dict[key] = DiskCacheMetadata(path=fpath, size=64)
+        backend.usage = 64
+        backend.current_cache_size = 64
+        backend.stats_monitor = MagicMock()
+
+        backend.close()
+
+        assert backend.usage == 0
+        assert backend.current_cache_size == 0
+        backend.stats_monitor.update_local_storage_usage.assert_called_once_with(0)
 
         local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## What this PR does / why we need it

`LocalDiskBackend` stores KV cache chunks as `.pt` files under `self.path`, but the key-to-file mapping (`self.dict`) lives in memory only. On every graceful shutdown, `close()` stopped the worker executor without deleting any files  leaving all cached `.pt` files orphaned and silently leaking disk space (issue #2840).

### Root cause

The original `close()` had no file cleanup at all. PR #2841 added cleanup, but in the wrong order: it called `batched_remove()` before `disk_worker.close()`. The disk worker runs up to 4 async threads that may still be executing `put` tasks at that point  each in-flight put writes a new file and adds a new entry to `self.dict` *after* the key snapshot is taken, so those files are never deleted.

### This fix

1. **Drain first**  call `disk_worker.close()` (`executor.shutdown(wait=True)`) before snapshotting keys, ensuring `self.dict` is fully up-to-date.
2. **Thread-safe cleanup**  acquire `disk_lock`, snapshot `dict.items()`, `dict.clear()` atomically, then delete files outside the lock. Prevents races with concurrent `get_blocking()` calls.
3. **Per-file error handling**  each `os.remove()` is wrapped in `try/except OSError` so a single missing or locked file cannot abort the rest of the cleanup.
4. **Exception safety**  `batched_msg_sender.close()` and `disk_worker.close()` are each wrapped in `try/except Exception`; `batched_msg_sender = None` is in a `finally` block so `close()` is properly idempotent even if the sender's `close()` raises.
5. **Logging**  INFO log with count of files deleted; WARNING per file removal failure.

**Limitation**: graceful shutdown only. On a hard crash (SIGKILL, OOM), files still orphan. Full cross-restart recovery via a persistent index is tracked separately in PR #2734, which is complementary to this fix.

## Special notes for reviewers

- This PR supersedes PR #2841 (same goal, fixes the ordering race, adds tests, adds error handling). A comment has been left on that PR explaining the issue.
- PR #2734 (persistent index / crash recovery) is orthogonal  both PRs should eventually merge.
- All pre-commit hooks pass (isort, ruff, ruff-format, mypy, codespell).

## Tests

New class `TestLocalDiskBackendClose` with 8 cases:

| Test | Verifies |
|------|----------|
| `test_close_deletes_tracked_files` | 3 injected files deleted, `dict` empty |
| `test_close_preserves_untracked_files` | File not in `dict` untouched |
| `test_close_missing_file_no_raise` | Dict entry with non-existent path  no exception |
| `test_close_idempotent` | Two `close()` calls  no exception |
| `test_close_empty_backend` | Empty `dict`  `close()` is safe no-op |
| `test_close_drains_disk_worker_before_file_removal` | Records call order; asserts `disk_worker.close()` precedes `os.remove()`  **would have caught PR #2841's bug** |
| `test_close_calls_batched_msg_sender_close` | Mock sender's `close()` called once, attribute set to `None` |
| `test_close_sender_raises_still_cleared` | Sender `close()` raises `RuntimeError`  attribute still set to `None` (verifies `finally` block) |

- [x] This PR contains unit tests

Fixes #2840

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shutdown and file-deletion logic in a storage backend; mistakes could leak disk or delete the wrong files, but deletion is limited to tracked paths and is covered by targeted regression tests.
> 
> **Overview**
> Fixes graceful shutdown of `LocalDiskBackend` to **prevent orphaned on-disk `.pt` cache files** and ordering races with in-flight async `put` operations.
> 
> `close()` now drains `disk_worker` *before* closing the controller sender and snapshotting `dict`, then clears cache bookkeeping under `disk_lock`, deletes each tracked file with per-file error handling, and logs deletion stats; sender shutdown is made exception-safe and idempotent.
> 
> Adds a new `TestLocalDiskBackendClose` suite covering deletion behavior, call ordering (drain-before-remove), sender closing semantics, idempotency, missing files, and metrics/usage reset (including a Windows-friendly `os.statvfs` mock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb73cc2267180cb5dab68a39db6ce59f271d97a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->