### PR TITLE
[CLI][fix] lazy torch import in __init__.py to unblock CLI-only installs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,6 +171,12 @@ jobs:
                 cp pyproject_cli.toml pyproject.toml
                 NO_CUDA_EXT=1 python -m build --wheel
 
+            - name: Smoke-test CLI wheel (no torch)
+              run: |
+                pip install dist/lmcache_cli-*.whl
+                python -c "import lmcache"
+                lmcache --help
+
             - name: Upload CLI release artifacts to GHA
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -74,4 +74,4 @@ try:
     _ops = _get_backend()
     sys.modules["lmcache.c_ops"] = _ops
 except (ImportError, ModuleNotFoundError):
-    pass  # torch not installed; CLI-only usage does not need CUDA ops
+    logger.debug("No compute backend loaded; CLI-only mode (torch/numba not installed)")

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -5,9 +5,6 @@ from typing import Any
 import importlib
 import sys
 
-# Third Party
-import torch
-
 # First Party
 from lmcache.logging import init_logger
 
@@ -21,6 +18,9 @@ def _get_backend() -> Any:
     """
     Try backends in order, first successful import wins.
     """
+    # Third Party
+    import torch
+
     backend_candidates = [
         (
             "lmcache.c_ops",
@@ -70,6 +70,8 @@ def _get_backend() -> Any:
 # --------------------------
 # Backend instance
 # --------------------------
-_ops = _get_backend()
-
-sys.modules["lmcache.c_ops"] = _ops
+try:
+    _ops = _get_backend()
+    sys.modules["lmcache.c_ops"] = _ops
+except (ImportError, ModuleNotFoundError):
+    pass  # torch not installed; CLI-only usage does not need CUDA ops

--- a/lmcache/cli/commands/tool/cache_simulator.py
+++ b/lmcache/cli/commands/tool/cache_simulator.py
@@ -28,13 +28,17 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     Args:
         subparsers: The subparsers action from the ``lmcache tool`` parser.
     """
-    # Lazy imports — keeps CLI startup fast (avoids loading matplotlib)
-    # First Party
-    from lmcache.tools.cache_simulator.gen_bench_dataset import (
-        add_gen_dataset_arguments,
-    )
-    from lmcache.tools.cache_simulator.plot_hit_rate import add_sweep_arguments
-    from lmcache.tools.cache_simulator.simulator import add_simulate_arguments
+    # Lazy imports — keeps CLI startup fast and makes cache-simulator optional.
+    # Missing sortedcontainers/matplotlib (plot extra) skips the subcommand.
+    try:
+        # First Party
+        from lmcache.tools.cache_simulator.gen_bench_dataset import (
+            add_gen_dataset_arguments,
+        )
+        from lmcache.tools.cache_simulator.plot_hit_rate import add_sweep_arguments
+        from lmcache.tools.cache_simulator.simulator import add_simulate_arguments
+    except ImportError:
+        return
 
     cs_parser = subparsers.add_parser(
         "cache-simulator",


### PR DESCRIPTION
lmcache/__init__.py imported torch at the top level, causing any import of a lmcache subpackage — including lmcache.cli — to
  unconditionally require torch. This broke the lightweight lmcache-cli wheel, which ships without torch.

  Changes

  - Move import torch inside _get_backend() so it only loads when a CUDA backend is being selected.
  - Wrap the _get_backend() call in try/except ImportError so CLI-only environments (no torch/numba) import cleanly; the compute
  backend is simply skipped.
  - Make the cache-simulator subcommand optional: skip registration if its extra dependencies (sortedcontainers, matplotlib) aren't
  installed.
  - Add a CI smoke test that installs the CLI wheel without torch and verifies import lmcache and lmcache --help succeed.