### PR TITLE
[MP] Add L0<->L1 throughput metrics (store/load GB/s)

### DIFF
--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -74,10 +74,10 @@ to correlate START/END pairs.
 
 | EventType | Metadata keys | Types |
 |---|---|---|
-| `MP_STORE_START` | `device` | `str` |
-| `MP_STORE_END` | `device`, `stored_count` | `str`, `int` |
-| `MP_RETRIEVE_START` | `device` | `str` |
-| `MP_RETRIEVE_END` | `device`, `retrieved_count` | `str`, `int` |
+| `MP_STORE_START` | `device`, `engine_id`, `gpu_id` | `str`, `int`, `int` |
+| `MP_STORE_END` | `device`, `stored_count`, `engine_id`, `gpu_id`, `total_bytes` | `str`, `int`, `int`, `int`, `int` |
+| `MP_RETRIEVE_START` | `device`, `engine_id`, `gpu_id` | `str`, `int`, `int` |
+| `MP_RETRIEVE_END` | `device`, `retrieved_count`, `engine_id`, `gpu_id`, `total_bytes` | `str`, `int`, `int`, `int`, `int` |
 | `MP_LOOKUP_PREFETCH_START` | *(none)* | — |
 | `MP_LOOKUP_PREFETCH_END` | `found_count` | `int` |
 | `MP_LOOKUP` | `request_id`, `chunk_hashes`, `model_name`, `chunk_size`, `seq_len`, `dtypes`, `shapes` | `str`, `list[str]`, `str`, `int`, `int`, `list[str]`, `list[list[int]]` |

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -164,10 +164,10 @@ pairs by `session_id`, computes `total_bytes / (end_ts - start_ts)` in GB/s.
 START/END events fire on the GPU cupy stream (`publish_on_stream`), so
 timestamps reflect true GPU-stream copy time — not Python/lock overhead.
 
