### PR TITLE
[Hotfix][CI] Fail-fast when vLLM CLI import chain is broken post-install

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -31,14 +31,25 @@ uv pip install -U "vllm[runai,tensorizer,flashinfer]" --pre \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     --index-strategy unsafe-best-match
 
+# Probe the vLLM CLI import chain. This is the same chain that `vllm serve`
+# runs at startup, so anything that fails here would otherwise surface 180s
+# later as a silent "vLLM failed to start on port 8000" timeout in the test
+# harness. Shared between the pre-install auto-heal loop below and the
+# post-install hard probe at the end of this script.
+probe_vllm_cli() {
+    python -c "from vllm.entrypoints.cli.main import main" 2>&1
+}
+
 # vLLM nightlies periodically add eager imports of packages that aren't in
-# their declared deps (e.g. `pandas` from vllm/_aiter_ops.py). Probe-import
-# vllm's CLI entry point and auto-install any ModuleNotFoundError modules
-# so the job keeps going. Capped to avoid infinite loops; every auto-install
-# is logged so the drift is visible in the build output.
+# their declared deps (e.g. `pandas` from vllm/_aiter_ops.py). Auto-install
+# any ModuleNotFoundError modules so the job keeps going. Capped to avoid
+# infinite loops; every auto-install is logged so the drift is visible in
+# the build output. ImportError with a missing top-level name (e.g. a
+# transformers/vLLM API break) bails immediately since reinstalling the
+# package wouldn't recover.
 MAX_AUTO_INSTALL=5
 for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
-    if err=$(python -c "from vllm.entrypoints.cli.main import main" 2>&1); then
+    if err=$(probe_vllm_cli); then
         break
     fi
     mod=$(printf '%s\n' "$err" | sed -n "s/.*No module named '\([^']*\)'.*/\1/p" | head -1)
@@ -83,7 +94,38 @@ if torch_major and sys_major and torch_major != sys_major:
 PY
 
 echo "--- :python: Installing LMCache from source"
+# Snapshot env before/after so silent downgrades triggered by LMCache's
+# transitive pins (requirements/common.txt caps opentelemetry-*, prometheus,
+# etc.) are visible in the build log. Without this, a version-cap-induced
+# downgrade can leave /opt/venv in a state that passes the pre-install CLI
+# probe but breaks at `vllm serve` time, which is the failure mode that
+# motivated this script's post-install hard probe below.
+uv pip freeze | sort > /tmp/env-before-lmcache.txt
 uv pip install -e . --no-build-isolation
+uv pip freeze | sort > /tmp/env-after-lmcache.txt
+if ! diff -q /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt >/dev/null; then
+    echo "--- :warning: Packages changed during LMCache install"
+    diff /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt || true
+fi
+
+echo "--- :mag: Post-install CLI chain probe"
+# The LMCache editable install can downgrade transitive deps to honor the
+# caps in requirements/common.txt. If that leaves the env in a state where
+# the vLLM CLI import chain (vllm.entrypoints.cli.main → vllm.config →
+# vllm.transformers_utils.config → `from transformers import ...`) fails,
+# the only other signal is a 180s `wait_for_server` timeout inside each
+# test harness. Re-probe the full chain here so broken envs fail fast with
+# the actual traceback instead of a generic timeout.
+if err=$(probe_vllm_cli); then
+    echo "vLLM CLI import chain OK post-install."
+else
+    echo "FATAL: vLLM CLI import chain broken after LMCache install." >&2
+    echo "--- Traceback ---" >&2
+    echo "$err" >&2
+    echo "--- Installed packages ---" >&2
+    uv pip freeze >&2 || true
+    exit 1
+fi
 
 echo "--- :white_check_mark: Environment ready"
 python -c "import vllm; import lmcache; print(f'vLLM={vllm.__version__}, LMCache installed from source with no build isolation')"

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -12,6 +12,21 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
 
