### PR TITLE
feat(mp): fully synchronous mode (sync lookup + sync retrieve)

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -26,12 +26,14 @@ from vllm.v1.utils import ConstantList
 try:
     from lmcache.integration.vllm.vllm_multi_process_adapter import (
         LMCacheMPSchedulerAdapter,
+        LMCacheMPSyncLookUpSchedulerAdapter,
         LMCacheMPWorkerAdapter,
         LoadStoreOp,
     )
 except ImportError:
     from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (
         LMCacheMPSchedulerAdapter,
+        LMCacheMPSyncLookUpSchedulerAdapter,
         LMCacheMPWorkerAdapter,
         LoadStoreOp,
     )
@@ -106,6 +108,7 @@ def create_scheduler_adapter(
     vllm_config: VllmConfig,
     mq_timeout: float,
     heartbeat_interval: float,
+    sync_mode: bool = False,
 ) -> LMCacheMPSchedulerAdapter:
     world_size, kv_rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
@@ -120,7 +123,12 @@ def create_scheduler_adapter(
     if _adapter_accepts_tp_size():
         kwargs["tp_size"] = tp_size
 
-    return LMCacheMPSchedulerAdapter(
+    adapter_cls = (
+        LMCacheMPSyncLookUpSchedulerAdapter
+        if sync_mode
+        else LMCacheMPSchedulerAdapter
+    )
+    return adapter_cls(
         server_url,
         zmq_context,
         vllm_config.model_config.model,
@@ -139,6 +147,7 @@ def create_worker_adapter(
     vllm_config: VllmConfig,
     mq_timeout: float,
     heartbeat_interval: float,
+    sync_mode: bool = False,
 ) -> LMCacheMPWorkerAdapter:
     world_size, kv_rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
@@ -154,6 +163,7 @@ def create_worker_adapter(
         vllm_config.cache_config.block_size,
         mq_timeout=mq_timeout,
         heartbeat_interval=heartbeat_interval,
+        sync_mode=sync_mode,
     )
 
 
@@ -477,6 +487,12 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             )
         )
 
+        self.sync_mode: bool = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.sync_mode", False
+            )
+        )
+
         server_url = f"{server_host}:{server_port}"
         zmq_context = zmq.Context.instance()
         if self.role == KVConnectorRole.SCHEDULER:
@@ -486,6 +502,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                 vllm_config,
                 mq_timeout,
                 heartbeat_interval,
+                sync_mode=self.sync_mode,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
         elif self.role == KVConnectorRole.WORKER:
@@ -495,6 +512,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                 vllm_config,
                 mq_timeout,
                 heartbeat_interval,
+                sync_mode=self.sync_mode,
             )
         else:
             raise ValueError(f"Unknown KVConnectorRole: {self.role}")
@@ -729,17 +747,28 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         if request.status == RequestStatus.PREEMPTED:
             return 0, False
 
-        self.scheduler_adapter.maybe_submit_lookup_request(
-            request.request_id,
-            token_ids=list(request.all_token_ids),
-        )
+        if self.sync_mode:
+            assert isinstance(
+                self.scheduler_adapter, LMCacheMPSyncLookUpSchedulerAdapter
+            )
+            ret = self.scheduler_adapter.sync_lookup(
+                request.request_id,
+                token_ids=list(request.all_token_ids),
+            )
+            if ret == 0:
+                return 0, False
+        else:
+            self.scheduler_adapter.maybe_submit_lookup_request(
+                request.request_id,
+                token_ids=list(request.all_token_ids),
+            )
 
-        ret = self.scheduler_adapter.check_lookup_result(request.request_id)
-        if ret is None:
-            return None, True
+            ret = self.scheduler_adapter.check_lookup_result(request.request_id)
+            if ret is None:
+                return None, True
 
-        if ret == 0:
-            return 0, False
+            if ret == 0:
+                return 0, False
 
         assert (
             ret % (self.scheduler_adapter.num_blocks_per_chunk() * self.vllm_block_size)
@@ -759,7 +788,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         logger.debug(
             "vLLM hit is: %d, Need to load is %d", num_computed_tokens, need_to_load
         )
-        return need_to_load, need_to_load > 0
+        return need_to_load, False if self.sync_mode else need_to_load > 0
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 import os
 import threading
+import time
 
 # Third Party
 import torch
@@ -551,6 +552,73 @@ class LMCacheMPSchedulerAdapter:
         )
 
 
