### PR TITLE
[Chore][Revert] MP adapter signature shim from #3100

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 import os
 import threading
 
@@ -210,20 +210,13 @@ LookupResult = int
 
 
 class LMCacheMPSchedulerAdapter:
-    # Signature kept backward-compatible with the vllm-bundled caller
-    # at vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py,
-    # which still passes (world_size, kv_rank, vllm_block_size) positionally
-    # and `mq_timeout` as a kwarg. Pass `parallel_strategy` for the new form.
     def __init__(
         self,
         server_url: str,
         context: zmq.Context,
         model_name: str,
-        world_size: int = 1,
-        kv_rank: int = 0,
-        vllm_block_size: int = 16,
-        tp_size: int = 1,
-        parallel_strategy: Optional[ParallelStrategy] = None,
+        vllm_block_size: int,
+        parallel_strategy: ParallelStrategy,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
@@ -235,21 +228,10 @@ class LMCacheMPSchedulerAdapter:
             vllm_block_size: The block size used in vLLM
             parallel_strategy:
                 The parallel strategy, which includes `use_mla`,
-                `kv_world_size`, `kv_worker_id` and so on. If None,
-                synthesised from world_size/kv_rank/tp_size.
+                `kv_world_size`, `kv_worker_id` and so on
             mq_timeout: Timeout in seconds for message queue requests.
             heartbeat_interval: Interval in seconds between heartbeat pings.
         """
-        if parallel_strategy is None:
-            parallel_strategy = ParallelStrategy(
-                use_mla=False,
-                kv_world_size=world_size,
-                kv_worker_id=kv_rank,
-                actual_world_size=world_size,
-                actual_worker_id=kv_rank,
-                tp_size=tp_size,
-                pp_size=1,
-            )
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 
@@ -570,31 +552,16 @@ class LMCacheMPSchedulerAdapter:
 
 
 class LMCacheMPWorkerAdapter:
-    # Signature kept backward-compatible with the vllm-bundled caller; see
-    # LMCacheMPSchedulerAdapter above for details.
     def __init__(
         self,
         server_url: str,
         context: zmq.Context,
         model_name: str,
-        world_size: int = 1,
-        kv_rank: int = 0,
-        vllm_block_size: int = 16,
-        tp_size: int = 1,
-        parallel_strategy: Optional[ParallelStrategy] = None,
+        vllm_block_size: int,
+        parallel_strategy: ParallelStrategy,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
-        if parallel_strategy is None:
-            parallel_strategy = ParallelStrategy(
-                use_mla=False,
-                kv_world_size=world_size,
-                kv_worker_id=kv_rank,
-                actual_world_size=world_size,
-                actual_worker_id=kv_rank,
-                tp_size=tp_size,
-                pp_size=1,
-            )
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 


### PR DESCRIPTION
PR #3100 bundled two unrelated changes: the CI sitecustomize/SCM fix and a backward-compat shim on LMCacheMPScheduler/WorkerAdapter that accepted the old positional (world_size, kv_rank, vllm_block_size) call form used by the vllm-bundled lmcache_mp_connector.

This reverts only the adapter shim (restores the pre-#3100 signature requiring parallel_strategy). The CI sitecustomize and SETUPTOOLS_SCM_PRETEND_VERSION changes from #3100 are kept.

Callers on an un-updated vllm that still pass the old positional args will break until the vllm side is updated to pass parallel_strategy.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `LMCacheMPSchedulerAdapter`/`LMCacheMPWorkerAdapter` constructor signatures; older vLLM callers using positional `(world_size, kv_rank, vllm_block_size)` will fail until updated.
> 
> **Overview**
> Restores the pre-#3100 API for vLLM multiprocess adapters by **removing the backward-compat constructor shim** on `LMCacheMPSchedulerAdapter` and `LMCacheMPWorkerAdapter`.
> 
> Both constructors now **require** `vllm_block_size` and a non-optional `parallel_strategy`, and no longer accept/derive values from `world_size`, `kv_rank`, or `tp_size` (including dropping related typing/imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18fbeab6d7f4be14b1a0cdfadc50197d557d1218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->