### PR TITLE
[CI] Add cu13.0 wheel + container builds and nightly wheel releases

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -8,6 +8,131 @@ permissions:
   contents: read
 
 jobs:
+  nightly-wheels:
+    name: Build and publish nightly wheels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          disable-sudo-and-containers: false
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            uploads.github.com:443
+            github.com:443
+            registry-1.docker.io:443
+            production.cloudflare.docker.com:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            pypi.org:443
+            files.pythonhosted.org:443
+            objects.githubusercontent.com:443
+            releases.githubusercontent.com:443
+            codeload.github.com:443
+            download.pytorch.org:443
+            download-r2.pytorch.org:443
+            pypi.nvidia.com:443
+
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
+      - name: Setup Python 3.13
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.13"
+
+      - name: Login to DockerHub
+        if: vars.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel
+
+      - name: Compute nightly version string
+        run: |
+          BASE=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+          NOW=$(date +'%Y%m%d')
+          echo "NIGHTLY_VERSION=${BASE}.dev${NOW}" >> "$GITHUB_ENV"
+
+      - name: Build cu12.9 nightly wheel
+        env:
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.NIGHTLY_VERSION }}'
+          CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
+        run: |
+          python -m cibuildwheel --output-dir dist/cu129
+
+      - name: Build cu13.0 nightly wheel
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.NIGHTLY_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair
+            --plat manylinux_2_28_x86_64
+            --exclude libtorch.so
+            --exclude libtorch_cuda.so
+            --exclude libtorch_python.so
+            --exclude libtorch_cpu.so
+            --exclude libc10.so
+            --exclude libc10_cuda.so
+            --exclude libcudart.so.13
+            -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
+        run: |
+          python -m cibuildwheel --output-dir dist/cu130
+
+      - name: Publish cu12.9 wheels to rolling nightly release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete nightly --yes --repo ${{ github.repository }} 2>/dev/null || true
+          git push origin :refs/tags/nightly 2>/dev/null || true
+          gh release create nightly \
+            --repo ${{ github.repository }} \
+            --title "Nightly $(date +'%Y-%m-%d') · CUDA 12.9" \
+            --notes "Nightly CUDA 12.9 wheels built from \`dev\` on $(date +'%Y-%m-%d').
+
+          \`\`\`
+          uv pip install lmcache --pre \\
+            --extra-index-url https://download.pytorch.org/whl/cu129 \\
+            --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/nightly \\
+            --index-strategy unsafe-best-match
+          \`\`\`" \
+            --prerelease \
+            dist/cu129/*.whl
+
+      - name: Publish cu13.0 wheels to rolling nightly-cu13 release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete nightly-cu13 --yes --repo ${{ github.repository }} 2>/dev/null || true
+          git push origin :refs/tags/nightly-cu13 2>/dev/null || true
+          gh release create nightly-cu13 \
+            --repo ${{ github.repository }} \
+            --title "Nightly $(date +'%Y-%m-%d') · CUDA 13.0" \
+            --notes "Nightly CUDA 13.0 wheels built from \`dev\` on $(date +'%Y-%m-%d').
+
+          \`\`\`
+          uv pip install lmcache --pre \\
+            --extra-index-url https://download.pytorch.org/whl/cu130 \\
+            --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/nightly-cu13 \\
+            --index-strategy unsafe-best-match
+          \`\`\`" \
+            --prerelease \
+            dist/cu130/*.whl
+
   nightly-build:
     name: Build image
     runs-on: ubuntu-latest
@@ -33,8 +158,10 @@ jobs:
               archive.ubuntu.com:80
               security.ubuntu.com:80
               astral.sh:443
+              download.pytorch.org:443
 
       - name: Login to DockerHub
+        if: vars.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -63,8 +190,10 @@ jobs:
 
       - name: Build lmcache/vllm-openai container image
         run: |
+          docker system prune -f --all
+          docker builder prune -af
           docker build \
-          --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+          --build-arg CUDA_VERSION=12.9 --build-arg UBUNTU_VERSION=24.04 \
           --target image-build \
           --tag lmcache/vllm-openai:latest-nightly --tag lmcache/vllm-openai:nightly-${{ env.NOW }} \
           --file docker/Dockerfile .
@@ -76,8 +205,10 @@ jobs:
 
       - name: Build lmcache/standalone container image
         run: |
+          docker system prune -f --all
+          docker builder prune -af
           docker build \
-          --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+          --build-arg CUDA_VERSION=12.9 --build-arg UBUNTU_VERSION=24.04 \
           --target lmcache-final \
           --tag lmcache/standalone:nightly --tag lmcache/standalone:nightly-${{ env.NOW }} \
           --file docker/Dockerfile.standalone .
@@ -86,3 +217,37 @@ jobs:
         run: |
           docker push lmcache/standalone:nightly
           docker push lmcache/standalone:nightly-${{ env.NOW }}
+
+      - name: Build lmcache/vllm-openai container image (cu13 nightly)
+        run: |
+          docker system prune -f --all
+          docker builder prune -af
+          docker build \
+          --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+          --build-arg CUDA_VERSION=13.0 \
+          --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+          --target image-build \
+          --tag lmcache/vllm-openai:latest-nightly-cu13 --tag lmcache/vllm-openai:nightly-${{ env.NOW }}-cu13 \
+          --file docker/Dockerfile .
+
+      - name: Push lmcache/vllm-openai cu13 nightly image to DockerHub
+        run: |
+          docker push lmcache/vllm-openai:latest-nightly-cu13
+          docker push lmcache/vllm-openai:nightly-${{ env.NOW }}-cu13
+
+      - name: Build lmcache/standalone container image (cu13 nightly)
+        run: |
+          docker system prune -f --all
+          docker builder prune -af
+          docker build \
+          --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+          --build-arg CUDA_VERSION=13.0 \
+          --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+          --target lmcache-final \
+          --tag lmcache/standalone:nightly-cu13 --tag lmcache/standalone:nightly-${{ env.NOW }}-cu13 \
+          --file docker/Dockerfile.standalone .
+
+      - name: Push lmcache/standalone cu13 nightly image to DockerHub
+        run: |
+          docker push lmcache/standalone:nightly-cu13
+          docker push lmcache/standalone:nightly-${{ env.NOW }}-cu13

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -74,25 +74,6 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist/cu129
 
-      - name: Build cu13.0 nightly wheel
-        env:
-          CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
-          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.NIGHTLY_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
-            auditwheel repair
-            --plat manylinux_2_28_x86_64
-            --exclude libtorch.so
-            --exclude libtorch_cuda.so
-            --exclude libtorch_python.so
-            --exclude libtorch_cpu.so
-            --exclude libc10.so
-            --exclude libc10_cuda.so
-            --exclude libcudart.so.13
-            -w {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
-        run: |
-          python -m cibuildwheel --output-dir dist/cu130
-
       - name: Publish cu12.9 wheels to rolling nightly release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -112,6 +93,25 @@ jobs:
           \`\`\`" \
             --prerelease \
             dist/cu129/*.whl
+
+      - name: Build cu13.0 nightly wheel
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.NIGHTLY_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+            auditwheel repair
+            --plat manylinux_2_28_x86_64
+            --exclude libtorch.so
+            --exclude libtorch_cuda.so
+            --exclude libtorch_python.so
+            --exclude libtorch_cpu.so
+            --exclude libc10.so
+            --exclude libc10_cuda.so
+            --exclude libcudart.so.13
+            -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
+        run: |
+          python -m cibuildwheel --output-dir dist/cu130
 
       - name: Publish cu13.0 wheels to rolling nightly-cu13 release
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,8 @@ jobs:
               # this will build lmcache with the latest version of torch
               # building from source will be required if a serving engine uses
               # an earlier non-ABI compatible version of torch
+              env:
+                CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
               run: |
                 python -m cibuildwheel --output-dir dist
 
@@ -175,6 +177,96 @@ jobs:
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                 name: release-cli-artifacts
+                path: dist/
+
+    # Build cu130 wheel and upload to GHA artifact storage
+    # The cu13 wheel carries no local version suffix and is published to a
+    # dedicated v{tag}-cu13 GitHub Release (not PyPI).
+    build-cu130-artifacts:
+        needs: changes
+        if: needs.changes.outputs.lmcache == 'true'
+        name: Build cu130 artifacts
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+              with:
+                disable-sudo-and-containers: false
+                egress-policy: block
+                allowed-endpoints: >
+                  api.github.com:443
+                  github.com:443
+                  registry-1.docker.io:443
+                  index.docker.io:443
+                  production.cloudflare.docker.com:443
+                  auth.docker.io:443
+                  azure.archive.ubuntu.com:80
+                  pypi.org:443
+                  files.pythonhosted.org:443
+                  codeload.github.com:443
+                  objects.githubusercontent.com:443
+                  releases.githubusercontent.com:443
+                  download.pytorch.org:443
+                  download-r2.pytorch.org:443
+                  pypi.nvidia.com:443
+
+            - name: Checkout code
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                fetch-depth: 0
+
+            - name: Login to DockerHub
+              if: vars.DOCKERHUB_USERNAME != ''
+              uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+              with:
+                username: ${{ vars.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Free disk space
+              uses: ./.github/actions/free-disk-space
+
+            - name: Setup Python 3.13
+              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              with:
+                python-version: "3.13"
+
+            - name: Install build tooling
+              run: |
+                python -m pip install --upgrade pip
+                pip install build cibuildwheel
+
+            - name: Clean up release artifacts
+              run: |
+                rm -rf dist/
+
+            - name: Get base version for cu13 wheel
+              run: |
+                BASE=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0.dev")
+                echo "CU130_VERSION=${BASE}" >> "$GITHUB_ENV"
+
+            - name: Build cu130 CUDA wheels with cibuildwheel
+              env:
+                CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
+                CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.CU130_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
+                CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
+                  auditwheel repair
+                  --plat manylinux_2_28_x86_64
+                  --exclude libtorch.so
+                  --exclude libtorch_cuda.so
+                  --exclude libtorch_python.so
+                  --exclude libtorch_cpu.so
+                  --exclude libc10.so
+                  --exclude libc10_cuda.so
+                  --exclude libcudart.so.13
+                  -w {dest_dir} {wheel}
+                CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
+              run: |
+                python -m cibuildwheel --output-dir dist
+
+            - name: Upload cu130 release artifacts to GHA
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                name: release-cu130-artifacts
                 path: dist/
 
     # Run tests and code quality checks before publishing
@@ -371,15 +463,63 @@ jobs:
               with:
                 verbose: true
 
+    # Publish cu130 wheel to GitHub Release (not PyPI) when a release is published
+    publish-cu130-github-release:
+        name: Publish cu130 wheel to GitHub Release
+        if: |
+            !failure() && !cancelled() &&
+            needs.changes.outputs.lmcache == 'true' &&
+            github.repository_owner == 'LMCache' && github.event.action == 'published'
+        permissions:
+            contents: write
+        runs-on: ubuntu-latest
+        needs: [changes, build-cu130-artifacts, test, code-quality]
+
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+              with:
+                  disable-sudo-and-containers: false
+                  egress-policy: block
+                  allowed-endpoints: >
+                    api.github.com:443
+                    uploads.github.com:443
+
+            - name: Fetch cu130 release artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: release-cu130-artifacts
+                  path: dist
+
+            - name: Publish cu13.0 wheel to dedicated GitHub Release
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  gh release create "${{ github.ref_name }}-cu13" \
+                    --repo ${{ github.repository }} \
+                    --latest=false \
+                    --title "Release ${{ github.ref_name }} · CUDA 13.0" \
+                    --notes "CUDA 13.0 wheel for LMCache ${{ github.ref_name }}.
+
+                  \`\`\`
+                  VERSION=${{ github.ref_name }}
+                  uv pip install lmcache==${VERSION#v} \\
+                    --extra-index-url https://download.pytorch.org/whl/cu130 \\
+                    --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/${VERSION}-cu13 \\
+                    --index-strategy unsafe-best-match
+                  \`\`\`" \
+                    dist/*.whl
+
     # Build container image and push to DockerHub when:
     # - a new GitHub release is created
     publish-image:
         name: Publish image to DockerHub
         if: |
+            !failure() && !cancelled() &&
             github.repository_owner == 'LMCache' && github.event.action == 'published'
 
         runs-on: ubuntu-latest
-        needs: publish-pypi
+        needs: [publish-pypi, publish-cu130-github-release]
 
         steps:
             - name: "Harden Runner"
@@ -403,6 +543,8 @@ jobs:
                   wrapdb.mesonbuild.com:443
                   nvcr.io:443
                   layers.nvcr.io:443
+                  wheels.vllm.ai:443
+                  download.pytorch.org:443
 
             - name: Login to DockerHub
               uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -426,10 +568,11 @@ jobs:
               run: |
                 echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
 
-            - name: Build lmcache/vllm-openai container image with latest releases
+            - name: Build lmcache/vllm-openai container image (cu12.9)
               run: |
                 docker build \
-                --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=12.9 \
                 --target image-release \
                 --tag lmcache/vllm-openai:latest --tag lmcache/vllm-openai:${{ env.LATEST_TAG }} \
                 --file docker/Dockerfile .
@@ -438,18 +581,18 @@ jobs:
               run: |
                 docker push lmcache/vllm-openai:latest
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}
-            
+
             - name: Clean up Docker layers and cache
               run: |
                 docker system prune -f --all
                 docker builder prune -af
 
             - name: Build lmcache/vllm-openai:lightweight
-              run: | 
+              run: |
                 docker build \
                 --tag lmcache/vllm-openai:lightweight --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-lightweight \
                 --file docker/Dockerfile.lightweight .
-            
+
             - name: Push lmcache/vllm-openai:lightweight image to DockerHub
               run: |
                 docker push lmcache/vllm-openai:lightweight
@@ -460,15 +603,61 @@ jobs:
                 docker system prune -f --all
                 docker builder prune -af
 
-            - name: Build lmcache/standalone container image
+            - name: Build lmcache/standalone container image (cu12.9)
               run: |
                 docker build \
-                --build-arg CUDA_VERSION=12.8 --build-arg UBUNTU_VERSION=24.04 \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=12.9 \
                 --target lmcache-final \
                 --tag lmcache/standalone:latest --tag lmcache/standalone:${{ env.LATEST_TAG }} \
                 --file docker/Dockerfile.standalone .
-            
+
             - name: Push lmcache/standalone container image to DockerHub
               run: |
                 docker push lmcache/standalone:latest
                 docker push lmcache/standalone:${{ env.LATEST_TAG }}
+
+            - name: Clean up Docker layers and cache
+              run: |
+                docker system prune -f --all
+                docker builder prune -af
+
+            - name: Build lmcache/vllm-openai container image (cu13)
+              if: needs.publish-cu130-github-release.result == 'success'
+              run: |
+                docker build \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=13.0 \
+                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+                --build-arg LMCACHE_VERSION=${{ env.LATEST_TAG }} \
+                --target image-release-cu13 \
+                --tag lmcache/vllm-openai:latest-cu13 --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu13 \
+                --file docker/Dockerfile .
+
+            - name: Push lmcache/vllm-openai cu13 container image to DockerHub
+              if: needs.publish-cu130-github-release.result == 'success'
+              run: |
+                docker push lmcache/vllm-openai:latest-cu13
+                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu13
+
+            - name: Clean up Docker layers and cache
+              run: |
+                docker system prune -f --all
+                docker builder prune -af
+
+            - name: Build lmcache/standalone container image (cu13)
+              if: needs.publish-cu130-github-release.result == 'success'
+              run: |
+                docker build \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=13.0 \
+                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+                --target lmcache-final \
+                --tag lmcache/standalone:latest-cu13 --tag lmcache/standalone:${{ env.LATEST_TAG }}-cu13 \
+                --file docker/Dockerfile.standalone .
+
+            - name: Push lmcache/standalone cu13 container image to DockerHub
+              if: needs.publish-cu130-github-release.result == 'success'
+              run: |
+                docker push lmcache/standalone:latest-cu13
+                docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu13

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -515,7 +515,8 @@ jobs:
     publish-image:
         name: Publish image to DockerHub
         if: |
-            !failure() && !cancelled() &&
+            needs.publish-pypi.result == 'success' &&
+            !cancelled() &&
             github.repository_owner == 'LMCache' && github.event.action == 'published'
 
         runs-on: ubuntu-latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,9 +60,6 @@ ENV NVCC_THREADS=$nvcc_threads
 
 ARG CUDA_VERSION
 ARG VLLM_VERSION=nightly
-# Set to 1 to install triton-kernels from source (slow git clone); off by default
-# as LMCache does not use triton-kernels directly.
-ARG BUILD_TRITON=0
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
@@ -81,18 +78,15 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
     CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
-    TRITON_PKG=$([ "${BUILD_TRITON}" = "1" ] && echo "triton-kernels@git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels" || echo "") && \
     if [ "$VLLM_VERSION" = "nightly" ]; then \
         uv pip install --prerelease=allow \
             'vllm[runai,tensorizer,flashinfer]' \
-            ${TRITON_PKG} \
             --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
             --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
             --index-strategy unsafe-best-match ; \
     else \
         uv pip install --prerelease=allow \
-            "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" \
-            ${TRITON_PKG} ; \
+            "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" ; \
     fi && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,13 +6,14 @@
 # docs/source/getting_started/installation.rst
 # docs/production/docker_deployment.rst
 
-ARG CUDA_VERSION=12.8
+ARG CUDA_VERSION=12.9
 ARG UBUNTU_VERSION=24.04
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
 # Prepare basic build environment
 
-FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS base
+FROM ${BASE_IMAGE} AS base
 
 ARG CUDA_VERSION
 ARG PYTHON_VERSION=3.12
@@ -37,13 +38,6 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
 
 WORKDIR /workspace
 
-# Install runtime dependencies
-COPY ./requirements/common.txt common.txt
-COPY ./requirements/cuda.txt cuda.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    . /opt/venv/bin/activate && \
-    uv pip install -r cuda.txt
-
 # CUDA arch list used by torch
 ARG torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
@@ -64,7 +58,11 @@ ENV MAX_JOBS=${max_jobs}
 ARG nvcc_threads=8
 ENV NVCC_THREADS=$nvcc_threads
 
+ARG CUDA_VERSION
 ARG VLLM_VERSION=nightly
+# Set to 1 to install triton-kernels from source (slow git clone); off by default
+# as LMCache does not use triton-kernels directly.
+ARG BUILD_TRITON=0
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     . /opt/venv/bin/activate && \
@@ -82,16 +80,19 @@ WORKDIR /workspace/LMCache
 RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
+    CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
+    TRITON_PKG=$([ "${BUILD_TRITON}" = "1" ] && echo "triton-kernels@git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels" || echo "") && \
     if [ "$VLLM_VERSION" = "nightly" ]; then \
         uv pip install --prerelease=allow \
             'vllm[runai,tensorizer,flashinfer]' \
-            'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' \
-            --extra-index-url https://wheels.vllm.ai/nightly \
+            ${TRITON_PKG} \
+            --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
+            --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
             --index-strategy unsafe-best-match ; \
     else \
         uv pip install --prerelease=allow \
             "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" \
-            'triton-kernels @ git+https://github.com/triton-lang/triton.git@v3.5.0#subdirectory=python/triton_kernels' ; \
+            ${TRITON_PKG} ; \
     fi && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
@@ -100,17 +101,40 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 
-#################### vLLM IMAGE & LMCache (Release) #######################
+#################### vLLM IMAGE & LMCache (Release, cu12) #######################
 # Integrate vLLM and LMCache stable releases, and expose vLLM OpenAI API
 
 FROM base AS image-release
 
 # Install LMCache and vLLM stable releases.
-# It is imperative that LMCache uses the same torch version as the 
+# It is imperative that LMCache uses the same torch version as the
 # vLLM stable release.
 RUN . /opt/venv/bin/activate && \
     uv pip install --prerelease=allow vllm[runai,tensorizer,flashinfer] && \
     uv pip install lmcache --verbose
+
+WORKDIR /workspace
+ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
+
+#################### vLLM IMAGE & LMCache (Release, cu13) #######################
+# Installs stable vLLM with cu13 index and lmcache from the v{tag}-cu13 GitHub Release.
+
+FROM base AS image-release-cu13
+
+ARG CUDA_VERSION
+ARG LMCACHE_VERSION
+
+RUN . /opt/venv/bin/activate && \
+    CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
+    VER=$(echo ${LMCACHE_VERSION} | sed 's/^v//') && \
+    uv pip install --prerelease=allow \
+        vllm[runai,tensorizer,flashinfer] \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+        --index-strategy unsafe-best-match && \
+    uv pip install lmcache==${VER} \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+        --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VER}-cu13 \
+        --index-strategy unsafe-best-match --verbose
 
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -1,13 +1,14 @@
 # The LMCache Standalone Dockerfile is used to build a LMCache image
 # without vLLM integration.
 
-ARG CUDA_VERSION=12.8
+ARG CUDA_VERSION=12.9
 ARG UBUNTU_VERSION=24.04
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
 # Prepare basic build environment
 
-FROM nvcr.io/nvidia/cuda-dl-base:25.03-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS base
+FROM ${BASE_IMAGE} AS base
 
 ARG CUDA_VERSION
 ARG PYTHON_VERSION=3.12
@@ -33,12 +34,11 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
 
 WORKDIR /workspace
 
-# Install runtime dependencies
-COPY ./requirements/common.txt common.txt
-COPY ./requirements/cuda.txt cuda.txt
+# Install small non-torch runtime dependencies; torch is installed in lmcache-build
+# against the exact CUDA version so the compiled C extensions match at runtime.
 RUN --mount=type=cache,target=/root/.cache/uv \
     . /opt/venv/bin/activate && \
-    uv pip install -r cuda.txt
+    uv pip install ray nvidia-ml-py
 
 # CUDA arch list used by torch
 ARG torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'
@@ -48,6 +48,8 @@ ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 # Build LMCache wheel
 
 FROM base AS lmcache-build
+
+ARG CUDA_VERSION
 
 # install build dependencies
 COPY ./requirements/build.txt build.txt
@@ -62,6 +64,10 @@ ENV NVCC_THREADS=$nvcc_threads
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     . /opt/venv/bin/activate && \
+    CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
+    uv pip install torch \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+        --index-strategy unsafe-best-match && \
     uv pip install -r build.txt
 
 ARG LMCACHE_COMMIT_ID=1
@@ -81,14 +87,21 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
 
 FROM base AS lmcache-final
 
+ARG CUDA_VERSION
+
 # Copy the built wheel from build stage
 COPY --from=lmcache-build /workspace/LMCache/dist_lmcache/*.whl /tmp/
 
-# Install LMCache from wheel
+# Install LMCache from wheel; use the same CUDA index as the build stage
+# so torch resolves to the matching CUDA variant (e.g. cu130 for CUDA 13.0).
 RUN --mount=type=cache,target=/root/.cache/uv \
     . /opt/venv/bin/activate && \
-    uv pip install /tmp/*.whl --verbose && \
-    rm -rf /tmp/*.whl 
+    CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
+    uv pip install /tmp/*.whl \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+        --index-strategy unsafe-best-match \
+        --verbose && \
+    rm -rf /tmp/*.whl
 
 WORKDIR /workspace
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -3,292 +3,201 @@
 Installation
 ============
 
-Setup using Python
-------------------
+**Prerequisites:** Linux · Python 3.9–3.13 · NVIDIA GPU (compute 7.0+) · CUDA 12.1+ · `uv <https://astral.sh/uv>`_
 
