### PR TITLE
[Hotfix][CI] Unblock CI: pandas          auto-heal + CUDA 12 build toolchain

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -62,32 +62,28 @@ for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
     uv pip install "$mod"
 done
 
-echo "--- :python: Installing LMCache from source"
+echo "--- :wrench: Installing CUDA 12.8 nvcc for LMCache build"
 # The base image ships CUDA 13 (for nvcc 13), but vLLM nightly's torch wheel
-# is built against CUDA 12. torch.utils.cpp_extension._check_cuda_version
-# refuses to compile LMCache's C++/CUDA extension on that major-version
-# mismatch. Install a pip-shipped CUDA 12 toolchain and point CUDA_HOME at
-# it for the editable-install build step only; runtime still uses the
-# libcudart12 already present in the base image.
-# Pin to 12.8.* to match torch's reported CUDA version exactly; the 12.9
-# wheels of this package ship with an empty bin/ directory.
-uv pip install \
-    "nvidia-cuda-nvcc-cu12>=12.8,<12.9" \
-    "nvidia-cuda-cccl-cu12>=12.8,<12.9" \
-    "nvidia-cuda-runtime-cu12>=12.8,<12.9"
-# nvidia.cuda_nvcc is a PEP 420 namespace package (no __init__.py). Use
-# __path__[0] to locate it, and `find` so we don't depend on the wheel's
-# bin/ layout staying the same across versions.
-CUDA_NVCC_ROOT=$(python -c "import nvidia.cuda_nvcc as m; print(m.__path__[0])")
-NVCC_BIN=$(find "$CUDA_NVCC_ROOT" -name nvcc -type f -executable 2>/dev/null | head -1)
-if [[ -z "$NVCC_BIN" ]]; then
-    echo "ERROR: no executable nvcc found under ${CUDA_NVCC_ROOT}; tree was:" >&2
-    find "$CUDA_NVCC_ROOT" -maxdepth 3 -ls >&2 || true
+# is built against CUDA 12.8. torch.utils.cpp_extension._check_cuda_version
+# refuses to compile LMCache's C++/CUDA extension on a major-version
+# mismatch, and the pip-published `nvidia-cuda-nvcc-cu12` wheel only ships
+# ptxas + nvvm (no nvcc driver). Install just `cuda-compiler-12-8` from
+# NVIDIA's apt repo (~100MB) alongside the existing CUDA 13 toolchain.
+# Runtime still uses the libcudart12 already present in the base image.
+if [[ ! -x /usr/local/cuda-12.8/bin/nvcc ]]; then
+    apt-get update -y
+    apt-get install -y --no-install-recommends cuda-compiler-12-8
+fi
+if [[ ! -x /usr/local/cuda-12.8/bin/nvcc ]]; then
+    echo "ERROR: nvcc still missing at /usr/local/cuda-12.8/bin/nvcc after apt install" >&2
+    ls /usr/local/ >&2 || true
     exit 1
 fi
-CUDA_HOME_CU12="$(dirname "$(dirname "$NVCC_BIN")")"
-echo "Using CUDA_HOME=${CUDA_HOME_CU12} (nvcc=$NVCC_BIN) for LMCache build"
-"$NVCC_BIN" --version || true
+CUDA_HOME_CU12=/usr/local/cuda-12.8
+echo "Using CUDA_HOME=${CUDA_HOME_CU12} for LMCache build"
+"${CUDA_HOME_CU12}/bin/nvcc" --version
+
+echo "--- :python: Installing LMCache from source"
 CUDA_HOME="$CUDA_HOME_CU12" uv pip install -e . --no-build-isolation
 
 echo "--- :white_check_mark: Environment ready"

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -69,17 +69,25 @@ echo "--- :python: Installing LMCache from source"
 # mismatch. Install a pip-shipped CUDA 12 toolchain and point CUDA_HOME at
 # it for the editable-install build step only; runtime still uses the
 # libcudart12 already present in the base image.
