### PR TITLE
[MP][optimize] unified touch all keys in end session request 

### DIFF
--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -144,7 +144,7 @@ class L1EvictionPolicy(L1ManagerListener):
         pass
 
     def on_l1_keys_read_finished(self, keys: list[ObjectKey]):
-        pass
+        self._policy.on_keys_touched(keys)
 
     def on_l1_keys_reserved_write(self, keys: list[ObjectKey]):
         # No-op

--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -144,7 +144,7 @@ class L1EvictionPolicy(L1ManagerListener):
         pass
 
     def on_l1_keys_read_finished(self, keys: list[ObjectKey]):
-        self._policy.on_keys_touched(keys)
+        pass
 
     def on_l1_keys_reserved_write(self, keys: list[ObjectKey]):
         # No-op
@@ -162,6 +162,9 @@ class L1EvictionPolicy(L1ManagerListener):
 
     def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]):
         self._policy.on_keys_created(keys)
+
+    def on_l1_keys_accessed(self, keys: list[ObjectKey]):
+        self._policy.on_keys_touched(keys)
 
 
 class L2EvictionPolicy(L2AdapterListener):

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -77,6 +77,8 @@ class LRUEvictionPolicy(EvictionPolicy):
         Args:
             keys (list[ObjectKey]): The keys that have been created
         """
+        if not keys:
+            return
         with self._lock:
             # NOTE: for the request, the later keys should be evicted first.
             # For example, the request has (key1, key2, key3), if we first
@@ -97,6 +99,8 @@ class LRUEvictionPolicy(EvictionPolicy):
         Args:
             keys (list[ObjectKey]): The keys that have been accessed
         """
+        if not keys:
+            return
         with self._lock:
             # NOTE: for the request, the later keys should be evicted first.
             # The example is the same as `on_keys_created`.
@@ -113,6 +117,8 @@ class LRUEvictionPolicy(EvictionPolicy):
         Args:
             keys (list[ObjectKey]): The keys that have been deleted
         """
+        if not keys:
+            return
         with self._lock:
             for key in keys:
                 # Remove from LRU order tracking

--- a/lmcache/v1/distributed/internal_api.py
+++ b/lmcache/v1/distributed/internal_api.py
@@ -99,6 +99,16 @@ class L1ManagerListener(EventListener):
         """
         pass
 
+    @abstractmethod
+    def on_l1_keys_accessed(self, keys: list[ObjectKey]):
+        """
+        Notify the listener that keys have been accessed on L1.
+
+        Args:
+            keys (list[ObjectKey]): The keys that have been accessed
+        """
+        pass
+
 
 class L2AdapterListener(EventListener):
     """Listener for L2 adapter events, analogous to L1ManagerListener."""

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -650,6 +650,15 @@ class L1Manager:
         )
         return ret
 
+    def touch_keys(self, keys: list[ObjectKey]):
+        """Touch the given keys to update their access time.
+
+        Args:
+            keys: The list of object keys to touch.
+        """
+        for listener in self._registered_listeners:
+            listener.on_l1_keys_accessed(keys)
+
     @l1_mgr_synchronized
     def clear(self, force: bool = False) -> None:
         """Clear objects from L1 cache.

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -651,7 +651,7 @@ class L1Manager:
         return ret
 
     def touch_keys(self, keys: list[ObjectKey]):
-        """Touch the given keys to update their access time.
+        """Touch the given keys, marking the keys as accessed(retrieved or stored).
 
         Args:
             keys: The list of object keys to touch.

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -116,7 +116,7 @@ class StoreListener(L1ManagerListener):
         # objects are prefetched to L1.
         pass
 
-    def on_l1_keys_accessed(self, keys: list[ObjectKey]):
+    def on_l1_keys_accessed(self, keys: list[ObjectKey]) -> None:
         pass
 
     def close(self) -> None:

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -116,6 +116,9 @@ class StoreListener(L1ManagerListener):
         # objects are prefetched to L1.
         pass
 
+    def on_l1_keys_accessed(self, keys: list[ObjectKey]):
+        pass
+
     def close(self) -> None:
         """Close the eventfd."""
         os.close(self._event_fd)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -457,6 +457,15 @@ class StorageManager:
             )
         return total_hits
 
+    def touch_l1_keys(self, keys: list[ObjectKey]):
+        """
+        Touch the keys in L1 storage.
+
+        Args:
+            keys (list[ObjectKey]): List of object keys to touch.
+        """
+        self._l1_manager.touch_keys(keys)
+
     def clear(self, force: bool = False):
         """
         Clear data in the storage manager.

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -459,7 +459,8 @@ class StorageManager:
 
     def touch_l1_keys(self, keys: list[ObjectKey]):
         """
-        Touch the keys in L1 storage.
+        Touch the keys in L1 storage, marking the keys
+        as accessed(retrieved or stored).
 
         Args:
             keys (list[ObjectKey]): List of object keys to touch.

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -873,7 +873,7 @@ class MPCacheEngine:
             )
             return
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_all_hashes()]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_hashes(0, -1)]
         obj_keys = ipc_key_to_object_keys(session.lookup_ipc_key, chunk_hashes)
         # unified touch of all keys, which include retrieved and stored keys
         # TODO(chunxiaozheng): when l2 is enabled, the prefetched keys from l2 are temp

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -665,7 +665,6 @@ class MPCacheEngine:
                     request_id=key.request_id,
                 )
             )
-
             return
 
         # Publish lookup event via EventBus for observability subscribers.
@@ -688,6 +687,10 @@ class MPCacheEngine:
                     },
                 )
             )
+
+        # set lookup ipc key, for session manager to use and generate object keys
+        session = self.session_manager.get_or_create(key.request_id)
+        session.lookup_ipc_key = key
 
         obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
 
@@ -854,13 +857,29 @@ class MPCacheEngine:
                 metadata={"request_id": request_id},
             )
         )
-        self.session_manager.remove(request_id)
+        session = self.session_manager.remove(request_id)
         self._event_bus.publish(
             Event(
                 event_type=EventType.MP_SESSION_END,
                 session_id=request_id,
             )
         )
+        if session is None:
+            logger.warning("Session %s not found, skipping touch", request_id)
+            return
+        if session.lookup_ipc_key is None:
+            logger.warning(
+                "Session %s has no lookup ipc key, skipping touch", request_id
+            )
+            return
+
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_all_hashes()]
+        obj_keys = ipc_key_to_object_keys(session.lookup_ipc_key, chunk_hashes)
+        # unified touch of all keys, which include retrieved and stored keys
+        # TODO(chunxiaozheng): when l2 is enabled, the prefetched keys from l2 are temp
+        #  and will be deleted after finish_read_prefetched, when we touch all keys,
+        #  these keys has been deleted and will not be touched.
+        self.storage_manager.touch_l1_keys(obj_keys)
 
     def report_status(self) -> dict:
         """Return a status dict for the entire cache engine."""

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -690,6 +690,7 @@ class MPCacheEngine:
 
         # set lookup ipc key, for session manager to use and generate object keys
         session = self.session_manager.get_or_create(key.request_id)
+        session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
 
         obj_keys = ipc_key_to_object_keys(key, chunk_hashes)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -874,7 +874,7 @@ class MPCacheEngine:
             )
             return
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_hashes(0, -1)]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_hashes(0)]
         obj_keys = ipc_key_to_object_keys(session.lookup_ipc_key, chunk_hashes)
         # unified touch of all keys, which include retrieved and stored keys
         # TODO(chunxiaozheng): when l2 is enabled, the prefetched keys from l2 are temp

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -45,11 +45,6 @@ class Session:
         with self._lock:
             self.token_ids = full_token_ids
 
-    def get_all_hashes(self) -> list:
-        """Return all computed chunk hashes."""
-        with self._lock:
-            return self.chunk_hashes
-
     def get_hashes(self, start: int, end: int) -> list:
         """Compute and return chunk hashes for the [start, end) token range.
 