-Prerequisites
-~~~~~~~~~~~~~
+Install LMCache
+---------------
 
-- OS: Linux
-- Python: 3.9 -- 3.13
-- GPU: NVIDIA compute capability 7.0+ (e.g., V100, T4, RTX20xx, A100, L4, H100, B200, etc.)
-- CUDA 12.1+
-- uv (Python package manager): ``curl -LsSf https://astral.sh/uv/install.sh | sh``
+.. tab-set::
 
-.. note::
-    LMCache does not support Windows natively. To run LMCache on Windows, you can use the Windows Subsystem for Linux (WSL) with a compatible Linux distribution, or use some community-maintained forks.
+    .. tab-item:: Python (pip / uv)
 
-(Recommended) Install Stable LMCache from PyPI
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        .. tab-set::
 
-The simplest way to install the latest stable release of LMCache is through PyPI.
-If you require a different version of torch for the LMCache instance that you built with (symbol undefined error), please follow the install from source instructions below.
+            .. tab-item:: Stable  
+
+                .. tab-set::
+
+                    .. tab-item:: CUDA 12.9  
+
+                        .. code-block:: bash
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+                            uv pip install lmcache
+
+                        .. important::
+
+                            You're all set! You can now start using LMCache. For hands-on guides and more
+                            usage examples, see the :ref:`quickstart_examples` section.
+
+                    .. tab-item:: CUDA 13.0
+
+                        The CUDA 13.0 wheel is published to a dedicated
+                        `GitHub Release <https://github.com/LMCache/LMCache/releases>`__ rather than PyPI.
+
+                        .. code-block:: bash
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+                            VERSION=0.4.3  # replace with target release
+                            uv pip install lmcache==${VERSION} \
+                                --extra-index-url https://download.pytorch.org/whl/cu130 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VERSION}-cu13 \
+                                --index-strategy unsafe-best-match
+
+                        .. note::
+
+                            ``--extra-index-url https://download.pytorch.org/whl/cu130`` ensures the CUDA 13.0
+                            build of PyTorch is resolved. Without it, pip may select a mismatched CUDA variant.
+
+            .. tab-item:: Nightly
+
+                Nightly wheels are built from the latest ``dev`` branch each day at 07:30 UTC
+                and published to GitHub Releases. No version pinning required — ``--pre``
+                picks the latest nightly automatically.
+
+                .. tab-set::
+
+                    .. tab-item:: CUDA 12.9
+
+                        .. code-block:: bash
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+                            uv pip install lmcache --pre \
+                                --extra-index-url https://download.pytorch.org/whl/cu129 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly \
+                                --index-strategy unsafe-best-match
+
+                    .. tab-item:: CUDA 13.0
+
+                        .. code-block:: bash
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+                            uv pip install lmcache --pre \
+                                --extra-index-url https://download.pytorch.org/whl/cu130 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-cu13 \
+                                --index-strategy unsafe-best-match
+
+            .. tab-item:: From Source
+
+                ``--no-build-isolation`` ensures the kernels are compiled against the same torch
+                already installed in your environment, preventing undefined symbol errors at runtime.
+
+                .. tab-set::
+
+                    .. tab-item:: CUDA
+
+                        .. code-block:: bash
+
+                            git clone https://github.com/LMCache/LMCache.git
+                            cd LMCache
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+
+                            uv pip install -r requirements/build.txt
+                            uv pip install vllm  # pulls in required torch version
+                            uv pip install -e . --no-build-isolation
+
+                    .. tab-item:: ROCm
+
+                        .. code-block:: bash
+
+                            git clone https://github.com/LMCache/LMCache.git
+                            cd LMCache
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+
+                            # Need to install these packages manually to avoid build isolation
+                            uv pip install -r requirements/build.txt
+
+                            # Install torch from the ROCm wheel index
+                            uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.0
+
+                            # Build LMCache. BUILD_WITH_HIP=1 makes setup.py pick cupy-rocm-7-0 automatically.
+                            PYTORCH_ROCM_ARCH="gfx942" \
+                            TORCH_DONT_CHECK_COMPILER_ABI=1 \
+                            CXX=hipcc \
+                            BUILD_WITH_HIP=1 \
+                            uv pip install -e . --no-build-isolation
+
+    .. tab-item:: Docker
+
+        .. tab-set::
+
+            .. tab-item:: Stable
+
+                .. tab-set::
+
+                    .. tab-item:: CUDA 12.9
+
+                        .. code-block:: bash
+
+                            docker pull lmcache/vllm-openai
+
+                    .. tab-item:: CUDA 13.0
+
+                        .. code-block:: bash
+
+                            docker pull lmcache/vllm-openai:latest-cu13
+
+            .. tab-item:: Nightly
+
+                .. tab-set::
+
+                    .. tab-item:: CUDA 12.9
+
+                        .. code-block:: bash
+
+                            docker pull lmcache/vllm-openai:latest-nightly
+
+                    .. tab-item:: CUDA 13.0
+
+                        .. code-block:: bash
+
+                            docker pull lmcache/vllm-openai:latest-nightly-cu13
+
+            .. tab-item:: ROCm
+
+                .. code-block:: bash
+
+                    docker pull rocm/vllm-dev:nightly_0624_rc2_0624_rc2_20250620
+
+        See :ref:`docker_deployment` for running the container and ROCm images.
+
+    .. tab-item:: CLI Only  
+
+        Lightweight CLI-only package for querying or benchmarking a remote LMCache server.
+        No CUDA required, works on any OS.
+
+        .. code-block:: bash
+
+            pip install lmcache-cli
+
+        .. note::
+
+            ``lmcache-cli`` and ``lmcache`` ship the same ``lmcache`` CLI command.
+            Do not install both in the same environment.
+
+Verify Installation
+-------------------
 
 .. code-block:: bash
 