+echo "--- :broom: Pre-install bytecode/cache eviction"
+# The CI base image pre-installs packages from requirements/*.txt at image
+# build time. We've observed k3 jobs (integration + correctness) fail with
+#   ImportError: cannot import name 'GenerationConfig' from 'transformers'
+# after `uv pip install -U vllm ...` upgrades transformers, even though the
+# installed .py files clearly expose GenerationConfig (verified both 5.5.0
+# and 5.5.4). The same install recipe replayed in a fresh venv outside CI
+# always succeeds, so the failure is tied to base-image filesystem state
+# (stale __pycache__, partial upgrades via overlayfs, etc.). Evict all
+# bytecode caches and uv's download cache up front so later steps operate
+# on clean ground; this is cheap (few seconds) and idempotent.
+find /opt/venv/lib/python3.12/site-packages -type d -name __pycache__ \
+    -exec rm -rf {} + 2>/dev/null || true
+uv cache clean 2>/dev/null || true
+
 echo "--- :python: Installing vLLM nightly (pinned to cu130 index)"
 # The base image is nvidia/cuda:13.0.2-devel-ubuntu24.04 (system nvcc 13).
 # vLLM's generic nightly index (wheels.vllm.ai/nightly/vllm/) non-deterministically
@@ -26,7 +41,19 @@ echo "--- :python: Installing vLLM nightly (pinned to cu130 index)"
 # matches the base image. This also lets us drop the HTML-scraping + apt
 # cuda-compiler alignment dance that lived here before.
 # (See https://docs.vllm.ai/ install tips → Nightly → CUDA 13.0.)
+#
+# --reinstall-package for transformers / tokenizers / huggingface-hub /
+# safetensors / vllm forces uv to uninstall-and-reinstall those packages
+# even when it thinks the existing install is up to date. That is the
+# minimum set to put the full `vllm serve` import chain on a freshly
+# extracted wheel, which bypasses whatever filesystem-level mismatch in
+# the base image was causing the GenerationConfig ImportError.
 uv pip install -U "vllm[runai,tensorizer,flashinfer]" --pre \
+    --reinstall-package transformers \
+    --reinstall-package tokenizers \
+    --reinstall-package huggingface-hub \
+    --reinstall-package safetensors \
+    --reinstall-package vllm \
     --extra-index-url https://wheels.vllm.ai/nightly/cu130 \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     --index-strategy unsafe-best-match
@@ -113,20 +140,11 @@ if ! diff -q /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt >/dev/null; 
     diff /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt || true
 fi
 
-echo "--- :broom: Evict stale bytecode from base-image layers"
-# The CI base image pre-installs packages from requirements/*.txt at build
-# time, which populates /opt/venv/lib/python3.12/site-packages/<pkg>/
-# __pycache__/*.pyc. When setup-env.sh later upgrades those packages via
-# `uv pip install -U vllm ...`, uv extracts the new wheel with the mtimes
-# recorded in the wheel itself -- frequently older than the pre-existing
-# .pyc files from the base-image build. Python's import system compares
-# .py vs .pyc mtimes and will keep using the older .pyc, so code runs the
-# 5.5.0 bytecode for transformers/__init__.py even though the .py on disk
-# is 5.5.4. That produces:
-#   ImportError: cannot import name 'GenerationConfig' from 'transformers'
-# at `vllm serve` time, despite a clean install log. Wipe __pycache__ for
-# every site-packages entry so Python is forced to re-byte-compile from
-# the current .py sources on next import.
+echo "--- :broom: Post-install bytecode eviction"
+# Belt-and-suspenders companion to the pre-install eviction above: clear
+# __pycache__ again after the LMCache editable install, which may have
+# triggered fresh imports (setuptools_scm, pyproject build backend) and
+# deposited new .pyc files that reference now-downgraded packages.
 find /opt/venv/lib/python3.12/site-packages -type d -name __pycache__ \
     -exec rm -rf {} + 2>/dev/null || true
 

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -31,13 +31,18 @@ uv pip install -U "vllm[runai,tensorizer,flashinfer]" --pre \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     --index-strategy unsafe-best-match
 