@@ -58,7 +53,8 @@ class Session:
 
         Args:
             start: Start token index.
-            end: End token index.
+            end: End token index. If negative, it is treated as the
+                last token and automatically aligned down to chunk_size.
 
         Returns:
             List of hash values for chunks in [start_chunk, end_chunk).
@@ -67,13 +63,20 @@ class Session:
         assert start % chunk_size == 0, (
             f"start ({start}) must be a multiple of chunk_size ({chunk_size})"
         )
-        assert end % chunk_size == 0, (
-            f"end ({end}) must be a multiple of chunk_size ({chunk_size})"
-        )
         start_chunk = start // chunk_size
-        end_chunk = end // chunk_size
 
         with self._lock:
+            # Lock must be held before resolving negative `end`, because
+            # it reads `self.token_ids` which may be concurrently replaced
+            # by `set_tokens` from another thread.
+            if end < 0:
+                # Negative end means "up to the last token",
+                # align down to chunk_size boundary.
+                end = len(self.token_ids) - (len(self.token_ids) % chunk_size)
+            assert end % chunk_size == 0, (
+                f"end ({end}) must be a multiple of chunk_size ({chunk_size})"
+            )
+            end_chunk = end // chunk_size
             self._compute_hash(end_chunk)
             return self.chunk_hashes[start_chunk:end_chunk]
 

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -6,7 +6,7 @@ in the multiprocess cache server.
 
 # Standard
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Optional, overload
 import threading
 import time
 
@@ -45,16 +45,28 @@ class Session:
         with self._lock:
             self.token_ids = full_token_ids
 
-    def get_hashes(self, start: int, end: int) -> list:
+    @overload
+    def get_hashes(self, start: int, end: int) -> list: ...
+
+    @overload
+    def get_hashes(self, start: int) -> list: ...
+
+    def get_hashes(self, start: int, end: int | None = None) -> list:
         """Compute and return chunk hashes for the [start, end) token range.
 
         Internally computes rolling hashes up to end_chunk, skipping
         already-computed chunks.
 
+        Two calling conventions are supported (declared via ``@overload``)::
+
+            get_hashes(start, end)  # explicit end
+            get_hashes(start)       # end = last full-chunk boundary
+
         Args:
-            start: Start token index.
-            end: End token index. If negative, it is treated as the
-                last token and automatically aligned down to chunk_size.
+            start: Start token index (must be aligned to chunk_size).
+            end: End token index (must be aligned to chunk_size).
+                When omitted (``None``), automatically set to the last
+                full-chunk boundary of the current token sequence.
 
         Returns:
             List of hash values for chunks in [start_chunk, end_chunk).
@@ -66,12 +78,10 @@ class Session:
         start_chunk = start // chunk_size
 
         with self._lock:
-            # Lock must be held before resolving negative `end`, because
-            # it reads `self.token_ids` which may be concurrently replaced
-            # by `set_tokens` from another thread.
-            if end < 0:
-                # Negative end means "up to the last token",
-                # align down to chunk_size boundary.
+            if end is None:
+                # No explicit end: use the last full-chunk boundary.
+                # Lock must be held here because `self.token_ids` may be
+                # concurrently replaced by `set_tokens` from another thread.
                 end = len(self.token_ids) - (len(self.token_ids) % chunk_size)
             assert end % chunk_size == 0, (
                 f"end ({end}) must be a multiple of chunk_size ({chunk_size})"

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -6,12 +6,13 @@ in the multiprocess cache server.
 
 # Standard
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 import threading
 import time
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
 logger = init_logger(__name__)
@@ -32,6 +33,7 @@ class Session:
     last_prefix_hash: Any = None
     num_chunks_processed: int = 0
     created_at: float = field(default_factory=time.time)
+    lookup_ipc_key: Optional[IPCCacheEngineKey] = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def set_tokens(self, full_token_ids: list[int]) -> None:
@@ -42,6 +44,11 @@ class Session:
         """
         with self._lock:
             self.token_ids = full_token_ids
