### PR TITLE
Fix pre-commit check failure about missing attributes

### DIFF
--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -1414,8 +1414,9 @@ def get_gpu_pci_bus_id(device_id: int = 0) -> str | None:
             props = torch.cuda.get_device_properties(device_id)
             # PCI function number is always 0 for GPUs
             bus_id = (
-                f"{props.pci_domain_id:04x}:{props.pci_bus_id:02x}:"
-                f"{props.pci_device_id:02x}.0"
+                f"{props.pci_domain_id:04x}:"  # type: ignore[attr-defined]
+                f"{props.pci_bus_id:02x}:"  # type: ignore[attr-defined]
+                f"{props.pci_device_id:02x}.0"  # type: ignore[attr-defined]
             )
             return bus_id.upper()
     except Exception:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix pre-commit issue that caused the following failure:

```
lmcache/non_cuda_equivalents.py:1436 — "_CudaDeviceProperties" has no attribute "pci_domain_id"
lmcache/non_cuda_equivalents.py:1436 — "_CudaDeviceProperties" has no attribute "pci_bus_id"
lmcache/non_cuda_equivalents.py:1437 — "_CudaDeviceProperties" has no attribute "pci_device_id"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-annotation-only change confined to a helper that formats a PCI bus ID; runtime logic is unchanged.
> 
> **Overview**
> Fixes pre-commit type-check failures in `get_gpu_pci_bus_id` by annotating CUDA device property PCI fields (`pci_domain_id`, `pci_bus_id`, `pci_device_id`) with `# type: ignore[attr-defined]`.
> 
> No runtime behavior changes; only static typing annotations were adjusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000ef53a512e5415b48f024ae2ff450890096dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->