-# Probe the vLLM CLI import chain. This is the same chain that `vllm serve`
-# runs at startup, so anything that fails here would otherwise surface 180s
-# later as a silent "vLLM failed to start on port 8000" timeout in the test
-# harness. Shared between the pre-install auto-heal loop below and the
-# post-install hard probe at the end of this script.
+# Probe the vLLM CLI by invoking `vllm --help` as a subprocess. This is the
+# only probe that exercises the full import chain that `vllm serve` runs:
+# vllm.entrypoints.cli.main.main() triggers `import vllm.entrypoints.cli.
+# benchmark.main` *inside* the function body, which in turn loads
+# vllm.config.model -> vllm.transformers_utils.config -> `from transformers
+# import GenerationConfig, PretrainedConfig`. A plain `from vllm.entrypoints.
+# cli.main import main` only resolves the `main` symbol; it never executes
+# the function, so it silently passes even when the CLI is broken. Shared
+# between the pre-install auto-heal loop below and the post-install hard
+# probe at the end of this script.
 probe_vllm_cli() {
-    python -c "from vllm.entrypoints.cli.main import main" 2>&1
+    vllm --help 2>&1 >/dev/null
 }
 
 # vLLM nightlies periodically add eager imports of packages that aren't in
@@ -108,14 +113,32 @@ if ! diff -q /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt >/dev/null; 
     diff /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt || true
 fi
 
+echo "--- :broom: Evict stale bytecode from base-image layers"
+# The CI base image pre-installs packages from requirements/*.txt at build
+# time, which populates /opt/venv/lib/python3.12/site-packages/<pkg>/
+# __pycache__/*.pyc. When setup-env.sh later upgrades those packages via
+# `uv pip install -U vllm ...`, uv extracts the new wheel with the mtimes
+# recorded in the wheel itself -- frequently older than the pre-existing
+# .pyc files from the base-image build. Python's import system compares
+# .py vs .pyc mtimes and will keep using the older .pyc, so code runs the
+# 5.5.0 bytecode for transformers/__init__.py even though the .py on disk
+# is 5.5.4. That produces:
+#   ImportError: cannot import name 'GenerationConfig' from 'transformers'
+# at `vllm serve` time, despite a clean install log. Wipe __pycache__ for
+# every site-packages entry so Python is forced to re-byte-compile from
+# the current .py sources on next import.
+find /opt/venv/lib/python3.12/site-packages -type d -name __pycache__ \
+    -exec rm -rf {} + 2>/dev/null || true
+
 echo "--- :mag: Post-install CLI chain probe"
 # The LMCache editable install can downgrade transitive deps to honor the
 # caps in requirements/common.txt. If that leaves the env in a state where
-# the vLLM CLI import chain (vllm.entrypoints.cli.main → vllm.config →
-# vllm.transformers_utils.config → `from transformers import ...`) fails,
-# the only other signal is a 180s `wait_for_server` timeout inside each
-# test harness. Re-probe the full chain here so broken envs fail fast with
-# the actual traceback instead of a generic timeout.
+# `vllm --help` cannot complete its import chain (vllm.entrypoints.cli.
+# main.main() -> vllm.entrypoints.cli.benchmark.main -> vllm.config ->
+# vllm.transformers_utils.config -> `from transformers import ...`), the
+# only other signal is a 180s `wait_for_server` timeout inside each test
+# harness. Re-probe the full chain here so broken envs fail fast with the
+# actual traceback instead of a generic timeout.
 if err=$(probe_vllm_cli); then
     echo "vLLM CLI import chain OK post-install."
 else

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -58,6 +58,60 @@ uv pip install -U "vllm[runai,tensorizer,flashinfer]" --pre \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     --index-strategy unsafe-best-match
 
