### PR TITLE
[MP] Add hit_rate to the describe cli output

### DIFF
--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -110,6 +110,7 @@ class KVCacheDescriber:
     def describe(self) -> None:
         """Run all section builders and emit."""
         self.add_overview()
+        self.add_hit_stats()
         self.add_l1_storage()
         self.add_models()
         self.add_l2_adapters()
@@ -123,6 +124,35 @@ class KVCacheDescriber:
         self.metrics.add("url", "URL", self.base_url)
         self.metrics.add("engine_type", "Engine type", self.data.get("engine_type"))
         self.metrics.add("chunk_size", "Chunk size", self.data.get("chunk_size"))
+
+    def add_hit_stats(self) -> None:
+        """Cumulative hit statistics since server startup."""
+        hs = self.data.get("hit_stats")
+        if not hs:
+            return
+        sec = self.metrics.add_section("hit_stats", "Hit Statistics")
+        sec.add(
+            "total_requests",
+            "Total requests",
+            hs.get("total_requests"),
+        )
+        sec.add(
+            "total_tokens",
+            "Total tokens",
+            hs.get("total_tokens"),
+        )
+        sec.add(
+            "retrieved_tokens",
+            "Retrieved tokens (GPU hit)",
+            hs.get("total_retrieved_tokens"),
+        )
+        hit_rate = hs.get("hit_rate")
+        if hit_rate is not None:
+            sec.add(
+                "hit_rate",
+                "Hit rate",
+                f"{hit_rate * 100:.1f}%",
+            )
 
     def add_l1_storage(self) -> None:
         """L1 cache capacity, usage, eviction, and object count."""

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -569,11 +569,14 @@ class MPCacheEngine:
                     ),
                 )
         tokens_retrieved = len(obj_keys) * self.chunk_size
+        session.update_retrieved_range(key.start, key.end)
         ed = time.perf_counter()
+        elapsed = ed - st
+        session.retrieve_time += elapsed
         logger.info(
             "Retrieved %d tokens in %.3f seconds",
             tokens_retrieved,
-            ed - st,
+            elapsed,
         )
 
         return event.ipc_handle(), True
@@ -693,6 +696,9 @@ class MPCacheEngine:
         session = self.session_manager.get_or_create(key.request_id)
         session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
+
+        # Record total tokens for hit-rate tracking
+        session.total_tokens = len(key.token_ids)
 
         obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
 
@@ -919,6 +925,7 @@ class MPCacheEngine:
             "gpu_context_meta": gpu_context_meta,
             "active_sessions": self.session_manager.active_count(),
             "active_prefetch_jobs": self._active_prefetch_count(),
+            "hit_stats": self.session_manager.report_hit_stats(),
             "storage_manager": sm,
         }
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -387,9 +387,15 @@ class MPCacheEngine:
 
         ed = time.perf_counter()
         elapsed = ed - st
-        session.store_time += elapsed
         stored_chunks = len(reserved_dict)
-        session.store_chunks += stored_chunks
+        # Single lock acquisition: time + (optional) range union.
+        # Different TP workers produce different reserved_dict keys but
+        # report the same [key.start, key.end); union deduplicates at
+        # the token level.
+        session.record_store(
+            elapsed,
+            token_range=(key.start, key.end) if stored_chunks else None,
+        )
         if stored_chunks:
             logger.info(
                 "Stored %d tokens in %.3f seconds",
@@ -573,10 +579,9 @@ class MPCacheEngine:
                     ),
                 )
         tokens_retrieved = len(obj_keys) * self.chunk_size
-        session.update_retrieved_range(key.start, key.end)
         ed = time.perf_counter()
         elapsed = ed - st
-        session.retrieve_time += elapsed
+        session.record_retrieve(elapsed, token_range=(key.start, key.end))
         logger.info(
             "Retrieved %d tokens in %.3f seconds",
             tokens_retrieved,
@@ -728,8 +733,14 @@ class MPCacheEngine:
             )
         finally:
             elapsed = time.perf_counter() - st
