### PR TITLE
[Docs] Drift check — sync multi-process docs with EventBus observability

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -38,20 +38,20 @@ All client commands use a `--url` flag pointing to the **LMCache HTTP server**
 ### `lmcache server`
 
 Replaces `python3 -m lmcache.v1.multiprocess.http_server`. Runs in foreground,
-Ctrl-C to stop. HTTP frontend is enabled by default; use `--no-http` to run
-ZMQ-only.
+Ctrl-C to stop. Always starts both the ZMQ server and the HTTP frontend
+(bind the HTTP frontend to a loopback interface via `--http-host 127.0.0.1`
+if the management endpoints should not be externally reachable).
 
 ```bash
 lmcache server \
     --engine-type blend --host 0.0.0.0 --port 5555 \
     --max-gpu-workers 2 \
-    --l1-size-gb 60 --eviction-policy LRU \
-    --no-http  # opt out of HTTP frontend
+    --l1-size-gb 60 --eviction-policy LRU
 ```
 
 Server args are composed from existing helpers: `add_mp_server_args()`,
-`add_storage_manager_args()`, `add_prometheus_args()`, `add_telemetry_args()`,
-`add_http_frontend_args()`.
+`add_storage_manager_args()`, `add_http_frontend_args()`,
+`add_observability_args()`.
 
 ### `lmcache describe`
 

--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -37,7 +37,7 @@ High-Level Architecture
          |--- EvictionController ----> L1Manager (watermark-triggered eviction)
          |
          v
-    PrometheusController + TelemetryController (observability)
+    EventBus --> metrics / logging / tracing subscribers (observability)
 
 Server Variants
 ---------------
@@ -146,8 +146,7 @@ Each config module exposes a composable triple:
     add_mp_server_args(parser)        # from multiprocess/config.py
     add_storage_manager_args(parser)  # from distributed/config.py
       # which internally calls add_l2_adapters_args(parser)
-    add_prometheus_args(parser)       # from mp_observability/config.py
-    add_telemetry_args(parser)        # from mp_observability/telemetry/config.py
+    add_observability_args(parser)    # from mp_observability/config.py
 
 Both ``blend_server_v2.py`` and ``http_server.py`` reuse this pattern, adding
 ``add_http_frontend_args()`` for the HTTP variant.
@@ -285,15 +284,26 @@ RETRIEVE Flow
 Observability Internals
 -----------------------
 
-**PrometheusController** is a global singleton (initialized at server startup).
-It runs a daemon thread that periodically calls ``log_prometheus()`` on all
-registered loggers (``StorageManagerStatsLogger``, ``L1ManagerStatsLogger``).
-Each logger atomically snapshots its stats, resets to zero, and pushes values
-to Prometheus counters.
+Observability is powered by a single **EventBus** (see
+``lmcache/v1/mp_observability/event_bus.py``).  Producers (MPCacheEngine,
+StorageManager, L1Manager, L2 adapters) publish events into a bounded queue
+(sized by ``--event-bus-queue-size``; tail-drops on overflow) and a drain
+thread dispatches each event to every registered subscriber.
 
-**TelemetryController** is also a global singleton.  It maintains an in-memory
-event queue (bounded by ``--telemetry-max-queue-size``).  A drain thread reads
-events and dispatches them to registered processors (e.g., ``LoggingProcessor``).
+Subscribers are registered at startup by
+:func:`lmcache.v1.mp_observability.config.init_observability` based on the
+observability flags:
+
+- **Metrics subscribers** (``--disable-metrics`` to skip) export OTel counters
+  and histograms.  When ``--otlp-endpoint`` is unset, metrics are exposed via
+  an in-process Prometheus ``/metrics`` endpoint on ``--prometheus-port``.
+  Histogram events are sampled at ``--metrics-sample-rate`` (default 1%).
+- **Logging subscribers** (``--disable-logging`` to skip) forward events to
+  the Python ``logging`` module.
+- **Tracing subscribers** (``--enable-tracing`` with ``--otlp-endpoint``)
+  export OTel spans for per-request latency analysis.
+- **Trace recorder** (``--trace-level storage``) writes a binary trace file
+  of ``StorageManager`` public-API calls for offline replay.
 
 How to Extend
 -------------
@@ -309,16 +319,19 @@ Adding a new L2 adapter
 4. Add an ``isinstance()`` branch in ``create_l2_adapter()``
    (``l2_adapters/__init__.py``).
 