-All throughput histograms carry `engine_id` (vLLM worker instance id) and
-`gpu_id` OTel attributes, enabling per-worker and per-GPU slicing in
-Prometheus (e.g.
-`lmcache_mp_l0_l1_store_throughput_gbs{engine_id="0",gpu_id="3"}`).
+All throughput histograms carry `engine_id` (vLLM worker instance id),
+`device` (e.g. `"cuda:3"`), and `model_name` OTel attributes, enabling
+per-worker, per-device, and per-model slicing in Prometheus (e.g.
+`lmcache_mp_l0_l1_store_throughput_gbs{engine_id="0",device="cuda:3",model_name="meta-llama/Llama-3.1-8B"}`).
 
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -156,6 +156,30 @@ per-instance and per-model Prometheus metric slicing (e.g.
 
 ---
 
+## L0 ↔ L1 Throughput Histograms
+
+Sampled (default 1%) per-request throughput of GPU↔CPU copies via
+`L0L1ThroughputSubscriber`. Correlates `MP_{STORE,RETRIEVE}_START` → `MP_{STORE,RETRIEVE}_END`
+pairs by `session_id`, computes `total_bytes / (end_ts - start_ts)` in GB/s.
+START/END events fire on the GPU cupy stream (`publish_on_stream`), so
+timestamps reflect true GPU-stream copy time — not Python/lock overhead.
+
+All throughput histograms carry `engine_id` (vLLM worker instance id) and
+`gpu_id` OTel attributes, enabling per-worker and per-GPU slicing in
+Prometheus (e.g.
+`lmcache_mp_l0_l1_store_throughput_gbs{engine_id="0",gpu_id="3"}`).
+
+| OTel metric name | Prometheus name | Type | Source event | Calculation |
+|---|---|---|---|---|
+| `lmcache_mp.l0_l1_store_throughput_gbs` | `lmcache_mp_l0_l1_store_throughput_gbs` | Histogram | `MP_STORE_START` → `MP_STORE_END` | `total_bytes / (end_ts - start_ts) / 1e9` per sampled request |
+| `lmcache_mp.l0_l1_load_throughput_gbs` | `lmcache_mp_l0_l1_load_throughput_gbs` | Histogram | `MP_RETRIEVE_START` → `MP_RETRIEVE_END` | `total_bytes / (end_ts - start_ts) / 1e9` per sampled request |
+
+**What it answers:** What GPU↔CPU throughput is each vLLM worker actually
+achieving for KV store/load? Does it match the theoretical PCIe bandwidth?
+Are some workers or GPUs underperforming?
+
+---
+
 ## MPCacheEngine Observable Gauges
 
 These metrics are registered directly via `register_gauge` (pull-based OTel

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -263,6 +263,35 @@ in Prometheus (e.g.
      - Histogram
      - Time gaps between consecutive accesses of the same GPU block.
 
+L0 ↔ L1 Throughput Histograms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sampled (default 1%) per-request throughput of GPU↔CPU copies via
+``L0L1ThroughputSubscriber``. Each sampled request contributes one sample
+to the appropriate histogram: ``total_bytes / (end_ts - start_ts)`` in
+GB/s. Timestamps come from ``MP_{STORE,RETRIEVE}_{START,END}`` events
+published on the GPU cupy stream, so they reflect true GPU-stream copy
+time — not Python/lock overhead.
+
+All throughput histograms are emitted with ``engine_id`` (vLLM worker
+instance id) and ``gpu_id`` OTel attributes, enabling per-worker and
+per-GPU slicing in Prometheus (e.g.
+``lmcache_mp_l0_l1_store_throughput_gbs{engine_id="0",gpu_id="3"}``).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Metric
+     - Type
+     - Description
+   * - ``lmcache_mp.l0_l1_store_throughput_gbs``
+     - Histogram
+     - GPU→CPU (L0→L1) store throughput in GB/s per sampled request.
+   * - ``lmcache_mp.l0_l1_load_throughput_gbs``
+     - Histogram
+     - CPU→GPU (L1→L0) load throughput in GB/s per sampled request.
+
 Observable Gauges
 ~~~~~~~~~~~~~~~~~
 

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -289,6 +289,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
     if obs_config.metrics_enabled:
         # First Party
         from lmcache.v1.mp_observability.subscribers.metrics import (
+            L0L1ThroughputSubscriber,
             L0LifecycleSubscriber,
             L1LifecycleSubscriber,
             L1MetricsSubscriber,
@@ -300,6 +301,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         bus.register_subscriber(L0LifecycleSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L1MetricsSubscriber())
         bus.register_subscriber(L1LifecycleSubscriber(sample_rate=sample_rate))
+        bus.register_subscriber(L0L1ThroughputSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L2MetricsSubscriber())
         bus.register_subscriber(SMMetricsSubscriber())
 

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # First Party
+from lmcache.v1.mp_observability.subscribers.metrics.l0_l1_throughput import (
+    L0L1ThroughputSubscriber,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.l0_lifecycle import (
     L0LifecycleSubscriber,
 )
@@ -12,6 +15,7 @@ from lmcache.v1.mp_observability.subscribers.metrics.l2 import L2MetricsSubscrib
 from lmcache.v1.mp_observability.subscribers.metrics.sm import SMMetricsSubscriber
 
 __all__ = [
+    "L0L1ThroughputSubscriber",
     "L0LifecycleSubscriber",
     "L1LifecycleSubscriber",
     "L1MetricsSubscriber",

--- a/lmcache/v1/mp_observability/subscribers/metrics/l0_l1_throughput.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l0_l1_throughput.py
@@ -2,14 +2,18 @@
 
 """L0↔L1 throughput metrics subscriber.
 
-Emits two OTel histograms in GB/s, labeled by ``engine_id`` and ``gpu_id``:
+Emits two OTel histograms in GB/s, labeled by ``engine_id``, ``device``,
+and ``model_name``:
   - ``lmcache_mp.l0_l1_store_throughput_gbs``  — GPU→CPU (L0→L1) store
   - ``lmcache_mp.l0_l1_load_throughput_gbs``   — CPU→GPU (L1→L0) load
 
 Implementation:
   - Correlates ``MP_STORE_START`` → ``MP_STORE_END`` and
-    ``MP_RETRIEVE_START`` → ``MP_RETRIEVE_END`` pairs by ``session_id``
-    (= vLLM ``request_id``).
+    ``MP_RETRIEVE_START`` → ``MP_RETRIEVE_END`` pairs by the compound key
+    ``(session_id, device)``.  ``session_id`` alone is not sufficient
+    because one MP server process serves multiple vLLM workers, so TP/PP
+    replicas of the same request fire concurrent START/END pairs on
+    different GPUs.
   - START/END events fire on the GPU cupy stream (``publish_on_stream``),
     so their timestamps reflect true GPU-stream time for the D2H/H2D
     copies — not Python/lock overhead.
@@ -46,11 +50,13 @@ class L0L1ThroughputSubscriber(EventSubscriber):
         )
         self._sample_rate = sample_rate
 
-        # session_id -> t_start. Populated only for sampled sessions.
-        self._pending_store: dict[str, float] = {}
-        self._pending_load: dict[str, float] = {}
+        # (session_id, device) -> t_start. Populated only for sampled
+        # sessions. Compound key avoids collisions when one MP server
+        # handles the same request_id from multiple GPUs (TP/PP).
+        self._pending_store: dict[tuple[str, str], float] = {}
+        self._pending_load: dict[tuple[str, str], float] = {}
 
-        meter = metrics.get_meter("lmcache.l0_l1")
+        meter = metrics.get_meter("lmcache_mp.perf")
         self._store_hist = meter.create_histogram(
             "lmcache_mp.l0_l1_store_throughput_gbs",
             description=(
@@ -85,8 +91,9 @@ class L0L1ThroughputSubscriber(EventSubscriber):
     def _on_store_start(self, event: Event) -> None:
         if random.random() >= self._sample_rate:
             return
-        if event.session_id:
-            self._pending_store[event.session_id] = event.timestamp
+        key = self._correlation_key(event)
+        if key is not None:
+            self._pending_store[key] = event.timestamp
 
     def _on_store_end(self, event: Event) -> None:
         self._record(
@@ -100,8 +107,9 @@ class L0L1ThroughputSubscriber(EventSubscriber):
     def _on_retrieve_start(self, event: Event) -> None:
         if random.random() >= self._sample_rate:
             return
-        if event.session_id:
-            self._pending_load[event.session_id] = event.timestamp
+        key = self._correlation_key(event)
+        if key is not None:
+            self._pending_load[key] = event.timestamp
 
     def _on_retrieve_end(self, event: Event) -> None:
         self._record(
@@ -113,12 +121,28 @@ class L0L1ThroughputSubscriber(EventSubscriber):
     # -- Core computation --------------------------------------------------
 
     @staticmethod
+    def _correlation_key(event: Event) -> tuple[str, str] | None:
+        """Build the ``(session_id, device)`` correlation key.
+
+        Returns ``None`` if either field is missing — such events cannot
+        be paired safely and are dropped.
+        """
+        device = event.metadata.get("device")
+        if not event.session_id or device is None:
+            return None
+        return (event.session_id, str(device))
+
+    @classmethod
     def _record(
+        cls,
         event: Event,
-        pending: dict[str, float],
+        pending: dict[tuple[str, str], float],
         hist: Any,
     ) -> None:
-        t_start = pending.pop(event.session_id, None)
+        key = cls._correlation_key(event)
+        if key is None:
+            return
+        t_start = pending.pop(key, None)
         if t_start is None:
             return  # session wasn't sampled
 
@@ -131,11 +155,11 @@ class L0L1ThroughputSubscriber(EventSubscriber):
             return
 
         engine_id = event.metadata.get("engine_id")
-        gpu_id = event.metadata.get("gpu_id")
-        attrs: dict[str, Any] = {}
+        model_name = event.metadata.get("model_name")
+        attrs: dict[str, Any] = {"device": key[1]}
         if engine_id is not None:
             attrs["engine_id"] = str(engine_id)
-        if gpu_id is not None:
-            attrs["gpu_id"] = str(gpu_id)
+        if model_name is not None:
+            attrs["model_name"] = str(model_name)
 
         hist.record(total_bytes / dt / 1e9, attributes=attrs)

--- a/lmcache/v1/mp_observability/subscribers/metrics/l0_l1_throughput.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l0_l1_throughput.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""L0↔L1 throughput metrics subscriber.
+
+Emits two OTel histograms in GB/s, labeled by ``engine_id`` and ``gpu_id``:
+  - ``lmcache_mp.l0_l1_store_throughput_gbs``  — GPU→CPU (L0→L1) store
+  - ``lmcache_mp.l0_l1_load_throughput_gbs``   — CPU→GPU (L1→L0) load
+
+Implementation:
+  - Correlates ``MP_STORE_START`` → ``MP_STORE_END`` and
+    ``MP_RETRIEVE_START`` → ``MP_RETRIEVE_END`` pairs by ``session_id``
+    (= vLLM ``request_id``).
+  - START/END events fire on the GPU cupy stream (``publish_on_stream``),
+    so their timestamps reflect true GPU-stream time for the D2H/H2D
+    copies — not Python/lock overhead.
+  - Sampling decision made at START time via ``random.random() <
+    sample_rate``.  Unsampled sessions leave zero state.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+import random
+
+# Third Party
+from opentelemetry import metrics
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+
+
+class L0L1ThroughputSubscriber(EventSubscriber):
+    """Records L0↔L1 throughput by correlating MP_*_START→MP_*_END pairs.
+
+    Parameters:
+        sample_rate: Fraction of requests to track (0, 1.0].  Default 0.01
+            (1%), matching other lifecycle subscribers.
+    """
+
+    def __init__(self, sample_rate: float = 0.01) -> None:
+        assert 0 < sample_rate <= 1.0, (
+            f"sample_rate must be in (0, 1.0], got {sample_rate}"
+        )
+        self._sample_rate = sample_rate
+
+        # session_id -> t_start. Populated only for sampled sessions.
+        self._pending_store: dict[str, float] = {}
+        self._pending_load: dict[str, float] = {}
+
+        meter = metrics.get_meter("lmcache.l0_l1")
+        self._store_hist = meter.create_histogram(
+            "lmcache_mp.l0_l1_store_throughput_gbs",
+            description=(
+                "Histogram of L0→L1 (GPU→CPU) store throughput in GB/s, "
+                "measured per request as total_bytes / (end_ts - start_ts) "
+                "on the GPU cupy stream."
+            ),
+            unit="GB/s",
+        )
+        self._load_hist = meter.create_histogram(
+            "lmcache_mp.l0_l1_load_throughput_gbs",
+            description=(
+                "Histogram of L1→L0 (CPU→GPU) load throughput in GB/s, "
+                "measured per request as total_bytes / (end_ts - start_ts) "
+                "on the GPU cupy stream."
+            ),
+            unit="GB/s",
+        )
+
+    # -- EventSubscriber interface -----------------------------------------
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {
+            EventType.MP_STORE_START: self._on_store_start,
+            EventType.MP_STORE_END: self._on_store_end,
+            EventType.MP_RETRIEVE_START: self._on_retrieve_start,
+            EventType.MP_RETRIEVE_END: self._on_retrieve_end,
+        }
+
+    # -- Store path (L0→L1, GPU→CPU) ---------------------------------------
+
+    def _on_store_start(self, event: Event) -> None:
+        if random.random() >= self._sample_rate:
+            return
+        if event.session_id:
+            self._pending_store[event.session_id] = event.timestamp
+
+    def _on_store_end(self, event: Event) -> None:
+        self._record(
+            event=event,
+            pending=self._pending_store,
+            hist=self._store_hist,
+        )
+
+    # -- Retrieve path (L1→L0, CPU→GPU) ------------------------------------
+
+    def _on_retrieve_start(self, event: Event) -> None:
+        if random.random() >= self._sample_rate:
+            return
+        if event.session_id:
+            self._pending_load[event.session_id] = event.timestamp
+
+    def _on_retrieve_end(self, event: Event) -> None:
+        self._record(
+            event=event,
+            pending=self._pending_load,
+            hist=self._load_hist,
+        )
+
+    # -- Core computation --------------------------------------------------
+
+    @staticmethod
+    def _record(
+        event: Event,
+        pending: dict[str, float],
+        hist: Any,
+    ) -> None:
+        t_start = pending.pop(event.session_id, None)
+        if t_start is None:
+            return  # session wasn't sampled
+
+        total_bytes = event.metadata.get("total_bytes", 0)
+        if total_bytes <= 0:
+            return
+
+        dt = event.timestamp - t_start
+        if dt <= 0:
+            return
+
+        engine_id = event.metadata.get("engine_id")
+        gpu_id = event.metadata.get("gpu_id")
+        attrs: dict[str, Any] = {}
+        if engine_id is not None:
+            attrs["engine_id"] = str(engine_id)
+        if gpu_id is not None:
+            attrs["gpu_id"] = str(gpu_id)
+
+        hist.record(total_bytes / dt / 1e9, attributes=attrs)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -319,7 +319,11 @@ class MPCacheEngine:
                 Event(
                     event_type=EventType.MP_STORE_START,
                     session_id=key.request_id,
-                    metadata={"device": str(gpu_context.device)},
+                    metadata={
+                        "device": str(gpu_context.device),
+                        "engine_id": instance_id,
+                        "gpu_id": gpu_context.device.index,
+                    },
                 ),
             )
 
@@ -373,6 +377,7 @@ class MPCacheEngine:
                         self.storage_manager.finish_write,
                         list(reserved_dict.keys()),
                     )
+                total_bytes = sum(mo.get_size() for mo in reserved_dict.values())
                 self._event_bus.publish_on_stream(
                     gpu_context.cupy_stream,
                     Event(
@@ -381,6 +386,9 @@ class MPCacheEngine:
                         metadata={
                             "stored_count": len(reserved_dict),
                             "device": str(gpu_context.device),
+                            "engine_id": instance_id,
+                            "gpu_id": gpu_context.device.index,
+                            "total_bytes": total_bytes,
                         },
                     ),
                 )
@@ -454,7 +462,11 @@ class MPCacheEngine:
             Event(
                 event_type=EventType.MP_RETRIEVE_START,
                 session_id=key.request_id,
-                metadata={"device": str(gpu_context.device)},
+                metadata={
+                    "device": str(gpu_context.device),
+                    "engine_id": instance_id,
+                    "gpu_id": gpu_context.device.index,
+                },
             ),
         )
 
@@ -535,6 +547,7 @@ class MPCacheEngine:
 
             prefetched_keys: list[ObjectKey] = []
             retrieve_succeeded = False
+            total_bytes = 0
             try:
                 with self.storage_manager.read_prefetched_results(
                     obj_keys
@@ -544,6 +557,7 @@ class MPCacheEngine:
                         return event.ipc_handle(), False
 
                     prefetched_keys = obj_keys[: len(memory_objs)]
+                    total_bytes = sum(mo.get_size() for mo in memory_objs)
                     _retrieve_loop(obj_keys, memory_objs)
                 # Only set True when with-block exits normally
                 retrieve_succeeded = True
@@ -565,6 +579,9 @@ class MPCacheEngine:
                         metadata={
                             "retrieved_count": len(prefetched_keys),
                             "device": str(gpu_context.device),
+                            "engine_id": instance_id,
+                            "gpu_id": gpu_context.device.index,
+                            "total_bytes": total_bytes,
                         },
                     ),
                 )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -285,6 +285,7 @@ class MPCacheEngine:
             f"KV cache not registered for GPU ID {instance_id}"
         )
         gpu_context = self.gpu_contexts[instance_id]
+        model_name = self.gpu_context_meta[instance_id][0]
 
         blocks_per_chunk = self.chunk_size // gpu_context.block_size
 
@@ -322,7 +323,7 @@ class MPCacheEngine:
                     metadata={
                         "device": str(gpu_context.device),
                         "engine_id": instance_id,
-                        "gpu_id": gpu_context.device.index,
+                        "model_name": model_name,
                     },
                 ),
             )
@@ -377,7 +378,13 @@ class MPCacheEngine:
                         self.storage_manager.finish_write,
                         list(reserved_dict.keys()),
                     )
-                total_bytes = sum(mo.get_size() for mo in reserved_dict.values())
+                # All reserved MemoryObjs share one layout_desc, so per-object
+                # size is identical — avoid summing N identical values.
+                total_bytes = (
+                    next(iter(reserved_dict.values())).get_size() * len(reserved_dict)
+                    if reserved_dict
+                    else 0
+                )
                 self._event_bus.publish_on_stream(
                     gpu_context.cupy_stream,
                     Event(
@@ -387,7 +394,7 @@ class MPCacheEngine:
                             "stored_count": len(reserved_dict),
                             "device": str(gpu_context.device),
                             "engine_id": instance_id,
-                            "gpu_id": gpu_context.device.index,
+                            "model_name": model_name,
                             "total_bytes": total_bytes,
                         },
                     ),
@@ -445,6 +452,7 @@ class MPCacheEngine:
             f"KV cache not registered for GPU ID {instance_id}"
         )
         gpu_context = self.gpu_contexts[instance_id]
+        model_name = self.gpu_context_meta[instance_id][0]
 
         # CPU-synchronous sentinel: a GPU retrieve is about to be enqueued.
         # Must be published via publish() (not publish_on_stream) so the
@@ -465,7 +473,7 @@ class MPCacheEngine:
                 metadata={
                     "device": str(gpu_context.device),
                     "engine_id": instance_id,
-                    "gpu_id": gpu_context.device.index,
+                    "model_name": model_name,
                 },
             ),
         )
@@ -580,7 +588,7 @@ class MPCacheEngine:
                             "retrieved_count": len(prefetched_keys),
                             "device": str(gpu_context.device),
                             "engine_id": instance_id,
-                            "gpu_id": gpu_context.device.index,
+                            "model_name": model_name,
                             "total_bytes": total_bytes,
                         },
                     ),

--- a/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
@@ -8,8 +8,8 @@ deterministic; the end-to-end test drives through ``EventBus``.
 """
 
 # Standard
-import time
 from unittest.mock import patch
+import time
 
 # Third Party
 import pytest
@@ -141,7 +141,9 @@ class TestStoreThroughput:
 
         # 2 GB in 0.1 s → 20 GB/s
         subscriber._on_store_start(
-            _start_event(EventType.MP_STORE_START, "req-1", 1000.0, engine_id=7, gpu_id=3)
+            _start_event(
+                EventType.MP_STORE_START, "req-1", 1000.0, engine_id=7, gpu_id=3
+            )
         )
         subscriber._on_store_end(
             _end_event(

--- a/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for L0L1ThroughputSubscriber.
+
+Uses ``InMemoryMetricReader`` (via ``otel_setup``) to read back OTel
+histogram values.  Most tests invoke handlers directly to stay
+deterministic; the end-to-end test drives through ``EventBus``.
+"""
+
+# Standard
+import time
+from unittest.mock import patch
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
+from lmcache.v1.mp_observability.subscribers.metrics.l0_l1_throughput import (
+    L0L1ThroughputSubscriber,
+)
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+
+_DRAIN_WAIT = 0.15
+_STORE_METRIC = "lmcache_mp.l0_l1_store_throughput_gbs"
+_LOAD_METRIC = "lmcache_mp.l0_l1_load_throughput_gbs"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _start_event(
+    event_type: EventType,
+    session_id: str,
+    t: float,
+    engine_id: int = 0,
+    gpu_id: int = 0,
+) -> Event:
+    return Event(
+        event_type=event_type,
+        timestamp=t,
+        session_id=session_id,
+        metadata={"engine_id": engine_id, "gpu_id": gpu_id},
+    )
+
+
+def _end_event(
+    event_type: EventType,
+    session_id: str,
+    t: float,
+    total_bytes: int,
+    engine_id: int = 0,
+    gpu_id: int = 0,
+) -> Event:
+    return Event(
+        event_type=event_type,
+        timestamp=t,
+        session_id=session_id,
+        metadata={
+            "engine_id": engine_id,
+            "gpu_id": gpu_id,
+            "total_bytes": total_bytes,
+        },
+    )
+
+
+def _read_histograms() -> dict[str, list]:
+    data = _reader.get_metrics_data()
+    result: dict[str, list] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                result[metric.name] = list(metric.data.data_points)
+    return result
+
+
+def _total_count(name: str) -> int:
+    dps = _read_histograms().get(name, [])
+    return sum(dp.count for dp in dps)
+
+
+def _sum(name: str) -> float:
+    dps = _read_histograms().get(name, [])
+    return sum(dp.sum for dp in dps)
+
+
+def _attrs_of_nonzero_dps(name: str) -> list[dict]:
+    dps = _read_histograms().get(name, [])
+    return [dict(dp.attributes) for dp in dps if dp.count > 0]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subscriber():
+    return L0L1ThroughputSubscriber(sample_rate=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Subscription surface
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptions:
+    def test_covers_expected_events(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.MP_STORE_START in subs
+        assert EventType.MP_STORE_END in subs
+        assert EventType.MP_RETRIEVE_START in subs
+        assert EventType.MP_RETRIEVE_END in subs
+
+    def test_does_not_subscribe_to_l1_events(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.L1_WRITE_RESERVED not in subs
+        assert EventType.L1_READ_RESERVED not in subs
+
+    def test_rejects_invalid_sample_rate(self):
+        with pytest.raises(AssertionError):
+            L0L1ThroughputSubscriber(sample_rate=0.0)
+        with pytest.raises(AssertionError):
+            L0L1ThroughputSubscriber(sample_rate=1.5)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path throughput recording
+# ---------------------------------------------------------------------------
+
+
+class TestStoreThroughput:
+    def test_records_gbps_with_attrs(self, subscriber):
+        count_before = _total_count(_STORE_METRIC)
+        sum_before = _sum(_STORE_METRIC)
+
+        # 2 GB in 0.1 s → 20 GB/s
+        subscriber._on_store_start(
+            _start_event(EventType.MP_STORE_START, "req-1", 1000.0, engine_id=7, gpu_id=3)
+        )
+        subscriber._on_store_end(
+            _end_event(
+                EventType.MP_STORE_END,
+                "req-1",
+                1000.1,
+                total_bytes=2_000_000_000,
+                engine_id=7,
+                gpu_id=3,
+            )
+        )
+
+        assert _total_count(_STORE_METRIC) == count_before + 1
+        observed_delta = _sum(_STORE_METRIC) - sum_before
+        assert observed_delta == pytest.approx(20.0, rel=1e-6)
+
+        attrs = _attrs_of_nonzero_dps(_STORE_METRIC)
+        assert any(a.get("engine_id") == "7" and a.get("gpu_id") == "3" for a in attrs)
+
+    def test_drains_pending_dict_on_end(self, subscriber):
+        subscriber._on_store_start(
+            _start_event(EventType.MP_STORE_START, "req-drain", 0.0)
+        )
+        assert "req-drain" in subscriber._pending_store
+
+        subscriber._on_store_end(
+            _end_event(EventType.MP_STORE_END, "req-drain", 0.1, total_bytes=1_000)
+        )
+        assert "req-drain" not in subscriber._pending_store
+
+
+class TestLoadThroughput:
+    def test_records_gbps_with_attrs(self, subscriber):
+        count_before = _total_count(_LOAD_METRIC)
+        sum_before = _sum(_LOAD_METRIC)
+
+        # 500 MB in 0.05 s → 10 GB/s
+        subscriber._on_retrieve_start(
+            _start_event(
+                EventType.MP_RETRIEVE_START, "req-r1", 2000.0, engine_id=2, gpu_id=0
+            )
+        )
+        subscriber._on_retrieve_end(
+            _end_event(
+                EventType.MP_RETRIEVE_END,
+                "req-r1",
+                2000.05,
+                total_bytes=500_000_000,
+                engine_id=2,
+                gpu_id=0,
+            )
+        )
+
+        assert _total_count(_LOAD_METRIC) == count_before + 1
+        observed_delta = _sum(_LOAD_METRIC) - sum_before
+        assert observed_delta == pytest.approx(10.0, rel=1e-6)
+
+        attrs = _attrs_of_nonzero_dps(_LOAD_METRIC)
+        assert any(a.get("engine_id") == "2" and a.get("gpu_id") == "0" for a in attrs)
+
+
+# ---------------------------------------------------------------------------
+# Sampling behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSampling:
+    def test_unsampled_session_leaves_no_state(self):
+        # Force "random" to always fail the sample gate.
+        sub = L0L1ThroughputSubscriber(sample_rate=0.01)
+        with patch(
+            "lmcache.v1.mp_observability.subscribers.metrics."
+            "l0_l1_throughput.random.random",
+            return_value=0.99,
+        ):
+            sub._on_store_start(_start_event(EventType.MP_STORE_START, "req-skip", 0.0))
+
+        assert "req-skip" not in sub._pending_store
+
+    def test_unsampled_session_does_not_record(self):
+        sub = L0L1ThroughputSubscriber(sample_rate=0.01)
+        count_before = _total_count(_STORE_METRIC)
+
+        with patch(
+            "lmcache.v1.mp_observability.subscribers.metrics."
+            "l0_l1_throughput.random.random",
+            return_value=0.99,
+        ):
+            sub._on_store_start(_start_event(EventType.MP_STORE_START, "req-u", 0.0))
+        # END arrives but START wasn't tracked → no record.
+        sub._on_store_end(
+            _end_event(EventType.MP_STORE_END, "req-u", 0.1, total_bytes=10**9)
+        )
+
+        assert _total_count(_STORE_METRIC) == count_before
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — must not crash or emit nonsense
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_end_without_start_is_noop(self, subscriber):
+        count_before = _total_count(_STORE_METRIC)
+        subscriber._on_store_end(
+            _end_event(EventType.MP_STORE_END, "orphan", 1.0, total_bytes=10**9)
+        )
+        assert _total_count(_STORE_METRIC) == count_before
+
+    def test_zero_bytes_is_noop(self, subscriber):
+        count_before = _total_count(_STORE_METRIC)
+        subscriber._on_store_start(
+            _start_event(EventType.MP_STORE_START, "req-zb", 0.0)
+        )
+        subscriber._on_store_end(
+            _end_event(EventType.MP_STORE_END, "req-zb", 0.1, total_bytes=0)
+        )
+        assert _total_count(_STORE_METRIC) == count_before
+
+    def test_nonpositive_duration_is_noop(self, subscriber):
+        count_before = _total_count(_STORE_METRIC)
+        subscriber._on_store_start(
+            _start_event(EventType.MP_STORE_START, "req-dt", 5.0)
+        )
+        # END at same timestamp → dt == 0 → skip.
+        subscriber._on_store_end(
+            _end_event(EventType.MP_STORE_END, "req-dt", 5.0, total_bytes=10**9)
+        )
+        assert _total_count(_STORE_METRIC) == count_before
+
+    def test_missing_session_id_skips_tracking(self, subscriber):
+        # session_id="" (default) must not populate pending map.
+        subscriber._on_store_start(
+            Event(
+                event_type=EventType.MP_STORE_START,
+                timestamp=1.0,
+                session_id="",
+                metadata={"engine_id": 1, "gpu_id": 0},
+            )
+        )
+        assert "" not in subscriber._pending_store
+
+    def test_store_and_load_dicts_are_independent(self, subscriber):
+        # Same session_id used for both paths — must not cross-pollinate.
+        subscriber._on_store_start(
+            _start_event(EventType.MP_STORE_START, "req-dual", 0.0)
+        )
+        subscriber._on_retrieve_start(
+            _start_event(EventType.MP_RETRIEVE_START, "req-dual", 0.0)
+        )
+
+        # Finish store only.
+        subscriber._on_store_end(
+            _end_event(EventType.MP_STORE_END, "req-dual", 0.1, total_bytes=10**9)
+        )
+        assert "req-dual" not in subscriber._pending_store
+        assert "req-dual" in subscriber._pending_load
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: drive through EventBus
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusIntegration:
+    def test_store_pair_via_bus_records_metric(self):
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        sub = L0L1ThroughputSubscriber(sample_rate=1.0)
+        bus.register_subscriber(sub)
+
+        count_before = _total_count(_STORE_METRIC)
+        bus.start()
+        bus.publish(
+            _start_event(
+                EventType.MP_STORE_START, "bus-req", 100.0, engine_id=9, gpu_id=1
+            )
+        )
+        bus.publish(
+            _end_event(
+                EventType.MP_STORE_END,
+                "bus-req",
+                100.2,
+                total_bytes=4_000_000_000,
+                engine_id=9,
+                gpu_id=1,
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        assert _total_count(_STORE_METRIC) == count_before + 1
+        attrs = _attrs_of_nonzero_dps(_STORE_METRIC)
+        assert any(a.get("engine_id") == "9" and a.get("gpu_id") == "1" for a in attrs)

--- a/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
@@ -37,13 +37,18 @@ def _start_event(
     session_id: str,
     t: float,
     engine_id: int = 0,
-    gpu_id: int = 0,
+    device: str = "cuda:0",
+    model_name: str = "test-model",
 ) -> Event:
     return Event(
         event_type=event_type,
         timestamp=t,
         session_id=session_id,
-        metadata={"engine_id": engine_id, "gpu_id": gpu_id},
+        metadata={
+            "engine_id": engine_id,
+            "device": device,
+            "model_name": model_name,
+        },
     )
 
 
@@ -53,7 +58,8 @@ def _end_event(
     t: float,
     total_bytes: int,
     engine_id: int = 0,
-    gpu_id: int = 0,
+    device: str = "cuda:0",
+    model_name: str = "test-model",
 ) -> Event:
     return Event(
         event_type=event_type,
@@ -61,7 +67,8 @@ def _end_event(
         session_id=session_id,
         metadata={
             "engine_id": engine_id,
-            "gpu_id": gpu_id,
+            "device": device,
+            "model_name": model_name,
             "total_bytes": total_bytes,
         },
     )
@@ -142,7 +149,7 @@ class TestStoreThroughput:
         # 2 GB in 0.1 s → 20 GB/s
         subscriber._on_store_start(
             _start_event(
-                EventType.MP_STORE_START, "req-1", 1000.0, engine_id=7, gpu_id=3
+                EventType.MP_STORE_START, "req-1", 1000.0, engine_id=7, device="cuda:3"
             )
         )
         subscriber._on_store_end(
@@ -152,7 +159,7 @@ class TestStoreThroughput:
                 1000.1,
                 total_bytes=2_000_000_000,
                 engine_id=7,
-                gpu_id=3,
+                device="cuda:3",
             )
         )
 
@@ -161,18 +168,23 @@ class TestStoreThroughput:
         assert observed_delta == pytest.approx(20.0, rel=1e-6)
 
         attrs = _attrs_of_nonzero_dps(_STORE_METRIC)
-        assert any(a.get("engine_id") == "7" and a.get("gpu_id") == "3" for a in attrs)
+        assert any(
+            a.get("engine_id") == "7"
+            and a.get("device") == "cuda:3"
+            and a.get("model_name") == "test-model"
+            for a in attrs
+        )
 
     def test_drains_pending_dict_on_end(self, subscriber):
         subscriber._on_store_start(
             _start_event(EventType.MP_STORE_START, "req-drain", 0.0)
         )
-        assert "req-drain" in subscriber._pending_store
+        assert ("req-drain", "cuda:0") in subscriber._pending_store
 
         subscriber._on_store_end(
             _end_event(EventType.MP_STORE_END, "req-drain", 0.1, total_bytes=1_000)
         )
-        assert "req-drain" not in subscriber._pending_store
+        assert ("req-drain", "cuda:0") not in subscriber._pending_store
 
 
 class TestLoadThroughput:
@@ -183,7 +195,11 @@ class TestLoadThroughput:
         # 500 MB in 0.05 s → 10 GB/s
         subscriber._on_retrieve_start(
             _start_event(
-                EventType.MP_RETRIEVE_START, "req-r1", 2000.0, engine_id=2, gpu_id=0
+                EventType.MP_RETRIEVE_START,
+                "req-r1",
+                2000.0,
+                engine_id=2,
+                device="cuda:0",
             )
         )
         subscriber._on_retrieve_end(
@@ -193,7 +209,7 @@ class TestLoadThroughput:
                 2000.05,
                 total_bytes=500_000_000,
                 engine_id=2,
-                gpu_id=0,
+                device="cuda:0",
             )
         )
 
@@ -202,7 +218,12 @@ class TestLoadThroughput:
         assert observed_delta == pytest.approx(10.0, rel=1e-6)
 
         attrs = _attrs_of_nonzero_dps(_LOAD_METRIC)
-        assert any(a.get("engine_id") == "2" and a.get("gpu_id") == "0" for a in attrs)
+        assert any(
+            a.get("engine_id") == "2"
+            and a.get("device") == "cuda:0"
+            and a.get("model_name") == "test-model"
+            for a in attrs
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +242,7 @@ class TestSampling:
         ):
             sub._on_store_start(_start_event(EventType.MP_STORE_START, "req-skip", 0.0))
 
-        assert "req-skip" not in sub._pending_store
+        assert ("req-skip", "cuda:0") not in sub._pending_store
 
     def test_unsampled_session_does_not_record(self):
         sub = L0L1ThroughputSubscriber(sample_rate=0.01)
@@ -282,10 +303,23 @@ class TestEdgeCases:
                 event_type=EventType.MP_STORE_START,
                 timestamp=1.0,
                 session_id="",
-                metadata={"engine_id": 1, "gpu_id": 0},
+                metadata={"engine_id": 1, "device": "cuda:0"},
             )
         )
-        assert "" not in subscriber._pending_store
+        assert len(subscriber._pending_store) == 0
+
+    def test_missing_device_skips_tracking(self, subscriber):
+        # Without "device" in metadata the correlation key is ambiguous
+        # across GPUs — event must be dropped.
+        subscriber._on_store_start(
+            Event(
+                event_type=EventType.MP_STORE_START,
+                timestamp=1.0,
+                session_id="req-no-dev",
+                metadata={"engine_id": 1},
+            )
+        )
+        assert len(subscriber._pending_store) == 0
 
     def test_store_and_load_dicts_are_independent(self, subscriber):
         # Same session_id used for both paths — must not cross-pollinate.
@@ -300,8 +334,61 @@ class TestEdgeCases:
         subscriber._on_store_end(
             _end_event(EventType.MP_STORE_END, "req-dual", 0.1, total_bytes=10**9)
         )
-        assert "req-dual" not in subscriber._pending_store
-        assert "req-dual" in subscriber._pending_load
+        assert ("req-dual", "cuda:0") not in subscriber._pending_store
+        assert ("req-dual", "cuda:0") in subscriber._pending_load
+
+    def test_same_session_id_different_devices_do_not_collide(self, subscriber):
+        # One MP server handles multiple GPUs; TP replicas of the same
+        # request_id must not stomp on each other's pending START timestamp.
+        count_before = _total_count(_STORE_METRIC)
+
+        # Two concurrent STARTs, same session_id, different devices.
+        subscriber._on_store_start(
+            _start_event(
+                EventType.MP_STORE_START,
+                "tp-req",
+                100.0,
+                engine_id=0,
+                device="cuda:0",
+            )
+        )
+        subscriber._on_store_start(
+            _start_event(
+                EventType.MP_STORE_START,
+                "tp-req",
+                100.0,
+                engine_id=1,
+                device="cuda:1",
+            )
+        )
+        assert ("tp-req", "cuda:0") in subscriber._pending_store
+        assert ("tp-req", "cuda:1") in subscriber._pending_store
+
+        # Both END independently — both must record.
+        subscriber._on_store_end(
+            _end_event(
+                EventType.MP_STORE_END,
+                "tp-req",
+                100.1,
+                total_bytes=1_000_000_000,
+                engine_id=0,
+                device="cuda:0",
+            )
+        )
+        subscriber._on_store_end(
+            _end_event(
+                EventType.MP_STORE_END,
+                "tp-req",
+                100.1,
+                total_bytes=1_000_000_000,
+                engine_id=1,
+                device="cuda:1",
+            )
+        )
+
+        assert _total_count(_STORE_METRIC) == count_before + 2
+        assert ("tp-req", "cuda:0") not in subscriber._pending_store
+        assert ("tp-req", "cuda:1") not in subscriber._pending_store
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +406,11 @@ class TestEventBusIntegration:
         bus.start()
         bus.publish(
             _start_event(
-                EventType.MP_STORE_START, "bus-req", 100.0, engine_id=9, gpu_id=1
+                EventType.MP_STORE_START,
+                "bus-req",
+                100.0,
+                engine_id=9,
+                device="cuda:1",
             )
         )
         bus.publish(
@@ -329,7 +420,7 @@ class TestEventBusIntegration:
                 100.2,
                 total_bytes=4_000_000_000,
                 engine_id=9,
-                gpu_id=1,
+                device="cuda:1",
             )
         )
         time.sleep(_DRAIN_WAIT)
@@ -337,4 +428,6 @@ class TestEventBusIntegration:
 
         assert _total_count(_STORE_METRIC) == count_before + 1
         attrs = _attrs_of_nonzero_dps(_STORE_METRIC)
-        assert any(a.get("engine_id") == "9" and a.get("gpu_id") == "1" for a in attrs)
+        assert any(
+            a.get("engine_id") == "9" and a.get("device") == "cuda:1" for a in attrs
+        )


### PR DESCRIPTION
Adds two OTel histograms exposed via Prometheus:

- lmcache_mp_l0_l1_store_throughput_gbs  — GPU->CPU (L0->L1)
- lmcache_mp_l0_l1_load_throughput_gbs   — CPU->GPU (L1->L0)

Both carry `engine_id` and `gpu_id` attributes so operators can distinguish per-vLLM-worker throughput within a shared MP server.

Implementation:

- server.py: augment MP_{STORE,RETRIEVE}_{START,END} event metadata with engine_id (= instance_id), gpu_id (= device.index), and total_bytes on END events (summed from reserved_dict / memory_objs). START/END fire via publish_on_stream, so timestamps reflect true GPU-stream copy time.
- L0L1ThroughputSubscriber correlates START->END pairs by session_id, samples per-request at START (default 1%), records GB/s on END.
- Registered in init_observability under metrics_enabled.
- Unit tests cover subscription surface, happy path, sampling behavior, and edge cases (orphan END, zero bytes, zero duration, etc.).

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes MP `store`/`retrieve` event metadata contracts and adds extra bookkeeping (`total_bytes`, `engine_id`, `model_name`) on the hot GPU-copy path, which could impact downstream subscribers if assumptions differ.
> 
> **Overview**
> Adds **sampled per-request GPU↔CPU throughput metrics** by introducing `L0L1ThroughputSubscriber`, which correlates `MP_{STORE,RETRIEVE}_{START,END}` pairs and records two new OTel histograms: `lmcache_mp.l0_l1_store_throughput_gbs` and `lmcache_mp.l0_l1_load_throughput_gbs`.
> 
> Updates MP server `store`/`retrieve` to enrich START/END events with `engine_id`/`model_name` and to include `total_bytes` on END events so throughput can be computed accurately from GPU-stream timestamps. Registers the new subscriber in observability config, documents the new event/metric contracts, and adds a comprehensive unit test suite covering sampling and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cccfc626e743979dce094befba7c53abcef7224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->