+
+    def get_all_hashes(self) -> list:
+        """Return all computed chunk hashes."""
+        with self._lock:
+            return self.chunk_hashes
 
     def get_hashes(self, start: int, end: int) -> list:
         """Compute and return chunk hashes for the [start, end) token range.
@@ -124,16 +131,22 @@ class SessionManager:
                 logger.debug("Created session for request_id=%s", request_id)
             return self._sessions[request_id]
 
-    def remove(self, request_id: str) -> None:
+    def remove(self, request_id: str) -> Optional[Session]:
         """Remove a session by request_id.
 
         Args:
             request_id: Unique request identifier.
+
+        Returns:
+            The removed session, or None if no session was found.
         """
         with self._lock:
             if request_id in self._sessions:
+                session = self._sessions[request_id]
                 del self._sessions[request_id]
                 logger.debug("Removed session for request_id=%s", request_id)
+                return session
+            return None
 
     def cleanup_expired(self) -> int:
         """Remove sessions that have exceeded their TTL.

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -9,6 +9,7 @@ import time
 import pytest
 
 # First Party
+from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
 from lmcache.v1.multiprocess.session import Session, SessionManager
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
@@ -115,14 +116,17 @@ class TestSessionManager:
 
     def test_remove(self, session_manager: SessionManager) -> None:
         session_manager.get_or_create("req-1")
-        session_manager.remove("req-1")
+        removed = session_manager.remove("req-1")
+        assert removed is not None
+        assert removed.request_id == "req-1"
         # Should create a fresh session
         s = session_manager.get_or_create("req-1")
         assert s.num_chunks_processed == 0
 
     def test_remove_nonexistent(self, session_manager: SessionManager) -> None:
-        """Removing a non-existent session should not raise."""
-        session_manager.remove("does-not-exist")
+        """Removing a non-existent session should return None."""
+        result = session_manager.remove("does-not-exist")
+        assert result is None
 
     def test_cleanup_expired(self, session_manager: SessionManager) -> None:
         """Sessions older than TTL should be cleaned up."""
@@ -215,3 +219,109 @@ class TestSessionThreadSafety:
             t.join(timeout=10)
 
         assert not errors, "\n".join(errors)
+
+
+class TestSessionGetAllHashes:
+    """Tests for Session.get_all_hashes method."""
+
+    def test_get_all_hashes_empty(self, session: Session) -> None:
+        """get_all_hashes should return empty list before any hash computation."""
+        assert session.get_all_hashes() == []
+
+    def test_get_all_hashes_after_compute(self, session: Session) -> None:
+        """get_all_hashes should return all computed hashes."""
+        session.set_tokens(list(range(12)))  # 3 chunks of 4
+        session.get_hashes(0, 12)
+        all_hashes = session.get_all_hashes()
+        assert len(all_hashes) == 3
+
+    def test_get_all_hashes_incremental(self, session: Session) -> None:
+        """get_all_hashes should accumulate hashes from incremental calls."""
+        session.set_tokens(list(range(12)))  # 3 chunks of 4
+        # First compute 2 chunks
+        session.get_hashes(0, 8)
+        assert len(session.get_all_hashes()) == 2
+        # Then compute 1 more chunk
+        session.get_hashes(8, 12)
+        assert len(session.get_all_hashes()) == 3
+
+    def test_get_all_hashes_matches_get_hashes(self, session: Session) -> None:
+        """get_all_hashes should return the same hashes as get_hashes(0, total)."""
+        session.set_tokens(list(range(12)))
+        expected = session.get_hashes(0, 12)
+        assert session.get_all_hashes() == expected
+
+    def test_get_all_hashes_matches_hasher(
+        self, hasher: TokenHasher, session: Session
+    ) -> None:
+        """get_all_hashes should match standalone TokenHasher results."""
+        tokens = list(range(12))
+        session.set_tokens(tokens)
+        session.get_hashes(0, 12)
+        session_hashes = session.get_all_hashes()
+        hasher_hashes = hasher.compute_chunk_hashes(tokens)
+        # Convert session hashes to bytes for comparison
+        converted = [TokenHasher.hash_to_bytes(h) for h in session_hashes]
+        assert converted == hasher_hashes
+
+
+class TestSessionLookupIpcKey:
+    """Tests for Session.lookup_ipc_key field."""
+
+    def test_lookup_ipc_key_default_none(self, session: Session) -> None:
+        """lookup_ipc_key should default to None."""
+        assert session.lookup_ipc_key is None
+
+    def test_lookup_ipc_key_set_and_get(self, session: Session) -> None:
+        """lookup_ipc_key should be settable and retrievable."""
+        key = IPCCacheEngineKey.from_token_ids(
+            model_name="test-model",
+            world_size=1,
+            worker_id=None,
+            token_ids=list(range(8)),
+            start=0,
+            end=8,
+            request_id="req-1",
+        )
+        session.lookup_ipc_key = key
+        assert session.lookup_ipc_key is key
+        assert session.lookup_ipc_key.model_name == "test-model"
+        assert session.lookup_ipc_key.worker_id is None
+
+
+class TestSessionManagerRemoveReturnsSession:
+    """Tests for SessionManager.remove returning the removed session."""
+
+    def test_remove_returns_session_with_state(self, hasher: TokenHasher) -> None:
+        """remove() should return the session with all accumulated state."""
+        mgr = SessionManager(hasher, ttl=600)
+        session = mgr.get_or_create("req-1")
+        session.set_tokens(list(range(8)))
+        session.get_hashes(0, 8)
+
+        key = IPCCacheEngineKey.from_token_ids(
+            model_name="model",
+            world_size=1,
+            worker_id=None,
+            token_ids=list(range(8)),
+            request_id="req-1",
+        )
+        session.lookup_ipc_key = key
+
+        removed = mgr.remove("req-1")
+        assert removed is not None
+        assert removed.request_id == "req-1"
+        assert len(removed.get_all_hashes()) == 2
+        assert removed.lookup_ipc_key is key
+
+    def test_remove_clears_from_manager(self, hasher: TokenHasher) -> None:
+        """After remove(), the session should no longer be in the manager."""
+        mgr = SessionManager(hasher, ttl=600)
+        mgr.get_or_create("req-1")
+        mgr.remove("req-1")
+        assert mgr.active_count() == 0
+
+    def test_remove_nonexistent_returns_none(self, hasher: TokenHasher) -> None:
+        """remove() on a non-existent request_id should return None."""
+        mgr = SessionManager(hasher, ttl=600)
+        assert mgr.remove("no-such-id") is None

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -221,49 +221,51 @@ class TestSessionThreadSafety:
         assert not errors, "\n".join(errors)
 
 
