### PR TITLE
[CI]  fix blend-server venv 

### DIFF
--- a/.buildkite/k3_harness/setup-blend-env.sh
+++ b/.buildkite/k3_harness/setup-blend-env.sh
@@ -54,17 +54,15 @@ TEST_VENV_BIN="/workspace/.venv/bin"
 # When flashinfer and flashinfer-cubin resolve to different patch versions, skip strict check.
 export FLASHINFER_DISABLE_VERSION_CHECK=1
 
-"${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" -U vllm "torch==2.10.0+cu128" --pre \
+"${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" -U vllm --pre \
     --extra-index-url https://wheels.vllm.ai/nightly/cu128 \
     --extra-index-url https://download.pytorch.org/whl/cu128 \
     --index-strategy unsafe-best-match
 
 
-# install LMCache from source twice as two torch version might be different
- 
-"${DEFAULT_VENV_BIN}/python" -c 'import vllm; print(f"default venv vllm={vllm.__version__}")' 
+"${DEFAULT_VENV_BIN}/python" -c 'import vllm; print(f"default venv vllm={vllm.__version__}")'
 "${TEST_VENV_BIN}/python" -c 'import vllm; print(f"test venv vllm={vllm.__version__}")'
-"${DEFAULT_VENV_BIN}/python" -c 'import torch; print(f"default venv torch={torch.__version__}, torch.version.cuda={torch.version.cuda}")' 
+"${DEFAULT_VENV_BIN}/python" -c 'import torch; print(f"default venv torch={torch.__version__}, torch.version.cuda={torch.version.cuda}")'
 "${TEST_VENV_BIN}/python" -c 'import torch; print(f"test venv torch={torch.__version__}, torch.version.cuda={torch.version.cuda}")'
 
 echo "--- :python: Installing LMCache from source"

--- a/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
+++ b/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
@@ -29,11 +29,15 @@ source .buildkite/k3_tests/common_scripts/helpers.sh
 SERVER_WAIT_TIMEOUT="${SERVER_WAIT_TIMEOUT:-400}"
 
 BUILD_ID="${BUILDKITE_BUILD_ID:-local_$$}"
-WORK_LOG="/tmp/build_${BUILD_ID}_blend.log" 
+# Write logs under REPO_ROOT so they are visible on the host immediately via the bind mount.
+# /tmp logs would be invisible until docker cp runs after the container exits.
+LOG_DIR="${REPO_ROOT}/logs_${BUILD_ID}"
+mkdir -p "${LOG_DIR}"
+WORK_LOG="${LOG_DIR}/build_${BUILD_ID}_blend.log"
 # Proxy stdout/stderr. Blend server/prefiller/decoder each get their own _blend_server/_prefiller_PORT/_decoder_PORT logs.
-VLLM_LOG="/tmp/build_${BUILD_ID}_proxy.log"
-BLEND_SERVER_LOG="/tmp/build_${BUILD_ID}_blend_server.log"
-ARTIFACT="build_${BUILD_ID}.log"
+VLLM_LOG="${LOG_DIR}/build_${BUILD_ID}_proxy.log"
+BLEND_SERVER_LOG="${LOG_DIR}/build_${BUILD_ID}_blend_server.log"
+ARTIFACT="${REPO_ROOT}/build_${BUILD_ID}.log"
 # Benchmark wall-clock limit (seconds). Exit 124 from `timeout` => failure. Default stays under blend pipeline 90m.
 BENCHMARK_TIMEOUT_SEC="${BENCHMARK_TIMEOUT_SEC:-4800}"
 