-    uv venv --python 3.12
-    source .venv/bin/activate
-    # LMCache wheels are built with the latest version of torch.
-    # vllm is required for LMCache to work; you may also choose to install it separately.
-    uv pip install lmcache vllm
-
-.. important::
-
-   You're all set! You can now start using LMCache. For hands-on guides and more usage examples, see the :ref:`quickstart_examples` section.
-
-Install LMCache CLI Only (no GPU required)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you only need the ``lmcache`` CLI tool (e.g., to query, ping, or benchmark a
-remote LMCache server) and do not need to run the server itself, install the
-lightweight ``lmcache-cli`` package instead.  It has no CUDA dependency and
-works on any OS.
-
-.. code-block:: bash
-
-    pip install lmcache-cli
-
-
-.. note::
-
-   ``lmcache-cli`` and ``lmcache`` ship the same ``lmcache`` CLI command.
-   Do not install both in the same environment.
-
-Install Latest LMCache from TestPyPI
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-TestPyPI wheels are continually built from the latest LMCache source code (not officially stable release).
-
-Full package:
-
-.. code-block:: bash
-
-    uv venv --python 3.12
-    source .venv/bin/activate
-    # By default, this will adopt the version of torch from the latest *NIGHTLY* vLLM wheel.
-    # If you require a different version of torch for the LMCache instance that you built with (symbol undefined error), please
-    # follow the install from source instructions below. 
-    uv pip install --index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple lmcache==0.3.4.dev61
-
-CLI-only package:
-
-.. code-block:: bash
-
-    pip install --index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple lmcache-cli==0.3.4.dev61
-
-See the latest pre-release of LMCache: `latest LMCache pre-releases <https://test.pypi.org/project/lmcache/#history>`__ and replace `0.3.4.dev61` with the latest pre-release version.
-
-This will install all dependencies from the real PyPI and only LMCache itself from TestPyPI.
-
-Confirm that you have the latest pre-release:
-
-.. code-block:: bash
-
-    python
-    >>> import lmcache
-    >>> from importlib.metadata import version
-    >>> print(version("lmcache"))
-    0.3.4.dev61 # should be the latest pre-release version you installed
-
-Install Latest LMCache from Source
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To install from source, clone the repository and install in editable mode. 
-
-`--no-build-isolation` bypasses `PEP 517 <https://peps.python.org/pep-0517/>`_ / `PEP 518 <https://peps.python.org/pep-0518/>`_
-avoiding a potential issue where LMCache's kernels are compiled with `torch.utils.cuda_extension` or `torch.utils.hipify`
-inside of `setup.py` with one torch version while during runtime, the version of torch differs across major versions 
-(which is possible because LMCache intentionally has an unpinned torch version in `requirements/common.txt`), causing 
-linker issues that will show up as undefined symbol references.
-
-.. code-block:: bash
-
-    git clone https://github.com/LMCache/LMCache.git
-    cd LMCache
-
-    uv venv --python 3.12
-    source .venv/bin/activate
-
-    # Need to install these packages manually to avoid build isolation
-    uv pip install -r requirements/build.txt
-
-    # Option 1. 
-    # select the torch version that matches the dependency of your serving engine
-    # 2.7.1 is an example for vllm 0.10.0
-    uv pip install torch==2.7.1
-
-    # Option 2. 
-    # install your serving engine with its required torch version bundled
-    # example: vllm 0.10.0 will install torch 2.7.1
-    uv pip install vllm==0.10.0
-
-    # no build isolation requires torch to already be installed
-    # with your desired version
-    uv pip install -e . --no-build-isolation
-
-You can quickly test whether you have undefined symbol references by running: 
-
-.. code-block:: bash
-
-    python3 -c "import lmcache.c_ops"
-
-LMCache with vLLM v1
-~~~~~~~~~~~~~~~~~~~~
-
-LMCache is integrated with the latest vLLM (vLLM v1). To use it, install the latest vLLM package:
-
-.. code-block:: bash
-
-    uv pip install vllm
-
-Test whether LMCache works with vLLM v1 by running:
-
-.. code-block:: bash
-
-    python3 -c "import vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector"
-
-LMCache with vLLM v0
-~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-    LMCache is also integrated with vLLM v0. Refer to `the example in vLLM <https://github.com/vllm-project/vllm/blob/main/examples/others/lmcache/cpu_offload_lmcache.py>`__.
-    See the `examples README <https://github.com/vllm-project/vllm/tree/main/examples/others/lmcache#2-cpu-offload-examples>`_ to understand how to run the script for vLLM v0.
+    python -c "import lmcache.c_ops"
 
 Compatibility Matrix
 ~~~~~~~~~~~~~~~~~~~~
 
