### PR TITLE
[MP][Observability] Add L1/L2 failure health monitoring metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# Virtual environments (including symlinks)
-.venv
-
-# Rust build artifacts
-rust/**/target/
-rust/**/Cargo.lock
-
 # Distribution / packaging
 .Python
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Virtual environments (including symlinks)
+.venv
+
+# Rust build artifacts
+rust/**/target/
+rust/**/Cargo.lock
+
 # Distribution / packaging
 .Python
 build/

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -21,6 +21,35 @@ these events see [METRICS.md](METRICS.md).
 
 ---
 
+## L1 Failure Events
+
+Published at the caller of the L1 API — **not** inside `L1Manager` — so the
+caller context (`during`) can be attached without leaking caller identity
+into the manager. See LM-291 for the health-monitoring rationale.
+
+Producers split keys by `(during[, reason])` and publish one event per
+non-empty bucket; `keys` is the list of ObjectKeys that failed for that
+bucket. Subscribers bucket by `ObjectKey.model_name` to emit per-model
+counter increments.
+
+| EventType | Metadata keys | Types | Vocabulary |
+|---|---|---|---|
+| `L1_ALLOCATION_FAILED` | `during`, `keys` | `str`, `list[ObjectKey]` | `during` ∈ {`l1_store`, `l2_prefetch`} |
+| `L1_READ_FAILED` | `during`, `reason`, `keys` | `str`, `str`, `list[ObjectKey]` | `during` ∈ {`l2_store`, `l1_retrieve`}; `reason` ∈ {`not_found`, `write_locked`} |
+
+`L1_READ_FAILED` is a **post-lookup anomaly** event, not a cache-miss
+event: in MP mode every `reserve_read` / `unsafe_read` that raises one of
+these errors represents a lookup/reserve race or unexpected eviction. The
+counter should stay near zero in healthy operation.
+
+Producers:
+- `L1_ALLOCATION_FAILED(during=l1_store)` — `StorageManager.reserve_write`, on `L1Error.OUT_OF_MEMORY`.
+- `L1_ALLOCATION_FAILED(during=l2_prefetch)` — `PrefetchController._transition_to_load_phase`, on `L1Error.OUT_OF_MEMORY` from L1 reservation.
+- `L1_READ_FAILED(during=l1_retrieve)` — `StorageManager.read_prefetched_results` (`unsafe_read` failure). `not_found` = `KEY_NOT_EXIST`, `write_locked` = `KEY_NOT_READABLE` (read lock lost).
+- `L1_READ_FAILED(during=l2_store)` — `StoreController._process_new_keys` (`reserve_read` failure on keys that just finished L1 write). `not_found` = `KEY_NOT_EXIST`, `write_locked` = `KEY_NOT_READABLE`.
+
+---
+
 ## StorageManager Events
 
 | EventType | Metadata keys | Types |
@@ -49,6 +78,25 @@ these events see [METRICS.md](METRICS.md).
 | `L2_PREFETCH_LOOKUP_COMPLETED` | `request_id`, `prefix_hit_count` | `int`, `int` |
 | `L2_PREFETCH_LOAD_SUBMITTED` | `request_id`, `key_count`, `adapter_count` | `int`, `int`, `int` |
 | `L2_PREFETCH_LOAD_COMPLETED` | `request_id`, `loaded_count`, `failed_count` | `int`, `int`, `int` |