+class LMCacheMPSyncLookUpSchedulerAdapter(LMCacheMPSchedulerAdapter):
+    """LMCacheMPSchedulerAdapter subclass that uses the synchronous
+    SYNC_LOOKUP protocol instead of the two-phase LOOKUP + polling path.
+
+    ``sync_lookup`` performs the entire lookup in a single blocking
+    round-trip and returns the matched token count directly.
+    """
+
+    @_lmcache_nvtx_annotate
+    def sync_lookup(
+        self,
+        request_id: str,
+        token_ids: list[int],
+    ) -> int:
+        """Synchronous prefix lookup — single blocking round-trip.
+
+        Sends a SYNC_LOOKUP request to the server that performs the L1
+        prefix scan and L2 existence check atomically.  Returns the
+        number of matched **tokens** (not chunks).
+
+        Args:
+            request_id: The request ID.
+            token_ids: Full token sequence for the request.
+
+        Returns:
+            Number of matched tokens (always a multiple of
+            ``chunk_size``), or 0 on error / unhealthy server.
+        """
+        self._ensure_heartbeat_started()
+
+        if not self.is_healthy:
+            return 0
+
+        aligned_end = (len(token_ids) // self.chunk_size) * self.chunk_size
+
+        key = self._create_key(
+            token_ids,
+            start=0,
+            end=aligned_end,
+            request_id=request_id,
+        ).no_worker_id_version()
+
+        future = send_lmcache_request(
+            self.mq_client,
+            RequestType.SYNC_LOOKUP,
+            [key, self.tp_size],
+        )
+        try:
+            hit_chunks = future.result(timeout=self._mq_timeout)
+        except TimeoutError:
+            logger.warning(
+                "SYNC_LOOKUP request timed out after %ss. Marking server as unhealthy.",
+                self._mq_timeout,
+            )
+            self._health_event.clear()
+            return 0
+
+        hit_tokens = hit_chunks * self.chunk_size
+        logger.debug(
+            "SYNC_LOOKUP: request_id=%s hit %d chunks (%d tokens)",
+            request_id,
+            hit_chunks,
+            hit_tokens,
+        )
+        return hit_tokens
+
+
 class LMCacheMPWorkerAdapter:
     def __init__(
         self,
@@ -561,9 +629,16 @@ class LMCacheMPWorkerAdapter:
         parallel_strategy: ParallelStrategy,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        sync_mode: bool = False,
     ):
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
+        # When True, submit_retrieve_request polls QUERY_PREFETCH_STATUS
+        # until the server-side L2→L1 prefetch is complete, and
+        # batched_submit_retrieve_requests blocks until all retrieves
+        # finish.  Activated by the connector when
+        # lmcache.mp.sync_mode=true in kv_connector_extra_config.
+        self.sync_mode = sync_mode
 
         # Instance id for GPU worker
         self.instance_id = os.getpid()
@@ -780,6 +855,23 @@ class LMCacheMPWorkerAdapter:
             self.error_block_ids.update(op.block_ids)
             return
 
+        # In sync mode, SYNC_LOOKUP has already confirmed the prefetch
+        # hits but the L2→L1 data transfer may still be in flight.  Poll
+        # QUERY_PREFETCH_STATUS until the server reports the prefetch
+        # complete before sending RETRIEVE.  A non-None response
+        # (including 0 — meaning another TP worker has already consumed
+        # the job entry) signals "ready"; we can dispatch.
+        if self.sync_mode:
+            while True:
+                result = send_lmcache_request(
+                    self.mq_client,
+                    RequestType.QUERY_PREFETCH_STATUS,
+                    [request_id],
+                ).result(timeout=self._mq_timeout)
+                if result is not None:
+                    break
+                time.sleep(0.005)
+
         assert op.token_ids is not None
         key = self._create_key(
             op.token_ids,
@@ -852,6 +944,14 @@ class LMCacheMPWorkerAdapter:
             cache_salts = [""] * len(request_ids)
         for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
             self.submit_retrieve_request(request_id, op, event, cache_salt=salt)
+
+        # In sync mode, block until all retrieves complete so that KV is
+        # ready in L1 before vLLM proceeds to the forward pass. This
+        # mirrors the native (non-MP) connector's synchronous flow.
+        if self.sync_mode:
+            for request_id, (r_future, _) in self.retrieve_futures.items():
+                r_future.result()
+            self.retrieve_futures.clear()
 
     def _process_finished_stores(
         self,

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -44,6 +44,7 @@ class RequestType(enum.Enum):
     STORE = enum.auto()
     RETRIEVE = enum.auto()
     LOOKUP = enum.auto()
+    SYNC_LOOKUP = enum.auto()
     QUERY_PREFETCH_STATUS = enum.auto()
     QUERY_PREFETCH_LOOKUP_HITS = enum.auto()
     FREE_LOOKUP_LOCKS = enum.auto()

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -27,6 +27,7 @@ REQUEST_NAMES = [
     "STORE",
     "RETRIEVE",
     "LOOKUP",
+    "SYNC_LOOKUP",
     "QUERY_PREFETCH_STATUS",
     "QUERY_PREFETCH_LOOKUP_HITS",
     "FREE_LOOKUP_LOCKS",
@@ -111,6 +112,17 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         "QUERY_PREFETCH_STATUS": ProtocolDefinition(
             payload_classes=[str],
             response_class=int | None,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Synchronous lookup (L1 + L2 existence check in a single blocking call)
+        # Payload:
+        #   - key: KeyType - Cache key to look up
+        #   - tp_size: int - Tensor-parallel size for
+        #       MLA multi-reader locking
+        # Returns: int - Number of matched chunks (prefix hit count)
+        "SYNC_LOOKUP": ProtocolDefinition(
+            payload_classes=[KeyType, int],
+            response_class=int,
             handler_type=HandlerType.BLOCKING,
         ),
         # Query the lookup hit chunks before the prefetch is done

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -793,6 +793,62 @@ class MPCacheEngine:
 
         return found_count
 
+    @_lmcache_nvtx_annotate
+    def sync_lookup(
+        self,
+        key: IPCCacheEngineKey,
+        tp_size: int,
+    ) -> int:
+        """Synchronous prefix lookup — returns hit count directly.
+
+        Internally calls :meth:`lookup` to submit a prefetch request
+        to the background prefetch loop, then polls
+        :meth:`query_prefetch_lookup_hits` until the lookup phase
+        (L1 prefix scan + L2 existence check) completes.
+
+        The prefetch job is left registered under ``key.request_id``
+        so that RETRIEVE workers can wait for the L2→L1 data transfer
+        to complete via :meth:`query_prefetch_status`.  When there are
+        zero hits, no RETRIEVE will follow, so the job is drained here
+        (otherwise it leaks until ``end_session``).
+
+        Args:
+            key: Cache key with request_id embedded.
+            tp_size: Tensor-parallel size for MLA multi-reader locking.
+
+        Returns:
+            Number of matched chunks (prefix hit count).
+        """
+        # NOTE: lookup() already publishes MP_LOOKUP_PREFETCH_START,
+        # so we do not emit it here to avoid duplicate events.
+
+        # Step 1: submit to the existing background prefetch loop.
+        self.lookup(key, tp_size)
+
+        # Step 2: poll until the lookup phase finishes.
+        while True:
+            found_count = self.query_prefetch_lookup_hits(key.request_id)
+            if found_count is not None:
+                break
+            time.sleep(0.005)  # 5 ms
+
+        # Step 3: on zero hits, eagerly drain the job.  No RETRIEVE will
+        # follow, so query_prefetch_status won't run to pop it.
+        if found_count == 0:
+            with self._prefetch_job_lock:
+                job = self._prefetch_jobs.pop(key.request_id, None)
+            if job is not None and job.handle.prefetch_request_id != -1:
+                self.storage_manager.query_prefetch_status(job.handle)
+
+        logger.info(
+            "SYNC_LOOKUP[%s]: found_count=%d, world_size=%d",
+            key.request_id,
+            found_count,
+            key.world_size,
+        )
+
+        return found_count
+
     def free_lookup_locks(
         self,
         key: IPCCacheEngineKey,
@@ -848,7 +904,7 @@ class MPCacheEngine:
         return self.chunk_size
 
     def end_session(self, request_id: str) -> None:
-        """Remove the session for a finished request.
+        """Remove the session and all associated prefetch state.
 
         Args:
             request_id: The request ID whose session should be removed.
@@ -882,6 +938,17 @@ class MPCacheEngine:
         #  and will be deleted after finish_read_prefetched, when we touch all keys,
         #  these keys has been deleted and will not be touched.
         self.storage_manager.touch_l1_keys(obj_keys)
+
+        # SYNC_LOOKUP path: the prefetch job is popped either by a
+        # follow-up query_prefetch_status poll (normal path) or by
+        # sync_lookup itself on zero hits.  As a safety net for the
+        # "client called SYNC_LOOKUP but never issued RETRIEVE" case
+        # (e.g. worker crash, early cancellation), drain any lingering
+        # job here so the prefetch controller result does not leak.
+        with self._prefetch_job_lock:
+            job = self._prefetch_jobs.pop(request_id, None)
+        if job is not None and job.handle.prefetch_request_id != -1:
+            self.storage_manager.query_prefetch_status(job.handle)
 
     def report_status(self) -> dict:
         """Return a status dict for the entire cache engine."""
@@ -1046,6 +1113,7 @@ def run_cache_server(
     )
     add_handler_helper(server, RequestType.STORE, engine.store)
     add_handler_helper(server, RequestType.LOOKUP, engine.lookup)
+    add_handler_helper(server, RequestType.SYNC_LOOKUP, engine.sync_lookup)
     add_handler_helper(
         server, RequestType.QUERY_PREFETCH_STATUS, engine.query_prefetch_status
     )
@@ -1075,6 +1143,7 @@ def run_cache_server(
     server.add_normal_thread_pool(
         [
             RequestType.LOOKUP,
+            RequestType.SYNC_LOOKUP,
             RequestType.QUERY_PREFETCH_STATUS,
             RequestType.QUERY_PREFETCH_LOOKUP_HITS,
             RequestType.FREE_LOOKUP_LOCKS,


### PR DESCRIPTION
Add an opt-in "fully synchronous" mode to the MP connector that mirrors the native (non-MP) LMCache connector's blocking flow:

- Scheduler uses SYNC_LOOKUP to get the hit count in a single round trip, instead of the two-phase LOOKUP + QUERY_PREFETCH_STATUS poll.
- Worker blocks in start_load_kv() until all retrieves complete, so KV data is in L1 before the vLLM forward pass runs.

With this, requests go directly from WAITING to RUNNING (no WAITING_FOR_REMOTE_KVS / get_finished promote-back), eliminating the scheduling latency of the async path.

Activated by setting lmcache.mp.sync_mode=true in
kv_connector_extra_config. Default (async) behavior is unchanged.

Changes
-------
Protocol (lmcache/v1/multiprocess/protocols/):
- New RequestType.SYNC_LOOKUP ([KeyType, int] -> int) served by the normal (non-affinity) thread pool.

Server (lmcache/v1/multiprocess/server.py):
- sync_lookup(key, tp_size) -> int: runs lookup(), polls query_prefetch_lookup_hits until the lookup phase completes, and returns the hit chunk count.  On non-zero hits the prefetch job stays registered under request_id so the worker can poll QUERY_PREFETCH_STATUS to gate RETRIEVE on the L2->L1 transfer. Zero-hits eagerly drain the job; end_session drains any lingering job as a fallback for worker crashes / early cancellation.

Scheduler adapter (LMCacheMPSyncLookUpSchedulerAdapter):
- Subclasses LMCacheMPSchedulerAdapter and exposes sync_lookup() as a single blocking SYNC_LOOKUP call returning matched token count.

Worker adapter (LMCacheMPWorkerAdapter):
- New sync_mode kwarg.  In sync_mode, submit_retrieve_request polls QUERY_PREFETCH_STATUS per request_id (treating a non-None response, including 0 from a TP peer that already consumed the job, as "ready") before dispatching RETRIEVE.  batched_submit_retrieve_requests blocks on all RETRIEVE futures before returning.

Connector (lmcache/integration/vllm/lmcache_mp_connector_0180.py):
- Parse lmcache.mp.sync_mode from kv_connector_extra_config, plumb through create_scheduler_adapter / create_worker_adapter.  In sync_mode, get_num_new_matched_tokens() issues sync_lookup and returns load_kv_async=False so the request bypasses WAITING_FOR_REMOTE_KVS and goes straight to RUNNING.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MP connector control flow and server protocol behavior; while opt-in, the new blocking/polling paths could impact scheduling latency or hang on timeouts/edge cases if prefetch job lifecycle handling is incorrect.
> 
> **Overview**
> Adds an opt-in **fully synchronous** multi-process (MP) connector flow (`lmcache.mp.sync_mode`) that replaces the scheduler’s async `LOOKUP`+polling with a single blocking `SYNC_LOOKUP`, and makes workers block until all `RETRIEVE` operations complete before the forward pass proceeds.
> 
> This introduces a new MP RPC `RequestType.SYNC_LOOKUP` (protocol + server handler + thread-pool wiring), implements `MPCacheEngine.sync_lookup()` with polling/drain logic to avoid leaking prefetch jobs, and updates the vLLM connector/adapters to select the sync scheduler adapter and gate `RETRIEVE` on prefetch completion in sync mode while keeping the default async behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70fa24c2c2e46bc4ac0b111b8098fa36ce448b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->