-This compatibility matrix accounts for dependencies as well as connector API changes. Please raise an issue on GitHub if you encounter any incompatibilities.
+✅ compatible · ❌ API incompatible · 🕯️ torch mismatch (use ``--no-build-isolation``)
 
-- 🕯️: torch version incompatibility (still compatible if using ``--no-build-isolation``)
-
-- ❌: API incompatibility
-
-- ✅: compatible out of the box (wheels only)
- 
 
 .. container:: compat-table-scroll
 
    .. csv-table::
       :file: Installation_compatibility_matrix.csv
       :header-rows: 1
-
-Notable Change List: 
-
-* June 30: vLLM Cached Req Scheduler Output Changes https://github.com/vllm-project/vllm/pull/20232 and https://github.com/vllm-project/vllm/pull/20291
-
-Setup using Docker
-------------------
-
-Docker Prerequisites
-~~~~~~~~~~~~~~~~~~~~
-
-- Docker Engine 27.0+
-
-Pre-built LMCache integrated with vLLM Images
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-We provide pre-built container images of LMCache integrated with vLLM.
-
-You can get the latest stable image as follows:
-
-.. code-block:: bash
-
-    docker pull lmcache/vllm-openai
-
-You can get the nightly build of latest code of LMcache and vLLM as follows:
-
-.. code-block:: bash
-
-    docker pull lmcache/vllm-openai:latest-nightly
-
-
-LMCache on ROCm
----------------
-
-With vLLM docker base image
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Get started through using vLLM docker image as base image
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The `AMD Infinity hub <https://hub.docker.com/r/rocm/vllm-dev>`__ for vLLM offers a prebuilt, optimized docker image designed for validating inference performance on the AMD Instinct™ MI300X accelerator.
-The image is based on the latest vLLM v1. Please check `LLM inference performance validation on AMD Instinct MI300X <https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference/benchmark-docker/vllm.html?model=pyt_vllm_llama-3.1-8b>`__ for instructions on how to use this prebuilt docker image.
-
-As of the date of writing, the steps are validated on the following environment:
-
-- docker image: rocm/vllm-dev:nightly_0624_rc2_0624_rc2_20250620
-- MI300X
-- vLLM V1
-
-.. code-block:: bash
-
-    #!/bin/bash
-    docker run -it \
-    --network=host \
-    --group-add=video \
-    --ipc=host \
-    --cap-add=SYS_PTRACE \
-    --security-opt seccomp=unconfined \
-    --device /dev/kfd \
-    --device /dev/dri \
-    -v <path_to_your_models>:/app/model \
-    -e HF_HOME="/app/model" \
-    --name lmcache_rocm \
-    rocm/vllm-dev:nightly_0624_rc2_0624_rc2_20250620 \
-    bash
-
-Install Latest LMCache from Source for ROCm
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To install from source, clone the repository and install in editable mode.
-
-.. code-block:: bash
-
-    PYTORCH_ROCM_ARCH="{your_rocm_arch}" \
-    TORCH_DONT_CHECK_COMPILER_ABI=1 \
-    CXX=hipcc \
-    BUILD_WITH_HIP=1 \
-    python3 -m pip install --no-build-isolation -e .
-
-Example on MI300X (gfx942):
-
-.. code-block:: bash
-
-    PYTORCH_ROCM_ARCH="gfx942" \
-    TORCH_DONT_CHECK_COMPILER_ABI=1 \
-    CXX=hipcc \
-    BUILD_WITH_HIP=1 \
-    python3 -m pip install --no-build-isolation -e .
-
-
-On a bare ROCm host 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Install Latest LMCache from Source for ROCm
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To install from source on a bare ROCm host (no ``rocm/vllm-dev`` base image),
-torch must be installed from the ROCm wheel index before building LMCache.
-This mirrors the CUDA from-source flow above, with the ROCm wheel index and
-HIP build flags in place of their CUDA equivalents.
-
-.. code-block:: bash
-
-    git clone https://github.com/LMCache/LMCache.git
-    cd LMCache
-
-    uv venv --python 3.12
-    source .venv/bin/activate
-
-    # Need to install these packages manually to avoid build isolation
-    uv pip install -r requirements/build.txt
-
-    # Install torch from the ROCm wheel index
-    uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.0
-
-    # Build LMCache. BUILD_WITH_HIP=1 makes setup.py pick cupy-rocm-7-0 automatically.
-    PYTORCH_ROCM_ARCH="gfx942" \
-    TORCH_DONT_CHECK_COMPILER_ABI=1 \
-    CXX=hipcc \
-    BUILD_WITH_HIP=1 \
-    uv pip install -e . --no-build-isolation