+
+---
+
+## L2 Failure Events
+
+Health-monitoring event for the L2 prefetch path. See LM-291.
+
+| EventType | Metadata keys | Types | Vocabulary |
+|---|---|---|---|
+| `L2_PREFETCH_FAILED` | `reason`, `keys` | `str`, `list[ObjectKey]` | `reason` ∈ {`l1_oom`, `not_found`} |
+
+Producers (both in `PrefetchController`):
+- `reason=l1_oom` — emitted when `reserve_write` into L1 returns `OUT_OF_MEMORY` during the transition-to-load phase. Published in parallel with `L1_ALLOCATION_FAILED(during=l2_prefetch)`.
+- `reason=not_found` — emitted in `_finalize_load` for keys reserved in L1 but missing from the adapter's load bitmap (L2 reported the key present at lookup but produced no data).
+
+The third reason `serde_failure` will be added as an additive, non-breaking
+extension once the serde PR lands and adapters can distinguish
+deserialization errors from missing objects. No dashboard migration
+needed when that happens.
 
 ---
 

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -89,6 +89,28 @@ For implementation guidance on adding new events and subscribers, see [README.md
 
 ---
 
+## L1 Failure Metrics (LM-291 health monitoring)
+
+Tagged counters covering L1 allocation and read failures. The subscriber
+groups keys by `ObjectKey.model_name` to emit a `model_name` OTel
+attribute on every data point, enabling per-model Prometheus slicing
+(e.g. `lmcache_mp_l1_allocation_failure_total{during="l1_store",model_name="llama-7b"}`).
+
+The ticket-specified `lmcache_instance_id` tag is **deferred** to a
+follow-up: threading it through `StorageManager`/`StoreController` would
+require a cross-cutting API change out of scope for this PR.
+
+| OTel metric name | Prometheus name | Type | Source event | Calculation | Tags |
+|---|---|---|---|---|---|
+| `lmcache_mp.l1_allocation_failure` | `lmcache_mp_l1_allocation_failure_total` | Counter | `L1_ALLOCATION_FAILED` | `+count` per `(during, model_name)` bucket | `during` ∈ {`l1_store`, `l2_prefetch`}, `model_name` |
+| `lmcache_mp.l1_read_failure` | `lmcache_mp_l1_read_failure_total` | Counter | `L1_READ_FAILED` | `+count` per `(during, reason, model_name)` bucket | `during` ∈ {`l2_store`, `l1_retrieve`}, `reason` ∈ {`not_found`, `write_locked`}, `model_name` |
+
+**What it answers:**
+- `l1_allocation_failure` — how often is L1 rejecting writes for lack of memory, split by whether the pressure is user stores or L2 prefetch?
+- `l1_read_failure` — a **post-lookup anomaly counter**, not a cache-miss counter. Should stay near zero in healthy operation; any non-zero value indicates a lookup/reserve race or unexpected eviction in MP mode.
+
+---
+
 ## L1 Chunk Lifecycle Histograms
 
 Sampled (default 1%) chunk-level lifecycle tracking.  Only sampled chunks
@@ -133,6 +155,20 @@ contribute to histograms; counters above always count all events.
 | `lmcache_mp.l2_prefetch_failed_keys` | `lmcache_mp_l2_prefetch_failed_keys_total` | Counter | `L2_PREFETCH_LOAD_COMPLETED` | `+failed_count` |
 
 **What it answers:** How effective is L2 prefetching? What is the L2 hit rate? How many keys fail to load?
+
+---
+
+## L2 Failure Metrics (LM-291 health monitoring)
+
+| OTel metric name | Prometheus name | Type | Source event | Calculation | Tags |
+|---|---|---|---|---|---|
+| `lmcache_mp.l2_prefetch_failure` | `lmcache_mp_l2_prefetch_failure_total` | Counter | `L2_PREFETCH_FAILED` | `+count` per `(reason, model_name)` bucket | `reason` ∈ {`l1_oom`, `not_found`}, `model_name` |
+
+**What it answers:** For keys L2 reported present at lookup but failed to land in L1: was L1 full (`l1_oom`), or did the adapter fail to produce the data (`not_found`)?
+
+> **Serde failures**: a third `reason=serde_failure` value will be added as an additive, non-breaking extension once the serde PR lands and L2 adapters distinguish deserialization errors from missing objects. No dashboard migration needed when that happens.
+
+> **TTL lock expiration**: `lmcache_mp.l1_ttl_lock_expire` from the ticket is deferred to a follow-up because the current `TTLLock` primitive (native) has no expiration callback; lazy detection requires a C++/Rust-side change.
 
 ---
 

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -577,18 +577,35 @@ class PrefetchController(StorageControllerInterface):
 
         # Step 4: filter to successfully reserved keys
         reserved_key_set: set[ObjectKey] = set()
+        oom_keys: list[ObjectKey] = []
         for key, (err, mem_obj) in write_results.items():
             if err == L1Error.SUCCESS and mem_obj is not None:
                 request.write_reserved_keys.append(key)
                 request.write_reserved_objs[key] = mem_obj
                 reserved_key_set.add(key)
             else:
+                if err == L1Error.OUT_OF_MEMORY:
+                    oom_keys.append(key)
                 logger.debug(
                     "Prefetch request %d: reserve write failed for %s: %s",
                     request.request_id,
                     key,
                     err,
                 )
+
+        if oom_keys:
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_ALLOCATION_FAILED,
+                    metadata={"during": "l2_prefetch", "keys": oom_keys},
+                )
+            )
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L2_PREFETCH_FAILED,
+                    metadata={"reason": "l1_oom", "keys": oom_keys},
+                )
+            )
 
         # Step 5: recompute load plan excluding failed reservations
         reserved_bitmap = Bitmap(len(request.keys))
@@ -750,6 +767,19 @@ class PrefetchController(StorageControllerInterface):
                 },
             )
         )
+
+        # L2 prefetch-failure anomaly reporting: keys were reserved in L1
+        # (expected to load from L2) but did not appear in the load bitmap.
+        # Classified as ``not_found`` — the serde_failure reason will be
+        # added once the serde PR lands and adapters can distinguish
+        # deserialization errors from missing objects.
+        if failed_keys:
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L2_PREFETCH_FAILED,
+                    metadata={"reason": "not_found", "keys": failed_keys},
+                )
+            )
 
         # Partial load failures can create gaps in the prefix.
         # Release read locks for loaded keys beyond the prefix.

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -316,12 +316,18 @@ class StoreController(StorageControllerInterface):
 
             successful_keys = []
             successful_objs = []
+            not_found_keys: list[ObjectKey] = []
+            write_locked_keys: list[ObjectKey] = []
             for key in target_keys:
                 result = read_results.get(key)
                 if result is None:
                     continue
                 err, obj = result
                 if err != L1Error.SUCCESS or obj is None:
+                    if err == L1Error.KEY_NOT_EXIST:
+                        not_found_keys.append(key)
+                    elif err == L1Error.KEY_NOT_READABLE:
+                        write_locked_keys.append(key)
                     logger.debug(
                         "Skipping key %s for L2 store (adapter %d): %s",
                         key,
@@ -331,6 +337,32 @@ class StoreController(StorageControllerInterface):
                     continue
                 successful_keys.append(key)
                 successful_objs.append(obj)
+
+            # L1 read-failure anomaly reporting: target_keys come from an
+            # L1_WRITE_FINISHED notification, so failing to reserve_read them
+            # immediately after means an unexpected eviction or lock race.
+            if not_found_keys:
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.L1_READ_FAILED,
+                        metadata={
+                            "during": "l2_store",
+                            "reason": "not_found",
+                            "keys": not_found_keys,
+                        },
+                    )
+                )
+            if write_locked_keys:
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.L1_READ_FAILED,
+                        metadata={
+                            "during": "l2_store",
+                            "reason": "write_locked",
+                            "keys": write_locked_keys,
+                        },
+                    )
+                )
 
             if not successful_keys:
                 continue

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -146,6 +146,18 @@ class StorageManager:
                 },
             )
         )
