### PR TITLE
[Calculator] Support Qwen3.5 model config in kv cache calculator

### DIFF
--- a/examples/kv_cache_calculator/generate_config.py
+++ b/examples/kv_cache_calculator/generate_config.py
@@ -41,12 +41,16 @@ def main():
             config_data["kv_lora_rank"] = getattr(config, "kv_lora_rank", None)
             config_data["qk_rope_head_dim"] = getattr(config, "qk_rope_head_dim", None)
 
-        # Check for Qwen3 models (fuzzy matching) or GLM4 models
-        if (
-            "qwen/qwen3" in args.model.lower()
-            or "zai-org/glm-4." in args.model.lower()
-        ):
+        # Check for GLM4 models
+        if ("zai-org/glm-4." in args.model.lower()):
             config_data["head_dim"] = getattr(config, "head_dim", None)
+
+        # Check for Qwen3 / Qwen3.5 / Qwen3.6 models (fuzzy matching)
+        if args.model.lower().startswith("qwen/qwen3"):
+            config_data["head_dim"] = getattr(config, "head_dim", None)
+            full_attention_interval = getattr(config, "full_attention_interval", None)
+            if full_attention_interval is not None:
+                config_data["full_attention_interval"] = full_attention_interval
 
         # Convert to JSON and print
         string = json.dumps(config_data, indent=4)

--- a/examples/kv_cache_calculator/generate_config.py
+++ b/examples/kv_cache_calculator/generate_config.py
@@ -25,6 +25,9 @@ def main():
     # Load model configuration using AutoConfig
     try:
         config = AutoConfig.from_pretrained(args.model)