-class TestSessionGetHashesNegativeEnd:
-    """Tests for Session.get_hashes with negative end (auto-align)."""
+class TestSessionGetHashesOptionalEnd:
+    """
+    Tests for Session.get_hashes with optional end (auto-align to last full chunk).
+    """
 
-    def test_get_hashes_negative_end_empty(self, session: Session) -> None:
-        """get_hashes(0, -1) should return empty list when no tokens set."""
-        assert session.get_hashes(0, -1) == []
+    def test_get_hashes_optional_end_empty(self, session: Session) -> None:
+        """get_hashes(0) should return empty list when no tokens set."""
+        assert session.get_hashes(0) == []
 
-    def test_get_hashes_negative_end_after_compute(self, session: Session) -> None:
-        """get_hashes(0, -1) should return all computed hashes."""
+    def test_get_hashes_optional_end_after_compute(self, session: Session) -> None:
+        """get_hashes(0) should return all computed hashes."""
         session.set_tokens(list(range(12)))  # 3 chunks of 4
-        all_hashes = session.get_hashes(0, -1)
+        all_hashes = session.get_hashes(0)
         assert len(all_hashes) == 3
 
-    def test_get_hashes_negative_end_incremental(self, session: Session) -> None:
-        """get_hashes(0, -1) should accumulate hashes from incremental calls."""
+    def test_get_hashes_optional_end_incremental(self, session: Session) -> None:
+        """get_hashes(0) should accumulate hashes from incremental calls."""
         session.set_tokens(list(range(12)))  # 3 chunks of 4
         # First compute 2 chunks
         session.get_hashes(0, 8)
-        # get_hashes(0, -1) should now compute all 3 chunks
-        assert len(session.get_hashes(0, -1)) == 3
+        # get_hashes(0) should now compute all 3 chunks
+        assert len(session.get_hashes(0)) == 3
 
-    def test_get_hashes_negative_end_matches_explicit(self, session: Session) -> None:
-        """get_hashes(0, -1) should return the same as get_hashes(0, aligned_len)."""
+    def test_get_hashes_optional_end_matches_explicit(self, session: Session) -> None:
+        """get_hashes(0) should return the same as get_hashes(0, aligned_len)."""
         session.set_tokens(list(range(12)))
         expected = session.get_hashes(0, 12)
-        assert session.get_hashes(0, -1) == expected
+        assert session.get_hashes(0) == expected
 
