### PR TITLE
[Fix][CI] fix nightly wheel versioning and build reliability

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -3,6 +3,7 @@ name: Build nightly container image of latest code
 on:
   schedule:
     - cron: '30 7 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -41,6 +42,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Remove non-release tags
+        run: git tag -l | grep -v '^v' | xargs -r git tag -d
+
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
@@ -61,15 +65,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install cibuildwheel
 
-      - name: Compute nightly version string
-        run: |
-          BASE=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
-          NOW=$(date +'%Y%m%d')
-          echo "NIGHTLY_VERSION=${BASE}.dev${NOW}" >> "$GITHUB_ENV"
-
       - name: Build cu12.9 nightly wheel
         env:
-          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.NIGHTLY_VERSION }}'
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1'
           CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
         run: |
           python -m cibuildwheel --output-dir dist/cu129
@@ -78,8 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release delete nightly --yes --repo ${{ github.repository }} 2>/dev/null || true
-          git push origin :refs/tags/nightly 2>/dev/null || true
+          gh release delete nightly --yes --cleanup-tag --repo ${{ github.repository }} 2>/dev/null || true
           gh release create nightly \
             --repo ${{ github.repository }} \
             --title "Nightly $(date +'%Y-%m-%d') · CUDA 12.9" \
@@ -97,7 +94,7 @@ jobs:
       - name: Build cu13.0 nightly wheel
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
-          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.NIGHTLY_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
             auditwheel repair
             --plat manylinux_2_28_x86_64
@@ -117,8 +114,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release delete nightly-cu13 --yes --repo ${{ github.repository }} 2>/dev/null || true
-          git push origin :refs/tags/nightly-cu13 2>/dev/null || true
+          gh release delete nightly-cu13 --yes --cleanup-tag --repo ${{ github.repository }} 2>/dev/null || true
           gh release create nightly-cu13 \
             --repo ${{ github.repository }} \
             --title "Nightly $(date +'%Y-%m-%d') · CUDA 13.0" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,9 @@ jobs:
                 # for setuptools-scm
                 fetch-depth: 0
 
+            - name: Remove non-release tags
+              run: git tag -l | grep -v '^v' | xargs -r git tag -d
+
             - name: Free disk space
               uses: ./.github/actions/free-disk-space
 
@@ -153,6 +156,9 @@ jobs:
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
               with:
                 fetch-depth: 0
+
+            - name: Remove non-release tags
+              run: git tag -l | grep -v '^v' | xargs -r git tag -d
 
             - name: Setup Python 3.13
               uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
@@ -220,6 +226,9 @@ jobs:
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
               with:
                 fetch-depth: 0
+
+            - name: Remove non-release tags
+              run: git tag -l | grep -v '^v' | xargs -r git tag -d
 
             - name: Login to DockerHub
               if: vars.DOCKERHUB_USERNAME != ''


### PR DESCRIPTION
  The nightly version (`0.4.3.dev20260421`) was less than stable (`0.4.3`)
  in PEP 440, so pip always resolved the stable PyPI release instead of
  the nightly wheel.

  - Remove `SETUPTOOLS_SCM_PRETEND_VERSION` — setuptools-scm now derives
    `0.4.4.devN` from git history, correctly higher than stable `0.4.3`
  - Strip non-`v*` tags after checkout — tags like `nightly-cu13` contain
    digits and match setuptools-scm's default `*[0-9]*` pattern, causing
    an `AssertionError` during version parsing
  - Replace `git push origin :refs/tags/<tag>` with `gh release delete
    --cleanup-tag` — deletes tags via API, no dependency on `origin`
  - Add `workflow_dispatch` for manual nightly triggers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflows and release-tag handling; main risk is accidentally deleting or mis-naming Git tags/releases in automation.
> 
> **Overview**
> Improves nightly wheel publishing reliability by adding `workflow_dispatch`, stripping non-`v*` tags after checkout to avoid `setuptools-scm` version parsing failures, and relying on `setuptools-scm`-derived versions (removes `SETUPTOOLS_SCM_PRETEND_VERSION` and the custom nightly version computation).
> 
> Simplifies nightly release cleanup by switching to `gh release delete --cleanup-tag` instead of manual tag deletion via `git push`, and applies the non-release tag cleanup step to `publish.yml` build jobs as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65da8db61a63be28bdd94a7f23d542afdb959634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->