+        get_text_config = getattr(config, "get_text_config", None)
+        if callable(get_text_config):
+            config = get_text_config(decoder=True)
 
         # Prepare configuration data in a dictionary format
         config_data = {
@@ -40,7 +43,7 @@ def main():
 
         # Check for Qwen3 models (fuzzy matching) or GLM4 models
         if (
-            "qwen/qwen3-" in args.model.lower()
+            "qwen/qwen3" in args.model.lower()
             or "zai-org/glm-4." in args.model.lower()
         ):
             config_data["head_dim"] = getattr(config, "head_dim", None)

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -116,8 +116,8 @@
 
         // Load model configurations from GitHub
         async function loadModelConfigs() {
-            // const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
-            const url = './modelConfig.json';
+            const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
+            // const url = './modelConfig.json';
             try {
                 const response = await fetch(url);
                 if (!response.ok) {

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -230,7 +230,7 @@
             } else if (isQwen3Model) {
                 total_elements = 2 * effective_kv_layers * tokens * num_key_value_heads * head_dim;
             } else if (isGLM4Model) {
-                total_elements = 2 * effective_kv_layers * tokens * num_key_value_heads * head_dim;
+                total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_dim;
             } else {
                 total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_size;
             }

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -116,8 +116,8 @@
 
         // Load model configurations from GitHub
         async function loadModelConfigs() {
-            const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
-            // const url = './modelConfig.json';
+            // const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
+            const url = './modelConfig.json';
             try {
                 const response = await fetch(url);
                 if (!response.ok) {
@@ -175,6 +175,7 @@
             let hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads;
             let kv_lora_rank, qk_rope_head_dim; // for deepseek-ai/DeepSeek-V3
             let head_size;
+            let head_dim, full_attention_interval;
 
             // Check for DeepSeek models (exact matching)
             const isDeepSeekModel = model === "deepseek-ai/DeepSeek-V3" || model === "deepseek-ai/DeepSeek-R1";
@@ -185,14 +186,14 @@
             // Check for GLM4 models (prefix matching)
             const isGLM4Model = model.startsWith("zai-org/GLM-4.");
 
-            const isGQAWithHeadDimModel = isQwen3Model || isGLM4Model;
-
             if (isDeepSeekModel) {
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, kv_lora_rank, qk_rope_head_dim } = config);
-            } else if (isGQAWithHeadDimModel) {
-                // The Qwen3 series and GLM use GQA, and `head_dim` needs to be read from config file.
+            } else if (isQwen3Model) {
+                // Qwen3 series uses GQA and may include hybrid attention metadata.
+                ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, head_dim, full_attention_interval } = config);
+            } else if (isGLM4Model) {
+                // GLM4 series uses GQA with explicit head_dim.
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads, head_dim } = config);
-                console.log(config);
             } else {
                 ({ hidden_size, num_attention_heads, num_hidden_layers, num_key_value_heads } = config);
                 head_size = hidden_size / num_attention_heads;
@@ -214,10 +215,22 @@
 
             // Calculate KV cache size
             let total_elements;
+            let effective_kv_layers = num_hidden_layers;
+
+            if (
+                isQwen3Model
+                && Number.isFinite(full_attention_interval)
+                && full_attention_interval > 0
+            ) {
+                effective_kv_layers = num_hidden_layers / full_attention_interval;
+            }
+
             if (isDeepSeekModel) {
                 total_elements = num_hidden_layers * tokens * (kv_lora_rank + qk_rope_head_dim);
-            } else if (isGQAWithHeadDimModel) {
-                total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_dim;
+            } else if (isQwen3Model) {
+                total_elements = 2 * effective_kv_layers * tokens * num_key_value_heads * head_dim;
+            } else if (isGLM4Model) {
+                total_elements = 2 * effective_kv_layers * tokens * num_key_value_heads * head_dim;
             } else {
                 total_elements = 2 * num_hidden_layers * tokens * num_key_value_heads * head_size;
             }
@@ -241,7 +254,26 @@
                 <b>Total Bytes:</b> ${total_elements} × ${dtype_size} = ${total_bytes} bytes<br>
                 <b>KV Cache Size:</b> ${total_bytes} / (1024³) ≈ ${kvCacheSizeGB.toFixed(4)} GB
                 `;
-            } else if (isGQAWithHeadDimModel) {
+            } else if (isQwen3Model) {
+                const usesFullAttentionInterval =
+                    isQwen3Model
+                    && Number.isFinite(full_attention_interval)
+                    && full_attention_interval > 0;
+
+                steps = `
+                <strong>Calculation Details:</strong><br><br>
+                <b>Selected Model:</b> ${model}<br>
+                <b>Number of Hidden Layers:</b> ${num_hidden_layers}<br>
+                ${usesFullAttentionInterval ? `<b>Full Attention Interval:</b> ${full_attention_interval} <br>` : ''}
+                ${usesFullAttentionInterval ? `<b>Effective Full-Attention Layers for KV:</b> ${num_hidden_layers} / ${full_attention_interval} = ${effective_kv_layers}<br>` : ''}
+                <b>Number of Key-Value Heads:</b> ${num_key_value_heads}<br>
+                <b>Head dim:</b> ${head_dim}<br>
+                <b>Data Type Size:</b> ${dtype_size} bytes<br>
+                <b>Total Elements:</b> 2 × ${usesFullAttentionInterval ? effective_kv_layers : num_hidden_layers} × ${tokens} × ${num_key_value_heads} × ${head_dim} = ${total_elements}<br>
+                <b>Total Bytes:</b> ${total_elements} × ${dtype_size} = ${total_bytes} bytes<br>
+                <b>KV Cache Size:</b> ${total_bytes} / (1024³) ≈ ${kvCacheSizeGB.toFixed(4)} GB
+                `;
+            } else if (isGLM4Model) {
                 steps = `
                 <strong>Calculation Details:</strong><br><br>
                 <b>Selected Model:</b> ${model}<br>
@@ -283,7 +315,6 @@
         window.onload = function() {
             loadModelConfigs();
         };
-
     </script>
 </body>
 </html>

--- a/examples/kv_cache_calculator/kv_cache_calculator.html
+++ b/examples/kv_cache_calculator/kv_cache_calculator.html
@@ -116,7 +116,8 @@
 
         // Load model configurations from GitHub
         async function loadModelConfigs() {
-            const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
+            // const url = 'https://raw.githubusercontent.com/LMCache/LMCache/refs/heads/dev/examples/kv_cache_calculator/modelconfig.json';
+            const url = './modelConfig.json';
             try {
                 const response = await fetch(url);
                 if (!response.ok) {
@@ -179,7 +180,7 @@
             const isDeepSeekModel = model === "deepseek-ai/DeepSeek-V3" || model === "deepseek-ai/DeepSeek-R1";
 
             // Check for Qwen3 models (fuzzy matching)
-            const isQwen3Model = model.toLowerCase().includes("qwen/qwen3-");
+            const isQwen3Model = model.toLowerCase().includes("qwen/qwen3");
 
             // Check for GLM4 models (prefix matching)
             const isGLM4Model = model.startsWith("zai-org/GLM-4.");

--- a/examples/kv_cache_calculator/modelconfig.json
+++ b/examples/kv_cache_calculator/modelconfig.json
@@ -141,5 +141,54 @@
         "num_hidden_layers": 92,
         "num_key_value_heads": 8,
         "head_dim": 128
+    },
+    "Qwen/Qwen3.5-4B": {
+        "hidden_size": 2560,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 32,
+        "num_key_value_heads": 4,
+        "head_dim": 256
+    },
+    "Qwen/Qwen3.5-9B": {
+        "hidden_size": 4096,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 32,
+        "num_key_value_heads": 4,
+        "head_dim": 256
+    },
+    "Qwen/Qwen3.5-27B": {
+        "hidden_size": 5120,
+        "num_attention_heads": 24,
+        "num_hidden_layers": 64,
+        "num_key_value_heads": 4,
+        "head_dim": 256
+    },
+    "Qwen/Qwen3.5-35B-A3B": {
+        "hidden_size": 2048,
+        "num_attention_heads": 16,
+        "num_hidden_layers": 40,
+        "num_key_value_heads": 2,
+        "head_dim": 256
+    },
+    "Qwen/Qwen3.5-122B-A10B": {
+        "hidden_size": 3072,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 48,
+        "num_key_value_heads": 2,
+        "head_dim": 256
+    },
+    "Qwen/Qwen3.5-397B-A17B": {
+        "hidden_size": 4096,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 60,
+        "num_key_value_heads": 2,
+        "head_dim": 256
+    },
+    "Qwen/Qwen3.6-35B-A3B": {     
+        "hidden_size": 2048,      
+        "num_attention_heads": 16,
+        "num_hidden_layers": 40,
+        "num_key_value_heads": 2,
+        "head_dim": 256
     }
 }

--- a/examples/kv_cache_calculator/modelconfig.json
+++ b/examples/kv_cache_calculator/modelconfig.json
@@ -147,48 +147,55 @@
         "num_attention_heads": 16,
         "num_hidden_layers": 32,
         "num_key_value_heads": 4,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     },
     "Qwen/Qwen3.5-9B": {
         "hidden_size": 4096,
         "num_attention_heads": 16,
         "num_hidden_layers": 32,
         "num_key_value_heads": 4,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     },
     "Qwen/Qwen3.5-27B": {
         "hidden_size": 5120,
         "num_attention_heads": 24,
         "num_hidden_layers": 64,
         "num_key_value_heads": 4,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     },
     "Qwen/Qwen3.5-35B-A3B": {
         "hidden_size": 2048,
         "num_attention_heads": 16,
         "num_hidden_layers": 40,
         "num_key_value_heads": 2,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     },
     "Qwen/Qwen3.5-122B-A10B": {
         "hidden_size": 3072,
         "num_attention_heads": 32,
         "num_hidden_layers": 48,
         "num_key_value_heads": 2,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     },
     "Qwen/Qwen3.5-397B-A17B": {
         "hidden_size": 4096,
         "num_attention_heads": 32,
         "num_hidden_layers": 60,
         "num_key_value_heads": 2,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     },
-    "Qwen/Qwen3.6-35B-A3B": {     
-        "hidden_size": 2048,      
+    "Qwen/Qwen3.6-35B-A3B": {
+        "hidden_size": 2048,
         "num_attention_heads": 16,
         "num_hidden_layers": 40,
         "num_key_value_heads": 2,
-        "head_dim": 256
+        "head_dim": 256,
+        "full_attention_interval": 4
     }
 }


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## **What this PR does / why we need it**: 

Optimize the key-value cache calculation of the qwen3.5 model

## **Special notes for your reviewers**: 

Optimize kv cache calculation in the qwen3.5 model.

Specifically, qwen3.5 is a multimodal model, and its config.json file contains `text_config` and `vision_config`. Example：https://huggingface.co/Qwen/Qwen3.5-27B/resolve/main/config.json

```json
"text_config": { "hidden_size": 5120,...}
"vision_config":{...}
````

Therefore, additional processing is required when extracting parameters otherwise the result will be null.

I am a beginner. I learned that the sequence length `L = L=L_{text} ​+ L_{image} ​+ L_{video}`, I'm not sure if the above formula is valid. If it does, the KV cache calculation should be correct. If that's not correct, perhaps I could add the following to the website: Calculate only text.

The results in `modelconfig.json` are all calculated by the new `generate_config.py` .

Thank you for your review!

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the `examples/kv_cache_calculator` tooling and model metadata, with the main risk being incorrect KV size estimates for Qwen3.x if the interval logic or config values are wrong.
> 
> **Overview**
> Updates the KV cache calculator to properly handle Qwen3.x multimodal configs by extracting `text_config` via `config.get_text_config()` when available and by treating any `qwen/qwen3*` model consistently.
> 
> Adds support for Qwen3.5/Qwen3.6 entries in `modelconfig.json`, including optional `full_attention_interval`, and updates the HTML calculator to incorporate this interval (using an “effective KV layers” count) in both the size computation and the displayed calculation steps; GLM-4 handling is kept separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40329773effba46eecbdc4898ee08999e29e8a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->