### PR TITLE
[CI] split logs in blend CI test

### DIFF
--- a/.buildkite/k3_tests/blend/pipeline.yml
+++ b/.buildkite/k3_tests/blend/pipeline.yml
@@ -25,4 +25,4 @@ steps:
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
     artifact_paths:
-      - "build_*.log"
+      - "logs_*/*.log"

--- a/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
+++ b/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
@@ -37,7 +37,6 @@ WORK_LOG="${LOG_DIR}/build_${BUILD_ID}_blend.log"
 # Proxy stdout/stderr. Blend server/prefiller/decoder each get their own _blend_server/_prefiller_PORT/_decoder_PORT logs.
 VLLM_LOG="${LOG_DIR}/build_${BUILD_ID}_proxy.log"
 BLEND_SERVER_LOG="${LOG_DIR}/build_${BUILD_ID}_blend_server.log"
-ARTIFACT="${REPO_ROOT}/build_${BUILD_ID}.log"
 # Benchmark wall-clock limit (seconds). Exit 124 from `timeout` => failure. Default stays under blend pipeline 90m.
 BENCHMARK_TIMEOUT_SEC="${BENCHMARK_TIMEOUT_SEC:-4800}"
 
@@ -93,20 +92,12 @@ resolve_port_csv() {
   echo "${joined}"
 }
 
-collect_artifact() {
-  # Individual logs are already in LOG_DIR (written there directly).
-  # Just produce the merged artifact for CI / backward-compatible harnesses.
-  cat "${LOG_DIR}"/build_"${BUILD_ID}"_*.log > "${ARTIFACT}" 2>/dev/null || true
-  echo "[INFO] Logs:     ${LOG_DIR}/"
-  echo "[INFO] Artifact: ${ARTIFACT}"
-}
-
 finalize() {
   local rc=$?
   echo ""
   echo "[INFO] Shutting down all processes..."
   cleanup_pids
-  collect_artifact
+  echo "[INFO] Logs: ${LOG_DIR}/"
   exit "$rc"
 }
 


### PR DESCRIPTION
 
**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters log artifact collection and removes the merged log artifact generation; failures would primarily impact debugging/consumers expecting the old `build_*.log` artifact name.
> 
> **Overview**
> The Blend k3 CI pipeline now uploads all logs from the per-run `logs_${BUILD_ID}/` directory (via `logs_*/*.log`) rather than a single `build_*.log` artifact.
> 
> `run-blend-test.sh` stops generating the merged `build_${BUILD_ID}.log` artifact and instead relies on the already-split component logs written under `LOG_DIR`, printing the log directory path on exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9830a16f066e01be7ebf6ecb0d23d456e842b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->