### PR TITLE
feat: pass enable_ssd_offload to MooncakeDistributedStore.setup()

### DIFF
--- a/docs/source/kv_cache/storage_backends/mooncake.rst
+++ b/docs/source/kv_cache/storage_backends/mooncake.rst
@@ -225,6 +225,12 @@ Configuration
    * - ``mooncake_prefer_local_alloc``
      - False
      - Prefer allocating on the local segment when possible.
+   * - ``enable_ssd_offload``
+     - False
+     - Enable LOCAL_DISK offload via Mooncake FileStorage. When true, Mooncake
+       replicates DRAM data to local SSD via a background heartbeat. Requires
+       Mooncake master config ``enable_offload: true`` and the ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH``
+       environment variable set. See `Mooncake PR #1857 <https://github.com/kvcache-ai/Mooncake/pull/1857>`_.
 
 .. important::
    **Understanding global_segment_size**: This parameter defines the amount of memory each vLLM worker contributes to the distributed memory pool. 

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -34,6 +34,7 @@ class MooncakeStoreConfig:
     transfer_timeout: int
     storage_root_dir: str
     prefer_local_alloc: bool = False
+    enable_ssd_offload: bool = False
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
@@ -54,6 +55,7 @@ class MooncakeStoreConfig:
             transfer_timeout=config.get("transfer_timeout", 1),
             storage_root_dir=config.get("storage_root_dir", ""),
             prefer_local_alloc=prefer_local_alloc,
+            enable_ssd_offload=config.get("enable_ssd_offload", False),
         )
 
     @staticmethod
@@ -88,6 +90,7 @@ class MooncakeStoreConfig:
             transfer_timeout=extra_config.get("transfer_timeout", 1),
             storage_root_dir=extra_config.get("storage_root_dir", ""),
             prefer_local_alloc=prefer_local_alloc,
+            enable_ssd_offload=extra_config.get("enable_ssd_offload", False),
         )
 
 
@@ -195,6 +198,7 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.protocol,
                 self.config.device_name,
                 self.config.master_server_address,
+                enable_ssd_offload=self.config.enable_ssd_offload,
             )
             logger.info("Mooncake store setup completed successfully")
 

--- a/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
+++ b/lmcache/v1/storage_backend/connector/mooncakestore_connector.py
@@ -190,6 +190,13 @@ class MooncakestoreConnector(RemoteConnector):
                     f"Failed to determine NUMA mapping before Mooncake setup: {e}"
                 )
 
+            # Only pass enable_ssd_offload when explicitly enabled to maintain
+            # backward compatibility with older Mooncake versions that don't
+            # support this parameter (added in kvcache-ai/Mooncake#1857).
+            optional_kwargs = {}
+            if self.config.enable_ssd_offload:
+                optional_kwargs["enable_ssd_offload"] = True
+
             self.store.setup(
                 self.config.local_hostname,
                 self.config.metadata_server,
@@ -198,7 +205,7 @@ class MooncakestoreConnector(RemoteConnector):
                 self.config.protocol,
                 self.config.device_name,
                 self.config.master_server_address,
-                enable_ssd_offload=self.config.enable_ssd_offload,
+                **optional_kwargs,
             )
             logger.info("Mooncake store setup completed successfully")
 