-    def test_get_hashes_negative_end_truncates_partial_chunk(
+    def test_get_hashes_optional_end_truncates_partial_chunk(
         self, session: Session
     ) -> None:
-        """get_hashes(0, -1) should ignore trailing tokens that don't fill a chunk."""
+        """get_hashes(0) should ignore trailing tokens that don't fill a chunk."""
         # 14 tokens with chunk_size=4 -> 3 full chunks (12 tokens), 2 leftover
         session.set_tokens(list(range(14)))
-        hashes = session.get_hashes(0, -1)
+        hashes = session.get_hashes(0)
         assert len(hashes) == 3
 
-    def test_get_hashes_negative_end_matches_hasher(
+    def test_get_hashes_optional_end_matches_hasher(
         self, hasher: TokenHasher, session: Session
     ) -> None:
-        """get_hashes(0, -1) should match standalone TokenHasher results."""
+        """get_hashes(0) should match standalone TokenHasher results."""
         tokens = list(range(12))
         session.set_tokens(tokens)
-        session_hashes = session.get_hashes(0, -1)
+        session_hashes = session.get_hashes(0)
         hasher_hashes = hasher.compute_chunk_hashes(tokens)
         # Convert session hashes to bytes for comparison
         converted = [TokenHasher.hash_to_bytes(h) for h in session_hashes]
@@ -316,7 +318,7 @@ class TestSessionManagerRemoveReturnsSession:
         removed = mgr.remove("req-1")
         assert removed is not None
         assert removed.request_id == "req-1"
-        assert len(removed.get_hashes(0, -1)) == 2
+        assert len(removed.get_hashes(0)) == 2
         assert removed.lookup_ipc_key is key
 
     def test_remove_clears_from_manager(self, hasher: TokenHasher) -> None:

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -221,44 +221,49 @@ class TestSessionThreadSafety:
         assert not errors, "\n".join(errors)
 
 
-class TestSessionGetAllHashes:
-    """Tests for Session.get_all_hashes method."""
+class TestSessionGetHashesNegativeEnd:
+    """Tests for Session.get_hashes with negative end (auto-align)."""
 
-    def test_get_all_hashes_empty(self, session: Session) -> None:
-        """get_all_hashes should return empty list before any hash computation."""
-        assert session.get_all_hashes() == []
+    def test_get_hashes_negative_end_empty(self, session: Session) -> None:
+        """get_hashes(0, -1) should return empty list when no tokens set."""
+        assert session.get_hashes(0, -1) == []
 
-    def test_get_all_hashes_after_compute(self, session: Session) -> None:
-        """get_all_hashes should return all computed hashes."""
+    def test_get_hashes_negative_end_after_compute(self, session: Session) -> None:
+        """get_hashes(0, -1) should return all computed hashes."""
         session.set_tokens(list(range(12)))  # 3 chunks of 4
-        session.get_hashes(0, 12)
-        all_hashes = session.get_all_hashes()
+        all_hashes = session.get_hashes(0, -1)
         assert len(all_hashes) == 3
 
-    def test_get_all_hashes_incremental(self, session: Session) -> None:
-        """get_all_hashes should accumulate hashes from incremental calls."""
+    def test_get_hashes_negative_end_incremental(self, session: Session) -> None:
+        """get_hashes(0, -1) should accumulate hashes from incremental calls."""
         session.set_tokens(list(range(12)))  # 3 chunks of 4
         # First compute 2 chunks
         session.get_hashes(0, 8)
-        assert len(session.get_all_hashes()) == 2
-        # Then compute 1 more chunk
-        session.get_hashes(8, 12)
-        assert len(session.get_all_hashes()) == 3
+        # get_hashes(0, -1) should now compute all 3 chunks
+        assert len(session.get_hashes(0, -1)) == 3
 
-    def test_get_all_hashes_matches_get_hashes(self, session: Session) -> None:
-        """get_all_hashes should return the same hashes as get_hashes(0, total)."""
+    def test_get_hashes_negative_end_matches_explicit(self, session: Session) -> None:
+        """get_hashes(0, -1) should return the same as get_hashes(0, aligned_len)."""
         session.set_tokens(list(range(12)))
         expected = session.get_hashes(0, 12)
-        assert session.get_all_hashes() == expected
+        assert session.get_hashes(0, -1) == expected
 
-    def test_get_all_hashes_matches_hasher(
+    def test_get_hashes_negative_end_truncates_partial_chunk(
+        self, session: Session
+    ) -> None:
+        """get_hashes(0, -1) should ignore trailing tokens that don't fill a chunk."""
+        # 14 tokens with chunk_size=4 -> 3 full chunks (12 tokens), 2 leftover
+        session.set_tokens(list(range(14)))
+        hashes = session.get_hashes(0, -1)
+        assert len(hashes) == 3
+
+    def test_get_hashes_negative_end_matches_hasher(
         self, hasher: TokenHasher, session: Session
     ) -> None:
-        """get_all_hashes should match standalone TokenHasher results."""
+        """get_hashes(0, -1) should match standalone TokenHasher results."""
         tokens = list(range(12))
         session.set_tokens(tokens)
-        session.get_hashes(0, 12)
-        session_hashes = session.get_all_hashes()
+        session_hashes = session.get_hashes(0, -1)
         hasher_hashes = hasher.compute_chunk_hashes(tokens)
         # Convert session hashes to bytes for comparison
         converted = [TokenHasher.hash_to_bytes(h) for h in session_hashes]
@@ -311,7 +316,7 @@ class TestSessionManagerRemoveReturnsSession:
         removed = mgr.remove("req-1")
         assert removed is not None
         assert removed.request_id == "req-1"
-        assert len(removed.get_all_hashes()) == 2
+        assert len(removed.get_hashes(0, -1)) == 2
         assert removed.lookup_ipc_key is key
 
     def test_remove_clears_from_manager(self, hasher: TokenHasher) -> None:

--- a/tests/v1/multiprocess/test_unified_touch.py
+++ b/tests/v1/multiprocess/test_unified_touch.py
@@ -3,7 +3,7 @@
 
 This module tests:
 1. L1EvictionPolicy.on_l1_keys_accessed bridges to policy.on_keys_touched
-2. L1EvictionPolicy.on_l1_keys_read_finished no longer triggers touch
+2. L1EvictionPolicy.on_l1_keys_read_finished also triggers touch
 3. L1Manager.touch_keys dispatches to all registered listeners
 4. MPCacheEngine.end_session performs unified touch with correct keys
 5. StorageManager.touch_l1_keys delegates to L1Manager
@@ -78,15 +78,15 @@ class TestL1EvictionPolicyAccessedBridge:
 
         mock_policy.on_keys_touched.assert_called_once_with(keys)
 
-    def test_on_l1_keys_read_finished_no_longer_touches(self):
-        """on_l1_keys_read_finished should NOT call on_keys_touched anymore."""
+    def test_on_l1_keys_read_finished_also_touches(self):
+        """on_l1_keys_read_finished should call on_keys_touched."""
         mock_policy = MagicMock()
         listener = L1EvictionPolicy(mock_policy)
         keys = [make_key(1), make_key(2)]
 
         listener.on_l1_keys_read_finished(keys)
 
-        mock_policy.on_keys_touched.assert_not_called()
+        mock_policy.on_keys_touched.assert_called_once_with(keys)
 
     def test_on_l1_keys_accessed_with_lru_policy(self):
         """on_l1_keys_accessed should update LRU order via real LRU policy."""
@@ -106,8 +106,8 @@ class TestL1EvictionPolicyAccessedBridge:
         assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 2
         assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 1
 
-    def test_on_l1_keys_read_finished_does_not_update_lru(self):
-        """on_l1_keys_read_finished should NOT update LRU order anymore."""
+    def test_on_l1_keys_read_finished_updates_lru(self):
+        """on_l1_keys_read_finished should update LRU order."""
         lru = LRUEvictionPolicy()
         listener = L1EvictionPolicy(lru)
 
@@ -115,10 +115,10 @@ class TestL1EvictionPolicyAccessedBridge:
         keys = [make_key(1), make_key(2), make_key(3)]
         lru.on_keys_created(keys)
 
-        # Call on_l1_keys_read_finished on key 1 - should be no-op
+        # Call on_l1_keys_read_finished on key 1 - should touch it
         listener.on_l1_keys_read_finished([make_key(1)])
 
-        # Eviction order should remain: 3, 2, 1 (unchanged)
+        # Key 1 is now most recently touched, eviction order: 2, 3, 1
         candidates = lru.get_eviction_candidates(3)
         assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 3
         assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 2

--- a/tests/v1/multiprocess/test_unified_touch.py
+++ b/tests/v1/multiprocess/test_unified_touch.py
@@ -209,7 +209,7 @@ class TestEndSessionTouchKeys:
         assert removed is not None
         assert removed.lookup_ipc_key is not None
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_all_hashes()]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0, -1)]
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
 
         # With world_size=1 and worker_id=None, should have 3 keys
