### PR TITLE
[MP] Add extra_config to construct lmcache mp adapter

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -122,8 +122,6 @@ def create_scheduler_adapter(
     server_url: str,
     zmq_context: zmq.Context,
     vllm_config: VllmConfig,
-    mq_timeout: float,
-    heartbeat_interval: float,
 ) -> LMCacheMPSchedulerAdapter:
     world_size, kv_rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
@@ -140,14 +138,14 @@ def create_scheduler_adapter(
         vllm_config.parallel_config.pipeline_parallel_size,
     )
 
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
     return LMCacheMPSchedulerAdapter(
         server_url=server_url,
         context=zmq_context,
         model_name=vllm_config.model_config.model,
         vllm_block_size=vllm_config.cache_config.block_size,
         parallel_strategy=parallel_strategy,
-        mq_timeout=mq_timeout,
-        heartbeat_interval=heartbeat_interval,
+        extra_config=extra_config,
     )
 
 
@@ -155,8 +153,6 @@ def create_worker_adapter(
     server_url: str,
     zmq_context: zmq.Context,
     vllm_config: VllmConfig,
-    mq_timeout: float,
-    heartbeat_interval: float,
 ) -> LMCacheMPWorkerAdapter:
     world_size, kv_rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
@@ -173,14 +169,14 @@ def create_worker_adapter(
         vllm_config.parallel_config.pipeline_parallel_size,
     )
 
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
     return LMCacheMPWorkerAdapter(
         server_url=server_url,
         context=zmq_context,
         model_name=vllm_config.model_config.model,
         vllm_block_size=vllm_config.cache_config.block_size,
         parallel_strategy=parallel_strategy,
-        mq_timeout=mq_timeout,
-        heartbeat_interval=heartbeat_interval,
+        extra_config=extra_config,
     )
 
 
@@ -499,16 +495,6 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         server_port = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache.mp.port", 5555
         )
-        mq_timeout = float(
-            vllm_config.kv_transfer_config.get_from_extra_config(
-                "lmcache.mp.mq_timeout", 300.0
-            )
-        )
-        heartbeat_interval = float(
-            vllm_config.kv_transfer_config.get_from_extra_config(
-                "lmcache.mp.heartbeat_interval", 10.0
-            )
-        )
 
         server_url = f"{server_host}:{server_port}"
         zmq_context = zmq.Context.instance()
@@ -517,8 +503,6 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                 server_url,
                 zmq_context,
                 vllm_config,
-                mq_timeout,
-                heartbeat_interval,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
         elif self.role == KVConnectorRole.WORKER:
@@ -526,8 +510,6 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                 server_url,
                 zmq_context,
                 vllm_config,
-                mq_timeout,
-                heartbeat_interval,
             )
         else:
             raise ValueError(f"Unknown KVConnectorRole: {self.role}")

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -3,6 +3,7 @@
 # Standard
 from dataclasses import dataclass
 from typing import Any, Callable
+import enum
 import os
 import threading
 
@@ -25,11 +26,80 @@ from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSum
 
 logger = init_logger(__name__)
 
