### PR TITLE
[Intel-XPU] add xpu ops to improve store/retrieve performance on xpu

### DIFF
--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -27,7 +27,11 @@ def _get_backend() -> Any:
             "cuda_ops",
             lambda: torch.cuda.is_available(),
         ),
-        # should extend to more HWs..
+        (
+            "lmcache.xpu_ops",
+            "xpu_ops",
+            lambda: hasattr(torch, "xpu") and torch.xpu.is_available(),
+        ),
     ]
 
     imported = False

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -502,12 +502,7 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
         slot_mapping_chunks = [
             slot_mapping[s:e] for s, e in zip(starts, ends, strict=False)
         ]
-        slot_mapping_full = torch.cat(slot_mapping_chunks, dim=0)
-
-        # Move mapping ONCE to device (fixes multiple small H2D copies).
-        slot_mapping_full = _ensure_xpu(slot_mapping_full)
-
-        num_tokens = int(slot_mapping_full.numel())
+        num_tokens = sum(c.numel() for c in slot_mapping_chunks)
         if num_tokens <= 0:
             for _ in range(self.num_layers):
                 _ = yield
@@ -516,6 +511,11 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                 torch.xpu.current_stream().wait_stream(self.load_stream)
             yield
             return
+
+        slot_mapping_full = torch.cat(slot_mapping_chunks, dim=0)
+
+        # Move mapping ONCE to device (fixes multiple small H2D copies).
+        slot_mapping_full = _ensure_xpu(slot_mapping_full)
 
         tmp_gpu_buffer_obj: Optional[MemoryObj] = None
         if self.use_xpu:
@@ -660,11 +660,18 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
         # Precompute “full” mapping for batched gather
         # NOTE: this assumes starts/ends partition slot_mapping contiguously.
         # If not contiguous, concatenation is still correct.
-        slot_mapping_full = torch.cat(
-            [slot_mapping_on_device[s:e] for s, e in zip(starts, ends, strict=False)],
-            dim=0,
-        )
-        total_tokens = int(slot_mapping_full.numel())
+        slot_chunks = [
+            slot_mapping_on_device[s:e]
+            for s, e in zip(starts, ends, strict=False)
+        ]
+        total_tokens = sum(c.numel() for c in slot_chunks)
+        if total_tokens <= 0:
+            for _ in range(self.num_layers):
+                yield
+            yield
+            return
+
+        slot_mapping_full = torch.cat(slot_chunks, dim=0)
 
         # Optional staging buffer (will be USED when self.use_xpu=True)
         tmp_gpu_buffer_obj: Optional[MemoryObj] = None

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Union
 import os
 
 # Third Party
+import numpy as np
 import torch
 
 # First Party
@@ -111,8 +112,6 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         Caches the result and only rebuilds when the underlying data
         pointers change (e.g. when kvcaches are replaced by new tensors).
         """
-        import numpy as np
-
         kv_caches = ensure_contiguous_kv_caches(kv_caches)
 
         # Device pointers may exceed signed int64 range on XPU.
@@ -247,7 +246,7 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
                 head_size=self.head_size,
             )
             memory_obj.tensor.copy_(self._d2h_staging)
-            torch.xpu.synchronize()
+            torch.xpu.synchronize(self.device)
         else:
             lmc_ops.multi_layer_kv_transfer(
                 memory_obj.tensor,
@@ -794,6 +793,9 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
 
     def batched_to_gpu(
         self,
+        memory_objs: Union[
+            List[List[MemoryObj]], List[MemoryObj], List[int], None
+        ] = None,
         starts: Optional[List[int]] = None,
         ends: Optional[List[int]] = None,
         **kwargs,

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Standard
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Union
 import os
 
 # Third Party
@@ -28,9 +28,8 @@ from lmcache.v1.gpu_connector.gpu_connectors import (
 )
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
-    _get_head_size_view,
-    _split_token2d_kv,
     discover_gpu_kv_format,
+    ensure_contiguous_kv_caches,
     get_block_size,
     get_dtype,
     get_head_size,
@@ -47,6 +46,7 @@ from lmcache.v1.memory_management import (
     MemoryObj,
 )
 from lmcache.v1.metadata import LMCacheMetadata
+import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 
@@ -76,6 +76,10 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         self._attributes_initialized = False
         self.kvcaches: Optional[List[torch.Tensor]] = None
         self.use_gpu = use_gpu
+        self._kv_cache_pointers_on_xpu: Optional[torch.Tensor] = None
+        self._kv_cache_ptrs_cpu: Optional["np.ndarray"] = None
+        # Two-stage D2H staging buffer (allocated lazily on first from_gpu call)
+        self._d2h_staging: Optional[torch.Tensor] = None
 
     @classmethod
     def from_metadata(
@@ -100,6 +104,37 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         return cls(
             use_gpu=use_gpu,
         )
+
+    def _initialize_xpu_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
+        """Build a device tensor of raw data pointers for the Triton kernel.
+
+        Caches the result and only rebuilds when the underlying data
+        pointers change (e.g. when kvcaches are replaced by new tensors).
+        """
+        import numpy as np
+
+        kv_caches = ensure_contiguous_kv_caches(kv_caches)
+
+        # Device pointers may exceed signed int64 range on XPU.
+        # Use numpy uint64 → view as int64 to avoid overflow.
+        ptrs_np = np.array(
+            [t.data_ptr() for t in kv_caches], dtype=np.uint64
+        )
+        ptrs_i64 = ptrs_np.view(np.int64)
+
+        # Fast check: skip rebuild if pointers haven't changed.
+        if (
+            self._kv_cache_pointers_on_xpu is not None
+            and self._kv_cache_ptrs_cpu is not None
+            and len(ptrs_i64) == len(self._kv_cache_ptrs_cpu)
+            and (ptrs_i64 == self._kv_cache_ptrs_cpu).all()
+        ):
+            return self._kv_cache_pointers_on_xpu
+
+        self._kv_cache_ptrs_cpu = ptrs_i64.copy()
+        ptrs_cpu = torch.from_numpy(ptrs_i64)
+        self._kv_cache_pointers_on_xpu = ptrs_cpu.to(self.device)
+        return self._kv_cache_pointers_on_xpu
 
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
         """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
@@ -130,25 +165,26 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             raise ValueError("'slot_mapping' should be provided in kwargs.")
 
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
-        slices = slot_mapping[start:end]
         self._initialize_attributes(self.kvcaches)
         self._validate_memory_format(memory_obj)
 