--- a/docs/source/production/docker_deployment.rst
+++ b/docs/source/production/docker_deployment.rst
@@ -3,10 +3,12 @@
 Docker deployment
 =================
 
-Running the container image
----------------------------
+**Prerequisites:** Docker Engine 27.0+
 
-You can run the LMCache integrated with vLLM image using Docker as follows:
+See :ref:`installation_guide` for pulling images.
+
+Running the container
+---------------------
 
 .. code-block:: bash
 
@@ -22,15 +24,30 @@ You can run the LMCache integrated with vLLM image using Docker as follows:
         meta-llama/Llama-3.1-8B-Instruct --kv-transfer-config \
         '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
 
+See the `docker run example <https://github.com/LMCache/LMCache/tree/dev/docker>`_ for more details.
 
-The image name and tag can be found on DockerHub - `LMCache/vllm-openai <https://hub.docker.com/r/lmcache/vllm-openai>`_.
-See example run file in `docker <https://github.com/LMCache/LMCache/tree/dev/docker>`_ for more details.
+ROCm (AMD)
+----------
 
-.. note::
+The `AMD Infinity hub <https://hub.docker.com/r/rocm/vllm-dev>`__ for vLLM offers a prebuilt,
+optimized image for the AMD Instinct™ MI300X. See
+`LLM inference performance validation on AMD Instinct MI300X <https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference/benchmark-docker/vllm.html?model=pyt_vllm_llama-3.1-8b>`__
+for full instructions.
 