+
+        oom_keys = [
+            k for k, (e, _) in reserve_result.items() if e == L1Error.OUT_OF_MEMORY
+        ]
+        if oom_keys:
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_ALLOCATION_FAILED,
+                    metadata={"during": "l1_store", "keys": oom_keys},
+                )
+            )
+
         return result
 
     @enable_tracing()
@@ -215,6 +227,8 @@ class StorageManager:
         good_keys: list[ObjectKey] = []
         good_objs: list[MemoryObj] = []
         bad_keys: list[ObjectKey] = []
+        not_found_keys: list[ObjectKey] = []
+        write_locked_keys: list[ObjectKey] = []
         all_good = True
         for k, (e, o) in read_results.items():
             if o is None:
@@ -225,10 +239,40 @@ class StorageManager:
                 )
                 bad_keys.append(k)
                 all_good = False
+                if e == L1Error.KEY_NOT_EXIST:
+                    not_found_keys.append(k)
+                elif e == L1Error.KEY_NOT_READABLE:
+                    write_locked_keys.append(k)
                 continue
 
             good_keys.append(k)
             good_objs.append(o)
+
+        # L1 read-failure anomaly reporting: unsafe_read is required to be
+        # called post-reserve_read, so any failure here is a lock/eviction
+        # race, not a normal cache miss.
+        if not_found_keys:
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_READ_FAILED,
+                    metadata={
+                        "during": "l1_retrieve",
+                        "reason": "not_found",
+                        "keys": not_found_keys,
+                    },
+                )
+            )
+        if write_locked_keys:
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_READ_FAILED,
+                    metadata={
+                        "during": "l1_retrieve",
+                        "reason": "write_locked",
+                        "keys": write_locked_keys,
+                    },
+                )
+            )
 
         successfully_yielded = False
 

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -290,8 +290,10 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         # First Party
         from lmcache.v1.mp_observability.subscribers.metrics import (
             L0LifecycleSubscriber,
+            L1FailureMetricsSubscriber,
             L1LifecycleSubscriber,
             L1MetricsSubscriber,
+            L2FailureMetricsSubscriber,
             L2MetricsSubscriber,
             SMMetricsSubscriber,
         )
@@ -300,7 +302,9 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         bus.register_subscriber(L0LifecycleSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L1MetricsSubscriber())
         bus.register_subscriber(L1LifecycleSubscriber(sample_rate=sample_rate))
+        bus.register_subscriber(L1FailureMetricsSubscriber())
         bus.register_subscriber(L2MetricsSubscriber())
+        bus.register_subscriber(L2FailureMetricsSubscriber())
         bus.register_subscriber(SMMetricsSubscriber())
 
     if obs_config.logging_enabled:

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -26,6 +26,10 @@ class EventType(Enum):
     L1_WRITE_FINISHED_AND_READ_RESERVED = "l1.write_finished_and_read_reserved"
     L1_KEYS_EVICTED = "l1.keys.evicted"
 
+    # L1 failure events (LM-291 health monitoring)
+    L1_ALLOCATION_FAILED = "l1.allocation.failed"
+    L1_READ_FAILED = "l1.read.failed"
+
     # StorageManager events
     SM_READ_PREFETCHED = "sm.read.prefetched"
     SM_READ_PREFETCHED_FINISHED = "sm.read.prefetched_finished"
@@ -41,6 +45,9 @@ class EventType(Enum):
     L2_PREFETCH_LOOKUP_COMPLETED = "l2.prefetch.lookup.completed"
     L2_PREFETCH_LOAD_SUBMITTED = "l2.prefetch.load.submitted"
     L2_PREFETCH_LOAD_COMPLETED = "l2.prefetch.load.completed"
+
+    # L2 failure events (LM-291 health monitoring)
+    L2_PREFETCH_FAILED = "l2.prefetch.failed"
 
     # MP Server request-level events (start/end pairs)
     MP_STORE_START = "mp.store.start"

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -5,16 +5,24 @@ from lmcache.v1.mp_observability.subscribers.metrics.l0_lifecycle import (
     L0LifecycleSubscriber,
 )
 from lmcache.v1.mp_observability.subscribers.metrics.l1 import L1MetricsSubscriber
