### PR TITLE
[MP] Introduce metrcs api

### DIFF
--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -274,11 +274,21 @@ def parse_args_to_observability_config(
     return config
 
 
-def init_observability(obs_config: ObservabilityConfig) -> EventBus:
+def init_observability(
+    obs_config: ObservabilityConfig,
+    *,
+    start_prometheus_http_server: bool = True,
+) -> EventBus:
     """Initialize OTel providers, EventBus, and register subscribers.
 
     This is the single entry-point that every MP server calls at startup.
     Returns a **started** EventBus.
+
+    Args:
+        obs_config: Observability configuration.
+        start_prometheus_http_server: Whether to start a standalone
+            Prometheus HTTP server.  Set to ``False`` when an
+            external HTTP framework already serves ``/metrics``.
     """
     # First Party
     from lmcache.v1.mp_observability.event_bus import (
@@ -303,6 +313,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
             otlp_endpoint=obs_config.otlp_endpoint,
             prometheus_port=obs_config.prometheus_port,
             resource_attributes=resource_attrs,
+            start_http_server=start_prometheus_http_server,
         )
 
     if obs_config.enabled and obs_config.tracing_enabled:

--- a/lmcache/v1/mp_observability/otel_init.py
+++ b/lmcache/v1/mp_observability/otel_init.py
@@ -104,12 +104,19 @@ def init_otel_metrics(
         metrics.set_meter_provider(provider)
         if start_http_server:
             prometheus_client.start_http_server(prometheus_port)
-        logger.info(
-            "OTel MeterProvider initialised with Prometheus fallback "
-            "(http://0.0.0.0:%d/metrics), resource=%s",
-            prometheus_port,
-            dict(resource.attributes),
-        )
+            logger.info(
+                "OTel MeterProvider initialised with Prometheus fallback "
+                "(http://0.0.0.0:%d/metrics), resource=%s",
+                prometheus_port,
+                dict(resource.attributes),
+            )
+        else:
+            logger.info(
+                "OTel MeterProvider initialised with Prometheus fallback "
+                "(standalone metrics HTTP server disabled; "
+                "/metrics must be exposed by the caller), resource=%s",
+                dict(resource.attributes),
+            )
 
 
 def init_otel_tracing(

--- a/lmcache/v1/mp_observability/otel_init.py
+++ b/lmcache/v1/mp_observability/otel_init.py
@@ -45,6 +45,7 @@ def init_otel_metrics(
     otlp_endpoint: str | None = None,
     prometheus_port: int | None = None,
     resource_attributes: dict[str, str] | None = None,
+    start_http_server: bool = True,
 ) -> None:
     """Set up the OpenTelemetry MeterProvider.
 
@@ -60,6 +61,9 @@ def init_otel_metrics(
             through the provider carries these attributes.  Intended for
             process-level identity (e.g. ``service.instance.id``) — never
             for per-request tags.
+        start_http_server: Whether to start a standalone Prometheus
+            HTTP server.  Set to ``False`` when metrics are already
+            served by an external HTTP framework (e.g. FastAPI).
     """
     # Third Party
     from opentelemetry import metrics
@@ -98,7 +102,8 @@ def init_otel_metrics(
         reader = PrometheusMetricReader()
         provider = MeterProvider(metric_readers=[reader], resource=resource)
         metrics.set_meter_provider(provider)
-        prometheus_client.start_http_server(prometheus_port)
+        if start_http_server:
+            prometheus_client.start_http_server(prometheus_port)
         logger.info(
             "OTel MeterProvider initialised with Prometheus fallback "
             "(http://0.0.0.0:%d/metrics), resource=%s",

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -1010,6 +1010,7 @@ def run_cache_server(
     storage_manager_config: StorageManagerConfig,
     obs_config: ObservabilityConfig,
     return_engine: bool = False,
+    start_prometheus_http_server: bool = True,
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
@@ -1020,12 +1021,16 @@ def run_cache_server(
         obs_config: Configuration for the observability stack
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
+        start_prometheus_http_server: If True, start a Prometheus HTTP server in a
+            background thread.
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, BlendEngineV2)
         If return_engine is False: None (blocks until interrupted)
     """
-    event_bus = init_observability(obs_config)
+    event_bus = init_observability(
+        obs_config, start_prometheus_http_server=start_prometheus_http_server
+    )
 
     # Wire up the trace recorder (no-op when --trace-level is unset).
     maybe_initialize_trace_recorder(event_bus, obs_config, storage_manager_config)

--- a/lmcache/v1/multiprocess/http_apis/metrics_api.py
+++ b/lmcache/v1/multiprocess/http_apis/metrics_api.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Any
+
+# Third Party
+from fastapi import APIRouter
+from prometheus_client import REGISTRY, generate_latest
+from starlette.responses import PlainTextResponse
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+async def get_metrics() -> Any:
+    """
+    Provide Prometheus metrics data in the standard
+    exposition format.
+    """
+    metrics_data = generate_latest(REGISTRY)
+    return PlainTextResponse(content=metrics_data, media_type="text/plain")

--- a/lmcache/v1/multiprocess/http_apis/metrics_api.py
+++ b/lmcache/v1/multiprocess/http_apis/metrics_api.py
@@ -1,20 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-# Standard
-from typing import Any
+"""Expose Prometheus metrics endpoints for the multiprocess HTTP server.
 
-# Third Party
-from fastapi import APIRouter
-from prometheus_client import REGISTRY, generate_latest
-from starlette.responses import PlainTextResponse
+Reuses the shared router from
+``lmcache.v1.internal_api_server.common.metrics_api`` so that the
+``/metrics`` and ``/metrics/reset`` endpoints stay in sync across
+deployments. The auto-discovery mechanism in
+``lmcache.v1.utils.router_discovery`` picks up the re-exported
+``router`` attribute below.
+"""
 
-router = APIRouter()
+# First Party
+from lmcache.v1.internal_api_server.common.metrics_api import router
 
-
-@router.get("/metrics")
-async def get_metrics() -> Any:
-    """
-    Provide Prometheus metrics data in the standard
-    exposition format.
-    """
-    metrics_data = generate_latest(REGISTRY)
-    return PlainTextResponse(content=metrics_data, media_type="text/plain")
+__all__ = ["router"]

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -73,6 +73,7 @@ async def lifespan(app: FastAPI):
         storage_manager_config=_configs["storage_manager"],
         obs_config=_configs["observability"],
         return_engine=True,
+        start_prometheus_http_server=False,
     )
     assert result is not None, "run_cache_server returned None with return_engine=True"
     zmq_server, engine = result

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -1048,6 +1048,7 @@ def run_cache_server(
     storage_manager_config: StorageManagerConfig,
     obs_config: ObservabilityConfig,
     return_engine: bool = False,
+    start_prometheus_http_server: bool = True,
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
@@ -1058,12 +1059,15 @@ def run_cache_server(
         obs_config: Configuration for the observability stack
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
+        start_prometheus_http_server: If True, start a Prometheus HTTP server
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
         If return_engine is False: None (blocks until interrupted)
     """
-    event_bus = init_observability(obs_config)
+    event_bus = init_observability(
+        obs_config, start_prometheus_http_server=start_prometheus_http_server
+    )
 
     # Wire up the trace recorder (no-op when --trace-level is unset).
     # Registered before the engine handlers are added so any


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how MP servers initialize metrics by optionally not starting the standalone Prometheus HTTP server, which could affect metrics availability and avoid/introduce port conflicts depending on deployment.
> 
> **Overview**
> Adds a multiprocess HTTP `metrics_api` that exposes the shared `/metrics` and `/metrics/reset` endpoints via FastAPI router auto-discovery.
> 
> Updates MP observability initialization (`init_observability`/`init_otel_metrics`) to accept a `start_prometheus_http_server`/`start_http_server` flag so Prometheus’ standalone server can be disabled when an external HTTP server is already serving metrics, and wires this through both `server.py` and `blend_server_v2.py` (with `http_server.py` setting it to `False`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7275932ad782f7d7822df4fbc677b83caae53f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->