### PR TITLE
[MP]Add platform module

### DIFF
--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -11,11 +11,16 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 
+# Install cross-platform shims (eventfd, torch.cuda) early,
+# so every module can use ``os.eventfd`` transparently.
+import lmcache.v1.platform  # noqa: F401
+
 try:
     # First Party
     from lmcache._version import __version__
 except ImportError:
     __version__ = "unknown"
+
 
 logger = init_logger(__name__)
 __all__ = ["__version__"]

--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -1422,3 +1422,126 @@ def get_gpu_pci_bus_id(device_id: int = 0) -> str | None:
         pass
 
     return None
+
+
+# ------------------------------------------------------------------
+# GPU kernel stubs (no-op on CPU-only platforms)
+# ------------------------------------------------------------------
+
+
+class PageBufferShapeDesc:
+    """No-op stand-in for the CUDA PageBufferShapeDesc."""
+
+    kv_size: int = 2
+    nl: int = 0
+    nb: int = 0
+    bs: int = 0
+    nh: int = 0
+    hs: int = 0
+    element_size: int = 2
+    dtype: torch.dtype | None = None
+
+
+def multi_layer_block_kv_transfer(
+    paged_buffer_ptrs_tensor: torch.Tensor,
+    lmcache_objects_ptrs: list[int],
+    block_ids: torch.Tensor,
+    device: torch.device,  # noqa: ARG001
+    direction: TransferDirection,
+    shape_desc: "PageBufferShapeDesc",
+    lmcache_chunk_size: int,
+    gpu_kv_format: "GPUKVFormat",  # noqa: ARG001
+    skip_prefix_n_blocks: int = 0,
+) -> None:
+    """CPU replacement for the CUDA block KV transfer kernel.
+
+    Transfers data between paged KV cache tensors and
+    contiguous LMCache memory objects.  Only the
+    ``NL_X_TWO_NB_BS_NH_HS`` layout is supported (the
+    default for ``CpuCacheContext``).
+
+    LMCache memory layout (contiguous, "2LTD"):
+        ``[2, NL, chunk_size, NH * HS]``  (in element units)
+    Paged buffer layout per layer (NL_X_TWO_NB_BS_NH_HS):
+        ``[2, NB, BS, NH, HS]``
+    """
+    num_objects = len(lmcache_objects_ptrs)
+    total_blocks = block_ids.shape[0]
+    blocks_per_obj = total_blocks // num_objects
+    nl = shape_desc.nl
+    bs = shape_desc.bs
+    nh = shape_desc.nh
+    hs = shape_desc.hs
+    nb = shape_desc.nb
+    elem_size = shape_desc.element_size
+    dtype = getattr(shape_desc, "dtype", None)
+    if dtype is None:
+        # Fallback: infer from element_size (ambiguous
+        # for 2-byte types; prefer setting dtype attr).
+        _ELEM_SIZE_MAP = {
+            1: torch.uint8,
+            2: torch.float16,
+            4: torch.float32,
+            8: torch.float64,
+        }
+        if elem_size not in _ELEM_SIZE_MAP:
+            raise ValueError("Unsupported element_size: %d" % elem_size)
+        dtype = _ELEM_SIZE_MAP[elem_size]
+
+    # Reconstruct per-layer paged tensors from raw pointers
+    layer_ptrs = paged_buffer_ptrs_tensor.tolist()
+    paged_tensors: list[torch.Tensor] = []
+    paged_nbytes = 2 * nb * bs * nh * hs * elem_size
+    for ptr in layer_ptrs:
+        buf = (ctypes.c_uint8 * paged_nbytes).from_address(int(ptr))
+        t = torch.frombuffer(buf, dtype=dtype).view(2, nb, bs, nh, hs)
+        paged_tensors.append(t)
+
+    block_ids_list = block_ids.tolist()
+    is_d2h = direction == TransferDirection.D2H
+
+    for obj_idx in range(num_objects):
+        obj_ptr = lmcache_objects_ptrs[obj_idx]
+        obj_numel = 2 * nl * lmcache_chunk_size * nh * hs
+        obj_nbytes = obj_numel * elem_size
+        obj_buf = (ctypes.c_uint8 * obj_nbytes).from_address(obj_ptr)
+        obj_tensor = torch.frombuffer(obj_buf, dtype=dtype).view(
+            2, nl, lmcache_chunk_size, nh * hs
+        )
+
+        blk_start = obj_idx * blocks_per_obj
+        for local_blk in range(blocks_per_obj):
+            flat_blk = blk_start + local_blk
+            if flat_blk < skip_prefix_n_blocks:
+                continue
+            engine_blk = block_ids_list[flat_blk]
+            token_off = local_blk * bs
+
+            for layer_idx in range(nl):
+                paged = paged_tensors[layer_idx]
+                for kv in range(2):
+                    # paged: [2, NB, BS, NH, HS]
+                    src_p = paged[kv, engine_blk, :, :, :]
+                    # obj: [2, NL, chunk_size, NH*HS]
+                    t_st = token_off
+                    t_ed = token_off + bs
+                    if is_d2h:
+                        obj_tensor[kv, layer_idx, t_st:t_ed, :] = src_p.reshape(
+                            bs, nh * hs
+                        )
+                    else:
+                        paged[kv, engine_blk, :, :, :] = obj_tensor[
+                            kv, layer_idx, t_st:t_ed, :
+                        ].reshape(bs, nh, hs)
+
+
+def record_event_on_stream(
+    *args,
+    **kwargs,  # noqa: ARG001
+) -> None:
+    """No-op replacement for CUDA stream event recording."""
+
+
+def drain_recorded_events() -> list:
+    """No-op replacement: no native events to drain on CPU."""
+    return []

--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -1446,17 +1446,18 @@ def multi_layer_block_kv_transfer(
     paged_buffer_ptrs_tensor: torch.Tensor,
     lmcache_objects_ptrs: list[int],
     block_ids: torch.Tensor,
-    device: torch.device,  # noqa: ARG001
+    device: torch.device,
     direction: TransferDirection,
     shape_desc: "PageBufferShapeDesc",
     lmcache_chunk_size: int,
     gpu_kv_format: "GPUKVFormat",  # noqa: ARG001
     skip_prefix_n_blocks: int = 0,
 ) -> None:
-    """CPU replacement for the CUDA block KV transfer kernel.
+    """Pure-Python replacement for the CUDA block KV transfer kernel.
 
     Transfers data between paged KV cache tensors and
-    contiguous LMCache memory objects.  Only the
+    contiguous LMCache memory objects.  Supports both CPU
+    and CUDA device pointers.  Only the
     ``NL_X_TWO_NB_BS_NH_HS`` layout is supported (the
     default for ``CpuCacheContext``).
 