-Adding a telemetry processor
+Adding an EventBus subscriber
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Create a config class subclassing ``TelemetryProcessorConfig`` with
-   ``from_dict()`` and ``help()`` methods.
-2. Call ``register_telemetry_processor_type("my_proc", MyProcConfig)`` at
-   module level.
-3. Create a processor class implementing ``TelemetryProcessor``
-   (``on_new_event()``, ``shutdown()``).
-4. Add a factory branch in the telemetry controller's processor creation code.
+1. Create a subscriber class in
+   ``lmcache/v1/mp_observability/subscribers/`` that implements the
+   ``EventSubscriber`` protocol (``on_event()``, optional ``shutdown()``).
+2. Register the subscriber from
+   :func:`lmcache.v1.mp_observability.config.init_observability` under the
+   relevant group (metrics / logging / tracing), guarded by the appropriate
+   config flag.
+3. If the subscriber needs new CLI options, extend
+   :func:`lmcache.v1.mp_observability.config.add_observability_args` and
+   :class:`lmcache.v1.mp_observability.config.ObservabilityConfig`.
 
 Adding a new request type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -365,10 +378,10 @@ Key Source Files
    * - ``lmcache/v1/distributed/storage_controllers/prefetch_controller.py``
      - PrefetchController (L2->L1 on miss)
    * - ``lmcache/v1/mp_observability/config.py``
-     - PrometheusConfig
-   * - ``lmcache/v1/mp_observability/prometheus_controller.py``
-     - PrometheusController singleton
-   * - ``lmcache/v1/mp_observability/telemetry/config.py``
-     - TelemetryConfig
-   * - ``lmcache/v1/mp_observability/telemetry/controller.py``
-     - TelemetryController singleton
+     - ObservabilityConfig + ``init_observability()``
+   * - ``lmcache/v1/mp_observability/event_bus.py``
+     - EventBus (producer/subscriber fan-out)
+   * - ``lmcache/v1/mp_observability/otel_init.py``
+     - OTel meter/tracer provider setup and Prometheus fallback
+   * - ``lmcache/v1/mp_observability/subscribers/``
+     - Built-in metrics, logging, and tracing subscribers

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -337,6 +337,19 @@ logging, tracing).
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` endpoint.
+   * - ``--metrics-sample-rate``
+     - ``0.01``
+     - Fraction of chunks/blocks to track for lifecycle histograms
+       (0, 1.0]. Counters always count all events.
+   * - ``--trace-level``
+     - *(none)*
+     - Enable trace recording at the given level. Currently only
+       ``storage`` is supported (records ``StorageManager`` public-API
+       calls for offline replay). See :doc:`observability` for details.
+   * - ``--trace-output``
+     - *(none)*
+     - Path to write the trace file. If omitted while ``--trace-level``
+       is set, a timestamped file under ``$TMPDIR`` is minted.
 
 vLLM Client Configuration
 --------------------------
@@ -397,6 +410,5 @@ Full Example
         --l2-prefetch-max-in-flight 8 \
         --l2-adapter '{"type": "nixl_store", "backend": "POSIX", "backend_params": {"file_path": "/data/lmcache/l2", "use_direct_io": "false"}, "pool_size": 64}' \
         --prometheus-port 9090 \
-        --prometheus-log-interval 10 \
-        --enable-telemetry \
-        --telemetry-processor '{"type": "logging", "log_level": "DEBUG"}'
+        --metrics-sample-rate 0.01 \
+        --enable-tracing --otlp-endpoint http://localhost:4317


### PR DESCRIPTION
The daily docs drift check found the MP docs still reference the old PrometheusController / TelemetryController observability pipeline that was replaced by the unified EventBus + subscribers stack.

Fixes in docs/source/mp/ (user-facing):

- configuration.rst: add missing observability flags --metrics-sample-rate, --trace-level, --trace-output; drop the removed --prometheus-log-interval, --enable-telemetry, --telemetry-processor from the Full Example.
- architecture.rst: replace PrometheusController / TelemetryController references (high-level diagram, config composition snippet, Observability Internals section, Key Source Files table) with EventBus + subscribers, and rewrite "Adding a telemetry processor" as "Adding an EventBus subscriber" to match lmcache/v1/mp_observability/.

Fixes in docs/design/cli/commands.md:

- Drop the non-existent --no-http flag from the lmcache server example (the server command always starts both ZMQ and HTTP; bind --http-host to loopback to scope the HTTP frontend).
- Update the server-arg composition list to add_observability_args().

Auto-generated by the daily drift-check routine; needs human review before merge. Docs only — no code changes.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to reflect the current EventBus-based observability flags and server behavior; no runtime code changes.
> 
> **Overview**
> Updates multiprocess documentation to match the newer **EventBus + subscribers** observability stack, replacing references to `PrometheusController`/`TelemetryController`, updating the config composition snippet to `add_observability_args()`, and revising the extension guide to “Adding an EventBus subscriber”.
> 
> Refreshes the configuration reference and example commands to include new observability flags (`--metrics-sample-rate`, `--trace-level`, `--trace-output`) and remove deprecated ones, and fixes the CLI design doc to clarify `lmcache server` always starts both ZMQ and HTTP (dropping the non-existent `--no-http` example and recommending `--http-host 127.0.0.1` for scoping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac92dbcb6f2a43107ea5eb44b08a76b5ca36641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->