### PR TITLE
[CI] change blend CI cuda version and nightly tags 

### DIFF
--- a/.buildkite/k3_harness/setup-blend-env.sh
+++ b/.buildkite/k3_harness/setup-blend-env.sh
@@ -17,7 +17,7 @@ fi
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
 
-echo "--- :python: Installing vLLM (nightly cu128 wheels)"
+echo "--- :python: Installing vLLM (nightly wheels)"
 
 
 DEFAULT_VENV_BIN="/opt/venv/bin"
@@ -38,7 +38,6 @@ vllm_default_out="$("${DEFAULT_VENV_BIN}/python" -c "import vllm; print(vllm.__v
 }
 echo "vLLM in default venv (${DEFAULT_VENV_BIN}): ${vllm_default_out}"
 
-
 # If uv prompts because /workspace/.venv already exists: use the `--clear` flag or set UV_VENV_CLEAR=1
 # to skip the prompt and recreate; this script defaults to --allow-existing (reuse, non-interactive).
 UV_VENV_CLEAR="${UV_VENV_CLEAR:-0}"
@@ -55,8 +54,8 @@ TEST_VENV_BIN="/workspace/.venv/bin"
 export FLASHINFER_DISABLE_VERSION_CHECK=1
 
 "${UV_BIN}" pip install -p "${TEST_VENV_BIN}/python" -U vllm --pre \
-    --extra-index-url https://wheels.vllm.ai/nightly/cu128 \
-    --extra-index-url https://download.pytorch.org/whl/cu128 \
+    --extra-index-url "https://wheels.vllm.ai/nightly/cu129" \
+    --extra-index-url "https://download.pytorch.org/whl/cu129" \
     --index-strategy unsafe-best-match
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ issues = "https://github.com/LMCache/LMCache"
 version_file = "lmcache/_version.py"
 # do not include +gREV local version, required for Test PyPI upload
 local_scheme = "no-local-version"
+# only treat vX.Y.Z-style tags as version anchors; ignores nightly/nightly-cu13 tags
+tag_regex = "^v?(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
 
 [tool.setuptools.packages.find]
 where = [""]


### PR DESCRIPTION
.buildkite/k3_harness/setup-blend-env.sh
  - Updated vLLM wheel index URLs from cu128 → cu129 (both wheels.vllm.ai and download.pytorch.org)
  - Simplified log message to remove the hardcoded cu128 reference
  - Minor: removed a stray blank line

  pyproject.toml
  - Added tag_regex to [tool.setuptools_scm] so only vX.Y.Z-style tags are treated as version anchors — prevents nightly / nightly-cu13 tags from crashing the version parse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI/runtime dependency resolution (CUDA-specific vLLM/PyTorch nightly indexes) and alters version derivation via `setuptools_scm`, which can affect builds/releases if tag patterns differ from expectations.
> 
> **Overview**
> Updates the blend CI environment setup to install vLLM from **CUDA 12.9 nightly wheel indexes** (switching `cu128` → `cu129`) and makes the install log message CUDA-agnostic.
> 
> Adds a `setuptools_scm` `tag_regex` in `pyproject.toml` so only `vX.Y.Z...` tags are treated as version anchors, avoiding failures when the repo contains non-PEP-440 tags like `nightly`/`nightly-cu13`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0721cf80c7aa58ad86fb0ffe0cce2021f841cfb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->