### PR TITLE
[MP][Feat] Attach service.instance.id to OTel Resource

### DIFF
--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -20,6 +20,23 @@ a `_total` suffix (e.g., `lmcache_mp_l1_read_keys_total`).
 
 For implementation guidance on adding new events and subscribers, see [README.md](README.md).
 
+## Global Resource Attributes
+
+Every metric (and span) exported by an MP server carries Resource-level
+attributes built at startup:
+
+| Attribute | CLI flag | Source | Applies to |
+|---|---|---|---|
+| `service.instance.id` | `--service-instance-id` | `ObservabilityConfig.service_instance_id` (`None` defaults to a random UUID v4; explicit `""` preserved) | All metrics + spans |
+
+Resource attributes are attached to the `MeterProvider` / `TracerProvider`
+in `otel_init.py` and therefore appear on every datapoint exported via
+OTLP.  On Prometheus, SDK resource attributes are typically surfaced via
+the `target_info` series rather than on each time-series.
+
+Per-metric attributes (e.g. `cache_salt`) remain on the individual
+datapoints and are orthogonal to these Resource attributes.
+
 ---
 
 ## StorageManager Read Metrics

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -337,6 +337,12 @@ logging, tracing).
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` endpoint.
+   * - ``--service-instance-id``
+     - *(unset, default UUID v4)*
+     - Identifier for this MP server instance, attached as the OTel
+       Resource attribute ``service.instance.id`` on every metric and
+       span. When the flag is not passed, defaults to a random UUID v4.
+       Pass ``--service-instance-id=""`` to force an empty value.
 
 vLLM Client Configuration
 --------------------------

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -65,6 +65,13 @@ Configuration
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` HTTP endpoint.
+   * - ``--service-instance-id``
+     - *(unset, default UUID v4)*
+     - Identifier for this MP server instance. Attached as the OTel
+       Resource attribute ``service.instance.id`` on every metric and
+       span. When the flag is not passed, defaults to a random UUID v4
+       minted at startup. Pass ``--service-instance-id=""`` to force an
+       explicit empty value. See :ref:`mp-observability-resource`.
    * - ``--metrics-sample-rate``
      - ``0.01``
      - Fraction of chunks/blocks to track for lifecycle histograms
@@ -106,6 +113,32 @@ collector.
 All metrics use the ``lmcache_mp.`` prefix (multiprocess). On Prometheus,
 dots are converted to underscores and counters get a ``_total`` suffix
 (e.g. ``lmcache_mp_l1_read_keys_total``).
+
+.. _mp-observability-resource:
+
+Global Resource Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every metric and span exported by an MP server carries Resource-level
+attributes built at startup. These identify the process producing the
+telemetry and are orthogonal to per-metric attributes such as
+``cache_salt``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Attribute
+     - CLI flag / config
+     - Default when unset
+   * - ``service.instance.id``
+     - ``--service-instance-id`` / ``ObservabilityConfig.service_instance_id``
+     - Random UUID v4 minted at startup.
+
+Resource attributes attach to the ``MeterProvider`` / ``TracerProvider``
+and propagate to every exported datapoint via OTLP. On Prometheus, SDK
+resource attributes surface on the ``target_info`` series rather than
+on each time-series — this is standard OTel behavior.
 
 StorageManager Metrics
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/mp_observability/README.md
+++ b/lmcache/v1/mp_observability/README.md
@@ -55,6 +55,7 @@ CLI, pass the flags below; when embedding programmatically, construct an
 | `--event-bus-queue-size N` | `10000` | Maximum number of events in the EventBus queue before tail-drop. |
 | `--otlp-endpoint URL` | *(none)* | OTLP gRPC endpoint (e.g. `http://localhost:4317`). When set, metrics and traces are pushed to an OTel collector. When unset, metrics fall back to Prometheus pull mode. |
 | `--prometheus-port PORT` | `9090` | Port for the Prometheus `/metrics` endpoint. Only used when `--otlp-endpoint` is not set. |