-            session.lookup_time += elapsed
-            session.lookup_chunks += len(obj_keys)
+            # Lookup covers the full token range carried by the key;
+            # union across TP workers yields the true token coverage.
+            # ``token_range=None`` on early-return (no obj_keys produced)
+            # keeps the time account but leaves range untouched.
+            session.record_lookup(
+                elapsed,
+                token_range=(key.start, key.end) if obj_keys else None,
+            )
 
     def _register_prefetch_job(self, job: _PrefetchJob) -> None:
         with self._prefetch_job_lock:

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -386,11 +386,15 @@ class MPCacheEngine:
                 )
 
         ed = time.perf_counter()
-        if length := len(reserved_dict):
+        elapsed = ed - st
+        session.store_time += elapsed
+        stored_chunks = len(reserved_dict)
+        session.store_chunks += stored_chunks
+        if stored_chunks:
             logger.info(
                 "Stored %d tokens in %.3f seconds",
-                length * self.chunk_size,
-                ed - st,
+                stored_chunks * self.chunk_size,
+                elapsed,
             )
         return event.ipc_handle(), True
 
@@ -615,106 +619,117 @@ class MPCacheEngine:
             key: Cache key with request_id embedded.
             tp_size: Tensor-parallel size for MLA multi-reader locking.
         """
-        model_name, world_size = key.model_name, key.world_size
-        self._event_bus.publish(
-            Event(
-                event_type=EventType.MP_REQUEST_START,
-                session_id=key.request_id,
-            )
-        )
-        self._event_bus.publish(
-            Event(
-                event_type=EventType.MP_LOOKUP_PREFETCH_START,
-                session_id=key.request_id,
-            )
-        )
-
-        layout_desc = self._find_layout_desc(model_name, world_size)
-        if layout_desc is None:
-            logger.error(
-                "No GPU context found for model %s with world size %d during lookup!",
-                model_name,
-                world_size,
-            )
-            self._register_prefetch_job(
-                _PrefetchJob(
-                    handle=PrefetchHandle(
-                        prefetch_request_id=-1,
-                        external_request_id=key.request_id,
-                        l1_prefix_hit_count=0,
-                        total_requested_keys=0,
-                        submit_time=time.monotonic(),
-                    ),
-                    world_size=1,
-                    request_id=key.request_id,
-                )
-            )
-            return
-
-        extra_count = compute_extra_count(tp_size, world_size)
-
-        # Compute chunk hashes for all full chunks
-        chunk_hashes = self.token_hasher.compute_chunk_hashes(list(key.token_ids))
-        if not chunk_hashes:
-            self._register_prefetch_job(
-                _PrefetchJob(
-                    handle=PrefetchHandle(
-                        prefetch_request_id=-1,
-                        external_request_id=key.request_id,
-                        l1_prefix_hit_count=0,
-                        total_requested_keys=0,
-                        submit_time=time.monotonic(),
-                    ),
-                    world_size=1,
-                    request_id=key.request_id,
-                )
-            )
-            return
-
-        # Publish lookup event via EventBus for observability subscribers.
-        # Guard with has_subscribers() to avoid allocating the metadata dict
-        # (including dtype/shape list comprehensions) when no subscriber is
-        # listening (e.g. lookup hash logger is disabled).
-        if self._event_bus.has_subscribers(EventType.MP_LOOKUP):
+        st = time.perf_counter()
+        # Track session up-front so early-return paths still contribute to
+        # the lookup_time/lookup_chunks stats exposed in END_SESSION logs.
+        session = self.session_manager.get_or_create(key.request_id)
+        obj_keys: list = []
+        try:
+            model_name, world_size = key.model_name, key.world_size
             self._event_bus.publish(
                 Event(
-                    event_type=EventType.MP_LOOKUP,
+                    event_type=EventType.MP_REQUEST_START,
                     session_id=key.request_id,
-                    metadata={
-                        "request_id": key.request_id,
-                        "chunk_hashes": chunk_hashes,
-                        "model_name": model_name,
-                        "chunk_size": self.chunk_size,
-                        "seq_len": len(key.token_ids),
-                        "dtypes": [str(d) for d in layout_desc.dtypes],
-                        "shapes": [list(s) for s in layout_desc.shapes],
-                    },
+                )
+            )
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.MP_LOOKUP_PREFETCH_START,
+                    session_id=key.request_id,
                 )
             )
 
-        # set lookup ipc key, for session manager to use and generate object keys
-        session = self.session_manager.get_or_create(key.request_id)
-        session.set_tokens(list(key.token_ids))
-        session.lookup_ipc_key = key
+            layout_desc = self._find_layout_desc(model_name, world_size)
+            if layout_desc is None:
+                logger.error(
+                    "No GPU context found for model %s with world size %d "
+                    "during lookup!",
+                    model_name,
+                    world_size,
+                )
+                self._register_prefetch_job(
+                    _PrefetchJob(
+                        handle=PrefetchHandle(
+                            prefetch_request_id=-1,
+                            external_request_id=key.request_id,
+                            l1_prefix_hit_count=0,
+                            total_requested_keys=0,
+                            submit_time=time.monotonic(),
+                        ),
+                        world_size=1,
+                        request_id=key.request_id,
+                    )
+                )
+                return
 
-        # Record total tokens for hit-rate tracking
-        session.total_tokens = len(key.token_ids)
+            extra_count = compute_extra_count(tp_size, world_size)
 
-        obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+            # Compute chunk hashes for all full chunks
+            chunk_hashes = self.token_hasher.compute_chunk_hashes(list(key.token_ids))
+            if not chunk_hashes:
+                self._register_prefetch_job(
+                    _PrefetchJob(
+                        handle=PrefetchHandle(
+                            prefetch_request_id=-1,
+                            external_request_id=key.request_id,
+                            l1_prefix_hit_count=0,
+                            total_requested_keys=0,
+                            submit_time=time.monotonic(),
+                        ),
+                        world_size=1,
+                        request_id=key.request_id,
+                    )
+                )
+                return
 
-        handle = self.storage_manager.submit_prefetch_task(
-            obj_keys,
-            layout_desc,
-            extra_count=extra_count,
-            external_request_id=key.request_id,
-        )
-        self._register_prefetch_job(
-            _PrefetchJob(
-                handle=handle,
-                world_size=key.world_size,
-                request_id=key.request_id,
+            # Publish lookup event via EventBus for observability subscribers.
+            # Guard with has_subscribers() to avoid allocating the metadata dict
+            # (including dtype/shape list comprehensions) when no subscriber is
+            # listening (e.g. lookup hash logger is disabled).
+            if self._event_bus.has_subscribers(EventType.MP_LOOKUP):
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.MP_LOOKUP,
+                        session_id=key.request_id,
+                        metadata={
+                            "request_id": key.request_id,
+                            "chunk_hashes": chunk_hashes,
+                            "model_name": model_name,
+                            "chunk_size": self.chunk_size,
+                            "seq_len": len(key.token_ids),
+                            "dtypes": [str(d) for d in layout_desc.dtypes],
+                            "shapes": [list(s) for s in layout_desc.shapes],
+                        },
+                    )
+                )
+
+            # set lookup ipc key, for session manager to use and
+            # generate object keys
+            session.set_tokens(list(key.token_ids))
+            session.lookup_ipc_key = key
+
+            # Record total tokens for hit-rate tracking
+            session.total_tokens = len(key.token_ids)
+
+            obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+
+            handle = self.storage_manager.submit_prefetch_task(
+                obj_keys,
+                layout_desc,
+                extra_count=extra_count,
+                external_request_id=key.request_id,
             )
-        )
+            self._register_prefetch_job(
+                _PrefetchJob(
+                    handle=handle,
+                    world_size=key.world_size,
+                    request_id=key.request_id,
+                )
+            )
+        finally:
+            elapsed = time.perf_counter() - st
+            session.lookup_time += elapsed
+            session.lookup_chunks += len(obj_keys)
 
     def _register_prefetch_job(self, job: _PrefetchJob) -> None:
         with self._prefetch_job_lock:

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -33,8 +33,46 @@ class Session:
     last_prefix_hash: Any = None
     num_chunks_processed: int = 0
     created_at: float = field(default_factory=time.time)
+    total_tokens: int = 0
+    _retrieved_start: int = 0
+    _retrieved_end: int = 0
+    lookup_time: float = 0.0
+    retrieve_time: float = 0.0
+    store_time: float = 0.0
+    lookup_chunks: int = 0
+    store_chunks: int = 0
     lookup_ipc_key: Optional[IPCCacheEngineKey] = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    @property
+    def retrieved_tokens(self) -> int:
+        """Number of retrieved tokens, derived from the range."""
+        return self._retrieved_end - self._retrieved_start
+
+    @property
+    def retrieve_chunks(self) -> int:
+        """Number of retrieved chunks, derived from the range."""
+        chunk_size = self.hasher.chunk_size
+        return (self._retrieved_end - self._retrieved_start) // chunk_size
+
+    def update_retrieved_range(self, start: int, end: int) -> None:
+        """Update the retrieved token range (idempotent union).
+
+        Multiple TP workers may call this with the same range;
+        the result is always the union of all reported ranges.
+
+        Args:
+            start: Start token index of the retrieved range.
+            end: End token index of the retrieved range.
+        """
+        with self._lock:
+            if self._retrieved_start == self._retrieved_end:
+                # First call: initialize the range
+                self._retrieved_start = start
+                self._retrieved_end = end
+            else:
+                self._retrieved_start = min(self._retrieved_start, start)
+                self._retrieved_end = max(self._retrieved_end, end)
 
     def set_tokens(self, full_token_ids: list[int]) -> None:
         """Update the token sequence (idempotent, replaces not extends).