@@ -237,7 +237,7 @@ class TestEndSessionTouchKeys:
         assert removed is not None
         assert removed.lookup_ipc_key is not None
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_all_hashes()]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0, -1)]
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
 
         # 2 chunks * 2 workers = 4 keys
@@ -278,7 +278,7 @@ class TestEndSessionTouchKeys:
         assert removed is not None
         assert removed.lookup_ipc_key is not None
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_all_hashes()]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0, -1)]
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
         assert len(obj_keys) == 0
 
@@ -289,7 +289,7 @@ class TestEndSessionTouchKeys:
         1. lookup computes all hashes (but via TokenHasher, not Session)
         2. retrieve calls session.get_hashes(0, hit_end)
         3. store calls session.get_hashes(hit_end, total)
-        4. end_session uses session.get_all_hashes() to get all
+        4. end_session uses session.get_hashes(0, -1) to get all
         """
         mgr = SessionManager(hasher, ttl=600)
         session = mgr.get_or_create("req-1")
@@ -306,7 +306,7 @@ class TestEndSessionTouchKeys:
         assert len(store_hashes) == 2
 
         # All hashes should cover all 5 chunks
-        all_hashes = session.get_all_hashes()
+        all_hashes = session.get_hashes(0, -1)
         assert len(all_hashes) == 5
         assert all_hashes == retrieve_hashes + store_hashes
 

--- a/tests/v1/multiprocess/test_unified_touch.py
+++ b/tests/v1/multiprocess/test_unified_touch.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the unified touch feature in end_session.
+
+This module tests:
+1. L1EvictionPolicy.on_l1_keys_accessed bridges to policy.on_keys_touched
+2. L1EvictionPolicy.on_l1_keys_read_finished no longer triggers touch
+3. L1Manager.touch_keys dispatches to all registered listeners
+4. MPCacheEngine.end_session performs unified touch with correct keys
+5. StorageManager.touch_l1_keys delegates to L1Manager
+"""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, ipc_key_to_object_keys
+from lmcache.v1.distributed.eviction import L1EvictionPolicy
+from lmcache.v1.distributed.eviction_policy import LRUEvictionPolicy
+from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
+from lmcache.v1.multiprocess.session import SessionManager
+from lmcache.v1.multiprocess.token_hasher import TokenHasher
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def make_key(chunk_hash: int, model: str = "model", kv_rank: int = 0) -> ObjectKey:
+    """Create an ObjectKey for testing."""
+    hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+    return ObjectKey(chunk_hash=hash_bytes, model_name=model, kv_rank=kv_rank)
+
+
+def make_ipc_key(
+    token_ids: list[int],
+    chunk_size: int = 4,
+    model_name: str = "model",
+    world_size: int = 1,
+    worker_id: int | None = None,
+    request_id: str = "req-1",
+) -> IPCCacheEngineKey:
+    """Create an IPCCacheEngineKey for testing."""
+    return IPCCacheEngineKey.from_token_ids(
+        model_name=model_name,
+        world_size=world_size,
+        worker_id=worker_id,
+        token_ids=token_ids,
+        start=0,
+        end=len(token_ids),
+        request_id=request_id,
+    )
+
+
+@pytest.fixture
+def hasher() -> TokenHasher:
+    """TokenHasher with small chunk_size for testing."""
+    return TokenHasher(chunk_size=4, hash_algorithm="blake3")
+
+
+# =============================================================================
+# L1EvictionPolicy Bridge Tests
+# =============================================================================
+
+
+class TestL1EvictionPolicyAccessedBridge:
+    """Tests for L1EvictionPolicy.on_l1_keys_accessed bridging."""
+
+    def test_on_l1_keys_accessed_calls_policy_on_keys_touched(self):
+        """on_l1_keys_accessed should delegate to policy.on_keys_touched."""
+        mock_policy = MagicMock()
+        listener = L1EvictionPolicy(mock_policy)
+        keys = [make_key(1), make_key(2)]
+
+        listener.on_l1_keys_accessed(keys)
+
+        mock_policy.on_keys_touched.assert_called_once_with(keys)
+
+    def test_on_l1_keys_read_finished_no_longer_touches(self):
+        """on_l1_keys_read_finished should NOT call on_keys_touched anymore."""
+        mock_policy = MagicMock()
+        listener = L1EvictionPolicy(mock_policy)
+        keys = [make_key(1), make_key(2)]
+
+        listener.on_l1_keys_read_finished(keys)
+
+        mock_policy.on_keys_touched.assert_not_called()
+
+    def test_on_l1_keys_accessed_with_lru_policy(self):
+        """on_l1_keys_accessed should update LRU order via real LRU policy."""
+        lru = LRUEvictionPolicy()
+        listener = L1EvictionPolicy(lru)
+
+        # Create keys in order: 1, 2, 3
+        keys = [make_key(1), make_key(2), make_key(3)]
+        lru.on_keys_created(keys)
+
+        # Touch key 1 via the listener bridge
+        listener.on_l1_keys_accessed([make_key(1)])
+
+        # Eviction order should now be: 3, 2, 1 (1 is most recent)
+        candidates = lru.get_eviction_candidates(3)
+        assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 3
+        assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 2
+        assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 1
+
+    def test_on_l1_keys_read_finished_does_not_update_lru(self):
+        """on_l1_keys_read_finished should NOT update LRU order anymore."""
+        lru = LRUEvictionPolicy()
+        listener = L1EvictionPolicy(lru)
+
+        # Create keys in order: 1, 2, 3
+        keys = [make_key(1), make_key(2), make_key(3)]
+        lru.on_keys_created(keys)
+
+        # Call on_l1_keys_read_finished on key 1 - should be no-op
+        listener.on_l1_keys_read_finished([make_key(1)])
+
+        # Eviction order should remain: 3, 2, 1 (unchanged)
+        candidates = lru.get_eviction_candidates(3)
+        assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 3
+        assert ObjectKey.Bytes2IntHash(candidates[1].chunk_hash) == 2
+        assert ObjectKey.Bytes2IntHash(candidates[2].chunk_hash) == 1
+
+
+class TestL1EvictionPolicyUnifiedTouchOrder:
+    """Tests for the unified touch producing correct eviction order.
+
+    The key benefit of unified touch is that all chunks of a request
+    are touched in order, so eviction proceeds from the last chunk
+    backwards (most recent chunk evicted last).
+    """
+
+    def test_unified_touch_produces_reverse_eviction_order(self):
+        """Touching keys in order [1,2,3] should evict 1 first (LRU)."""
+        lru = LRUEvictionPolicy()
+        listener = L1EvictionPolicy(lru)
+
+        keys = [make_key(i) for i in range(1, 6)]
+        lru.on_keys_created(keys)
+
+        # Unified touch: touch all keys in order (simulating end_session)
+        listener.on_l1_keys_accessed(keys)
+
+        # Eviction should be in reverse order: 1 first (least recently touched)
+        # because on_keys_touched processes them sequentially,
+        # so key 5 is the most recently touched
+        candidates = lru.get_eviction_candidates(5)
+        evicted_ids = [ObjectKey.Bytes2IntHash(c.chunk_hash) for c in candidates]
+        # LRU evicts from the back of the ordered dict (least recent first)
+        # After touching [1,2,3,4,5] in order, 1 is least recent, 5 is most recent
+        assert evicted_ids == [5, 4, 3, 2, 1]
+
+    def test_per_read_touch_vs_unified_touch_order(self):
+        """Compare per-read touch (old behavior) vs unified touch (new behavior).
+
+        Old behavior: each retrieve touches its keys immediately.
+        New behavior: all keys are touched together at end_session.
+
+        With unified touch, the eviction order reflects the full request's
+        chunk ordering, not the order of individual retrieve calls.
+        """
+        # Scenario: request has chunks [1,2,3,4,5]
+        # Retrieve touches [1,2,3] (prefix hit), Store creates [4,5]
+        lru = LRUEvictionPolicy()
+
+        keys = [make_key(i) for i in range(1, 6)]
+        lru.on_keys_created(keys)
+
+        # Unified touch at end_session: touch all in order
+        lru.on_keys_touched(keys)
+
+        candidates = lru.get_eviction_candidates(5)
+        evicted_ids = [ObjectKey.Bytes2IntHash(c.chunk_hash) for c in candidates]
+        # Last chunk (5) should be evicted last (most recently touched)
+        assert evicted_ids[-1] == 1
+
+
+# =============================================================================
+# End Session Touch Integration Tests
+# =============================================================================
+
+
+class TestEndSessionTouchKeys:
+    """Tests for the end_session unified touch key generation logic.
+
+    These tests verify that end_session correctly:
+    1. Retrieves the session with accumulated hashes
+    2. Generates the correct ObjectKeys using lookup_ipc_key
+    3. Handles edge cases (no session, no lookup key, empty hashes)
+    """
+
+    def test_end_session_generates_correct_keys(self, hasher: TokenHasher):
+        """end_session should generate ObjectKeys from session hashes and lookup key."""
+        mgr = SessionManager(hasher, ttl=600)
+        session = mgr.get_or_create("req-1")
+
+        tokens = list(range(12))  # 3 chunks of 4
+        session.set_tokens(tokens)
+        session.get_hashes(0, 12)
+
+        ipc_key = make_ipc_key(tokens, chunk_size=4, worker_id=None, request_id="req-1")
+        session.lookup_ipc_key = ipc_key
+
+        # Simulate end_session logic
+        removed = mgr.remove("req-1")
+        assert removed is not None
+        assert removed.lookup_ipc_key is not None
+
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_all_hashes()]
+        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
+
+        # With world_size=1 and worker_id=None, should have 3 keys
+        assert len(obj_keys) == 3
+
+    def test_end_session_expands_keys_for_world_size(self, hasher: TokenHasher):
+        """end_session should expand keys for all workers when world_size > 1."""
+        mgr = SessionManager(hasher, ttl=600)
+        session = mgr.get_or_create("req-1")
+
+        tokens = list(range(8))  # 2 chunks of 4
+        session.set_tokens(tokens)
+        session.get_hashes(0, 8)
+
+        ipc_key = make_ipc_key(
+            tokens,
+            chunk_size=4,
+            world_size=2,
+            worker_id=None,
+            request_id="req-1",
+        )
+        session.lookup_ipc_key = ipc_key
+
+        removed = mgr.remove("req-1")
+        assert removed is not None
+        assert removed.lookup_ipc_key is not None
+
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_all_hashes()]
+        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
+
+        # 2 chunks * 2 workers = 4 keys
+        assert len(obj_keys) == 4
+
+    def test_end_session_no_session_skips_touch(self, hasher: TokenHasher):
+        """end_session should skip touch when session doesn't exist."""
+        mgr = SessionManager(hasher, ttl=600)
+        removed = mgr.remove("nonexistent")
+        assert removed is None
+        # No error should occur
+
+    def test_end_session_no_lookup_key_skips_touch(self, hasher: TokenHasher):
+        """end_session should skip touch when session has no lookup_ipc_key."""
+        mgr = SessionManager(hasher, ttl=600)
+        session = mgr.get_or_create("req-1")
+        session.set_tokens(list(range(8)))
+        session.get_hashes(0, 8)
+        # Don't set lookup_ipc_key
+
+        removed = mgr.remove("req-1")
+        assert removed is not None
+        assert removed.lookup_ipc_key is None
+        # No error should occur
+
+    def test_end_session_empty_hashes_produces_no_keys(self, hasher: TokenHasher):
+        """end_session should produce no keys when session has no computed hashes."""
+        mgr = SessionManager(hasher, ttl=600)
+        session = mgr.get_or_create("req-1")
+
+        ipc_key = make_ipc_key(
+            list(range(8)), chunk_size=4, worker_id=None, request_id="req-1"
+        )
+        session.lookup_ipc_key = ipc_key
+        # Don't compute any hashes
+
+        removed = mgr.remove("req-1")
+        assert removed is not None
+        assert removed.lookup_ipc_key is not None
+
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_all_hashes()]
+        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
+        assert len(obj_keys) == 0
+
+    def test_end_session_hashes_cover_retrieve_and_store(self, hasher: TokenHasher):
+        """Session hashes should cover both retrieve and store ranges.
+
+        Simulates the typical flow:
+        1. lookup computes all hashes (but via TokenHasher, not Session)
+        2. retrieve calls session.get_hashes(0, hit_end)
+        3. store calls session.get_hashes(hit_end, total)
+        4. end_session uses session.get_all_hashes() to get all
+        """
+        mgr = SessionManager(hasher, ttl=600)
+        session = mgr.get_or_create("req-1")
+
+        tokens = list(range(20))  # 5 chunks of 4
+        session.set_tokens(tokens)
+
+        # Simulate retrieve: first 3 chunks
+        retrieve_hashes = session.get_hashes(0, 12)
+        assert len(retrieve_hashes) == 3
+
+        # Simulate store: last 2 chunks
+        store_hashes = session.get_hashes(12, 20)
+        assert len(store_hashes) == 2
+
+        # All hashes should cover all 5 chunks
+        all_hashes = session.get_all_hashes()
+        assert len(all_hashes) == 5
+        assert all_hashes == retrieve_hashes + store_hashes
+
+
+# =============================================================================
+# StoreListener No-op Tests
+# =============================================================================
+
+
+class TestStoreListenerAccessedNoop:
+    """Tests that StoreListener.on_l1_keys_accessed is a no-op."""
+
+    def test_store_listener_accessed_is_noop(self):
+        """StoreListener.on_l1_keys_accessed should not raise."""
+        # Import here to avoid import errors if store_controller has
+        # heavy dependencies
+        # First Party
+        from lmcache.v1.distributed.storage_controllers.store_controller import (
+            StoreListener,
+        )
+
+        # StoreListener requires an event_fd; use a mock
+        listener = MagicMock(spec=StoreListener)
+        # Call the real method on the class
+        StoreListener.on_l1_keys_accessed(listener, [make_key(1)])
+        # Should not raise - that's the test