+| `--service-instance-id ID` | *unset* (default random UUID v4) | Identifier for this MP server instance.  Attached as the OTel Resource attribute `service.instance.id` on every metric and span.  When the flag is not passed, defaults to a random UUID v4 minted at startup.  Pass `--service-instance-id=""` to force an explicit empty value. |
 
 ### `ObservabilityConfig` fields
 
@@ -67,6 +68,7 @@ CLI, pass the flags below; when embedding programmatically, construct an
 | `tracing_enabled` | `bool` | `False` | Register tracing subscribers (OTel spans). |
 | `otlp_endpoint` | `str \| None` | `None` | OTLP gRPC endpoint. When set, metrics and traces are pushed. When `None`, metrics use Prometheus pull fallback. |
 | `prometheus_port` | `int` | `9090` | Port for the Prometheus `/metrics` endpoint (pull fallback only). |
+| `service_instance_id` | `str \| None` | `None` (default random UUID v4) | Identifier for this MP server instance; attached as the OTel Resource attribute `service.instance.id` on every metric and span.  `None` defaults to a random UUID v4 at `init_observability` time.  An explicit `""` is preserved. |
 
 ### Metrics export modes
 

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 import argparse
+import uuid
 
 if TYPE_CHECKING:
     # First Party
@@ -71,6 +72,16 @@ class ObservabilityConfig:
     """Path to write the trace file.  When :attr:`trace_level` is set
     but this is ``None``, a timestamped path under ``$TMPDIR`` is
     minted and logged at INFO."""
+
+    service_instance_id: str | None = None
+    """Identifier for this MP server instance.  Attached as the OTel
+    Resource attribute ``service.instance.id`` on every metric and span.
+    One MP server has exactly one instance id.
+
+    ``None`` (the default, also the state when the CLI flag is not
+    passed) falls back to a random UUID v4 at ``init_observability``
+    time.  An explicit empty string is preserved verbatim so operators
+    who want the attribute to report ``""`` can ask for it."""
 
 
 DEFAULT_OBSERVABILITY_CONFIG = ObservabilityConfig(enabled=False)
@@ -149,6 +160,18 @@ def add_observability_args(
         help=(
             "Fraction of chunks/blocks to track for lifecycle histograms "
             "(0, 1.0]. Counters always count all events. Default is 0.01 (1%%)."
+        ),
+    )
+    group.add_argument(
+        "--service-instance-id",
+        type=str,
+        default=None,
+        help=(
+            "Identifier for this MP server instance. Attached as the OTel "
+            "Resource attribute 'service.instance.id' on every metric and "
+            "span. When the flag is not passed, defaults to a random "
+            "UUID v4 minted at startup. Pass --service-instance-id='' to "
+            "force an empty attribute value."
         ),
     )
 
@@ -239,6 +262,7 @@ def parse_args_to_observability_config(
         ),
         trace_level=args.trace_level,
         trace_output=args.trace_output,
+        service_instance_id=args.service_instance_id,
     )
 
     if config.tracing_enabled and config.otlp_endpoint is None:
@@ -264,6 +288,13 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
 
     # Set up OTel providers BEFORE creating subscribers so that
     # module-level get_meter()/get_tracer() calls bind to the real provider
+    instance_id = (
+        obs_config.service_instance_id
+        if obs_config.service_instance_id is not None
+        else str(uuid.uuid4())
+    )
+    resource_attrs = {"service.instance.id": instance_id}
+
     if obs_config.enabled and obs_config.metrics_enabled:
         # First Party
         from lmcache.v1.mp_observability.otel_init import init_otel_metrics
@@ -271,13 +302,17 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         init_otel_metrics(
             otlp_endpoint=obs_config.otlp_endpoint,
             prometheus_port=obs_config.prometheus_port,
+            resource_attributes=resource_attrs,
         )
 
     if obs_config.enabled and obs_config.tracing_enabled:
         # First Party
         from lmcache.v1.mp_observability.otel_init import init_otel_tracing
 