@@ -127,6 +165,12 @@ class SessionManager:
         self._sessions: dict[str, Session] = {}
         self._lock = threading.Lock()
 
+        # Cumulative stats accumulated when sessions end
+        self._stats_lock = threading.Lock()
+        self._total_requests: int = 0
+        self._total_tokens: int = 0
+        self._total_retrieved_tokens: int = 0
+
     def get_or_create(self, request_id: str) -> Session:
         """Get existing session or create a new one.
 
@@ -144,22 +188,49 @@ class SessionManager:
                 logger.debug("Created session for request_id=%s", request_id)
             return self._sessions[request_id]
 
-    def remove(self, request_id: str) -> Optional[Session]:
-        """Remove a session by request_id.
+    def remove(self, request_id: str, reason: str = "normal") -> Optional[Session]:
+        """Remove a session and accumulate its stats.
 
         Args:
             request_id: Unique request identifier.
+            reason: Why the session is being removed, e.g. ``"normal"``
+                for an explicit end_session from vLLM or ``"expired"``
+                for TTL-based cleanup. Included in the END_SESSION log.
 
         Returns:
             The removed session, or None if no session was found.
         """
         with self._lock:
-            if request_id in self._sessions:
-                session = self._sessions[request_id]
-                del self._sessions[request_id]
-                logger.debug("Removed session for request_id=%s", request_id)
-                return session
-            return None
+            session = self._sessions.pop(request_id, None)
+        if session is not None:
+            with self._stats_lock:
+                self._total_requests += 1
+                self._total_tokens += session.total_tokens
+                self._total_retrieved_tokens += session.retrieved_tokens
+            hit_rate = (
+                session.retrieved_tokens / session.total_tokens
+                if session.total_tokens > 0
+                else 0.0
+            )
+            logger.info(
+                "END_SESSION[%s] reason=%s: total_tokens=%d, "
+                "retrieved_tokens=%d, hit_rate=%.2f%%, "
+                "lookup=%d chunks/%.3fs, "
+                "retrieve=%d chunks/%.3fs, "
+                "store=%d chunks/%.3fs",
+                request_id,
+                reason,
+                session.total_tokens,
+                session.retrieved_tokens,
+                hit_rate * 100,
+                session.lookup_chunks,
+                session.lookup_time,
+                session.retrieve_chunks,
+                session.retrieve_time,
+                session.store_chunks,
+                session.store_time,
+            )
+        return session
 
     def cleanup_expired(self) -> int:
         """Remove sessions that have exceeded their TTL.
@@ -168,13 +239,15 @@ class SessionManager:
             Number of sessions removed.
         """
         now = time.time()