--- a/tests/v1/multiprocess/test_unified_touch.py
+++ b/tests/v1/multiprocess/test_unified_touch.py
@@ -209,7 +209,7 @@ class TestEndSessionTouchKeys:
         assert removed is not None
         assert removed.lookup_ipc_key is not None
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0, -1)]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0)]
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
 
         # With world_size=1 and worker_id=None, should have 3 keys
@@ -237,7 +237,7 @@ class TestEndSessionTouchKeys:
         assert removed is not None
         assert removed.lookup_ipc_key is not None
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0, -1)]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0)]
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
 
         # 2 chunks * 2 workers = 4 keys
@@ -278,7 +278,7 @@ class TestEndSessionTouchKeys:
         assert removed is not None
         assert removed.lookup_ipc_key is not None
 
-        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0, -1)]
+        chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0)]
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
         assert len(obj_keys) == 0
 
@@ -289,7 +289,7 @@ class TestEndSessionTouchKeys:
         1. lookup computes all hashes (but via TokenHasher, not Session)
         2. retrieve calls session.get_hashes(0, hit_end)
         3. store calls session.get_hashes(hit_end, total)
-        4. end_session uses session.get_hashes(0, -1) to get all
+        4. end_session uses session.get_hashes(0) to get all
         """
         mgr = SessionManager(hasher, ttl=600)
         session = mgr.get_or_create("req-1")
@@ -306,7 +306,7 @@ class TestEndSessionTouchKeys:
         assert len(store_hashes) == 2
 
         # All hashes should cover all 5 chunks
-        all_hashes = session.get_hashes(0, -1)
+        all_hashes = session.get_hashes(0)
         assert len(all_hashes) == 5
         assert all_hashes == retrieve_hashes + store_hashes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes L1 eviction recency tracking by introducing an explicit `on_l1_keys_accessed` event and by touching keys only when read locks fully release, which can alter eviction order and cache hit rates across MP requests.
> 
> **Overview**
> Implements a **unified “touch” path** for L1 eviction recency: adds `L1ManagerListener.on_l1_keys_accessed`, wires it through `L1Manager.touch_keys`/`StorageManager.touch_l1_keys`, and bridges it in `L1EvictionPolicy` to `EvictionPolicy.on_keys_touched`.
> 
> Updates MP request lifecycle so `lookup` records the session’s `lookup_ipc_key`, and `end_session` computes all chunk `ObjectKey`s from the session and touches them in one call (covering both retrieved and stored chunks).
> 
> Adjusts `L1Manager.finish_read` to only report “touched” keys once the final read lock is released and the key is non-temporary, and hardens `LRUEvictionPolicy` against empty key lists. Adds comprehensive tests for the new touch semantics and session API changes (including `Session.get_hashes(start)` and `SessionManager.remove` returning the removed session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3863688018d4e439822c7173b6f8d82f045ed3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->