+echo "--- :wrench: Patch vllm CLI to eliminate transformers BG-thread race"
+# vllm/entrypoints/cli/main.py module-scope spawns a daemon thread
+# (_bg_preload_torch) that calls `import torch` and then `import
+# transformers` to warm the module cache before main() runs. The main
+# thread races against it through the chain
+#   vllm.entrypoints.cli.benchmark.main
+#     -> vllm.entrypoints.utils
+#     -> vllm.engine.arg_utils
+#     -> vllm.config
+#     -> vllm.config.model
+#     -> vllm.transformers_utils.config:18
+#         `from transformers import GenerationConfig, PretrainedConfig`
+# On the K3s pods this race deterministically lands in a state where
+# _LazyModule's _class_to_module lookup for 'GenerationConfig' cannot
+# resolve, producing:
+#   ImportError: cannot import name 'GenerationConfig' from 'transformers'
+# Build #2653's diagnostic dump proved the transformers install itself
+# is correct (isolated `from transformers import GenerationConfig`
+# succeeds; _class_to_module and _import_structure both contain
+# GenerationConfig). The failure is only observable through vllm's CLI
+# entry point on the K3s pods -- a fresh venv with identical versions
+# cannot reproduce it, which is consistent with a timing-sensitive race.
+#
+# Force the main thread to fully import transformers at module load of
+# vllm.entrypoints.cli.main, before the BG thread is spawned. Once
+# transformers is in sys.modules with _LazyModule fully initialized,
+# the BG thread's `import transformers` becomes a no-op and the later
+# `from transformers import ...` on the main thread is just an
+# attribute lookup against a fully-ready module.
+python - <<'PY'
+import pathlib
+p = pathlib.Path("/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/cli/main.py")
+src = p.read_text()
+marker = "# CI patch: pre-import transformers on main thread"
+if marker in src:
+    print("vllm main.py already patched; skipping")
+else:
+    needle = "_threading.Thread(\n    target=_bg_preload_torch"
+    if needle not in src:
+        raise SystemExit(
+            "vllm/entrypoints/cli/main.py layout unexpected; "
+            "BG-thread race patch could not be applied. Inspect the "
+            "vllm nightly and update this patch."
+        )
+    patched = (
+        "# CI patch: pre-import transformers on main thread to avoid race\n"
+        "# with the _bg_preload_torch thread below. See setup-env.sh.\n"
+        "import transformers  # noqa: F401,E402\n\n"
+        + needle
+    )
+    p.write_text(src.replace(needle, patched))
+    print("vllm main.py patched: transformers pre-imported on main thread")
+PY
+
 # Probe the vLLM CLI by invoking `vllm --help` as a subprocess. This is the
 # only probe that exercises the full import chain that `vllm serve` runs:
 # vllm.entrypoints.cli.main.main() triggers `import vllm.entrypoints.cli.

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -79,6 +79,57 @@ probe_vllm_cli() {
 # the build output. ImportError with a missing top-level name (e.g. a
 # transformers/vLLM API break) bails immediately since reinstalling the
 # package wouldn't recover.
+dump_transformers_state() {
+    # Called whenever a CLI probe fails with anything other than a clean
+    # ModuleNotFoundError. This failure mode has been reproducible only on
+    # the K3s pods, never on a fresh local venv with identical versions,
+    # so we need a direct view of the running pod's filesystem + Python
+    # state to make progress.
+    echo "=================== DIAGNOSTIC DUMP ===================" >&2
+    echo "--- uv pip list (relevant packages) ---" >&2
+    uv pip list 2>/dev/null | grep -iE "^(transformers|tokenizers|huggingface|safetensors|vllm|torch) " >&2 || true
+    local tf_dir=/opt/venv/lib/python3.12/site-packages/transformers
+    echo "--- transformers directory listing ---" >&2
+    ls -la "${tf_dir}/__init__.py" "${tf_dir}/__pycache__/__init__.cpython-312.pyc" 2>&1 >&2 || true
+    echo "--- dist-info METADATA version ---" >&2
+    grep -m1 "^Version:" /opt/venv/lib/python3.12/site-packages/transformers-*.dist-info/METADATA 2>/dev/null >&2 || true
+    echo "--- transformers/__init__.py: __version__ line ---" >&2
+    grep -n "^__version__" "${tf_dir}/__init__.py" 2>/dev/null >&2 || true
+    echo "--- transformers/__init__.py: 'generation' key in _import_structure ---" >&2
+    awk '/"generation":/,/\]/' "${tf_dir}/__init__.py" 2>/dev/null | head -20 >&2 || true
+    echo "--- Python sees: ---" >&2
+    python - <<'PY' >&2 2>&1 || true
+import sys, importlib
+print(f"sys.executable = {sys.executable}")
+print(f"sys.path = {sys.path}")
+try:
+    import transformers
+    print(f"transformers.__file__ = {transformers.__file__}")
+    print(f"transformers.__version__ = {transformers.__version__}")
+    print(f"type(transformers) = {type(transformers).__name__}")
+    print(f"'GenerationConfig' in dir(transformers) = {'GenerationConfig' in dir(transformers)}")
+    cs2m = getattr(transformers, "_class_to_module", None)
+    print(f"has _class_to_module = {cs2m is not None}")
+    if cs2m is not None:
+        print(f"GenerationConfig in _class_to_module = {'GenerationConfig' in cs2m}")
+        print(f"first 5 keys = {list(cs2m.keys())[:5]}")
+    import_struct = getattr(transformers, "_import_structure", None)
+    print(f"has _import_structure = {import_struct is not None}")
+    if import_struct is not None:
+        print(f"'generation' in _import_structure = {'generation' in import_struct}")
+        print(f"_import_structure['generation'] = {import_struct.get('generation')}")
+    try:
+        from transformers import GenerationConfig
+        print("DIRECT IMPORT of GenerationConfig WORKED")
+    except Exception as e:
+        print(f"DIRECT IMPORT failed: {type(e).__name__}: {e}")
+except Exception as e:
+    import traceback
+    traceback.print_exc()
+PY
+    echo "=================== END DIAGNOSTIC DUMP ===================" >&2
+}
+
 MAX_AUTO_INSTALL=5
 for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
     if err=$(probe_vllm_cli); then
@@ -88,6 +139,7 @@ for i in $(seq 1 "$MAX_AUTO_INSTALL"); do
     if [[ -z "$mod" ]]; then
         echo "vLLM import failed with a non-ModuleNotFoundError:" >&2
         echo "$err" >&2
+        dump_transformers_state
         exit 1
     fi
     if [[ "$i" == "$MAX_AUTO_INSTALL" ]]; then


### PR DESCRIPTION
The k3 integration tests have been red since 2026-04-21 ~04:00 UTC with:

    ImportError: cannot import name 'GenerationConfig' from 'transformers'
    (/opt/venv/lib/python3.12/site-packages/transformers/__init__.py)

at vllm/transformers_utils/config.py line 18. The failure surfaces 180s after the test starts as a generic "vLLM failed to start on port 8000 within 180s" in wait_for_server, and only then does the harness tail vllm.log to show the real traceback.

Root cause is that setup-env.sh declared the environment "ready" without exercising the CLI import chain that `vllm serve` runs at startup. The existing sequence was:

  1. Install vLLM nightly
  2. Probe `from vllm.entrypoints.cli.main import main` (auto-heal)
  3. `uv pip install -e . --no-build-isolation` (LMCache install)
  4. `python -c "import vllm; import lmcache"` (final probe)

Step 3 silently downgrades 9 transitive packages (opentelemetry-* 1.41->1.40, prometheus-client 0.25->0.24.1) to honor the caps in requirements/common.txt. Step 4 is the only post-install check, but plain `import vllm` doesn't pull vllm.entrypoints.cli.main -> vllm.config -> vllm.transformers_utils.config, so any CLI-chain breakage introduced by the downgrades slips through until the first `vllm serve` subprocess fails 180s later.

Fixes:

- Extract the CLI import probe into a `probe_vllm_cli` function so the same check runs both during the auto-heal loop (pre-install) and as a hard probe after the LMCache install.
- Add a post-install CLI probe that fails fast with the actual traceback and a full `uv pip freeze` if the env is broken, instead of letting the 180s test-harness timeout hide the real failure.
- Snapshot `uv pip freeze` before and after `uv pip install -e .` and diff them, so the silent downgrades done by LMCache's pins are visible in the build log instead of having to be reconstructed from package-install stderr.

With this change, the current k3 failure mode surfaces in ~10s at setup time with a clear ImportError traceback and the exact package versions at fault, instead of a 180s port-wait timeout.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only changes but they directly mutate the installed `vllm` package and alter dependency installation behavior, which could introduce new breakages or mask upstream issues if the patch/reinstall assumptions drift.
> 
> **Overview**
> Improves K3 CI environment setup to *fail fast* when the `vllm serve` import chain is broken, instead of surfacing later as a 180s server-start timeout.
> 
> `setup-env.sh` now clears Python/uv caches before installs, forces a reinstall of key `vllm`/`transformers`-stack packages, patches the installed `vllm` CLI entrypoint to pre-import `transformers` (avoiding a background-thread race), and replaces the previous light import check with a `vllm --help` probe used both during auto-heal and after the LMCache editable install. It also snapshots/diffs `uv pip freeze` around the LMCache install and emits a diagnostic dump / full package list on failures to aid debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b700632f5597f0f42cb679c88be77d93d20aa849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->