-# Timeout (seconds) for blocking MQ requests: initial chunk-size query,
-# KV cache registration/unregistration, and other synchronous operations.
-DEFAULT_MQ_TIMEOUT: float = 300.0
-# Interval (seconds) between periodic heartbeat pings to the server.
-DEFAULT_HEARTBEAT_INTERVAL: float = 10.0
+
+class ExtraConfigDefault(enum.Enum):
+    """Centralized default values for extra_config keys.
+
+    Each member's *name* is the key used in the extra_config dict,
+    and its *value* is the default.
+    """
+
+    # Timeout (seconds) for blocking MQ requests: initial
+    # chunk-size query, KV cache registration/unregistration,
+    # and other synchronous operations.
+    mq_timeout = 300.0
+    # Interval (seconds) between periodic heartbeat pings
+    # to the server.
+    heartbeat_interval = 10.0
+
+
+# Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
+# entry point, which still passes these as positional/keyword args.
+DEFAULT_MQ_TIMEOUT: float = ExtraConfigDefault.mq_timeout.value
+DEFAULT_HEARTBEAT_INTERVAL: float = ExtraConfigDefault.heartbeat_interval.value
+
+_EXTRA_CONFIG_KEY_PREFIX = "lmcache.mp."
+
+
+def _resolve_extra_config(
+    extra_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve extra_config against :class:`ExtraConfigDefault`.
+
+    Keys in *extra_config* are expected to carry the
+    ``lmcache.mp.`` prefix (e.g. ``lmcache.mp.mq_timeout``).
+    The prefix is stripped before matching against
+    :class:`ExtraConfigDefault` members.
+
+    All ``lmcache.mp.*`` entries are logged.  Entries whose
+    value differs from the default are additionally marked as
+    *overridden*.
+
+    Args:
+        extra_config: User-supplied config dict (may be *None*).
+
+    Returns:
+        A dict keyed by :pyattr:`ExtraConfigDefault` member names.
+    """
+    stripped: dict[str, Any] = {}
+    if extra_config is not None:
+        for k, v in extra_config.items():
+            if k.startswith(_EXTRA_CONFIG_KEY_PREFIX):
+                short = k[len(_EXTRA_CONFIG_KEY_PREFIX) :]
+                stripped[short] = v
+
+    resolved: dict[str, Any] = {}
+    for item in ExtraConfigDefault:
+        default = item.value
+        raw = stripped.get(item.name)
+        value = type(default)(raw) if raw is not None else default
+        if value != default:
+            logger.info(
+                "%s%s = %s (overridden, default: %s)",
+                _EXTRA_CONFIG_KEY_PREFIX,
+                item.name,
+                value,
+                default,
+            )
+        else:
+            logger.info(
+                "%s%s = %s",
+                _EXTRA_CONFIG_KEY_PREFIX,
+                item.name,
+                value,
+            )
+        resolved[item.name] = value
+    return resolved
 
 
 def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
@@ -77,18 +147,20 @@ def send_lmcache_request(
 
 def get_lmcache_chunk_size(
     mq_client: MessageQueueClient,
+    timeout: float = DEFAULT_MQ_TIMEOUT,
 ) -> int:
     """
     Helper function to get the LMCache chunk size from the server
 
     Args:
         mq_client: The LMCache multiprocess mode message queue client
+        timeout: Timeout in seconds for the blocking request.
 
     Returns:
         An integer representing the LMCache chunk size
     """
     future = send_lmcache_request(mq_client, RequestType.GET_CHUNK_SIZE, [])
-    chunk_size = future.result(timeout=DEFAULT_MQ_TIMEOUT)
+    chunk_size = future.result(timeout=timeout)
     return chunk_size
 
 
@@ -322,6 +394,7 @@ class LMCacheMPSchedulerAdapter:
         *,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        extra_config: dict[str, Any] | None = None,
     ):
         """
         Args:
@@ -336,7 +409,12 @@ class LMCacheMPSchedulerAdapter:
             legacy_block_size: The vLLM block size passed positionally by
                 older vLLM connectors.
             mq_timeout: Timeout in seconds for message queue requests.
+                Ignored when ``extra_config`` is provided.
             heartbeat_interval: Interval in seconds between heartbeat pings.
+                Ignored when ``extra_config`` is provided.
+            extra_config: Optional dict with keys starting with
+                ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
+                provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
         """
         vllm_block_size, parallel_strategy, mq_timeout = _normalize_adapter_init_args(
             vllm_block_size,
@@ -344,6 +422,10 @@ class LMCacheMPSchedulerAdapter:
             legacy_block_size,
             mq_timeout,
         )
+        if extra_config is not None:
+            cfg = _resolve_extra_config(extra_config)
+            mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
+            heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 
@@ -360,11 +442,13 @@ class LMCacheMPSchedulerAdapter:
 
         # Read chunk size from lmcache
         try:
-            self.chunk_size = get_lmcache_chunk_size(self.mq_client)
+            self.chunk_size = get_lmcache_chunk_size(
+                self.mq_client, timeout=self._mq_timeout
+            )
         except TimeoutError:
             self.mq_client.close()
             raise ConnectionError(
-                f"LMCache server did not respond within {mq_timeout}s. "
+                f"LMCache server did not respond within {self._mq_timeout}s. "
                 "Is the server running?"
             ) from None
         assert self.chunk_size % vllm_block_size == 0, (
@@ -675,6 +759,7 @@ class LMCacheMPWorkerAdapter:
         *,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        extra_config: dict[str, Any] | None = None,
     ):
         """Initialize the worker adapter for current or legacy vLLM callers.
 
@@ -689,7 +774,12 @@ class LMCacheMPWorkerAdapter:
             legacy_block_size: The vLLM block size passed positionally by
                 older vLLM connectors.
             mq_timeout: Timeout in seconds for message queue requests.
+                Ignored when ``extra_config`` is provided.
             heartbeat_interval: Interval in seconds between heartbeat pings.
+                Ignored when ``extra_config`` is provided.
+            extra_config: Optional dict with keys starting with
+                ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
+                provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
 
         Raises:
             TypeError: If the connector argument shape is unsupported.
@@ -700,6 +790,10 @@ class LMCacheMPWorkerAdapter:
             legacy_block_size,
             mq_timeout,
         )
+        if extra_config is not None:
+            cfg = _resolve_extra_config(extra_config)
+            mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
+            heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 
@@ -733,11 +827,13 @@ class LMCacheMPWorkerAdapter:
 
         # Read chunk size from lmcache
         try:
-            chunk_size = get_lmcache_chunk_size(self.mq_client)
+            chunk_size = get_lmcache_chunk_size(
+                self.mq_client, timeout=self._mq_timeout
+            )
         except TimeoutError:
             self.mq_client.close()
             raise ConnectionError(
-                f"LMCache server did not respond within {mq_timeout}s. "
+                f"LMCache server did not respond within {self._mq_timeout}s. "
                 "Is the server running?"
             ) from None
         assert chunk_size % vllm_block_size == 0, (

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -36,7 +36,7 @@ def fake_adapter(monkeypatch):
     # send_lmcache_request call don't touch a real socket.
     fake_client = MagicMock(name="mq_client")
     monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
-    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda mq: 256)
+    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
 
     future = MagicMock(name="future")
     future.result.return_value = None


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MP adapter initialization and timeout/heartbeat configuration resolution; mis-typed `extra_config` values or missing prefix handling could change runtime behavior or cause connection failures.
> 
> **Overview**
> Wires vLLM’s `kv_connector_extra_config` through `lmcache_mp_connector_0180` into the LMCache MP scheduler/worker adapters, replacing the previous hardcoded/locally-parsed `mq_timeout` and `heartbeat_interval` constructor args.
> 
> Adds centralized `ExtraConfigDefault` + `_resolve_extra_config()` in `vllm_multi_process_adapter.py` to parse `lmcache.mp.*` settings (type-cast + log defaults/overrides) and uses the resolved values for chunk-size queries, MQ request timeouts, and heartbeat intervals, including updated connection-timeout error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69c417e296c3b90bdbd29f9122a5dce689c7903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->