### PR TITLE
[BugFix]: Fix async retrieve path missing backend.unpin() in cleanup

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1313,14 +1313,28 @@ class LMCacheEngine:
             # Flatten nested lists (each backend returns a list of chunks)
             memory_objs_flat = [mm for m in memory_objs for mm in m]
 
-            # Release each memory object
+            # Release each memory object's ref count first (while
+            # pin_count > 0 the object won't be freed prematurely).
             for key, memory_obj in memory_objs_flat:
                 try:
                     logger.debug("Releasing memory object for lookup_id=%s", lookup_id)
-                    memory_obj.unpin()
                     memory_obj.ref_count_down()
                 except Exception as e:
                     logger.error(f"Error releasing memory object: {e}")
+
+            # Unpin via storage_manager so backends with server-side
+            # pin state (e.g. MaruBackend) are properly notified.
+            # For LocalCPUBackend, backend.unpin(key) internally calls
+            # memory_obj.unpin(), so behavior is equivalent.
+            try:
+                keys_to_unpin = [key for key, _ in memory_objs_flat]
+                if keys_to_unpin:
+                    self.storage_manager.batched_unpin(keys_to_unpin)
+            except Exception as e:
+                logger.error(
+                    f"Error during batched_unpin for "
+                    f"lookup_id={lookup_id}: {e}"
+                )
         except Exception as e:
             logger.error(
                 f"Error during cleanup_memory_objs for lookup_id={lookup_id}: {e}"

--- a/tests/v1/test_cleanup_memory_objs.py
+++ b/tests/v1/test_cleanup_memory_objs.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression test for GitHub issue #3027.
+
+cleanup_memory_objs() must propagate unpin to storage backends via
+storage_manager.batched_unpin(), not just call memory_obj.unpin() locally.
+"""
+# Standard
+from unittest.mock import MagicMock
+import asyncio
+
+# First Party
+from lmcache.v1.cache_engine import LMCacheEngine
+from lmcache.v1.event_manager import EventManager, EventStatus, EventType
+
+
+class FakeMemoryObj:
+    """Tracks unpin() and ref_count_down() calls."""
+
+    def __init__(self):
+        self.unpin_called = False
+        self.ref_count_down_called = False
+
+    def unpin(self):
+        self.unpin_called = True
+
+    def ref_count_down(self):
+        self.ref_count_down_called = True
+
+
+def _make_engine_stub():
+    """Build a minimal object with only the attrs cleanup_memory_objs needs."""
+    engine = object.__new__(LMCacheEngine)  # skip __init__
+    engine.event_manager = EventManager()
+    engine.storage_manager = MagicMock()  # spy on batched_unpin
+    return engine
+
+
+def _seed_done_event(engine, lookup_id, memory_objs_nested):
+    """Register a completed LOADING event containing memory_objs_nested.
+
+    The EventManager requires events to be added as ONGOING first, then
+    moved to DONE.  We simulate a finished async prefetch by adding the
+    future and immediately marking it DONE.
+    """
+    loop = asyncio.new_event_loop()
+    future = loop.create_future()
+    future.set_result(memory_objs_nested)
+
+    engine.event_manager.add_event(EventType.LOADING, lookup_id, future)
+    engine.event_manager.update_event_status(
+        EventType.LOADING, lookup_id, EventStatus.DONE
+    )
+    loop.close()
+
+
+class TestCleanupMemoryObjsUnpinPropagation:
+    """Issue #3027: backend unpin must be called, not just local unpin."""
+
+    def test_batched_unpin_called_with_all_keys(self):
+        """After fix, cleanup_memory_objs must call
+        storage_manager.batched_unpin(keys) so backends with server-side
+        pin state are properly notified."""
+        engine = _make_engine_stub()
+        key_a = MagicMock(name="key_a")
+        key_b = MagicMock(name="key_b")
+        mem_a, mem_b = FakeMemoryObj(), FakeMemoryObj()
+
+        _seed_done_event(engine, "lu-1", [[(key_a, mem_a), (key_b, mem_b)]])
+
+        engine.cleanup_memory_objs("lu-1")
+
+        engine.storage_manager.batched_unpin.assert_called_once_with(
+            [key_a, key_b]
+        )
+
+    def test_ref_count_down_still_called(self):
+        """ref_count_down must still happen for every memory object."""
+        engine = _make_engine_stub()
+        mem_a, mem_b = FakeMemoryObj(), FakeMemoryObj()
+        _seed_done_event(
+            engine,
+            "lu-2",
+            [[(MagicMock(), mem_a)], [(MagicMock(), mem_b)]],
+        )
+
+        engine.cleanup_memory_objs("lu-2")
+
+        assert mem_a.ref_count_down_called
+        assert mem_b.ref_count_down_called
+
+    def test_local_unpin_not_called_directly(self):
+        """memory_obj.unpin() should NOT be called directly — unpin is
+        delegated to storage_manager.batched_unpin()."""
+        engine = _make_engine_stub()
+        mem = FakeMemoryObj()
+        _seed_done_event(engine, "lu-3", [[(MagicMock(), mem)]])
+
+        engine.cleanup_memory_objs("lu-3")
+
+        assert not mem.unpin_called
+
+    def test_multi_tier_keys_collected(self):
+        """Keys from multiple tiers are all collected into one batch."""
+        engine = _make_engine_stub()
+        keys = [MagicMock(name=f"k{i}") for i in range(4)]
+        mems = [FakeMemoryObj() for _ in range(4)]
+        _seed_done_event(
+            engine,
+            "lu-4",
+            [
+                [(keys[0], mems[0]), (keys[1], mems[1])],
+                [(keys[2], mems[2]), (keys[3], mems[3])],
+            ],
+        )
+
+        engine.cleanup_memory_objs("lu-4")
+
+        engine.storage_manager.batched_unpin.assert_called_once_with(keys)
+        for m in mems:
+            assert m.ref_count_down_called
+
+    def test_ref_count_down_before_batched_unpin(self):
+        """ref_count_down must complete for ALL objects before
+        batched_unpin to prevent premature eviction."""
+        call_log = []
+        engine = _make_engine_stub()
+        mem = FakeMemoryObj()
+        mem.ref_count_down = lambda: call_log.append("ref_count_down")
+        engine.storage_manager.batched_unpin.side_effect = (
+            lambda keys: call_log.append("batched_unpin")
+        )
+        _seed_done_event(engine, "lu-order", [[(MagicMock(), mem)]])
+
+        engine.cleanup_memory_objs("lu-order")
+
+        assert call_log == ["ref_count_down", "batched_unpin"]
+
+    def test_no_completed_event_is_noop(self):
+        """If no DONE event exists, cleanup is a no-op."""
+        engine = _make_engine_stub()
+
+        engine.cleanup_memory_objs("nonexistent")  # should not raise
+
+        engine.storage_manager.batched_unpin.assert_not_called()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #3027

The async retrieve path pins entries via `batched_async_contains(keys, pin=True)` but never calls `backend.unpin()` afterwards. `cleanup_memory_objs()` only called `memory_obj.unpin()` — a local Python object operation that does not propagate to backends with server-side pin state (e.g., `MaruBackend`, where `unpin()` sends an RPC to decrement the server-side pin count). This caused permanent pin accumulation after each async retrieve.

This PR replaces the local `memory_obj.unpin()` with `storage_manager.batched_unpin(keys)` in `cleanup_memory_objs()`, making the async cleanup path symmetric with the sync path in `lookup_unpin()`.

### Root cause

PR #2559 introduced `cleanup_memory_objs()` with `memory_obj.unpin()` to fix local memory leaks. At the time, only `LocalCPUBackend` existed, where `backend.unpin(key)` internally calls `memory_obj.unpin()` — so the local-only call was sufficient. When `MaruBackend` (PR #2705) introduced server-side pin state via RPC, the async path's local-only unpin became a bug.

### Changes

**`lmcache/v1/cache_engine.py`** — `cleanup_memory_objs()`:

Before:
```python
for key, memory_obj in memory_objs_flat:
    memory_obj.unpin()          # local only — backend never notified
    memory_obj.ref_count_down()
```

After:
```python
# ref_count_down first (while pin_count > 0, preventing premature free)
for key, memory_obj in memory_objs_flat:
    memory_obj.ref_count_down()

# Then unpin via storage_manager (propagates to all backends)
keys_to_unpin = [key for key, _ in memory_objs_flat]
if keys_to_unpin:
    self.storage_manager.batched_unpin(keys_to_unpin)
```

For `LocalCPUBackend`, `backend.unpin(key)` internally calls `memory_obj.unpin()` — behavior is equivalent. For `MaruBackend`, it sends the required RPC. For no-op backends (GDS, PD, Remote, P2P), it's harmless.

### Note on PR #3028

PR #3028 addresses the same issue with a more conservative approach (opt-in `requires_backend_unpin` flag + registry + lock, 3 files, ~60 lines). This PR implements the simpler alternative [suggested in the issue](https://github.com/LMCache/LMCache/issues/3027) by the issue author: routing unpin through the existing backend path with no new abstractions. It also covers the `LookupCleanupMsg` path in `lmcache_async_lookup_client.py`, which calls `cleanup_memory_objs()` directly.

**Special notes for your reviewers**:

- Operation ordering: `ref_count_down()` runs first while `pin_count > 0` (preventing premature free), then `batched_unpin()` triggers final release. Both have independent error handling.
- `batched_unpin(keys)` with `locations=None` iterates all backends. Each backend's `unpin(key)` returns `False` gracefully for unknown keys, so this is safe.

cc @ApostaC @YaoJiayi @maobaolong

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Testing**:

- 6 regression tests in `tests/v1/test_cleanup_memory_objs.py` — all pass (CPU-only, no GPU required):
  - `test_batched_unpin_called_with_all_keys` — core regression for #3027
  - `test_ref_count_down_still_called` — verifies existing behavior preserved
  - `test_local_unpin_not_called_directly` — ensures unpin delegated to backend
  - `test_multi_tier_keys_collected` — multi-backend key flattening
  - `test_ref_count_down_before_batched_unpin` — ordering invariant locked in
  - `test_no_completed_event_is_noop` — edge case
- `ruff check` and `isort --check` pass
- `py_compile` on all changed files passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache pin/unpin lifecycle during async retrieval cleanup; mistakes could cause leaked pins or premature eviction across backends, but the change is small and regression-tested.
> 
> **Overview**
> Fixes the async lookup/prefetch cleanup path so `cleanup_memory_objs()` decrements ref counts and then propagates unpinning through `storage_manager.batched_unpin(keys)`, ensuring backends with server-side pin state are properly released.
> 
> Adds regression tests covering key collection across tiers, call ordering (`ref_count_down` before `batched_unpin`), and the no-op behavior when no completed event exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8782334598624305bd69d007975e494ad1d55ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->