### PR TITLE
[Bugfix] Fix infinite loop in MooncakeLookupClient due to missing lookup_cache() override

### DIFF
--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -78,6 +78,17 @@ class MooncakeLookupClient(LookupClientInterface):
         # All keys were found, return the last end position
         return ends[-1] if ends else 0
 
+    def lookup_cache(self, lookup_id: str) -> Optional[int]:
+        """MooncakeLookupClient is synchronous — no cached/async results.
+
+        Return -1 to indicate "not found in cache", so the caller
+        falls through to the actual lookup() call.
+
+        Without this override the base class returns None (="ongoing"),
+        which causes the scheduler to retry indefinitely.
+        """
+        return -1
+
     def supports_producer_reuse(self) -> bool:
         """Return True as MooncakeLookupClient supports producer kvcache reuse"""
         return True

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -79,13 +79,17 @@ class MooncakeLookupClient(LookupClientInterface):
         return ends[-1] if ends else 0
 
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
-        """MooncakeLookupClient is synchronous — no cached/async results.
+        """
+        Lookup the cache for the given lookup ID. MooncakeLookupClient is
+        synchronous and does not support async/cached results.
 
-        Return -1 to indicate "not found in cache", so the caller
-        falls through to the actual lookup() call.
+        Args:
+            lookup_id: The lookup ID to lookup
 
-        Without this override the base class returns None (="ongoing"),
-        which causes the scheduler to retry indefinitely.
+        Returns:
+            Always returns -1 to indicate "not found in cache". Returning None
+            (the base class default) would cause the scheduler to retry
+            indefinitely.
         """
         return -1
 

--- a/tests/v1/lookup_client/test_mooncake_lookup_client.py
+++ b/tests/v1/lookup_client/test_mooncake_lookup_client.py
@@ -6,17 +6,12 @@ These tests guard against known bugs in the MooncakeLookupClient,
 notably the infinite-retry loop caused by inheriting the base class
 default of ``lookup_cache() -> None`` (which the scheduler interprets
 as "still ongoing").
+
+The tests do not require the ``mooncake`` package: the mooncake import
+inside ``MooncakeLookupClient`` is lazy (inside ``__init__``), and the
+tests bypass ``__init__`` via ``__new__()`` to target ``lookup_cache()``
+in isolation.
 """
-
-# Third Party
-import pytest
-
-
-# Skip the whole module if the mooncake package is not installed.
-# MooncakeLookupClient imports ``from mooncake.store import
-# MooncakeDistributedStore`` inside __init__, so the import itself does
-# not require mooncake, but instantiation does.
-mooncake = pytest.importorskip("mooncake.store")
 
 
 def test_lookup_cache_returns_minus_one_not_none():

--- a/tests/v1/lookup_client/test_mooncake_lookup_client.py
+++ b/tests/v1/lookup_client/test_mooncake_lookup_client.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for MooncakeLookupClient.
+
+These tests guard against known bugs in the MooncakeLookupClient,
+notably the infinite-retry loop caused by inheriting the base class
+default of ``lookup_cache() -> None`` (which the scheduler interprets
+as "still ongoing").
+"""
+
+# Third Party
+import pytest
+
+
+# Skip the whole module if the mooncake package is not installed.
+# MooncakeLookupClient imports ``from mooncake.store import
+# MooncakeDistributedStore`` inside __init__, so the import itself does
+# not require mooncake, but instantiation does.
+mooncake = pytest.importorskip("mooncake.store")
+
+
+def test_lookup_cache_returns_minus_one_not_none():
+    """
+    Regression test for the infinite-loop bug.
+
+    ``MooncakeLookupClient`` is a synchronous lookup client and must
+    override ``lookup_cache()`` to return -1 ("not found").  If it
+    inherits the base class default (``None`` = "ongoing"), the vLLM
+    scheduler interprets every probe as "still ongoing" and retries
+    forever without ever calling the real ``lookup()``.
+    """
+    # First Party
+    from lmcache.v1.lookup_client.mooncake_lookup_client import (
+        MooncakeLookupClient,
+    )
+
+    # Skip Mooncake store setup by constructing without __init__ side
+    # effects.  The test targets only the lookup_cache() method.
+    client = MooncakeLookupClient.__new__(MooncakeLookupClient)
+
+    result = client.lookup_cache(lookup_id="test-request-id")
+
+    assert result == -1, (
+        "MooncakeLookupClient.lookup_cache() must return -1 "
+        "(not found).  Returning None (the base class default) "
+        "causes the scheduler to retry indefinitely."
+    )
+    assert result is not None
+
+
+def test_lookup_cache_override_does_not_raise_for_any_lookup_id():
+    """``lookup_cache()`` must never raise — it is called per request."""
+    # First Party
+    from lmcache.v1.lookup_client.mooncake_lookup_client import (
+        MooncakeLookupClient,
+    )
+
+    client = MooncakeLookupClient.__new__(MooncakeLookupClient)
+
+    for lookup_id in ("req-0", "req-1", "", "with-dashes-123"):
+        assert client.lookup_cache(lookup_id=lookup_id) == -1


### PR DESCRIPTION
  **What this PR does / why we need it**:

  `MooncakeLookupClient` does not override `lookup_cache()` from the base class `LookupClientInterface`. The base
  class returns `None` (meaning "ongoing/async"), but `MooncakeLookupClient` is a **synchronous** lookup client — it
  never has an async result to return.

  In `vllm_v1_adapter.py`, the scheduler calls `lookup_cache()` first to check for a cached result. When it receives
  `None`, it interprets this as "lookup still in progress" and retries on the next scheduler loop iteration. Since
  `MooncakeLookupClient.lookup_cache()` always returns `None`, this creates an **infinite retry loop** — the actual
  `lookup()` method is never called.

  **Fix**: Override `lookup_cache()` to return `-1` ("not found in cache"), so the caller falls through to the actual
  `lookup()` call which performs the synchronous `batch_is_exist()` against Mooncake Master.

  **Special notes for your reviewers**:

  This likely affects all synchronous `LookupClientInterface` implementations that don't override `lookup_cache()`.
  The base class default of `None` is only correct for async clients. Consider either:
  1. Making `lookup_cache()` abstract (forces all subclasses to implement it), or
  2. Changing the base class default to `-1` instead of `None`

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [ ] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change limited to Mooncake lookup caching semantics plus targeted regression tests; low risk aside from any downstream code that incorrectly relied on `lookup_cache()` returning `None` for Mooncake.
> 
> **Overview**
> Fixes an infinite-retry condition for synchronous `MooncakeLookupClient` by overriding `lookup_cache()` to always return `-1` ("not found"), preventing the scheduler from treating lookups as perpetually "ongoing".
> 
> Adds regression tests ensuring `lookup_cache()` never returns `None` and does not raise for various `lookup_id` values, without requiring the external `mooncake` dependency (tests construct the client via `__new__()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0feb7faccfbd05732217bf849d1b2c5fcd2bea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->