-        expired = []
         with self._lock:
-            for rid, session in self._sessions.items():
-                if now - session.created_at > self._ttl:
-                    expired.append(rid)
-            for rid in expired:
-                del self._sessions[rid]
+            expired = [
+                rid
+                for rid, s in self._sessions.items()
+                if now - s.created_at > self._ttl
+            ]
+
+        for rid in expired:
+            self.remove(rid, reason="expired")
 
         if expired:
             logger.info("Cleaned up %d expired sessions", len(expired))
@@ -188,3 +261,22 @@ class SessionManager:
         """
         with self._lock:
             return len(self._sessions)
+
+    def report_hit_stats(self) -> dict[str, int | float]:
+        """Return cumulative hit statistics.
+
+        Returns:
+            Dict with total_requests, total_tokens,
+            total_retrieved_tokens, and hit_rate.
+        """
+        with self._stats_lock:
+            total_req = self._total_requests
+            total_tok = self._total_tokens
+            retrieved_tok = self._total_retrieved_tokens
+        hit_rate = round(retrieved_tok / total_tok, 4) if total_tok > 0 else 0.0
+        return {
+            "total_requests": total_req,
+            "total_tokens": total_tok,
+            "total_retrieved_tokens": retrieved_tok,
+            "hit_rate": hit_rate,
+        }

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -19,6 +19,36 @@ logger = init_logger(__name__)
 
 
 @dataclass
+class TokenRange:
+    """Union of [start, end) token ranges reported by multiple TP workers.
+
+    Each TP worker reports the same logical token range for a given
+    storage-path invocation; storing the min/max produces the union,
+    which represents the actual token coverage regardless of TP degree.
+    """
+
+    start: int = 0
+    end: int = 0
+    initialized: bool = False
+
+    def update(self, start: int, end: int) -> None:
+        if not self.initialized:
+            self.start = start
+            self.end = end
+            self.initialized = True
+        else:
+            self.start = min(self.start, start)
+            self.end = max(self.end, end)
+
+    @property
+    def tokens(self) -> int:
+        return self.end - self.start
+
+    def chunks(self, chunk_size: int) -> int:
+        return self.tokens // chunk_size
+
+
+@dataclass
 class Session:
     """Tracks accumulated token IDs and computed chunk hashes for a request.
 