@@ -90,8 +94,11 @@ resolve_port_csv() {
 }
 
 collect_artifact() {
-  echo "[INFO] Collecting logs into ${ARTIFACT}"
-  cat /tmp/build_"${BUILD_ID}"_*.log > "${ARTIFACT}" 2>/dev/null || true
+  # Individual logs are already in LOG_DIR (written there directly).
+  # Just produce the merged artifact for CI / backward-compatible harnesses.
+  cat "${LOG_DIR}"/build_"${BUILD_ID}"_*.log > "${ARTIFACT}" 2>/dev/null || true
+  echo "[INFO] Logs:     ${LOG_DIR}/"
+  echo "[INFO] Artifact: ${ARTIFACT}"
 }
 
 finalize() {
@@ -107,17 +114,14 @@ trap finalize EXIT INT TERM
 
 exec > >(tee -a "${WORK_LOG}") 2>&1
 
-# Scan every /tmp/build_${BUILD_ID}_*.log for severe/error lines (same family as other k3 build logs).
-# Strip bash xtrace lines first: `set -x` tees "+ grep ... \\berror\\b ..." into the same log and
-# would false-positive this check.
 check_build_logs_for_errors() {
   local -a logs=()
   local f
   shopt -s nullglob
-  logs=(/tmp/build_"${BUILD_ID}"_*.log)
+  logs=("${LOG_DIR}"/build_"${BUILD_ID}"_*.log)
   shopt -u nullglob
   if [[ ${#logs[@]} -eq 0 ]]; then
-    echo "[WARN] No /tmp/build_${BUILD_ID}_*.log files found for error scan"
+    echo "[WARN] No build logs found in ${LOG_DIR}/ for error scan"
     return 0
   fi
   for f in "${logs[@]}"; do
@@ -180,8 +184,8 @@ echo "  Service port:    ${SERVICE_PORT}"
 echo "  Telemetry port:  ${TELEMETRY_PORT}"
 echo "  Blend MP port:   ${LMCACHE_MP_PORT}"
 echo "  GPUs per instance: ${TENSOR_PARALLEL}"
-echo "  Default venv dir: ${DEFAULT_VENV_DIR} (prefiller / blend server python: ${DEFAULT_PYTHON})"
-echo "  Test venv dir:    ${TEST_VENV_DIR} (decoder / proxy / benchmark python: ${TEST_PYTHON})"
+echo "  Default venv dir: ${DEFAULT_VENV_DIR} (prefiller vLLM: image-built)"
+echo "  Test venv dir:    ${TEST_VENV_DIR} (blend server / decoder vLLM / proxy / benchmark: nightly)"
 echo "  Prefiller vLLM:   ${PREFILLER_VLLM_BIN}"
 echo "  Decoder vLLM:     ${DECODER_VLLM_BIN}"
 
@@ -193,7 +197,7 @@ export LD_LIBRARY_PATH=/opt/nvidia/nsight-compute/2025.1.0/host/linux-desktop-gl
 # 1. Start the LMCache blend server
 # ---------------------------------------------------------------------------
 
-"${DEFAULT_PYTHON}" -m lmcache.v1.multiprocess.blend_server_v2 \
+"${TEST_PYTHON}" -m lmcache.v1.multiprocess.blend_server_v2 \
   --max-workers 1 \
   --port "${LMCACHE_MP_PORT}" \
   --l1-size 70 \
@@ -211,7 +215,7 @@ GPU_IDX=0
 for port in "${PREFILLER_PORTS[@]}"; do
   GPU_END=$((GPU_IDX + TENSOR_PARALLEL - 1))
   CUDA_DEVS=$(seq -s, "$GPU_IDX" "$GPU_END")
-  PREFILLER_LOG="/tmp/build_${BUILD_ID}_prefiller_${port}.log"
+  PREFILLER_LOG="${LOG_DIR}/build_${BUILD_ID}_prefiller_${port}.log"
   : > "${PREFILLER_LOG}"
   echo "Starting prefiller on GPUs ${CUDA_DEVS}, port ${port}"
   CUDA_VISIBLE_DEVICES=$CUDA_DEVS \
@@ -242,7 +246,7 @@ done
 for port in "${DECODER_PORTS[@]}"; do
   GPU_END=$((GPU_IDX + TENSOR_PARALLEL - 1))
   CUDA_DEVS=$(seq -s, "$GPU_IDX" "$GPU_END")
-  DECODER_LOG="/tmp/build_${BUILD_ID}_decoder_${port}.log"
+  DECODER_LOG="${LOG_DIR}/build_${BUILD_ID}_decoder_${port}.log"
   : > "${DECODER_LOG}"
   echo "Starting decoder on GPUs ${CUDA_DEVS}, port ${port}"
   CUDA_VISIBLE_DEVICES=$CUDA_DEVS \

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -836,7 +836,6 @@ def run_cache_server(
             RequestType.CB_STORE_PRE_COMPUTED,
             RequestType.CB_RETRIEVE_PRE_COMPUTED_V2,
             RequestType.CB_STORE_FINAL,
-            RequestType.REPORT_BLOCK_ALLOCATION,
         ],
         max_workers=mp_config.max_gpu_workers,
     )
@@ -849,6 +848,7 @@ def run_cache_server(
             RequestType.CLEAR,
             RequestType.CB_LOOKUP_PRE_COMPUTED_V2,
             RequestType.PING,
+            RequestType.REPORT_BLOCK_ALLOCATION,
         ],
         max_workers=mp_config.max_cpu_workers,
     )

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -804,7 +804,11 @@ def run_cache_server(
     add_handler_helper(server, RequestType.GET_CHUNK_SIZE, engine.get_chunk_size)
     add_handler_helper(server, RequestType.END_SESSION, engine.end_session)
     add_handler_helper(server, RequestType.NOOP, engine.debug)
-
+    add_handler_helper(
+        server,
+        RequestType.REPORT_BLOCK_ALLOCATION,
+        engine.report_block_allocations,
+    )
     # Add handler for blend operations
     add_handler_helper(
         server, RequestType.CB_REGISTER_KV_CACHE, engine.cb_register_kv_cache
@@ -832,6 +836,7 @@ def run_cache_server(
             RequestType.CB_STORE_PRE_COMPUTED,
             RequestType.CB_RETRIEVE_PRE_COMPUTED_V2,
             RequestType.CB_STORE_FINAL,
+            RequestType.REPORT_BLOCK_ALLOCATION,
         ],
         max_workers=mp_config.max_gpu_workers,
     )


### PR DESCRIPTION
 
**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI dependency resolution (drops explicit torch pin) and the runtime environment used to launch the blend server, which could surface version/compatibility issues during integration runs.
> 
> **Overview**
> Runs the LMCache blend server using the *nightly/test* venv (`TEST_PYTHON`) instead of the default image venv, aligning the blend test components with the intended vLLM/LMCache environment.
> 
> Updates the blend CI environment setup to install nightly `vllm` without an explicit `torch==...` pin, and enhances the blend test harness to write per-process logs under a repo-root `logs_<BUILD_ID>/` directory (with a merged artifact still produced for CI).
> 
> Wires `RequestType.REPORT_BLOCK_ALLOCATION` into `blend_server_v2` (handler registration + normal thread pool) so observability reports are accepted by the blend server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96556c6189be1746e71df625abe0f794492b4a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->