-        if self.use_mla:
-            tmp = memory_obj.tensor[0].to(slot_mapping.device)
-            total_blocks = self.num_blocks * self.block_size
-            for i, kvcache in enumerate(self.kvcaches):
-                kvcache.view(total_blocks, self.head_size).index_copy_(
-                    0, slices, tmp[i]
-                )
-        else:
-            tmp_k = memory_obj.tensor[0].to(slot_mapping.device)
-            tmp_v = memory_obj.tensor[1].to(slot_mapping.device)
-            total_blocks = self.num_blocks * self.block_size
-            d = self.num_heads * self.head_size
-            for i, (kcache, vcache) in enumerate(self.kvcaches):
-                kcache.view(total_blocks, d).index_copy_(0, slices, tmp_k[i])
-                vcache.view(total_blocks, d).index_copy_(0, slices, tmp_v[i])
+        kv_cache_pointers = self._initialize_xpu_pointers(self.kvcaches)
+
+        vllm_cached = kwargs.get("vllm_cached_tokens", 0)
+        skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
+
+        lmc_ops.multi_layer_kv_transfer(
+            memory_obj.tensor,
+            kv_cache_pointers,
+            slot_mapping[start:end],
+            self.device,
+            self.page_buffer_size,
+            lmc_ops.TransferDirection.H2D,
+            self.gpu_kv_format,
+            block_size=self.block_size,
+            head_size=self.head_size,
+            skip_prefix_n_tokens=skip_prefix_n_tokens,
+        )
 
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
         """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
@@ -180,41 +216,50 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
             raise ValueError("'slot_mapping' should be provided in kwargs.")
 
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
-        slices = slot_mapping[start:end]
         self._initialize_attributes(self.kvcaches)
         self._validate_memory_format(memory_obj)
 
-        if self.use_mla:
-            total_blocks = self.num_blocks * self.block_size
-            tmp = torch.stack(
-                [
-                    kvcache.view(total_blocks, self.head_size).index_select(0, slices)
-                    for kvcache in self.kvcaches
-                ]
-            )
-        else:
-            total_blocks = self.num_blocks * self.block_size
-            d = self.num_heads * self.head_size
-            tmp_k = torch.stack(
-                [
-                    kvcache[0].view(total_blocks, d).index_select(0, slices)
-                    for kvcache in self.kvcaches
-                ]
-            )
-            tmp_v = torch.stack(
-                [
-                    kvcache[1].view(total_blocks, d).index_select(0, slices)
-                    for kvcache in self.kvcaches
-                ]
-            )
-            tmp = torch.stack([tmp_k, tmp_v])
-        memory_obj.tensor.copy_(tmp, non_blocking=True)
+        kv_cache_pointers = self._initialize_xpu_pointers(self.kvcaches)
 
         if not memory_obj.tensor.is_xpu:
-            # Force a synchronize if the target buffer is NOT XPU device
-            # NOTE: for better performance, we may not want to sync for every
-            # memory object
+            # Two-stage: Triton gather → XPU staging (device-local),
+            # then staging → CPU pinned (bulk DMA).
+            # Direct scattered PCIe writes from GPU to CPU are very slow.
+            target_shape = memory_obj.tensor.shape
+            if (
+                self._d2h_staging is None
+                or self._d2h_staging.shape != target_shape
+            ):
+                self._d2h_staging = torch.empty(
+                    target_shape,
+                    dtype=memory_obj.tensor.dtype,
+                    device=self.kvcaches[0].device,
+                )
+            lmc_ops.multi_layer_kv_transfer(
+                self._d2h_staging,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                self.kvcaches[0].device,
+                self.page_buffer_size,
+                lmc_ops.TransferDirection.D2H,
+                self.gpu_kv_format,
+                block_size=self.block_size,
+                head_size=self.head_size,
+            )
+            memory_obj.tensor.copy_(self._d2h_staging)
             torch.xpu.synchronize()
+        else:
+            lmc_ops.multi_layer_kv_transfer(
+                memory_obj.tensor,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                self.kvcaches[0].device,
+                self.page_buffer_size,
+                lmc_ops.TransferDirection.D2H,
+                self.gpu_kv_format,
+                block_size=self.block_size,
+                head_size=self.head_size,
+            )
 
         if self.use_mla:
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
@@ -325,7 +370,8 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
       - batched_to_gpu(...) yields num_layers + 2 times
       - batched_from_gpu(...) yields num_layers + 1 times
 
-    Transfer is implemented with pure torch ops (index_copy_/index_select).
+    Transfer uses the Triton ``single_layer_kv_transfer`` kernel when
+    available, falling back to PyTorch index_copy_/index_select otherwise.
     """
 
     def __init__(
@@ -355,6 +401,15 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
 
         # Optional device staging buffer allocator (same pattern as CUDA class)
         self.gpu_buffer_allocator: Optional[MemoryAllocatorInterface] = None
+        self.gpu_kv_format = None
+
+    def initialize_kvcaches_ptr(self, **kwargs):
+        """Override to discover gpu_kv_format from the KV cache tensors."""
+        super().initialize_kvcaches_ptr(**kwargs)
+        if self.kvcaches is not None and self.gpu_kv_format is None:
+            self.gpu_kv_format = discover_gpu_kv_format(
+                self.kvcaches, EngineType.VLLM
+            )
 
     @classmethod
     def from_metadata(
@@ -507,16 +562,6 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
 
                 with torch.xpu.stream(self.load_stream):
                     dst_layer = self.kvcaches[layer_id]
-                    if self.use_mla:
-                        dst_flat = cast(
-                            torch.Tensor,
-                            _get_head_size_view(dst_layer, use_mla=True),
-                        )
-                    else:
-                        dst_k_flat, dst_v_flat = _get_head_size_view(  # type: ignore[misc]
-                            dst_layer, use_mla=False
-                        )
-
                     cursor = 0
 
                     if self.use_xpu:
@@ -537,52 +582,15 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                             staged[cursor : cursor + n].copy_(src, non_blocking=True)
                             cursor += n
 
-                        sl = slot_mapping_full  # already intended to be on device
-                        sl = _ensure_xpu(sl)
-
-                        if self.use_mla:
-                            staged_xpu = _ensure_xpu(staged)
-                            if staged_xpu.dim() == 2:
-                                dst_flat.index_copy_(0, sl, staged_xpu)
-                            elif staged_xpu.dim() == 3 and staged_xpu.shape[0] == 1:
-                                dst_flat.index_copy_(0, sl, staged_xpu[0])
-                            else:
-                                raise ValueError(
-                                    f"Unexpected MLA staged tensor: {staged_xpu.shape}"
-                                )
-                        else:
-                            k_tok, v_tok = _split_token2d_kv(staged)
-
-                            # Make sure k_tok/v_tok are on XPU before index_copy_.
-                            k_tok = _ensure_xpu(k_tok)
-                            v_tok = _ensure_xpu(v_tok)
-
-                            # Keep your reshape logic as-is (only triggers when needed)
-                            if (
-                                k_tok.dim() == 2
-                                and dst_k_flat.dim() == 3
-                                and k_tok.shape[1]
-                                == dst_k_flat.shape[1] * dst_k_flat.shape[2]
-                            ):
-                                k_tok = k_tok.reshape(
-                                    k_tok.shape[0],
-                                    dst_k_flat.shape[1],
-                                    dst_k_flat.shape[2],
-                                )
-                            if (
-                                v_tok.dim() == 2
-                                and dst_v_flat.dim() == 3
-                                and v_tok.shape[1]
-                                == dst_v_flat.shape[1] * dst_v_flat.shape[2]
-                            ):
-                                v_tok = v_tok.reshape(
-                                    v_tok.shape[0],
-                                    dst_v_flat.shape[1],
-                                    dst_v_flat.shape[2],
-                                )
-
-                            dst_k_flat.index_copy_(0, sl, k_tok)
-                            dst_v_flat.index_copy_(0, sl, v_tok)
+                        sl = _ensure_xpu(slot_mapping_full)
+                        lmc_ops.single_layer_kv_transfer(
+                            staged[:num_tokens],
+                            dst_layer,
+                            sl,
+                            lmc_ops.TransferDirection.H2D,
+                            self.gpu_kv_format,
+                            token_major=True,
+                        )
 
                     else:
                         for s, e, mem in zip(
@@ -598,45 +606,20 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                             sl = _ensure_xpu(sl)
                             cursor += n
 
-                            if self.use_mla:
-                                if src.dim() == 2:
-                                    dst_flat.index_copy_(0, sl, src)
-                                elif src.dim() == 3 and src.shape[0] == 1:
-                                    dst_flat.index_copy_(0, sl, src[0])
-                                else:
-                                    raise ValueError(
-                                        f"Unexpected MLA token tensor: {src.shape}"
-                                    )
+                            # Detect token_major from tensor shape
+                            if self.use_mla or src.dim() != 3:
+                                token_major = False
                             else:
-                                k_tok, v_tok = _split_token2d_kv(src)
-                                k_tok = _ensure_xpu(k_tok)
-                                v_tok = _ensure_xpu(v_tok)
+                                token_major = src.shape[1] == 2
 
-                                if (
-                                    k_tok.dim() == 2
-                                    and dst_k_flat.dim() == 3
-                                    and k_tok.shape[1]
-                                    == dst_k_flat.shape[1] * dst_k_flat.shape[2]
-                                ):
-                                    k_tok = k_tok.reshape(
-                                        k_tok.shape[0],
-                                        dst_k_flat.shape[1],
-                                        dst_k_flat.shape[2],
-                                    )
-                                if (
-                                    v_tok.dim() == 2
-                                    and dst_v_flat.dim() == 3
-                                    and v_tok.shape[1]
-                                    == dst_v_flat.shape[1] * dst_v_flat.shape[2]
-                                ):
-                                    v_tok = v_tok.reshape(
-                                        v_tok.shape[0],
-                                        dst_v_flat.shape[1],
-                                        dst_v_flat.shape[2],
-                                    )
-
-                                dst_k_flat.index_copy_(0, sl, k_tok)
-                                dst_v_flat.index_copy_(0, sl, v_tok)
+                            lmc_ops.single_layer_kv_transfer(
+                                src,
+                                dst_layer,
+                                sl,
+                                lmc_ops.TransferDirection.H2D,
+                                self.gpu_kv_format,
+                                token_major=token_major,
+                            )
 
             yield
 
@@ -672,82 +655,6 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
         self._lazy_initialize_buffer(self.kvcaches)
 
         current_stream = torch.xpu.current_stream()
-
-        # ---- helpers (keep local to minimize file-wide changes) ----
-        def _flatten_last2_if_needed(
-            src: torch.Tensor, dst: torch.Tensor
-        ) -> torch.Tensor:
-            """
-            Make src match dst for the common KV layouts:
-            - src: [..., H, HS] -> dst: [..., H*HS]
-            - or already matches
-            """
-            if src.shape == dst.shape:
-                return src
-
-            # dst has one less trailing dim: [..., D] where D=H*HS
-            if src.dim() == dst.dim() + 1:
-                # e.g., src [..., 8, 128] -> dst [..., 1024]
-                if dst.shape == (*src.shape[:-2], src.shape[-2] * src.shape[-1]):
-                    return src.reshape(*src.shape[:-2], -1)
-
-            # same ndim but dst last dim is flattened (dst ends with D)
-            if src.dim() == dst.dim():
-                if (
-                    dst.shape[:-1] == src.shape[:-2]
-                    and dst.shape[-1] == src.shape[-2] * src.shape[-1]
-                ):
-                    return src.reshape(*src.shape[:-2], -1)
-
-            return src  # caller will error if still incompatible
-
-        def _copy_kv_into_mem(
-            mem_tensor: torch.Tensor, k_src: torch.Tensor, v_src: torch.Tensor
-        ) -> None:
-            """
-            Copy K/V into mem.tensor supporting:
-            - [2, ..., D]  (K in 0, V in 1)
-            - [..., 2, D]  (K in [:,0,:], V in [:,1,:])
-            - [2, ..., H, HS] or [..., 2, H, HS] similarly
-            """
-            if mem_tensor.dim() < 3:
-                raise ValueError(
-                    f"Unexpected output token2d layout: {mem_tensor.shape}"
-                )
-
-            # Case A: mem is [2, ...]
-            if mem_tensor.shape[0] == 2:
-                k_dst = mem_tensor[0]
-                v_dst = mem_tensor[1]
-                k_src2 = _flatten_last2_if_needed(k_src, k_dst)
-                v_src2 = _flatten_last2_if_needed(v_src, v_dst)
-                if k_src2.shape != k_dst.shape or v_src2.shape != v_dst.shape:
-                    raise ValueError(
-                        f"KV shape mismatch after reshape: "
-                        f"k src {k_src.shape}->{k_src2.shape} vs dst {k_dst.shape}; "
-                        f"v src {v_src.shape}->{v_src2.shape} vs dst {v_dst.shape}"
-                    )
-                k_dst.copy_(k_src2.to(k_dst.device), non_blocking=True)
-                v_dst.copy_(v_src2.to(v_dst.device), non_blocking=True)
-                return
-
-            # Case B: mem is [..., 2, ...]
-            if mem_tensor.shape[1] == 2:
-                k_dst = mem_tensor[:, 0, ...]
-                v_dst = mem_tensor[:, 1, ...]
-                k_src2 = _flatten_last2_if_needed(k_src, k_dst)
-                v_src2 = _flatten_last2_if_needed(v_src, v_dst)
-                if k_src2.shape != k_dst.shape or v_src2.shape != v_dst.shape:
-                    raise ValueError(
-                        f"KV shape mismatch after reshape: "
-                        f"k src {k_src.shape}->{k_src2.shape} vs dst {k_dst.shape}; "
-                        f"v src {v_src.shape}->{v_src2.shape} vs dst {v_dst.shape}"
-                    )
-                k_dst.copy_(k_src2.to(k_dst.device), non_blocking=True)
-                v_dst.copy_(v_src2.to(v_dst.device), non_blocking=True)
-                return
-
-            raise ValueError(f"Unexpected output token2d layout: {mem_tensor.shape}")
 
         slot_mapping_on_device = slot_mapping.to(self.device)
 
@@ -805,90 +712,76 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
 
                     src_layer = self.kvcaches[layer_id]
 
-                    if self.use_mla:
-                        src_flat = cast(
-                            torch.Tensor,
-                            _get_head_size_view(src_layer, use_mla=True),
+                    if self.use_xpu:
+                        assert tmp_gpu_buffer_obj is not None
+                        tmp = tmp_gpu_buffer_obj.tensor
+
+                        # Gather from paged KV cache into staging buffer
+                        lmc_ops.single_layer_kv_transfer(
+                            tmp[:total_tokens],
+                            src_layer,
+                            slot_mapping_full,
+                            lmc_ops.TransferDirection.D2H,
+                            self.gpu_kv_format,
+                            token_major=not self.use_mla,
                         )
 
-                        if self.use_xpu:
-                            gathered_full = src_flat.index_select(0, slot_mapping_full)
-                            # Write into tmp if possible, else fallback to per-chunk
-                            tmp_src = (
-                                _flatten_last2_if_needed(gathered_full, tmp)
-                                if "tmp" in locals()
-                                else gathered_full
+                        # Copy chunks from staging to mem tensors
+                        off = 0
+                        for s, e, mem in zip(
+                            starts, ends, mem_layer, strict=False
+                        ):
+                            assert mem.tensor is not None
+                            n = e - s
+                            chunk = tmp[off : off + n]
+                            off += n
+                            mem.tensor.copy_(
+                                chunk.to(mem.tensor.device), non_blocking=True
                             )
-                            if "tmp" in locals() and tmp_src.shape == tmp.shape:
-                                tmp.copy_(tmp_src, non_blocking=True)
-                                off = 0
-                                for s, e, mem in zip(
-                                    starts, ends, mem_layer, strict=False
-                                ):
-                                    assert mem.tensor is not None
-                                    n = e - s
-                                    chunk = tmp[off : off + n]
-                                    off += n
-                                    mem.tensor.copy_(
-                                        chunk.to(mem.tensor.device), non_blocking=True
-                                    )
+                    else:
+                        # Non-staged: per-chunk gather with D2H staging
+                        for s, e, mem in zip(
+                            starts, ends, mem_layer, strict=False
+                        ):
+                            assert mem.tensor is not None
+                            sl = slot_mapping_on_device[s:e]
+
+                            if self.use_mla or mem.tensor.dim() != 3:
+                                token_major = False
                             else:
-                                for s, e, mem in zip(
-                                    starts, ends, mem_layer, strict=False
-                                ):
-                                    assert mem.tensor is not None
-                                    sl = slot_mapping_on_device[s:e]
-                                    gathered = src_flat.index_select(0, sl)
-                                    mem.tensor.copy_(
-                                        gathered.to(mem.tensor.device),
-                                        non_blocking=True,
-                                    )
-                        else:
-                            for s, e, mem in zip(starts, ends, mem_layer, strict=False):
-                                assert mem.tensor is not None
-                                sl = slot_mapping_on_device[s:e]
-                                gathered = src_flat.index_select(0, sl)
-                                mem.tensor.copy_(
-                                    gathered.to(mem.tensor.device), non_blocking=True
+                                token_major = mem.tensor.shape[1] == 2
+
+                            if not mem.tensor.is_xpu:
+                                # Two-stage: gather into device staging,
+                                # then bulk DMA to CPU (avoids slow
+                                # scattered PCIe writes).
+                                d2h_stg = torch.empty_like(
+                                    mem.tensor, device=self.device
+                                )
+                                lmc_ops.single_layer_kv_transfer(
+                                    d2h_stg,
+                                    src_layer,
+                                    sl,
+                                    lmc_ops.TransferDirection.D2H,
+                                    self.gpu_kv_format,
+                                    token_major=token_major,
+                                )
+                                mem.tensor.copy_(d2h_stg)
+                            else:
+                                lmc_ops.single_layer_kv_transfer(
+                                    mem.tensor,
+                                    src_layer,
+                                    sl,
+                                    lmc_ops.TransferDirection.D2H,
+                                    self.gpu_kv_format,
+                                    token_major=token_major,
                                 )
 
-                        # Keep memory format metadata consistent for downstream checks.
+                    if self.use_mla:
                         target_fmt = MemoryFormat.KV_MLA_FMT
                         for mem in mem_layer:
                             self._validate_format_transition(mem, target_fmt)
                             mem.metadata.fmt = target_fmt
-
-                    else:
-                        src_k_flat, src_v_flat = _get_head_size_view(
-                            src_layer, use_mla=False
-                        )
-
-                        if self.use_xpu:
-                            k_full = src_k_flat.index_select(0, slot_mapping_full)
-                            v_full = src_v_flat.index_select(0, slot_mapping_full)
-
-                            # Slice from staging. If tmp exists and can hold
-                            # the layout, use it; otherwise slice k/v directly.
-                            off = 0
-                            for s, e, mem in zip(starts, ends, mem_layer, strict=False):
-                                assert mem.tensor is not None
-                                n = e - s
-
-                                k_chunk = k_full[off : off + n]
-                                v_chunk = v_full[off : off + n]
-                                off += n
-
-                                _copy_kv_into_mem(mem.tensor, k_chunk, v_chunk)
-
-                        else:
-                            # per-chunk gather (original behavior);
-                            # avoids per-iteration H2D slot_mapping transfers
-                            for s, e, mem in zip(starts, ends, mem_layer, strict=False):
-                                assert mem.tensor is not None
-                                sl = slot_mapping_on_device[s:e]
-                                k = src_k_flat.index_select(0, sl)
-                                v = src_v_flat.index_select(0, sl)
-                                _copy_kv_into_mem(mem.tensor, k, v)
 
                 if sync:
                     self.store_stream.synchronize()
@@ -901,9 +794,6 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
 
     def batched_to_gpu(
         self,
-        memory_objs: Union[
-            List[List[MemoryObj]], List[MemoryObj], List[int], None
-        ] = None,
         starts: Optional[List[int]] = None,
         ends: Optional[List[int]] = None,
         **kwargs,

--- a/lmcache/xpu_ops.py
+++ b/lmcache/xpu_ops.py
@@ -1,0 +1,583 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# XPU backend for LMCache using Triton kernels for performance-critical
+# operations and re-exporting non-CUDA fallbacks for everything else.
+#
+# This module is loaded by lmcache/__init__.py when XPU is detected.
+
+# Re-export everything from non_cuda_equivalents as the baseline.
+# Only the functions overridden below will differ on XPU.
+from lmcache.non_cuda_equivalents import *  # noqa: F401, F403
+from lmcache.non_cuda_equivalents import (
+    GPUKVFormat,
+    TransferDirection,
+    _tensor_from_ptr,
+)
+
+# Third Party
+import torch
+import triton
+import triton.language as tl
+
+# ======================================================================
+# GPUKVFormat constants (mirrors the IntEnum values for use in Triton
+# constexpr dispatch).
+# ======================================================================
+_FMT_NB_NL_TWO_BS_NH_HS = int(GPUKVFormat.NB_NL_TWO_BS_NH_HS)  # 0
+_FMT_NL_X_TWO_NB_BS_NH_HS = int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS)  # 1
+_FMT_NL_X_NB_TWO_BS_NH_HS = int(GPUKVFormat.NL_X_NB_TWO_BS_NH_HS)  # 2
+_FMT_NL_X_NB_BS_HS = int(GPUKVFormat.NL_X_NB_BS_HS)  # 3
+_FMT_TWO_X_NL_X_NBBS_NH_HS = int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)  # 4
+_FMT_NL_X_NBBS_ONE_HS = int(GPUKVFormat.NL_X_NBBS_ONE_HS)  # 5
+_FMT_NL_X_TWO_NB_NH_BS_HS = int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS)  # 6
+_FMT_NL_X_NB_TWO_NH_BS_HS = int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS)  # 7
+
+
+# ======================================================================
+# Triton kernel: multi-layer KV transfer
+#
+# Grid: (num_transfer_tokens, num_layers, kv_size)
+#   - kv_size = 1 for MLA, 2 otherwise
+#
+# Each program instance copies one token's worth of data for one layer
+# and one of K/V between the LMCache buffer and the paged KV cache.
+# ======================================================================
+@triton.jit
+def _multi_layer_kv_transfer_kernel(
+    # Pointers
+    key_value_ptr,  # LMCache buffer flat pointer
+    paged_buffer_ptrs,  # Device tensor of int64 pointers, one per layer
+    slot_mapping_ptr,  # [num_tokens] int64
+    # Dimensions
+    scalars_per_token: tl.constexpr,  # hidden_size (in elements)
+    num_tokens,  # total tokens in key_value (including skipped prefix)
+    num_layers,
+    page_buffer_size,  # NB * BS
+    block_size,
+    head_size,  # only used by HND formats
+    skip_prefix_n_tokens,
+    # Compile-time constants
+    DIRECTION: tl.constexpr,  # 0 = H2D (lmc→paged), 1 = D2H (paged→lmc)
+    FORMAT: tl.constexpr,  # GPUKVFormat int value
+    BLOCK: tl.constexpr,  # tile width for the inner loop
+):
+    token_id = tl.program_id(0)
+    layer_id = tl.program_id(1)
+    k_or_v = tl.program_id(2)
+
+    # When key_value_ptr comes as a raw int (CPU pinned buffer passed via
+    # data_ptr()), cast it to a proper Triton pointer so tl.load/tl.store work.
+    kv_ptr = key_value_ptr.to(tl.pointer_type(tl.int16))
+
+    kv_token_id = token_id + skip_prefix_n_tokens
+    slot_idx = tl.load(slot_mapping_ptr + kv_token_id)
+
+    if slot_idx < 0:
+        return
+
+    # Load the device pointer for this layer's paged buffer
+    layer_ptr_int = tl.load(paged_buffer_ptrs + layer_id)
+    layer_ptr = layer_ptr_int.to(tl.pointer_type(tl.int16))
+
+    offsets = tl.arange(0, BLOCK)
+
+    for start in range(0, scalars_per_token, BLOCK):
+        i = offsets + start
+        mask = i < scalars_per_token
+
+        # ── LMCache buffer offset ──
+        # Layout: [kv_size, num_layers, num_tokens, scalars_per_token]
+        lmc_off = (
+            k_or_v * num_layers * num_tokens * scalars_per_token
+            + layer_id * num_tokens * scalars_per_token
+            + kv_token_id * scalars_per_token
+            + i
+        )
+
+        # ── Paged buffer offset (depends on format) ──
+        # NB_NL_TWO_BS_NH_HS (0) and NL_X_TWO_NB_BS_NH_HS (1):
+        #   k_or_v * PBS * SPT + slot * SPT + i
+        # NL_X_NB_TWO_BS_NH_HS (2) — flash infer NHD:
+        #   block_idx * 2 * BS * SPT + k_or_v * BS * SPT + block_off * SPT + i
+        # NL_X_NB_BS_HS (3) and NL_X_NBBS_ONE_HS (5) — MLA:
+        #   slot * SPT + i
+        # NL_X_TWO_NB_NH_BS_HS (6) — flash attn HND:
+        #   k_or_v * PBS * SPT + block_idx * NH * BS * HS
+        #   + head_idx * BS * HS + block_off * HS + head_off
+        # NL_X_NB_TWO_NH_BS_HS (7) — flash infer HND:
+        #   block_idx * 2 * NH * BS * HS + k_or_v * NH * BS * HS
+        #   + head_idx * BS * HS + block_off * HS + head_off
+
+        if FORMAT == 0 or FORMAT == 1:
+            # NB_NL_TWO_BS_NH_HS / NL_X_TWO_NB_BS_NH_HS
+            page_off = (
+                k_or_v * page_buffer_size * scalars_per_token
+                + slot_idx * scalars_per_token
+                + i
+            )
+        elif FORMAT == 2:
+            # NL_X_NB_TWO_BS_NH_HS (flash infer NHD)
+            block_idx = slot_idx // block_size
+            block_off = slot_idx % block_size
+            page_off = (
+                block_idx * 2 * block_size * scalars_per_token
+                + k_or_v * block_size * scalars_per_token
+                + block_off * scalars_per_token
+                + i
+            )
+        elif FORMAT == 3 or FORMAT == 5:
+            # MLA: NL_X_NB_BS_HS / NL_X_NBBS_ONE_HS
+            page_off = slot_idx * scalars_per_token + i
+        elif FORMAT == 6:
+            # NL_X_TWO_NB_NH_BS_HS (flash attn HND)
+            block_idx = slot_idx // block_size
+            block_off = slot_idx % block_size
+            head_idx = i // head_size
+            head_off = i % head_size
+            page_off = (
+                k_or_v * page_buffer_size * scalars_per_token
+                + block_idx * (scalars_per_token // head_size) * block_size * head_size
+                + head_idx * block_size * head_size
+                + block_off * head_size
+                + head_off
+            )
+        elif FORMAT == 7:
+            # NL_X_NB_TWO_NH_BS_HS (flash infer HND)
+            block_idx = slot_idx // block_size
+            block_off = slot_idx % block_size
+            head_idx = i // head_size
+            head_off = i % head_size
+            num_heads = scalars_per_token // head_size
+            page_off = (
+                block_idx * 2 * num_heads * block_size * head_size
+                + k_or_v * num_heads * block_size * head_size
+                + head_idx * block_size * head_size
+                + block_off * head_size
+                + head_off
+            )
+        else:
+            # Unsupported format — should not reach here
+            page_off = i
+
+        if DIRECTION == 1:
+            # D2H: paged → lmcache
+            vals = tl.load(layer_ptr + page_off, mask=mask)
+            tl.store(kv_ptr + lmc_off, vals, mask=mask)
+        else:
+            # H2D: lmcache → paged
+            vals = tl.load(kv_ptr + lmc_off, mask=mask)
+            tl.store(layer_ptr + page_off, vals, mask=mask)
+
+
+# ======================================================================
+# Triton kernel: multi-layer KV transfer (unilateral / SGLang MHA)
+#
+# Separate K and V paged buffers:
+#   ptrs = [K_layer0, K_layer1, ..., V_layer0, V_layer1, ...]
+# ======================================================================
+@triton.jit
+def _multi_layer_kv_transfer_unilateral_kernel(
+    key_value_ptr,
+    paged_buffer_ptrs,  # [num_layers * 2] pointers
+    slot_mapping_ptr,
+    scalars_per_token: tl.constexpr,
+    num_tokens,
+    num_layers,
+    page_buffer_size,
+    DIRECTION: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    layer_id = tl.program_id(1)
+    k_or_v = tl.program_id(2)
+
+    kv_ptr = key_value_ptr.to(tl.pointer_type(tl.int16))
+
+    slot_idx = tl.load(slot_mapping_ptr + token_id)
+    if slot_idx < 0:
+        return
+
+    # K pointers are at [0..num_layers), V at [num_layers..2*num_layers)
+    ptr_idx = layer_id + k_or_v * num_layers
+    layer_ptr_int = tl.load(paged_buffer_ptrs + ptr_idx)
+    layer_ptr = layer_ptr_int.to(tl.pointer_type(tl.int16))
+
+    offsets = tl.arange(0, BLOCK)
+
+    for start in range(0, scalars_per_token, BLOCK):
+        i = offsets + start
+        mask = i < scalars_per_token
+
+        lmc_off = (
+            k_or_v * num_layers * num_tokens * scalars_per_token
+            + layer_id * num_tokens * scalars_per_token
+            + token_id * scalars_per_token
+            + i
+        )
+        page_off = slot_idx * scalars_per_token + i
+
+        if DIRECTION == 1:
+            vals = tl.load(layer_ptr + page_off, mask=mask)
+            tl.store(kv_ptr + lmc_off, vals, mask=mask)
+        else:
+            vals = tl.load(kv_ptr + lmc_off, mask=mask)
+            tl.store(layer_ptr + page_off, vals, mask=mask)
+
+
+# ======================================================================
+# Triton kernel: single-layer KV transfer (for layerwise connector)
+#
+# Grid: (num_tokens, kv_size)
+#   - kv_size = 1 for MLA, 2 otherwise
+#
+# Transfers one token's K (and V) between lmc buffer and one layer's
+# paged KV cache.  Both tensors are passed directly (not via pointers).
+# ======================================================================
+@triton.jit
+def _single_layer_kv_transfer_kernel(
+    lmc_ptr,   # LMCache buffer (flat int16 view)
+    vllm_ptr,  # vLLM paged KV cache for one layer (flat int16 view)
+    slot_mapping_ptr,  # [num_tokens] int64
+    # Strides / offsets (in int16 units)
+    lmc_stride,        # stride between tokens in lmc buffer
+    lmc_value_offset,  # offset from K to V in lmc buffer
+    vllm_block_stride, # stride per block in vllm cache
+    vllm_value_offset, # offset from K to V in vllm cache
+    scalars_per_token,  # num_heads * head_size in int16 units
+    block_size,
+    head_size,  # in int16 units, only for HND
+    # Compile-time
+    DIRECTION: tl.constexpr,  # 0=H2D, 1=D2H
+    IS_MLA: tl.constexpr,
+    IS_HND: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    # Cast raw int64 pointers to typed pointers (needed when CPU pinned
+    # buffers are passed as data_ptr() ints to avoid Triton driver
+    # rejecting non-XPU tensors).
+    lmc_ptr = lmc_ptr.to(tl.pointer_type(tl.int16))
+    vllm_ptr = vllm_ptr.to(tl.pointer_type(tl.int16))
+
+    token_idx = tl.program_id(0)
+    k_or_v = tl.program_id(1)
+
+    slot_idx = tl.load(slot_mapping_ptr + token_idx)
+    if slot_idx < 0:
+        return
+
+    block_idx = slot_idx // block_size
+    block_offset = slot_idx % block_size
+
+    offsets = tl.arange(0, BLOCK)
+
+    for start in range(0, scalars_per_token, BLOCK):
+        i = offsets + start
+        mask = i < scalars_per_token
+
+        # LMCache offset
+        lmc_off = token_idx * lmc_stride + i
+        if not IS_MLA:
+            lmc_off = lmc_off + k_or_v * lmc_value_offset
+
+        # vLLM offset depends on layout
+        if IS_HND:
+            head_idx = i // head_size
+            head_off = i % head_size
+            vllm_off = (
+                block_idx * vllm_block_stride
+                + head_idx * block_size * head_size
+                + block_offset * head_size
+                + head_off
+            )
+        else:
+            # NHD (also correct for MLA where num_heads==1)
+            vllm_off = (
+                block_idx * vllm_block_stride
+                + block_offset * scalars_per_token
+                + i
+            )
+        if not IS_MLA:
+            vllm_off = vllm_off + k_or_v * vllm_value_offset
+
+        if DIRECTION == 1:
+            # D2H: vllm → lmc
+            vals = tl.load(vllm_ptr + vllm_off, mask=mask)
+            tl.store(lmc_ptr + lmc_off, vals, mask=mask)
+        else:
+            # H2D: lmc → vllm
+            vals = tl.load(lmc_ptr + lmc_off, mask=mask)
+            tl.store(vllm_ptr + vllm_off, vals, mask=mask)
+
+
+# ======================================================================
+# Python dispatch wrappers
+# ======================================================================
+
+# Determine the appropriate Triton pointer type width based on dtype.
+# The CUDA kernel templates on int64 (8 bytes) for best coalescing,
+# then falls back to int32/int16/int8. We use int16 (2 bytes) which
+# matches bf16/fp16 element size — the most common KV dtype.
+_TRITON_BLOCK = 128
+
+
+def _get_scalars_and_view(key_value: torch.Tensor):
+    """Return (num_elements_per_token, key_value_as_int16_view).
+
+    We reinterpret the data as int16 so the Triton kernel works on 2-byte
+    elements regardless of the actual dtype (bf16/fp16 are both 2 bytes).
+    For dtypes with different element sizes, we adjust the element count.
+    """
+    elem_size = key_value.element_size()
+    num_origin_elements = key_value.size(3)
+    # Number of int16 (2-byte) elements per token
+    scalars_per_token = num_origin_elements * elem_size // 2
+    # Reinterpret as int16 for the kernel
+    kv_view = key_value.view(torch.int16)
+    return scalars_per_token, kv_view
+
+
+def multi_layer_kv_transfer(
+    key_value: torch.Tensor,
+    key_value_ptrs: torch.Tensor | list[torch.Tensor],
+    slot_mapping: torch.Tensor,
+    paged_memory_device: torch.device,
+    page_buffer_size: int,
+    direction: TransferDirection,
+    gpu_kv_format: GPUKVFormat,
+    block_size: int = 0,
+    head_size: int = 0,
+    skip_prefix_n_tokens: int = 0,
+):
+    """XPU Triton-accelerated multi_layer_kv_transfer.
+
+    When key_value_ptrs is a raw-pointer int64 tensor (the standard path
+    from VLLMPagedMemGPUConnectorV2._initialize_pointers), we launch a
+    single Triton kernel that processes all layers × tokens × K/V in one
+    shot, matching the CUDA kernel's grid=(tokens, layers, kv_size).
+
+    When key_value_ptrs is a list[Tensor] (the non_cuda_equivalents path),
+    we fall back to the vectorized PyTorch implementation.
+    """
+    # If pointers come as a list of tensors, we can't use pointer-of-pointers.
+    # Fall back to the per-layer PyTorch path (imported from non_cuda_equivalents).
+    if isinstance(key_value_ptrs, list):
+        from lmcache.non_cuda_equivalents import (
+            multi_layer_kv_transfer as _fallback_multi_layer_kv_transfer,
+        )
+        _fallback_multi_layer_kv_transfer(
+            key_value, key_value_ptrs, slot_mapping, paged_memory_device,
+            page_buffer_size, direction, gpu_kv_format, block_size,
+            head_size, skip_prefix_n_tokens,
+        )
+        return
+
+    fmt = int(gpu_kv_format)
+    is_mla = fmt in (_FMT_NL_X_NB_BS_HS, _FMT_NL_X_NBBS_ONE_HS)
+
+    scalars_per_token, kv_view = _get_scalars_and_view(key_value)
+    # Convert head_size from element units to int16 units
+    elem_size = key_value.element_size()
+    head_size_i16 = head_size * elem_size // 2 if head_size > 0 else 0
+
+    num_layers = key_value.size(1)
+    num_tokens = key_value.size(2)
+    num_transfer_tokens = num_tokens - skip_prefix_n_tokens
+    kv_size = 1 if is_mla else 2
+
+    direction_int = 1 if direction == TransferDirection.D2H else 0
+
+    # Triton XPU driver rejects CPU-device tensors at the Python level even
+    # when the underlying memory is USM-host (pinned).  Passing the raw
+    # data_ptr as an int bypasses the tensor-device check; the L0 driver
+    # then calls zeMemGetAllocProperties and correctly identifies it as
+    # ZE_MEMORY_TYPE_HOST, which is accessible from device kernels.
+    kv_arg = kv_view if kv_view.is_xpu else kv_view.data_ptr()
+
+    grid = (num_transfer_tokens, num_layers, kv_size)
+
+    _multi_layer_kv_transfer_kernel[grid](
+        kv_arg,
+        key_value_ptrs,
+        slot_mapping,
+        scalars_per_token,
+        num_tokens,
+        num_layers,
+        page_buffer_size,
+        block_size,
+        head_size_i16,
+        skip_prefix_n_tokens,
+        DIRECTION=direction_int,
+        FORMAT=fmt,
+        BLOCK=_TRITON_BLOCK,
+    )
+
+
+def multi_layer_kv_transfer_unilateral(
+    key_value: torch.Tensor,
+    key_value_ptrs: torch.Tensor | list[torch.Tensor],
+    slot_mapping: torch.Tensor,
+    paged_memory_device: torch.device,
+    page_buffer_size: int,
+    direction: TransferDirection,
+    gpu_kv_format: GPUKVFormat,
+):
+    """XPU Triton-accelerated multi_layer_kv_transfer_unilateral."""
+    is_mla = int(gpu_kv_format) in (_FMT_NL_X_NB_BS_HS, _FMT_NL_X_NBBS_ONE_HS)
+
+    # MLA collapses to multi_layer_kv_transfer
+    if is_mla:
+        return multi_layer_kv_transfer(
+            key_value, key_value_ptrs, slot_mapping,
+            paged_memory_device, page_buffer_size,
+            direction, gpu_kv_format,
+        )
+
+    if isinstance(key_value_ptrs, list):
+        from lmcache.non_cuda_equivalents import (
+            multi_layer_kv_transfer_unilateral as _fallback,
+        )
+        _fallback(
+            key_value, key_value_ptrs, slot_mapping,
+            paged_memory_device, page_buffer_size,
+            direction, gpu_kv_format,
+        )
+        return
+
+    scalars_per_token, kv_view = _get_scalars_and_view(key_value)
+
+    num_layers = key_value.size(1)
+    num_tokens = key_value.size(2)
+    direction_int = 1 if direction == TransferDirection.D2H else 0
+
+    kv_arg = kv_view if kv_view.is_xpu else kv_view.data_ptr()
+
+    grid = (num_tokens, num_layers, 2)
+
+    _multi_layer_kv_transfer_unilateral_kernel[grid](
+        kv_arg,
+        key_value_ptrs,
+        slot_mapping,
+        scalars_per_token,
+        num_tokens,
+        num_layers,
+        page_buffer_size,
+        DIRECTION=direction_int,
+        BLOCK=_TRITON_BLOCK,
+    )
+
+
+def single_layer_kv_transfer(
+    lmc_key_value_cache: torch.Tensor,
+    vllm_key_value_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    direction: TransferDirection,
+    gpu_kv_format: GPUKVFormat,
+    token_major: bool = False,
+):
+    """XPU Triton-accelerated single_layer_kv_transfer.
+
+    Transfers KV data between an LMCache buffer and one vLLM paged KV
+    cache layer.  Falls back to the PyTorch path when either tensor is
+    not on XPU.
+    """
+    fmt = int(gpu_kv_format)
+    is_mla = fmt in (_FMT_NL_X_NB_BS_HS, _FMT_NL_X_NBBS_ONE_HS)
+    is_hnd = fmt in (_FMT_NL_X_TWO_NB_NH_BS_HS, _FMT_NL_X_NB_TWO_NH_BS_HS)
+
+    # Fall back for non-XPU tensors or unsupported formats
+    if not vllm_key_value_cache.is_xpu:
+        from lmcache.non_cuda_equivalents import (
+            single_layer_kv_transfer as _fallback,
+        )
+        return _fallback(
+            lmc_key_value_cache, vllm_key_value_cache, slot_mapping,
+            direction, gpu_kv_format, token_major,
+        )
+
+    elem_size = lmc_key_value_cache.element_size()
+    direction_int = 1 if direction == TransferDirection.D2H else 0
+
+    if is_mla:
+        # lmc: [num_tokens, head_size]
+        # vllm: [num_blocks, block_size, head_size]
+        num_tokens = lmc_key_value_cache.size(0)
+        hidden = lmc_key_value_cache.size(1)
+        block_size = vllm_key_value_cache.size(1)
+        scalars_per_token = hidden * elem_size // 2
+        head_size_i16 = 0
+
+        lmc_view = lmc_key_value_cache.view(torch.int16)
+        vllm_view = vllm_key_value_cache.view(torch.int16)
+
+        lmc_stride = scalars_per_token
+        lmc_value_offset = 0
+        vllm_block_stride = block_size * scalars_per_token
+        vllm_value_offset = 0
+
+        lmc_arg = lmc_view if lmc_view.is_xpu else lmc_view.data_ptr()
+
+        grid = (num_tokens, 1)
+        _single_layer_kv_transfer_kernel[grid](
+            lmc_arg, vllm_view, slot_mapping,
+            lmc_stride, lmc_value_offset,
+            vllm_block_stride, vllm_value_offset,
+            scalars_per_token, block_size, head_size_i16,
+            DIRECTION=direction_int, IS_MLA=True, IS_HND=False,
+            BLOCK=_TRITON_BLOCK,
+        )
+    else:
+        # Non-MLA
+        is_two_major = fmt in (
+            _FMT_NL_X_TWO_NB_BS_NH_HS,
+            _FMT_NL_X_TWO_NB_NH_BS_HS,
+        )
+        if is_hnd:
+            # [prefix, num_heads, block_size, head_size]
+            num_heads = vllm_key_value_cache.size(2)
+            block_size = vllm_key_value_cache.size(3)
+            head_dim = vllm_key_value_cache.size(4)
+        else:
+            # [prefix, block_size, num_heads, head_size]
+            block_size = vllm_key_value_cache.size(2)
+            num_heads = vllm_key_value_cache.size(3)
+            head_dim = vllm_key_value_cache.size(4)
+        hidden = num_heads * head_dim
+        scalars_per_token = hidden * elem_size // 2
+        head_size_i16 = head_dim * elem_size // 2
+
+        if token_major:
+            # lmc: [num_tokens, 2, hidden]
+            num_tokens = lmc_key_value_cache.size(0)
+            lmc_stride = 2 * scalars_per_token
+            lmc_value_offset = scalars_per_token
+        else:
+            # lmc: [2, num_tokens, hidden]
+            num_tokens = lmc_key_value_cache.size(1)
+            lmc_stride = scalars_per_token
+            lmc_value_offset = num_tokens * scalars_per_token
+
+        lmc_view = lmc_key_value_cache.view(torch.int16)
+        vllm_view = vllm_key_value_cache.view(torch.int16)
+
+        # vllm block stride and value offset in int16 units
+        if is_two_major:
+            # [2, num_blocks, ...] → value is num_blocks * block_size * hidden away
+            num_blocks = vllm_key_value_cache.size(1)
+            vllm_block_stride = block_size * scalars_per_token
+            vllm_value_offset = num_blocks * block_size * scalars_per_token
+        else:
+            # [num_blocks, 2, ...] → value is block_size * hidden away
+            vllm_block_stride = 2 * block_size * scalars_per_token
+            vllm_value_offset = block_size * scalars_per_token
+
+        lmc_arg = lmc_view if lmc_view.is_xpu else lmc_view.data_ptr()
+
+        grid = (num_tokens, 2)
+        _single_layer_kv_transfer_kernel[grid](
+            lmc_arg, vllm_view, slot_mapping,
+            lmc_stride, lmc_value_offset,
+            vllm_block_stride, vllm_value_offset,
+            scalars_per_token, block_size, head_size_i16,
+            DIRECTION=direction_int, IS_MLA=False, IS_HND=is_hnd,
+            BLOCK=_TRITON_BLOCK,
+        )

--- a/lmcache/xpu_ops.py
+++ b/lmcache/xpu_ops.py
@@ -21,16 +21,12 @@ import triton.language as tl
 
 # ======================================================================
 # GPUKVFormat constants (mirrors the IntEnum values for use in Triton
-# constexpr dispatch).
+# constexpr dispatch).  Only XPU-supported formats are defined here.
 # ======================================================================
-_FMT_NB_NL_TWO_BS_NH_HS = int(GPUKVFormat.NB_NL_TWO_BS_NH_HS)  # 0
 _FMT_NL_X_TWO_NB_BS_NH_HS = int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS)  # 1
-_FMT_NL_X_NB_TWO_BS_NH_HS = int(GPUKVFormat.NL_X_NB_TWO_BS_NH_HS)  # 2
 _FMT_NL_X_NB_BS_HS = int(GPUKVFormat.NL_X_NB_BS_HS)  # 3
 _FMT_TWO_X_NL_X_NBBS_NH_HS = int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)  # 4
 _FMT_NL_X_NBBS_ONE_HS = int(GPUKVFormat.NL_X_NBBS_ONE_HS)  # 5
-_FMT_NL_X_TWO_NB_NH_BS_HS = int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS)  # 6
-_FMT_NL_X_NB_TWO_NH_BS_HS = int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS)  # 7
 
 
 # ======================================================================
@@ -53,8 +49,6 @@ def _multi_layer_kv_transfer_kernel(
     num_tokens,  # total tokens in key_value (including skipped prefix)
     num_layers,
     page_buffer_size,  # NB * BS
-    block_size,
-    head_size,  # only used by HND formats
     skip_prefix_n_tokens,
     # Compile-time constants
     DIRECTION: tl.constexpr,  # 0 = H2D (lmc→paged), 1 = D2H (paged→lmc)
@@ -95,66 +89,22 @@ def _multi_layer_kv_transfer_kernel(
         )
 
         # ── Paged buffer offset (depends on format) ──
-        # NB_NL_TWO_BS_NH_HS (0) and NL_X_TWO_NB_BS_NH_HS (1):
+        # Only XPU-supported formats are implemented here.
+        # NL_X_TWO_NB_BS_NH_HS (1) — vLLM flash attention NHD:
         #   k_or_v * PBS * SPT + slot * SPT + i
-        # NL_X_NB_TWO_BS_NH_HS (2) — flash infer NHD:
-        #   block_idx * 2 * BS * SPT + k_or_v * BS * SPT + block_off * SPT + i
         # NL_X_NB_BS_HS (3) and NL_X_NBBS_ONE_HS (5) — MLA:
         #   slot * SPT + i
-        # NL_X_TWO_NB_NH_BS_HS (6) — flash attn HND:
-        #   k_or_v * PBS * SPT + block_idx * NH * BS * HS
-        #   + head_idx * BS * HS + block_off * HS + head_off
-        # NL_X_NB_TWO_NH_BS_HS (7) — flash infer HND:
-        #   block_idx * 2 * NH * BS * HS + k_or_v * NH * BS * HS
-        #   + head_idx * BS * HS + block_off * HS + head_off
 
-        if FORMAT == 0 or FORMAT == 1:
-            # NB_NL_TWO_BS_NH_HS / NL_X_TWO_NB_BS_NH_HS
+        if FORMAT == 1:
+            # NL_X_TWO_NB_BS_NH_HS (vLLM flash attention NHD)
             page_off = (
                 k_or_v * page_buffer_size * scalars_per_token
                 + slot_idx * scalars_per_token
                 + i
             )
-        elif FORMAT == 2:
-            # NL_X_NB_TWO_BS_NH_HS (flash infer NHD)
-            block_idx = slot_idx // block_size
-            block_off = slot_idx % block_size
-            page_off = (
-                block_idx * 2 * block_size * scalars_per_token
-                + k_or_v * block_size * scalars_per_token
-                + block_off * scalars_per_token
-                + i
-            )
         elif FORMAT == 3 or FORMAT == 5:
             # MLA: NL_X_NB_BS_HS / NL_X_NBBS_ONE_HS
             page_off = slot_idx * scalars_per_token + i
-        elif FORMAT == 6:
-            # NL_X_TWO_NB_NH_BS_HS (flash attn HND)
-            block_idx = slot_idx // block_size
-            block_off = slot_idx % block_size
-            head_idx = i // head_size
-            head_off = i % head_size
-            page_off = (
-                k_or_v * page_buffer_size * scalars_per_token
-                + block_idx * (scalars_per_token // head_size) * block_size * head_size
-                + head_idx * block_size * head_size
-                + block_off * head_size
-                + head_off
-            )
-        elif FORMAT == 7:
-            # NL_X_NB_TWO_NH_BS_HS (flash infer HND)
-            block_idx = slot_idx // block_size
-            block_off = slot_idx % block_size
-            head_idx = i // head_size
-            head_off = i % head_size
-            num_heads = scalars_per_token // head_size
-            page_off = (
-                block_idx * 2 * num_heads * block_size * head_size
-                + k_or_v * num_heads * block_size * head_size
-                + head_idx * block_size * head_size
-                + block_off * head_size
-                + head_off
-            )
         else:
             # Unsupported format — should not reach here
             page_off = i
@@ -245,11 +195,9 @@ def _single_layer_kv_transfer_kernel(
     vllm_value_offset, # offset from K to V in vllm cache
     scalars_per_token,  # num_heads * head_size in int16 units
     block_size,
-    head_size,  # in int16 units, only for HND
     # Compile-time
     DIRECTION: tl.constexpr,  # 0=H2D, 1=D2H
     IS_MLA: tl.constexpr,
-    IS_HND: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     # Cast raw int64 pointers to typed pointers (needed when CPU pinned
@@ -279,23 +227,12 @@ def _single_layer_kv_transfer_kernel(
         if not IS_MLA:
             lmc_off = lmc_off + k_or_v * lmc_value_offset
 
-        # vLLM offset depends on layout
-        if IS_HND:
-            head_idx = i // head_size
-            head_off = i % head_size
-            vllm_off = (
-                block_idx * vllm_block_stride
-                + head_idx * block_size * head_size
-                + block_offset * head_size
-                + head_off
-            )
-        else:
-            # NHD (also correct for MLA where num_heads==1)
-            vllm_off = (
-                block_idx * vllm_block_stride
-                + block_offset * scalars_per_token
-                + i
-            )
+        # vLLM offset: NHD layout (also correct for MLA where num_heads==1)
+        vllm_off = (
+            block_idx * vllm_block_stride
+            + block_offset * scalars_per_token
+            + i
+        )
         if not IS_MLA:
             vllm_off = vllm_off + k_or_v * vllm_value_offset
 
@@ -375,9 +312,6 @@ def multi_layer_kv_transfer(
     is_mla = fmt in (_FMT_NL_X_NB_BS_HS, _FMT_NL_X_NBBS_ONE_HS)
 
     scalars_per_token, kv_view = _get_scalars_and_view(key_value)
-    # Convert head_size from element units to int16 units
-    elem_size = key_value.element_size()
-    head_size_i16 = head_size * elem_size // 2 if head_size > 0 else 0
 
     num_layers = key_value.size(1)
     num_tokens = key_value.size(2)
@@ -403,8 +337,6 @@ def multi_layer_kv_transfer(
         num_tokens,
         num_layers,
         page_buffer_size,
-        block_size,
-        head_size_i16,
         skip_prefix_n_tokens,
         DIRECTION=direction_int,
         FORMAT=fmt,
@@ -482,7 +414,6 @@ def single_layer_kv_transfer(
     """
     fmt = int(gpu_kv_format)
     is_mla = fmt in (_FMT_NL_X_NB_BS_HS, _FMT_NL_X_NBBS_ONE_HS)
-    is_hnd = fmt in (_FMT_NL_X_TWO_NB_NH_BS_HS, _FMT_NL_X_NB_TWO_NH_BS_HS)
 
     # Fall back for non-XPU tensors or unsupported formats
     if not vllm_key_value_cache.is_xpu:
@@ -504,7 +435,6 @@ def single_layer_kv_transfer(
         hidden = lmc_key_value_cache.size(1)
         block_size = vllm_key_value_cache.size(1)
         scalars_per_token = hidden * elem_size // 2
-        head_size_i16 = 0
 
         lmc_view = lmc_key_value_cache.view(torch.int16)
         vllm_view = vllm_key_value_cache.view(torch.int16)
@@ -521,29 +451,18 @@ def single_layer_kv_transfer(
             lmc_arg, vllm_view, slot_mapping,
             lmc_stride, lmc_value_offset,
             vllm_block_stride, vllm_value_offset,
-            scalars_per_token, block_size, head_size_i16,
-            DIRECTION=direction_int, IS_MLA=True, IS_HND=False,
+            scalars_per_token, block_size,
+            DIRECTION=direction_int, IS_MLA=True,
             BLOCK=_TRITON_BLOCK,
         )
     else:
-        # Non-MLA
-        is_two_major = fmt in (
-            _FMT_NL_X_TWO_NB_BS_NH_HS,
-            _FMT_NL_X_TWO_NB_NH_BS_HS,
-        )
-        if is_hnd:
-            # [prefix, num_heads, block_size, head_size]
-            num_heads = vllm_key_value_cache.size(2)
-            block_size = vllm_key_value_cache.size(3)
-            head_dim = vllm_key_value_cache.size(4)
-        else:
-            # [prefix, block_size, num_heads, head_size]
-            block_size = vllm_key_value_cache.size(2)
-            num_heads = vllm_key_value_cache.size(3)
-            head_dim = vllm_key_value_cache.size(4)
+        # Non-MLA: only NHD layout (format 1) is supported on XPU.
+        # vllm shape: [prefix, block_size, num_heads, head_size]
+        block_size = vllm_key_value_cache.size(2)
+        num_heads = vllm_key_value_cache.size(3)
+        head_dim = vllm_key_value_cache.size(4)
         hidden = num_heads * head_dim
         scalars_per_token = hidden * elem_size // 2
-        head_size_i16 = head_dim * elem_size // 2
 
         if token_major:
             # lmc: [num_tokens, 2, hidden]
@@ -560,15 +479,11 @@ def single_layer_kv_transfer(
         vllm_view = vllm_key_value_cache.view(torch.int16)
 
         # vllm block stride and value offset in int16 units
-        if is_two_major:
-            # [2, num_blocks, ...] → value is num_blocks * block_size * hidden away
-            num_blocks = vllm_key_value_cache.size(1)
-            vllm_block_stride = block_size * scalars_per_token
-            vllm_value_offset = num_blocks * block_size * scalars_per_token
-        else:
-            # [num_blocks, 2, ...] → value is block_size * hidden away
-            vllm_block_stride = 2 * block_size * scalars_per_token
-            vllm_value_offset = block_size * scalars_per_token
+        # Format 1 (NL_X_TWO_NB_BS_NH_HS): [2, num_blocks, BS, NH, HS]
+        #   value is num_blocks * block_size * hidden away
+        num_blocks = vllm_key_value_cache.size(1)
+        vllm_block_stride = block_size * scalars_per_token
+        vllm_value_offset = num_blocks * block_size * scalars_per_token
 
         lmc_arg = lmc_view if lmc_view.is_xpu else lmc_view.data_ptr()
 
@@ -577,7 +492,7 @@ def single_layer_kv_transfer(
             lmc_arg, vllm_view, slot_mapping,
             lmc_stride, lmc_value_offset,
             vllm_block_stride, vllm_value_offset,
-            scalars_per_token, block_size, head_size_i16,
-            DIRECTION=direction_int, IS_MLA=False, IS_HND=is_hnd,
+            scalars_per_token, block_size,
+            DIRECTION=direction_int, IS_MLA=False,
             BLOCK=_TRITON_BLOCK,
         )

--- a/lmcache/xpu_ops.py
+++ b/lmcache/xpu_ops.py
@@ -12,6 +12,9 @@ from lmcache.non_cuda_equivalents import (
     GPUKVFormat,
     TransferDirection,
     _tensor_from_ptr,
+    multi_layer_kv_transfer as _fallback_multi_layer_kv_transfer,
+    multi_layer_kv_transfer_unilateral as _fallback_multi_layer_kv_transfer_unilateral,
+    single_layer_kv_transfer as _fallback_single_layer_kv_transfer,
 )
 
 # Third Party
@@ -95,14 +98,14 @@ def _multi_layer_kv_transfer_kernel(
         # NL_X_NB_BS_HS (3) and NL_X_NBBS_ONE_HS (5) — MLA:
         #   slot * SPT + i
 
-        if FORMAT == 1:
+        if FORMAT == 1:  # _FMT_NL_X_TWO_NB_BS_NH_HS
             # NL_X_TWO_NB_BS_NH_HS (vLLM flash attention NHD)
             page_off = (
                 k_or_v * page_buffer_size * scalars_per_token
                 + slot_idx * scalars_per_token
                 + i
             )
-        elif FORMAT == 3 or FORMAT == 5:
+        elif FORMAT == 3 or FORMAT == 5:  # _FMT_NL_X_NB_BS_HS / _FMT_NL_X_NBBS_ONE_HS
             # MLA: NL_X_NB_BS_HS / NL_X_NBBS_ONE_HS
             page_off = slot_idx * scalars_per_token + i
         else:
@@ -298,9 +301,6 @@ def multi_layer_kv_transfer(
     # If pointers come as a list of tensors, we can't use pointer-of-pointers.
     # Fall back to the per-layer PyTorch path (imported from non_cuda_equivalents).
     if isinstance(key_value_ptrs, list):
-        from lmcache.non_cuda_equivalents import (
-            multi_layer_kv_transfer as _fallback_multi_layer_kv_transfer,
-        )
         _fallback_multi_layer_kv_transfer(
             key_value, key_value_ptrs, slot_mapping, paged_memory_device,
             page_buffer_size, direction, gpu_kv_format, block_size,
@@ -365,10 +365,7 @@ def multi_layer_kv_transfer_unilateral(
         )
 
     if isinstance(key_value_ptrs, list):
-        from lmcache.non_cuda_equivalents import (
-            multi_layer_kv_transfer_unilateral as _fallback,
-        )
-        _fallback(
+        _fallback_multi_layer_kv_transfer_unilateral(
             key_value, key_value_ptrs, slot_mapping,
             paged_memory_device, page_buffer_size,
             direction, gpu_kv_format,
@@ -417,10 +414,7 @@ def single_layer_kv_transfer(
 
     # Fall back for non-XPU tensors or unsupported formats
     if not vllm_key_value_cache.is_xpu:
-        from lmcache.non_cuda_equivalents import (
-            single_layer_kv_transfer as _fallback,
-        )
-        return _fallback(
+        return _fallback_single_layer_kv_transfer(
             lmc_key_value_cache, vllm_key_value_cache, slot_mapping,
             direction, gpu_kv_format, token_major,
         )

--- a/tests/benchmarks/test_xpu_connector_benchmark.py
+++ b/tests/benchmarks/test_xpu_connector_benchmark.py
@@ -466,3 +466,249 @@ def test_lookup_20k_tokens_v2(
             engine.lookup(t)
 
     benchmark.pedantic(run_func, iterations=1, rounds=num_repeats)
+
+
+# --------------------------
+# Raw transfer baselines (PyTorch per-layer indexing, no engine/Triton)
+# --------------------------
+def _baseline_scatter(kv_caches, staging, slots, num_layers, num_kv_heads,
+                      head_dim, block_size):
+    """Per-layer PyTorch fancy-indexing scatter (H2D baseline)."""
+    block_indices = slots // block_size
+    block_offsets = slots % block_size
+    for layer_id in range(num_layers):
+        paged = kv_caches[layer_id]
+        for kv in range(2):
+            src = staging[kv, layer_id, :, :]  # [T, H]
+            paged[kv, block_indices, block_offsets, :, :] = (
+                src.reshape(-1, num_kv_heads, head_dim)
+            )
+
+
+def _baseline_gather(kv_caches, staging, slots, num_layers, num_kv_heads,
+                     head_dim, block_size):
+    """Per-layer PyTorch fancy-indexing gather (D2H baseline)."""
+    block_indices = slots // block_size
+    block_offsets = slots % block_size
+    for layer_id in range(num_layers):
+        paged = kv_caches[layer_id]
+        for kv in range(2):
+            gathered = paged[kv, block_indices, block_offsets, :, :]
+            staging[kv, layer_id, :, :] = gathered.reshape(-1, num_kv_heads * head_dim)
+
+
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="raw-store")
+@pytest.mark.parametrize("device_type", DEVICE_PARAMS)
+def test_store_raw_baseline(benchmark, device_type):
+    """Baseline Store: bulk DMA + per-layer PyTorch scatter (no Triton)."""
+    _skip_if_no_xpu()
+    import gc; gc.collect(); torch.xpu.empty_cache()
+    num_heads = 8
+    head_dim = 128
+    num_layers = 28
+    hidden = num_heads * head_dim
+    dtype = torch.bfloat16
+    device = _device_from_type(device_type)
+    num_tokens = 2048
+    num_blocks = 1024
+    block_size = 64
+    num_requests = 4
+    num_repeats = 5
+
+    kv_caches = [
+        torch.rand(2, num_blocks, block_size, num_heads, head_dim,
+                    dtype=dtype, device=device)
+        for _ in range(num_layers)
+    ]
+    staging = torch.empty(2, num_layers, num_tokens, hidden,
+                          dtype=dtype, device=device)
+
+    cpu_buffers = [
+        torch.empty(2, num_layers, num_tokens, hidden,
+                    dtype=dtype, pin_memory=True).normal_()
+        for _ in range(num_requests)
+    ]
+    slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
+
+    def run_func():
+        for buf, slots in zip(cpu_buffers, slot_mappings):
+            staging.copy_(buf, non_blocking=True)
+            _baseline_scatter(kv_caches, staging, slots, num_layers,
+                              num_heads, head_dim, block_size)
+        torch.xpu.synchronize(device)
+
+    run_func()
+    benchmark.pedantic(run_func, rounds=num_repeats, iterations=1)
+
+
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="raw-retrieve")
+@pytest.mark.parametrize("device_type", DEVICE_PARAMS)
+def test_retrieve_raw_baseline(benchmark, device_type):
+    """Baseline Retrieve: per-layer PyTorch gather + bulk DMA (no Triton)."""
+    _skip_if_no_xpu()
+    import gc; gc.collect(); torch.xpu.empty_cache()
+    num_heads = 8
+    head_dim = 128
+    num_layers = 28
+    hidden = num_heads * head_dim
+    dtype = torch.bfloat16
+    device = _device_from_type(device_type)
+    num_tokens = 2048
+    num_blocks = 1024
+    block_size = 64
+    num_requests = 4
+    num_repeats = 5
+
+    kv_caches = [
+        torch.rand(2, num_blocks, block_size, num_heads, head_dim,
+                    dtype=dtype, device=device)
+        for _ in range(num_layers)
+    ]
+    staging = torch.empty(2, num_layers, num_tokens, hidden,
+                          dtype=dtype, device=device)
+
+    cpu_buffers = [
+        torch.empty(2, num_layers, num_tokens, hidden,
+                    dtype=dtype, pin_memory=True)
+        for _ in range(num_requests)
+    ]
+    slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
+
+    def run_func():
+        for buf, slots in zip(cpu_buffers, slot_mappings):
+            _baseline_gather(kv_caches, staging, slots, num_layers,
+                             num_heads, head_dim, block_size)
+            torch.xpu.synchronize(device)
+            buf.copy_(staging)
+        torch.xpu.synchronize(device)
+
+    run_func()
+    benchmark.pedantic(run_func, rounds=num_repeats, iterations=1)
+
+
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="raw-store")
+@pytest.mark.parametrize("device_type", DEVICE_PARAMS)
+def test_store_raw_triton(benchmark, device_type):
+    """Triton Store: bulk DMA + Triton scatter (production path)."""
+    _skip_if_no_xpu()
+    import gc; gc.collect(); torch.xpu.empty_cache()
+    import numpy as np
+    import lmcache.c_ops as lmc_ops
+    from lmcache.non_cuda_equivalents import TransferDirection, GPUKVFormat
+
+    num_heads = 8
+    head_dim = 128
+    num_layers = 28
+    hidden = num_heads * head_dim
+    dtype = torch.bfloat16
+    device = _device_from_type(device_type)
+    num_tokens = 2048
+    num_blocks = 1024
+    block_size = 64
+    num_requests = 4
+    num_repeats = 5
+
+    kv_caches = [
+        torch.rand(2, num_blocks, block_size, num_heads, head_dim,
+                    dtype=dtype, device=device)
+        for _ in range(num_layers)
+    ]
+    staging = torch.empty(2, num_layers, num_tokens, hidden,
+                          dtype=dtype, device=device)
+    page_buffer_size = num_blocks * block_size
+
+    ptrs_np = np.array([t.data_ptr() for t in kv_caches], dtype=np.uint64)
+    ptrs = torch.from_numpy(ptrs_np.view(np.int64).copy()).to(device)
+
+    cpu_buffers = [
+        torch.empty(2, num_layers, num_tokens, hidden,
+                    dtype=dtype, pin_memory=True).normal_()
+        for _ in range(num_requests)
+    ]
+    slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
+    gpu_kv_format = GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+    def run_func():
+        for buf, slots in zip(cpu_buffers, slot_mappings):
+            staging.copy_(buf, non_blocking=True)
+            lmc_ops.multi_layer_kv_transfer(
+                staging, ptrs, slots, device, page_buffer_size,
+                TransferDirection.H2D, gpu_kv_format,
+                block_size=block_size, head_size=head_dim,
+            )
+        torch.xpu.synchronize(device)
+
+    run_func()
+    benchmark.pedantic(run_func, rounds=num_repeats, iterations=1)
+
+
+@pytest.mark.no_shared_allocator
+@pytest.mark.benchmark(group="raw-retrieve")
+@pytest.mark.parametrize("device_type", DEVICE_PARAMS)
+def test_retrieve_raw_triton(benchmark, device_type):
+    """Triton Retrieve: Triton gather + bulk DMA (production path)."""
+    _skip_if_no_xpu()
+    import gc; gc.collect(); torch.xpu.empty_cache()
+    import numpy as np
+    import lmcache.c_ops as lmc_ops
+    from lmcache.non_cuda_equivalents import TransferDirection, GPUKVFormat
+
+    num_heads = 8
+    head_dim = 128
+    num_layers = 28
+    hidden = num_heads * head_dim
+    dtype = torch.bfloat16
+    device = _device_from_type(device_type)
+    num_tokens = 2048
+    num_blocks = 1024
+    block_size = 64
+    num_requests = 4
+    num_repeats = 5
+
+    kv_caches = [
+        torch.rand(2, num_blocks, block_size, num_heads, head_dim,
+                    dtype=dtype, device=device)
+        for _ in range(num_layers)
+    ]
+    staging = torch.empty(2, num_layers, num_tokens, hidden,
+                          dtype=dtype, device=device)
+    page_buffer_size = num_blocks * block_size
+
+    ptrs_np = np.array([t.data_ptr() for t in kv_caches], dtype=np.uint64)
+    ptrs = torch.from_numpy(ptrs_np.view(np.int64).copy()).to(device)
+
+    cpu_buffers = [
+        torch.empty(2, num_layers, num_tokens, hidden,
+                    dtype=dtype, pin_memory=True)
+        for _ in range(num_requests)
+    ]
+    slot_mappings = [
+        generate_random_slot_mapping(num_blocks, block_size, num_tokens, device)
+        for _ in range(num_requests)
+    ]
+    gpu_kv_format = GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+    def run_func():
+        for buf, slots in zip(cpu_buffers, slot_mappings):
+            lmc_ops.multi_layer_kv_transfer(
+                staging, ptrs, slots, device, page_buffer_size,
+                TransferDirection.D2H, gpu_kv_format,
+                block_size=block_size, head_size=head_dim,
+            )
+            buf.copy_(staging)
+        torch.xpu.synchronize(device)
+
+    run_func()
+    benchmark.pedantic(run_func, rounds=num_repeats, iterations=1)


### PR DESCRIPTION
Add XPU Triton kernels for KV cache gather/scatter, replacing per-layer PyTorch index_copy_/index_select in both V2 and layerwise XPU connectors, with a two-stage D2H path (device staging → bulk DMA) to avoid slow scattered PCIe writes.
Based on the test, triton kernels approach delivers 1.37–1.40× store and 1.17–1.20× retrieve speedup on V2, and 4.5–4.9× store speedup on layerwise 

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new XPU backend with Triton kernels and rewires XPU KV-cache transfer paths, which can affect correctness/performance across multiple KV layouts and host/device transfer edge cases.
> 
> **Overview**
> Adds a new `lmcache.xpu_ops` backend (auto-selected when `torch.xpu.is_available()`), implementing Triton-accelerated `multi_layer_kv_transfer`/`single_layer_kv_transfer` while falling back to existing Python implementations when needed.
> 
> Refactors both XPU connectors to route store/retrieve through these ops: V2 now builds/caches XPU-safe raw KV-cache pointer tensors (handling uint64 pointers), supports skipping prefix tokens, and uses a *two-stage* device-staging→CPU copy for `from_gpu` to avoid slow scattered writes.
> 
> Extends XPU benchmarks with raw PyTorch baselines vs Triton transfer microbenchmarks to quantify store/retrieve speedups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b2720905a431c537e550c0113fdd8e6e1f64b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->