-uv pip install nvidia-cuda-nvcc-cu12 nvidia-cuda-cccl-cu12 nvidia-cuda-runtime-cu12
-# nvidia.cuda_nvcc is a PEP 420 namespace package (no __init__.py), so
-# __file__ is None — use __path__[0] to resolve its installed directory.
-CUDA_HOME_CU12=$(python -c "import nvidia.cuda_nvcc as m; print(m.__path__[0])")
-if [[ ! -x "${CUDA_HOME_CU12}/bin/nvcc" ]]; then
-    echo "ERROR: expected nvcc at ${CUDA_HOME_CU12}/bin/nvcc but it's missing; layout was:" >&2
-    ls -la "${CUDA_HOME_CU12}" >&2 || true
+# Pin to 12.8.* to match torch's reported CUDA version exactly; the 12.9
+# wheels of this package ship with an empty bin/ directory.
+uv pip install \
+    "nvidia-cuda-nvcc-cu12>=12.8,<12.9" \
+    "nvidia-cuda-cccl-cu12>=12.8,<12.9" \
+    "nvidia-cuda-runtime-cu12>=12.8,<12.9"
+# nvidia.cuda_nvcc is a PEP 420 namespace package (no __init__.py). Use
+# __path__[0] to locate it, and `find` so we don't depend on the wheel's
+# bin/ layout staying the same across versions.
+CUDA_NVCC_ROOT=$(python -c "import nvidia.cuda_nvcc as m; print(m.__path__[0])")
+NVCC_BIN=$(find "$CUDA_NVCC_ROOT" -name nvcc -type f -executable 2>/dev/null | head -1)
+if [[ -z "$NVCC_BIN" ]]; then
+    echo "ERROR: no executable nvcc found under ${CUDA_NVCC_ROOT}; tree was:" >&2
+    find "$CUDA_NVCC_ROOT" -maxdepth 3 -ls >&2 || true
     exit 1
 fi
-echo "Using CUDA_HOME=${CUDA_HOME_CU12} for LMCache build"
-"${CUDA_HOME_CU12}/bin/nvcc" --version || true
+CUDA_HOME_CU12="$(dirname "$(dirname "$NVCC_BIN")")"
+echo "Using CUDA_HOME=${CUDA_HOME_CU12} (nvcc=$NVCC_BIN) for LMCache build"
+"$NVCC_BIN" --version || true
 CUDA_HOME="$CUDA_HOME_CU12" uv pip install -e . --no-build-isolation
 
 echo "--- :white_check_mark: Environment ready"

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -37,11 +37,30 @@ else
         --index-strategy unsafe-best-match
 fi
 
-# Workaround: recent vLLM nightlies eagerly `import pandas` in
-# vllm/_aiter_ops.py without declaring pandas as a dependency, which breaks
-# `vllm serve` in our CI venv. Install pandas explicitly until vLLM either
-# makes the import lazy or adds pandas to their declared deps.
-uv pip install pandas
+# vLLM nightlies periodically add eager imports of packages that aren't in
+# their declared deps (e.g. `pandas` from vllm/_aiter_ops.py). Probe-import
+# vllm's CLI entry point and auto-install any ModuleNotFoundError modules
+# so the job keeps going. Capped to avoid infinite loops; every auto-install
+# is logged so the drift is visible in the build output.
+MAX_AUTO_INSTALL=5
+for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
+    if err=$(python -c "from vllm.entrypoints.cli.main import main" 2>&1); then
+        break
+    fi
+    mod=$(printf '%s\n' "$err" | sed -n "s/.*No module named '\([^']*\)'.*/\1/p" | head -1)
+    if [[ -z "$mod" ]]; then
+        echo "vLLM import failed with a non-ModuleNotFoundError:" >&2
+        echo "$err" >&2
+        exit 1
+    fi
+    if [[ "$i" == "$MAX_AUTO_INSTALL" ]]; then
+        echo "Hit $MAX_AUTO_INSTALL auto-install retries; last missing module: $mod" >&2
+        echo "$err" >&2
+        exit 1
+    fi
+    echo "Auto-installing missing vLLM runtime dep: $mod"
+    uv pip install "$mod"
+done
 
 echo "--- :python: Installing LMCache from source"
 uv pip install -e . --no-build-isolation

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -70,8 +70,16 @@ echo "--- :python: Installing LMCache from source"
 # it for the editable-install build step only; runtime still uses the
 # libcudart12 already present in the base image.
 uv pip install nvidia-cuda-nvcc-cu12 nvidia-cuda-cccl-cu12 nvidia-cuda-runtime-cu12
