### PR TITLE
[Doc] Fix instance_id typo, add kv_events config and UCX_TLS note in move example

### DIFF
--- a/docs/source/kv_cache_management/move.rst
+++ b/docs/source/kv_cache_management/move.rst
@@ -30,6 +30,7 @@ configure two lmcache instances:
     chunk_size: 256
     local_cpu: True
     max_local_cpu_size: 5
+    enable_kv_events: True
 
     # cache controller configurations
     enable_controller: True
@@ -52,10 +53,11 @@ configure two lmcache instances:
     chunk_size: 256
     local_cpu: True
     max_local_cpu_size: 5
+    enable_kv_events: True
 
     # cache controller configurations
     enable_controller: True
-    lmcache_instance_id: "lmcache_instance_1"
+    lmcache_instance_id: "lmcache_instance_2"
     controller_pull_url: "localhost:8300"
     controller_reply_url: "localhost:8400"
     lmcache_worker_ports: 8501
@@ -78,6 +80,21 @@ Start two vllm engines:
 
     PYTHONHASHSEED=123 UCX_TLS=rc CUDA_VISIBLE_DEVICES=1 LMCACHE_CONFIG_FILE=instance2.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 4096 \
       --gpu-memory-utilization 0.8 --port 8001 --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
+
+.. note::
+
+   The examples above use ``UCX_TLS=rc`` (InfiniBand RDMA). If your GPUs are
+   on the **same node**, replace it with CUDA IPC:
+
+   .. code-block:: bash
+
+      export UCX_TLS=cuda_ipc,cuda_copy,tcp
+
+   For environments **without RDMA or CUDA IPC**, use TCP as a fallback:
+
+   .. code-block:: bash
+
+      export UCX_TLS=tcp
 
 Start the lmcache controller at port 9000 and the monitor at port 9001:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #2571

The [KV cache move documentation](https://docs.lmcache.ai/kv_cache_management/move.html) has three mistakes that cause the move example to silently fail (returning `num_tokens: 0`).

## What's broken?

Any user following the KV cache move tutorial gets `num_tokens: 0` instead of the expected token count.

## Where is the bug?

`docs/source/kv_cache_management/move.rst`, introduced in PR #1610 (`[Core] P2P Backend`).

## Root Cause

1. **Wrong instance_id** — `instance2.yaml` sets `lmcache_instance_id: "lmcache_instance_1"` (copy-paste from instance1). The controller can't route the move to the correct destination.
2. **Missing `enable_kv_events`** — neither config block has `enable_kv_events: True`, needed for KV event tracking.
3. **No CUDA IPC example** — only `UCX_TLS=rc` (InfiniBand) is shown. Users without InfiniBand have no guidance.

## How we fixed it

Three surgical edits to `move.rst`:

| Fix | Before | After |
|-----|--------|-------|
| instance_id | `lmcache_instance_id: "lmcache_instance_1"` | `lmcache_instance_id: "lmcache_instance_2"` |
| kv_events | (missing) | `enable_kv_events: True` in both YAML blocks |
| UCX_TLS | no note | `.. note::` with copy-pasteable `export` commands for CUDA IPC and TCP fallback |

## Testing

- RST parsed cleanly with docutils (0 warnings, 0 errors)
- codespell: no spelling errors
- All 3 `UCX_TLS` values cross-referenced against CI scripts, test READMEs, and other docs pages

**Special notes for your reviewers**:

cc @YaoJiayi — the instance_id typo was introduced in your PR #1610 (copy-paste from instance1 to instance2 config). This is a minimal fix.

Note: `examples/cache_controller/move/` README and YAML files have the same issues but are left for a separate follow-up to keep this PR scoped.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts example configuration and adds environment guidance; no runtime code paths are modified.
> 
> **Overview**
> Updates the KV cache `move` documentation example to avoid silent failures by **fixing `instance2.yaml` to use `lmcache_instance_id: "lmcache_instance_2"`** and adding `enable_kv_events: True` to both example configs.
> 
> Adds a `.. note::` explaining `UCX_TLS` options, including CUDA IPC for same-node GPUs and a TCP fallback when RDMA/CUDA IPC aren’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd71823665a1d97113a38b4a2dfc7d3e369452ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->