@@ -34,49 +64,113 @@ class Session:
     num_chunks_processed: int = 0
     created_at: float = field(default_factory=time.time)
     total_tokens: int = 0
-    _retrieved_start: int = 0
-    _retrieved_end: int = 0
-    _retrieved_initialized: bool = False
+    # Token coverage ranges, deduplicated across TP workers via union.
+    retrieved_range: TokenRange = field(default_factory=TokenRange)
+    lookup_range: TokenRange = field(default_factory=TokenRange)
+    store_range: TokenRange = field(default_factory=TokenRange)
     # Accumulated storage-path time (excludes token hashing in server.py).
     lookup_time: float = 0.0
     retrieve_time: float = 0.0
     store_time: float = 0.0
-    # Number of chunks processed on the storage path, independent of time.
-    lookup_chunks: int = 0
-    store_chunks: int = 0
     lookup_ipc_key: Optional[IPCCacheEngineKey] = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     @property
     def retrieved_tokens(self) -> int:
         """Number of retrieved tokens, derived from the range."""
-        return self._retrieved_end - self._retrieved_start
+        return self.retrieved_range.tokens
 
     @property
     def retrieve_chunks(self) -> int:
         """Number of retrieved chunks, derived from the range."""
-        chunk_size = self.hasher.chunk_size
-        return (self._retrieved_end - self._retrieved_start) // chunk_size
+        return self.retrieved_range.chunks(self.hasher.chunk_size)
+
+    @property
+    def lookup_chunks(self) -> int:
+        """Number of looked-up chunks, derived from the range."""
+        return self.lookup_range.chunks(self.hasher.chunk_size)
+
+    @property
+    def store_chunks(self) -> int:
+        """Number of stored chunks, derived from the range.
+
+        This reflects the token-level coverage, not the per-TP-worker
+        physical write count; it is deduplicated across TP workers.
+        """
+        return self.store_range.chunks(self.hasher.chunk_size)
 
     def update_retrieved_range(self, start: int, end: int) -> None:
-        """Update the retrieved token range (idempotent union).
+        """Union-update the retrieved token range (thread-safe).
 
