### PR TITLE
[Chore][CI]: K3 MP output token quantity tolerance

### DIFF
--- a/.buildkite/k3_tests/multiprocess/scripts/run-vllm-bench.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-vllm-bench.sh
@@ -121,19 +121,26 @@ verify_results() {
 
     echo "=== Verification ==="
 
-    if [ "$lmcache_total_input_tokens" -eq "$EXPECTED_TOTAL_INPUT_TOKENS" ] 2>/dev/null; then
-        echo "LMCache total_input_tokens: $lmcache_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS) PASS"
-    else
-        echo "LMCache total_input_tokens: $lmcache_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS) FAIL"
-        failed=1
-    fi
+    # vLLM's random dataset decodes and re-encodes token sequences, which can
+    # drift slightly from the requested length (see RandomDataset in
+    # vllm/benchmarks/datasets.py). Allow 1% tolerance.
+    local token_tolerance=$((EXPECTED_TOTAL_INPUT_TOKENS / 100))
 
-    if [ "$baseline_total_input_tokens" -eq "$EXPECTED_TOTAL_INPUT_TOKENS" ] 2>/dev/null; then
-        echo "Baseline total_input_tokens: $baseline_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS) PASS"
-    else
-        echo "Baseline total_input_tokens: $baseline_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS) FAIL"
-        failed=1
-    fi
+    check_input_tokens() {
+        local label="$1"
+        local actual="$2"
+        local diff=$((actual - EXPECTED_TOTAL_INPUT_TOKENS))
+        local abs_diff=${diff#-}
+        if [ "$abs_diff" -le "$token_tolerance" ] 2>/dev/null; then
+            echo "$label total_input_tokens: $actual (expected: $EXPECTED_TOTAL_INPUT_TOKENS ±$token_tolerance) PASS"
+        else
+            echo "$label total_input_tokens: $actual (expected: $EXPECTED_TOTAL_INPUT_TOKENS ±$token_tolerance) FAIL"
+            failed=1
+        fi
+    }
+
+    check_input_tokens "LMCache" "$lmcache_total_input_tokens"
+    check_input_tokens "Baseline" "$baseline_total_input_tokens"
 
     if [ "$lmcache_completed" -eq "$EXPECTED_COMPLETED" ] 2>/dev/null; then
         echo "LMCache completed: $lmcache_completed (expected: $EXPECTED_COMPLETED) PASS"

--- a/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-vllm-bench.sh
@@ -137,21 +137,26 @@ verify_results() {
     
     echo "=== Verification ==="
     
-    # Check total_input_tokens for LMCache
-    if [ "$lmcache_total_input_tokens" -eq "$EXPECTED_TOTAL_INPUT_TOKENS" ] 2>/dev/null; then
-        echo "✅ LMCache total_input_tokens: $lmcache_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
-    else
-        echo "❌ LMCache total_input_tokens: $lmcache_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
-        failed=1
-    fi
-    
-    # Check total_input_tokens for baseline
-    if [ "$baseline_total_input_tokens" -eq "$EXPECTED_TOTAL_INPUT_TOKENS" ] 2>/dev/null; then
-        echo "✅ Baseline total_input_tokens: $baseline_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
-    else
-        echo "❌ Baseline total_input_tokens: $baseline_total_input_tokens (expected: $EXPECTED_TOTAL_INPUT_TOKENS)"
-        failed=1
-    fi
+    # vLLM's random dataset decodes and re-encodes token sequences, which can
+    # drift slightly from the requested length (see RandomDataset in
+    # vllm/benchmarks/datasets.py). Allow 1% tolerance.
+    local token_tolerance=$((EXPECTED_TOTAL_INPUT_TOKENS / 100))
+
+    check_input_tokens() {
+        local label="$1"
+        local actual="$2"
+        local diff=$((actual - EXPECTED_TOTAL_INPUT_TOKENS))
+        local abs_diff=${diff#-}
+        if [ "$abs_diff" -le "$token_tolerance" ] 2>/dev/null; then
+            echo "✅ $label total_input_tokens: $actual (expected: $EXPECTED_TOTAL_INPUT_TOKENS ±$token_tolerance)"
+        else
+            echo "❌ $label total_input_tokens: $actual (expected: $EXPECTED_TOTAL_INPUT_TOKENS ±$token_tolerance)"
+            failed=1
+        fi
+    }
+
+    check_input_tokens "LMCache" "$lmcache_total_input_tokens"
+    check_input_tokens "Baseline" "$baseline_total_input_tokens"
     
     # Check completed for LMCache
     if [ "$lmcache_completed" -eq "$EXPECTED_COMPLETED" ] 2>/dev/null; then


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only bash script changes that relax an assertion to account for known vLLM random-dataset token length drift; no production code or security-sensitive logic touched.
> 
> **Overview**
> Updates the Buildkite vLLM bench verification scripts to **treat `total_input_tokens` as approximate** rather than requiring an exact match.
> 
> Both `run-vllm-bench.sh` variants now compute a 1% tolerance and use a shared `check_input_tokens` helper for LMCache and baseline runs, reducing spurious CI failures caused by vLLM’s random dataset re-tokenization drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f407e09b71d3806eb5261345778387ffd63f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->