### PR TITLE
[Bugfix] Include vLLM cache_salt in LMCache cache identity (#2878)

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
+import hashlib
 import os
 
 # Third Party
@@ -90,7 +91,28 @@ class DisaggSpec:
 tmp_disagg_tracker: dict[str, DisaggSpec] = {}
 
 
-def extract_request_configs(sampling_params: SamplingParams) -> Optional[dict]:
+def extract_request_configs(
+    sampling_params: SamplingParams,
+    cache_salt: Optional[str] = None,
+) -> Optional[dict]:
+    """Build the ``request_configs`` dict that influences LMCache cache key
+    identity.
+
+    Extracts all ``lmcache.*`` keys from the vLLM
+    ``sampling_params.extra_args["kv_transfer_params"]`` dict and,
+    optionally, folds a vLLM ``cache_salt`` into the config as a
+    ``lmcache.tag.cachesalt`` entry so that requests with different salts
+    produce distinct cache keys.
+
+    Args:
+        sampling_params: The vLLM sampling parameters for the request.
+        cache_salt: The optional vLLM ``cache_salt`` string. An empty
+            string is treated as *no salt* (same as ``None``).
+
+    Returns:
+        A dict of ``lmcache.*`` config entries, or ``None`` if there are
+        no relevant entries.
+    """
     request_configs = None
     if sampling_params and sampling_params.extra_args is not None:
         if kv_transfer_params := sampling_params.extra_args.get("kv_transfer_params"):
@@ -99,7 +121,25 @@ def extract_request_configs(sampling_params: SamplingParams) -> Optional[dict]:
                     if request_configs is None:
                         request_configs = {}
                     request_configs[k] = v
+
+    if cache_salt:  # treats "" the same as None (no salt)
+        if request_configs is None:
+            request_configs = {}
+        request_configs["lmcache.tag.cachesalt"] = _cache_salt_tag_value(
+            cache_salt
+        )
+
     return request_configs
+
+
+def _cache_salt_tag_value(cache_salt: str) -> str:
+    """Return a tag-safe digest of a vLLM ``cache_salt`` string.
+
+    The LMCache tag serialization format uses ``%`` and ``@`` as
+    delimiters, so a raw salt could break parsing.  SHA-256 hex is
+    always safe and collision-resistant.
+    """
+    return hashlib.sha256(cache_salt.encode("utf-8")).hexdigest()
 
 
 @dataclass
@@ -147,6 +187,7 @@ class RequestTracker:
         num_tokens_to_compute: int,
         lmcache_cached_tokens: int,
         skip_save: bool,
+        cache_salt: Optional[str] = None,
     ) -> "RequestTracker":
         """Create the request tracker from a new request.
 
@@ -158,8 +199,10 @@ class RequestTracker:
                 local cache hit) and new tokens that will be scheduled.
             lmcache_cached_tokens (int): the number of tokens that are
                 cached in LMCache.
-            request_priority (int): the priority of the request
             skip_save (bool): whether the request cache should be saved
+            cache_salt (Optional[str]): the vLLM ``cache_salt`` for
+                this request, used to isolate cache entries. ``None``
+                or ``""`` means no salt.
         """
         # vLLM 0.9.0 update: request.block_ids changed from list[int] to
         # tuple[list[int]]
@@ -183,7 +226,9 @@ class RequestTracker:
         # NOTE: Initialized in `update_state_after_alloc`
         disagg_spec = tmp_disagg_tracker.pop(new_request.req_id, None)
 
-        request_configs = extract_request_configs(new_request.sampling_params)
+        request_configs = extract_request_configs(
+            new_request.sampling_params, cache_salt=cache_salt
+        )
 
         mm_hashes, mm_positions = extract_mm_features(new_request, modify=True)
 
@@ -829,6 +874,7 @@ class LMCacheConnectorV1Impl:
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         vllm_cached_tokens=request.load_spec.vllm_cached_tokens,
                         sync=sync,
+                        request_configs=request.request_configs,
                     )
                     # NOTE: retrieve for two layers at the first layer
                     next(layerwise_retriever)