+from lmcache.v1.mp_observability.subscribers.metrics.l1_failures import (
+    L1FailureMetricsSubscriber,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.l1_lifecycle import (
     L1LifecycleSubscriber,
 )
 from lmcache.v1.mp_observability.subscribers.metrics.l2 import L2MetricsSubscriber
+from lmcache.v1.mp_observability.subscribers.metrics.l2_failures import (
+    L2FailureMetricsSubscriber,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.sm import SMMetricsSubscriber
 
 __all__ = [
     "L0LifecycleSubscriber",
+    "L1FailureMetricsSubscriber",
     "L1LifecycleSubscriber",
     "L1MetricsSubscriber",
+    "L2FailureMetricsSubscriber",
     "L2MetricsSubscriber",
     "SMMetricsSubscriber",
 ]

--- a/lmcache/v1/mp_observability/subscribers/metrics/l1_failures.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l1_failures.py
@@ -36,7 +36,7 @@ class L1FailureMetricsSubscriber(EventSubscriber):
     """Maintains OTel counters for L1 allocation and read failures."""
 
     def __init__(self) -> None:
-        meter = metrics.get_meter("lmcache.l1")
+        meter = metrics.get_meter("lmcache_mp.health")
         self._allocation_counter = meter.create_counter(
             "lmcache_mp.l1_allocation_failure",
             description=(

--- a/lmcache/v1/mp_observability/subscribers/metrics/l1_failures.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l1_failures.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""L1 failure metrics subscriber — OTel counters for L1 allocation and read failures.
+
+These counters cover the health-monitoring surface for L1 (see LM-291):
+
+- ``lmcache_mp.l1_allocation_failure`` — L1 memory allocation failures (OOM)
+  during reserve_write. Tagged by ``during`` (``l1_store`` vs ``l2_prefetch``)
+  to distinguish user-initiated stores from prefetch-triggered allocations.
+- ``lmcache_mp.l1_read_failure`` — L1 reserve_read failures. This is an
+  anomaly counter, not a cache-miss counter: in MP mode ``reserve_read`` is
+  only called after a successful lookup, so any failure here indicates a
+  lookup/reserve race or unexpected eviction and should stay near zero in
+  healthy operation.
+
+All counters carry ``model_name`` extracted from each ``ObjectKey`` so operators
+can slice by model on the Prometheus ``/metrics`` endpoint.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections import Counter
+
+# Third Party
+from opentelemetry import metrics
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+
+
+class L1FailureMetricsSubscriber(EventSubscriber):
+    """Maintains OTel counters for L1 allocation and read failures."""
+
+    def __init__(self) -> None:
+        meter = metrics.get_meter("lmcache.l1")
+        self._allocation_counter = meter.create_counter(
+            "lmcache_mp.l1_allocation_failure",
+            description=(
+                "Count of L1 memory allocation failures (OOM) during "
+                "reserve_write. Tagged by ``during`` = l1_store | l2_prefetch "
+                "and ``model_name``."
+            ),
+        )
+        self._read_counter = meter.create_counter(
+            "lmcache_mp.l1_read_failure",
+            description=(
+                "Count of L1 reserve_read failures (post-lookup anomaly). "
+                "Tagged by ``during`` = l2_store | l1_retrieve, ``reason`` = "
+                "not_found | write_locked, and ``model_name``. Should stay "
+                "near zero in healthy operation; non-zero indicates a "
+                "lookup/reserve race or unexpected eviction."
+            ),
+        )
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {
+            EventType.L1_ALLOCATION_FAILED: self._on_allocation_failed,
+            EventType.L1_READ_FAILED: self._on_read_failed,
+        }
+
+    def _on_allocation_failed(self, event: Event) -> None:
+        during: str = event.metadata["during"]
+        keys: list[ObjectKey] = event.metadata["keys"]
+        for model_name, count in Counter(k.model_name for k in keys).items():
+            self._allocation_counter.add(
+                count,
+                {"during": during, "model_name": model_name},
+            )
+
+    def _on_read_failed(self, event: Event) -> None:
+        during: str = event.metadata["during"]
+        reason: str = event.metadata["reason"]
+        keys: list[ObjectKey] = event.metadata["keys"]
+        for model_name, count in Counter(k.model_name for k in keys).items():
+            self._read_counter.add(
+                count,
+                {
+                    "during": during,
+                    "reason": reason,
+                    "model_name": model_name,
+                },
+            )

--- a/lmcache/v1/mp_observability/subscribers/metrics/l2_failures.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l2_failures.py
@@ -36,7 +36,7 @@ class L2FailureMetricsSubscriber(EventSubscriber):
     """Maintains OTel counters for L2 prefetch failures."""
 
     def __init__(self) -> None:
-        meter = metrics.get_meter("lmcache.l2")
+        meter = metrics.get_meter("lmcache_mp.health")
         self._prefetch_counter = meter.create_counter(
             "lmcache_mp.l2_prefetch_failure",
             description=(

--- a/lmcache/v1/mp_observability/subscribers/metrics/l2_failures.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l2_failures.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 failure metrics subscriber — OTel counters for L2 prefetch failures.
+
+This covers the health-monitoring surface for L2 prefetch (see LM-291):
+
+- ``lmcache_mp.l2_prefetch_failure`` — count of keys that failed to load from
+  L2 to L1. Tagged by ``reason``:
+    * ``l1_oom``    — L1 had no room to receive the prefetched object.
+    * ``not_found`` — L2 reported the key present during lookup but the load
+      returned no data (adapter-level inconsistency, e.g. concurrent delete).
+
+The ``serde_failure`` reason is intentionally omitted until the serde PR
+lands; once it does, it becomes an additive third value of the same tag
+with no breaking change to dashboards.
+
+All emissions carry ``model_name`` extracted from each ``ObjectKey``.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections import Counter
+
+# Third Party
+from opentelemetry import metrics
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+
+
+class L2FailureMetricsSubscriber(EventSubscriber):
+    """Maintains OTel counters for L2 prefetch failures."""
+
+    def __init__(self) -> None:
+        meter = metrics.get_meter("lmcache.l2")
+        self._prefetch_counter = meter.create_counter(
+            "lmcache_mp.l2_prefetch_failure",
+            description=(
+                "Count of keys that were expected in L2 but failed to load "
+                "into L1. Tagged by ``reason`` = l1_oom | not_found and "
+                "``model_name``."
+            ),
+        )
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {EventType.L2_PREFETCH_FAILED: self._on_prefetch_failed}
+
+    def _on_prefetch_failed(self, event: Event) -> None:
+        reason: str = event.metadata["reason"]
+        keys: list[ObjectKey] = event.metadata["keys"]
+        for model_name, count in Counter(k.model_name for k in keys).items():
+            self._prefetch_counter.add(
+                count,
+                {"reason": reason, "model_name": model_name},
+            )

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -22,6 +22,8 @@ from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
 )
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBusConfig, init_event_bus
 
 try:
     # First Party
@@ -655,3 +657,123 @@ class TestStorageManagerL2Prefetch:
 
         sm.finish_read_prefetched(all_keys)
         sm.close()
+
+
+# =============================================================================
+# Tests for LM-291 failure event production
+# =============================================================================
+
+
+@pytest.fixture
+def captured_events():
+    """Enable the global event bus and capture all L1/L2 failure events.
+
+    Replaces the process-wide ``_global_bus`` with a fresh enabled bus,
+    subscribes a callback for the three failure event types, yields the
+    captured-events list, then resets the bus to disabled on teardown so
+    later tests don't see leftover state.
+    """
+    bus = init_event_bus(EventBusConfig(enabled=True, max_queue_size=10_000))
+    events: list[Event] = []
+
+    def _capture(event: Event) -> None:
+        events.append(event)
+
+    for et in (
+        EventType.L1_ALLOCATION_FAILED,
+        EventType.L1_READ_FAILED,
+        EventType.L2_PREFETCH_FAILED,
+    ):
+        bus.subscribe(et, _capture)
+    bus.start()
+    try:
+        yield events
+    finally:
+        bus.stop()
+        init_event_bus(EventBusConfig(enabled=False))
+
+
+def _events_of_type(events: list, event_type: EventType) -> list:
+    return [e for e in events if e.event_type == event_type]
+
+
+class TestFailureEventProduction:
+    """Verifies LM-291 health-monitoring events are published at the
+    right producer call sites with the expected metadata."""
+
+    def test_reserve_write_oom_emits_l1_allocation_failed(
+        self, small_storage_manager_config, large_layout, captured_events
+    ):
+        """OOM during user store must publish L1_ALLOCATION_FAILED with
+        during=l1_store and the OOM keys."""
+        sm = StorageManager(small_storage_manager_config)
+        try:
+            keys = [make_object_key(i) for i in range(20)]
+            sm.reserve_write(keys, large_layout, mode="new")
+
+            # Allow drain thread to deliver the event.
+            assert wait_for_condition(
+                lambda: len(
+                    _events_of_type(captured_events, EventType.L1_ALLOCATION_FAILED)
+                )
+                >= 1,
+                timeout=2.0,
+            )
+
+            alloc_events = _events_of_type(
+                captured_events, EventType.L1_ALLOCATION_FAILED
+            )
+            assert len(alloc_events) == 1
+            meta = alloc_events[0].metadata
+            assert meta["during"] == "l1_store"
+            assert len(meta["keys"]) > 0
+            # All emitted keys must be from the OOM subset of the request.
+            assert set(meta["keys"]).issubset(set(keys))
+        finally:
+            sm.close()
+
+    def test_unsafe_read_missing_key_emits_l1_read_failed(
+        self, basic_storage_manager_config, basic_layout, captured_events
+    ):
+        """Deleting a key between reserve_read and unsafe_read must publish
+        L1_READ_FAILED with during=l1_retrieve, reason=not_found."""
+        sm = StorageManager(basic_storage_manager_config)
+        try:
+            keys = [make_object_key(i) for i in range(3)]
+
+            # Write + finish_write so the keys are readable.
+            ret = sm.reserve_write(keys, basic_layout, mode="new")
+            assert len(ret) == len(keys)
+            sm.finish_write(list(ret.keys()))
+
+            # Prefetch to acquire read locks on all keys.
+            handle = sm.submit_prefetch_task(keys, basic_layout)
+            assert wait_for_prefetch_status(sm, handle) == len(keys)
+
+            # Force a mid-read race by removing the key from L1Manager's
+            # internal state dict, bypassing the lock check that
+            # ``L1Manager.delete`` enforces. This simulates the exact TOCTOU
+            # anomaly the metric is designed to catch: reserve_read acquired
+            # a lock, but the key vanished before unsafe_read.
+            del sm._l1_manager._objects[keys[1]]
+
+            # Now attempt to read — unsafe_read should find the middle key
+            # missing, emitting L1_READ_FAILED(during=l1_retrieve,
+            # reason=not_found).
+            with sm.read_prefetched_results(keys) as objs:
+                assert objs is None  # all_good=False because middle key is gone
+
+            assert wait_for_condition(
+                lambda: len(_events_of_type(captured_events, EventType.L1_READ_FAILED))
+                >= 1,
+                timeout=2.0,
+            )
+
+            read_events = _events_of_type(captured_events, EventType.L1_READ_FAILED)
+            assert len(read_events) == 1
+            meta = read_events[0].metadata
+            assert meta["during"] == "l1_retrieve"
+            assert meta["reason"] == "not_found"
+            assert keys[1] in meta["keys"]
+        finally:
+            sm.close()

--- a/tests/v1/mp_observability/subscribers/metrics/counter_helpers.py
+++ b/tests/v1/mp_observability/subscribers/metrics/counter_helpers.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for tagged-counter subscriber tests.
+
+Reads back counter data points from the in-memory OTel reader (see
+``otel_setup.py``) keyed by ``(metric_name, frozenset_of_attribute_pairs)``.
+This enables tests to assert on exact counts for specific attribute
+combinations (e.g. ``during=l1_store``, ``model_name=llama-7b``) without
+hand-rolling the plumbing in every test file.
+"""
+
+# Future
+from __future__ import annotations
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+
+TaggedKey = tuple[str, frozenset[tuple[str, str]]]
+
+
+def make_key(model: str, chunk_id: int) -> ObjectKey:
+    """Build a test ObjectKey with the given model name and chunk id."""
+    return ObjectKey(
+        chunk_hash=chunk_id.to_bytes(4, byteorder="big"),
+        model_name=model,
+        kv_rank=0,
+    )
+
+
+def read_tagged_counters() -> dict[TaggedKey, int]:
+    """Snapshot all counter values keyed by (metric_name, attrs).
+
+    Works for tagged counters where multiple data points differ only by
+    their attribute set. Histogram data points (which lack ``value``) are
+    skipped.
+    """
+    data = _reader.get_metrics_data()
+    result: dict[TaggedKey, int] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue
+                    attrs = frozenset(
+                        (str(k), str(v)) for k, v in dict(dp.attributes).items()
+                    )
+                    result[(metric.name, attrs)] = int(dp.value)
+    return result
+
+
+def counter_delta(
+    before: dict[TaggedKey, int],
+    after: dict[TaggedKey, int],
+) -> dict[TaggedKey, int]:
+    """Return the per-tagged-key delta between two snapshots."""
+    all_keys = set(before) | set(after)
+    return {k: after.get(k, 0) - before.get(k, 0) for k in all_keys}
+
+
+def counter_value(
+    delta: dict[TaggedKey, int],
+    metric: str,
+    **attrs: str,
+) -> int:
+    """Look up a counter delta by metric name + attribute equality.
+
+    Returns 0 if no data point matches the attribute set exactly.
+    """
+    key = (metric, frozenset(attrs.items()))
+    return delta.get(key, 0)

--- a/tests/v1/mp_observability/subscribers/metrics/test_l1_failures.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l1_failures.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for L1FailureMetricsSubscriber.
+
+Verifies that ``L1_ALLOCATION_FAILED`` and ``L1_READ_FAILED`` events
+produce the expected OTel counters with correct ``during``, ``reason``,
+and ``model_name`` attributes. Uses the shared ``InMemoryMetricReader``
+to assert on counter deltas keyed by (metric_name, attributes).
+"""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
+from lmcache.v1.mp_observability.subscribers.metrics.l1_failures import (
+    L1FailureMetricsSubscriber,
+)
+from tests.v1.mp_observability.subscribers.metrics.counter_helpers import (
+    counter_delta,
+    counter_value,
+    make_key,
+    read_tagged_counters,
+)
+
+# Time for the drain thread to process queued events.
+_DRAIN_WAIT = 0.15
+
+
+@pytest.fixture
+def bus():
+    return EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+
+
+@pytest.fixture
+def subscriber(bus):
+    sub = L1FailureMetricsSubscriber()
+    bus.register_subscriber(sub)
+    return sub
+
+
+@pytest.fixture
+def snapshot():
+    before = read_tagged_counters()
+
+    def get_delta():
+        return counter_delta(before, read_tagged_counters())
+
+    return get_delta
+
+
+class TestL1AllocationFailure:
+    def test_during_l1_store_single_model(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [make_key("llama-7b", i) for i in range(3)]
+        bus.publish(
+            Event(
+                event_type=EventType.L1_ALLOCATION_FAILED,
+                metadata={"during": "l1_store", "keys": keys},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_allocation_failure",
+                during="l1_store",
+                model_name="llama-7b",
+            )
+            == 3
+        )
+
+    def test_during_l2_prefetch_single_model(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [make_key("mistral-7b", i) for i in range(5)]
+        bus.publish(
+            Event(
+                event_type=EventType.L1_ALLOCATION_FAILED,
+                metadata={"during": "l2_prefetch", "keys": keys},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_allocation_failure",
+                during="l2_prefetch",
+                model_name="mistral-7b",
+            )
+            == 5
+        )
+
+    def test_multi_model_in_one_event_buckets_separately(
+        self, bus, subscriber, snapshot
+    ):
+        """A single event with keys from multiple models should emit
+        per-model increments."""
+        bus.start()
+        keys = [
+            make_key("llama-7b", 1),
+            make_key("llama-7b", 2),
+            make_key("mistral-7b", 3),
+        ]
+        bus.publish(
+            Event(
+                event_type=EventType.L1_ALLOCATION_FAILED,
+                metadata={"during": "l1_store", "keys": keys},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_allocation_failure",
+                during="l1_store",
+                model_name="llama-7b",
+            )
+            == 2
+        )
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_allocation_failure",
+                during="l1_store",
+                model_name="mistral-7b",
+            )
+            == 1
+        )
+
+    def test_accumulates_across_events(self, bus, subscriber, snapshot):
+        bus.start()
+        for _ in range(4):
+            bus.publish(
+                Event(
+                    event_type=EventType.L1_ALLOCATION_FAILED,
+                    metadata={
+                        "during": "l1_store",
+                        "keys": [make_key("llama-7b", 0)],
+                    },
+                )
+            )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_allocation_failure",
+                during="l1_store",
+                model_name="llama-7b",
+            )
+            == 4
+        )
+
+
+class TestL1ReadFailure:
+    def test_during_l2_store_not_found(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [make_key("llama-7b", i) for i in range(2)]
+        bus.publish(
+            Event(
+                event_type=EventType.L1_READ_FAILED,
+                metadata={
+                    "during": "l2_store",
+                    "reason": "not_found",
+                    "keys": keys,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_read_failure",
+                during="l2_store",
+                reason="not_found",
+                model_name="llama-7b",
+            )
+            == 2
+        )
+
+    def test_during_l1_retrieve_write_locked(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [make_key("llama-7b", i) for i in range(3)]
+        bus.publish(
+            Event(
+                event_type=EventType.L1_READ_FAILED,
+                metadata={
+                    "during": "l1_retrieve",
+                    "reason": "write_locked",
+                    "keys": keys,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_read_failure",
+                during="l1_retrieve",
+                reason="write_locked",
+                model_name="llama-7b",
+            )
+            == 3
+        )
+
+    def test_different_reasons_counted_separately(self, bus, subscriber, snapshot):
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.L1_READ_FAILED,
+                metadata={
+                    "during": "l2_store",
+                    "reason": "not_found",
+                    "keys": [make_key("llama-7b", 0)],
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.L1_READ_FAILED,
+                metadata={
+                    "during": "l2_store",
+                    "reason": "write_locked",
+                    "keys": [make_key("llama-7b", 1), make_key("llama-7b", 2)],
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_read_failure",
+                during="l2_store",
+                reason="not_found",
+                model_name="llama-7b",
+            )
+            == 1
+        )
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l1_read_failure",
+                during="l2_store",
+                reason="write_locked",
+                model_name="llama-7b",
+            )
+            == 2
+        )
+
+
+class TestL1FailureSubscriptions:
+    def test_subscriptions_cover_both_failure_events(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.L1_ALLOCATION_FAILED in subs
+        assert EventType.L1_READ_FAILED in subs
+        assert len(subs) == 2
+
+    def test_no_subscription_for_normal_l1_events(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.L1_READ_FINISHED not in subs
+        assert EventType.L1_WRITE_FINISHED not in subs
+
+
+class TestL1FailureEdgeCases:
+    def test_empty_keys_list_is_noop(self, bus, subscriber, snapshot):
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.L1_ALLOCATION_FAILED,
+                metadata={"during": "l1_store", "keys": []},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        # No keys → no emissions
+        for (name, _attrs), val in delta.items():
+            assert not (name == "lmcache_mp.l1_allocation_failure" and val != 0), (
+                f"Unexpected emission for empty keys: {name}={val}"
+            )

--- a/tests/v1/mp_observability/subscribers/metrics/test_l2_failures.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l2_failures.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for L2FailureMetricsSubscriber.
+
+Verifies that ``L2_PREFETCH_FAILED`` events produce the expected
+``lmcache_mp.l2_prefetch_failure`` counter with ``reason`` and
+``model_name`` attributes. Uses the shared ``InMemoryMetricReader`` to
+assert on counter deltas.
+"""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
+from lmcache.v1.mp_observability.subscribers.metrics.l2_failures import (
+    L2FailureMetricsSubscriber,
+)
+from tests.v1.mp_observability.subscribers.metrics.counter_helpers import (
+    counter_delta,
+    counter_value,
+    make_key,
+    read_tagged_counters,
+)
+
+_DRAIN_WAIT = 0.15
+
+
+@pytest.fixture
+def bus():
+    return EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+
+
+@pytest.fixture
+def subscriber(bus):
+    sub = L2FailureMetricsSubscriber()
+    bus.register_subscriber(sub)
+    return sub
+
+
+@pytest.fixture
+def snapshot():
+    before = read_tagged_counters()
+
+    def get_delta():
+        return counter_delta(before, read_tagged_counters())
+
+    return get_delta
+
+
+class TestL2PrefetchFailure:
+    def test_reason_l1_oom(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [make_key("llama-7b", i) for i in range(4)]
+        bus.publish(
+            Event(
+                event_type=EventType.L2_PREFETCH_FAILED,
+                metadata={"reason": "l1_oom", "keys": keys},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l2_prefetch_failure",
+                reason="l1_oom",
+                model_name="llama-7b",
+            )
+            == 4
+        )
+
+    def test_reason_not_found(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [make_key("mistral-7b", i) for i in range(2)]
+        bus.publish(
+            Event(
+                event_type=EventType.L2_PREFETCH_FAILED,
+                metadata={"reason": "not_found", "keys": keys},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l2_prefetch_failure",
+                reason="not_found",
+                model_name="mistral-7b",
+            )
+            == 2
+        )
+
+    def test_multi_model_buckets_separately(self, bus, subscriber, snapshot):
+        bus.start()
+        keys = [
+            make_key("llama-7b", 1),
+            make_key("mistral-7b", 2),
+            make_key("mistral-7b", 3),
+        ]
+        bus.publish(
+            Event(
+                event_type=EventType.L2_PREFETCH_FAILED,
+                metadata={"reason": "not_found", "keys": keys},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l2_prefetch_failure",
+                reason="not_found",
+                model_name="llama-7b",
+            )
+            == 1
+        )
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l2_prefetch_failure",
+                reason="not_found",
+                model_name="mistral-7b",
+            )
+            == 2
+        )
+
+    def test_different_reasons_counted_separately(self, bus, subscriber, snapshot):
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.L2_PREFETCH_FAILED,
+                metadata={
+                    "reason": "l1_oom",
+                    "keys": [make_key("llama-7b", 0), make_key("llama-7b", 1)],
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.L2_PREFETCH_FAILED,
+                metadata={
+                    "reason": "not_found",
+                    "keys": [make_key("llama-7b", 2)],
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l2_prefetch_failure",
+                reason="l1_oom",
+                model_name="llama-7b",
+            )
+            == 2
+        )
+        assert (
+            counter_value(
+                delta,
+                "lmcache_mp.l2_prefetch_failure",
+                reason="not_found",
+                model_name="llama-7b",
+            )
+            == 1
+        )
+
+
+class TestL2FailureSubscriptions:
+    def test_subscribes_only_to_prefetch_failed(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.L2_PREFETCH_FAILED in subs
+        assert len(subs) == 1
+
+    def test_no_subscription_for_normal_l2_events(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.L2_STORE_SUBMITTED not in subs
+        assert EventType.L2_PREFETCH_LOAD_COMPLETED not in subs
+
+
+class TestL2FailureEdgeCases:
+    def test_empty_keys_is_noop(self, bus, subscriber, snapshot):
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.L2_PREFETCH_FAILED,
+                metadata={"reason": "l1_oom", "keys": []},
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        for (name, _attrs), val in delta.items():
+            assert not (name == "lmcache_mp.l2_prefetch_failure" and val != 0), (
+                f"Unexpected emission for empty keys: {name}={val}"
+            )


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements LM-291: L1/L2 failure health monitoring. Adds three tagged OTel counter metrics to the MP-mode observability pipeline so operators can alert on cache-tier failure modes that previously were only visible in debug logs.

Three new metrics, all carrying a `model_name` tag extracted from `ObjectKey`:

| Metric | Source event | Tags |
|---|---|---|
| `lmcache_mp.l1_allocation_failure` | `L1_ALLOCATION_FAILED` | `during` ∈ {`l1_store`, `l2_prefetch`} |
| `lmcache_mp.l1_read_failure` | `L1_READ_FAILED` | `during` ∈ {`l2_store`, `l1_retrieve`}, `reason` ∈ {`not_found`, `write_locked`} |
| `lmcache_mp.l2_prefetch_failure` | `L2_PREFETCH_FAILED` | `reason` ∈ {`l1_oom`, `not_found`} |

Producer emissions at 5 call sites:

- `StorageManager.reserve_write` — `L1_ALLOCATION_FAILED(during=l1_store)` on `L1Error.OUT_OF_MEMORY`.
- `StorageManager.read_prefetched_results` (`unsafe_read` failure path) — `L1_READ_FAILED(during=l1_retrieve)`.
- `StoreController._process_new_keys` (`reserve_read` on freshly L1-written keys) — `L1_READ_FAILED(during=l2_store)`.
- `PrefetchController._transition_to_load_phase` — `L1_ALLOCATION_FAILED(during=l2_prefetch)` **and** `L2_PREFETCH_FAILED(reason=l1_oom)` when L1 OOMs during prefetch reservation.
- `PrefetchController._finalize_load` — `L2_PREFETCH_FAILED(reason=not_found)` for reserved-but-not-loaded keys.

**Special notes for your reviewers**:

Semantic note on `l1_read_failure`: it's intentionally narrow — fires only from `unsafe_read` (required to be called post-`reserve_read`) and from `StoreController.reserve_read` on keys that just finished L1 write. It is **not** a cache-miss counter; any non-zero value indicates a lookup/reserve race or unexpected eviction.

Also bundles a tiny `.gitignore` update for `.venv` (symlink) and `rust/**/target/` + `rust/**/Cargo.lock`. Happy to split that out if preferred.

**If applicable**:

- [x] this PR contains user facing changes - docs added
  - `docs/design/v1/mp_observability/METRICS.md` — new "L1 Failure Metrics" and "L2 Failure Metrics" sections.
  - `docs/design/v1/mp_observability/EVENTS.md` — new metadata contracts for the 3 events.
- [x] this PR contains unit tests
  - 17 subscriber tests with exact counter + attribute assertions via `InMemoryMetricReader` (shared helpers in `tests/v1/mp_observability/subscribers/metrics/counter_helpers.py`).
  - 2 producer-side tests in `test_distributed_storage_manager.py::TestFailureEventProduction` exercising the OOM path and a TOCTOU race on `unsafe_read`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MP storage paths to emit new failure events on OOM and post-lookup read anomalies, which could affect observability overhead and event-bus volume under failure conditions. Functional behavior is otherwise unchanged and guarded by focused unit tests.
> 
> **Overview**
> Adds MP-mode *health monitoring* for cache-tier failures by introducing new events `L1_ALLOCATION_FAILED`, `L1_READ_FAILED`, and `L2_PREFETCH_FAILED` plus tagged OTel counters that bucket by `model_name` (and `during`/`reason`).
> 
> Emits these failure events from key producer call sites: L1 OOM during user store (`StorageManager.reserve_write`) and L2 prefetch reservation (`PrefetchController._transition_to_load_phase`), post-lookup L1 read anomalies in both retrieve (`StorageManager.read_prefetched_results`) and L2 store pipeline (`StoreController._process_new_keys`), and L2 prefetch “reserved but not loaded” anomalies (`PrefetchController._finalize_load`).
> 
> Wires new metrics subscribers into `init_observability`, updates the event/metric contract docs, and adds unit tests covering both event production and exact tagged-counter increments via an in-memory OTel reader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c63d8af0a650a62e7812a4c39e8746291d0687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->