-        Multiple TP workers may call this with the same range;
-        the result is always the union of all reported ranges.
-
-        Args:
-            start: Start token index of the retrieved range.
-            end: End token index of the retrieved range.
+        Prefer :meth:`record_retrieve` to update time and range in a
+        single lock acquisition; this method is kept for callers that
+        only need the range operation (e.g. unit tests or out-of-band
+        updates).
         """
         with self._lock:
-            if not self._retrieved_initialized:
-                # First call: initialize the range
-                self._retrieved_start = start
-                self._retrieved_end = end
-                self._retrieved_initialized = True
-            else:
-                self._retrieved_start = min(self._retrieved_start, start)
-                self._retrieved_end = max(self._retrieved_end, end)
+            self.retrieved_range.update(start, end)
+
+    def update_lookup_range(self, start: int, end: int) -> None:
+        """Union-update the lookup token range (thread-safe).
+
+        See :meth:`update_retrieved_range` for the relationship with
+        the combined :meth:`record_lookup` API.
+        """
+        with self._lock:
+            self.lookup_range.update(start, end)
+
+    def update_store_range(self, start: int, end: int) -> None:
+        """Union-update the store token range (thread-safe).
+
+        See :meth:`update_retrieved_range` for the relationship with
+        the combined :meth:`record_store` API.
+        """
+        with self._lock:
+            self.store_range.update(start, end)
+
+    def record_lookup(
+        self, elapsed: float, token_range: Optional[tuple[int, int]] = None
+    ) -> None:
+        """Accumulate lookup-path time and (optionally) union the range.
+
+        Pass ``token_range=None`` for early-return paths that consumed
+        wall-clock time but covered no tokens (e.g. lookup miss before
+        any object key is produced). Single lock acquisition for both
+        time and range update, reducing contention under multi-TP.
+
+        Args:
+            elapsed: Seconds spent on this lookup invocation.
+            token_range: Optional (start, end) of tokens actually looked
+                up; when provided, unioned into ``lookup_range``.
+        """
+        with self._lock:
+            self.lookup_time += elapsed
+            if token_range is not None:
+                self.lookup_range.update(*token_range)
+
+    def record_retrieve(
+        self, elapsed: float, token_range: Optional[tuple[int, int]] = None
+    ) -> None:
+        """Accumulate retrieve-path time and (optionally) union the range.
+
+        See :meth:`record_lookup` for the ``token_range=None`` semantics.
+        """
+        with self._lock:
+            self.retrieve_time += elapsed
+            if token_range is not None:
+                self.retrieved_range.update(*token_range)
+
+    def record_store(
+        self, elapsed: float, token_range: Optional[tuple[int, int]] = None
+    ) -> None:
+        """Accumulate store-path time and (optionally) union the range.
+
+        See :meth:`record_lookup` for the ``token_range=None`` semantics.
+        """
+        with self._lock:
+            self.store_time += elapsed
+            if token_range is not None:
+                self.store_range.update(*token_range)
 
     def set_tokens(self, full_token_ids: list[int]) -> None:
         """Update the token sequence (idempotent, replaces not extends).

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -36,9 +36,12 @@ class Session:
     total_tokens: int = 0
     _retrieved_start: int = 0
     _retrieved_end: int = 0
+    _retrieved_initialized: bool = False
+    # Accumulated storage-path time (excludes token hashing in server.py).
     lookup_time: float = 0.0
     retrieve_time: float = 0.0
     store_time: float = 0.0
+    # Number of chunks processed on the storage path, independent of time.
     lookup_chunks: int = 0
     store_chunks: int = 0
     lookup_ipc_key: Optional[IPCCacheEngineKey] = None
