### PR TITLE
[MP][observability] Use monotonic clock for CUDA-host-callback event timestamps

### DIFF
--- a/csrc/event_recorder.cpp
+++ b/csrc/event_recorder.cpp
@@ -9,9 +9,28 @@
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Monotonic wall-clock reader.
+//
+// Why not just `system_clock::now()`?  `system_clock` maps to CLOCK_REALTIME,
+// which NTP / chrony can slew backward by tens of microseconds to stay synced
+// with upstream.  CUDA host callbacks fire at arbitrary wall moments, so two
+// consecutive callbacks (e.g. MP_STORE_START then MP_STORE_END on the same
+// stream) can straddle a backward slew and land with end_ts < start_ts.
+// Jaeger then renders span duration as unsigned 64-bit subtraction, producing
+// the characteristic ~213503982d span duration (= 2^64 microseconds).
+//
+// Fix: anchor once to the (system_clock, steady_clock) pair at first call.
+// Every subsequent timestamp is computed as
+//   epoch_sys + (steady_now - epoch_steady)
+// which is monotonic (steady_clock == CLOCK_MONOTONIC on Linux) while
+// remaining expressed in Unix-epoch seconds so downstream consumers don't
+// notice any change.
 static double wall_clock_time() {
-  auto now = std::chrono::system_clock::now();
-  return std::chrono::duration<double>(now.time_since_epoch()).count();
+  static const auto epoch_sys = std::chrono::system_clock::now();
+  static const auto epoch_steady = std::chrono::steady_clock::now();
+  auto now_steady = std::chrono::steady_clock::now();
+  auto since_epoch = epoch_sys.time_since_epoch() + (now_steady - epoch_steady);
+  return std::chrono::duration<double>(since_epoch).count();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

TL;DR — The wall-clock function used in the C++ callback is not monotonic, causing ~1% of operation spans to have negative durations (e.g., “store cost = -2 ms”). This breaks MP observability and must be fixed.

In the Jaeger screenshot below, these negative values are interpreted as extremely large positive integers.
<img width="468" height="78" alt="Screenshot 2026-04-22 at 17 13 55" src="https://github.com/user-attachments/assets/bac0ab11-04a2-4967-8cea-acca09af1d05" />

Fixes corrupted span durations in Jaeger for `mp.store` (and, in principle, `mp.retrieve`) spans emitted via the CUDA host-callback path.

The root cause is a non-monotonic clock read inside the C++ `event_host_callback`:

```cpp
auto now = std::chrono::system_clock::now();   // CLOCK_REALTIME
```

NTP/chrony routinely slews `CLOCK_REALTIME` backward by tens of microseconds. When two consecutive host callbacks — typically `MP_STORE_START` and `MP_STORE_END` on the same rank's stream — straddle a backward slew, `end_ts < start_ts`. Jaeger then computes `end − start` as an **unsigned 64-bit** subtraction and the UI shows the characteristic **`213503982d 8h`** duration (= 2⁶⁴ μs).

## Fix

Anchor once at first call to the `(system_clock, steady_clock)` pair, then compute every subsequent timestamp as:

```
epoch_sys + (steady_now - epoch_steady)
```

`steady_clock` maps to `CLOCK_MONOTONIC` on Linux, so NTP steering is invisible. The return value stays in Unix-epoch seconds, so downstream consumers (OTel SDK, the Python drain thread, Jaeger) are unchanged.

Only `MP_STORE_{START,END}` and `MP_RETRIEVE_{START,END}` use this code path today (via `publish_on_stream` → `record_event_on_stream` → the host callback). Other events stamp via Python `time.time()`, which reads the same `CLOCK_REALTIME` but has not triggered the bug in practice because those start/end pairs are further apart in wall time and rarely straddle an NTP step.

The change is a one-function edit in `csrc/event_recorder.cpp`:

```cpp
static double wall_clock_time() {
  static const auto epoch_sys = std::chrono::system_clock::now();
  static const auto epoch_steady = std::chrono::steady_clock::now();
  auto now_steady = std::chrono::steady_clock::now();
  auto since_epoch = epoch_sys.time_since_epoch() + (now_steady - epoch_steady);
  return std::chrono::duration<double>(since_epoch).count();
}
```

## Evidence

Before the fix, on a 75-trace sample from a live `repetition_bench.sh` run:

| operation | span count | corrupted |
|---|---|---|
| `mp.store` | 496 | **7** (~1.4%) |
| `mp.retrieve` | 25 | 0 |
| `mp.lookup_prefetch` | 75 | 0 |
| `request` (root) | 75 | 0 |

Every corrupted span had the same signature — `duration ≈ 2⁶⁴ μs`, with the true inversion (`2⁶⁴ − duration`) between 6 μs and 42 μs. Example from trace `0A90dcBc…d5b5bCA`, session `cmpl-a7c4a57f…`:

```
spanID=7afaf9b3f5152e0f  start=1776844383143755 dur=18446744073709551604  device=cuda:6
```

= 2⁶⁴ − 12 μs inversion.

Full distribution of inversions across the 7 bad spans:

| device | inversion (μs) |
|---|---|
| cuda:1 | 6 |
| cuda:6 | 10 |
| cuda:6 | 12 |
| cuda:5 | 17 |
| cuda:4 | 24 |
| cuda:3 | 40 |
| cuda:3 | 42 |

The 6–42 μs range is the expected size of a chrony micro-correction, not a logic bug — which is consistent with only ~1.4% of spans being affected and the pattern being sporadic across ranks. Within a single request (trace `0A90dcBc…`), 10 of 11 `mp.store` spans had normal durations (4–177 μs); one span on `cuda:6` had the pathological value.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the timestamp source for CUDA host-callback events to prevent non-monotonic time causing negative/overflowed span durations; no functional data-path logic is modified.
> 
> **Overview**
> Fixes corrupted Jaeger span durations for events recorded via the CUDA host-callback path by making `wall_clock_time()` monotonic.
> 
> `wall_clock_time()` now anchors once to a `(system_clock, steady_clock)` pair and computes subsequent timestamps as *epoch wall time + steady-clock delta*, avoiding NTP/chrony backward slews while keeping timestamps in Unix-epoch seconds for downstream compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7480586f6574af7047eb5650f7ec1fb5d071968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->