@@ -1069,6 +1115,7 @@ class LMCacheConnectorV1Impl:
                     offset=skip_leading_tokens,
                     sync=is_first,
                     req_id=request.req_id,
+                    request_configs=request.request_configs,
                 )
                 self._layerwise_save_storers[request.req_id] = layerwise_storer
                 if is_first:
@@ -1275,7 +1322,10 @@ class LMCacheConnectorV1Impl:
                 apply_mm_hashes_to_token_ids(token_ids, mm_hashes, mm_positions)
                 token_ids = token_ids.tolist()
 
-            request_configs = extract_request_configs(request.sampling_params)
+            request_configs = extract_request_configs(
+                request.sampling_params,
+                cache_salt=getattr(request, "cache_salt", None),
+            )
             if self.skip_last_n_tokens > 0:
                 token_ids = token_ids[: -self.skip_last_n_tokens]
 
@@ -1468,12 +1518,23 @@ class LMCacheConnectorV1Impl:
                 and request_priority > self.config.priority_limit
             )
 
+            # Retrieve cache_salt from the full Request object stored
+            # during update_state_after_alloc; NewRequestData doesn't
+            # carry cache_salt.
+            vllm_request = self._unfinished_requests.get(request.req_id)
+            cache_salt = (
+                getattr(vllm_request, "cache_salt", None)
+                if vllm_request is not None
+                else None
+            )
+
             request_tracker = RequestTracker.from_new_request(
                 self.config,
                 request,
                 num_tokens_to_compute,
                 lmcache_cached_tokens,
                 skip_save,
+                cache_salt=cache_salt,
             )
             self._request_trackers[request.req_id] = request_tracker
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -865,6 +865,7 @@ class LMCacheConnectorV1Impl:
                         kvcaches=kvcaches,
                         slot_mapping=slot_mapping[:lmcache_cached_tokens],
                         vllm_cached_tokens=request.load_spec.vllm_cached_tokens,
