### PR TITLE
[Feat] Add is_user_level property and cache_salt param to EvictionPolicy

### DIFF
--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -27,6 +27,20 @@ class EvictionPolicy:
     L1EvictionPolicy and L2EvictionPolicy respectively.
     """
 
+    @property
+    def is_user_level(self) -> bool:
+        """Whether this policy supports per-user eviction.
+
+        When True, the eviction controller checks per-user usage and
+        passes ``cache_salt`` to ``get_eviction_actions()`` to scope
+        eviction to individual users. When False, the controller uses
+        aggregate usage only.
+
+        Default is False. Subclasses that support per-user eviction
+        (e.g., ``UserLRUEvictionPolicy``) should override to return True.
+        """
+        return False
+
     @abstractmethod
     def register_eviction_destination(self, destination: EvictionDestination):
         """
@@ -73,6 +87,7 @@ class EvictionPolicy:
         self,
         expected_ratio: float,
         key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
+        cache_salt: str | None = None,
     ) -> list[EvictionAction]:
         """
         Get the eviction actions to evict objects from cache.
@@ -88,6 +103,11 @@ class EvictionPolicy:
                 provided, keys for which the filter returns False will be
                 skipped. This is useful for skipping locked keys that
                 cannot be deleted.
+            cache_salt: When set, scope eviction to keys belonging to this
+                salt only (identified by ``ObjectKey.cache_salt``). When
+                None, evict globally across all salts. Only meaningful for
+                policies where ``is_user_level`` is True; other policies
+                ignore this parameter.
 
         Returns:
             list[EvictionAction]: The eviction actions to perform. Each

--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -28,16 +28,16 @@ class EvictionPolicy:
     """
 
     @property
-    def is_user_level(self) -> bool:
-        """Whether this policy supports per-user eviction.
+    def support_isolation(self) -> bool:
+        """Whether this policy supports isolation eviction (e.g., per user isolation).
 
-        When True, the eviction controller checks per-user usage and
-        passes ``cache_salt`` to ``get_eviction_actions()`` to scope
-        eviction to individual users. When False, the controller uses
+        When True, the eviction controller checks isolated usage (e.g., per user usage)
+        and passes ``cache_salt`` to ``get_eviction_actions()`` to scope
+        eviction to specific cache_salt. When False, the controller uses
         aggregate usage only.
 
-        Default is False. Subclasses that support per-user eviction
-        (e.g., ``UserLRUEvictionPolicy``) should override to return True.
+        Default is False. Subclasses that support isolated eviction.
+        (e.g., ``IsolatedLRUEvictionPolicy``) should override to return True.
         """
         return False
 
@@ -106,7 +106,7 @@ class EvictionPolicy:
             cache_salt: When set, scope eviction to keys belonging to this
                 salt only (identified by ``ObjectKey.cache_salt``). When
                 None, evict globally across all salts. Only meaningful for
-                policies where ``is_user_level`` is True; other policies
+                policies where ``support_isolation`` is True; other policies
                 ignore this parameter.
 
         Returns:

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -123,6 +123,7 @@ class LRUEvictionPolicy(EvictionPolicy):
         self,
         expected_ratio: float,
         key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
+        cache_salt: str | None = None,
     ) -> list[EvictionAction]:
         """
         Get the eviction actions to evict objects from L1 cache.
@@ -137,6 +138,7 @@ class LRUEvictionPolicy(EvictionPolicy):
                 provided, keys for which the filter returns False will be
                 skipped. This is useful for skipping locked keys that
                 cannot be deleted.
+            cache_salt: Ignored by LRU policy (not user-level).
 
         Returns:
             list[EvictionAction]: The eviction actions to perform. Each

--- a/lmcache/v1/distributed/eviction_policy/noop.py
+++ b/lmcache/v1/distributed/eviction_policy/noop.py
@@ -45,5 +45,6 @@ class NoOpEvictionPolicy(EvictionPolicy):
         self,
         expected_ratio: float,
         key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
+        cache_salt: str | None = None,
     ) -> list[EvictionAction]:
         return []


### PR DESCRIPTION
## Summary

- Add `is_user_level` property to `EvictionPolicy` base class (default `False`)
- Add `cache_salt: str | None = None` parameter to `get_eviction_actions()`
- `LRUEvictionPolicy` and `NoOpEvictionPolicy` accept and ignore `cache_salt`

## Why

The eviction controller needs a way to distinguish aggregate-level policies (LRU) from per-user-level policies (UserLRU, coming in a follow-up PR) without `isinstance` checks. `is_user_level` is the extension point — future policies override it to `True` and use the `cache_salt` parameter for scoped eviction.

## Changes

| File | Change |
|------|--------|
| `eviction.py` | `is_user_level` property (default `False`); `cache_salt` param on `get_eviction_actions()` |
| `lru.py` | Accept (ignore) `cache_salt` |
| `noop.py` | Accept (ignore) `cache_salt` |

## Test plan

- [x] 441 distributed tests pass
- [x] pre-commit clean
- [x] No behavioral change (all defaults are None, existing callers unaffected)

## Context

PR4 of the per-user L2 quota feature. See design doc: `docs/design/l2_adapters/l2_per_user_quota.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a backward-compatible interface extension (new property + optional parameter) with no behavior change in existing policies, which simply accept/ignore `cache_salt`.
> 
> **Overview**
> Adds an isolation-capability extension point to `EvictionPolicy` via a new `support_isolation` property (default `False`) and an optional `cache_salt` argument on `get_eviction_actions()` for scoping evictions.
> 
> Updates `LRUEvictionPolicy` and `NoOpEvictionPolicy` to accept the new `cache_salt` parameter (documented as ignored), keeping current eviction behavior unchanged while enabling future per-salt/user eviction policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 762966e3d46cce3c8eb45cdb93df99f7fcb40f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->