-        init_otel_tracing(otlp_endpoint=obs_config.otlp_endpoint)
+        init_otel_tracing(
+            otlp_endpoint=obs_config.otlp_endpoint,
+            resource_attributes=resource_attrs,
+        )
 
     bus = init_event_bus(
         EventBusConfig(

--- a/lmcache/v1/mp_observability/otel_init.py
+++ b/lmcache/v1/mp_observability/otel_init.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Third Party
+    from opentelemetry.sdk.resources import Resource
 
 # First Party
 from lmcache.logging import init_logger
@@ -22,9 +27,24 @@ from lmcache.logging import init_logger
 logger = init_logger(__name__)
 
 
+def _build_resource(resource_attributes: dict[str, str] | None) -> "Resource":
+    """Build an OTel ``Resource`` from the given attribute dict.
+
+    Returns an empty ``Resource`` when *resource_attributes* is empty or
+    ``None`` so that telemetry carries no stale process-level tags.
+    """
+    # Third Party
+    from opentelemetry.sdk.resources import Resource
+
+    if not resource_attributes:
+        return Resource.create({})
+    return Resource.create(dict(resource_attributes))
+
+
 def init_otel_metrics(
     otlp_endpoint: str | None = None,
     prometheus_port: int | None = None,
+    resource_attributes: dict[str, str] | None = None,
 ) -> None:
     """Set up the OpenTelemetry MeterProvider.
 
@@ -35,10 +55,17 @@ def init_otel_metrics(
         prometheus_port: Port for the fallback Prometheus ``/metrics``
             endpoint.  Only used when *otlp_endpoint* is ``None``.
             Defaults to 9090.
+        resource_attributes: Optional ``{attr_name: value}`` map attached
+            to the ``MeterProvider`` ``Resource``.  Every metric emitted
+            through the provider carries these attributes.  Intended for
+            process-level identity (e.g. ``service.instance.id``) — never
+            for per-request tags.
     """
     # Third Party
     from opentelemetry import metrics
     from opentelemetry.sdk.metrics import MeterProvider
+
+    resource = _build_resource(resource_attributes)
 
     if otlp_endpoint is not None:
         # OTLP push mode
@@ -52,11 +79,12 @@ def init_otel_metrics(
 
         exporter = OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True)
         reader = PeriodicExportingMetricReader(exporter, export_interval_millis=10000)
-        provider = MeterProvider(metric_readers=[reader])
+        provider = MeterProvider(metric_readers=[reader], resource=resource)
         metrics.set_meter_provider(provider)
         logger.info(
-            "OTel MeterProvider initialised with OTLP exporter (%s)",
+            "OTel MeterProvider initialised with OTLP exporter (%s), resource=%s",
             otlp_endpoint,
+            dict(resource.attributes),
         )
     else:
         # Prometheus pull fallback — no collector needed
@@ -68,17 +96,21 @@ def init_otel_metrics(
             prometheus_port = 9090
 
         reader = PrometheusMetricReader()
-        provider = MeterProvider(metric_readers=[reader])
+        provider = MeterProvider(metric_readers=[reader], resource=resource)
         metrics.set_meter_provider(provider)
         prometheus_client.start_http_server(prometheus_port)
         logger.info(
             "OTel MeterProvider initialised with Prometheus fallback "
-            "(http://0.0.0.0:%d/metrics)",
+            "(http://0.0.0.0:%d/metrics), resource=%s",
             prometheus_port,
+            dict(resource.attributes),
         )
 
 
-def init_otel_tracing(otlp_endpoint: str | None = None) -> None:
+def init_otel_tracing(
+    otlp_endpoint: str | None = None,
+    resource_attributes: dict[str, str] | None = None,
+) -> None:
     """Set up the OpenTelemetry TracerProvider with an OTLP exporter.
 
     Tracing requires an OTLP endpoint — there is no local fallback.
@@ -87,6 +119,9 @@ def init_otel_tracing(otlp_endpoint: str | None = None) -> None:
     Args:
         otlp_endpoint: OTLP gRPC endpoint.  When ``None``, tracing
             init is skipped (no-op).
+        resource_attributes: Optional ``{attr_name: value}`` map attached
+            to the ``TracerProvider`` ``Resource``.  Every span emitted
+            through the provider carries these attributes.
     """
     if otlp_endpoint is None:
         logger.debug("No OTLP endpoint configured, skipping tracing init")
@@ -100,13 +135,15 @@ def init_otel_tracing(otlp_endpoint: str | None = None) -> None:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
+    resource = _build_resource(resource_attributes)
     exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
-    provider = TracerProvider()
+    provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
     logger.info(
-        "OTel TracerProvider initialised with OTLP exporter (%s)",
+        "OTel TracerProvider initialised with OTLP exporter (%s), resource=%s",
         otlp_endpoint,
+        dict(resource.attributes),
     )
 
 


### PR DESCRIPTION
## Summary

Adds a `service.instance.id` OTel Resource attribute to every metric
and span exported by the MP observability layer so operators can
distinguish individual LMCache MP server processes in Grafana, Jaeger,
Prometheus, etc.

## Design

- New `ObservabilityConfig.service_instance_id` field + `--service-instance-id`
  CLI flag.  Empty / unset falls back to a random UUID v4 minted at
  `init_observability` time, matching the OTel semantic-conventions
  guidance for ephemeral service-instance identifiers when no inherent
  stable id exists.
- `otel_init._build_resource` constructs the SDK `Resource` from the
  attribute dict.  `init_otel_metrics` / `init_otel_tracing` accept a
  `resource_attributes` kwarg and attach the Resource to the
  `MeterProvider` (OTLP + Prometheus paths) and the `TracerProvider`.
- Documentation: `METRICS.md` gains a Global Resource Attributes
  section; `README.md` lists the CLI flag + config field.

## Notes

- Resource attributes propagate to every datapoint exported via OTLP.
  On Prometheus, SDK resource attributes surface via the `target_info`
  series rather than on each time-series — this is standard OTel
  behavior and not something the SDK lets us change.
- `service.instance.id` is the OTel-standard attribute name (per
  semantic conventions).  No LMCache-specific tag is added here.
- Per-metric attributes (e.g. `cache_salt`) remain on individual
  datapoints and are orthogonal to Resource attributes.

## Test plan

- [x] `tests/v1/mp_observability/test_otel_resource.py` covers:
  - empty attrs → clean Resource,
  - explicit attrs carried through `_build_resource`,
  - Prometheus-path `MeterProvider` receives the Resource,
  - exported metric datapoints carry `service.instance.id`.
- [x] `tests/v1/mp_observability/` full suite: **180 passed, 1 skipped**.
- [x] Pre-commit clean (ruff, isort, codespell, mypy, SPDX).

## If applicable

- [x] this PR contains user facing changes — docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to MP observability startup/OTel provider initialization and should only affect telemetry labeling and CLI/config surface area.
> 
> **Overview**
> Adds a new MP observability identity knob so every exported metric/span carries an OTel Resource attribute `service.instance.id`.
> 
> Introduces `ObservabilityConfig.service_instance_id` and a `--service-instance-id` CLI flag (defaulting to a startup-minted UUID v4, with explicit `""` preserved), threads this into `init_observability`, and updates `otel_init` to build/attach an OTel `Resource` to both the `MeterProvider` (OTLP and Prometheus paths) and `TracerProvider`. Docs are updated to describe the new attribute and how it appears in OTLP vs Prometheus (`target_info`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baf0637cb2ded085ae3e1de2152ffed5737e5aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->