### PR TITLE
[Chore] add coding standard and PR review instructions

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: create-pr
+description: Create a GitHub pull request from the current branch to the upstream repo, using the repo's PR template
+allowed-tools: Bash, Read, Glob, Grep, Agent, mcp__github__create_pull_request
+argument-hint: "[base_branch] [--draft] [--title 'PR title']"
+---
+
+# Create Pull Request
+
+Create a GitHub pull request from the current branch to the upstream repository.
+
+## Arguments
+
+`$ARGUMENTS` may contain:
+- First positional arg: base branch to merge into (default: auto-detect from upstream's default branch)
+- `--draft`: create as a draft PR
+- `--title 'PR title'`: override the PR title (default: auto-generated from changes)
+
+## Steps
+
+### 1. Gather context
+
+Run these in parallel:
+
+```bash
+# Check remotes — identify the fork remote and the upstream remote
+git remote -v
+
+# Current branch and tracking info
+git branch -vv --contains HEAD
+
+# Untracked/unstaged changes (warn user if dirty)
+git status -s
+
+# Default branch of the upstream repo
+gh api repos/<UPSTREAM_OWNER>/<UPSTREAM_REPO> --jq '.default_branch'
+```
+
+Determine:
+- **Fork remote**: the remote pointing to the user's fork (usually `local` or `origin` if the user's fork)
+- **Upstream remote**: the remote pointing to the upstream repo (look for the canonical org/repo)
+- **Fork owner**: extracted from the fork remote URL (e.g., `alice` from `git@github.com:alice/LMCache.git`)
+- **Upstream owner/repo**: extracted from the upstream remote URL
+- **Base branch**: from `$ARGUMENTS` or the upstream repo's default branch
+
+### 2. Check the branch is pushed
+
+Verify the current branch is pushed to the fork remote. If not, warn the user and stop — do NOT push without explicit permission.
+
+### 3. Find and read the PR template
+
+```
+Glob pattern: .github/PULL_REQUEST_TEMPLATE.md
+Glob pattern: .github/PULL_REQUEST_TEMPLATE/**/*.md
+Glob pattern: .github/pull_request_template.md
+```
+
+Read the template to understand required sections.
+
+### 4. Analyze changes
+
+```bash
+# Commits on this branch vs the base
+git log --oneline <upstream_remote>/<base_branch>..HEAD
+
+# Diff stat for summary
+git diff <upstream_remote>/<base_branch>..HEAD --stat
+```
+
+If there are many commits, also read the full diff to understand the changes:
+```bash
+git diff <upstream_remote>/<base_branch>..HEAD
+```
+
+### 5. Draft the PR
+
+- **Title**: Use `--title` from arguments if provided. Otherwise, generate a concise title (under 70 chars) summarizing the change.
+- **Body**: Fill in the PR template sections based on the changes. Focus on:
+  - **Why** the change is needed (motivation, problem being solved)
+  - **User-facing changes** (new CLI args, changed behavior, breaking changes)
+  - Do NOT enumerate per-file changes — reviewers can read the diff
+  - Keep it concise and informative
+
+Show the drafted title and body to the user and ask for confirmation before creating the PR.
+
+### 6. Create the PR
+
+Use the `mcp__github__create_pull_request` tool:
+- `owner`: upstream repo owner
+- `repo`: upstream repo name
+- `head`: `<fork_owner>:<branch_name>`
+- `base`: the base branch
+- `title`: the PR title
+- `body`: the PR body
+- `draft`: true if `--draft` was specified
+
+### 7. Report
+
+Print the PR URL so the user can review it.
+
+## Important Notes
+
+- Never push code or create commits — this skill only creates the PR from already-pushed branches.
+- Always show the PR title and body to the user for confirmation before creating.
+- If the working tree is dirty, warn the user that uncommitted changes won't be included.
+- Respect the PR template structure — fill in all sections, use checkboxes where the template has them.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: pr-review
+description: Review a GitHub pull request against the LMCache coding standards
+allowed-tools: Bash, Read, Grep, Glob, Agent, mcp__github__pull_request_read, mcp__github__list_pull_requests, mcp__github__search_pull_requests, mcp__github__add_reply_to_pull_request_comment
+argument-hint: "<PR number or URL>"
+---
+
+# PR Review: LMCache Code Quality Standard
+
+Review a pull request against the LMCache coding standards defined in `docs/coding_standards.md`.
+
+## Inputs
+
+`$ARGUMENTS` is a PR number (e.g., `3032`) or a GitHub PR URL.
+
+## Review Process
+
+### Step 0 -- Load the standards
+
+Read `docs/coding_standards.md` at the repo root. This is the authoritative reference for
+all quality checks. Also read `AGENTS.md` for the quick-reference checklist.
+
+### Step 1 -- Understand the PR
+
+1. Fetch the PR metadata (`get`) to understand the title, description, author, and base branch.
+2. Fetch the diff (`get_diff`) to see exactly what changed.
+3. Fetch the list of changed files (`get_files`) for a structural overview.
+4. Read any design docs referenced in the PR description or located in the module directory (e.g., `docs/design/<module>/`).
+5. For each **changed public symbol** (function, method, class, field), note its fully qualified name. You will use these in Step 4 to find callers.
+
+### Step 2 -- Design Doc Compliance
+
+If a relevant design doc exists (check `docs/design/` and any `DESIGN.md` in the changed module directories):
+
+- Check that the implementation conforms to documented contracts, invariants, and assumptions.
+- Present compliance as a table:
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| ... | pass/fail | ... |
+
+If no design doc is relevant, state that and skip this section.
+
+### Step 3 -- Coding Quality Review
+
+Review the diff against these standards (from `docs/coding_standards.md`):
+
+**Typing (Section 2)**:
+- All new/modified functions have type hints for arguments and return values.
+- No use of `Any` or bare generic containers (`list`, `dict`, `tuple`).
+- No `assert` used for runtime validation -- must use `if/raise ValueError`.
+
+**Docstrings (Section 3)**:
+- All new/modified public functions have complete docstrings (summary, args, returns, raises, notes).
+- Docstrings match actual current behavior (not planned future behavior).
+- Modified functions have updated docstrings.
+
+**Function and Interface Design (Section 4)**:
+- Function names are self-explanatory.
+- No ambiguous return values (e.g., `None` meaning two different things).
+- No boolean parameters where an enum or function split would be clearer.
+- Dict/container parameters have documented schemas.
+- Caller assumptions documented in docstrings.
+- Class interfaces are minimal (no unnecessary public methods).
+- No cross-class private member access.
+
+**New Functionality (Section 5)**:
+- Design doc present for non-trivial features.
+- Tests cover new features (error-severity if missing).
+- Tests verify public interface, not implementation details.
+- Tests do not access private members.
+
+**Modifications (Section 6)**:
+- Docstrings updated for changed functions.
+- User/design docs updated if behavior changes.
+- Checked for reusable existing code.
+
+**Code Organization (Section 7)**:
+- License header present on new Python files.
+- Import ordering correct (Standard / Third Party / First Party / Local).
+- All imports at file top (no lazy imports).
+- `import torch` before native C extensions.
+- Uses `init_logger(__name__)` from `lmcache.logging`, not bare `logging.getLogger()`.
+- Operational logs at DEBUG level (not INFO).
+- Log levels appropriate (no WARNING for expected concurrent conditions).
+- Module-level helpers at top; private methods at end of class.
+
+**Resource Management (Section 7.5-7.6)**:
+- Error paths release locks, free pool entries, close file descriptors.
+- No unbounded collection growth (sets/dicts cleaned up when resources freed).
+- No unnecessary memory copies in hot paths.
+- CUDA/GPU resources properly managed.
+
+### Step 4 -- Caller Impact Analysis (Section 6.2)
+
+This step is what distinguishes a real review from a diff-reader. For each changed
+public symbol identified in Step 1, verify the change is safe for **every unchanged caller**.
+
+**Triggers -- run this step whenever the PR:**
+- Adds, removes, renames, or reorders parameters of a public function/method
+- Changes parameter types, defaults, or accepted domains (e.g., adds `None` to accepted values, narrows a type)
+- Changes return types or the meaning of sentinel returns (e.g., what `None` means)
+- Adds, removes, or changes raised exceptions
+- Changes side effects, ordering, blocking behavior, or thread-safety guarantees
+- Modifies a method on a base class or protocol (subclasses are callers)
+- Changes an invariant of a class field accessed by public API
+
+**How to find callers:**
+
+1. Use `Grep` with the symbol name across the repo (do not filter to only changed files).
+   Include `tests/`, `benchmarks/`, `lmcache/integration/`, and `docs/` in the search.
+2. For common function names that may have many false matches, use `Grep` with
+   `-A 2 -B 2` to see context, or use the `Agent` (Explore) tool with a focused
+   prompt (e.g., "find all callers of `L1Manager.is_key_evictable` and summarize
+   what they do with the return value").
+3. For base-class/protocol changes, also grep for subclasses
+   (`class \w+\(<BaseName>`).
+
+**For each caller, check:**
+- Is the new signature compatible with this call site? (Keyword arg renames are especially dangerous.)
+- Does the caller still handle the new return type / new exceptions correctly?
+- Does the caller pass the output to something else whose contract would now be violated?
+- If the change is backwards-compatible at the signature level, is it also backwards-compatible at the **semantic** level (e.g., does a now-optional param change default behavior)?
+
+**Flag as error severity:**
+- Any unchanged caller that is now broken and not updated in the PR.
+- Any protocol/base-class change where at least one implementer is not updated.
+
+**Flag as warning severity:**
+- Callers whose assumptions are weakened by the change and whose correctness is not obviously preserved.
+
+Report findings as part of the issues list, with the path:line of the affected caller and a one-line explanation of the impact.
+
+### Step 5 -- Thread Safety (Section 8)
+
+- Shared state protected by locks.
+- Lock granularity appropriate.
+- Concurrent access from multiple controller threads is safe.
+- Even debug/test-only methods hold locks when accessing shared state.
+
+### Step 6 -- Test Coverage (Section 5.2)
+
+- New features have tests (error-severity if missing).
+- Bug fixes have regression tests (error-severity if missing).
+- Tests verify public API and docstring contract.
+- Tests do not access private members or test private functions directly.
+- Note what is tested and what is missing (especially failure paths and concurrent access).
+
+### Step 7 -- PR Structure (Section 1.1)
+
+- Is the PR appropriately scoped? If too many changed files, suggest how to break it down.
+
+## Output Format
+
+### Summary
+One paragraph describing what the PR does.
+
+### Design Doc Compliance
+Table (if applicable) or "No relevant design doc."
+
+### Issues
+
+Group issues by severity, following the calibration from `docs/coding_standards.md` Section 9.2:
+
+**error** (must fix before merge):
+- Missing SPDX header, missing type hints, missing docstrings on public functions,
+  new feature with zero tests, bug fix with no regression test, cross-class private
+  member access, poor architectural decision, ambiguous return values, `assert` for
+  runtime validation, docstring that misrepresents behavior.
+
+**warning** (should fix):
+- Docstring could be more detailed, tests that test implementation details, naming
+  could be clearer, code could be more modular, missing `strict=True` on `zip` of
+  parallel lists, log level too high for operational messages.
+
+**info** (suggestion, non-blocking):
+- Optional naming improvement, minor refactor for readability, style preference.
+
+For each issue, include:
+- File path and line number(s)
+- What the issue is and why it matters
+- Suggested fix (if straightforward)
+
+### Summary Table
+
+| Severity | Count | Key Items |
+|----------|-------|-----------|
+| error    | N     | ... |
+| warning  | N     | ... |
+| info     | N     | ... |
+
+## Reviewer Rules
+
+- The review is scoped to the diff, with **one exception**: unchanged callers of
+  changed symbols (Step 4). Flag a caller in unchanged code only when the PR's
+  changes demonstrably affect it; do not review unrelated issues in those files.
+- Do NOT praise the code. Only report issues or confirm the PR is clean.
+- Do NOT pad findings. If the PR is clean, say "PR is clean" and list what was checked.
+- Be precise about file paths and line numbers.
+- If unsure whether something is an issue, treat it as `info`, not `error`.
+- Do NOT leave trivial or nitpick comments that linters would catch.
+- Focus on design decisions, architectural soundness, correctness, caller impact, thread safety, code cleanliness, modularity, and maintainability.

--- a/.claude/skills/pre-pr-check/SKILL.md
+++ b/.claude/skills/pre-pr-check/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: pre-pr-check
+description: Check local changes against the LMCache coding standards and fix issues before creating a PR
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Agent
+argument-hint: "[--scope uncommitted|branch|staged] [--fix|--check-only]"
+---
+
+# Pre-PR Check: LMCache Coding Standard Compliance
+
+Check the developer's local changes against the coding standards defined in
+`docs/coding_standards.md` and modify the code to fix compliance issues, so the
+PR is clean before it is opened.
+
+This skill is meant to be run **before** `/create-pr`.
+
+## Arguments
+
+- `--scope` (default: `branch`)
+  - `uncommitted` -- check only unstaged + staged changes vs HEAD
+  - `staged` -- check only staged changes
+  - `branch` -- check all commits on the current branch not yet in `dev` (the
+    full PR diff). This is the default since that matches what a reviewer sees.
+- `--fix` (default) -- automatically fix issues that can be fixed mechanically
+- `--check-only` -- only report issues, do not modify files
+
+## Workflow
+
+### Step 0 -- Load the standard
+
+Read `docs/coding_standards.md` at the repo root. This is the authoritative reference.
+
+### Step 1 -- Detect the scope of changes
+
+Run `git status --short` and `git branch --show-current` to orient yourself.
+
+Then, based on `--scope`, compute the diff:
+
+| Scope | Command |
+|-------|---------|
+| `uncommitted` | `git diff HEAD` |
+| `staged` | `git diff --cached` |
+| `branch` (default) | `git diff dev...HEAD` |
+
+Also list changed files:
+
+| Scope | Command |
+|-------|---------|
+| `uncommitted` | `git diff --name-only HEAD` |
+| `staged` | `git diff --cached --name-only` |
+| `branch` | `git diff --name-only dev...HEAD` |
+
+If there are no changes in the selected scope, report that and stop.
+
+### Step 2 -- Read the changed files
+
+For each changed file, read the current content (not just the diff) so you can
+make accurate edits. Focus on:
+- `.py` files -- full coding-standard review
+- `.md`, `.rst` -- documentation review (brief)
+- `.cpp`, `.cu`, `.rs` -- light review (style only; clang-format / cargo fmt handle most of it)
+
+For each changed file, also identify the **changed public symbols** (functions,
+methods, classes, fields whose signature, return type, raised exceptions, or
+behavior contract changed). You will use these in Step 4 to find and inspect callers.
+
+For large changes, delegate to the Explore agent to summarize per-file
+responsibilities before reviewing.
+
+### Step 3 -- Run the checks
+
+For each changed Python file, check the following (from `docs/coding_standards.md`):
+
+#### A. Mechanical issues (fix automatically unless `--check-only`)
+
+These are straightforward to fix:
+
+1. **License header** (Section 1.3): Missing `# SPDX-License-Identifier: Apache-2.0` on line 1 of new Python files.
+2. **`assert` used for runtime validation** (Section 2.2): Replace with `if <not cond>: raise ValueError(<clear msg>)`.
+3. **`Optional` usage** (Section 2.1): Where a value is always initialized, remove the `Optional` wrapper and initialize directly. Where None is genuinely possible, rewrite as `X | None`.
+4. **Bare generics** (Section 2.1): Replace bare `list`, `dict`, `tuple`, `set` in annotations with parameterized forms (`list[T]`, `dict[K, V]`).
+5. **Lazy imports** (Section 7.2): Move imports to the top of the file, under the correct section heading. Preserve `torch`-before-native-C-extension ordering.
+6. **Bare `logging.getLogger(__name__)`** (Section 7.4): Replace with `init_logger(__name__)` from `lmcache.logging`.
+7. **Operational logs at `INFO` level** (Section 7.4): If a log is about store/retrieve/task progress, change `logger.info(...)` to `logger.debug(...)`.
+8. **Inappropriate `WARNING`** (Section 7.4): For log messages about benign concurrent conditions (e.g., "key not found, this should not happen" in a code path documented as not holding the global lock), downgrade to `debug` and fix the misleading message.
+
+#### B. Docstring issues (fix when content is clear; ask when content is unclear)
+
+9. **Missing docstrings** on public/modified functions (Section 3.1-3.2):
+   - If the function is simple and its purpose is obvious from the code, draft a full docstring (summary, args, returns, raises).
+   - If behavior is non-obvious, draft a docstring with clear sections but add a `TODO: confirm` note where you are uncertain, and flag it in the report.
+10. **Docstring accuracy** (Section 3.3): If you added a parameter but the docstring still describes the old signature, update it. If a parameter is currently a no-op (accepted but ignored), the docstring must say so explicitly.
+11. **Missing type hints** on function args or return values (Section 2.1): Add them based on the function's body.
+
+#### C. Design issues (flag; do NOT silently refactor)
+
+These are judgment calls and should be reported, not auto-fixed:
+
+12. **Cross-class private member access** (Section 4.4): Accessing `other._private` outside the defining class.
+13. **Ambiguous return values** (Section 4.3): Function returns `None` for multiple distinct meanings.
+14. **Boolean parameters on public APIs** (Section 4.3).
+15. **New features without tests** (Section 5.2).
+16. **Bug fixes without regression tests** (Section 5.2).
+17. **Unbounded collection growth** (Section 7.6): A set/dict that is appended to without cleanup.
+18. **Error paths that leave state inconsistent** (Section 7.5): Exceptions that skip lock release, FD close, or pool free.
+19. **Missing design doc** for non-trivial new features (Section 5.1).
+20. **PR scope too large** (Section 1.1): If the diff touches many unrelated modules, suggest how to split.
+21. **Lock protocol violations** (Section 8): Debug methods not holding `self._lock`; shared state accessed without synchronization.
+
+### Step 4 -- Apply fixes
+
+For category A and B issues (unless `--check-only`):
+- Use `Edit` to make precise, minimal changes.
+- Preserve existing comments and code style.
+- After fixes, re-read the file to confirm the edit applied cleanly.
+
+For category C issues: do NOT auto-fix. Report them for the developer to address.
+
+### Step 5 -- Caller Impact Analysis (Section 6.2 of the standard)
+
+Even when the diff itself looks clean, a change can silently break unchanged
+callers. Before declaring the changes ready for PR, verify the global view for
+each changed public symbol identified in Step 2.
+
+**Triggers -- run this step if the diff does any of:**
+- Adds, removes, renames, or reorders parameters of a public function/method
+- Changes parameter types, defaults, or accepted domains (e.g., adds `None` to accepted values, narrows a type)
+- Changes the return type or the meaning of sentinel returns (e.g., what `None` means)
+- Adds, removes, or changes raised exceptions
+- Changes side effects, ordering, blocking behavior, or thread-safety guarantees
+- Modifies a method on a base class or protocol (subclasses are callers)
+- Changes an invariant of a class field accessed by public API
+
+If none of the above applies, skip this step.
+
+**How to run it:**
+
+1. For each changed public symbol, `Grep` its name across the whole repo
+   (production code, `tests/`, `benchmarks/`, `lmcache/integration/`, `docs/`).
+   Do not limit to files in the diff.
+2. For commonly-named symbols with many false matches, use `Grep -A 2 -B 2`
+   for context, or delegate to the `Agent` (Explore) tool with a focused prompt
+   (e.g., "find all callers of `LMCacheMPWorkerAdapter.submit_store_request`
+   and summarize the arguments each caller passes").
+3. For base-class / protocol changes, also grep for subclasses
+   (`class \w+\(<BaseName>`).
+
+**For each caller, decide:**
+
+- **Broken and must be fixed in this PR** (category A-like, fix it):
+  - Removed / renamed parameter that the caller passes by keyword
+  - Reordered positional parameters the caller relies on
+  - Return type change that the caller destructures (e.g., tuple shape change)
+  - Newly raised exception the caller doesn't handle, when the caller is on the normal success path
+
+  For these, update the caller in the same pass as the main change. Apply the
+  edit using `Edit`, then re-read to confirm. If the caller is in an unrelated
+  module and the fix is non-trivial, flag it for manual review instead.
+
+- **Behaviorally risky** (category C-like, flag for the developer):
+  - Signature is still compatible but semantics changed (e.g., a return value
+    that used to always be non-empty can now be empty)
+  - Caller passes through to another function whose contract may now be violated
+  - Base-class change where a subclass may need updating even though the
+    signature is backwards-compatible
+
+  Do NOT silently edit these -- the developer needs to confirm the intent. Flag
+  them in the output with `path:line` of the caller and a one-line explanation.
+
+- **Safe** (no action):
+  - Backwards-compatible signature extension the caller does not use
+  - Change in an internal detail not observable at the call site
+
+Track the caller-impact findings under the existing output sections:
+- Auto-fixed callers go under "Auto-fixed issues" with a new category "Caller updates"
+- Flagged risky callers go under "Manual review required" with severity
+  `error` if the caller is clearly broken and `warning` otherwise
+
+### Step 6 -- Final verification
+
+Run these checks and report the outcome. Do NOT auto-run them; print the command the developer should run (respecting the user's preference to run these themselves):
+
+```bash
+pre-commit run --all-files
+pytest -xvs tests/v1/distributed/        # if distributed/ changed
+pytest -xvs tests/v1/mp_observability/   # if mp_observability/ changed
+```
+
+## Output Format
+
+### Summary
+- Scope: `<uncommitted|staged|branch>`
+- Files changed: `<N>`
+- Issues found: `<total>` (auto-fixed: `<N>`, manual: `<N>`)
+
+### Auto-fixed issues
+Grouped by category, with file:line references. E.g.:
+
+**Typing (3 fixes)**
+- `lmcache/v1/foo.py:42` -- replaced `Optional[int]` with `int | None`
+- `lmcache/v1/foo.py:87` -- added type hint for `limit: int` and return type `-> list[str]`
+- `lmcache/v1/bar.py:120` -- replaced `dict` with `dict[str, int]`
+
+**Runtime validation (1 fix)**
+- `lmcache/v1/config.py:548` -- replaced `assert config.url is not None` with `if config.url is None: raise ValueError("url is required")`
+
+**Docstrings (2 fixes)**
+- `lmcache/v1/baz.py:15` -- added full docstring for public method `submit_request`
+- `lmcache/v1/baz.py:60` -- updated docstring for `lookup` to reflect new `cache_salt` parameter
+
+### Manual review required (needs developer judgment)
+
+Grouped by severity:
+
+**error** (must fix before PR):
+- `lmcache/v1/foo.py:230` -- new feature `BatchProcessor.process_async` has no tests in `tests/v1/`. Add unit tests that exercise the public `process_async` API.
+- `lmcache/v1/bar.py:15` -- `BarAdapter.do_thing` accesses `self._cache._internal_map` directly; use a public accessor or expose a method on `Cache`.
+
+**warning** (should fix):
+- `lmcache/v1/baz.py:42` -- `register(name: str, force: bool)` uses a boolean parameter. Consider splitting into `register(name)` and `register_overwrite(name)`, or using an enum `RegisterMode`.
+
+**info** (suggestion):
+- `lmcache/v1/baz.py:78` -- filter parameter is named `filter`; consider `key_eligible_filter` for clarity.
+
+### Commands to run next
+
+```bash
+pre-commit run --all-files
+# then run relevant test suites
+```
+
+### Summary table
+
+| Category | Auto-fixed | Manual | Total |
+|----------|-----------|--------|-------|
+| Typing | 3 | 0 | 3 |
+| Runtime validation | 1 | 0 | 1 |
+| Docstrings | 2 | 0 | 2 |
+| Design | 0 | 2 | 2 |
+| Tests | 0 | 1 | 1 |
+| **Total** | **6** | **3** | **9** |
+
+## Rules
+
+- Only touch files in the selected scope, **except** when Step 5 identifies an
+  unchanged caller that is clearly broken by a signature change in this PR. In
+  that case, update the caller in the same pass. Do not otherwise "improve"
+  unchanged files.
+- Never add error handling, fallbacks, or validation that the task does not require.
+- Never introduce new abstractions, helpers, or dependencies in fixes.
+- When a fix requires judgment (e.g., "what should this docstring say?" or "is
+  this caller's assumption still valid?"), prefer to flag it for manual review
+  rather than guess.
+- Never run `git add`, `git commit`, or `git push`. The developer handles git operations themselves.
+- Never run `pre-commit` or the test suite automatically; print the command for the developer to run.
+- If the scope is `branch` and the branch has no upstream or is far behind `dev`, warn the developer but proceed.
+- If `docs/coding_standards.md` is missing, stop and ask the developer to check it out or pull the latest `dev`.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -13,6 +13,7 @@ modularity, and future maintainability and readability.
 ## Project conventions
 
 Read these files for project standards:
+- `docs/coding_standards.md` — **authoritative** coding quality and review standard
 - `AGENTS.md` — coding conventions, testing practices, review checklist
 - `CONTRIBUTING.md` — contribution guidelines
 

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,6 @@ lmcache/experimental/tests
 uv.lock
 
 # Coding agent instructions
-CLAUDE.md
 GEMINI.md
 COPILOT.md
 CURSOR.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Code Quality Standards
+
+The authoritative reference for coding quality, review process, and PR expectations is
+**[docs/coding_standards.md](docs/coding_standards.md)**. Read it before writing or reviewing code.
+
+Key principles (see the full doc for details and rationale):
+
+- **Strong typing**: All functions have type hints. No `Any`, no bare generics. Avoid `Optional` -- initialize objects even if empty.
+- **Docstrings**: Every public function has a complete docstring (summary, args, returns, raises). Docstrings must match actual current behavior.
+- **Encapsulation**: Never access private members (`_`-prefixed) of other classes. Minimize public interfaces.
+- **Interface design**: No ambiguous return values. No boolean parameters (use enums or split functions). Document schemas for dict/container params.
+- **Testing**: New features and bug fixes require tests. Tests verify the public interface, not implementation details.
+- **No `assert` for validation**: Use `if/raise ValueError` for runtime checks.
+- **PR scope**: Keep PRs small and focused. Break large changes into multiple PRs.
+
+For the quick-reference checklist and build/test/lint commands, see **[AGENTS.md](AGENTS.md)**.
+
+## PR Review Instructions
+
+When asked to review a PR, use the `/pr-review` skill which implements the full review
+process from `docs/coding_standards.md` Section 9.
+
+The review covers:
+
+1. **Design doc compliance** -- check implementation against documented contracts (table format).
+2. **Coding quality** -- typing, docstrings, naming, interface design per Sections 2-4.
+3. **Correctness** -- logic bugs, error handling paths, resource management.
+4. **Thread safety** -- shared state, lock protocols, concurrent access patterns.
+5. **Test coverage** -- especially failure paths and concurrent access.
+6. **PR structure** -- is the scope appropriate, or should it be broken down?
+
+Issues are grouped by severity:
+- **error**: Must fix before merge (missing types/docstrings, no tests, architectural problems).
+- **warning**: Should fix (naming, modularity, test quality).
+- **info**: Suggestion only, non-blocking.
+
+See `docs/coding_standards.md` Section 9 for the full severity calibration and reviewer guidelines.

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -1,0 +1,365 @@
+# LMCache Code Quality and Review Standard
+
+This document defines the coding quality standards and code review expectations for the LMCache project. All contributors (human and AI) should follow these standards. Reviewers should use this as the authoritative reference when reviewing PRs.
+
+> **Source of truth**: This file is the canonical reference. `AGENTS.md` contains the
+> quick-reference checklist; `CLAUDE.md` and `.gemini/styleguide.md` point here for details.
+
+---
+
+## 1. General Rules
+
+### 1.1 PR Scope and Breakdown
+
+- **PRs must be small and focused.** If the number of changed files is large, break it down conceptually into multiple PRs. Each PR should do one thing well.
+- Prefer a series of small, reviewable PRs over one large omnibus PR.
+- If a feature spans multiple modules, split by module boundary or by logical phase (e.g., interface change first, then implementation, then tests).
+
+### 1.2 Documentation Requirements
+
+- **User docs** (`docs/source/`) and **design docs** (`docs/design/`) must be updated whenever there are user-facing changes or new functionalities.
+- **Docstrings** must be updated whenever there are changes to existing functions, methods, or class fields.
+- If there are documents specifying schemas of arguments or return values, update them as well.
+- **Code owners** must be updated if ownership changes. Reviewers should remind PR authors.
+
+### 1.3 License Header
+
+All Python files must have `# SPDX-License-Identifier: Apache-2.0` as the first line.
+
+---
+
+## 2. Typing
+
+### 2.1 Strong Typing is Enforced
+
+- All functions and methods must have type hints for arguments and return values.
+- **Avoid `Any`**. If the type is not clear, redesign the interface until it is.
+- Generic containers must be fully typed:
+  - Use `list[SomeType]`, not bare `list`.
+  - Use `dict[KeyType, ValueType]`, not bare `dict`.
+  - Use `tuple[int, str]` or `tuple[int, ...]`, not bare `tuple`.
+- **Avoid `Optional`**. Prefer always initializing objects (even if empty/unused) over wrapping in `Optional`. If a value can genuinely be absent, use `X | None` syntax rather than `Optional[X]`.
+
+### 2.2 Runtime Validation
+
+- **Never use `assert` for runtime-dependent checks** (e.g., config validation, input validation). Assertions are stripped by `python -O`. Use explicit `if ...: raise ValueError(...)` instead.
+- Only use `assert` for development-time invariant checks that indicate programmer errors.
+
+---
+
+## 3. Docstrings
+
+### 3.1 When Docstrings Are Required
+
+| Scope | Requirement |
+|-------|-------------|
+| Public functions and methods | Full docstring (always required) |
+| Module-level / global helper functions | Full docstring |
+| Long private helper functions | Full docstring |
+| Short, clear class-private helpers | Short docstring acceptable |
+| Override methods with no new behavior | Short docstring acceptable |
+
+### 3.2 Full Docstring Format
+
+A full docstring must include:
+
+1. **Summary**: A clear one-sentence description of what the function does.
+2. **Details** (when needed): A few more sentences covering:
+   - Thread safety guarantees or requirements
+   - Assumptions about the caller/callee
+   - Important invariants
+3. **Args**: Detailed description of every argument, including:
+   - Type and purpose
+   - Assumptions or constraints (e.g., "length of `keys` must equal length of `values`")
+4. **Returns**: Detailed description of the return value.
+5. **Raises**: All exceptions the function may raise.
+6. **Note** (when needed): Important assumptions or caveats that developers should be aware of.
+
+### 3.3 Docstring Accuracy
+
+- Docstrings must match the function's **actual current behavior**, not planned future behavior.
+- When modifying a function, always update the docstring to reflect the change.
+- If a parameter is currently a no-op (accepted but not yet used), the docstring must say so explicitly. Do not describe behavior that is not yet implemented.
+
+---
+
+## 4. Function and Interface Design
+
+### 4.1 Naming
+
+- Function names must be **self-explanatory**. A developer should understand the behavior without reading the implementation.
+- Parameter names should imply semantics. For predicates/filters, name them to indicate what `True`/`False` means (e.g., `key_eligible_filter` rather than just `filter`).
+- Variable naming must be consistent across files and modules.
+- Private methods and private members start with `_`.
+
+### 4.2 Self-Contained Functions
+
+- Functions should be self-contained. If a function's input is expected to come from another specific function (or its output is expected to feed into another), this must be **documented explicitly** in the docstring.
+
+### 4.3 Parameter and Return Value Design
+
+- **Avoid ambiguity in return values.** For example, returning `None` for both "process not finished" and "request not found" makes it impossible for the caller to distinguish. Use distinct return types or raise exceptions.
+- **Document schemas** if the parameter or return value includes `dict` or complex containers. Specify the expected keys, value types, and semantics.
+- **Avoid boolean parameters.** They make call sites unreadable. Prefer:
+  - Breaking into two separate functions, or
+  - Using an `enum` to make intent explicit.
+- **Clarify caller assumptions** in the docstring (e.g., "caller must hold the lock", "must be called from the main thread").
+
+### 4.4 Class Design
+
+- **Minimize the public interface.** Follow the principle of minimal surface area -- only add a new public method or property when there is a concrete need.
+- **Class fields with internal state** must have:
+  - A clear, documented meaning
+  - A clear invariant (at any point in time, a developer should know what the value should be without running the code)
+  - A docstring or inline comment explaining it
+- **Private members must never be directly accessed by other classes.** Interact only through public APIs. This is enforced by CI in `lmcache/v1/multiprocess/` and `lmcache/v1/distributed/`, but applies project-wide.
+- Prefer `@property` that derives from existing data over storing redundant fields.
+
+### 4.5 Config and Dispatch
+
+- Use `isinstance()` on config objects to determine behavior, not string-based type names.
+- Config classes should follow existing conventions (e.g., `@dataclass`). Controllers and managers should always be created (even with empty/default config), never wrapped in `Optional`.
+
+---
+
+## 5. New Functionality
+
+### 5.1 Design Documentation
+
+- **A design doc is required** for non-trivial new features or architectural changes. Place design docs in `docs/design/` under the appropriate module subdirectory.
+
+### 5.2 Testing
+
+- All new features must include corresponding unit tests.
+- All bug fixes must include regression tests.
+- Tests must:
+  - Verify the **public interface and docstring contract**, not implementation details.
+  - Be written as if the function's implementation is unknown.
+  - **Not access private members** (`_`-prefixed) of the class under test.
+  - Not test private helper functions directly. Exercise them through the public API.
+- Test files should mirror the source structure under `tests/`.
+
+### 5.3 Reuse Existing Code
+
+- When adding or updating functions, variables, or logic, check whether there is existing code that can be reused or existing state that can be exported instead of duplicating.
+
+---
+
+## 6. Modification to Existing Code
+
+### 6.1 Documentation and Schema Updates
+
+- **Must update docstrings** for any modified functions or fields.
+- **Should update** user docs and design docs if the change affects behavior or APIs.
+- Update schema documents if argument or return value structures change.
+- Check for existing reusable code before introducing new helpers or utilities.
+
+### 6.2 Caller Impact Analysis (Global View)
+
+Any change to an existing function, class, or module must be evaluated in the
+context of its **callers**, not just the file being edited. A local change that
+looks correct in isolation can silently break unchanged code that depends on the
+prior contract. Authors and reviewers must both take this global view.
+
+**When caller analysis is required:**
+
+- Adding, removing, renaming, or reordering function parameters
+- Changing a parameter's type, default value, or accepted domain (e.g., allowing `None` where it wasn't before, or narrowing an accepted type)
+- Changing the return type, return semantics, or the meaning of sentinel values (e.g., what `None` means)
+- Adding, removing, or changing the exceptions a function raises
+- Changing side effects, ordering guarantees, thread-safety guarantees, or blocking vs. non-blocking behavior
+- Changing invariants of a class field that other classes read via a public accessor
+- Modifying a public method that is part of an interface or base class (subclasses are callers too)
+
+**How to perform the analysis:**
+
+1. **Find every caller** of the changed symbol across the codebase, including:
+   - Non-test production code
+   - Unit tests and integration tests
+   - Documentation snippets and examples
+   - Downstream integrations (e.g., `lmcache/integration/vllm/`)
+2. **For each caller, verify:**
+   - The new signature is compatible (keyword-arg callers are especially sensitive to renames).
+   - Caller assumptions about return values, exceptions, and side effects still hold.
+   - If the caller passes the function's output to another function, that downstream contract still holds.
+3. **Update callers in the same PR** when a breaking change is genuinely required. Do not leave callers broken with the intent to fix them later.
+4. **Prefer backwards-compatible extensions** (new parameter with a default, new optional return field) over breaking changes unless there is a strong reason.
+5. **If the change affects a base class or protocol**, check all implementers, not just direct callers.
+
+**When in doubt, err on the side of reading one more caller.** The cost of
+reading five call sites is small; the cost of a latent bug that ships because no
+one looked is large.
+
+---
+
+## 7. Code Organization and Style
+
+### 7.1 File Structure
+
+- Module-level helper functions go **at the top** of the file (after imports, before classes).
+- Private/helper methods within a class go **at the end** of the class, after all public methods.
+- Code file length should not be too long. If a file is growing large, think about breaking it into smaller modules.
+
+### 7.2 Import Ordering
+
+Imports must follow this section-heading convention:
+
+```python
+# Standard
+import os
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.config import LMCacheEngineConfig
+
+# Local
+from .utils import helper
+```
+
+- All imports must be at the top of the file. No lazy imports.
+- Always `import torch` before importing native C extensions (`lmcache.c_ops`, etc.).
+
+### 7.3 Formatting and Linting
+
+```bash
+# Run all checks (mirrors CI)
+pre-commit run --all-files
+
+# Individual tools
+ruff check .              # Lint (E, F, B, SLF rules)
+ruff format .             # Format (line-length 88)
+isort .                   # Import sorting (black profile, from_first=true)
+mypy --config-file=pyproject.toml   # Type checking
+codespell --toml pyproject.toml     # Spell checking
+```
+
+C++/CUDA files use clang-format (Google style, 80-col). Rust code uses `cargo fmt` and `cargo clippy`.
+
+### 7.4 Logging
+
+- Use the project's `init_logger(__name__)` from `lmcache.logging`, not bare `logging.getLogger()`.
+- Operational logs (store/retrieve activity, background task progress) should be at `DEBUG` level, not `INFO`.
+- Log levels must be appropriate: do not use `WARNING` for conditions that are expected during normal concurrent operation (e.g., a key not found due to a benign race condition).
+
+### 7.5 Error Handling
+
+- Replace `assert` with `if/raise` for all runtime validation (see Section 2.2).
+- Error/failure paths must not leave the system in an inconsistent state. Check:
+  - Locks are released
+  - Pool entries are freed
+  - File descriptors are closed
+  - Partial state is cleaned up on failure
+
+### 7.6 Resource Management
+
+- Unbounded collections are memory leaks. If a set or dict grows over time (e.g., tracking seen keys), ensure entries are cleaned up when the corresponding resource is freed.
+- CUDA/GPU resources must be properly managed (allocated, freed, synchronized).
+- No unnecessary memory copies or allocations in hot paths.
+
+---
+
+## 8. Thread Safety
+
+- All shared state access must be protected by appropriate locks.
+- Lock granularity should be appropriate -- not too coarse (blocking unrelated operations) and not too fine (risking missed synchronization).
+- Even test-only or debug methods must hold `self._lock` for thread safety.
+- When code runs under multiple controller threads (e.g., StoreController + PrefetchController), verify that concurrent access is safe.
+- Start with the simplest correct design. Only introduce threading, locks, and queues when there is a concrete need that cannot be met otherwise.
+
+---
+
+## 9. Code Review Process
+
+### 9.1 Review Focus
+
+Reviews should focus on:
+1. **Design decisions and architectural soundness** -- is this the right approach?
+2. **Correctness** -- logic bugs, error handling, resource management, edge cases.
+3. **Caller impact (global view)** -- do the changes break any unchanged callers, tests, or subclasses? (See Section 6.2.)
+4. **Thread safety** -- shared state, lock protocols, concurrent access patterns.
+5. **Code cleanliness and maintainability** -- naming, modularity, readability.
+6. **Documentation** -- docstrings, design docs, user docs.
+7. **Test coverage** -- especially failure paths and concurrent access.
+8. **Design doc compliance** -- does the implementation match documented contracts?
+
+Reviews should **not** focus on:
+- Security-related issues (out of scope for most changes)
+- Trivial style matters already caught by linters
+- Unrelated refactors of unchanged code (only flag unchanged code when it is a **caller of a changed symbol** and the change affects it; do not report unrelated issues in unchanged code)
+
+### 9.2 Severity Levels
+
+| Severity | Meaning | Examples |
+|----------|---------|----------|
+| **error** | Must fix before merge | Missing SPDX header, missing type hints on public function, missing docstring on public function, new feature with zero tests, cross-class private member access, poor architectural decision, ambiguous return values, `assert` used for runtime validation, **breaking change that leaves unchanged callers broken** |
+| **warning** | Should fix | Docstring could be more detailed, tests that test implementation details, naming could be clearer, code could be more modular, missing `strict=True` on `zip` of parallel lists, **caller assumptions weakened without audit** |
+| **info** | Suggestion only, non-blocking | Optional naming improvement, minor refactor for readability, style preference, **backwards-compatible extension where a cleaner API break might be justified** |
+
+### 9.3 Reviewer Guidelines
+
+- Only review lines in the diff. Do not report issues in unchanged code.
+- Do not praise the code. Only report issues or confirm the PR is clean.
+- Do not pad findings. If the PR is clean, say so.
+- Be precise about file paths and line numbers.
+- If unsure whether something is an issue, treat it as `info`, not `error`.
+- Do not leave trivial or nitpick comments that do not affect correctness, maintainability, or readability.
+
+### 9.4 Review Output Format
+
+1. Start with a short summary of what the PR does.
+2. Present **design doc compliance** as a table (requirement | pass/fail | notes) if a relevant design doc exists.
+3. List issues grouped by severity (`error` > `warning` > `info`).
+4. End with a summary table: severity | count | key items.
+
+---
+
+## 10. Quick Reference Checklist
+
+Use this checklist before submitting a PR or during review:
+
+### Correctness
+- [ ] Code does what it claims; matches PR description
+- [ ] Edge cases handled (empty inputs, `None` values, boundary conditions)
+- [ ] Error/failure paths do not leave inconsistent state
+- [ ] No regressions (existing tests still pass)
+
+### Typing and Style
+- [ ] `pre-commit run --all-files` passes
+- [ ] All functions have type hints (arguments + return values)
+- [ ] No use of `Any` or bare generic containers
+- [ ] License header present on all Python files
+- [ ] Import ordering follows section-heading convention
+
+### Documentation
+- [ ] All public functions have complete docstrings
+- [ ] Docstrings match actual behavior
+- [ ] Design docs updated for non-trivial changes
+- [ ] User docs updated for user-facing changes
+
+### Encapsulation and Design
+- [ ] No cross-class private member access
+- [ ] Public APIs minimal and well-defined
+- [ ] Module-level helpers at top; private methods at end of class
+- [ ] No boolean parameters (use enum or split into separate functions)
+- [ ] No ambiguous return values
+
+### Caller Impact (Global View)
+- [ ] All callers of changed signatures still compile/pass type checks
+- [ ] All callers still handle the new return type / new exceptions correctly
+- [ ] Subclasses/implementers of modified base classes or protocols updated
+- [ ] Tests and integration code (`tests/`, `lmcache/integration/`) checked, not just production paths
+
+### Testing
+- [ ] New features have corresponding tests
+- [ ] Bug fixes have regression tests
+- [ ] Tests target public interface, not implementation details
+- [ ] Tests do not access private members
+
+### Safety and Performance
+- [ ] No `assert` for runtime validation (use `if/raise`)
+- [ ] No unbounded collection growth
+- [ ] Thread safety maintained for shared state
+- [ ] No unnecessary memory copies in hot paths
+- [ ] CUDA/GPU resources properly managed


### PR DESCRIPTION
**What this PR does / why we need it**:

Consolidates the LMCache coding quality and review standards into a single
authoritative document (`docs/coding_standards.md`) and adds two Claude Code
skills that reference it, so authors and reviewers have a shared, actionable
playbook.

The standards doc synthesizes:
- The existing `AGENTS.md` checklist
- The `.gemini/styleguide.md` review philosophy
- Patterns observed in recent PR reviews (e.g., `assert` vs `if/raise`,
  missing tests as error-severity, log-level discipline, docstring accuracy,
  caller-impact analysis)

Changes in this PR:
- `docs/coding_standards.md` (new): sections on typing, docstrings, function
  and interface design, new functionality, modification to existing code
  (including **caller impact / global view**), code organization, thread
  safety, and the review process with severity calibration.
- `CLAUDE.md` (new): high-level pointers into the standards doc for the
  Claude Code harness.
- `.claude/skills/pr-review/SKILL.md` (new): reviews a GitHub PR against the
  standards, including a caller-impact step that checks unchanged callers of
  modified symbols.
- `.claude/skills/pre-pr-check/SKILL.md` (new): checks local changes before a
  PR is opened, auto-fixes mechanical issues (typing, `Optional`, `assert` →
  `if/raise`, imports, logging), and flags design/test concerns for manual
  review.
- `.gemini/styleguide.md`: points to the new canonical doc.
- `.gitignore`: removes `CLAUDE.md` so agent instructions can be tracked.

**Special notes for your reviewers**:

No code or runtime behavior changes in this PR -- docs and agent configs
only. The `.claude/skills/` directory is a new location; per-developer local
state (`.claude/settings.local.json`, `.claude/worktrees/`) stays ignored via
`.git/info/exclude`.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and agent-skill configuration only; no runtime code paths or APIs are modified.
> 
> **Overview**
> Adds an **authoritative** `docs/coding_standards.md` covering typing/docstrings/interface design, test expectations, logging/style rules, and a review process (including *caller-impact analysis* and severity calibration).
> 
> Introduces Claude Code automation docs/config: new `CLAUDE.md` plus `.claude/skills/` workflows for `/create-pr`, `/pre-pr-check` (local standards checking with optional auto-fixes), and `/pr-review` (PR review checklist driven by the standards). Updates `.gemini/styleguide.md` to point at the new standard and adjusts `.gitignore` to track `CLAUDE.md` by no longer ignoring it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba9f19c68d356121c4c3138f20f846d15d27390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->