### PR TITLE
test: add layerwise remote backend tests and fix bytes_read guard

### DIFF
--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -112,14 +112,12 @@ def pad_shape_to_4d(shape: torch.Size) -> list[int]:
         A list of exactly 4 integers representing the padded shape.
 
     Raises:
-        AssertionError: If the shape has more than 4 dimensions.
+        ValueError: If the shape has more than 4 dimensions.
     """
-    assert len(shape) <= 4, (
-        f"Shape dimension must be <= 4 for serialization, got {len(shape)}"
-    )
-    if len(shape) == 4:
-        return list(shape)
-
+    if len(shape) > 4:
+        raise ValueError(
+            f"Shape dimension must be <= 4 for serialization, got {len(shape)}"
+        )
     padded = list(shape) + [0] * (4 - len(shape))
     return padded
 

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -91,7 +91,7 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         assert self.full_chunk_size_bytes is not None
         assert self.single_token_size is not None
         if (
-            bytes_read == 0
+            bytes_read <= 0
             or bytes_read % self.single_token_size != 0
             or bytes_read > self.full_chunk_size_bytes
         ):

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -107,6 +107,13 @@ class RemoteConnector(metaclass=abc.ABCMeta):
 
         # NOTE: for unfull chunk, we have no way to verify
         shape_list = list(memory_obj.meta.shape)
+        # Determine the token dimension based on shape dimensionality.
+        # NOTE: We cannot use ``memory_obj.meta.fmt.token_dim()`` here
+        # because the remote connector always stores the full-chunk format
+        # (KV_2LTD / KV_MLA_FMT, both with token_dim=2), even when the
+        # actual per-layer shape in layerwise mode is 3D or 2D with tokens
+        # at dim 0.  Using fmt.token_dim() on a 3D shape would silently
+        # index into the wrong dimension.
         if len(shape_list) == 4:
             # Standard: [2, num_layers, num_tokens, hidden_dim]
             # or MLA:   [1, num_layers, num_tokens, hidden_dim]

--- a/lmcache/v1/storage_backend/connector/base_connector.py
+++ b/lmcache/v1/storage_backend/connector/base_connector.py
@@ -137,10 +137,36 @@ class RemoteConnector(metaclass=abc.ABCMeta):
         actual_shape = torch.Size(shape_list)
         memory_obj.raw_data = memory_obj.raw_data[:bytes_read]
         memory_obj.meta.shape = actual_shape
+
+        # Update shapes list if it exists (multi-group support)
+        if memory_obj.meta.shapes is not None:
+            new_shapes = []
+            for s in memory_obj.meta.shapes:
+                sl = list(s)
+                td = 2 if len(sl) == 4 else 0
+                sl[td] = num_tokens
+                new_shapes.append(torch.Size(sl))
+            memory_obj.meta.shapes = new_shapes
+
         # Sync group_prefix_sum so that get_size() / byte_array reflect the
         # truncated size rather than the original full-chunk size.
         if hasattr(memory_obj, "group_prefix_sum"):
-            memory_obj.group_prefix_sum = [0, bytes_read]  # type: ignore[attr-defined]
+            if (
+                memory_obj.meta.shapes is not None
+                and memory_obj.meta.dtypes is not None
+            ):
+                new_prefix_sum = [0]
+                current_offset = 0
+                for s, d in zip(
+                    memory_obj.meta.shapes,
+                    memory_obj.meta.dtypes,
+                    strict=True,
+                ):
+                    current_offset += s.numel() * d.itemsize
+                    new_prefix_sum.append(current_offset)
+                memory_obj.group_prefix_sum = new_prefix_sum
+            else:
+                memory_obj.group_prefix_sum = [0, bytes_read]  # type: ignore[attr-defined]
 
         return memory_obj
 

--- a/tests/v1/storage_backend/connector/__init__.py
+++ b/tests/v1/storage_backend/connector/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/storage_backend/connector/test_reshape_partial_chunk.py
+++ b/tests/v1/storage_backend/connector/test_reshape_partial_chunk.py
@@ -191,3 +191,6 @@ def test_reshape_partial_chunk_invalid_bytes_raises(shape):
 
     with pytest.raises(ValueError):
         connector.reshape_partial_chunk(memory_obj, full_bytes + tok_size)
+
+    with pytest.raises(ValueError):
+        connector.reshape_partial_chunk(memory_obj, -tok_size)

--- a/tests/v1/storage_backend/connector/test_reshape_partial_chunk.py
+++ b/tests/v1/storage_backend/connector/test_reshape_partial_chunk.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for RemoteConnector.reshape_partial_chunk with 2D/3D/4D shapes.
+
+The ``reshape_partial_chunk`` method recalculates the token count when
+only part of a chunk was read from the remote backend.  It must work
+for all supported shape layouts:
+
+* 4-D  ``[2, num_layers, num_tokens, hidden_dim]`` (standard / MLA)
+* 3-D  ``[num_tokens, 2, hidden_dim]``             (layerwise MHA)
+* 2-D  ``[num_tokens, hidden_dim]``                 (layerwise MLA)
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_obj(
+    shape: torch.Size,
+    dtype: torch.dtype = torch.float16,
+    fmt: MemoryFormat = MemoryFormat.KV_2LTD,
+) -> TensorMemoryObj:
+    """Create a minimal TensorMemoryObj backed by a contiguous buffer."""
+    numel = 1
+    for d in shape:
+        numel *= d
+    raw_data = torch.zeros(
+        numel * torch.tensor([], dtype=dtype).element_size(), dtype=torch.uint8
+    )
+    metadata = MemoryObjMetadata(
+        shape=shape,
+        dtype=dtype,
+        address=0,
+        phy_size=raw_data.numel(),
+        ref_count=1,
+        fmt=fmt,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+class _StubConnector:
+    """Minimal stand-in that only exposes the fields reshape_partial_chunk
+    reads, avoiding the need to satisfy RemoteConnector's abstract interface.
+    """
+
+    def __init__(self, full_chunk_size_bytes: int, single_token_size: int):
+        self.full_chunk_size_bytes = full_chunk_size_bytes
+        self.single_token_size = single_token_size
+
+    # Bind the real method so we can test it on the stub.
+    # First Party
+    from lmcache.v1.storage_backend.connector.base_connector import (
+        RemoteConnector,
+    )
+
+    reshape_partial_chunk = RemoteConnector.reshape_partial_chunk
+
+
+# ---------------------------------------------------------------------------
+# Parametrised test data
+# ---------------------------------------------------------------------------
+
+_4D_SHAPE = torch.Size([2, 10, 16, 128])  # token_dim = 2
+_3D_SHAPE = torch.Size([16, 2, 128])  # token_dim = 0
+_2D_SHAPE = torch.Size([16, 128])  # token_dim = 0
+
+_DTYPE = torch.float16
+_ELEM = torch.tensor([], dtype=_DTYPE).element_size()  # 2 bytes
+
+
+def _token_size(shape: torch.Size) -> int:
+    """Bytes per single token for a given shape layout."""
+    if len(shape) == 4:
+        # [2, L, T, D]  → per-token = 2 * L * D * elem
+        return shape[0] * shape[1] * shape[3] * _ELEM
+    elif len(shape) == 3:
+        # [T, 2, D]  → per-token = 2 * D * elem
+        return shape[1] * shape[2] * _ELEM
+    else:
+        # [T, D]  → per-token = D * elem
+        return shape[1] * _ELEM
+
+
+def _full_bytes(shape: torch.Size) -> int:
+    numel = 1
+    for d in shape:
+        numel *= d
+    return numel * _ELEM
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shape, expected_token_dim",
+    [
+        (_4D_SHAPE, 2),
+        (_3D_SHAPE, 0),
+        (_2D_SHAPE, 0),
+    ],
+    ids=["4D-standard", "3D-layerwise-MHA", "2D-layerwise-MLA"],
+)
+@pytest.mark.parametrize("num_tokens", [1, 8, 15])
+def test_reshape_partial_chunk_token_count(shape, expected_token_dim, num_tokens):
+    """Verify that the token dimension is correctly updated after a
+    partial read."""
+    full_bytes = _full_bytes(shape)
+    tok_size = _token_size(shape)
+    full_tokens = shape[expected_token_dim]
+
+    # Only test if requested num_tokens < full tokens
+    if num_tokens >= full_tokens:
+        pytest.skip("num_tokens must be less than full chunk tokens")
+
+    connector = _StubConnector(full_bytes, tok_size)
+    memory_obj = _make_memory_obj(shape, _DTYPE)
+    bytes_read = num_tokens * tok_size
+
+    result = connector.reshape_partial_chunk(memory_obj, bytes_read)
+
+    assert result.meta.shape[expected_token_dim] == num_tokens
+    # Other dimensions unchanged
+    for i, dim in enumerate(shape):
+        if i != expected_token_dim:
+            assert result.meta.shape[i] == dim
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [_4D_SHAPE, _3D_SHAPE, _2D_SHAPE],
+    ids=["4D", "3D", "2D"],
+)
+def test_reshape_full_chunk_returns_unchanged(shape):
+    """A full-chunk read should return the memory object unchanged."""
+    full_bytes = _full_bytes(shape)
+    tok_size = _token_size(shape)
+    connector = _StubConnector(full_bytes, tok_size)
+    memory_obj = _make_memory_obj(shape, _DTYPE)
+
+    result = connector.reshape_partial_chunk(memory_obj, full_bytes)
+    assert result.meta.shape == shape
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [_4D_SHAPE, _3D_SHAPE, _2D_SHAPE],
+    ids=["4D", "3D", "2D"],
+)
+def test_reshape_partial_chunk_truncates_raw_data(shape):
+    """raw_data should be sliced to bytes_read length."""
+    full_bytes = _full_bytes(shape)
+    tok_size = _token_size(shape)
+    connector = _StubConnector(full_bytes, tok_size)
+    memory_obj = _make_memory_obj(shape, _DTYPE)
+
+    bytes_read = tok_size  # 1 token
+    result = connector.reshape_partial_chunk(memory_obj, bytes_read)
+    assert result.raw_data.numel() == bytes_read
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [_4D_SHAPE, _3D_SHAPE, _2D_SHAPE],
+    ids=["4D", "3D", "2D"],
+)
+def test_reshape_partial_chunk_invalid_bytes_raises(shape):
+    """Non-aligned or zero bytes_read should raise ValueError."""
+    full_bytes = _full_bytes(shape)
+    tok_size = _token_size(shape)
+    connector = _StubConnector(full_bytes, tok_size)
+    memory_obj = _make_memory_obj(shape, _DTYPE)
+
+    with pytest.raises(ValueError):
+        connector.reshape_partial_chunk(memory_obj, 0)
+
+    with pytest.raises(ValueError):
+        connector.reshape_partial_chunk(memory_obj, tok_size + 1)
+
+    with pytest.raises(ValueError):
+        connector.reshape_partial_chunk(memory_obj, full_bytes + tok_size)

--- a/tests/v1/test_remote_metadata.py
+++ b/tests/v1/test_remote_metadata.py
@@ -4,9 +4,14 @@ import pytest
 import torch
 
 # First Party
+from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryFormat
 from lmcache.v1.protocol import (
+    ClientCommand,
+    ClientMetaMessage,
     RemoteMetadata,
+    ServerMetaMessage,
+    ServerReturnCode,
     get_remote_metadata_bytes,
     init_remote_metadata_info,
     pad_shape_to_4d,
@@ -99,3 +104,63 @@ def test_remote_metadata_roundtrip_sub4d(shape):
     )
     restored = RemoteMetadata.deserialize(original.serialize())
     assert restored.shapes[0] == shape
+
+
+# ---- ClientMetaMessage round-trip for sub-4D shapes ----
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        torch.Size([10, 128]),  # 2D (layerwise MLA)
+        torch.Size([10, 2, 128]),  # 3D (layerwise MHA)
+        torch.Size([2, 4, 10, 128]),  # 4D (standard)
+    ],
+    ids=["2D", "3D", "4D"],
+)
+def test_client_meta_message_roundtrip_sub4d(shape):
+    key = CacheEngineKey("model", 0, 1, "abc123")
+    original = ClientMetaMessage(
+        command=ClientCommand.PUT,
+        key=key,
+        length=1024,
+        fmt=MemoryFormat.KV_2LTD,
+        dtype=torch.float16,
+        shape=shape,
+        location=None,
+    )
+    restored = ClientMetaMessage.deserialize(original.serialize())
+    assert restored.shape == shape
+    assert restored.length == original.length
+    assert restored.fmt == original.fmt
+    assert restored.dtype == original.dtype
+    assert restored.command == original.command
+
+
+# ---- ServerMetaMessage round-trip for sub-4D shapes ----
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        torch.Size([10, 128]),  # 2D (layerwise MLA)
+        torch.Size([10, 2, 128]),  # 3D (layerwise MHA)
+        torch.Size([2, 4, 10, 128]),  # 4D (standard)
+    ],
+    ids=["2D", "3D", "4D"],
+)
+def test_server_meta_message_roundtrip_sub4d(shape):
+    original = ServerMetaMessage(
+        code=ServerReturnCode.SUCCESS,
+        length=2048,
+        fmt=MemoryFormat.KV_MLA_FMT,
+        dtype=torch.bfloat16,
+        shape=shape,
+        location=None,
+    )
+    restored = ServerMetaMessage.deserialize(original.serialize())
+    assert restored.shape == shape
+    assert restored.length == original.length
+    assert restored.fmt == original.fmt
+    assert restored.dtype == original.dtype
+    assert restored.code == original.code

--- a/tests/v1/test_remote_metadata.py
+++ b/tests/v1/test_remote_metadata.py
@@ -66,7 +66,7 @@ def test_pad_shape_to_4d_3d():
 
 
 def test_pad_shape_too_large():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         pad_shape_to_4d(torch.Size([1, 2, 3, 4, 5]))
 
 
@@ -119,7 +119,7 @@ def test_remote_metadata_roundtrip_sub4d(shape):
     ids=["2D", "3D", "4D"],
 )
 def test_client_meta_message_roundtrip_sub4d(shape):
-    key = CacheEngineKey("model", 0, 1, "abc123")
+    key = CacheEngineKey("model", 0, 1, 12345, torch.float16)
     original = ClientMetaMessage(
         command=ClientCommand.PUT,
         key=key,


### PR DESCRIPTION
## Summary

Follow-up to #2751 which fixes the core `assert len(shape) == 4` crashes for layerwise remote backend support.

This PR adds missing test coverage and fixes subtle bugs found during review.

## Changes

### Fix: `bytes_read <= 0` guard in `reshape_partial_chunk`

The original guard used `bytes_read == 0`, but Python's modulo operator returns non-negative results for positive divisors:

```python
-256 % 256 == 0   # True -- bypasses the guard!
-256 > 81920      # False -- bypasses the check!
```

A negative `bytes_read` would silently produce `shape_list[token_dim] = -1` and truncate data from the wrong end. Changed to `bytes_read <= 0`.

### Fix: Multi-group `reshape_partial_chunk` support

`reshape_partial_chunk` previously only updated `meta.shape` (singular) and forced `group_prefix_sum = [0, bytes_read]`. For multi-group MemoryObj (e.g., separate K and V tensors), this left `meta.shapes` stale and broke `get_tensor(1)`. Now:
- All shapes in `meta.shapes` are updated (token dim adjusted per shape)
- `group_prefix_sum` is recalculated from actual `shapes x dtypes`
- Falls back to `[0, bytes_read]` when `shapes`/`dtypes` are None

### Fix: `assert`  `ValueError` in `pad_shape_to_4d`

Replaced `assert len(shape) <= 4` with `raise ValueError(...)` so the check is never disabled by `python -O`.

### Tests: `reshape_partial_chunk` with 2D/3D/4D shapes

`reshape_partial_chunk` had zero test coverage for sub-4D shapes (the exact shapes introduced by layerwise mode). Added parametrized tests covering:
- 4D: `[kv, layers, tokens, hidden]` (non-layerwise)
- 3D: `[tokens, 2, hidden]` (layerwise MHA, `token_dim=0`)
- 2D: `[tokens, hidden]` (layerwise MLA, `token_dim=0`)
- Invalid/edge cases: zero bytes, misaligned, over-size, negative

### Tests: `ClientMetaMessage` / `ServerMetaMessage` sub-4D round-trips

Added serialization round-trip tests for 3D and 2D shapes through the wire protocol, complementing the tests added in #2751 for `RemoteMetadata`.

## Relationship to #2751

This PR is designed to be merged **after** #2751. It merges #2751's branch as a base and adds improvements on top.

Closes #2752

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote-backend partial-read reshaping logic and multi-group size accounting; mistakes here could corrupt tensor views or sizes when reading from remote storage. Changes are well-scoped and backed by new parametrized tests, reducing regression risk.
> 
> **Overview**
> Improves remote-backend handling of *partial chunk reads* by tightening validation (`bytes_read <= 0`) and correctly recomputing token counts for layerwise 2D/3D shapes (token dimension selection no longer relies on the stored full-chunk `fmt`).
> 
> Extends `reshape_partial_chunk` to update multi-group metadata (`meta.shapes`) and to recompute `group_prefix_sum` from `shapes`×`dtypes` so `get_size()`/`get_tensor()` reflect the truncated buffer.
> 
> Hardens protocol shape serialization by replacing an `assert` in `pad_shape_to_4d` with a `ValueError`, and adds tests for sub-4D shape round-trips through `RemoteMetadata`, `ClientMetaMessage`, and `ServerMetaMessage`, plus new connector tests covering 2D/3D/4D layouts and invalid `bytes_read` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfb87c8571b238b6038f20b234267f53a36aa16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->