-    DockerHub contains the following image types:
+Validated environment: ``rocm/vllm-dev:nightly_0624_rc2_0624_rc2_20250620``, MI300X, vLLM V1.
 
-    - Nightly build images of LMCache and vLLM latest code (e.g. tagged with `latest-nightly` and `nightly-<date>`)
-    - Images of stable releases of LMCache and vLLM (tagged with `v0.x.x`, the exact version of vllm a version of lmcache was built with can be discovered by consulting the compatibility matrix inside of `installation <../installation.rst>`_)
-    
-    - Lightweight image that cannot run PD disaggregation (tagged with `lightweight`)
+.. code-block:: bash
+
+    docker run -it \
+        --network=host \
+        --group-add=video \
+        --ipc=host \
+        --cap-add=SYS_PTRACE \
+        --security-opt seccomp=unconfined \
+        --device /dev/kfd \
+        --device /dev/dri \
+        -v <path_to_your_models>:/app/model \
+        -e HF_HOME="/app/model" \
+        --name lmcache_rocm \
+        rocm/vllm-dev:nightly_0624_rc2_0624_rc2_20250620 \
+        bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,9 @@ build = "cp3*-manylinux_x86_64"
 # 10.0: GB200, B200
 environment = {TORCH_CUDA_ARCH_LIST = "7.0;7.5;8.0;8.6;8.9;9.0;10.0", ENABLE_CXX11_ABI = "1"}
 