@@ -66,10 +69,11 @@ class Session:
             end: End token index of the retrieved range.
         """
         with self._lock:
-            if self._retrieved_start == self._retrieved_end:
+            if not self._retrieved_initialized:
                 # First call: initialize the range
                 self._retrieved_start = start
                 self._retrieved_end = end
+                self._retrieved_initialized = True
             else:
                 self._retrieved_start = min(self._retrieved_start, start)
                 self._retrieved_end = max(self._retrieved_end, end)

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -45,6 +45,12 @@ SAMPLE_STATUS = {
         },
     },
     "active_sessions": 3,
+    "hit_stats": {
+        "total_requests": 50,
+        "total_tokens": 12800,
+        "total_retrieved_tokens": 8960,
+        "hit_rate": 0.7,
+    },
     "storage_manager": {
         "is_healthy": True,
         "l1_manager": {
@@ -172,6 +178,14 @@ class TestDescribeKvcacheFields:
         assert m["eviction_policy"] == "LRU"
         assert m["cached_objects"] == 1024
         assert m["active_sessions"] == 3
+
+        # Hit statistics section (list)
+        assert "hit_stats" in m
+        hs = m["hit_stats"]
+        assert hs["total_requests"] == 50
+        assert hs["total_tokens"] == 12800
+        assert hs["retrieved_tokens"] == 8960
+        assert hs["hit_rate"] == "70.0%"
 
         # Per-model section (list)
         assert "models" in m

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -98,6 +98,44 @@ class TestSession:
         assert store_hashes == all_hashes[1:]
         assert session.num_chunks_processed == 3  # no extra computation
 
+    def test_retrieved_range_initial_zero(self, session: Session) -> None:
+        """Before any update, retrieved range derives 0 tokens / 0 chunks."""
+        assert session.retrieved_tokens == 0
+        assert session.retrieve_chunks == 0
+
+    def test_retrieved_range_first_update(self, session: Session) -> None:
+        """First update sets the range exactly as provided."""
+        session.update_retrieved_range(8, 20)
+        assert session.retrieved_tokens == 12
+        # chunk_size=4 -> 3 chunks in [8, 20)
+        assert session.retrieve_chunks == 3
+
+    def test_retrieved_range_union(self, session: Session) -> None:
+        """Subsequent updates union (min start, max end)."""
+        session.update_retrieved_range(4, 12)
+        session.update_retrieved_range(8, 20)
+        # Union = [4, 20) -> 16 tokens, 4 chunks
+        assert session.retrieved_tokens == 16
+        assert session.retrieve_chunks == 4
+
+    def test_retrieved_range_first_update_zero_range(self, session: Session) -> None:
+        """First update with (0, 0) must still mark the range as
+        initialized so later (0, 12) unions correctly instead of being
+        treated as a fresh init that overwrites. Regression test for
+        the ``_retrieved_initialized`` flag."""
+        session.update_retrieved_range(0, 0)
+        session.update_retrieved_range(0, 12)
+        assert session.retrieved_tokens == 12
+        assert session.retrieve_chunks == 3
+
+    def test_retrieved_range_idempotent_same_range(self, session: Session) -> None:
+        """Repeated identical updates (as from multiple TP workers) must
+        not double-count."""
+        for _ in range(4):
+            session.update_retrieved_range(0, 16)
+        assert session.retrieved_tokens == 16
+        assert session.retrieve_chunks == 4
+
 
 class TestSessionManager:
     def test_get_or_create_new(self, session_manager: SessionManager) -> None:

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -128,6 +128,32 @@ class TestSessionManager:
         result = session_manager.remove("does-not-exist")
         assert result is None
 
+    def test_remove_accumulates_stats(self, session_manager: SessionManager) -> None:
+        """Stats from removed sessions accumulate."""
+        s1 = session_manager.get_or_create("req-1")
+        s1.total_tokens = 1000
+        s1.update_retrieved_range(0, 600)
+        session_manager.remove("req-1")
+
+        s2 = session_manager.get_or_create("req-2")
+        s2.total_tokens = 2000
+        s2.update_retrieved_range(0, 1500)
+        session_manager.remove("req-2")
+
+        stats = session_manager.report_hit_stats()
+        assert stats["total_requests"] == 2
+        assert stats["total_tokens"] == 3000
+        assert stats["total_retrieved_tokens"] == 2100
+        assert stats["hit_rate"] == round(2100 / 3000, 4)
+
+    def test_report_hit_stats_empty(self, session_manager: SessionManager) -> None:
+        """Empty manager returns zero stats."""
+        stats = session_manager.report_hit_stats()
+        assert stats["total_requests"] == 0
+        assert stats["total_tokens"] == 0
+        assert stats["total_retrieved_tokens"] == 0
+        assert stats["hit_rate"] == 0.0
+
     def test_cleanup_expired(self, session_manager: SessionManager) -> None:
         """Sessions older than TTL should be cleaned up."""
         session_manager.get_or_create("req-1")

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -396,3 +396,84 @@ class TestSessionManagerRemoveReturnsSession:
         """remove() on a non-existent request_id should return None."""
         mgr = SessionManager(hasher, ttl=600)
         assert mgr.remove("no-such-id") is None
+
+
+class TestSessionRecordStats:
+    """Tests for the thread-safe time accumulators and range unions.
+
+    ``*_chunks`` properties derive from the union of [start, end) ranges
+    reported by multiple TP workers (token-level coverage), so they are
+    deduplicated across workers - not simple accumulators.
+    """
+
+    def test_record_lookup_accumulates_time_and_range(self, session: Session) -> None:
+        chunk_size = session.hasher.chunk_size
+        session.record_lookup(0.1)
+        session.record_lookup(0.2)
+        session.update_lookup_range(0, 2 * chunk_size)
+        session.update_lookup_range(0, 3 * chunk_size)
+        assert session.lookup_time == pytest.approx(0.3)
+        # Union is [0, 3 * chunk_size) -> 3 chunks.
+        assert session.lookup_chunks == 3
+
+    def test_record_retrieve_accumulates_time(self, session: Session) -> None:
+        session.record_retrieve(0.25)
+        session.record_retrieve(0.75)
+        assert session.retrieve_time == pytest.approx(1.0)
+
+    def test_record_store_accumulates_time_and_range(self, session: Session) -> None:
+        chunk_size = session.hasher.chunk_size
+        session.record_store(0.1)
+        session.record_store(0.3)
+        session.update_store_range(0, 4 * chunk_size)
+        session.update_store_range(0, 6 * chunk_size)
+        assert session.store_time == pytest.approx(0.4)
+        # Union is [0, 6 * chunk_size) -> 6 chunks.
+        assert session.store_chunks == 6
+
+    def test_store_range_idempotent_across_tp_workers(self, session: Session) -> None:
+        """Repeated identical store-range updates (as from multiple TP
+        workers with differing reserved_dict keys but identical token
+        ranges) must not double-count at the token level."""
+        chunk_size = session.hasher.chunk_size
+        for _ in range(8):
+            session.update_store_range(0, 5 * chunk_size)
+        assert session.store_chunks == 5
+
+    def test_record_store_concurrent_no_lost_updates(self, session: Session) -> None:
+        """Many threads each calling record_store must not lose
+        any update (regression for non-atomic += under concurrent
+        writers, mirroring the multi-TP-worker STORE path)."""
+        n_threads = 16
+        n_calls = 500
+
+        def worker() -> None:
+            for _ in range(n_calls):
+                session.record_store(0.001)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected_total = n_threads * n_calls * 0.001
+        assert session.store_time == pytest.approx(expected_total, rel=1e-6)
+
+    def test_record_lookup_concurrent_no_lost_updates(self, session: Session) -> None:
+        """Same regression for the LOOKUP path (normal thread pool)."""
+        n_threads = 8
+        n_calls = 500
+
+        def worker() -> None:
+            for _ in range(n_calls):
+                session.record_lookup(0.001)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected_total = n_threads * n_calls * 0.001
+        assert session.lookup_time == pytest.approx(expected_total, rel=1e-6)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path MP server methods (`lookup`/`retrieve`/`store`) to add new locking/timing and finally-block recording; while intended to be observability-only, bugs here could affect concurrency or performance under load.
> 
> **Overview**
> Adds **cumulative cache hit statistics** (total requests/tokens, retrieved tokens, hit rate) to the MP engine `/api/status` payload and displays them in `lmcache describe kvcache` under a new `Hit Statistics` section.
> 
> Implements new per-session accounting in `Session`/`SessionManager` (token-range union across TP workers plus lookup/retrieve/store timing), records these metrics from `lookup`/`retrieve`/`store`, emits an `END_SESSION[...]` log with hit rate + timings, and accumulates totals for server-lifetime reporting; tests are expanded accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934bdbea7dbc89da88bd58e12429670039b14d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->