### PR TITLE
 [CI] Fix  nightly build image job GHA

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -160,6 +160,7 @@ jobs:
               astral.sh:443
               releases.astral.sh:443
               download.pytorch.org:443
+              download-r2.pytorch.org:443
 
       - name: Login to DockerHub
         if: vars.DOCKERHUB_USERNAME != ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -546,6 +546,7 @@ jobs:
                   layers.nvcr.io:443
                   wheels.vllm.ai:443
                   download.pytorch.org:443
+                  download-r2.pytorch.org:443
 
             - name: Login to DockerHub
               uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
  Description:
  The nightly build image job was failing because PyTorch redirects wheel
  downloads to `download-r2.pytorch.org` (a Cloudflare R2 CDN mirror),
  which was not in the `allowed-endpoints` list. With `egress-policy: block`,
  the connection was refused and the `uv pip install` step failed.

  Add `download-r2.pytorch.org:443` to the harden-runner allowed-endpoints
  in the Build image job of `nightly_build.yml` and `publish.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that expands the egress allowlist for hardened GitHub runners, with no impact on application/runtime behavior. The main risk is unintentionally allowing outbound traffic to an additional host during builds.
> 
> **Overview**
> Fixes CI failures where PyTorch wheel downloads redirect to `download-r2.pytorch.org` while `egress-policy: block` is enabled.
> 
> Adds `download-r2.pytorch.org:443` to the `step-security/harden-runner` `allowed-endpoints` list in the nightly image build (`nightly_build.yml`) and release image publish job (`publish.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f669a2cf52acc5c67036fb9d381b9225296e3398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->