-CUDA_HOME_CU12=$(python -c "import os, nvidia.cuda_nvcc as m; print(os.path.dirname(m.__file__))")
+# nvidia.cuda_nvcc is a PEP 420 namespace package (no __init__.py), so
+# __file__ is None — use __path__[0] to resolve its installed directory.
+CUDA_HOME_CU12=$(python -c "import nvidia.cuda_nvcc as m; print(m.__path__[0])")
+if [[ ! -x "${CUDA_HOME_CU12}/bin/nvcc" ]]; then
+    echo "ERROR: expected nvcc at ${CUDA_HOME_CU12}/bin/nvcc but it's missing; layout was:" >&2
+    ls -la "${CUDA_HOME_CU12}" >&2 || true
+    exit 1
+fi
 echo "Using CUDA_HOME=${CUDA_HOME_CU12} for LMCache build"
+"${CUDA_HOME_CU12}/bin/nvcc" --version || true
 CUDA_HOME="$CUDA_HOME_CU12" uv pip install -e . --no-build-isolation
 
 echo "--- :white_check_mark: Environment ready"

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -62,29 +62,52 @@ for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
     uv pip install "$mod"
 done
 
-echo "--- :wrench: Installing CUDA 12.8 nvcc for LMCache build"
-# The base image ships CUDA 13 (for nvcc 13), but vLLM nightly's torch wheel
-# is built against CUDA 12.8. torch.utils.cpp_extension._check_cuda_version
-# refuses to compile LMCache's C++/CUDA extension on a major-version
-# mismatch, and the pip-published `nvidia-cuda-nvcc-cu12` wheel only ships
-# ptxas + nvvm (no nvcc driver). Install just `cuda-compiler-12-8` from
-# NVIDIA's apt repo (~100MB) alongside the existing CUDA 13 toolchain.
-# Runtime still uses the libcudart12 already present in the base image.
-if [[ ! -x /usr/local/cuda-12.8/bin/nvcc ]]; then
-    apt-get update -y
-    apt-get install -y --no-install-recommends cuda-compiler-12-8
+echo "--- :wrench: Aligning nvcc with torch's reported CUDA version"
+# The base image's nvcc major version and vLLM nightly's torch CUDA major
+# version have drifted apart before (image bumped to CUDA 13 while torch
+# shipped cu128, then torch rolled to cu130). If they mismatch,
+# torch.utils.cpp_extension._check_cuda_version refuses to compile
+# LMCache's CUDAExtension. Detect the mismatch and install the matching
+# `cuda-compiler-<major>-<minor>` package via NVIDIA's apt repo so the
+# build gets a nvcc whose major version lines up with torch. No-op when
+# they already agree.
+read -r TORCH_CUDA TORCH_CUDA_MAJOR TORCH_CUDA_MINOR < <(python -c "
+import torch
+v = torch.version.cuda or ''
+parts = v.split('.') + ['0']
+print(v, parts[0], parts[1])
+")
+SYS_NVCC_MAJOR=$(nvcc --version 2>/dev/null | sed -n 's/.*release \([0-9]\+\).*/\1/p' | head -1)
+echo "torch.version.cuda=${TORCH_CUDA}; system nvcc major=${SYS_NVCC_MAJOR:-none}"
+
+if [[ -z "$TORCH_CUDA" ]]; then
+    echo "torch has no CUDA version (CPU-only build?); skipping nvcc alignment"
+    CUDA_HOME_BUILD=""
+elif [[ "$TORCH_CUDA_MAJOR" == "$SYS_NVCC_MAJOR" ]]; then
+    echo "System nvcc major matches torch; using system nvcc for LMCache build"
+    CUDA_HOME_BUILD=""
+else
+    APT_PKG="cuda-compiler-${TORCH_CUDA_MAJOR}-${TORCH_CUDA_MINOR}"
+    CUDA_HOME_BUILD="/usr/local/cuda-${TORCH_CUDA_MAJOR}.${TORCH_CUDA_MINOR}"
+    echo "Major version mismatch; installing ${APT_PKG} to get matching nvcc at ${CUDA_HOME_BUILD}"
+    if [[ ! -x "${CUDA_HOME_BUILD}/bin/nvcc" ]]; then
+        apt-get update -y
+        apt-get install -y --no-install-recommends "$APT_PKG"
+    fi
+    if [[ ! -x "${CUDA_HOME_BUILD}/bin/nvcc" ]]; then
+        echo "ERROR: nvcc still missing at ${CUDA_HOME_BUILD}/bin/nvcc after apt install" >&2
+        ls /usr/local/ >&2 || true
+        exit 1
+    fi
+    "${CUDA_HOME_BUILD}/bin/nvcc" --version
 fi
-if [[ ! -x /usr/local/cuda-12.8/bin/nvcc ]]; then
-    echo "ERROR: nvcc still missing at /usr/local/cuda-12.8/bin/nvcc after apt install" >&2
-    ls /usr/local/ >&2 || true
-    exit 1
-fi
-CUDA_HOME_CU12=/usr/local/cuda-12.8
-echo "Using CUDA_HOME=${CUDA_HOME_CU12} for LMCache build"
-"${CUDA_HOME_CU12}/bin/nvcc" --version
 
 echo "--- :python: Installing LMCache from source"
-CUDA_HOME="$CUDA_HOME_CU12" uv pip install -e . --no-build-isolation
+if [[ -n "$CUDA_HOME_BUILD" ]]; then
+    CUDA_HOME="$CUDA_HOME_BUILD" uv pip install -e . --no-build-isolation
+else
+    uv pip install -e . --no-build-isolation
+fi
 
 echo "--- :white_check_mark: Environment ready"
 python -c "import vllm; import lmcache; print(f'vLLM={vllm.__version__}, LMCache installed from source with no build isolation')"

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -63,7 +63,16 @@ for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
 done
 
 echo "--- :python: Installing LMCache from source"
-uv pip install -e . --no-build-isolation
+# The base image ships CUDA 13 (for nvcc 13), but vLLM nightly's torch wheel
+# is built against CUDA 12. torch.utils.cpp_extension._check_cuda_version
+# refuses to compile LMCache's C++/CUDA extension on that major-version
+# mismatch. Install a pip-shipped CUDA 12 toolchain and point CUDA_HOME at
+# it for the editable-install build step only; runtime still uses the
+# libcudart12 already present in the base image.
+uv pip install nvidia-cuda-nvcc-cu12 nvidia-cuda-cccl-cu12 nvidia-cuda-runtime-cu12
+CUDA_HOME_CU12=$(python -c "import os, nvidia.cuda_nvcc as m; print(os.path.dirname(m.__file__))")
+echo "Using CUDA_HOME=${CUDA_HOME_CU12} for LMCache build"
+CUDA_HOME="$CUDA_HOME_CU12" uv pip install -e . --no-build-isolation
 
 echo "--- :white_check_mark: Environment ready"
 python -c "import vllm; import lmcache; print(f'vLLM={vllm.__version__}, LMCache installed from source with no build isolation')"

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -37,6 +37,12 @@ else
         --index-strategy unsafe-best-match
 fi
 
+# Workaround: recent vLLM nightlies eagerly `import pandas` in
+# vllm/_aiter_ops.py without declaring pandas as a dependency, which breaks
+# `vllm serve` in our CI venv. Install pandas explicitly until vLLM either
+# makes the import lazy or adds pandas to their declared deps.
+uv pip install pandas
+
 echo "--- :python: Installing LMCache from source"
 uv pip install -e . --no-build-isolation
 

--- a/.buildkite/k3_tests/common_scripts/helpers.sh
+++ b/.buildkite/k3_tests/common_scripts/helpers.sh
@@ -78,10 +78,14 @@ find_free_port() {
 }
 
 # Wait for a vLLM server to become ready by polling /v1/models.
-# Usage: wait_for_server <port> [timeout_secs]
+# Usage: wait_for_server <port> [timeout_secs] [log_file]
+# If log_file is provided, its tail is dumped to stderr on timeout so the
+# real failure (e.g. an ImportError during startup) is visible inline in the
+# job output instead of requiring a trip through build artifacts.
 wait_for_server() {
     local port="$1"
     local timeout="${2:-180}"
+    local log_file="${3:-}"
     echo "Waiting for vLLM on port $port (timeout=${timeout}s)..."
     for ((i = 0; i < timeout; i++)); do
         if curl -sf "http://localhost:${port}/v1/models" >/dev/null 2>&1; then
@@ -91,6 +95,10 @@ wait_for_server() {
         sleep 1
     done
     echo "vLLM failed to start on port $port within ${timeout}s" >&2
+    if [[ -n "$log_file" && -f "$log_file" ]]; then
+        echo "--- :page_facing_up: Last 200 lines of ${log_file}" >&2
+        tail -n 200 "$log_file" >&2
+    fi
     return 1
 }
 

--- a/.buildkite/k3_tests/integration/scripts/run-integration.sh
+++ b/.buildkite/k3_tests/integration/scripts/run-integration.sh
@@ -56,7 +56,7 @@ run_test() {
             > "${test_name}-vllm.log" 2>&1 &
     VLLM_PID=$!
 
-    wait_for_server "$PORT" 180
+    wait_for_server "$PORT" 180 "${test_name}-vllm.log"
 
     # Send requests -- same prompt twice to exercise the cache (second hit should be cached)
     local prompt="The quick brown fox jumps over the lazy dog. Explain this sentence in detail."


### PR DESCRIPTION
Recent vLLM nightlies (>= 0.19.1rc1.dev325) eagerly `import pandas` from vllm/_aiter_ops.py without declaring pandas in their install deps. That causes `vllm serve` to fail at import time in our CI venv, so the k3 integration-test jobs time out waiting on port 8000.

Install pandas explicitly in setup-env.sh as a workaround until vLLM either makes the import lazy or adds pandas to their declared deps.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI bootstrap scripts and introduces apt-based CUDA compiler installation and dynamic pip installs, which can affect build determinism and fail in unexpected environments, but does not change runtime product code.
> 
> **Overview**
> CI setup now **auto-recovers from vLLM nightly undeclared runtime deps** by probe-importing vLLM’s CLI and `uv pip install`ing missing modules on `ModuleNotFoundError` (bounded retries, with logging).
> 
> The environment bootstrap also **aligns the CUDA compiler toolchain** by comparing `torch.version.cuda` with the system `nvcc` major version and, on mismatch, installing the matching `cuda-compiler-<major>-<minor>` via apt and using that `CUDA_HOME` when building LMCache.
> 
> Integration test harnesses were updated so `wait_for_server` can accept a log file and dump its tail on timeout; `run-integration.sh` now passes the vLLM log to surface startup errors directly in job output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c0d1f5e71bd43c98b4bf957de6ea3066415165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->