-# Use the PyTorch manylinux image version '2_28' that contains CUDA 12.8
+# Use the PyTorch manylinux image version '2_28' that contains CUDA 12.9
 # and torch 2.7 supports (https://pypi.org/project/torch/2.7.0/#files)
-manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda12.8"
+manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda12.9"
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = """


### PR DESCRIPTION
Summary

  - Nightly wheels: daily nightly-wheels job publishes cu12.9 → nightly and cu13.0 → nightly-cu13 rolling GitHub Releases; install with --pre --find-links,
  no version pinning
  - Stable cu13.0: published to dedicated v{tag}-cu13 GitHub Release (not PyPI); no +cu130 suffix, installs cleanly as lmcache=={VERSION}
  - Dockerfiles: BASE_IMAGE ARG overrides NVIDIA base without file edits; BUILD_TRITON=0 makes triton opt-in; removed redundant cuda.txt pre-install
  - Docs: "Pre-release" → "Nightly" tab; cu13 install simplified; ROCm steps merged

  Release workflow

           push tag / release published          cron 07:30 UTC daily
                      │                                   │
          ┌───────────┴───────────┐           ┌───────────┴───────────┐
          │      publish.yml      │           │   nightly_build.yml   │
          └───────────┬───────────┘           └───────────┬───────────┘
                      │                                   │
          ┌───────────┼───────────┐           ┌───────────┼───────────┐
          ▼           ▼           ▼           ▼           ▼           ▼
       cu12.9      cu13.0      Docker      cu12.9      cu13.0      Docker
        wheel       wheel      images       wheel       wheel      images
          │           │           │           │           │           │
          ▼           ▼           ▼           ▼           ▼           ▼
        PyPI      v{tag}-cu13  DockerHub   nightly    nightly-cu13 DockerHub
     test.pypi   GitHub Rel.  lmcache/    GitHub Rel. GitHub Rel.  :latest-nightly
    (dev push)               vllm-openai             (rolling)    :latest-nightly-cu13
                             :latest
                             :{tag}

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands release automation (new nightly wheel publishing, new cu13 release artifacts, and additional Docker image variants), which could break packaging or deployment if misconfigured.
> 
> **Overview**
> Adds automated **nightly wheel publishing**: the nightly workflow now builds CUDA 12.9 and CUDA 13.0 wheels via `cibuildwheel` and publishes them as rolling prerelease GitHub Releases (`nightly` and `nightly-cu13`).
> 
> Extends the **release pipeline** to build a dedicated CUDA 13.0 (`cu130`) wheel artifact, publish it to a separate `${tag}-cu13` GitHub Release (not PyPI), and gate additional Docker publishing steps on that job.
> 
> Updates Docker builds to default to **CUDA 12.9**, allow overriding the NVIDIA base via `BASE_IMAGE`, pull vLLM/torch from CUDA-specific indexes, and add new **CUDA 13** image targets/tags for both nightly and release; docs and `pyproject.toml` are updated accordingly (incl. manylinux image bump to `cuda12.9`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecfecf441c643379174d2ee69a2a757fc67698c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->