### PR TITLE
[Misc] Reduce the logs generated by lazy memory allocator

### DIFF
--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -67,6 +67,7 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
 
     PIN_CHUNK_SIZE = 1 << 26  # 64 MB pin chunk
     COMMIT_SIZE = 1 << 30  # Do a commit every 1 GB
+    LOG_INTERVAL = 10 << 30  # Log expansion progress every 10 GB
 
     def __init__(
         self,
@@ -240,10 +241,19 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         Call sbrk in the address manager to commit the expansion.
         """
         self._address_manager.sbrk(expand_size)
+
+    def _log_expansion_progress(self, expanded_since_last_log: int):
+        """
+        Log the cumulative expansion progress since the last log.
+        """
+        percent = 100.0 * self._curr_size / self._final_size
         logger.info(
-            "LazyMemoryAllocator: Expanded %s MB pinned memory, now total is %s MB",
-            expand_size >> 20,
+            "LazyMemoryAllocator: Expanded %s MB pinned memory, "
+            "now total is %s MB / %s MB (%.1f%%)",
+            expanded_since_last_log >> 20,
             self._curr_size >> 20,
+            self._final_size >> 20,
+            percent,
         )
 
     def _expand_worker(self):
@@ -251,6 +261,7 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         Background worker to expand the pinned memory.
         """
         last_commit_size = self._curr_size
+        last_log_size = self._curr_size
         while self._curr_size < self._final_size and not self._stop_expand.is_set():
             # Expand chunk by chunk and commit
             for i in range(self.COMMIT_SIZE // self.PIN_CHUNK_SIZE):
@@ -262,3 +273,12 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             expand_size = self._curr_size - last_commit_size
             self._commit_expansion(expand_size)
             last_commit_size = self._curr_size
+
+            # Log every LOG_INTERVAL bytes, and always on the final commit.
+            expanded_since_last_log = self._curr_size - last_log_size
+            if (
+                expanded_since_last_log >= self.LOG_INTERVAL
+                or self._curr_size >= self._final_size
+            ):
+                self._log_expansion_progress(expanded_since_last_log)
+                last_log_size = self._curr_size


### PR DESCRIPTION
**What this PR does / why we need it**:

The `LazyMemoryAllocator` currently logs every 1 GB of background pinned-memory expansion (`COMMIT_SIZE`). On machines with large pools (e.g. ~164 GB seen during MP server runs), this floods the log with hundreds of lines like:

```
LazyMemoryAllocator: Expanded 1024 MB pinned memory, now total is 167936 MB
```

This PR:
- Throttles the log to every 10 GB of cumulative expansion (still emitted on the final commit so the total is always reported).
- Includes the final target and a percentage in each line so the user can see progress, e.g.:

```
LazyMemoryAllocator: Expanded 10240 MB pinned memory, now total is 20480 MB / 167936 MB (12.2%)
```

The commit cadence (1 GB) is unchanged — only logging is decoupled from it.

**Special notes for your reviewers**:

No functional change to allocation behavior. Introduces a new class constant `LOG_INTERVAL = 10 << 30` and a small `_log_expansion_progress` helper.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in the background expansion worker; allocation/commit behavior is unchanged, with minimal runtime risk beyond altered observability cadence.
> 
> **Overview**
> Reduces log volume from `LazyMemoryAllocator` background pinned-memory expansion by decoupling logging from the 1GB commit cadence and emitting progress logs only every 10GB (and on the final commit).
> 
> Adds `LOG_INTERVAL`, tracks `last_log_size`, and updates the log message to include the final target size and percent complete via a new `_log_expansion_progress` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d29311467a07ce48a7e5ec627d311883c03ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->