@@ -1480,10 +1481,15 @@ def multi_layer_block_kv_transfer(
         # for 2-byte types; prefer setting dtype attr).
         _ELEM_SIZE_MAP = {
             1: torch.uint8,
-            2: torch.float16,
             4: torch.float32,
             8: torch.float64,
         }
+        if elem_size == 2:
+            raise ValueError(
+                "element_size=2 is ambiguous "
+                "(float16 vs bfloat16). "
+                "Set shape_desc.dtype explicitly."
+            )
         if elem_size not in _ELEM_SIZE_MAP:
             raise ValueError("Unsupported element_size: %d" % elem_size)
         dtype = _ELEM_SIZE_MAP[elem_size]
@@ -1491,10 +1497,9 @@ def multi_layer_block_kv_transfer(
     # Reconstruct per-layer paged tensors from raw pointers
     layer_ptrs = paged_buffer_ptrs_tensor.tolist()
     paged_tensors: list[torch.Tensor] = []
-    paged_nbytes = 2 * nb * bs * nh * hs * elem_size
+    paged_shape = (2, nb, bs, nh, hs)
     for ptr in layer_ptrs:
-        buf = (ctypes.c_uint8 * paged_nbytes).from_address(int(ptr))
-        t = torch.frombuffer(buf, dtype=dtype).view(2, nb, bs, nh, hs)
+        t = _tensor_from_ptr(int(ptr), paged_shape, dtype, device)
         paged_tensors.append(t)
 
     block_ids_list = block_ids.tolist()
@@ -1502,12 +1507,8 @@ def multi_layer_block_kv_transfer(
 
     for obj_idx in range(num_objects):
         obj_ptr = lmcache_objects_ptrs[obj_idx]
-        obj_numel = 2 * nl * lmcache_chunk_size * nh * hs
-        obj_nbytes = obj_numel * elem_size
-        obj_buf = (ctypes.c_uint8 * obj_nbytes).from_address(obj_ptr)
-        obj_tensor = torch.frombuffer(obj_buf, dtype=dtype).view(
-            2, nl, lmcache_chunk_size, nh * hs
-        )
+        obj_shape = (2, nl, lmcache_chunk_size, nh * hs)
+        obj_tensor = _tensor_from_ptr(obj_ptr, obj_shape, dtype, device)
 
         blk_start = obj_idx * blocks_per_obj
         for local_blk in range(blocks_per_obj):
@@ -1536,8 +1537,11 @@ def multi_layer_block_kv_transfer(
 
 
 def record_event_on_stream(
-    *args,
-    **kwargs,  # noqa: ARG001
+    cuda_stream_ptr: int,  # noqa: ARG001
+    event_type_name: str,  # noqa: ARG001
+    session_id: str,  # noqa: ARG001
+    str_metadata: dict,  # noqa: ARG001
+    int_metadata: dict,  # noqa: ARG001
 ) -> None:
     """No-op replacement for CUDA stream event recording."""
 

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -33,14 +33,10 @@ from lmcache.v1.gpu_connector.utils import (
     is_mla,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
-
-if torch.cuda.is_available():
-    import lmcache.c_ops as lmc_ops
-
-# First Party
 from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
+import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -268,6 +268,7 @@ class GPUCacheContext:
         """Returns the KV layer groups manager."""
         return self.kv_layer_groups_manager_
 
+    @property
     def gpu_kv_format_name(self) -> str:
         """Returns the GPU KV format enum name (e.g. ``'NL_X_TWO_NB_BS_NH_HS'``)."""
         return self.gpu_kv_format_.name

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -52,9 +52,7 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
     KVCache,
 )
-from lmcache.v1.multiprocess.gpu_context import (
-    GPUCacheContext,
-)
+from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
 from lmcache.v1.multiprocess.mq import MessageQueueServer
 from lmcache.v1.multiprocess.protocol import (
     RequestType,
@@ -63,6 +61,7 @@ from lmcache.v1.multiprocess.protocol import (
 )
 from lmcache.v1.multiprocess.session import SessionManager
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
+from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -219,7 +218,7 @@ class MPCacheEngine:
             layout_hints: See :class:`LayoutHints`.  Forwarded to
                 :class:`GPUCacheContext` for GPU KV format detection.
         """
-        gpu_context = GPUCacheContext(
+        gpu_context = create_cache_context(
             kv_caches,
             self.chunk_size,
             layout_hints=layout_hints or None,

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -163,7 +163,14 @@ class TokenHasher:
                 none_hash = kv_cache_utils.NONE_HASH
                 logger.info("Initialized NONE_HASH=%s from vLLM", none_hash)
                 return none_hash
-        except (ImportError, AttributeError, ValueError):
+        except (
+            ImportError,
+            AttributeError,
+            ValueError,
+            # torch._dynamo.device_interface raises AssertionError
+            # when CudaInterface is defined on non-CUDA platforms.
+            AssertionError,
+        ):
             pass
 
         # Fallback: compute none_hash using our hash function

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-platform abstraction layer for LMCache.
+
+This package centralizes all platform-specific logic.
+"""
+
+# First Party
+from lmcache.v1.platform.cuda_compat import install_cuda_compat
+from lmcache.v1.platform.cupy_compat import install_cupy_compat
+from lmcache.v1.platform.eventfd_compat import (
+    install_eventfd_compat,
+)
+
+# Safety net: patch torch.cuda on CPU-only platforms so that
+# any stray ``torch.cuda.xxx()`` call is a harmless no-op.
+install_cuda_compat()
+
+# Safety net: inject a fake cupy module on CPU-only platforms
+# so that ``import cupy`` succeeds with harmless no-ops.
+install_cupy_compat()
+
+# Safety net: patch os.eventfd on non-Linux platforms so that
+# call-sites can keep using ``os.eventfd`` transparently.
+install_eventfd_compat()
+
+
+def __getattr__(name: str) -> object:
+    """Lazy re-export of platform cache utilities.
+
+    Deferred so that ``lmcache.c_ops`` (a compiled extension)
+    is fully available by the time the class is first used.
+    """
+    if name == "CpuCacheContext":
+        # First Party
+        from lmcache.v1.platform.cache_context import (
+            CpuCacheContext,
+        )
+
+        return CpuCacheContext
+
+    if name == "create_cache_context":
+        # First Party
+        from lmcache.v1.platform.cache_context import (
+            create_cache_context,
+        )
+
+        return create_cache_context
+
+    raise AttributeError(name)

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -108,7 +108,12 @@ class CpuCacheContext:
             sd.nh = num_heads
             sd.hs = head_size
             sd.element_size = dtype.itemsize
-            sd.dtype = dtype
+            # C++ PageBufferShapeDesc has no dtype field;
+            # only the Python fallback needs it.
+            try:
+                sd.dtype = dtype
+            except AttributeError:
+                pass
             self.shape_descs_.append(sd)
 
             self.group_kv_pointers_.append(
@@ -164,91 +169,133 @@ class CpuCacheContext:
 
     @property
     def dtype(self) -> torch.dtype:
+        """Returns the dtype of the KV cache tensors."""
         return self.kv_caches_[0].dtype
 
     @property
     def device(self) -> torch.device:
+        """Returns the device (always CPU)."""
         return self.device_
 
     @property
     def kv_tensors(self) -> list[torch.Tensor]:
+        """Returns the list of per-layer KV cache tensors."""
         return self.kv_caches_
 
     @property
     def kv_pointers(self) -> torch.Tensor:
+        """Returns a tensor of KV cache data pointers."""
         return self.kv_cache_pointers_
 
     @property
     def stream(self) -> torch.cuda.Stream:
+        """Returns the (mock) CUDA stream."""
         return self.cuda_stream_
 
     @property
     def cupy_stream(self) -> cupy.cuda.Stream:
+        """Returns the (mock) cupy stream."""
         return self.cupy_stream_
 
     @property
     def high_priority_stream(self) -> torch.cuda.Stream:
+        """Returns the high-priority (mock) CUDA stream."""
         return self.high_priority_cuda_stream_
 
     @property
     def high_priority_cupy_stream(self) -> cupy.cuda.Stream:
+        """Returns the high-priority (mock) cupy stream."""
         return self.high_priority_cupy_stream_
 
     @property
     def block_size(self) -> int:
+        """Returns the block size (tokens per block)."""
         return self.block_size_
 
     @property
     def num_layers(self) -> int:
+        """Returns the number of layers in the model."""
         return self.num_layers_
 
     @property
     def num_blocks(self) -> int:
+        """Returns the number of blocks in the KV cache."""
         return self.num_blocks_
 
     @property
     def is_mla(self) -> bool:
+        """Returns whether the model uses MLA."""
         return self.is_mla_
 
     @property
     def hidden_dim_sizes(self) -> list[int]:
+        """Returns hidden dimension sizes per KV layer group."""
         return self.hidden_dim_sizes_
 
     @property
     def kv_layer_groups_manager(
         self,
     ) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
         return self.kv_layer_groups_manager_
 
     @property
     def gpu_kv_format_name(self) -> str:
+        """Returns the GPU KV format enum name."""
         return self.gpu_kv_format_.name
 
     @property
     def gpu_kv_shape(self) -> str:
+        """Returns the GPU KV cache layout description."""
         return "NL_X_TWO_NB_BS_NH_HS"
 
     @property
     def attention_backend(self) -> str:
+        """Returns the attention backend name."""
         return "cpu"
 
     @property
     def concrete_gpu_kv_shape(self) -> str:
+        """Returns the GPU KV shape with actual values."""
         return "cpu-context"
 
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for the given group.
+
+        Args:
+            group_idx: Index of the KV layer group.
+        """
         return self.shape_descs_[group_idx]
 
     def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        """Returns the KV cache pointer tensor for the given group.
+
+        Args:
+            group_idx: Index of the KV layer group.
+        """
         return self.group_kv_pointers_[group_idx]
 
     def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
+        """Returns the KV buffer shape for the given token count.
+
+        Args:
+            num_tokens: Number of tokens.
+            group_idx: Index of the KV layer group.
+        """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
         num_layers_in_group = group.num_layers
         hidden_dim = self.hidden_dim_sizes_[group_idx]
         return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
 
     def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        """Returns the flat uint8 temp buffer for the given chunk.
+
+        Args:
+            chunk_idx: Chunk index (< max_batch_size).
+
+        Raises:
+            ValueError: If chunk_idx >= max_batch_size.
+        """
         if chunk_idx >= self.max_batch_size:
             raise ValueError(
                 "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
@@ -257,6 +304,11 @@ class CpuCacheContext:
         return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
 
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        """Returns a typed view of the temp buffer for one chunk.
+
+        Args:
+            group_idx: Index of the KV layer group.
+        """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
         shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
@@ -266,6 +318,15 @@ class CpuCacheContext:
     def get_tmp_chunk_gpu_buffer_batched(
         self, batch_size: int, group_idx: int = 0
     ) -> list[torch.Tensor]:
+        """Returns a list of non-overlapping temp buffer views.
+
+        Args:
+            batch_size: Number of concurrent chunks.
+            group_idx: Index of the KV layer group.
+
+        Raises:
+            ValueError: If batch_size > max_batch_size.
+        """
         if batch_size > self.max_batch_size:
             raise ValueError(
                 "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
@@ -283,6 +344,14 @@ class CpuCacheContext:
         ]
 
     def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
+        """Copy block IDs into the pre-allocated buffer.
+
+        Args:
+            block_ids: Block indices as a Python list.
+
+        Returns:
+            A tensor view into the pre-allocated buffer.
+        """
         n = len(block_ids)
         cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
         buf = self.block_ids_buffer_[:n]
@@ -290,6 +359,7 @@ class CpuCacheContext:
         return buf
 
     def cache_size_per_token(self) -> int:
+        """Returns cache size per token in bytes, summed across groups."""
         total = 0
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only cache context for platforms without CUDA GPUs.
+
+This module lives in the ``platform`` package because it is part
+of the cross-platform compatibility layer — it provides the same
+public API as :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext`
+but allocates all tensors on CPU and uses the mock CUDA / cupy
+objects installed by :func:`_install_cuda_compat` /
+:func:`_install_cupy_compat`.
+"""
+
+# Standard
+from typing import Any, Mapping
+
+# Third Party
+import cupy
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+
+_DTYPE_MAP: dict[str, torch.dtype] = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
+
+
+class CpuCacheContext:
+    """CPU-only cache context with the same public API as
+    :class:`GPUCacheContext`.
+
+    All tensors live on CPU.  CUDA streams and cupy streams
+    are replaced by the platform compat layer's mock objects
+    (installed at import time when CUDA is unavailable).
+
+    This allows ``store`` / ``retrieve`` in
+    :class:`MPCacheEngine` to run the same code path on
+    CPU-only machines — ``lmc_ops`` falls back to the pure-
+    Python ``non_cuda_equivalents`` automatically.
+    """
+
+    def __init__(
+        self,
+        layout_hints: Mapping[str, Any],
+        lmcache_chunk_size: int = 256,
+    ):
+        num_layers: int = layout_hints.get("num_layers", 32)
+        num_heads: int = layout_hints.get("num_heads", 8)
+        head_size: int = layout_hints.get("head_size", 128)
+        num_blocks: int = layout_hints.get("num_blocks", 1024)
+        block_size: int = layout_hints.get("block_size", 16)
+        dtype_str: str = layout_hints.get("dtype", "float16")
+        dtype = _DTYPE_MAP.get(dtype_str, torch.float16)
+
+        self.device_ = torch.device("cpu")
+        self.num_layers_ = num_layers
+        self.num_blocks_ = num_blocks
+        self.block_size_ = block_size
+        self.is_mla_ = False
+        self.lmcache_chunk_size = lmcache_chunk_size
+
+        # Allocate paged KV cache tensors on CPU
+        # Shape: [2, num_blocks, block_size, num_heads, head_size]
+        # (NL_X_TWO_NB_BS_NH_HS layout)
+        self.kv_caches_: list[torch.Tensor] = [
+            torch.zeros(
+                (2, num_blocks, block_size, num_heads, head_size),
+                dtype=dtype,
+                device="cpu",
+            )
+            for _ in range(num_layers)
+        ]
+
+        # Pointers
+        pointers_list = [t.data_ptr() for t in self.kv_caches_]
+        self.kv_cache_pointers_ = torch.tensor(pointers_list, dtype=torch.long)
+
+        # GPU KV format: use NL_X_TWO_NB_BS_NH_HS (value 1)
+        self.gpu_kv_format_ = lmc_ops.GPUKVFormat(1)
+
+        # Build KV layer groups
+        self.kv_layer_groups_manager_ = KVLayerGroupsManager()
+        self.kv_layer_groups_manager_.build_kv_layer_groups_from_list(self.kv_caches_)
+
+        # Per-group attributes
+        kv_size = 2
+        self.hidden_dim_sizes_: list[int] = []
+        self.group_num_heads_: list[int] = []
+        self.group_head_sizes_: list[int] = []
+        self.shape_descs_: list[lmc_ops.PageBufferShapeDesc] = []
+        self.group_kv_pointers_: list[torch.Tensor] = []
+        for group in self.kv_layer_groups_manager_.kv_layer_groups:
+            hidden_dim = num_heads * head_size
+            self.hidden_dim_sizes_.append(hidden_dim)
+            self.group_num_heads_.append(num_heads)
+            self.group_head_sizes_.append(head_size)
+
+            sd = lmc_ops.PageBufferShapeDesc()
+            sd.kv_size = kv_size
+            sd.nl = group.num_layers
+            sd.nb = num_blocks
+            sd.bs = block_size
+            sd.nh = num_heads
+            sd.hs = head_size
+            sd.element_size = dtype.itemsize
+            sd.dtype = dtype
+            self.shape_descs_.append(sd)
+
+            self.group_kv_pointers_.append(
+                torch.tensor(
+                    [self.kv_caches_[i].data_ptr() for i in group.layer_indices],
+                    dtype=torch.long,
+                )
+            )
+
+        # Pre-allocated block IDs buffer (CPU)
+        _MAX_BLOCK_IDS = 1_000_000
+        self.block_ids_buffer_ = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
+
+        # Temporary buffer for transfers (same layout as
+        # GPUCacheContext but on CPU)
+        self.max_batch_size = 4
+        self.tmp_chunk_group_offsets_: list[int] = [0]
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            shape = self.get_kv_buffer_shape(lmcache_chunk_size, group_idx)
+            byte_size = shape.numel() * group.dtype.itemsize
+            self.tmp_chunk_group_offsets_.append(
+                self.tmp_chunk_group_offsets_[-1] + byte_size
+            )
+        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
+        self.tmp_gpu_buffer_ = torch.empty(
+            self.tmp_chunk_bytes_ * self.max_batch_size,
+            dtype=torch.uint8,
+        )
+
+        # Mock CUDA / cupy streams (platform compat layer)
+        self.cuda_stream_ = torch.cuda.Stream(device=self.device_)
+        self.cupy_stream_ = cupy.cuda.ExternalStream(0, 0)
+
+        _, high_priority = torch.cuda.Stream.priority_range()
+        self.high_priority_cuda_stream_ = torch.cuda.Stream(
+            device=self.device_, priority=high_priority
+        )
+        self.high_priority_cupy_stream_ = cupy.cuda.ExternalStream(0, 0)
+
+        logger.info(
+            "CpuCacheContext: %d layers, %dx%d heads, blocks=%dx%d, dtype=%s",
+            num_layers,
+            num_heads,
+            head_size,
+            num_blocks,
+            block_size,
+            dtype,
+        )
+
+    # -- Properties (same API as GPUCacheContext) --
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.kv_caches_[0].dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.device_
+
+    @property
+    def kv_tensors(self) -> list[torch.Tensor]:
+        return self.kv_caches_
+
+    @property
+    def kv_pointers(self) -> torch.Tensor:
+        return self.kv_cache_pointers_
+
+    @property
+    def stream(self) -> torch.cuda.Stream:
+        return self.cuda_stream_
+
+    @property
+    def cupy_stream(self) -> cupy.cuda.Stream:
+        return self.cupy_stream_
+
+    @property
+    def high_priority_stream(self) -> torch.cuda.Stream:
+        return self.high_priority_cuda_stream_
+
+    @property
+    def high_priority_cupy_stream(self) -> cupy.cuda.Stream:
+        return self.high_priority_cupy_stream_
+
+    @property
+    def block_size(self) -> int:
+        return self.block_size_
+
+    @property
+    def num_layers(self) -> int:
+        return self.num_layers_
+
+    @property
+    def num_blocks(self) -> int:
+        return self.num_blocks_
+
+    @property
+    def is_mla(self) -> bool:
+        return self.is_mla_
+
+    @property
+    def hidden_dim_sizes(self) -> list[int]:
+        return self.hidden_dim_sizes_
+
+    @property
+    def kv_layer_groups_manager(
+        self,
+    ) -> KVLayerGroupsManager:
+        return self.kv_layer_groups_manager_
+
+    @property
+    def gpu_kv_format_name(self) -> str:
+        return self.gpu_kv_format_.name
+
+    @property
+    def gpu_kv_shape(self) -> str:
+        return "NL_X_TWO_NB_BS_NH_HS"
+
+    @property
+    def attention_backend(self) -> str:
+        return "cpu"
+
+    @property
+    def concrete_gpu_kv_shape(self) -> str:
+        return "cpu-context"
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        return self.shape_descs_[group_idx]
+
+    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        return self.group_kv_pointers_[group_idx]
+
+    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        num_layers_in_group = group.num_layers
+        hidden_dim = self.hidden_dim_sizes_[group_idx]
+        return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
+
+    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        if chunk_idx >= self.max_batch_size:
+            raise ValueError(
+                "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
+            )
+        start = chunk_idx * self.tmp_chunk_bytes_
+        return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
+        start = self.tmp_chunk_group_offsets_[group_idx]
+        end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
+
+    def get_tmp_chunk_gpu_buffer_batched(
+        self, batch_size: int, group_idx: int = 0
+    ) -> list[torch.Tensor]:
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
+        g_start = self.tmp_chunk_group_offsets_[group_idx]
+        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return [
+            self.tmp_gpu_buffer_[i * chunk + g_start : i * chunk + g_end]
+            .view(group.dtype)
+            .view(shape)
+            for i in range(batch_size)
+        ]
+
+    def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
+        n = len(block_ids)
+        cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
+        buf = self.block_ids_buffer_[:n]
+        buf.copy_(cpu_tensor)
+        return buf
+
+    def cache_size_per_token(self) -> int:
+        total = 0
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            numels = self.get_kv_buffer_shape(1, group_idx).numel()
+            total += numels * group.dtype.itemsize
+        return total
+
+
+def create_cache_context(
+    kv_caches: Any,
+    chunk_size: int,
+    layout_hints: Any = None,
+) -> Any:
+    """Create the appropriate cache context.
+
+    On CUDA platforms with non-empty *kv_caches*,
+    ``GPUCacheContext`` is returned.  Otherwise a
+    ``CpuCacheContext`` is created from *layout_hints*.
+    """
+    if torch.cuda.is_available() and kv_caches:
+        # First Party
+        from lmcache.v1.multiprocess.gpu_context import (
+            GPUCacheContext,
+        )
+
+        return GPUCacheContext(
+            kv_caches,
+            chunk_size,
+            layout_hints=layout_hints or None,
+        )
+
+    # CPU mode — forward layout_hints as-is
+    hints = layout_hints if isinstance(layout_hints, dict) else {}
+    return CpuCacheContext(
+        layout_hints=hints,
+        lmcache_chunk_size=chunk_size,
+    )

--- a/lmcache/v1/platform/cuda_compat.py
+++ b/lmcache/v1/platform/cuda_compat.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Monkey-patch ``torch.cuda`` on CPU-only platforms.
+
+When CUDA is unavailable the helpers here replace core
+``torch.cuda`` classes and functions with harmless no-op stubs
+so that business-logic code does not crash with
+``AssertionError``.
+"""
+
+# Standard
+from typing import Any
+
+# Third Party
+import torch
+
+HAS_CUDA: bool = torch.cuda.is_available()
+
+_cuda_compat_installed: bool = False
+
+
+class _MockCudaStream:
+    """Minimal stand-in for ``torch.cuda.Stream``."""
+
+    def __init__(
+        self,
+        device: Any = None,  # noqa: ARG002
+        priority: int = 0,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+    def wait_event(
+        self,
+        event: Any,  # noqa: ARG002
+    ) -> None:
+        pass
+
+    def record_event(
+        self,
+        event: Any = None,  # noqa: ARG002
+    ) -> "_MockCudaEvent":
+        return _MockCudaEvent()
+
+    @property
+    def cuda_stream(self) -> int:
+        return 0
+
+    @staticmethod
+    def priority_range() -> tuple[int, int]:
+        return (-1, 0)
+
+
+class _MockCudaEvent:
+    """Minimal stand-in for ``torch.cuda.Event``."""
+
+    def __init__(
+        self,
+        *,
+        interprocess: bool = False,  # noqa: ARG002
+        enable_timing: bool = False,  # noqa: ARG002
+    ) -> None:
+        pass
+
+    def record(
+        self,
+        stream: Any = None,  # noqa: ARG002
+    ) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+    def wait(
+        self,
+        stream: Any = None,  # noqa: ARG002
+    ) -> None:
+        pass
+
+    def query(self) -> bool:
+        return True
+
+    def ipc_handle(self) -> bytes:
+        return b""
+
+    @classmethod
+    def from_ipc_handle(
+        cls,
+        device: Any,  # noqa: ARG003
+        handle: bytes,  # noqa: ARG003
+    ) -> "_MockCudaEvent":
+        return cls()
+
+
+class _FakeCudart:
+    """No-op replacement for ``torch.cuda.cudart()``."""
+
+    @staticmethod
+    def cudaHostRegister(
+        ptr: int,  # noqa: ARG004, N802
+        size: int,  # noqa: ARG004
+        flags: int,  # noqa: ARG004
+    ) -> None:
+        return None
+
+    @staticmethod
+    def cudaHostUnregister(
+        ptr: int,  # noqa: ARG004, N802
+    ) -> None:
+        return None
+
+
+class _FakeDeviceProperties:
+    """No-op replacement for device properties."""
+
+    total_memory: int = 0
+    name: str = "CPU (no CUDA)"
+    major: int = 0
+    minor: int = 0
+    uuid: str = "cpu-0000"
+
+
+class _NoopCtx:
+    """No-op context manager / type stub.
+
+    Unlike a ``@contextmanager`` function, a *class* supports
+    the ``|`` union operator used in runtime type annotations
+    such as ``torch.cuda.device | None``.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        pass
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *args: Any) -> None:  # noqa: ARG002
+        pass
+
+
+def install_cuda_compat() -> None:
+    """Monkey-patch ``torch.cuda`` when CUDA is unavailable.
+
+    Must be called exactly once, at platform package init time.
+    """
+    global _cuda_compat_installed  # noqa: PLW0603
+    if _cuda_compat_installed or HAS_CUDA:
+        return
+    _cuda_compat_installed = True
+
+    cuda = torch.cuda
+
+    # Classes
+    cuda.Stream = _MockCudaStream  # type: ignore[misc,assignment]
+    cuda.Event = _MockCudaEvent  # type: ignore[misc,assignment]
+
+    # Context managers
+    cuda.device = _NoopCtx  # type: ignore[misc,assignment]
+    cuda.stream = _NoopCtx  # type: ignore[assignment]
+
+    # Functions
+    cuda.current_device = lambda: 0  # type: ignore[assignment]
+    cuda.device_count = lambda: 0  # type: ignore[assignment]
+    cuda.synchronize = (  # type: ignore[assignment]
+        lambda device=None: None  # noqa: ARG005
+    )
+    cuda.empty_cache = lambda: None  # type: ignore[assignment]
+    cuda.init = lambda: None  # type: ignore[assignment]
+    cuda.set_device = (  # type: ignore[assignment]
+        lambda device: None  # noqa: ARG005
+    )
+    cuda.cudart = (  # type: ignore[assignment]
+        lambda: _FakeCudart()
+    )
+
+    def _fake_props(
+        device: Any = 0,  # noqa: ARG001
+    ) -> _FakeDeviceProperties:
+        return _FakeDeviceProperties()
+
+    cuda.get_device_properties = (  # type: ignore[assignment]
+        _fake_props
+    )
+    cuda._lazy_init = lambda: None  # type: ignore[attr-defined]

--- a/lmcache/v1/platform/cupy_compat.py
+++ b/lmcache/v1/platform/cupy_compat.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inject a fake ``cupy`` package on CPU-only platforms.
+
+On CPU-only platforms ``cupy`` cannot be installed at all,
+so we create a minimal shim module in ``sys.modules`` so that
+``import cupy`` succeeds and the handful of APIs used by the
+codebase (``cupy.cuda.ExternalStream``) resolve to harmless
+no-ops.
+"""
+
+# Standard
+from typing import Any
+import sys
+import types
+
+# Third Party
+import torch
+
+HAS_CUDA: bool = torch.cuda.is_available()
+
+_cupy_compat_installed: bool = False
+
+
+class _MockCupyStream:
+    """Minimal stand-in for ``cupy.cuda.ExternalStream``."""
+
+    def __init__(
+        self,
+        ptr: int = 0,
+        device_id: int = 0,
+    ) -> None:
+        self.ptr = ptr
+        self.device_id = device_id
+
+    def launch_host_func(
+        self,
+        fn: Any,
+        *args: Any,
+    ) -> None:
+        fn(*args)
+
+    def synchronize(self) -> None:
+        pass
+
+
+def install_cupy_compat() -> None:
+    """Inject a fake ``cupy`` when CUDA is unavailable.
+
+    Must be called exactly once, at platform package init time.
+    """
+    global _cupy_compat_installed  # noqa: PLW0603
+    if _cupy_compat_installed or HAS_CUDA:
+        return
+    if "cupy" in sys.modules:
+        # Real cupy already loaded — nothing to do.
+        return
+    _cupy_compat_installed = True
+
+    cupy = types.ModuleType("cupy")
+    cuda = types.ModuleType("cupy.cuda")
+    cuda.ExternalStream = _MockCupyStream  # type: ignore[attr-defined]
+    cuda.Stream = _MockCupyStream  # type: ignore[attr-defined]
+    cupy.cuda = cuda  # type: ignore[attr-defined]
+    sys.modules["cupy"] = cupy
+    sys.modules["cupy.cuda"] = cuda

--- a/lmcache/v1/platform/eventfd_compat.py
+++ b/lmcache/v1/platform/eventfd_compat.py
@@ -9,6 +9,7 @@ transparently.
 
 # Standard
 import os
+import struct
 
 HAS_EVENTFD: bool = hasattr(os, "eventfd")
 
@@ -35,25 +36,41 @@ def _compat_eventfd() -> int:
 
 
 def _compat_eventfd_write(efd: int, value: int = 1) -> None:
-    """Signal the pipe-based eventfd."""
+    """Signal the pipe-based eventfd.
+
+    Real eventfd_write always writes an 8-byte uint64 counter.
+    We replicate that here so the read side can decode properly.
+    """
     pair = _pipe_registry.get(efd)
     if pair is None:
         raise OSError("compat_eventfd_write: unknown fd %d" % efd)
     _, w = pair
     try:
-        os.write(w, b"\x01" * value)
+        os.write(w, struct.pack("<Q", value))
     except BlockingIOError:
         pass  # pipe buffer full, already signaled
 
 
 def _compat_eventfd_read(efd: int) -> int:
-    """Consume the pipe-based eventfd signal."""
+    """Consume the pipe-based eventfd signal.
+
+    Drains all pending 8-byte counter values and returns
+    their sum, matching real eventfd semantics.
+    """
+    total = 0
     try:
-        while os.read(efd, 4096):
-            pass
+        while True:
+            data = os.read(efd, 4096)
+            if not data:
+                break
+            # Each write is an 8-byte uint64 frame.
+            for off in range(0, len(data), 8):
+                chunk = data[off : off + 8]
+                if len(chunk) == 8:
+                    total += struct.unpack("<Q", chunk)[0]
     except (BlockingIOError, OSError):
         pass
-    return 1
+    return total if total else 1
 
 
 def install_eventfd_compat() -> None:

--- a/lmcache/v1/platform/eventfd_compat.py
+++ b/lmcache/v1/platform/eventfd_compat.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch ``os`` with eventfd shims on non-Linux platforms.
+
+Linux exposes ``os.eventfd`` natively; macOS and other systems
+do not.  The helpers here emulate eventfd semantics using
+``os.pipe`` so that call-sites can keep using ``os.eventfd``
+transparently.
+"""
+
+# Standard
+import os
+
+HAS_EVENTFD: bool = hasattr(os, "eventfd")
+
+# When using pipe-based fallback, map the "public" read-end fd
+# to the (read_fd, write_fd) pair so we can write to the
+# correct end.
+_pipe_registry: dict[int, tuple[int, int]] = {}
+
+_eventfd_compat_installed: bool = False
+
+
+def _compat_eventfd() -> int:
+    """Create an eventfd-like file descriptor via ``os.pipe``."""
+    # Standard
+    import fcntl
+
+    r, w = os.pipe()
+    for fd in (r, w):
+        flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        fcntl.fcntl(fd, fcntl.F_SETFD, fcntl.FD_CLOEXEC)
+    _pipe_registry[r] = (r, w)
+    return r
+
+
+def _compat_eventfd_write(efd: int, value: int = 1) -> None:
+    """Signal the pipe-based eventfd."""
+    pair = _pipe_registry.get(efd)
+    if pair is None:
+        raise OSError("compat_eventfd_write: unknown fd %d" % efd)
+    _, w = pair
+    try:
+        os.write(w, b"\x01" * value)
+    except BlockingIOError:
+        pass  # pipe buffer full, already signaled
+
+
+def _compat_eventfd_read(efd: int) -> int:
+    """Consume the pipe-based eventfd signal."""
+    try:
+        while os.read(efd, 4096):
+            pass
+    except (BlockingIOError, OSError):
+        pass
+    return 1
+
+
+def install_eventfd_compat() -> None:
+    """Patch ``os`` with eventfd shims when missing.
+
+    Must be called exactly once, at platform package init time.
+    """
+    global _eventfd_compat_installed  # noqa: PLW0603
+    if _eventfd_compat_installed or HAS_EVENTFD:
+        return
+    _eventfd_compat_installed = True
+
+    os.eventfd = lambda _i=0, _f=0: _compat_eventfd()  # type: ignore[attr-defined,misc]
+    os.eventfd_read = _compat_eventfd_read  # type: ignore[attr-defined,assignment]
+    os.eventfd_write = _compat_eventfd_write  # type: ignore[attr-defined,assignment]
+    os.EFD_NONBLOCK = 0  # type: ignore[attr-defined]
+    os.EFD_CLOEXEC = 0  # type: ignore[attr-defined]
+
+    # Wrap os.close so that closing a pipe-based efd also
+    # closes the hidden write-end.
+    _orig_close = os.close
+
+    def _patched_close(fd: int) -> None:
+        pair = _pipe_registry.pop(fd, None)
+        if pair is not None:
+            r, w = pair
+            try:
+                _orig_close(r)
+            except OSError:
+                pass
+            try:
+                _orig_close(w)
+            except OSError:
+                pass
+        else:
+            _orig_close(fd)
+
+    os.close = _patched_close  # type: ignore[assignment]

--- a/tests/v1/test_c_ops_fallback_parity.py
+++ b/tests/v1/test_c_ops_fallback_parity.py
@@ -1,18 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
-Verify that every public function/enum in non_cuda_equivalents that also
-exists in c_ops has a matching signature.
+"""Verify 1:1 parity between c_ops and non_cuda_equivalents.
 
-Does NOT require non_cuda_equivalents to implement everything in c_ops —
-only checks the intersection. If you implement a function in the fallback,
-its signature must match c_ops exactly.
+Two categories of checks:
+
+1. **Coverage (1:1 mapping)** — every public callable, enum, and
+   descriptor class in c_ops MUST have a counterpart in
+   non_cuda_equivalents.  Missing symbols cause a hard failure.
+
+2. **Signature / member parity** — for every symbol that exists in
+   both modules, signatures (parameter names, count, defaults) and
+   enum members must match exactly.
 
 Default value rules (relaxed):
-  - If c_ops has a default, fallback MUST also have one with the same value —
-    otherwise callers relying on the default will break.
-  - If c_ops has NO default, fallback MAY add one (superset, backward-compatible).
+  - If c_ops has a default, fallback MUST also have one with the
+    same value — otherwise callers relying on the default will break.
+  - If c_ops has NO default, fallback MAY add one
+    (superset, backward-compatible).
 
-Requires CUDA (c_ops must be importable). Automatically skipped on CPU-only CI.
+Requires CUDA (c_ops must be importable).  Automatically skipped
+on CPU-only CI.
 """
 
 # Standard
@@ -200,6 +206,26 @@ _c_ops_enums = _public_enums(c_ops) if HAS_C_OPS else {}
 _shared_enum_names = sorted(set(_fallback_enums) & set(_c_ops_enums))
 
 
+# ── Discover shared "descriptor" classes (non-enum, non-callable) ──
+
+
+def _public_descriptor_classes(module):
+    """Return {name: cls} for public classes that are
+    neither enums nor plain functions — e.g. PageBufferShapeDesc."""
+    return {
+        name: obj
+        for name, obj in inspect.getmembers(module, inspect.isclass)
+        if not name.startswith("_")
+        and not (issubclass(obj, enum.Enum) or hasattr(obj, "__members__"))
+        and callable(obj)
+    }
+
+
+_fallback_descs = _public_descriptor_classes(fallback)
+_c_ops_descs = _public_descriptor_classes(c_ops) if HAS_C_OPS else {}
+_shared_desc_names = sorted(set(_fallback_descs) & set(_c_ops_descs))
+
+
 # ── Tests ──
 
 
@@ -298,4 +324,85 @@ def test_enum_parity(enum_name):
 
     assert c_members == py_members, (
         f"{enum_name} mismatch:\n  c_ops:    {c_members}\n  fallback: {py_members}"
+    )
+
+
+@pytest.mark.skipif(not HAS_C_OPS, reason="c_ops not available (no CUDA)")
+@pytest.mark.parametrize(
+    "cls_name",
+    _shared_desc_names if _shared_desc_names else ["__placeholder__"],
+)
+def test_descriptor_class_parity(cls_name):
+    """For every descriptor class that non_cuda_equivalents
+    defines, its writable attributes must match c_ops.
+
+    Instantiates both classes with no arguments and compares
+    the set of public, non-dunder attributes that are present
+    on the c_ops instance.
+    """
+    if cls_name == "__placeholder__":
+        pytest.skip("No shared descriptor classes found")
+
+    c_cls = _c_ops_descs[cls_name]
+    py_cls = _fallback_descs[cls_name]
+
+    c_inst = c_cls()
+    py_inst = py_cls()
+
+    # Collect public non-dunder attributes from c_ops
+    c_attrs = {
+        a
+        for a in dir(c_inst)
+        if not a.startswith("_") and not callable(getattr(c_inst, a))
+    }
+    py_attrs = {
+        a
+        for a in dir(py_inst)
+        if not a.startswith("_") and not callable(getattr(py_inst, a))
+    }
+
+    missing = c_attrs - py_attrs
+    assert not missing, (
+        f"{cls_name}: fallback is missing attributes "
+        f"present in c_ops: {sorted(missing)}"
+    )
+
+
+# ── 1:1 mapping tests ──
+
+
+@pytest.mark.skipif(
+    not HAS_C_OPS,
+    reason="c_ops not available (no CUDA)",
+)
+def test_all_c_ops_callables_have_fallback():
+    """Every public callable in c_ops must exist in
+    non_cuda_equivalents (1:1 coverage)."""
+    missing = sorted(set(_c_ops_callables) - set(_fallback_callables))
+    assert not missing, (
+        "c_ops callables missing from non_cuda_equivalents: %s" % missing
+    )
+
+
+@pytest.mark.skipif(
+    not HAS_C_OPS,
+    reason="c_ops not available (no CUDA)",
+)
+def test_all_c_ops_enums_have_fallback():
+    """Every public enum in c_ops must exist in
+    non_cuda_equivalents (1:1 coverage)."""
+    missing = sorted(set(_c_ops_enums) - set(_fallback_enums))
+    assert not missing, "c_ops enums missing from non_cuda_equivalents: %s" % missing
+
+
+@pytest.mark.skipif(
+    not HAS_C_OPS,
+    reason="c_ops not available (no CUDA)",
+)
+def test_all_c_ops_descriptors_have_fallback():
+    """Every public descriptor class in c_ops must exist
+    in non_cuda_equivalents (1:1 coverage)."""
+    missing = sorted(set(_c_ops_descs) - set(_fallback_descs))
+    assert not missing, (
+        "c_ops descriptor classes missing from non_cuda_equivalents: %s" % missing
     )

--- a/tests/v1/test_non_cuda_equivalents.py
+++ b/tests/v1/test_non_cuda_equivalents.py
@@ -1615,6 +1615,234 @@ def scenario_multi_layer_kv_transfer_unilateral(
     return results
 
 
+def scenario_multi_layer_block_kv_transfer(
+    ops: Any, device: str
+) -> dict[str, torch.Tensor]:
+    """Test multi_layer_block_kv_transfer D2H/H2D roundtrip.
+
+    Only the NL_X_TWO_NB_BS_NH_HS layout is supported by the
+    CPU fallback, so we test that single format with both
+    directions and skip_prefix_n_blocks.
+    """
+    torch.manual_seed(42)
+
+    nl = 2
+    nb = 8
+    bs = 4
+    nh = 2
+    hs = 8
+    chunk_size = 8  # tokens per object = nb_per_obj * bs
+    num_objects = 2
+    blocks_per_obj = chunk_size // bs  # 2
+    total_blocks = num_objects * blocks_per_obj  # 4
+    dtype = torch.float32
+    elem_size = dtype.itemsize
+    hidden = nh * hs
+
+    fmt = ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+    # -- helper: build paged tensors and shape_desc --
+    def _make_paged(fill: bool = False):
+        tensors = []
+        for ly in range(nl):
+            t = torch.zeros(2, nb, bs, nh, hs, dtype=dtype, device=device)
+            if fill:
+                t.copy_(torch.arange(t.numel(), dtype=dtype).fmod_(1000).view_as(t))
+            tensors.append(t)
+        return tensors
+
+    def _make_objects(fill: bool = False):
+        objs = []
+        for i in range(num_objects):
+            t = torch.zeros(
+                2,
+                nl,
+                chunk_size,
+                hidden,
+                dtype=dtype,
+                device=device,
+            )
+            if fill:
+                t.copy_(
+                    torch.arange(t.numel(), dtype=dtype)
+                    .fmod_(500)
+                    .add_(i * 100)
+                    .view_as(t)
+                )
+            objs.append(t)
+        return objs
+
+    def _shape_desc():
+        sd = ops.PageBufferShapeDesc()
+        sd.kv_size = 2
+        sd.nl = nl
+        sd.nb = nb
+        sd.bs = bs
+        sd.nh = nh
+        sd.hs = hs
+        sd.element_size = elem_size
+        # C++ PageBufferShapeDesc has no dtype field;
+        # only the Python fallback needs it.
+        try:
+            sd.dtype = dtype
+        except AttributeError:
+            pass
+        return sd
+
+    # ── D2H then H2D roundtrip ──
+    src_paged = _make_paged(fill=True)
+    mem_objs = _make_objects(fill=False)
+    dst_paged = _make_paged(fill=False)
+
+    block_ids_d2h = list(range(total_blocks))
+    block_ids_h2d = list(range(total_blocks, 2 * total_blocks))
+
+    paged_ptrs = torch.tensor(
+        [t.data_ptr() for t in src_paged],
+        dtype=torch.int64,
+        device=device,
+    )
+    obj_ptrs = [t.data_ptr() for t in mem_objs]
+    block_ids_t = torch.tensor(
+        block_ids_d2h,
+        dtype=torch.int64,
+        device=device,
+    )
+
+    ops.multi_layer_block_kv_transfer(
+        paged_ptrs,
+        obj_ptrs,
+        block_ids_t,
+        torch.device(device),
+        ops.TransferDirection.D2H,
+        _shape_desc(),
+        chunk_size,
+        fmt,
+        0,
+    )
+
+    dst_ptrs = torch.tensor(
+        [t.data_ptr() for t in dst_paged],
+        dtype=torch.int64,
+        device=device,
+    )
+    block_ids_h = torch.tensor(
+        block_ids_h2d,
+        dtype=torch.int64,
+        device=device,
+    )
+
+    ops.multi_layer_block_kv_transfer(
+        dst_ptrs,
+        obj_ptrs,
+        block_ids_h,
+        torch.device(device),
+        ops.TransferDirection.H2D,
+        _shape_desc(),
+        chunk_size,
+        fmt,
+        0,
+    )
+
+    # Verify: dst_paged[h2d_block] == src_paged[d2h_block]
+    for obj_idx in range(num_objects):
+        for local_blk in range(blocks_per_obj):
+            flat = obj_idx * blocks_per_obj + local_blk
+            s_blk = block_ids_d2h[flat]
+            d_blk = block_ids_h2d[flat]
+            for ly in range(nl):
+                for kv in range(2):
+                    src_v = src_paged[ly][kv, s_blk].cpu()
+                    dst_v = dst_paged[ly][kv, d_blk].cpu()
+                    assert torch.equal(src_v, dst_v), (
+                        "Mismatch: obj=%d blk=%d "
+                        "ly=%d kv=%d" % (obj_idx, local_blk, ly, kv)
+                    )
+
+    # ── skip_prefix_n_blocks ──
+    skip = 2
+    mem_objs2 = _make_objects(fill=False)
+    obj_ptrs2 = [t.data_ptr() for t in mem_objs2]
+
+    ops.multi_layer_block_kv_transfer(
+        paged_ptrs,
+        obj_ptrs2,
+        block_ids_t,
+        torch.device(device),
+        ops.TransferDirection.D2H,
+        _shape_desc(),
+        chunk_size,
+        fmt,
+        skip,
+    )
+
+    # Skipped region should remain zero
+    for obj_idx in range(num_objects):
+        obj_t = mem_objs2[obj_idx]
+        blk_start = obj_idx * blocks_per_obj
+        for local_blk in range(blocks_per_obj):
+            flat = blk_start + local_blk
+            if flat < skip:
+                t_st = local_blk * bs
+                t_ed = t_st + bs
+                region = obj_t[:, :, t_st:t_ed, :].cpu()
+                assert region.abs().sum().item() == 0, (
+                    "Skipped block %d not zero" % flat
+                )
+
+    return {"multi_layer_block_kv_transfer": torch.tensor([1], dtype=torch.int32)}
+
+
+def scenario_page_buffer_shape_desc(ops: Any, device: str) -> dict[str, torch.Tensor]:
+    """Test PageBufferShapeDesc can be instantiated and
+    its fields can be read/written."""
+    sd = ops.PageBufferShapeDesc()
+
+    # NOTE: default values differ between the Python fallback
+    # (kv_size=2, element_size=2) and the C++ extension (all zero),
+    # so we only verify that fields are readable and writable.
+    sd.kv_size = 1
+    sd.nl = 32
+    sd.nb = 1024
+    sd.bs = 16
+    sd.nh = 8
+    sd.hs = 128
+    sd.element_size = 4
+
+    assert sd.kv_size == 1
+    assert sd.nl == 32
+    assert sd.nb == 1024
+    assert sd.bs == 16
+    assert sd.nh == 8
+    assert sd.hs == 128
+    assert sd.element_size == 4
+
+    return {"page_buffer_shape_desc": torch.tensor([1], dtype=torch.int32)}
+
+
+def scenario_record_event_on_stream(ops: Any, device: str) -> dict[str, torch.Tensor]:
+    """Test record_event_on_stream is callable and does
+    not crash (no-op on CPU fallback)."""
+    ops.record_event_on_stream(0, "test.event", "session-0", {}, {})
+    # Second call with metadata
+    ops.record_event_on_stream(
+        0,
+        "test.event.meta",
+        "session-1",
+        {"key": "value"},
+        {"count": 42},
+    )
+    return {"record_event_on_stream": torch.tensor([1], dtype=torch.int32)}
+
+
+def scenario_drain_recorded_events(ops: Any, device: str) -> dict[str, torch.Tensor]:
+    """Test drain_recorded_events returns a list
+    (empty on CPU fallback)."""
+    events = ops.drain_recorded_events()
+    assert isinstance(events, list)
+    return {"drain_recorded_events": torch.tensor([1], dtype=torch.int32)}
+
+
 def scenario_alloc_free_pinned_ptr(ops: Any, device: str) -> dict[str, torch.Tensor]:
     """Test alloc_pinned_ptr and free_pinned_ptr round-trip."""
     alloc_size = 4096
@@ -1731,6 +1959,10 @@ SCENARIO_REGISTRY = {
     "alloc_free_numa_ptr": scenario_alloc_free_numa_ptr,
     "alloc_free_shm_pinned_ptr": scenario_alloc_free_shm_pinned_ptr,
     "get_gpu_pci_bus_id": scenario_get_gpu_pci_bus_id,
+    "multi_layer_block_kv_transfer": scenario_multi_layer_block_kv_transfer,
+    "page_buffer_shape_desc": scenario_page_buffer_shape_desc,
+    "record_event_on_stream": scenario_record_event_on_stream,
+    "drain_recorded_events": scenario_drain_recorded_events,
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces global monkey-patching of `torch.cuda`, `cupy`, and `os.eventfd/os.close` to enable CPU-only operation, which can have broad side effects if any behavior diverges from real CUDA/eventfd semantics. Also changes MP server to instantiate a CPU cache context and rely on new pure-Python KV block transfer code paths, which could impact correctness/perf of store/retrieve flows on non-CUDA platforms.
> 
> **Overview**
> Adds a new `lmcache.v1.platform` package that installs early cross-platform shims for `torch.cuda`, `cupy`, and `os.eventfd` (including an `os.close` wrapper) so CPU-only and non-Linux environments don’t crash on CUDA/eventfd usage.
> 
> Switches MP KV-cache registration to `create_cache_context()` so the server can run with a new `CpuCacheContext` when CUDA or real KV tensors aren’t available, while keeping the `GPUCacheContext` API surface.
> 
> Expands `non_cuda_equivalents` to cover missing `c_ops` symbols needed by the MP engine (`PageBufferShapeDesc`, `multi_layer_block_kv_transfer`, and no-op event recording APIs) and strengthens tests to enforce **1:1 symbol coverage** plus signature/enum/descriptor parity between `c_ops` and the Python fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9832b8763e45b2b21de283c262171d1604a5982c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->