### PR TITLE
[Hotfix][CI] Use pip-shipped CUDA 12 toolchain when building LMCache

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -38,7 +38,16 @@ else
 fi
 
 echo "--- :python: Installing LMCache from source"
-uv pip install -e . --no-build-isolation
+# The base image ships CUDA 13 (for nvcc 13), but vLLM nightly's torch wheel
+# is built against CUDA 12. torch.utils.cpp_extension._check_cuda_version
+# refuses to compile LMCache's C++/CUDA extension on that major-version
+# mismatch. Install a pip-shipped CUDA 12 toolchain and point CUDA_HOME at
+# it for the editable-install build step only; runtime still uses the
+# libcudart12 already present in the base image.
+uv pip install nvidia-cuda-nvcc-cu12 nvidia-cuda-cccl-cu12 nvidia-cuda-runtime-cu12
+CUDA_HOME_CU12=$(python -c "import os, nvidia.cuda_nvcc as m; print(os.path.dirname(m.__file__))")
+echo "Using CUDA_HOME=${CUDA_HOME_CU12} for LMCache build"
+CUDA_HOME="$CUDA_HOME_CU12" uv pip install -e . --no-build-isolation
 
 echo "--- :white_check_mark: Environment ready"
 python -c "import vllm; import lmcache; print(f'vLLM={vllm.__version__}, LMCache installed from source with no build isolation')"


### PR DESCRIPTION
The base image is `nvidia/cuda:13.0.2-devel-ubuntu24.04` (nvcc 13), but vLLM nightly's bundled torch wheel is compiled against CUDA 12. During the editable install, torch.utils.cpp_extension._check_cuda_version aborts with:

    RuntimeError: The detected CUDA version (13.0) mismatches the
    version that was used to compile PyTorch (12.8).

Install nvidia-cuda-nvcc-cu12 (+ cccl/runtime headers) from PyPI and point CUDA_HOME at that wheel for the build step only. Runtime still uses the libcudart12 already present in the base image, and the rest of the job keeps the system CUDA 13 environment untouched.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that alters how the CUDA toolchain is selected during build; main risk is CI breakage due to new PyPI dependencies or CUDA_HOME resolution.
> 
> **Overview**
> Adjusts the Buildkite `k3_harness` environment setup to build LMCache with a **pip-installed CUDA 12 toolchain** to avoid PyTorch/vLLM nightly CUDA version mismatches.
> 
> During the editable install, the script now installs `nvidia-cuda-*-cu12` packages, derives a CUDA 12 `CUDA_HOME`, and uses it only for `uv pip install -e .`, leaving the base image’s CUDA 13 environment otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf263c8612992a0f78868ad1d5393ff79428119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->