--- a/tests/v1/storage_backend/test_mooncake_store_config.py
+++ b/tests/v1/storage_backend/test_mooncake_store_config.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for MooncakeStoreConfig.enable_ssd_offload field."""
 import json
-import tempfile
-from pathlib import Path
 
 import pytest
 

--- a/tests/v1/storage_backend/test_mooncake_store_config.py
+++ b/tests/v1/storage_backend/test_mooncake_store_config.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MooncakeStoreConfig.enable_ssd_offload field."""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from lmcache.v1.storage_backend.connector.mooncakestore_connector import (
+    MooncakeStoreConfig,
+)
+
+
+@pytest.fixture()
+def base_config_dict():
+    """Minimal valid config dict for MooncakeStoreConfig."""
+    return {
+        "local_hostname": "localhost",
+        "metadata_server": "P2PHANDSHAKE",
+        "global_segment_size": 3355443200,
+        "local_buffer_size": 1073741824,
+        "protocol": "tcp",
+        "device_name": "",
+        "master_server_address": "localhost:50051",
+        "transfer_timeout": 1,
+        "storage_root_dir": "",
+    }
+
+
+class TestMooncakeStoreConfigFromFile:
+    def test_enable_ssd_offload_true(self, base_config_dict, tmp_path):
+        base_config_dict["enable_ssd_offload"] = True
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(base_config_dict))
+
+        config = MooncakeStoreConfig.from_file(str(config_file))
+        assert config.enable_ssd_offload is True
+
+    def test_enable_ssd_offload_false(self, base_config_dict, tmp_path):
+        base_config_dict["enable_ssd_offload"] = False
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(base_config_dict))
+
+        config = MooncakeStoreConfig.from_file(str(config_file))
+        assert config.enable_ssd_offload is False
+
+    def test_enable_ssd_offload_default(self, base_config_dict, tmp_path):
+        # Key not present → defaults to False
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(base_config_dict))
+
+        config = MooncakeStoreConfig.from_file(str(config_file))
+        assert config.enable_ssd_offload is False
+
+
+class TestMooncakeStoreConfigFromLMCacheConfig:
+    def test_enable_ssd_offload_from_extra_config(self, base_config_dict):
+        base_config_dict["enable_ssd_offload"] = True
+
+        class FakeConfig:
+            extra_config = base_config_dict
+
+        config = MooncakeStoreConfig.load_from_lmcache_config(FakeConfig())
+        assert config.enable_ssd_offload is True
+
+    def test_enable_ssd_offload_default_from_extra_config(self, base_config_dict):
+        # Key not present → defaults to False
+        class FakeConfig:
+            extra_config = base_config_dict
+
+        config = MooncakeStoreConfig.load_from_lmcache_config(FakeConfig())
+        assert config.enable_ssd_offload is False


### PR DESCRIPTION
  **What this PR does / why we need it**:

  Adds `enable_ssd_offload` field to `MooncakeStoreConfig` and passes it through to
  `MooncakeDistributedStore.setup()` as a keyword argument.

  Mooncake upstream (kvcache-ai/Mooncake#1857) added `enable_ssd_offload` parameter to the
  Python binding's `setup()` method, which enables LOCAL_DISK offload via Mooncake's
  FileStorage. Without this change, LMCache has no way to activate Mooncake's SSD offload
  feature through the connector.

  The parameter is read from:
  - JSON config file (`MOONCAKE_CONFIG_PATH`): `"enable_ssd_offload"` key
  - `LMCacheEngineConfig.extra_config`: `"enable_ssd_offload"` key

  Default: `false` (no offload). Existing deployments are unaffected.

  Refs kvcache-ai/Mooncake#1857

  **Special notes for your reviewers**:

  Requires Mooncake with SSD offload Python binding support (kvcache-ai/Mooncake#1857,
  merged).

  **If applicable**:

  - [x] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a gated, opt-in config field and passes it through to Mooncake setup; default behavior remains unchanged and backward-compatibility is explicitly handled.
> 
> **Overview**
> Adds a new Mooncake connector configuration flag, `enable_ssd_offload`, sourced from both the Mooncake JSON config and `LMCacheEngineConfig.extra_config`, and documents it in the Mooncake backend docs.
> 
> When enabled, the connector now forwards `enable_ssd_offload=True` into `MooncakeDistributedStore.setup()` via optional kwargs (only if set) to preserve compatibility with older Mooncake bindings. Includes unit tests covering default/true/false parsing for the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1e315eebd71fcee829fc9eee8ea76de4f126fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->