+                        request_configs=request.request_configs,
                     )
                 else:
                     layerwise_retriever = self.lmcache_engine.retrieve_layer(

--- a/tests/v1/test_vllm_cache_salt.py
+++ b/tests/v1/test_vllm_cache_salt.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for vLLM cache_salt integration in LMCacheConnectorV1.
+
+Covers GitHub issue #2878: LMCacheConnectorV1 does not include vLLM
+cache_salt in LMCache cache identity.
+"""
+
+# Standard
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm")
+
+# First Party
+from lmcache.integration.vllm.vllm_v1_adapter import (
+    extract_request_configs,
+    _cache_salt_tag_value,
+)
+
+_TAG_KEY = "lmcache.tag.cachesalt"
+
+
+def _make_sampling_params(extra_args=None):
+    """Return a minimal SamplingParams-like object."""
+    return SimpleNamespace(extra_args=extra_args)
+
+
+# ---------------------------------------------------------------------------
+# extract_request_configs — basic salt handling
+# ---------------------------------------------------------------------------
+
+
+def test_extract_request_configs_cache_salt_none():
+    """cache_salt=None produces no cachesalt tag."""
+    sp = _make_sampling_params()
+    result = extract_request_configs(sp, cache_salt=None)
+    assert result is None
+
+
+def test_extract_request_configs_cache_salt_empty_string():
+    """cache_salt='' (vLLM default no-salt state) produces no cachesalt tag.
+
+    This is the critical edge case missing from PR #2880: empty string
+    must be treated identically to None, not as a distinct salt value.
+    """
+    sp = _make_sampling_params()
+    result = extract_request_configs(sp, cache_salt="")
+    assert result is None
+
+
+def test_extract_request_configs_cache_salt_value():
+    """A non-empty cache_salt injects a SHA-256 tag."""
+    sp = _make_sampling_params()
+    result = extract_request_configs(sp, cache_salt="salt-a")
+    assert result is not None
+    assert _TAG_KEY in result
+    expected = hashlib.sha256("salt-a".encode("utf-8")).hexdigest()
+    assert result[_TAG_KEY] == expected
+
+
+def test_extract_request_configs_salt_with_kv_transfer_params():
+    """Both kv_transfer_params lmcache keys and cache_salt merge into one dict."""
+    sp = _make_sampling_params(
+        extra_args={"kv_transfer_params": {"lmcache.skip_save": True}}
+    )
+    result = extract_request_configs(sp, cache_salt="salt-a")
+    assert result is not None
+    assert result.get("lmcache.skip_save") is True
+    assert _TAG_KEY in result
+    assert len(result) == 2
+
+
+def test_different_salts_produce_different_tags():
+    """Different salts map to different hash values."""
+    sp = _make_sampling_params()
+    result_a = extract_request_configs(sp, cache_salt="salt-a")
+    result_b = extract_request_configs(sp, cache_salt="salt-b")
+    assert result_a[_TAG_KEY] != result_b[_TAG_KEY]
+
+
+def test_same_salt_produces_same_tag():
+    """SHA-256 is deterministic — same input always yields the same tag."""
+    sp = _make_sampling_params()
+    result_1 = extract_request_configs(sp, cache_salt="salt-a")
+    result_2 = extract_request_configs(sp, cache_salt="salt-a")
+    assert result_1[_TAG_KEY] == result_2[_TAG_KEY]
+
+
+# ---------------------------------------------------------------------------
+# _cache_salt_tag_value — helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_cache_salt_tag_value_is_hex_sha256():
+    """_cache_salt_tag_value returns a 64-char hex SHA-256 digest."""
+    value = _cache_salt_tag_value("mysalt")
+    assert len(value) == 64
+    assert all(c in "0123456789abcdef" for c in value)
+    assert value == hashlib.sha256("mysalt".encode("utf-8")).hexdigest()
+
+
+def test_cache_salt_tag_value_no_special_chars():
+    """The tag value must not contain LMCache delimiters ('@', '%')."""
+    for salt in ["salt@foo", "bar%baz", "hello/world", "a b c"]:
+        value = _cache_salt_tag_value(salt)
+        assert "@" not in value
+        assert "%" not in value
+
+
+# ---------------------------------------------------------------------------
+# Layerwise paths: retrieve_layer / store_layer pass request_configs
+# ---------------------------------------------------------------------------
+
+
+def test_start_load_kv_layerwise_passes_request_configs():
+    """retrieve_layer() must receive request_configs so cache_salt tags are used."""
+    from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
+
+    req_configs = {_TAG_KEY: _cache_salt_tag_value("salt-a")}
+
+    mock_engine = MagicMock()
+    # retrieve_layer must return a generator (next() is called twice internally)
+    mock_engine.retrieve_layer.return_value = iter([None, None])
+
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector.lmcache_engine = mock_engine
+    connector.enable_blending = False
+    connector.use_layerwise = True
+    connector.layerwise_retrievers = []
+    connector.device = "cpu"
+    connector._lmcache_chunk_size = 8
+
+    import torch
+
+    kvcaches = {"layer0": torch.zeros(1)}
+    tokens = list(range(4))
+    token_mask = [True] * 4
+    slot_mapping = torch.arange(4, dtype=torch.long)
+
+    load_spec = SimpleNamespace(
+        lmcache_cached_tokens=4,
+        vllm_cached_tokens=0,
+    )
+    request = SimpleNamespace(
+        req_id="req-1",
+        request_configs=req_configs,
+        load_spec=load_spec,
+    )
+
+    # Directly invoke the layerwise retrieve branch logic
+    connector.lmcache_engine.retrieve_layer(
+        tokens[:4],
+        token_mask[:4],
+        kvcaches=kvcaches,
+        slot_mapping=slot_mapping[:4],
+        vllm_cached_tokens=load_spec.vllm_cached_tokens,
+        sync=True,
+        request_configs=request.request_configs,
+    )
+
+    call_kwargs = mock_engine.retrieve_layer.call_args.kwargs
+    assert "request_configs" in call_kwargs
+    assert call_kwargs["request_configs"] == req_configs
+
+
+def test_save_kv_layer_layerwise_passes_request_configs():
+    """store_layer() must receive request_configs so cache_salt tags are used."""
+    from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
+
+    req_configs = {_TAG_KEY: _cache_salt_tag_value("salt-a")}
+
+    mock_engine = MagicMock()
+    mock_engine.store_layer.return_value = iter([None])
+
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector.lmcache_engine = mock_engine
+
+    import torch
+
+    kvcaches = {"layer0": torch.zeros(1)}
+    token_ids = list(range(4))
+    store_mask = [True] * 4
+    slot_mapping = torch.arange(4, dtype=torch.long)
+
+    # Directly invoke the layerwise store call with request_configs
+    connector.lmcache_engine.store_layer(
+        token_ids,
+        mask=store_mask,
+        kvcaches=kvcaches,
+        slot_mapping=slot_mapping,
+        offset=0,
+        sync=True,
+        req_id="req-1",
+        request_configs=req_configs,
+    )
+
+    call_kwargs = mock_engine.store_layer.call_args.kwargs
+    assert "request_configs" in call_kwargs
+    assert call_kwargs["request_configs"] == req_configs

--- a/tests/v1/test_vllm_cache_salt.py
+++ b/tests/v1/test_vllm_cache_salt.py
@@ -17,8 +17,11 @@ pytest.importorskip("vllm")
 
 # First Party
 from lmcache.integration.vllm.vllm_v1_adapter import (
-    extract_request_configs,
+    LMCacheConnectorMetadata,
+    LMCacheConnectorV1Impl,
+    RequestTracker,
     _cache_salt_tag_value,
+    extract_request_configs,
 )
 
 _TAG_KEY = "lmcache.tag.cachesalt"
@@ -117,87 +120,172 @@ def test_cache_salt_tag_value_no_special_chars():
 
 
 def test_start_load_kv_layerwise_passes_request_configs():
-    """retrieve_layer() must receive request_configs so cache_salt tags are used."""
-    from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
-
-    req_configs = {_TAG_KEY: _cache_salt_tag_value("salt-a")}
-
-    mock_engine = MagicMock()
-    # retrieve_layer must return a generator (next() is called twice internally)
-    mock_engine.retrieve_layer.return_value = iter([None, None])
-
-    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
-    connector.lmcache_engine = mock_engine
-    connector.enable_blending = False
-    connector.use_layerwise = True
-    connector.layerwise_retrievers = []
-    connector.device = "cpu"
-    connector._lmcache_chunk_size = 8
-
+    """retrieve_layer() must receive request_configs when called via start_load_kv()."""
     import torch
 
-    kvcaches = {"layer0": torch.zeros(1)}
-    tokens = list(range(4))
-    token_mask = [True] * 4
-    slot_mapping = torch.arange(4, dtype=torch.long)
+    req_configs = {_TAG_KEY: _cache_salt_tag_value("salt-a")}
+    recorded: dict = {}
 
-    load_spec = SimpleNamespace(
-        lmcache_cached_tokens=4,
-        vllm_cached_tokens=0,
-    )
-    request = SimpleNamespace(
+    def _fake_retrieve_layer(token_ids, token_mask, **kwargs):
+        recorded.update(kwargs)
+        return iter([None, None, None])  # next() is called twice internally
+
+    req = SimpleNamespace(
         req_id="req-1",
+        token_ids=[1, 2, 3, 4],
+        slot_mapping=torch.arange(4, dtype=torch.long),
+        load_spec=SimpleNamespace(
+            lmcache_cached_tokens=4,
+            vllm_cached_tokens=0,
+            can_load=True,
+        ),
         request_configs=req_configs,
-        load_spec=load_spec,
     )
-
-    # Directly invoke the layerwise retrieve branch logic
-    connector.lmcache_engine.retrieve_layer(
-        tokens[:4],
-        token_mask[:4],
-        kvcaches=kvcaches,
-        slot_mapping=slot_mapping[:4],
-        vllm_cached_tokens=load_spec.vllm_cached_tokens,
-        sync=True,
-        request_configs=request.request_configs,
+    metadata = LMCacheConnectorMetadata(requests=[req])
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector._parent = SimpleNamespace(
+        _get_connector_metadata=lambda: metadata,
     )
+    connector.lmcache_engine = SimpleNamespace(retrieve_layer=_fake_retrieve_layer)
+    connector.enable_blending = False
+    connector.use_layerwise = True
+    connector.device = "cpu"
+    connector._lmcache_chunk_size = 8
+    connector.kv_caches = {"layer0": torch.zeros(1)}
+    connector.layerwise_retrievers = []
+    connector._stats_monitor = SimpleNamespace(
+        update_interval_vllm_hit_tokens=lambda x: None,
+        update_interval_prompt_tokens=lambda x: None,
+    )
+    forward_context = SimpleNamespace(attn_metadata=object())  # non-None triggers load
 
-    call_kwargs = mock_engine.retrieve_layer.call_args.kwargs
-    assert "request_configs" in call_kwargs
-    assert call_kwargs["request_configs"] == req_configs
+    connector.start_load_kv(forward_context)
+
+    assert "request_configs" in recorded, (
+        "retrieve_layer() was not called with request_configs"
+    )
+    assert recorded["request_configs"] == req_configs
 
 
 def test_save_kv_layer_layerwise_passes_request_configs():
-    """store_layer() must receive request_configs so cache_salt tags are used."""
-    from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
-
-    req_configs = {_TAG_KEY: _cache_salt_tag_value("salt-a")}
-
-    mock_engine = MagicMock()
-    mock_engine.store_layer.return_value = iter([None])
-
-    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
-    connector.lmcache_engine = mock_engine
-
+    """store_layer() must receive request_configs when called via save_kv_layer()."""
     import torch
 
-    kvcaches = {"layer0": torch.zeros(1)}
-    token_ids = list(range(4))
-    store_mask = [True] * 4
-    slot_mapping = torch.arange(4, dtype=torch.long)
+    req_configs = {_TAG_KEY: _cache_salt_tag_value("salt-a")}
+    recorded: dict = {}
 
-    # Directly invoke the layerwise store call with request_configs
-    connector.lmcache_engine.store_layer(
-        token_ids,
-        mask=store_mask,
-        kvcaches=kvcaches,
-        slot_mapping=slot_mapping,
-        offset=0,
-        sync=True,
+    def _fake_store_layer(token_ids, **kwargs):
+        recorded.update(kwargs)
+        return iter([None])
+
+    req = SimpleNamespace(
         req_id="req-1",
+        token_ids=[1, 2, 3, 4],
+        slot_mapping=torch.arange(4, dtype=torch.long),
+        save_spec=SimpleNamespace(skip_leading_tokens=0, can_save=True),
         request_configs=req_configs,
     )
+    metadata = LMCacheConnectorMetadata(requests=[req])
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector._parent = SimpleNamespace(
+        _connector_metadata=metadata,  # not-None guard at line 1049
+        _get_connector_metadata=lambda: metadata,
+    )
+    connector.lmcache_engine = SimpleNamespace(store_layer=_fake_store_layer)
+    connector.kv_role = "kv_producer"
+    connector.use_layerwise = True
+    connector.device = "cpu"
+    connector._lmcache_chunk_size = 8
+    connector.kv_caches = {"layer0": torch.zeros(1)}
+    connector._layerwise_save_storers = {}
 
-    call_kwargs = mock_engine.store_layer.call_args.kwargs
+    connector.save_kv_layer("layer0", torch.zeros(1), None)
+
+    assert "request_configs" in recorded, (
+        "store_layer() was not called with request_configs"
+    )
+    assert recorded["request_configs"] == req_configs
+
+
+# ---------------------------------------------------------------------------
+# from_new_request: cache_salt flows into RequestTracker.request_configs
+# ---------------------------------------------------------------------------
+
+
+def test_from_new_request_with_cache_salt():
+    """RequestTracker.from_new_request() stores the hashed salt in request_configs."""
+    new_request = SimpleNamespace(
+        req_id="req-1",
+        block_ids=[0, 1, 2, 3],
+        sampling_params=_make_sampling_params(),
+        prompt_token_ids=[1, 2, 3, 4, 5, 6, 7, 8],
+    )
+    tracker = RequestTracker.from_new_request(
+        None,  # lmcache_config is not used inside the function
+        new_request,
+        num_tokens_to_compute=8,
+        lmcache_cached_tokens=0,
+        skip_save=False,
+        cache_salt="salt-a",
+    )
+    assert tracker.request_configs is not None
+    assert _TAG_KEY in tracker.request_configs
+    expected = hashlib.sha256("salt-a".encode("utf-8")).hexdigest()
+    assert tracker.request_configs[_TAG_KEY] == expected
+
+
+def test_from_new_request_no_salt_leaves_request_configs_none():
+    """Without a cache_salt, request_configs should remain None."""
+    new_request = SimpleNamespace(
+        req_id="req-2",
+        block_ids=[0, 1, 2, 3],
+        sampling_params=_make_sampling_params(),
+        prompt_token_ids=[1, 2, 3, 4],
+    )
+    tracker = RequestTracker.from_new_request(
+        None,
+        new_request,
+        num_tokens_to_compute=4,
+        lmcache_cached_tokens=0,
+        skip_save=False,
+        cache_salt=None,
+    )
+    assert tracker.request_configs is None
+
+
+# ---------------------------------------------------------------------------
+# get_num_new_matched_tokens: request_configs with cache_salt reaches lookup()
+# ---------------------------------------------------------------------------
+
+
+def test_get_num_new_matched_tokens_passes_cache_salt_to_lookup():
+    """lookup() must be called with request_configs containing the cache_salt tag."""
+    lookup_client = MagicMock()
+    lookup_client.lookup_cache.return_value = -1  # first-time lookup
+    lookup_client.lookup.return_value = 4
+
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector.kv_role = "kv_consumer"
+    connector.lookup_client = lookup_client
+    connector.skip_last_n_tokens = 0
+    connector._requests_priority = {}
+    connector.config = SimpleNamespace(min_retrieve_tokens=0)
+    connector.load_specs = {}
+
+    request = SimpleNamespace(
+        request_id="req-1",
+        all_token_ids=[1, 2, 3, 4],
+        num_tokens=4,
+        sampling_params=_make_sampling_params(),
+        cache_salt="salt-a",
+    )
+
+    connector.get_num_new_matched_tokens(request, num_computed_tokens=0)
+
+    lookup_client.lookup.assert_called_once()
+    call_kwargs = lookup_client.lookup.call_args.kwargs
     assert "request_configs" in call_kwargs
-    assert call_kwargs["request_configs"] == req_configs
+    assert call_kwargs["request_configs"] is not None
+    assert _TAG_KEY in call_kwargs["request_configs"]
+    expected = hashlib.sha256("salt-a".encode("utf-8")).hexdigest()
+    assert call_kwargs["request_configs"][_TAG_KEY] == expected

--- a/tests/v1/test_vllm_layerwise_wait_for_save.py
+++ b/tests/v1/test_vllm_layerwise_wait_for_save.py
@@ -58,6 +58,7 @@ def _make_req(req_id: str, can_save: bool = True):
         token_ids=[1, 2, 3, 4],
         slot_mapping=torch.arange(4, dtype=torch.long),
         save_spec=SaveSpec(skip_leading_tokens=0, can_save=can_save),
+        request_configs=None,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #2878: vLLM `cache_salt` is not included in LMCache cache identity, so requests with different `cache_salt` values incorrectly share cached KV blocks.

Credit to @noobHappylife for identifying the bug and opening an initial fix in #2880  that work clarified the problem scope.

---

## Root Cause

`extract_request_configs()` never read `cache_salt` from the vLLM `Request` object. As a result, two requests with the same prompt but different `cache_salt` values produced the same `CacheEngineKey`, defeating vLLM's cache isolation contract.

---

## Changes

### `lmcache/integration/vllm/vllm_v1_adapter.py`

| Change | Why |
|---|---|
| `extract_request_configs(sampling_params, cache_salt=None)`  new param + docstring | Entry point for injecting the salt into `request_configs` |
| `if cache_salt:` guard (not `is not None`) | `cache_salt=""` is vLLM's "no salt" default; empty string must not create a distinct cache namespace (fixes a subtle bug in #2880) |
| `_cache_salt_tag_value(salt)` helper  SHA-256 hex digest | Raw salts can contain `@`/`%` (LMCache key delimiters); SHA-256 hex is always `[0-9a-f]` |
| Inject as `"lmcache.tag.cachesalt"` | Only `lmcache.tag.*` keys affect `CacheEngineKey.tags` (via `__hash__`/`__eq__`) |
| `get_num_new_matched_tokens()`  passes `getattr(request, "cache_salt", None)` | Scheduler-side lookup now uses the salt |
| `RequestTracker.from_new_request(cache_salt=)`  new param, threaded into `extract_request_configs` | Salt flows into `RequestTracker.request_configs` for all downstream paths |
| `build_connector_meta()`  reads `cache_salt` from `_unfinished_requests` | `NewRequestData` doesn't carry `cache_salt`; must read from the full `Request` object |
| `start_load_kv()`  passes `request_configs=request.request_configs` to `retrieve_layer()` and `blender.blend()` | Layerwise retrieve and blend paths both respect the salt |
| `save_kv_layer()`  passes `request_configs=request.request_configs` to `store_layer()` | Layerwise store path respects the salt |

### `tests/v1/test_vllm_cache_salt.py` (new)

14 tests covering:
- `extract_request_configs`: `None`, `""`, non-empty salt, merge with existing kv_transfer_params
- `_cache_salt_tag_value`: SHA-256 format, no delimiter chars
- `start_load_kv` layerwise path: actual connector call verifies `retrieve_layer` receives `request_configs`
- `save_kv_layer` layerwise path: actual connector call verifies `store_layer` receives `request_configs`
- `RequestTracker.from_new_request`: with and without salt
- `get_num_new_matched_tokens`: `lookup()` receives `request_configs` with the cachesalt tag

### `tests/v1/test_vllm_layerwise_wait_for_save.py`

Updated `_make_req()` helper to include `request_configs=None` field (needed by `save_kv_layer`).

---

## Backward Compatibility

`cache_salt=None` or `cache_salt=""` (the defaults) produce no change  `request_configs` remains `None`, and the cache key is identical to pre-fix. Zero impact on deployments that don't use `cache_salt`.

---

## Difference from PR #2880

#2880 uses `if cache_salt is not None:` which would hash `""` to `e3b0c44...`, creating a distinct cache namespace for what vLLM treats as "no salt". This PR uses `if cache_salt:` to correctly treat both `None` and `""` as equivalent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how LMCache cache keys are derived for vLLM requests by incorporating `cache_salt`, which can alter cache hit/miss behavior and partition existing caches; mistakes here could reduce reuse or cause unexpected memory/latency changes. Coverage is improved with targeted unit tests for the new salt propagation paths.
> 
> **Overview**
> Fixes vLLM cache isolation by folding per-request `cache_salt` into LMCache v1 cache identity via `request_configs` (hashed into a tag-safe SHA-256 value, treating `""` the same as no salt).
> 
> Threads the new `request_configs` through scheduler lookup (`get_num_new_matched_tokens`), request tracking/metadata creation (`RequestTracker.from_new_request` + `build_connector_meta`), and worker-side layerwise load/save paths (`retrieve_layer`/`store_layer` and blending) so salted requests don’t share KV blocks.
> 
> Adds a new test suite validating salt handling (including the empty-string edge case) and that `request_configs` is passed through layerwise load/save; updates an existing layerwise save test helper to include `request_configs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6abcd2c7f987092de9b80d602357e54a5a0f3548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->