### PR TITLE
[MP] Add raw_block MP L2 adapter support via shared RawBlockCore

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/l2_eviction.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_eviction.md
@@ -196,6 +196,7 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 |----------------------------|----------|-------------|---------------------|
 | `MockL2Adapter`            | ✓        | ✓           | stored, deleted     |
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
+| `RawBlockL2Adapter`        | ✓ (skips locked) | ✓ | stored, accessed, deleted |
 | `FSL2Adapter`              | no-op    | `(-1, -1)`  | none                |
 | `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
 

--- a/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md
@@ -491,7 +491,7 @@ sizes)`. The base class handles all byte accounting.
 |---------|-----------------------------|---------------------|
 | MockL2Adapter | `int(config.max_size_gb * 1024**3)` | `True` |
 | NixlStoreL2Adapter | Pool total size | `True` |
-| RawBlockL2Adapter | RawBlockCore usable capacity, internal slot recycling | `False` |
+| RawBlockL2Adapter | RawBlockCore usable capacity | `True` |
 | NativeConnectorL2Adapter | `int(max_capacity_gb * 1024**3)` | `True` |
 | FSL2Adapter | 0 | `False` |
 

--- a/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md
@@ -491,6 +491,7 @@ sizes)`. The base class handles all byte accounting.
 |---------|-----------------------------|---------------------|
 | MockL2Adapter | `int(config.max_size_gb * 1024**3)` | `True` |
 | NixlStoreL2Adapter | Pool total size | `True` |
+| RawBlockL2Adapter | RawBlockCore usable capacity, internal slot recycling | `False` |
 | NativeConnectorL2Adapter | `int(max_capacity_gb * 1024**3)` | `True` |
 | FSL2Adapter | 0 | `False` |
 

--- a/docs/design/v1/distributed/l2_adapters/overall.md
+++ b/docs/design/v1/distributed/l2_adapters/overall.md
@@ -493,9 +493,11 @@ class PrefetchHandle:
 ### Pure-Python Adapters
 
 Implement `L2AdapterInterface` directly. See `mock_l2_adapter.py` for a
-reference implementation. **No existing files need to be modified.** Create a
-new module (e.g., `my_l2_adapter.py`) in the `l2_adapters/` package and
-self-register at module level:
+reference implementation for an in-memory adapter, or
+[`raw_block.md`](raw_block.md) for a durable local-device adapter.
+**No existing files need to be modified.** Create a new module
+(e.g., `my_l2_adapter.py`) in the `l2_adapters/` package and self-register at
+module level:
 
 ```python
 # At the bottom of your module:

--- a/docs/design/v1/distributed/l2_adapters/plugin.md
+++ b/docs/design/v1/distributed/l2_adapters/plugin.md
@@ -345,6 +345,10 @@ __init__.py
        │    ├─ register_l2_adapter_type("plugin", PluginL2AdapterConfig)
        │    └─ register_l2_adapter_factory("plugin", _create_plugin_adapter)
        │
+       ├─ raw_block_l2_adapter.py (auto-discovered)
+       │    ├─ register_l2_adapter_type("raw_block", RawBlockL2AdapterConfig)
+       │    └─ register_l2_adapter_factory("raw_block", _create_raw_block_adapter)
+       │
        └─ native_connector_l2_adapter.py (auto-discovered)
             ├─ register_l2_adapter_type("resp", ...)
             ├─ register_l2_adapter_type("fs_native", ...)

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -1,0 +1,148 @@
+# Raw Block L2 Adapter Design
+
+This document describes the built-in `raw_block` L2 adapter for LMCache MP
+mode. It covers the adapter shape, the shared raw-block core, and the recovery
+model.
+
+## Overview
+
+`raw_block` is a persistent MP L2 adapter backed by a raw block device or a
+dedicated file. It is designed to keep the MP request flow unchanged while
+reusing the existing raw-block on-device metadata format and the low-level Rust
+raw-device I/O path.
+
+```text
+StoreController / PrefetchController
+                |
+                v
+        RawBlockL2Adapter
+                |
+                v
+           RawBlockCore
+      (index, locks, slots, checkpoints)
+                |
+                v
+         lmcache_rust_raw_block_io
+      (pwrite_from_buffer / pread_into)
+                |
+                v
+         raw block device / file
+```
+
+## Goals
+
+- Support LMCache MP mode using raw block storage as an L2 cache.
+- Reuse the same durable metadata and checkpoint model as the existing
+  non-MP raw-block backend.
+- Reuse the existing Rust raw-device I/O layer.
+- Preserve restart recovery semantics.
+- Keep the MP controller flow unchanged: store, lookup-and-lock, load, unlock.
+
+## TODO
+
+- FDP / placement-hint support.
+- A raw NVMe command path.
+
+## Key Design Choice
+
+The implementation is split into:
+
+- `RawBlockCore` in `lmcache/v1/storage_backend/raw_block/`
+- `RawBlockL2Adapter` in `lmcache/v1/distributed/l2_adapters/`
+- `RustRawBlockBackend` as the legacy non-MP wrapper
+
+`RawBlockCore` owns the durable state and blocking I/O:
+
+- raw device open/close
+- in-memory key index
+- free-slot tracking and internal LRU
+- lock refcounts used by MP lookup/load/unlock
+- metadata checkpointing and recovery
+- direct reads and writes through the Rust binding
+
+This avoids maintaining separate raw-block implementations for MP and non-MP
+mode.
+
+## Adapter Contract
+
+`RawBlockL2Adapter` implements `L2AdapterInterface` directly. It exposes:
+
+- three distinct eventfds: store, lookup, load
+- non-blocking task submission APIs
+- worker-thread execution for blocking raw-device operations
+- result maps keyed by adapter-local task id
+- listener notifications for stored, accessed, and deleted keys
+
+The adapter uses caller-provided `MemoryObj` buffers for load operations. It
+does not allocate destination buffers on the load path.
+
+## Locking Model
+
+LMCache MP already uses L1 locks for CPU-memory object lifetime. `raw_block`
+adds a separate L2-side lock refcount so a looked-up key cannot be deleted
+between `lookup_and_lock` and `load`.
+
+Rules:
+
+- `exists_many(..., lock=True)` increments the refcount for hits
+- `unlock_many(keys)` decrements and floors at zero
+- `delete(keys)` skips locked entries
+
+## Persistence and Recovery
+
+`RawBlockCore` keeps the existing metadata checkpoint model:
+
+- metadata region reserved on the same device
+- periodic checkpointing
+- optional verification on load
+- recovery by loading the latest durable checkpoint and rebuilding the in-memory
+  index
+
+The on-device format is intentionally unchanged by the MP adapter work.
+
+## Configuration
+
+The MP adapter is configured through `--l2-adapter` JSON:
+
+```json
+{
+  "type": "raw_block",
+  "device_path": "/dev/nvme0n1",
+  "slot_bytes": 1048576,
+  "capacity_bytes": 0,
+  "use_odirect": true,
+  "block_align": 4096,
+  "header_bytes": 4096,
+  "meta_total_bytes": 268435456,
+  "meta_magic": "LMCIDX01",
+  "meta_version": 1,
+  "meta_checkpoint_interval_sec": 60,
+  "meta_enable_periodic": true,
+  "meta_verify_on_load": true,
+  "num_store_workers": 2,
+  "num_lookup_workers": 1,
+  "num_load_workers": 4
+}
+```
+
+Important validation rules:
+
+- `slot_bytes`, `header_bytes`, and `meta_total_bytes` must be aligned to
+  `block_align`
+- `slot_bytes >= header_bytes + 1`
+- `per_tp_device_paths` is rejected in MP mode
+- with `use_odirect=true`, MP L1 alignment must satisfy
+  `l1_align_bytes >= block_align`
+
+## Relationship to Non-MP Mode
+
+The legacy `RustRawBlockBackend` now acts as a thin facade over `RawBlockCore`.
+It preserves non-MP behavior such as prefix-oriented contains/get semantics,
+while the MP adapter uses the core's full-bitmap lookup/load API.
+
+## References
+
+- Implementation: `lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py`
+- Shared core: `lmcache/v1/storage_backend/raw_block/core.py`
+- User docs: `docs/source/mp/l2_storage.rst`
+- Rust device layer: `rust/raw_block/README.md`

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -55,7 +55,7 @@ The implementation is split into:
 
 - raw device open/close
 - in-memory key index
-- free-slot tracking and internal LRU
+- free-slot tracking
 - lock refcounts used by MP lookup/load/unlock
 - metadata checkpointing and recovery
 - direct reads and writes through the Rust binding
@@ -99,6 +99,9 @@ Rules:
   index
 
 The on-device format is intentionally unchanged by the MP adapter work.
+
+Recovered keys are exposed to the shared L2 eviction policy on adapter startup,
+so reclaimed slots come from global L2 eviction or explicit `delete()` calls.
 
 ## Configuration
 

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -6,7 +6,7 @@ LMCache multiprocess mode supports a two-tier storage architecture:
 - **L1 (in-memory)** -- Fast CPU memory managed by the L1 Manager.  All KV
   cache chunks live here during active use.
 - **L2 (persistent)** -- Durable storage backends (NIXL-based or plain
-  file-system).  The StoreController asynchronously pushes data from L1
+  file-system/raw-block).  The StoreController asynchronously pushes data from L1
   to L2, and the PrefetchController loads data from L2 back into L1 on
   cache misses.
 
@@ -187,6 +187,61 @@ object is stored as a raw ``.data`` file whose name encodes the full
 
     # With O_DIRECT for bypassing page cache
     --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "use_odirect": true}'
+
+``raw_block`` -- Raw block device backed persistent storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A built-in L2 adapter that stores KV objects in fixed-size slots on a raw block
+device or pre-sized file using the Rust raw-device I/O bindings. It reuses the
+existing raw-block metadata checkpoint model and writes directly into the
+caller-provided load buffers during prefetch.
+
+**Required fields:**
+
+- ``device_path``: Raw device path or pre-sized file path.
+- ``slot_bytes``: Fixed slot size in bytes. Must be aligned to ``block_align``.
+
+**Optional fields:**
+
+- ``capacity_bytes``: Optional cap on the usable device bytes. Default ``0``
+  means use the full device/file size.
+- ``use_odirect``: ``true`` or ``false`` (default ``true``).
+- ``block_align``: Device alignment in bytes (default ``4096``).
+- ``header_bytes``: Per-slot header reservation (default ``4096``).
+- ``meta_total_bytes``: Reserved metadata checkpoint region (default ``256MiB``).
+- ``meta_magic`` / ``meta_version``: Metadata checkpoint identity/version knobs.
+- ``meta_checkpoint_interval_sec`` / ``meta_idle_quiet_ms`` /
+  ``meta_enable_periodic`` / ``meta_verify_on_load``: Checkpoint and recovery
+  controls carried over from the legacy raw-block backend.
+- ``enable_zero_copy``: Try aligned direct-buffer I/O when possible.
+- ``io_engine``: Rust raw-block I/O engine. Valid values are ``"posix"``
+  (default synchronous ``pread``/``pwrite`` path), ``"io_uring"`` (direct Rust
+  io_uring syscall path).
+- ``iouring_queue_depth``: Queue depth for ``io_engine="io_uring"``.
+- ``num_store_workers`` / ``num_lookup_workers`` / ``num_load_workers``:
+  Worker-thread counts for each operation type.
+
+**Notes:**
+
+- ``raw_block`` is a server-owned MP adapter. It does **not** support
+  per-TP device-path mappings in MP mode.
+- ``raw_block`` remains ``"type": "raw_block"`` for both supported engines.
+- ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
+  through ``RawBlockCore``. Slot reclamation is driven by the shared/global
+  L2 eviction controller or explicit ``delete()`` calls.
+- If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
+  at least ``block_align``.
+- ``persist_enabled`` must remain ``true`` for this adapter.
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "block_align": 4096, "header_bytes": 4096, "meta_total_bytes": 268435456, "use_odirect": true, "num_store_workers": 2, "num_lookup_workers": 1, "num_load_workers": 4}'
+
+    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true}'
+
+    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'
 
 ``mooncake_store`` -- Mooncake Store native connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -539,6 +594,9 @@ drops by ``eviction_ratio``.
    * - ``mock``
      - Full support. Useful for testing eviction behaviour without
        real storage hardware.
+   * - ``raw_block``
+     - Full shared/global eviction support. ``delete`` recycles raw-block
+       slots; locked entries are skipped and retried on the next cycle.
    * - ``s3``
      - ``delete`` removes objects from the bucket and frees aggregate
        byte accounting. ``get_usage`` reports ``usage_fraction == -1.0``

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -129,6 +129,52 @@ class ParallelStrategy:
     """The pipeline parallel size."""
 
 
+def _normalize_adapter_init_args(
+    vllm_block_size: int,
+    parallel_strategy: ParallelStrategy | int,
+    legacy_block_size: int | None,
+    mq_timeout: float,
+) -> tuple[int, ParallelStrategy, float]:
+    """Normalize adapter constructor args from old and new vLLM connectors.
+
+    Args:
+        vllm_block_size: The vLLM block size for the current connector API, or
+            the legacy KV world size when ``parallel_strategy`` is an int.
+        parallel_strategy: The current ``ParallelStrategy`` object, or the
+            legacy KV worker id from older vLLM MP connectors.
+        legacy_block_size: The legacy vLLM block size passed positionally by
+            older vLLM MP connectors.
+        mq_timeout: Timeout in seconds for synchronous message queue requests.
+
+    Returns:
+        A tuple of normalized ``(vllm_block_size, parallel_strategy,
+        mq_timeout)``.
+
+    Raises:
+        TypeError: If the connector argument shape is not supported.
+    """
+    if isinstance(parallel_strategy, ParallelStrategy):
+        return vllm_block_size, parallel_strategy, mq_timeout
+    if not isinstance(parallel_strategy, int) or legacy_block_size is None:
+        raise TypeError(
+            "parallel_strategy must be ParallelStrategy, or legacy "
+            "(kv_world_size, kv_worker_id, block_size) arguments"
+        )
+
+    kv_world_size = int(vllm_block_size)
+    kv_worker_id = int(parallel_strategy)
+    strategy = ParallelStrategy(
+        use_mla=False,
+        kv_world_size=kv_world_size,
+        kv_worker_id=kv_worker_id,
+        actual_world_size=kv_world_size,
+        actual_worker_id=kv_worker_id,
+        tp_size=kv_world_size,
+        pp_size=1,
+    )
+    return int(legacy_block_size), strategy, mq_timeout
+
+
 class HeartbeatThread(PeriodicThread):
     """Periodically checks server health via PING.
 
@@ -216,7 +262,9 @@ class LMCacheMPSchedulerAdapter:
         context: zmq.Context,
         model_name: str,
         vllm_block_size: int,
-        parallel_strategy: ParallelStrategy,
+        parallel_strategy: ParallelStrategy | int,
+        legacy_block_size: int | None = None,
+        *,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
@@ -228,10 +276,19 @@ class LMCacheMPSchedulerAdapter:
             vllm_block_size: The block size used in vLLM
             parallel_strategy:
                 The parallel strategy, which includes `use_mla`,
-                `kv_world_size`, `kv_worker_id` and so on
+                `kv_world_size`, `kv_worker_id` and so on. Older vLLM
+                connectors pass the KV worker id here.
+            legacy_block_size: The vLLM block size passed positionally by
+                older vLLM connectors.
             mq_timeout: Timeout in seconds for message queue requests.
             heartbeat_interval: Interval in seconds between heartbeat pings.
         """
+        vllm_block_size, parallel_strategy, mq_timeout = _normalize_adapter_init_args(
+            vllm_block_size,
+            parallel_strategy,
+            legacy_block_size,
+            mq_timeout,
+        )
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 
@@ -558,10 +615,36 @@ class LMCacheMPWorkerAdapter:
         context: zmq.Context,
         model_name: str,
         vllm_block_size: int,
-        parallel_strategy: ParallelStrategy,
+        parallel_strategy: ParallelStrategy | int,
+        legacy_block_size: int | None = None,
+        *,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
     ):
+        """Initialize the worker adapter for current or legacy vLLM callers.
+
+        Args:
+            server_url: The server URL for the LMCache message queue.
+            context: The ZMQ context.
+            model_name: The model name used for LMCache keys.
+            vllm_block_size: The block size used in vLLM, or legacy KV world
+                size when ``parallel_strategy`` is an int.
+            parallel_strategy: Current ``ParallelStrategy`` metadata, or the
+                legacy KV worker id from older vLLM connectors.
+            legacy_block_size: The vLLM block size passed positionally by
+                older vLLM connectors.
+            mq_timeout: Timeout in seconds for message queue requests.
+            heartbeat_interval: Interval in seconds between heartbeat pings.
+
+        Raises:
+            TypeError: If the connector argument shape is unsupported.
+        """
+        vllm_block_size, parallel_strategy, mq_timeout = _normalize_adapter_init_args(
+            vllm_block_size,
+            parallel_strategy,
+            legacy_block_size,
+            mq_timeout,
+        )
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -18,7 +18,7 @@ import threading
 
 if TYPE_CHECKING:
     from lmcache.native_storage_ops import Bitmap
-    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 
 # First Party
 from lmcache.logging import init_logger
@@ -40,6 +40,7 @@ from lmcache.v1.storage_backend.raw_block import (
     DEFAULT_IOURING_QUEUE_DEPTH,
     RawBlockCore,
     RawBlockCoreConfig,
+    decode_object_key,
     encode_object_key,
     normalize_raw_block_io_engine,
     validate_raw_block_io_options,
@@ -318,6 +319,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
             self._max_capacity_bytes = int(
                 self._core.report_status().get("usable_capacity_bytes", 0)
             )
+            self._seed_usage_from_core_snapshot()
 
             self._store_efd = create_event_notifier()
             self._lookup_efd = create_event_notifier()
@@ -505,7 +507,23 @@ class RawBlockL2Adapter(L2AdapterInterface):
             deleted_keys.append(key)
             deleted_sizes.append(0 if meta is None else int(self._core.slot_bytes))
         if deleted_keys:
-            self._notify_keys_deleted(deleted_keys, deleted_sizes)
+            try:
+                self._notify_keys_deleted(deleted_keys, deleted_sizes)
+            except Exception as e:
+                logger.warning("RawBlockL2Adapter delete notification failed: %s", e)
+
+    def register_listener(self, listener: "L2AdapterListener") -> None:
+        """Register a listener and seed it with currently indexed keys."""
+        super().register_listener(listener)
+        keys = self._snapshot_indexed_object_keys()
+        if not keys:
+            return
+        try:
+            listener.on_l2_keys_stored(keys)
+        except Exception as e:
+            logger.warning(
+                "RawBlockL2Adapter listener recovery bootstrap failed: %s", e
+            )
 
     def close(self) -> None:
         """Wait for worker pools, close the core, and close eventfds."""
@@ -559,6 +577,39 @@ class RawBlockL2Adapter(L2AdapterInterface):
         task_id = self._next_task_id
         self._next_task_id += 1
         return task_id
+
+    def _seed_usage_from_core_snapshot(self) -> None:
+        """Seed byte counters for entries recovered by RawBlockCore startup."""
+        recovered_keys = self._snapshot_indexed_object_keys()
+        if not recovered_keys:
+            return
+
+        slot_bytes = int(self._core.slot_bytes)
+        total_delta = len(recovered_keys) * slot_bytes
+        by_salt: dict[str, int] = {}
+        for key in recovered_keys:
+            by_salt[key.cache_salt] = by_salt.get(key.cache_salt, 0) + slot_bytes
+
+        with self._usage_lock:
+            self._total_bytes_used += total_delta
+            for salt, delta in by_salt.items():
+                self._bytes_by_cache_salt[salt] = (
+                    self._bytes_by_cache_salt.get(salt, 0) + delta
+                )
+
+    def _snapshot_indexed_object_keys(self) -> list[ObjectKey]:
+        """Return decoded ObjectKeys for all indexed raw-block entries."""
+        keys: list[ObjectKey] = []
+        for encoded_key in self._core.snapshot_indexed_keys():
+            try:
+                keys.append(decode_object_key(encoded_key))
+            except Exception as e:
+                logger.warning(
+                    "RawBlockL2Adapter could not decode indexed key %r: %s",
+                    encoded_key,
+                    e,
+                )
+        return keys
 
     def _run_store_task(
         self,

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -1,0 +1,712 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Raw-block L2 adapter for LMCache MP mode.
+
+Uses RawBlockCore as the synchronous durable engine and adapts it to the
+non-blocking L2AdapterInterface contract with separate eventfds for store,
+lookup, and load.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from concurrent.futures import Future, ThreadPoolExecutor
+from functools import partial
+from typing import TYPE_CHECKING, Any, Optional
+import threading
+
+if TYPE_CHECKING:
+    from lmcache.native_storage_ops import Bitmap
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.base import (
+    L2AdapterInterface,
+    L2TaskId,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
+)
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import EventNotifier, create_event_notifier
+from lmcache.v1.storage_backend.raw_block import (
+    DEFAULT_IOURING_QUEUE_DEPTH,
+    RawBlockCore,
+    RawBlockCoreConfig,
+    encode_object_key,
+    normalize_raw_block_io_engine,
+    validate_raw_block_io_options,
+)
+
+logger = init_logger(__name__)
+
+RawBlockStoreTaskResult = tuple[
+    bool,
+    list[ObjectKey],
+    list[int],
+]
+
+
+def _make_bitmap(size: int) -> "Bitmap":
+    # First Party
+    from lmcache.native_storage_ops import Bitmap
+
+    return Bitmap(size)
+
+
+class RawBlockL2AdapterConfig(L2AdapterConfigBase):
+    """Configuration object for the built-in raw-block MP L2 adapter."""
+
+    def __init__(
+        self,
+        *,
+        device_path: str,
+        slot_bytes: int,
+        capacity_bytes: int = 0,
+        use_odirect: bool = True,
+        block_align: int = 4096,
+        header_bytes: int = 4096,
+        meta_total_bytes: int = 256 * 1024 * 1024,
+        meta_magic: str = "LMCIDX01",
+        meta_version: int = 1,
+        meta_checkpoint_interval_sec: int = 60,
+        meta_idle_quiet_ms: int = 100,
+        meta_enable_periodic: bool = True,
+        meta_verify_on_load: bool = True,
+        enable_zero_copy: bool = True,
+        io_engine: str = "posix",
+        iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH,
+        num_store_workers: int = 2,
+        num_lookup_workers: int = 1,
+        num_load_workers: int = 4,
+    ):
+        """Initialize raw-block MP adapter configuration.
+
+        Args:
+            device_path: Raw device path or pre-sized file path used for L2.
+            slot_bytes: Fixed data-slot size in bytes.
+            capacity_bytes: Optional cap on usable bytes; zero uses device size.
+            use_odirect: Whether to open the raw path with O_DIRECT.
+            block_align: Required block alignment in bytes.
+            header_bytes: Per-slot header reservation in bytes.
+            meta_total_bytes: Reserved metadata checkpoint region size.
+            meta_magic: Eight-byte ASCII metadata checkpoint magic.
+            meta_version: Metadata checkpoint version.
+            meta_checkpoint_interval_sec: Periodic checkpoint interval.
+            meta_idle_quiet_ms: Quiet period before periodic checkpoints.
+            meta_enable_periodic: Whether to run the checkpoint thread.
+            meta_verify_on_load: Whether recovery verifies slot headers.
+            enable_zero_copy: Whether to use aligned direct-buffer I/O.
+            io_engine: Raw-block I/O engine: ``"posix"`` or ``"io_uring"``.
+            iouring_queue_depth: Queue depth for the Rust io_uring engine.
+            num_store_workers: Number of store worker threads.
+            num_lookup_workers: Number of lookup worker threads.
+            num_load_workers: Number of load worker threads.
+        """
+        super().__init__()
+        self.device_path = device_path
+        self.slot_bytes = int(slot_bytes)
+        self.capacity_bytes = int(capacity_bytes)
+        self.use_odirect = bool(use_odirect)
+        self.block_align = int(block_align)
+        self.header_bytes = int(header_bytes)
+        self.meta_total_bytes = int(meta_total_bytes)
+        self.meta_magic = meta_magic
+        self.meta_version = int(meta_version)
+        self.meta_checkpoint_interval_sec = int(meta_checkpoint_interval_sec)
+        self.meta_idle_quiet_ms = int(meta_idle_quiet_ms)
+        self.meta_enable_periodic = bool(meta_enable_periodic)
+        self.meta_verify_on_load = bool(meta_verify_on_load)
+        self.enable_zero_copy = bool(enable_zero_copy)
+        self.io_engine = normalize_raw_block_io_engine(io_engine)
+        self.iouring_queue_depth = int(iouring_queue_depth)
+        validate_raw_block_io_options(
+            iouring_queue_depth=self.iouring_queue_depth,
+        )
+        self.num_store_workers = int(num_store_workers)
+        self.num_lookup_workers = int(num_lookup_workers)
+        self.num_load_workers = int(num_load_workers)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "RawBlockL2AdapterConfig":
+        """Build and validate a raw-block config from ``--l2-adapter`` JSON."""
+        device_path = d.get("device_path")
+        if not isinstance(device_path, str) or not device_path:
+            raise ValueError("device_path must be a non-empty string")
+        if "per_tp_device_paths" in d:
+            raise ValueError(
+                "per_tp_device_paths is not supported in MP raw_block mode"
+            )
+        if not bool(d.get("persist_enabled", True)):
+            raise ValueError("raw_block requires persist_enabled=true")
+
+        slot_bytes = d.get("slot_bytes")
+        if not isinstance(slot_bytes, int) or slot_bytes <= 0:
+            raise ValueError("slot_bytes must be a positive integer")
+
+        block_align = int(d.get("block_align", 4096))
+        header_bytes = int(d.get("header_bytes", 4096))
+        meta_total_bytes = int(d.get("meta_total_bytes", 256 * 1024 * 1024))
+        capacity_bytes = int(d.get("capacity_bytes", 0))
+        io_engine = normalize_raw_block_io_engine(
+            d.get("io_engine"),
+            use_iouring=d.get("use_iouring"),
+            use_uring=d.get("use_uring"),
+        )
+        iouring_queue_depth = int(
+            d.get("iouring_queue_depth", DEFAULT_IOURING_QUEUE_DEPTH)
+        )
+
+        if block_align <= 0:
+            raise ValueError("block_align must be > 0")
+        if slot_bytes % block_align != 0:
+            raise ValueError("slot_bytes must be a multiple of block_align")
+        if header_bytes % block_align != 0:
+            raise ValueError("header_bytes must be a multiple of block_align")
+        if meta_total_bytes % block_align != 0:
+            raise ValueError("meta_total_bytes must be a multiple of block_align")
+        if slot_bytes < header_bytes + 1:
+            raise ValueError("slot_bytes must be >= header_bytes + 1")
+        if capacity_bytes > 0 and capacity_bytes <= meta_total_bytes:
+            raise ValueError("capacity_bytes must leave space for at least one slot")
+        validate_raw_block_io_options(
+            iouring_queue_depth=iouring_queue_depth,
+        )
+
+        worker_defaults = {
+            "num_store_workers": 2,
+            "num_lookup_workers": 1,
+            "num_load_workers": 4,
+        }
+        worker_counts: dict[str, int] = {}
+        for field_name, default in worker_defaults.items():
+            value = int(d.get(field_name, default))
+            if value <= 0:
+                raise ValueError(f"{field_name} must be > 0")
+            worker_counts[field_name] = value
+
+        return cls(
+            device_path=device_path,
+            slot_bytes=slot_bytes,
+            capacity_bytes=capacity_bytes,
+            use_odirect=bool(d.get("use_odirect", True)),
+            block_align=block_align,
+            header_bytes=header_bytes,
+            meta_total_bytes=meta_total_bytes,
+            meta_magic=str(d.get("meta_magic", "LMCIDX01")),
+            meta_version=int(d.get("meta_version", 1)),
+            meta_checkpoint_interval_sec=int(d.get("meta_checkpoint_interval_sec", 60)),
+            meta_idle_quiet_ms=int(d.get("meta_idle_quiet_ms", 100)),
+            meta_enable_periodic=bool(d.get("meta_enable_periodic", True)),
+            meta_verify_on_load=bool(d.get("meta_verify_on_load", True)),
+            enable_zero_copy=bool(d.get("enable_zero_copy", True)),
+            io_engine=io_engine,
+            iouring_queue_depth=iouring_queue_depth,
+            num_store_workers=worker_counts["num_store_workers"],
+            num_lookup_workers=worker_counts["num_lookup_workers"],
+            num_load_workers=worker_counts["num_load_workers"],
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        """Return human-readable raw-block adapter configuration help."""
+        return (
+            "raw_block L2 adapter config fields:\n"
+            "- device_path (str): raw device or file path (required)\n"
+            "- slot_bytes (int): slot size in bytes, aligned to block_align "
+            "(required)\n"
+            "- capacity_bytes (int): optional usable capacity cap "
+            "(default 0 = device size)\n"
+            "- use_odirect (bool): enable O_DIRECT raw I/O (default true)\n"
+            "- block_align (int): required block alignment in bytes (default 4096)\n"
+            "- header_bytes (int): per-slot header reservation (default 4096)\n"
+            "- meta_total_bytes (int): reserved metadata checkpoint region "
+            "(default 256MiB)\n"
+            "- meta_magic (str): 8-byte metadata magic (default LMCIDX01)\n"
+            "- meta_version (int): metadata version (default 1)\n"
+            "- meta_checkpoint_interval_sec (int): periodic checkpoint interval "
+            "(default 60)\n"
+            "- meta_idle_quiet_ms (int): quiet period before checkpoint (default 100)\n"
+            "- meta_enable_periodic (bool): enable periodic checkpointing "
+            "(default true)\n"
+            "- meta_verify_on_load (bool): validate slot headers on recovery "
+            "(default true)\n"
+            "- enable_zero_copy (bool): use aligned direct buffers when possible "
+            "(default true)\n"
+            "- io_engine (str): posix or io_uring (default posix)\n"
+            "- iouring_queue_depth (int): Rust io_uring queue depth "
+            f"(default {DEFAULT_IOURING_QUEUE_DEPTH})\n"
+            "- num_store_workers (int): store worker threads (default 2)\n"
+            "- num_lookup_workers (int): lookup worker threads (default 1)\n"
+            "- num_load_workers (int): load worker threads (default 4)"
+        )
+
+    def to_core_config(self) -> RawBlockCoreConfig:
+        """Convert this adapter config to the shared RawBlockCore config."""
+        return RawBlockCoreConfig(
+            device_path=self.device_path,
+            capacity_bytes=self.capacity_bytes,
+            block_align=self.block_align,
+            header_bytes=self.header_bytes,
+            slot_bytes=self.slot_bytes,
+            use_odirect=self.use_odirect,
+            enable_zero_copy=self.enable_zero_copy,
+            meta_total_bytes=self.meta_total_bytes,
+            meta_magic=self.meta_magic.encode("ascii"),
+            meta_version=self.meta_version,
+            meta_checkpoint_interval_sec=self.meta_checkpoint_interval_sec,
+            meta_idle_quiet_ms=self.meta_idle_quiet_ms,
+            meta_enable_periodic=self.meta_enable_periodic,
+            meta_verify_on_load=self.meta_verify_on_load,
+            io_engine=self.io_engine,
+            iouring_queue_depth=self.iouring_queue_depth,
+        )
+
+
+class RawBlockL2Adapter(L2AdapterInterface):
+    """MP L2 adapter that persists KV objects into raw-block slots."""
+
+    def __init__(
+        self,
+        config: RawBlockL2AdapterConfig,
+        l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+    ):
+        """Initialize the MP raw-block L2 adapter.
+
+        Args:
+            config: Validated raw-block adapter configuration.
+            l1_memory_desc: Optional L1 allocation descriptor used to validate
+                O_DIRECT alignment compatibility.
+
+        Raises:
+            ValueError: If O_DIRECT is enabled and L1 alignment is insufficient.
+            RuntimeError: If the shared core cannot open or recover the raw
+                device.
+
+        Notes:
+            Resources created before an initialization failure are closed before
+            the exception is re-raised.
+        """
+        super().__init__()
+        if (
+            config.use_odirect
+            and l1_memory_desc is not None
+            and l1_memory_desc.align_bytes < config.block_align
+        ):
+            raise ValueError(
+                "raw_block requires l1_align_bytes >= block_align when use_odirect=true"
+            )
+
+        self._closed = False
+        self._core: RawBlockCore
+        self._store_efd: EventNotifier | None = None
+        self._lookup_efd: EventNotifier | None = None
+        self._load_efd: EventNotifier | None = None
+        self._store_pool: ThreadPoolExecutor
+        self._lookup_pool: ThreadPoolExecutor
+        self._load_pool: ThreadPoolExecutor
+
+        try:
+            self._core = RawBlockCore(config.to_core_config(), key_namespace="object")
+            self._max_capacity_bytes = int(
+                self._core.report_status().get("usable_capacity_bytes", 0)
+            )
+
+            self._store_efd = create_event_notifier()
+            self._lookup_efd = create_event_notifier()
+            self._load_efd = create_event_notifier()
+
+            self._store_pool = ThreadPoolExecutor(
+                max_workers=config.num_store_workers,
+                thread_name_prefix="rawblk-store",
+            )
+            self._lookup_pool = ThreadPoolExecutor(
+                max_workers=config.num_lookup_workers,
+                thread_name_prefix="rawblk-lookup",
+            )
+            self._load_pool = ThreadPoolExecutor(
+                max_workers=config.num_load_workers,
+                thread_name_prefix="rawblk-load",
+            )
+        except Exception:
+            self._cleanup_after_init_failure()
+            raise
+
+        self._lock = threading.Lock()
+        self._next_task_id: L2TaskId = 0
+
+        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
+        self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
+
+        self._store_inflight_tasks: int = 0
+        self._lookup_inflight_tasks: int = 0
+        self._load_inflight_tasks: int = 0
+
+    def get_store_event_fd(self) -> int:
+        """Return the eventfd signaled when store tasks complete."""
+        if self._store_efd is None:
+            return -1
+        return self._store_efd.fileno()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        """Return the eventfd signaled when lookup-and-lock tasks complete."""
+        if self._lookup_efd is None:
+            return -1
+        return self._lookup_efd.fileno()
+
+    def get_load_event_fd(self) -> int:
+        """Return the eventfd signaled when load tasks complete."""
+        if self._load_efd is None:
+            return -1
+        return self._load_efd.fileno()
+
+    def submit_store_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        """Submit a non-blocking raw-block store task.
+
+        Args:
+            keys: Object keys to persist.
+            objects: Memory objects containing payloads for ``keys``.
+
+        Returns:
+            Task ID that can be observed through ``pop_completed_store_tasks``.
+
+        Raises:
+            ValueError: If either list is empty or the lengths differ.
+        """
+        if not keys or not objects:
+            raise ValueError("keys and objects must be non-empty")
+        if len(keys) != len(objects):
+            raise ValueError("keys and objects must have the same length")
+
+        with self._lock:
+            self._raise_if_closed_locked()
+            task_id = self._get_next_task_id_locked()
+            self._store_inflight_tasks += 1
+        try:
+            future = self._store_pool.submit(
+                self._run_store_task, list(keys), list(objects)
+            )
+        except Exception:
+            with self._lock:
+                self._store_inflight_tasks -= 1
+            raise
+        future.add_done_callback(partial(self._finish_store_task, task_id))
+        return task_id
+
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+        """Drain and return completed store task results."""
+        with self._lock:
+            completed = self._completed_store_tasks
+            self._completed_store_tasks = {}
+        return completed
+
+    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+        """Submit a non-blocking lookup-and-lock task.
+
+        Args:
+            keys: Object keys to look up in raw-block L2.
+
+        Returns:
+            Task ID whose bitmap can be queried with
+            ``query_lookup_and_lock_result``.
+
+        Raises:
+            ValueError: If ``keys`` is empty.
+        """
+        if not keys:
+            raise ValueError("keys must be non-empty")
+        with self._lock:
+            self._raise_if_closed_locked()
+            task_id = self._get_next_task_id_locked()
+            self._lookup_inflight_tasks += 1
+        try:
+            future = self._lookup_pool.submit(self._run_lookup_task, list(keys))
+        except Exception:
+            with self._lock:
+                self._lookup_inflight_tasks -= 1
+            raise
+        future.add_done_callback(partial(self._finish_lookup_task, task_id, len(keys)))
+        return task_id
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Return and remove a completed lookup bitmap if available."""
+        with self._lock:
+            return self._completed_lookup_tasks.pop(task_id, None)
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        """Release L2 locks acquired by lookup-and-lock."""
+        encoded_keys = [encode_object_key(key).encoded for key in keys]
+        self._core.unlock_many(encoded_keys)
+
+    def submit_load_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        """Submit a non-blocking raw-block load task.
+
+        Args:
+            keys: Object keys to load.
+            objects: Caller-provided destination buffers.
+
+        Returns:
+            Task ID whose bitmap can be queried with ``query_load_result``.
+
+        Raises:
+            ValueError: If either list is empty or the lengths differ.
+        """
+        if not keys or not objects:
+            raise ValueError("keys and objects must be non-empty")
+        if len(keys) != len(objects):
+            raise ValueError("keys and objects must have the same length")
+
+        with self._lock:
+            self._raise_if_closed_locked()
+            task_id = self._get_next_task_id_locked()
+            self._load_inflight_tasks += 1
+        try:
+            future = self._load_pool.submit(
+                self._run_load_task, list(keys), list(objects)
+            )
+        except Exception:
+            with self._lock:
+                self._load_inflight_tasks -= 1
+            raise
+        future.add_done_callback(partial(self._finish_load_task, task_id, len(keys)))
+        return task_id
+
+    def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Return and remove a completed load bitmap if available."""
+        with self._lock:
+            return self._completed_load_tasks.pop(task_id, None)
+
+    def delete(self, keys: list[ObjectKey]) -> None:
+        """Delete keys from raw-block L2 and notify listeners for removals."""
+        encoded_keys = [encode_object_key(key).encoded for key in keys]
+        metas = self._core.get_metadata_many(encoded_keys)
+        deleted_bitmap = self._core.delete_many(encoded_keys, force=False)
+        deleted_keys: list[ObjectKey] = []
+        deleted_sizes: list[int] = []
+        for key, meta, deleted in zip(keys, metas, deleted_bitmap, strict=False):
+            if not deleted:
+                continue
+            deleted_keys.append(key)
+            deleted_sizes.append(0 if meta is None else int(self._core.slot_bytes))
+        if deleted_keys:
+            self._notify_keys_deleted(deleted_keys, deleted_sizes)
+
+    def close(self) -> None:
+        """Wait for worker pools, close the core, and close eventfds."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        self._store_pool.shutdown(wait=True)
+        self._lookup_pool.shutdown(wait=True)
+        self._load_pool.shutdown(wait=True)
+
+        self._core.close()
+
+        with self._lock:
+            store_efd = self._store_efd
+            lookup_efd = self._lookup_efd
+            load_efd = self._load_efd
+            self._store_efd = None
+            self._lookup_efd = None
+            self._load_efd = None
+
+        if store_efd is not None:
+            store_efd.close()
+        if lookup_efd is not None:
+            lookup_efd.close()
+        if load_efd is not None:
+            load_efd.close()
+
+    def report_status(self) -> dict:
+        """Return adapter health, task counters, and core status."""
+        core_status = self._core.report_status()
+        with self._lock:
+            return {
+                "is_healthy": core_status.get("is_healthy", True) and not self._closed,
+                "type": "RawBlockL2Adapter",
+                "store_inflight_task_count": self._store_inflight_tasks,
+                "lookup_inflight_task_count": self._lookup_inflight_tasks,
+                "load_inflight_task_count": self._load_inflight_tasks,
+                "completed_store_task_count": len(self._completed_store_tasks),
+                "completed_lookup_task_count": len(self._completed_lookup_tasks),
+                "completed_load_task_count": len(self._completed_load_tasks),
+                "core": core_status,
+            }
+
+    def _raise_if_closed_locked(self) -> None:
+        if self._closed:
+            raise RuntimeError("RawBlockL2Adapter is closed")
+
+    def _get_next_task_id_locked(self) -> L2TaskId:
+        task_id = self._next_task_id
+        self._next_task_id += 1
+        return task_id
+
+    def _run_store_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> RawBlockStoreTaskResult:
+        """Persist one submitted store batch in the worker pool.
+
+        Args:
+            keys: Object keys submitted for storage.
+            objects: Payload buffers aligned with ``keys``.
+
+        Returns:
+            A 3-tuple containing:
+
+            - task success for the whole batch
+            - newly stored object keys
+            - raw-block slot byte charges aligned with the newly stored keys
+        """
+        specs = [encode_object_key(key) for key in keys]
+        put_result = self._core.put_many(specs, objects)
+        stored_encoded = set(put_result.stored_keys)
+        slot_bytes = int(self._core.slot_bytes)
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
+        for key, spec in zip(keys, specs, strict=False):
+            if spec.encoded not in stored_encoded:
+                continue
+            stored_keys.append(key)
+            stored_sizes.append(slot_bytes)
+        return all(put_result.results), stored_keys, stored_sizes
+
+    def _finish_store_task(
+        self,
+        task_id: L2TaskId,
+        future: Future[RawBlockStoreTaskResult],
+    ) -> None:
+        success = False
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
+        try:
+            success, stored_keys, stored_sizes = future.result()
+        except Exception as e:
+            logger.error("RawBlockL2Adapter store task %d failed: %s", task_id, e)
+        with self._lock:
+            self._store_inflight_tasks -= 1
+            self._completed_store_tasks[task_id] = success
+            event_fd = self._store_efd
+        if stored_keys:
+            try:
+                self._notify_keys_stored(stored_keys, stored_sizes)
+            except Exception as e:
+                logger.warning("RawBlockL2Adapter store notification failed: %s", e)
+        self._signal_event_fd(event_fd)
+
+    def _run_lookup_task(self, keys: list[ObjectKey]) -> Bitmap:
+        specs = [encode_object_key(key) for key in keys]
+        exists = self._core.exists_many([spec.encoded for spec in specs], lock=True)
+        bitmap = _make_bitmap(len(keys))
+        for i, ok in enumerate(exists):
+            if ok:
+                bitmap.set(i)
+        return bitmap
+
+    def _finish_lookup_task(
+        self, task_id: L2TaskId, bitmap_size: int, future: Future[Any]
+    ) -> None:
+        bitmap = _make_bitmap(bitmap_size)
+        try:
+            bitmap = future.result()
+        except Exception as e:
+            logger.error("RawBlockL2Adapter lookup task %d failed: %s", task_id, e)
+        with self._lock:
+            self._lookup_inflight_tasks -= 1
+            self._completed_lookup_tasks[task_id] = bitmap
+            event_fd = self._lookup_efd
+        self._signal_event_fd(event_fd)
+
+    def _run_load_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> tuple[Bitmap, list[ObjectKey]]:
+        specs = [encode_object_key(key) for key in keys]
+        results = self._core.load_many_into([spec.encoded for spec in specs], objects)
+        bitmap = _make_bitmap(len(keys))
+        accessed_keys: list[ObjectKey] = []
+        for i, ok in enumerate(results):
+            if ok:
+                bitmap.set(i)
+                accessed_keys.append(keys[i])
+        return bitmap, accessed_keys
+
+    def _finish_load_task(
+        self, task_id: L2TaskId, bitmap_size: int, future: Future[Any]
+    ) -> None:
+        bitmap = _make_bitmap(bitmap_size)
+        accessed_keys: list[ObjectKey] = []
+        try:
+            bitmap, accessed_keys = future.result()
+        except Exception as e:
+            logger.error("RawBlockL2Adapter load task %d failed: %s", task_id, e)
+        with self._lock:
+            self._load_inflight_tasks -= 1
+            self._completed_load_tasks[task_id] = bitmap
+            event_fd = self._load_efd
+        if accessed_keys:
+            try:
+                self._notify_keys_accessed(accessed_keys)
+            except Exception as e:
+                logger.warning("RawBlockL2Adapter access notification failed: %s", e)
+        self._signal_event_fd(event_fd)
+
+    def _signal_event_fd(self, event_fd: EventNotifier | None) -> None:
+        try:
+            if event_fd is not None:
+                event_fd.notify()
+        except OSError:
+            logger.debug("event notifier was closed before signaling")
+
+    def _cleanup_after_init_failure(self) -> None:
+        for pool_name in ("_store_pool", "_lookup_pool", "_load_pool"):
+            pool = getattr(self, pool_name, None)
+            if pool is not None:
+                pool.shutdown(wait=False, cancel_futures=True)
+                setattr(self, pool_name, None)
+
+        core = getattr(self, "_core", None)
+        if core is not None:
+            core.close()
+
+        for fd_name in ("_store_efd", "_lookup_efd", "_load_efd"):
+            fd = getattr(self, fd_name, None)
+            if fd is not None:
+                fd.close()
+                setattr(self, fd_name, None)
+
+        self._closed = True
+
+
+register_l2_adapter_type("raw_block", RawBlockL2AdapterConfig)
+
+
+def _create_raw_block_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> L2AdapterInterface:
+    return RawBlockL2Adapter(config, l1_memory_desc)  # type: ignore[arg-type]
+
+
+register_l2_adapter_factory("raw_block", _create_raw_block_adapter)

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -406,8 +406,17 @@ class LocalCPUBackend(AllocatorBackendInterface):
             return paged_mem_allocator
         else:
             # Check if io_uring is enabled for fixed buffer support
-            use_uring = bool(
-                config.get_extra_config_value("rust_raw_block.use_uring", False)
+            io_engine = str(
+                config.get_extra_config_value("rust_raw_block.io_engine", "") or ""
+            ).lower()
+            use_uring = (
+                io_engine == "io_uring"
+                or bool(
+                    config.get_extra_config_value("rust_raw_block.use_iouring", False)
+                )
+                or bool(
+                    config.get_extra_config_value("rust_raw_block.use_uring", False)
+                )
             )
 
             # Check if lazy memory allocator should be enabled
@@ -522,7 +531,12 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         rust_device_path = extra.get("rust_raw_block.device_path")
         rust_use_odirect = bool(extra.get("rust_raw_block.use_odirect", False))
-        rust_use_uring = bool(extra.get("rust_raw_block.use_uring", False))
+        rust_io_engine = str(extra.get("rust_raw_block.io_engine", "") or "").lower()
+        rust_use_uring = (
+            rust_io_engine == "io_uring"
+            or bool(extra.get("rust_raw_block.use_iouring", False))
+            or bool(extra.get("rust_raw_block.use_uring", False))
+        )
         rust_auto_align = bool(
             extra.get("rust_raw_block.align_local_cpu_allocator", True)
         )

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -4,47 +4,51 @@
 from __future__ import annotations
 
 # Standard
-from collections import OrderedDict
 from collections.abc import Mapping
-from dataclasses import dataclass
+from concurrent.futures import Future
 from typing import Any, Callable, List, Optional, Sequence
 import asyncio
-import ctypes
-import json
-import struct
 import threading
 import time
-import zlib
-
-# Third Party
-import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey, DiskCacheMetadata
-from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,
     StoragePluginInterface,
 )
+from lmcache.v1.storage_backend.raw_block import (
+    DEFAULT_IOURING_QUEUE_DEPTH,
+    RawBlockCore,
+    RawBlockCoreConfig,
+    RawBlockKeySpec,
+    decode_legacy_key,
+    encode_legacy_key,
+    normalize_raw_block_io_engine,
+    round_up,
+    validate_raw_block_io_options,
+)
 
 logger = init_logger(__name__)
 
-
 _DEFAULT_META_MAGIC = b"LMCIDX01"
 _DEFAULT_META_VERSION = 1
-_META_HEADER_STRUCT = struct.Struct("<8sIQQI")
+
 TPRankKey = int | str
 PerTPDevicePaths = Mapping[TPRankKey, str]
 
 
-def _round_up(x: int, align: int) -> int:
-    """Round up to nearest multiple of alignment (required for O_DIRECT)."""
-    return ((x + align - 1) // align) * align
-
-
 def _validate_per_tp_device_paths(per_tp_devices: PerTPDevicePaths) -> None:
-    """Validate per-TP device mapping and enforce unique paths."""
+    """Validate that each TP rank uses a distinct raw-block device path.
+
+    Args:
+        per_tp_devices: Mapping from TP rank to raw-block device path.
+
+    Raises:
+        ValueError: If the same device path is assigned to multiple ranks.
+    """
     values = list(per_tp_devices.values())
     if len(values) != len(set(values)):
         raise ValueError(
@@ -55,58 +59,27 @@ def _validate_per_tp_device_paths(per_tp_devices: PerTPDevicePaths) -> None:
 def _get_per_tp_device_path(
     per_tp_devices: PerTPDevicePaths, tp_rank: int
 ) -> Optional[str]:
-    """Return the configured device path for a TP rank.
+    """Return the device path configured for a TP rank.
 
-    Looks up both string and integer forms of ``tp_rank`` so YAML mappings
-    with either quoted or unquoted numeric keys are accepted.
+    Args:
+        per_tp_devices: Mapping with string or integer rank keys.
+        tp_rank: Tensor-parallel rank to look up.
+
+    Returns:
+        The configured path, or None when the rank is absent.
     """
     return per_tp_devices.get(str(tp_rank), per_tp_devices.get(tp_rank))
 
 
-@dataclass
-class _Entry:
-    """In-memory index entry for a stored chunk."""
-
-    offset: int
-    size: int
-    meta: DiskCacheMetadata
-
-
-@dataclass
-class _Inflight:
-    offset: int
-    meta: DiskCacheMetadata
-    canceled: bool = False
-
-
 class RustRawBlockBackend(StoragePluginInterface):
     """
-    A storage plugin backend that stores KV chunks into a block device (raw)
-    using a Rust extension for pread/pwrite or io_uring.
+    Legacy raw-block storage plugin wrapper.
 
-    Features:
-    - High-throughput I/O via direct block device access
-    - O_DIRECT support to bypass page cache (requires aligned buffers)
-    - On-device metadata checkpoint for restart recovery
-    - Efficient buffer operations via Rust extension
-
-    - TP > 1 support via per-TP partitions
-
-    TP > 1 Support:
-    ----------------
-    When using Tensor Parallelism (TP > 1), each TP worker must use a
-    separate partition to avoid metadata conflicts and data corruption.
-
-    Configuration:
-    For TP > 1, you must explicitly configure device paths for each TP worker:
-       extra_config:
-         rust_raw_block.per_tp_device_paths:
-           "0": "/dev/nvme0n1p1"
-           "1": "/dev/nvme0n1p2"
-           "2": "/dev/nvme0n1p3"
-           "3": "/dev/nvme0n1p4"
-
-    Note: Partitions must be pre-created on the device before use.
+    The durable raw-device/index/checkpoint logic now lives in RawBlockCore.
+    This wrapper preserves the existing non-MP interface and prefix semantics:
+    - TP>1 still uses explicit per-TP device partitions
+    - batched_async_contains reports only the leading hit prefix
+    - batched_get_{blocking,non_blocking} load only the leading hit prefix
     """
 
     def __init__(
@@ -133,8 +106,6 @@ class RustRawBlockBackend(StoragePluginInterface):
 
         extra = self.config.extra_config or {}
 
-        # Support TP > 1 via per-TP device paths.
-        # Each TP worker uses its own partition to avoid conflicts.
         self.device_path: str
         if self.metadata is not None and self.metadata.world_size > 1:
             tp_rank = self.metadata.worker_id
@@ -144,78 +115,131 @@ class RustRawBlockBackend(StoragePluginInterface):
                     "rust_raw_block.per_tp_device_paths must be a mapping from "
                     "TP rank to device path"
                 )
-
             if not per_tp_devices:
                 raise ValueError(
                     "For TP > 1, rust_raw_block.per_tp_device_paths is required. "
                     "Each TP worker must have an explicit device path configured."
                 )
             _validate_per_tp_device_paths(per_tp_devices)
-
-            tp_rank_str = str(tp_rank)
             device_path = _get_per_tp_device_path(per_tp_devices, tp_rank)
             if not device_path:
                 raise ValueError(
-                    f"No device path configured for TP rank {tp_rank_str}. "
+                    f"No device path configured for TP rank {tp_rank}. "
                     f"Available ranks: {list(per_tp_devices.keys())}"
                 )
             self.device_path = device_path
-            logger.info(
-                f"RustRawBlockBackend: TP={self.metadata.world_size} mode, "
-                f"using explicit device path for rank {tp_rank}: {self.device_path}"
-            )
         else:
-            self.device_path = extra.get("rust_raw_block.device_path", "")
+            self.device_path = str(extra.get("rust_raw_block.device_path", "") or "")
             if not self.device_path:
                 raise ValueError(
                     "extra_config['rust_raw_block.device_path'] is required"
                 )
 
-        self.capacity_bytes: int = int(extra.get("rust_raw_block.capacity_bytes", 0))
-        self.block_align: int = int(extra.get("rust_raw_block.block_align", 4096))
-        self.header_bytes: int = int(extra.get("rust_raw_block.header_bytes", 4096))
-        self.use_odirect: bool = bool(extra.get("rust_raw_block.use_odirect", False))
-        # Try direct aligned O_DIRECT I/O when allocator buffers permit.
-        self.enable_zero_copy: bool = bool(
-            extra.get("rust_raw_block.enable_zero_copy", True)
+        self._core = RawBlockCore(
+            self._build_core_config(extra),
+            key_namespace="legacy",
         )
-        self.use_uring: bool = bool(extra.get("rust_raw_block.use_uring", False))
+        self._warn_if_loaded_metadata_looks_cross_rank()
 
-        # On-device metadata region config.
-        self.meta_total_bytes: int = int(
+        self._put_lock = threading.Lock()
+        self._put_tasks: set[CacheEngineKey] = set()
+        self._pin_lock = threading.Lock()
+        self._pinned_keys: set[str] = set()
+
+    def __str__(self) -> str:
+        return "RustRawBlockBackend"
+
+    @property
+    def capacity_bytes(self) -> int:
+        """Return the effective raw-block capacity in bytes."""
+        return int(self._core.capacity_bytes)
+
+    @property
+    def block_align(self) -> int:
+        """Return the configured raw-device block alignment."""
+        return int(self._core.block_align)
+
+    @property
+    def header_bytes(self) -> int:
+        """Return the per-slot header reservation in bytes."""
+        return int(self._core.header_bytes)
+
+    @property
+    def slot_bytes(self) -> int:
+        """Return the configured raw-block slot size in bytes."""
+        return int(self._core.slot_bytes)
+
+    @property
+    def meta_total_bytes(self) -> int:
+        """Return the reserved metadata checkpoint region size."""
+        return int(self._core.meta_total_bytes)
+
+    @property
+    def meta_magic_text(self) -> str:
+        """Return the ASCII metadata checkpoint magic."""
+        return str(self._core.meta_magic_text)
+
+    @property
+    def meta_version(self) -> int:
+        """Return the metadata checkpoint format version."""
+        return int(self._core.meta_version)
+
+    @property
+    def data_base_offset(self) -> int:
+        """Return the byte offset where data slots begin."""
+        return self._core.data_base_offset()
+
+    def lock_refcount(self, encoded_key: str) -> int:
+        """Return the L2 lock refcount for a legacy encoded key."""
+        return self._core.lock_refcount(encoded_key)
+
+    def inflight_io_count(self) -> int:
+        """Return the number of active raw-device I/O operations."""
+        return self._core.inflight_io_count()
+
+    def indexed_key_count(self) -> int:
+        """Return the number of keys currently indexed by raw-block."""
+        return self._core.indexed_key_count()
+
+    def entry_offset(self, key: CacheEngineKey) -> int | None:
+        """Return the raw-block slot offset for a legacy key."""
+        return self._core.entry_offset(encode_legacy_key(key).encoded)
+
+    def metadata_container_offsets(self) -> list[int]:
+        """Return checkpoint metadata container offsets in bytes."""
+        return self._core.metadata_container_offsets()
+
+    def apply_loaded_state(self, data: dict[str, Any]) -> bool:
+        """Validate and apply a raw-block metadata checkpoint payload."""
+        return self._core.apply_loaded_state(data)
+
+    def _build_core_config(self, extra: Mapping[str, Any]) -> RawBlockCoreConfig:
+        block_align = int(extra.get("rust_raw_block.block_align", 4096))
+        header_bytes = int(extra.get("rust_raw_block.header_bytes", 4096))
+        use_odirect = bool(extra.get("rust_raw_block.use_odirect", False))
+        enable_zero_copy = bool(extra.get("rust_raw_block.enable_zero_copy", True))
+        capacity_bytes = int(extra.get("rust_raw_block.capacity_bytes", 0))
+        io_engine = normalize_raw_block_io_engine(
+            extra.get("rust_raw_block.io_engine"),
+            use_iouring=extra.get("rust_raw_block.use_iouring"),
+            use_uring=extra.get("rust_raw_block.use_uring"),
+        )
+        iouring_queue_depth = int(
+            extra.get("rust_raw_block.iouring_queue_depth", DEFAULT_IOURING_QUEUE_DEPTH)
+        )
+        validate_raw_block_io_options(
+            iouring_queue_depth=iouring_queue_depth,
+        )
+        meta_total_bytes = int(
             extra.get("rust_raw_block.meta_total_bytes", 128 * 1024 * 1024)
         )
         meta_magic_raw = extra.get("rust_raw_block.meta_magic", "LMCIDX01")
         if isinstance(meta_magic_raw, str):
-            self.meta_magic: bytes = meta_magic_raw.encode("ascii")
+            meta_magic = meta_magic_raw.encode("ascii")
         elif isinstance(meta_magic_raw, bytes):
-            self.meta_magic = meta_magic_raw
+            meta_magic = meta_magic_raw
         else:
             raise ValueError("rust_raw_block.meta_magic must be str or bytes")
-        if len(self.meta_magic) != 8:
-            raise ValueError("rust_raw_block.meta_magic must be exactly 8 bytes")
-        try:
-            self.meta_magic_text: str = self.meta_magic.decode("ascii")
-        except UnicodeDecodeError as e:
-            raise ValueError("rust_raw_block.meta_magic must be ASCII bytes") from e
-        self.meta_version: int = int(
-            extra.get("rust_raw_block.meta_version", _DEFAULT_META_VERSION)
-        )
-        if self.meta_version <= 0:
-            raise ValueError("rust_raw_block.meta_version must be > 0")
-        self.meta_checkpoint_interval_sec: int = int(
-            extra.get("rust_raw_block.meta_checkpoint_interval_sec", 60)
-        )
-        self.meta_idle_quiet_ms: int = int(
-            extra.get("rust_raw_block.meta_idle_quiet_ms", 100)
-        )
-        self.meta_enable_periodic: bool = bool(
-            extra.get("rust_raw_block.meta_enable_periodic", True)
-        )
-        self.meta_verify_on_load: bool = bool(
-            extra.get("rust_raw_block.meta_verify_on_load", True)
-        )
-        self._meta_copy_count: int = 2
 
         get_full_chunk_size_bytes = getattr(
             self.local_cpu_backend, "get_full_chunk_size_bytes", None
@@ -232,336 +256,90 @@ class RustRawBlockBackend(StoragePluginInterface):
                     "or get_full_chunk_size()"
                 )
             full_chunk_bytes = int(get_full_chunk_size())
-        default_slot_bytes = _round_up(
-            self.header_bytes + full_chunk_bytes, self.block_align
+        default_slot_bytes = round_up(header_bytes + full_chunk_bytes, block_align)
+        slot_bytes = int(extra.get("rust_raw_block.slot_bytes", default_slot_bytes))
+
+        return RawBlockCoreConfig(
+            device_path=self.device_path,
+            capacity_bytes=capacity_bytes,
+            block_align=block_align,
+            header_bytes=header_bytes,
+            slot_bytes=slot_bytes,
+            use_odirect=use_odirect,
+            enable_zero_copy=enable_zero_copy,
+            meta_total_bytes=meta_total_bytes,
+            meta_magic=meta_magic,
+            meta_version=int(
+                extra.get("rust_raw_block.meta_version", _DEFAULT_META_VERSION)
+            ),
+            meta_checkpoint_interval_sec=int(
+                extra.get("rust_raw_block.meta_checkpoint_interval_sec", 60)
+            ),
+            meta_idle_quiet_ms=int(extra.get("rust_raw_block.meta_idle_quiet_ms", 100)),
+            meta_enable_periodic=bool(
+                extra.get("rust_raw_block.meta_enable_periodic", True)
+            ),
+            meta_verify_on_load=bool(
+                extra.get("rust_raw_block.meta_verify_on_load", True)
+            ),
+            io_engine=io_engine,
+            iouring_queue_depth=iouring_queue_depth,
         )
-        self.slot_bytes: int = int(
-            extra.get("rust_raw_block.slot_bytes", default_slot_bytes)
-        )
 
-        if self.slot_bytes < self.header_bytes + 1:
-            raise ValueError("rust_raw_block.slot_bytes too small")
-        if self.slot_bytes % self.block_align != 0:
-            raise ValueError(
-                "rust_raw_block.slot_bytes must be multiple of block_align"
-            )
-        if self.header_bytes % self.block_align != 0:
-            raise ValueError(
-                "rust_raw_block.header_bytes must be multiple of block_align"
-            )
-        if self.meta_total_bytes <= 0:
-            raise ValueError("rust_raw_block.meta_total_bytes must be > 0")
-        if self.meta_total_bytes % self.block_align != 0:
-            raise ValueError(
-                "rust_raw_block.meta_total_bytes must align to block_align"
-            )
-        if self.meta_total_bytes <= self.block_align:
-            raise ValueError(
-                "rust_raw_block.meta_total_bytes must be > block_align "
-                "(room for metadata header + payload)"
-            )
-        self._meta_container_bytes: int = (
-            (self.meta_total_bytes // self._meta_copy_count) // self.block_align
-        ) * self.block_align
-        if self._meta_container_bytes <= self.block_align:
-            raise ValueError(
-                "rust_raw_block.meta_total_bytes must provide room for at least "
-                "two metadata copies (header + payload)"
-            )
-
-        self._lock = threading.Lock()
-        self._index: dict[CacheEngineKey, _Entry] = {}
-        self._pinned: set[CacheEngineKey] = set()
-        self._inflight: dict[CacheEngineKey, _Inflight] = {}
-        self._lru: "OrderedDict[CacheEngineKey, None]" = OrderedDict()
-
-        self._next_slot: int = 0
-        self._free_slots: list[int] = []
-        self._max_slots: int = 0
-        self._effective_capacity_bytes: int = 0
-        self._data_base_offset: int = 0
-
-        self._dbg_first_n: int = int(extra.get("rust_raw_block.debug_first_n", 4) or 0)
-        self._dbg_every_n: int = int(
-            extra.get("rust_raw_block.debug_every_n", 256) or 0
-        )
-        self._dbg_put_batches: int = 0
-        self._dbg_put_keys: int = 0
-        self._dbg_put_bytes: int = 0
-        self._dbg_get_calls: int = 0
-        self._dbg_get_bytes: int = 0
-
-        self._raw = None
-
-        self._put_lock = threading.Lock()
-        self._put_tasks: set[CacheEngineKey] = set()
-
-        # Metadata checkpoint state.
-        self._meta_seq: int = 0
-        self._meta_dirty_total: int = 0
-        self._meta_persisted: int = 0
-        self._inflight_io_count: int = 0
-        self._last_io_ts: float = time.monotonic()
-        self._meta_stop_evt = threading.Event()
-        self._meta_thread: Optional[threading.Thread] = None
-
-        self._ensure_capacity_and_layout()
-
-        logger.info(
-            "RustRawBlockBackend init: device=%s cap=%s slot=%d align=%d header=%d "
-            "meta_total=%d data_base=%d zero_copy=%s",
+    def _warn_if_loaded_metadata_looks_cross_rank(self) -> None:
+        if self.metadata is None:
+            return
+        first_encoded_key = self._core.first_encoded_key()
+        if first_encoded_key is None:
+            return
+        try:
+            first_loaded_key = decode_legacy_key(first_encoded_key)
+        except Exception:
+            return
+        expected_worker_id = int(self.metadata.worker_id)
+        loaded_worker_id = int(first_loaded_key.worker_id)
+        if loaded_worker_id == expected_worker_id:
+            return
+        logger.warning(
+            "RustRawBlockBackend: loaded metadata may belong to another "
+            "worker (device=%s, current_worker_id=%d, "
+            "first_entry_worker_id=%d, first_entry_key=%s)",
             self.device_path,
-            self.capacity_bytes,
-            self.slot_bytes,
-            self.block_align,
-            self.header_bytes,
-            self.meta_total_bytes,
-            self._data_base_offset,
-            self.enable_zero_copy,
+            expected_worker_id,
+            loaded_worker_id,
+            first_loaded_key.to_string(),
         )
-
-        # Register paged buffers with io_uring for fixed buffer support
-        if self.use_uring:
-            self._register_paged_buffers()
-
-        # Load latest checkpoint from device (no JSON fallback).
-        self._load_checkpoint_from_device()
-
-        if self.meta_enable_periodic:
-            self._meta_thread = threading.Thread(
-                target=self._checkpoint_loop,
-                name="rust-raw-block-meta-checkpoint",
-                daemon=True,
-            )
-            self._meta_thread.start()
-
-    def _dbg_should_log(self, n: int) -> bool:
-        if not logger.isEnabledFor(10):
-            return False
-        if self._dbg_first_n and n <= self._dbg_first_n:
-            return True
-        if self._dbg_every_n and n % self._dbg_every_n == 0:
-            return True
-        return False
-
-    def _dbg_key_short(self, key: CacheEngineKey) -> str:
-        try:
-            return f"chunk_hash={int(key.chunk_hash)}"
-        except Exception:
-            return "chunk_hash=?"
-
-    def __str__(self) -> str:
-        return "RustRawBlockBackend"
-
-    def _rawdev(self):
-        if self._raw is None:
-            try:
-                # Third Party
-                from lmcache_rust_raw_block_io import RawBlockDevice  # type: ignore
-            except Exception as e:
-                raise RuntimeError(
-                    "Rust raw-block extension is not installed. "
-                    "Install / build `rust_raw_block_io` and retry."
-                ) from e
-            self._raw = RawBlockDevice(
-                self.device_path,
-                writable=True,
-                use_odirect=self.use_odirect,
-                alignment=self.block_align,
-                use_iouring=self.use_uring,
-            )
-        return self._raw
-
-    def _register_paged_buffers(self) -> None:
-        """Register paged buffers with io_uring for fixed buffer support."""
-        try:
-            assert self.local_cpu_backend is not None
-            memory_allocator = self.local_cpu_backend.get_memory_allocator()
-            paged_buffers = getattr(memory_allocator, "get_paged_buffers", None)
-
-            if paged_buffers is not None and callable(paged_buffers):
-                buffers = paged_buffers()
-                if buffers is not None and len(buffers) > 0:
-                    raw_dev = self._rawdev()
-                    # Register buffers with io_uring
-                    buffer_ptrs = [buf.data_ptr() for buf in buffers]
-                    buffer_sizes = [buf.numel() * buf.element_size() for buf in buffers]
-
-                    raw_dev.register_fixed_buffers(buffer_ptrs, buffer_sizes)
-
-                    logger.info(
-                        "RustRawBlockBackend: registered %d paged buffers with "
-                        "io_uring for fixed buffer support (true zero copy)",
-                        len(buffers),
-                    )
-                else:
-                    logger.warning(
-                        "RustRawBlockBackend: no paged buffers available for "
-                        "io_uring fixed buffer registration"
-                    )
-            else:
-                logger.warning(
-                    "RustRawBlockBackend: memory allocator does not support "
-                    "paged buffers for io_uring fixed buffer registration"
-                )
-        except Exception as e:
-            logger.warning(
-                "RustRawBlockBackend: failed to register paged buffers with "
-                "io_uring: %s. Falling back to non-fixed buffer mode.",
-                e,
-            )
-
-    def _build_direct_odirect_view(
-        self,
-        memory_obj: MemoryObj,
-        payload_len: int,
-        total_len: int,
-        buffer_len: int,
-        *,
-        zero_tail: bool,
-    ) -> Optional[memoryview]:
-        """Build direct physical-memory view for O_DIRECT without staging copy."""
-        if not self.use_odirect or not self.enable_zero_copy:
-            return None
-
-        ptr_val = getattr(memory_obj, "data_ptr", None)
-        if callable(ptr_val):
-            try:
-                ptr_val = ptr_val()
-            except Exception:
-                ptr_val = None
-        if ptr_val is None:
-            return None
-
-        if buffer_len <= 0:
-            return None
-
-        try:
-            ptr = int(ptr_val)
-        except Exception:
-            return None
-
-        if ptr <= 0 or ptr % self.block_align != 0:
-            return None
-        if buffer_len < payload_len:
-            return None
-
-        view_len = min(buffer_len, total_len)
-        if view_len < payload_len:
-            return None
-
-        try:
-            raw = (ctypes.c_ubyte * view_len).from_address(ptr)
-            view = memoryview(raw)
-            if zero_tail and total_len > payload_len and view_len >= total_len:
-                ctypes.memset(ptr + payload_len, 0, total_len - payload_len)
-            return view
-        except Exception:
-            return None
-
-    def _ensure_capacity_and_layout(self) -> None:
-        if self._effective_capacity_bytes > 0 and self._max_slots > 0:
-            return
-
-        device_size = int(self._rawdev().size_bytes())
-        requested = self.capacity_bytes if self.capacity_bytes > 0 else device_size
-        self._effective_capacity_bytes = min(requested, device_size)
-        self.capacity_bytes = self._effective_capacity_bytes
-
-        if self.meta_total_bytes >= self._effective_capacity_bytes:
-            raise RuntimeError("metadata region exceeds usable device capacity")
-
-        self._data_base_offset = self.meta_total_bytes
-        data_bytes = self._effective_capacity_bytes - self._data_base_offset
-        self._max_slots = data_bytes // self.slot_bytes
-        if self._max_slots <= 0:
-            raise RuntimeError(
-                "raw block capacity too small for slot size after metadata"
-            )
-
-    def _slot_to_offset(self, slot: int) -> int:
-        return self._data_base_offset + slot * self.slot_bytes
-
-    def _offset_to_slot(self, offset: int) -> int:
-        return (offset - self._data_base_offset) // self.slot_bytes
-
-    def _allocate_slot(self) -> int:
-        self._ensure_capacity_and_layout()
-
-        if self._free_slots:
-            return self._slot_to_offset(self._free_slots.pop())
-
-        if self._next_slot < self._max_slots:
-            slot = self._next_slot
-            self._next_slot += 1
-            return self._slot_to_offset(slot)
-
-        raise RuntimeError("No free slots available; eviction required")
-
-    def _touch(self, key: CacheEngineKey) -> None:
-        self._lru.pop(key, None)
-        self._lru[key] = None
-
-    def _append_free_slot_locked(self, slot: int) -> None:
-        if slot < 0 or slot >= self._max_slots:
-            return
-        if slot in self._free_slots:
-            return
-        self._free_slots.append(slot)
-
-    def _evict_one(self) -> bool:
-        for victim in list(self._lru.keys()):
-            if victim in self._pinned or victim in self._inflight:
-                continue
-            entry = self._index.pop(victim, None)
-            if entry is None:
-                self._lru.pop(victim, None)
-                continue
-            self._lru.pop(victim, None)
-            self._pinned.discard(victim)
-            self._append_free_slot_locked(self._offset_to_slot(int(entry.offset)))
-            self._meta_dirty_total += 1
-            return True
-        return False
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
-        with self._lock:
-            ok = key in self._index
-            if ok and pin:
-                self._pinned.add(key)
-            return ok
+        spec = encode_legacy_key(key)
+        return (
+            self._pin_if_needed(spec.encoded)
+            if pin
+            else self._core.contains_key(
+                spec.encoded,
+                lock=False,
+            )
+        )
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
         with self._put_lock:
             return key in self._put_tasks
 
     def pin(self, key: CacheEngineKey) -> bool:
-        with self._lock:
-            if key in self._index:
-                self._pinned.add(key)
-                return True
-            return False
+        spec = encode_legacy_key(key)
+        return self._pin_if_needed(spec.encoded)
 
     def unpin(self, key: CacheEngineKey) -> bool:
-        with self._lock:
-            if key in self._pinned:
-                self._pinned.remove(key)
-                return True
-            return key in self._index
+        spec = encode_legacy_key(key)
+        return self._unpin_if_needed(spec.encoded)
 
-    def remove(self, key: CacheEngineKey, force: bool = True) -> bool:  # noqa: ARG002
-        with self._lock:
-            existed = key in self._index or key in self._inflight
-            entry = self._index.pop(key, None)
-            inflight = self._inflight.get(key)
-            self._pinned.discard(key)
-            self._lru.pop(key, None)
-            if entry is not None:
-                self._append_free_slot_locked(self._offset_to_slot(int(entry.offset)))
-                self._meta_dirty_total += 1
-            if inflight is not None:
-                inflight.canceled = True
-            return existed
+    def remove(self, key: CacheEngineKey, force: bool = True) -> bool:
+        spec = encode_legacy_key(key)
+        with self._pin_lock:
+            removed = self._core.delete_many([spec.encoded], force=force)[0]
+            if removed:
+                self._pinned_keys.discard(spec.encoded)
+        return removed
 
     def batched_submit_put_task(
         self,
@@ -569,604 +347,136 @@ class RustRawBlockBackend(StoragePluginInterface):
         objs: List[MemoryObj],
         transfer_spec: Any = None,  # noqa: ARG002
         on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
-    ):
-        if logger.isEnabledFor(10):
-            self._dbg_put_batches += 1
-            self._dbg_put_keys += int(len(keys))
-            try:
-                self._dbg_put_bytes += int(sum(len(o.byte_array) for o in objs))
-            except Exception:
-                pass
-            if self._dbg_should_log(self._dbg_put_batches):
-                logger.debug(
-                    "RustRawBlockBackend PUT: keys=%d inflight=%d indexed=%d",
-                    len(keys),
-                    len(self._inflight),
-                    len(self._index),
-                )
-
-        # Use io_uring path if enabled
-        if self.use_uring:
-            # TODO(Ankit): Find a better way to handle this.
-            for obj in objs:
-                obj.ref_count_up()
-
-            assert self.loop is not None
-            fut = asyncio.run_coroutine_threadsafe(
-                self._batched_submit_put_task_uring(keys, objs, on_complete_callback),
-                self.loop,
-            )
-            return [fut]
-
-        futures = []
+    ) -> list[Future] | None:
+        del transfer_spec
+        futures: list[Future] = []
         for key, obj in zip(keys, objs, strict=False):
             with self._put_lock:
                 if key in self._put_tasks:
                     continue
                 self._put_tasks.add(key)
 
-            with self._lock:
-                if key in self._index or key in self._inflight:
-                    with self._put_lock:
-                        self._put_tasks.discard(key)
-                    continue
-                while True:
-                    try:
-                        offset = self._allocate_slot()
-                        break
-                    except RuntimeError:
-                        if not self._evict_one():
-                            with self._put_lock:
-                                self._put_tasks.discard(key)
-                            raise
+            spec = encode_legacy_key(key)
+            exists = self._core.contains_key(
+                spec.encoded,
+                lock=False,
+            ) or self._core.exists_inflight(spec.encoded)
+            if exists:
+                with self._put_lock:
+                    self._put_tasks.discard(key)
+                continue
 
-                meta = DiskCacheMetadata(
-                    path=f"{self.device_path}@{offset}",
-                    size=len(obj.byte_array),
-                    shape=obj.metadata.shape,
-                    dtype=obj.metadata.dtype,
-                    cached_positions=obj.metadata.cached_positions,
-                    fmt=obj.metadata.fmt,
-                    pin_count=0,
-                )
-                self._inflight[key] = _Inflight(offset=offset, meta=meta)
-
-            header = self._encode_header(key, meta.size)
             obj.ref_count_up()
-            assert self.loop is not None
+            loop = self.loop
+            if loop is None:
+                obj.ref_count_down()
+                raise RuntimeError("RustRawBlockBackend requires an asyncio event loop")
             fut = asyncio.run_coroutine_threadsafe(
-                self._submit_write(
-                    key=key,
-                    offset=offset,
-                    header=header,
-                    memory_obj=obj,
-                    on_complete_callback=on_complete_callback,
-                ),
-                self.loop,
+                self._submit_put_one(key, spec, obj, on_complete_callback),
+                loop,
             )
             futures.append(fut)
         return futures or None
 
-    async def _batched_submit_put_task_uring(
-        self,
-        keys: Sequence[CacheEngineKey],
-        objs: List[MemoryObj],
-        on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
-    ):
-        """Batched put using io_uring"""
-
-        # Collect all write requests
-        write_requests: list[tuple[CacheEngineKey, int, bytes, MemoryObj]] = []
-        valid_keys: list[CacheEngineKey] = []
-        valid_objs: list[MemoryObj] = []
-
-        # Track which items had inflight_io_count incremented
-        successfully_submitted: list[CacheEngineKey] = []
-
-        # Track which objects have incremented ref counts
-        objs_with_inc_ref = list(objs)
-
-        if self._raw is None:
-            raise RuntimeError("device is closed")
-
-        write_error: Optional[Exception] = None
-        try:
-            for key, obj in zip(keys, objs, strict=False):
-                with self._put_lock:
-                    if key in self._put_tasks:
-                        obj.ref_count_down()
-                        objs_with_inc_ref.remove(obj)
-                        continue
-                    self._put_tasks.add(key)
-
-                with self._lock:
-                    if key in self._index or key in self._inflight:
-                        with self._put_lock:
-                            self._put_tasks.discard(key)
-                        obj.ref_count_down()
-                        objs_with_inc_ref.remove(obj)
-                        continue
-                    while True:
-                        try:
-                            offset = self._allocate_slot()
-                            break
-                        except RuntimeError:
-                            if not self._evict_one():
-                                with self._put_lock:
-                                    self._put_tasks.discard(key)
-                                raise
-
-                    meta = DiskCacheMetadata(
-                        path=f"{self.device_path}@{offset}",
-                        size=len(obj.byte_array),
-                        shape=obj.metadata.shape,
-                        dtype=obj.metadata.dtype,
-                        cached_positions=obj.metadata.cached_positions,
-                        fmt=obj.metadata.fmt,
-                        pin_count=0,
-                    )
-                    self._inflight[key] = _Inflight(offset=offset, meta=meta)
-
-                header = self._encode_header(key, meta.size)
-                write_requests.append((key, offset, header, obj))
-                valid_keys.append(key)
-                valid_objs.append(obj)
-
-            if not write_requests:
-                return None
-
-            raw_dev = self._rawdev()
-            offsets = []
-            buffers = []
-            total_lens = []
-
-            for key, offset, header, obj in write_requests:
-                # Prepare payload with proper O_DIRECT alignment and zero-copy handling.
-                try:
-                    buf, payload_len, total_len = self._prepare_write_payload(obj)
-                    assert payload_len == total_len
-                except Exception as e:
-                    write_error = e
-                    logger.error(f"Failed to prepare payload for key {key}: {e}")
-                    raise
-
-                hdr_total = (
-                    _round_up(len(header), self.block_align)
-                    if self.use_odirect
-                    else len(header)
-                )
-                header_bytes = bytearray(header)
-                if self.use_odirect and len(header_bytes) < hdr_total:
-                    header_bytes.extend(b"\x00" * (hdr_total - len(header_bytes)))
-
-                offsets.append(offset)
-                buffers.append(header_bytes)
-                total_lens.append(hdr_total)
-                offsets.append(offset + self.header_bytes)
-                buffers.append(buf)
-                total_lens.append(total_len)
-
-                with self._lock:
-                    self._inflight_io_count += 1
-                successfully_submitted.append(key)
-
-            batch_id = raw_dev.batched_write(offsets, buffers, total_lens)
-            # Wait for headers and payloads to complete. Buffer lifetime is managed by
-            # Rust via Py_buffer views.
-            # Pass batch_id to capture any error from this batch completions.
-            # TODO(Ankit): Add a way to capture specific write failures.
-            await asyncio.to_thread(raw_dev.wait_iouring, batch_id)
-        except Exception as e:
-            if write_error is None:
-                write_error = e
-            logger.error(f"Batched write failed for keys {valid_keys}: {e}")
-        finally:
-            with self._lock:
-                for key in successfully_submitted:
-                    self._inflight_io_count -= 1
-                    self._last_io_ts = time.monotonic()
-
-            for obj in objs_with_inc_ref:
-                obj.ref_count_down()
-
-            with self._put_lock:
-                for key in valid_keys:
-                    self._put_tasks.discard(key)
-
-            if write_error is None:
-                with self._lock:
-                    for key, offset, header, obj in write_requests:
-                        inflight = self._inflight.pop(key, None)
-                        if inflight is not None and not inflight.canceled:
-                            self._index[key] = _Entry(
-                                offset=inflight.offset,
-                                size=inflight.meta.size,
-                                meta=inflight.meta,
-                            )
-                            self._touch(key)
-                            self._meta_dirty_total += 1
-
-                if on_complete_callback is not None:
-                    for key in valid_keys:
-                        try:
-                            on_complete_callback(key)
-                        except Exception as e:
-                            logger.warning(
-                                f"on_complete_callback failed for key {key}: {e}"
-                            )
-            else:
-                with self._lock:
-                    for key in valid_keys:
-                        inflight = self._inflight.pop(key, None)
-                        if inflight is not None:
-                            self._append_free_slot_locked(
-                                self._offset_to_slot(int(inflight.offset))
-                            )
-                            self._meta_dirty_total += 1
-            if write_error is not None:
-                raise write_error
-        return None
-
-    def _prepare_write_payload(self, memory_obj: MemoryObj) -> tuple[Any, int, int]:
-        """Prepare payload view and aligned lengths for write path."""
-        buf = memory_obj.byte_array
-        if hasattr(buf, "cast"):
-            buf = buf.cast("B")
-        payload_len = len(memory_obj.byte_array)
-        total_len = payload_len
-        if self.use_odirect:
-            total_len = _round_up(payload_len, self.block_align)
-            if total_len > (self.slot_bytes - self.header_bytes):
-                raise RuntimeError(f"O_DIRECT payload {total_len} > slot capacity")
-            direct_view = self._build_direct_odirect_view(
-                memory_obj=memory_obj,
-                payload_len=payload_len,
-                total_len=total_len,
-                buffer_len=len(buf),
-                zero_tail=True,
-            )
-            if direct_view is not None:
-                buf = direct_view
-        return buf, payload_len, total_len
-
-    async def _submit_write(
+    async def _submit_put_one(
         self,
         key: CacheEngineKey,
-        offset: int,
-        header: bytes,
+        spec: RawBlockKeySpec,
         memory_obj: MemoryObj,
-        on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
+        on_complete_callback: Optional[Callable[[CacheEngineKey], None]],
     ) -> None:
         try:
-            buf, payload_len, total_len = self._prepare_write_payload(memory_obj)
-
-            def _do_write():
-                with self._lock:
-                    self._inflight_io_count += 1
+            put_result = await asyncio.to_thread(
+                self._core.put_many,
+                [spec],
+                [memory_obj],
+            )
+            if not put_result.results or not put_result.results[0]:
+                raise RuntimeError(f"Failed to persist raw-block key {spec.encoded}")
+            if on_complete_callback is not None:
                 try:
-                    raw_dev = self._rawdev()
-                    hdr_total = (
-                        _round_up(len(header), self.block_align)
-                        if self.use_odirect
-                        else len(header)
-                    )
-                    raw_dev.pwrite_from_buffer(offset, header, len(header), hdr_total)
-                    raw_dev.pwrite_from_buffer(
-                        offset + self.header_bytes, buf, payload_len, total_len
-                    )
+                    on_complete_callback(key)
                 except Exception as e:
-                    logger.error(
-                        f"Write failed for key {self._dbg_key_short(key)}: {e}"
-                    )
-                    raise
-                finally:
-                    with self._lock:
-                        self._inflight_io_count -= 1
-                        self._last_io_ts = time.monotonic()
-
-            write_error: Optional[Exception] = None
-            try:
-                await asyncio.to_thread(_do_write)
-            except Exception as e:
-                write_error = e
-
-            with self._lock:
-                inflight = self._inflight.pop(key, None)
-                if inflight is not None:
-                    if inflight.canceled or write_error is not None:
-                        self._append_free_slot_locked(
-                            self._offset_to_slot(int(inflight.offset))
-                        )
-                        self._meta_dirty_total += 1
-                    else:
-                        self._index[key] = _Entry(
-                            offset=inflight.offset,
-                            size=inflight.meta.size,
-                            meta=inflight.meta,
-                        )
-                        self._touch(key)
-                        self._meta_dirty_total += 1
-
-            if write_error is None:
-                if on_complete_callback is not None:
-                    try:
-                        on_complete_callback(key)
-                    except Exception as e:
-                        logger.warning(
-                            f"on_complete_callback failed for key {key}: {e}"
-                        )
-            else:
-                raise write_error
+                    logger.warning("on_complete_callback failed for key %s: %s", key, e)
         finally:
             memory_obj.ref_count_down()
             with self._put_lock:
                 self._put_tasks.discard(key)
 
-    def _encode_header(self, key: CacheEngineKey, payload_len: int) -> bytes:
-        magic = b"LMCBLK01"
-        chunk_hash = int(key.chunk_hash) & ((1 << 64) - 1)
-        hdr = bytearray(self.header_bytes)
-        hdr[0:8] = magic
-        hdr[8:16] = chunk_hash.to_bytes(8, "little", signed=False)
-        hdr[16:24] = int(payload_len).to_bytes(8, "little", signed=False)
-        return bytes(hdr)
-
-    def _decode_slot_header(self, hdr: bytes) -> Optional[tuple[int, int]]:
-        if len(hdr) < 24:
-            return None
-        if hdr[0:8] != b"LMCBLK01":
-            return None
-        chunk_hash = int.from_bytes(hdr[8:16], "little", signed=False)
-        payload_len = int.from_bytes(hdr[16:24], "little", signed=False)
-        return chunk_hash, payload_len
-
-    def _read_slot_header(self, offset: int) -> Optional[tuple[int, int]]:
-        raw = self._rawdev()
-        buf = bytearray(self.header_bytes)
-        try:
-            with self._lock:
-                self._inflight_io_count += 1
-            if self.use_uring:
-                raw.read_uring(offset, buf, self.header_bytes, self.header_bytes)
-            else:
-                raw.pread_into(offset, buf, self.header_bytes, self.header_bytes)
-            return self._decode_slot_header(buf)
-        except Exception:
-            return None
-        finally:
-            with self._lock:
-                self._inflight_io_count -= 1
-                self._last_io_ts = time.monotonic()
-
-    async def _batched_get_prefix_uring(
-        self, keys: Sequence[CacheEngineKey]
+    def _batched_get_prefix(
+        self,
+        keys: Sequence[CacheEngineKey],
     ) -> list[MemoryObj]:
-        """Batched get using io_uring"""
         if not keys:
             return []
 
-        if self._raw is None:
-            raise RuntimeError("device is closed")
+        specs = [encode_legacy_key(key) for key in keys]
+        encoded_keys = [spec.encoded for spec in specs]
+        allocated: list[MemoryObj] = []
+        locked_specs: list[RawBlockKeySpec] = []
+        with self._pin_lock:
+            prefix_metas = self._core.get_metadata_prefix(
+                encoded_keys,
+                lock=True,
+                skip_locked=self._pinned_keys,
+            )
+            prefix_specs = specs[: len(prefix_metas)]
+            locked_specs = [
+                spec for spec in prefix_specs if spec.encoded not in self._pinned_keys
+            ]
 
-        items: list[tuple[CacheEngineKey, _Entry]] = []
-        with self._lock:
-            for key in keys:
-                entry = self._index.get(key)
-                if entry is None:
-                    break
-                items.append((key, entry))
-            if not items:
-                return []
-            self._inflight_io_count += 1
-
-        loaded: list[MemoryObj] = []
-        touched: list[CacheEngineKey] = []
-        offsets = []
-        buffers = []
-        total_lens = []
-        valid_keys = []
-        valid_objs = []
-        try:
-            raw_dev = self._rawdev()
-
-            for key, entry in items:
-                meta = entry.meta
-                assert meta.shape is not None and meta.dtype is not None
-                assert self.local_cpu_backend is not None
-                memory_obj = self.local_cpu_backend.allocate(
-                    meta.shape, meta.dtype, meta.fmt
-                )
-                if memory_obj is None:
-                    logger.error(
-                        "Failed to allocate memory for key %s",
-                        self._dbg_key_short(key),
-                    )
-
-                    for obj in valid_objs:
-                        obj.ref_count_down()
-                    return []
-
-                total_len = int(meta.size)
-                assert (total_len % self.block_align) == 0
-                if logger.isEnabledFor(10):
-                    self._dbg_get_calls += 1
-                    self._dbg_get_bytes += total_len
-                    if self._dbg_should_log(self._dbg_get_calls):
-                        logger.debug(
-                            "RustRawBlockBackend GET (uring): %s offset=%d size=%d",
-                            self._dbg_key_short(key),
-                            int(entry.offset),
-                            total_len,
-                        )
-
-                buf = memory_obj.byte_array
-                try:
-                    buf = buf.cast("B")
-                except Exception:
-                    pass
-
-                direct_view = self._build_direct_odirect_view(
-                    memory_obj=memory_obj,
-                    payload_len=total_len,
-                    total_len=total_len,
-                    buffer_len=len(buf),
-                    zero_tail=False,
-                )
-
-                if direct_view is not None:
-                    offsets.append(entry.offset + self.header_bytes)
-                    buffers.append(direct_view)
-                    total_lens.append(total_len)
-                else:
-                    offsets.append(entry.offset + self.header_bytes)
-                    buffers.append(buf)
-                    total_lens.append(total_len)
-
-                valid_keys.append(key)
-                valid_objs.append(memory_obj)
-
-            if not offsets:
-                return []
-
-            batch_id = raw_dev.batched_read(offsets, buffers, total_lens)
-            # Wait for all reads to complete.
-            # Pass batch_id to capture any error from this batch completions.
-            # TODO(Ankit): Add a way to capture specific read failures.
-            await asyncio.to_thread(raw_dev.wait_iouring, batch_id)
-
-            # Update metadata for successfully loaded items
-            for key, obj in zip(valid_keys, valid_objs, strict=False):
-                entry = next((e for k, e in items if k == key), None)
-                if entry is not None:
-                    obj.metadata.cached_positions = entry.meta.cached_positions
-                loaded.append(obj)
-                touched.append(key)
-
-        except Exception as e:
-            for memory_obj in valid_objs:
-                memory_obj.ref_count_down()
-            loaded.clear()
-            touched.clear()
-            logger.error("Batched io_uring read failed: %s", e)
-            raise
-        finally:
-            with self._lock:
-                for key in touched:
-                    self._touch(key)
-                self._inflight_io_count -= 1
-                self._last_io_ts = time.monotonic()
-        return loaded
-
-    def _batched_get_prefix(self, keys: Sequence[CacheEngineKey]) -> list[MemoryObj]:
-        if not keys:
+        if not prefix_specs:
             return []
 
-        items: list[tuple[CacheEngineKey, _Entry]] = []
-        with self._lock:
-            for key in keys:
-                entry = self._index.get(key)
-                if entry is None:
-                    break
-                items.append((key, entry))
-            if not items:
-                return []
-            self._inflight_io_count += 1
-
-        loaded: list[MemoryObj] = []
-        touched: list[CacheEngineKey] = []
         try:
-            raw_dev = self._rawdev()
-            for key, entry in items:
-                meta = entry.meta
-                assert meta.shape is not None and meta.dtype is not None
-                assert self.local_cpu_backend is not None
+            for spec, meta in zip(prefix_specs, prefix_metas, strict=False):
+                if meta.shape is None or meta.dtype is None:
+                    logger.warning(
+                        "Raw-block metadata missing shape/dtype for key %s; "
+                        "aborting prefix load",
+                        spec.encoded,
+                    )
+                    break
+                if self.local_cpu_backend is None:
+                    raise RuntimeError("RustRawBlockBackend requires local_cpu_backend")
                 memory_obj = self.local_cpu_backend.allocate(
-                    meta.shape, meta.dtype, meta.fmt
+                    meta.shape,
+                    meta.dtype,
+                    meta.fmt,
                 )
                 if memory_obj is None:
-                    logger.error(
-                        "Failed to allocate memory for key %s",
-                        self._dbg_key_short(key),
-                    )
+                    logger.error("Failed to allocate memory for key %s", spec.encoded)
                     break
+                allocated.append(memory_obj)
 
-                try:
-                    payload_len = int(meta.size)
-                    total_len = (
-                        _round_up(payload_len, self.block_align)
-                        if self.use_odirect
-                        else payload_len
-                    )
-                    if logger.isEnabledFor(10):
-                        self._dbg_get_calls += 1
-                        self._dbg_get_bytes += payload_len
-                        if self._dbg_should_log(self._dbg_get_calls):
-                            logger.debug(
-                                "RustRawBlockBackend GET: %s offset=%d size=%d",
-                                self._dbg_key_short(key),
-                                int(entry.offset),
-                                payload_len,
-                            )
+            if not allocated:
+                return []
 
-                    buf = memory_obj.byte_array
-                    try:
-                        buf = buf.cast("B")
-                    except Exception:
-                        pass
-                    direct_view = self._build_direct_odirect_view(
-                        memory_obj=memory_obj,
-                        payload_len=payload_len,
-                        total_len=total_len,
-                        buffer_len=len(buf),
-                        zero_tail=False,
-                    )
-                    if direct_view is not None:
-                        raw_dev.pread_into(
-                            entry.offset + self.header_bytes,
-                            direct_view,
-                            total_len if len(direct_view) >= total_len else payload_len,
-                            total_len,
-                        )
-                    else:
-                        raw_dev.pread_into(
-                            entry.offset + self.header_bytes,
-                            buf,
-                            payload_len,
-                            total_len,
-                        )
+            load_specs = prefix_specs[: len(allocated)]
+            load_results = self._core.load_many_into(
+                [spec.encoded for spec in load_specs],
+                allocated,
+                raise_on_error=True,
+            )
+            loaded_count = 0
+            for ok in load_results:
+                if not ok:
+                    break
+                loaded_count += 1
+            if loaded_count == len(allocated):
+                return allocated
 
-                    memory_obj.metadata.cached_positions = meta.cached_positions
-                except Exception as e:
-                    memory_obj.ref_count_down()
-                    logger.error(
-                        "Read failed for key %s: %s", self._dbg_key_short(key), e
-                    )
-                    raise
-
-                loaded.append(memory_obj)
-                touched.append(key)
+            for obj in allocated[loaded_count:]:
+                obj.ref_count_down()
+            return allocated[:loaded_count]
         except Exception:
-            for memory_obj in loaded:
-                memory_obj.ref_count_down()
-            loaded.clear()
-            touched.clear()
+            for obj in allocated:
+                obj.ref_count_down()
             raise
         finally:
-            with self._lock:
-                for key in touched:
-                    self._touch(key)
-                self._inflight_io_count -= 1
-                self._last_io_ts = time.monotonic()
-        return loaded
+            self._core.unlock_many([spec.encoded for spec in locked_specs])
 
     def get_blocking(self, key: CacheEngineKey) -> Optional[MemoryObj]:
-        if self.use_uring:
-            assert self.loop is not None
-            loaded = asyncio.run_coroutine_threadsafe(
-                self._batched_get_prefix_uring([key]),
-                self.loop,
-            ).result()
-            return loaded[0] if loaded else None
         loaded = self._batched_get_prefix([key])
         return loaded[0] if loaded else None
 
@@ -1174,27 +484,21 @@ class RustRawBlockBackend(StoragePluginInterface):
         self,
         keys: List[CacheEngineKey],
     ) -> List[Optional[MemoryObj]]:
-        """
-        Get a batch of cache entries until the first miss.
+        """Synchronously load the leading raw-block hit prefix.
 
-        :param List[CacheEngineKey] keys: Ordered keys to retrieve.
+        Args:
+            keys: Ordered legacy cache keys to load.
 
-        :return: A list aligned to ``keys`` where the successful prefix contains
-            loaded memory objects and the remaining suffix is ``None``.
+        Returns:
+            A list aligned with ``keys`` containing loaded memory objects for
+            the contiguous hit prefix and ``None`` for the remaining suffix.
 
-        :raises Exception: Propagates raw-device initialization or read failures.
+        Raises:
+            RuntimeError: If the local CPU allocator backend is unavailable.
+            Exception: Propagates raw-device load failures from the core.
         """
         if not keys:
             return []
-
-        if self.use_uring:
-            assert self.loop is not None
-            loaded = asyncio.run_coroutine_threadsafe(
-                self._batched_get_prefix_uring(keys),
-                self.loop,
-            ).result()
-            return [*loaded, *([None] * (len(keys) - len(loaded)))]
-
         loaded = self._batched_get_prefix(keys)
         return [*loaded, *([None] * (len(keys) - len(loaded)))]
 
@@ -1205,15 +509,22 @@ class RustRawBlockBackend(StoragePluginInterface):
         pin: bool = False,
     ) -> int:
         del lookup_id
-        hit = 0
-        with self._lock:
-            for k in keys:
-                if k not in self._index:
+        specs = [encode_legacy_key(key) for key in keys]
+        encoded_keys = [spec.encoded for spec in specs]
+        results = self._core.exists_many(encoded_keys, lock=False)
+        prefix_hits = 0
+        for ok in results:
+            if not ok:
+                break
+            prefix_hits += 1
+        if pin and prefix_hits > 0:
+            pinned_hits = 0
+            for encoded_key in encoded_keys[:prefix_hits]:
+                if not self._pin_if_needed(encoded_key):
                     break
-                if pin:
-                    self._pinned.add(k)
-                hit += 1
-        return hit
+                pinned_hits += 1
+            prefix_hits = pinned_hits
+        return prefix_hits
 
     async def batched_get_non_blocking(
         self,
@@ -1221,44 +532,29 @@ class RustRawBlockBackend(StoragePluginInterface):
         keys: list[CacheEngineKey],
         transfer_spec: Any = None,
     ) -> list[MemoryObj]:
-        """
-        Asynchronously get a batch of cache entries until the first miss.
+        """Asynchronously load the leading raw-block hit prefix.
 
-        :param str lookup_id: Lookup identifier used by the storage manager.
-        :param list[CacheEngineKey] keys: Ordered keys to retrieve.
-        :param Any transfer_spec: Unused transfer hint for API compatibility.
+        Args:
+            lookup_id: Lookup identifier supplied by the storage manager.
+            keys: Ordered legacy cache keys to load.
+            transfer_spec: Optional transfer metadata; unused by raw-block.
 
-        :return: The successfully loaded prefix of ``keys`` in input order.
+        Returns:
+            Loaded memory objects for the contiguous hit prefix only.
 
-        :raises Exception: Propagates raw-device initialization or read failures.
+        Raises:
+            RuntimeError: If the local CPU allocator backend is unavailable.
+            Exception: Propagates raw-device load failures from the core.
         """
         del lookup_id, transfer_spec
-        if self.use_uring:
-            return await self._batched_get_prefix_uring(keys)
         return await asyncio.to_thread(self._batched_get_prefix, keys)
 
-    def get_allocator_backend(self) -> "AllocatorBackendInterface":
-        assert self.local_cpu_backend is not None
+    def get_allocator_backend(self) -> AllocatorBackendInterface:
+        if self.local_cpu_backend is None:
+            raise RuntimeError("RustRawBlockBackend requires local_cpu_backend")
         return self.local_cpu_backend
 
     def close(self) -> None:
-        if logger.isEnabledFor(10):
-            logger.debug(
-                "RustRawBlockBackend stats: put=%d/%d/%d get=%d/%d",
-                self._dbg_put_batches,
-                self._dbg_put_keys,
-                self._dbg_put_bytes,
-                self._dbg_get_calls,
-                self._dbg_get_bytes,
-            )
-
-        # Stop checkpoint background thread.
-        self._meta_stop_evt.set()
-        if self._meta_thread is not None:
-            self._meta_thread.join(timeout=5)
-            self._meta_thread = None
-
-        # Wait briefly for inflight put tasks to drain.
         deadline = time.monotonic() + 10.0
         while True:
             with self._put_lock:
@@ -1266,463 +562,21 @@ class RustRawBlockBackend(StoragePluginInterface):
             if pending == 0 or time.monotonic() >= deadline:
                 break
             time.sleep(0.01)
+        self._core.close()
 
-        # Force final metadata checkpoint.
-        try:
-            self._checkpoint_once(force=True)
-        except Exception as e:
-            logger.warning(f"Failed to write final on-device metadata checkpoint: {e}")
-
-        if self._raw is not None:
-            try:
-                self._raw.close()
-            except Exception as e:
-                logger.warning(f"Failed to close raw block device: {e}")
-            finally:
-                self._raw = None
-
-    # ------------------- On-device metadata checkpoint -------------------
-
-    def _checkpoint_loop(self) -> None:
-        interval = max(1, self.meta_checkpoint_interval_sec)
-        while not self._meta_stop_evt.wait(interval):
-            try:
-                self._checkpoint_once(force=False)
-            except Exception as e:
-                logger.warning(f"Periodic metadata checkpoint failed: {e}")
-
-    def _meta_payload_capacity(self) -> int:
-        return self._meta_container_bytes - self.block_align
-
-    def _meta_container_offsets(self) -> list[int]:
-        return [
-            idx * self._meta_container_bytes for idx in range(self._meta_copy_count)
-        ]
-
-    def _read_meta_header(self, container_offset: int) -> Optional[dict[str, int]]:
-        raw = self._rawdev()
-        buf = bytearray(self.block_align)
-        try:
-            if self.use_uring:
-                raw.read_uring(
-                    container_offset, buf, self.block_align, self.block_align
-                )
-            else:
-                raw.pread_into(
-                    container_offset, buf, self.block_align, self.block_align
-                )
-        except Exception:
-            return None
-
-        hdr = bytes(buf[: _META_HEADER_STRUCT.size])
-        magic, version, seq, payload_len, crc = _META_HEADER_STRUCT.unpack(hdr)
-        if magic != self.meta_magic or version != self.meta_version:
-            return None
-
-        payload_cap = self._meta_payload_capacity()
-        if payload_len <= 0 or payload_len > payload_cap:
-            return None
-
-        return {
-            "seq": int(seq),
-            "payload_len": int(payload_len),
-            "crc": int(crc),
-            "container_offset": int(container_offset),
-        }
-
-    def _load_meta_payload(self, header: dict[str, int]) -> Optional[bytes]:
-        raw = self._rawdev()
-        payload_len = int(header["payload_len"])
-        payload_off = int(header["container_offset"]) + self.block_align
-        total_len = _round_up(payload_len, self.block_align)
-        buf = bytearray(total_len)
-        try:
-            if self.use_uring:
-                raw.read_uring(payload_off, buf, payload_len, total_len)
-            else:
-                raw.pread_into(payload_off, buf, payload_len, total_len)
-        except Exception:
-            return None
-
-        payload = bytes(buf[:payload_len])
-        crc = zlib.crc32(payload) & 0xFFFFFFFF
-        if crc != int(header["crc"]):
-            return None
-        return payload
-
-    def _select_latest_checkpoint(
-        self,
-    ) -> tuple[Optional[dict[str, int]], Optional[bytes]]:
-        best_header: Optional[dict[str, int]] = None
-        best_payload: Optional[bytes] = None
-        for offset in self._meta_container_offsets():
-            header = self._read_meta_header(offset)
-            if header is None:
-                continue
-            payload = self._load_meta_payload(header)
-            if payload is None:
-                continue
-            if best_header is None or int(header["seq"]) > int(best_header["seq"]):
-                best_header = header
-                best_payload = payload
-        return best_header, best_payload
-
-    def _snapshot_state(self) -> tuple[dict[str, Any], int]:
-        with self._lock:
-            dirty_total = self._meta_dirty_total
-            snapshot = {
-                "version": 1,
-                "device_path": self.device_path,
-                "capacity_bytes": self.capacity_bytes,
-                "block_align": self.block_align,
-                "header_bytes": self.header_bytes,
-                "slot_bytes": self.slot_bytes,
-                "meta_total_bytes": self.meta_total_bytes,
-                "meta_magic": self.meta_magic_text,
-                "meta_version": self.meta_version,
-                "data_base_offset": self._data_base_offset,
-                "next_slot": self._next_slot,
-                "free_slots": list(self._free_slots),
-                "lru_keys": [k.to_string() for k in self._lru.keys()],
-                "entries": {
-                    k.to_string(): {
-                        "offset": e.offset,
-                        "size": e.meta.size,
-                        "shape": list(e.meta.shape)
-                        if e.meta.shape is not None
-                        else None,
-                        "dtype": k._dtype_str,
-                        "fmt": (
-                            e.meta.fmt.name
-                            if e.meta.fmt is not None and hasattr(e.meta.fmt, "name")
-                            else str(e.meta.fmt)
-                            if e.meta.fmt is not None
-                            else None
-                        ),
-                        "cached_positions": (
-                            e.meta.cached_positions.tolist()
-                            if e.meta.cached_positions is not None
-                            and hasattr(e.meta.cached_positions, "tolist")
-                            else None
-                        ),
-                    }
-                    for k, e in self._index.items()
-                },
-            }
-        return snapshot, dirty_total
-
-    def _write_checkpoint(self, payload: bytes, dirty_total_snapshot: int) -> bool:
-        payload_cap = self._meta_payload_capacity()
-        if len(payload) > payload_cap:
-            logger.warning(
-                "Metadata payload too large (%d > %d), skipping checkpoint",
-                len(payload),
-                payload_cap,
-            )
-            return False
-
-        next_seq = self._meta_seq + 1
-        target_idx = int((next_seq - 1) % self._meta_copy_count)
-        target = self._meta_container_offsets()[target_idx]
-
-        payload_len = len(payload)
-        payload_total_len = _round_up(payload_len, self.block_align)
-        payload_off = target + self.block_align
-        crc = zlib.crc32(payload) & 0xFFFFFFFF
-
-        header_block = bytearray(self.block_align)
-        header_block[: _META_HEADER_STRUCT.size] = _META_HEADER_STRUCT.pack(
-            self.meta_magic,
-            self.meta_version,
-            int(next_seq),
-            int(payload_len),
-            int(crc),
-        )
-
-        raw = self._rawdev()
-
-        raw.pwrite_from_buffer(payload_off, payload, payload_len, payload_total_len)
-        raw.pwrite_from_buffer(target, header_block, self.block_align, self.block_align)
-
-        with self._lock:
-            self._meta_seq = int(next_seq)
-            self._meta_persisted = max(self._meta_persisted, int(dirty_total_snapshot))
-
-        return True
-
-    def _checkpoint_once(self, force: bool) -> bool:
-        with self._lock:
-            dirty = self._meta_dirty_total > self._meta_persisted
-            idle_ok = self._inflight_io_count == 0 and (
-                time.monotonic() - self._last_io_ts
-            ) >= (self.meta_idle_quiet_ms / 1000.0)
-
-        if not dirty:
-            return False
-        if not force and not idle_ok:
-            return False
-
-        snapshot, dirty_total_snapshot = self._snapshot_state()
-        payload = json.dumps(snapshot, separators=(",", ":"), ensure_ascii=True).encode(
-            "utf-8"
-        )
-
-        ok = self._write_checkpoint(payload, dirty_total_snapshot)
-        if ok and logger.isEnabledFor(10):
-            logger.debug(
-                "RustRawBlockBackend: checkpoint saved seq=%d entries=%d",
-                self._meta_seq,
-                len(snapshot.get("entries", {})),
-            )
-        return ok
-
-    def _is_valid_checkpoint_entry(self, offset: int, size: int) -> bool:
-        if offset < self._data_base_offset:
-            return False
-        rel = offset - self._data_base_offset
-        if rel % self.slot_bytes != 0:
-            return False
-        slot = rel // self.slot_bytes
-        if slot < 0 or slot >= self._max_slots:
-            return False
-        return 0 < size <= (self.slot_bytes - self.header_bytes)
-
-    def _apply_loaded_state(self, data: dict[str, Any]) -> bool:
-        if not isinstance(data, dict):
-            return False
-        if int(data.get("version", 0)) != 1:
-            return False
-        if data.get("device_path") and data.get("device_path") != self.device_path:
-            logger.warning("Device metadata device_path mismatch; ignoring metadata")
-            return False
-        if int(data.get("slot_bytes", self.slot_bytes)) != self.slot_bytes:
-            logger.warning("Device metadata slot_bytes mismatch; ignoring metadata")
-            return False
-        if (
-            int(data.get("meta_total_bytes", self.meta_total_bytes))
-            != self.meta_total_bytes
-        ):
-            logger.warning(
-                "Device metadata meta_total_bytes mismatch; ignoring metadata"
-            )
-            return False
-        if str(data.get("meta_magic", self.meta_magic_text)) != self.meta_magic_text:
-            logger.warning("Device metadata meta_magic mismatch; ignoring metadata")
-            return False
-        if int(data.get("meta_version", self.meta_version)) != self.meta_version:
-            logger.warning("Device metadata meta_version mismatch; ignoring metadata")
-            return False
-
-        try:
-            next_slot = int(data.get("next_slot", 0))
-        except Exception:
-            logger.warning("Device metadata next_slot is invalid; ignoring metadata")
-            return False
-        if next_slot < 0 or next_slot > self._max_slots:
-            logger.warning(
-                "Device metadata next_slot out of range (%d); ignoring metadata",
-                next_slot,
-            )
-            return False
-
-        raw_free_slots = data.get("free_slots", [])
-        if not isinstance(raw_free_slots, list):
-            logger.warning("Device metadata free_slots is invalid; ignoring metadata")
-            return False
-        free_slots: list[int] = []
-        seen_slots: set[int] = set()
-        for raw_slot in raw_free_slots:
-            try:
-                slot = int(raw_slot)
-            except Exception:
-                logger.warning(
-                    "Device metadata free_slots contains non-integer; ignoring metadata"
-                )
+    def _pin_if_needed(self, encoded_key: str) -> bool:
+        with self._pin_lock:
+            if encoded_key in self._pinned_keys:
+                return True
+            if not self._core.exists_many([encoded_key], lock=True)[0]:
                 return False
-            if slot < 0 or slot >= self._max_slots:
-                logger.warning(
-                    "Device metadata free_slots contains out-of-range slot %d; "
-                    "ignoring metadata",
-                    slot,
-                )
-                return False
-            if slot in seen_slots:
-                continue
-            seen_slots.add(slot)
-            free_slots.append(slot)
+            self._pinned_keys.add(encoded_key)
+            return True
 
-        with self._lock:
-            self._next_slot = next_slot
-            self._free_slots = free_slots
-            self._index.clear()
-            self._lru.clear()
-
-            entries = data.get("entries", {})
-            if isinstance(entries, dict):
-                for k_str, entry in entries.items():
-                    if not isinstance(entry, dict):
-                        logger.warning(
-                            "Invalid entry in metadata for key '%s': not a dict.", k_str
-                        )
-                        continue
-                    try:
-                        key = CacheEngineKey.from_string(k_str)
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to parse key string '%s' from metadata: %s",
-                            k_str,
-                            e,
-                        )
-                        continue
-
-                    offset = int(entry.get("offset", 0))
-                    size = int(entry.get("size", 0))
-                    shape_list = entry.get("shape")
-                    fmt_name = entry.get("fmt")
-                    cached_positions_list = entry.get("cached_positions")
-
-                    if not self._is_valid_checkpoint_entry(offset, size):
-                        logger.warning(
-                            "Skipping invalid checkpoint entry for key '%s': "
-                            "offset=%d size=%d",
-                            k_str,
-                            offset,
-                            size,
-                        )
-                        continue
-
-                    shape = (
-                        torch.Size(list(shape_list)) if shape_list is not None else None
-                    )
-                    fmt = (
-                        MemoryFormat[fmt_name]
-                        if isinstance(fmt_name, str)
-                        and fmt_name in MemoryFormat.__members__
-                        else MemoryFormat.UNDEFINED
-                    )
-                    cached_positions = (
-                        torch.tensor(cached_positions_list, dtype=torch.long)
-                        if cached_positions_list is not None
-                        else None
-                    )
-
-                    meta = DiskCacheMetadata(
-                        path=f"{self.device_path}@{offset}",
-                        size=size,
-                        shape=shape,
-                        dtype=key.dtype,
-                        cached_positions=cached_positions,
-                        fmt=fmt,
-                        pin_count=0,
-                    )
-                    self._index[key] = _Entry(offset=offset, size=size, meta=meta)
-
-            if self.metadata is not None and self._index:
-                first_loaded_key = next(iter(self._index))
-                expected_worker_id = int(self.metadata.worker_id)
-                loaded_worker_id = int(first_loaded_key.worker_id)
-                if loaded_worker_id != expected_worker_id:
-                    logger.warning(
-                        "RustRawBlockBackend: loaded metadata may belong to another "
-                        "worker (device=%s, current_worker_id=%d, "
-                        "first_entry_worker_id=%d, first_entry_key=%s)",
-                        self.device_path,
-                        expected_worker_id,
-                        loaded_worker_id,
-                        first_loaded_key.to_string(),
-                    )
-
-            # Remove free-slot entries that overlap with loaded index slots.
-            used_slots = {
-                self._offset_to_slot(int(entry.offset))
-                for entry in self._index.values()
-            }
-            self._free_slots = [
-                slot for slot in self._free_slots if slot not in used_slots
-            ]
-
-            lru_keys = data.get("lru_keys", [])
-            if isinstance(lru_keys, list) and lru_keys:
-                for k_str in lru_keys:
-                    try:
-                        key = CacheEngineKey.from_string(k_str)
-                    except Exception:
-                        continue
-                    if key in self._index:
-                        self._lru[key] = None
-            else:
-                for key in self._index:
-                    self._lru[key] = None
-
-            # Loaded state should start as clean.
-            self._meta_dirty_total = 0
-            self._meta_persisted = 0
-
-        if self.meta_verify_on_load:
-            self._validate_loaded_entries()
-        return True
-
-    def _validate_loaded_entries(self) -> None:
-        to_drop: list[CacheEngineKey] = []
-        with self._lock:
-            entries = list(self._index.items())
-
-        for key, entry in entries:
-            slot_hdr = self._read_slot_header(int(entry.offset))
-            if slot_hdr is None:
-                to_drop.append(key)
-                continue
-            chunk_hash, payload_len = slot_hdr
-            if int(chunk_hash) != (int(key.chunk_hash) & ((1 << 64) - 1)):
-                to_drop.append(key)
-                continue
-            if int(payload_len) != int(entry.size):
-                to_drop.append(key)
-
-        if not to_drop:
-            return
-
-        with self._lock:
-            for key in to_drop:
-                removed_entry: Optional[_Entry] = None
-                if key in self._index:
-                    removed_entry = self._index.pop(key)
-                self._lru.pop(key, None)
-                self._pinned.discard(key)
-                if removed_entry is not None:
-                    self._append_free_slot_locked(
-                        self._offset_to_slot(int(removed_entry.offset))
-                    )
-            self._meta_dirty_total += 1
-
-        logger.warning(
-            "RustRawBlockBackend: dropped %d stale metadata entries after slot-header "
-            "validation",
-            len(to_drop),
-        )
-
-    def _load_checkpoint_from_device(self) -> None:
-        header, payload = self._select_latest_checkpoint()
-        if header is None:
-            logger.info(
-                "RustRawBlockBackend: no valid on-device metadata checkpoint found"
-            )
-            return
-        assert payload is not None
-        try:
-            data = json.loads(payload.decode("utf-8"))
-        except Exception:
-            logger.warning("RustRawBlockBackend: failed to decode metadata payload")
-            return
-        applied = self._apply_loaded_state(data)
-        if not applied:
-            logger.warning("RustRawBlockBackend: metadata payload rejected by checks")
-            return
-        self._meta_seq = int(header["seq"])
-        logger.info(
-            "RustRawBlockBackend: loaded on-device metadata checkpoint "
-            "(entries=%d, next_slot=%d, seq=%d)",
-            len(self._index),
-            self._next_slot,
-            self._meta_seq,
-        )
+    def _unpin_if_needed(self, encoded_key: str) -> bool:
+        with self._pin_lock:
+            if encoded_key in self._pinned_keys:
+                self._core.unlock_many([encoded_key])
+                self._pinned_keys.discard(encoded_key)
+                return True
+            return self._core.contains_key(encoded_key, lock=False)

--- a/lmcache/v1/storage_backend/raw_block/__init__.py
+++ b/lmcache/v1/storage_backend/raw_block/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# First Party
+from lmcache.v1.storage_backend.raw_block.core import (
+    DEFAULT_IOURING_QUEUE_DEPTH,
+    RAW_BLOCK_IO_ENGINES,
+    RawBlockCore,
+    RawBlockCoreConfig,
+    RawBlockPutManyResult,
+    normalize_raw_block_io_engine,
+    round_up,
+    validate_raw_block_io_options,
+)
+from lmcache.v1.storage_backend.raw_block.key_codec import (
+    RawBlockKeyNamespace,
+    RawBlockKeySpec,
+    decode_legacy_key,
+    decode_object_key,
+    encode_legacy_key,
+    encode_object_key,
+    object_key_to_string,
+    slot_identity_from_encoded_key,
+)
+
+__all__ = [
+    "RawBlockCore",
+    "RawBlockCoreConfig",
+    "RAW_BLOCK_IO_ENGINES",
+    "DEFAULT_IOURING_QUEUE_DEPTH",
+    "RawBlockKeyNamespace",
+    "RawBlockKeySpec",
+    "RawBlockPutManyResult",
+    "decode_legacy_key",
+    "decode_object_key",
+    "encode_legacy_key",
+    "encode_object_key",
+    "object_key_to_string",
+    "normalize_raw_block_io_engine",
+    "round_up",
+    "slot_identity_from_encoded_key",
+    "validate_raw_block_io_options",
+]

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -400,6 +400,11 @@ class RawBlockCore:
         with self._lock:
             return len(self._index)
 
+    def snapshot_indexed_keys(self) -> list[str]:
+        """Return a detached snapshot of encoded keys currently in the index."""
+        with self._lock:
+            return list(self._index.keys())
+
     def entry_offset(self, encoded_key: str) -> int | None:
         """Return the raw-device slot offset for an indexed key.
 
@@ -860,12 +865,19 @@ class RawBlockCore:
         if hasattr(buf, "cast"):
             buf = buf.cast("B")
         payload_len = len(memory_obj.byte_array)
+        payload_capacity = self.slot_bytes - self.header_bytes
+        if payload_len > payload_capacity:
+            raise RuntimeError(
+                f"RawBlockCore payload {payload_len} exceeds slot capacity "
+                f"{payload_capacity}"
+            )
         total_len = payload_len
         if self.use_odirect:
             total_len = round_up(payload_len, self.block_align)
-            if total_len > (self.slot_bytes - self.header_bytes):
+            if total_len > payload_capacity:
                 raise RuntimeError(
-                    f"O_DIRECT payload {total_len} exceeds slot capacity"
+                    f"O_DIRECT payload {total_len} exceeds slot capacity "
+                    f"{payload_capacity}"
                 )
             direct_view = self._build_direct_odirect_view(
                 memory_obj=memory_obj,

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1,0 +1,1459 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Optional
+import ctypes
+import json
+import struct
+import threading
+import time
+import zlib
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import (
+    STR_DTYPE_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_STR_DTYPE,
+    DiskCacheMetadata,
+)
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.storage_backend.raw_block.key_codec import (
+    RawBlockKeyNamespace,
+    RawBlockKeySpec,
+    decode_legacy_key,
+    slot_identity_from_encoded_key,
+)
+
+logger = init_logger(__name__)
+
+
+_DEFAULT_META_MAGIC = b"LMCIDX01"
+_DEFAULT_META_VERSION = 1
+_META_HEADER_STRUCT = struct.Struct("<8sIQQI")
+RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
+DEFAULT_IOURING_QUEUE_DEPTH = 256
+
+
+def round_up(x: int, align: int) -> int:
+    """Round a value up to the nearest alignment boundary.
+
+    Args:
+        x: Value to align.
+        align: Positive alignment in bytes.
+
+    Returns:
+        ``x`` rounded up to a multiple of ``align``.
+    """
+    return ((x + align - 1) // align) * align
+
+
+def normalize_raw_block_io_engine(
+    io_engine: Any = None,
+    *,
+    use_iouring: Any = None,
+    use_uring: Any = None,
+) -> str:
+    """Normalize raw-block I/O engine config with legacy compatibility.
+
+    Args:
+        io_engine: Explicit engine string. Valid values are ``"posix"``,
+            and ``"io_uring"``.
+        use_iouring: Legacy boolean knob. Used only when ``io_engine`` is not
+            set.
+        use_uring: Legacy boolean alias. Used only when ``io_engine`` is not
+            set.
+
+    Returns:
+        The normalized engine string.
+
+    Raises:
+        ValueError: If ``io_engine`` names an unsupported engine.
+    """
+    if io_engine is None or io_engine == "":
+        if bool(use_iouring) or bool(use_uring):
+            return "io_uring"
+        return "posix"
+    normalized = str(io_engine).lower()
+    if normalized not in RAW_BLOCK_IO_ENGINES:
+        allowed = ", ".join(sorted(RAW_BLOCK_IO_ENGINES))
+        raise ValueError(f"io_engine must be one of: {allowed}")
+    return normalized
+
+
+def validate_raw_block_io_options(
+    *,
+    iouring_queue_depth: int,
+) -> None:
+    """Validate numeric raw-block I/O engine options.
+
+    Args:
+        iouring_queue_depth: Queue depth for the Rust io_uring path.
+
+    Raises:
+        ValueError: If any numeric option is not positive.
+    """
+    if int(iouring_queue_depth) <= 0:
+        raise ValueError("iouring_queue_depth must be > 0")
+
+
+@dataclass(frozen=True)
+class RawBlockCoreConfig:
+    """Configuration for RawBlockCore device layout, I/O, and checkpoints."""
+
+    device_path: str
+    capacity_bytes: int
+    block_align: int
+    header_bytes: int
+    slot_bytes: int
+    use_odirect: bool
+    enable_zero_copy: bool
+    meta_total_bytes: int
+    meta_magic: bytes
+    meta_version: int
+    meta_checkpoint_interval_sec: int
+    meta_idle_quiet_ms: int
+    meta_enable_periodic: bool
+    meta_verify_on_load: bool
+    io_engine: str = "posix"
+    iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
+
+
+@dataclass
+class _Entry:
+    offset: int
+    size: int
+    meta: DiskCacheMetadata
+
+
+@dataclass
+class _Inflight:
+    offset: int
+    meta: DiskCacheMetadata
+    canceled: bool = False
+
+
+@dataclass(frozen=True)
+class RawBlockPutManyResult:
+    """Result of a RawBlockCore batched write."""
+
+    results: list[bool]
+    stored_keys: list[str]
+
+
+class RawBlockCore:
+    """
+    Shared raw-block storage engine used by both legacy non-MP and MP L2 paths.
+
+    This class owns the raw-device I/O path, slot allocation, checkpoint/recovery,
+    and lock refcounts that protect slots from deletion while in use.
+    """
+
+    def __init__(
+        self,
+        config: RawBlockCoreConfig,
+        *,
+        key_namespace: RawBlockKeyNamespace,
+    ):
+        """Initialize the raw-block storage engine.
+
+        Args:
+            config: Raw-block device, layout, I/O, and checkpoint settings.
+            key_namespace: Encoding namespace used by keys stored in this core.
+
+        Raises:
+            ValueError: If the supplied configuration is invalid.
+            RuntimeError: If the raw device cannot be opened or the computed
+                layout cannot fit metadata and at least one data slot.
+
+        Notes:
+            If initialization opens the device and a later recovery step fails,
+            the partially opened resources are closed before the exception is
+            re-raised.
+        """
+        self.device_path = config.device_path
+        self.capacity_bytes = int(config.capacity_bytes)
+        self.block_align = int(config.block_align)
+        self.header_bytes = int(config.header_bytes)
+        self.slot_bytes = int(config.slot_bytes)
+        self.use_odirect = bool(config.use_odirect)
+        self.enable_zero_copy = bool(config.enable_zero_copy)
+
+        self.meta_total_bytes = int(config.meta_total_bytes)
+        self.meta_magic = bytes(config.meta_magic)
+        self.meta_version = int(config.meta_version)
+        self.meta_checkpoint_interval_sec = int(config.meta_checkpoint_interval_sec)
+        self.meta_idle_quiet_ms = int(config.meta_idle_quiet_ms)
+        self.meta_enable_periodic = bool(config.meta_enable_periodic)
+        self.meta_verify_on_load = bool(config.meta_verify_on_load)
+        self.io_engine = normalize_raw_block_io_engine(config.io_engine)
+        self.iouring_queue_depth = int(config.iouring_queue_depth)
+        self.key_namespace = key_namespace
+
+        if not self.device_path:
+            raise ValueError("RawBlockCore requires a non-empty device_path")
+        if self.block_align <= 0:
+            raise ValueError("block_align must be > 0")
+        if self.header_bytes < 24:
+            raise ValueError("header_bytes must be >= 24")
+        if self.header_bytes % self.block_align != 0:
+            raise ValueError("header_bytes must be a multiple of block_align")
+        if self.slot_bytes < self.header_bytes + 1:
+            raise ValueError("slot_bytes must be >= header_bytes + 1")
+        if self.slot_bytes % self.block_align != 0:
+            raise ValueError("slot_bytes must be a multiple of block_align")
+        if self.meta_total_bytes <= self.block_align:
+            raise ValueError("meta_total_bytes must provide room for metadata header")
+        if self.meta_total_bytes % self.block_align != 0:
+            raise ValueError("meta_total_bytes must be a multiple of block_align")
+        if len(self.meta_magic) != 8:
+            raise ValueError("meta_magic must be exactly 8 bytes")
+        if self.meta_version <= 0:
+            raise ValueError("meta_version must be > 0")
+        validate_raw_block_io_options(
+            iouring_queue_depth=self.iouring_queue_depth,
+        )
+
+        try:
+            self.meta_magic_text = self.meta_magic.decode("ascii")
+        except UnicodeDecodeError as e:
+            raise ValueError("meta_magic must be ASCII bytes") from e
+
+        self._meta_copy_count: int = 2
+        self._meta_container_bytes: int = (
+            (self.meta_total_bytes // self._meta_copy_count) // self.block_align
+        ) * self.block_align
+        if self._meta_container_bytes <= self.block_align:
+            raise ValueError(
+                "meta_total_bytes must provide room for at least two metadata copies"
+            )
+
+        self._lock = threading.Lock()
+        self._index: dict[str, _Entry] = {}
+        self._lock_refcnt: dict[str, int] = {}
+        self._inflight: dict[str, _Inflight] = {}
+
+        self._next_slot: int = 0
+        self._free_slots: list[int] = []
+        self._max_slots: int = 0
+        self._effective_capacity_bytes: int = 0
+        self._data_base_offset: int = 0
+
+        self._raw = None
+        self._closed = False
+
+        self._meta_seq: int = 0
+        self._meta_dirty_total: int = 0
+        self._meta_persisted: int = 0
+        self._inflight_io_count: int = 0
+        self._last_io_ts: float = time.monotonic()
+        self._meta_stop_evt = threading.Event()
+        self._meta_thread: Optional[threading.Thread] = None
+
+        try:
+            self._ensure_capacity_and_layout()
+            self._load_checkpoint_from_device()
+
+            if self.meta_enable_periodic:
+                self._meta_thread = threading.Thread(
+                    target=self._checkpoint_loop,
+                    daemon=True,
+                    name="raw-block-core-checkpoint",
+                )
+                self._meta_thread.start()
+        except Exception:
+            self._cleanup_after_init_failure()
+            raise
+
+    def _rawdev(self):
+        """Return the lazily opened Rust raw-block device binding."""
+        if self._raw is None:
+            try:
+                # Third Party
+                from lmcache_rust_raw_block_io import RawBlockDevice  # type: ignore
+            except Exception as e:
+                raise RuntimeError(
+                    "Rust raw-block extension is not installed. "
+                    "Install / build `rust_raw_block_io` and retry."
+                ) from e
+            self._raw = RawBlockDevice(
+                self.device_path,
+                writable=True,
+                use_odirect=self.use_odirect,
+                alignment=self.block_align,
+                io_engine=self.io_engine,
+                iouring_queue_depth=self.iouring_queue_depth,
+            )
+        return self._raw
+
+    def contains_key(self, encoded_key: str, *, lock: bool = False) -> bool:
+        """Return whether one encoded key is present in the raw-block index.
+
+        Args:
+            encoded_key: Encoded raw-block key string.
+            lock: If true, increment the key's L2 lock refcount on hit.
+
+        Returns:
+            True when the key is indexed and available for load.
+        """
+        return self.exists_many([encoded_key], lock=lock)[0]
+
+    def exists_inflight(self, encoded_key: str) -> bool:
+        """Return whether a key currently has an in-flight write.
+
+        Args:
+            encoded_key: Encoded raw-block key string.
+
+        Returns:
+            True when the key is being written but not committed yet.
+        """
+        with self._lock:
+            return encoded_key in self._inflight
+
+    def get_metadata_many(
+        self, encoded_keys: Sequence[str]
+    ) -> list[DiskCacheMetadata | None]:
+        """Return metadata for encoded keys without loading payload bytes.
+
+        Args:
+            encoded_keys: Ordered encoded raw-block keys to inspect.
+
+        Returns:
+            A metadata-or-None list aligned with ``encoded_keys``.
+        """
+        with self._lock:
+            metas: list[DiskCacheMetadata | None] = []
+            for encoded_key in encoded_keys:
+                entry = self._index.get(encoded_key)
+                metas.append(entry.meta if entry is not None else None)
+            return metas
+
+    def get_metadata_prefix(
+        self,
+        encoded_keys: Sequence[str],
+        *,
+        lock: bool = False,
+        skip_locked: set[str] | None = None,
+    ) -> list[DiskCacheMetadata]:
+        """Return leading-hit metadata and optionally lock those entries.
+
+        Args:
+            encoded_keys: Ordered encoded raw-block keys to inspect.
+            lock: If true, increment L2 lock refcounts for every returned
+                metadata entry while holding the index lock.
+            skip_locked: Encoded keys that are already protected by the caller
+                and should not receive an additional lock refcount.
+
+        Returns:
+            Metadata for the contiguous leading hit prefix. The returned list
+            stops at the first missing key.
+        """
+        with self._lock:
+            metas: list[DiskCacheMetadata] = []
+            for encoded_key in encoded_keys:
+                entry = self._index.get(encoded_key)
+                if entry is None:
+                    break
+                metas.append(entry.meta)
+                if lock and (skip_locked is None or encoded_key not in skip_locked):
+                    self._lock_refcnt[encoded_key] = (
+                        self._lock_refcnt.get(encoded_key, 0) + 1
+                    )
+            return metas
+
+    def first_encoded_key(self) -> str | None:
+        """Return one indexed encoded key for diagnostics.
+
+        Returns:
+            The first indexed key according to dictionary iteration order, or
+            None if the recovered/indexed metadata is empty.
+        """
+        with self._lock:
+            return next(iter(self._index), None)
+
+    def lock_refcount(self, encoded_key: str) -> int:
+        """Return the L2 lock refcount for an encoded key.
+
+        Args:
+            encoded_key: Encoded raw-block key string.
+
+        Returns:
+            Current lock refcount, or zero when the key is unlocked or absent.
+        """
+        with self._lock:
+            return int(self._lock_refcnt.get(encoded_key, 0))
+
+    def inflight_io_count(self) -> int:
+        """Return the number of currently active raw-device I/O operations."""
+        with self._lock:
+            return int(self._inflight_io_count)
+
+    def indexed_key_count(self) -> int:
+        """Return the number of entries currently present in the key index."""
+        with self._lock:
+            return len(self._index)
+
+    def entry_offset(self, encoded_key: str) -> int | None:
+        """Return the raw-device slot offset for an indexed key.
+
+        Args:
+            encoded_key: Encoded raw-block key string.
+
+        Returns:
+            Slot offset in bytes, or None when the key is not indexed.
+        """
+        with self._lock:
+            entry = self._index.get(encoded_key)
+            return None if entry is None else int(entry.offset)
+
+    def metadata_container_offsets(self) -> list[int]:
+        """Return checkpoint metadata container offsets in bytes."""
+        return self._meta_container_offsets()
+
+    def data_base_offset(self) -> int:
+        """Return the byte offset where raw-block data slots begin."""
+        return int(self._data_base_offset)
+
+    def put_many(
+        self,
+        keys: Sequence[RawBlockKeySpec],
+        objs: Sequence[MemoryObj],
+    ) -> RawBlockPutManyResult:
+        """Persist a batch of memory objects into raw-block slots.
+
+        Args:
+            keys: Ordered raw-block key specs corresponding to ``objs``.
+            objs: Memory objects whose byte buffers should be written.
+
+        Returns:
+            Per-key success results and newly stored encoded keys. If no free
+            raw-block slot is available, that key is reported as failed; slot
+            reclamation is owned by the adapter/controller calling
+            ``delete_many``.
+
+        Raises:
+            ValueError: If either sequence is empty or the sequence lengths do
+                not match.
+        """
+        if not keys or not objs:
+            raise ValueError("keys and objs must be non-empty")
+        if len(keys) != len(objs):
+            raise ValueError("keys and objs must have the same length")
+
+        results = [False] * len(keys)
+        stored_keys: list[str] = []
+
+        for i, (key, obj) in enumerate(zip(keys, objs, strict=False)):
+            if self._closed:
+                break
+
+            with self._lock:
+                if key.encoded in self._index:
+                    results[i] = True
+                    continue
+                if key.encoded in self._inflight:
+                    continue
+
+                try:
+                    offset = self._allocate_slot_locked()
+                except RuntimeError:
+                    logger.warning(
+                        "RawBlockCore: no free slot available for key %s",
+                        key.encoded,
+                    )
+                    continue
+
+                meta = DiskCacheMetadata(
+                    path=f"{self.device_path}@{offset}",
+                    size=len(obj.byte_array),
+                    shape=obj.metadata.shape,
+                    dtype=obj.metadata.dtype,
+                    cached_positions=obj.metadata.cached_positions,
+                    fmt=obj.metadata.fmt,
+                    pin_count=0,
+                )
+                self._inflight[key.encoded] = _Inflight(offset=offset, meta=meta)
+
+            success = self._write_one(key, obj, offset)
+
+            with self._lock:
+                inflight = self._inflight.pop(key.encoded, None)
+                if inflight is None:
+                    results[i] = False
+                    continue
+                if inflight.canceled or not success:
+                    self._append_free_slot_locked(
+                        self._offset_to_slot(int(inflight.offset))
+                    )
+                    self._meta_dirty_total += 1
+                    results[i] = False
+                    continue
+
+                self._index[key.encoded] = _Entry(
+                    offset=inflight.offset,
+                    size=inflight.meta.size,
+                    meta=inflight.meta,
+                )
+                self._meta_dirty_total += 1
+                results[i] = True
+                stored_keys.append(key.encoded)
+
+        return RawBlockPutManyResult(
+            results=results,
+            stored_keys=stored_keys,
+        )
+
+    def exists_many(
+        self,
+        encoded_keys: Sequence[str],
+        *,
+        lock: bool = False,
+    ) -> list[bool]:
+        """Return a full hit bitmap as booleans for encoded keys.
+
+        Args:
+            encoded_keys: Ordered encoded raw-block keys to check.
+            lock: If true, increment L2 lock refcounts for every hit.
+
+        Returns:
+            A list of booleans aligned with ``encoded_keys``.
+        """
+        results: list[bool] = []
+        with self._lock:
+            for encoded_key in encoded_keys:
+                found = encoded_key in self._index
+                results.append(found)
+                if found and lock:
+                    self._lock_refcnt[encoded_key] = (
+                        self._lock_refcnt.get(encoded_key, 0) + 1
+                    )
+        return results
+
+    def load_many_into(
+        self,
+        encoded_keys: Sequence[str],
+        objs: Sequence[MemoryObj],
+        *,
+        raise_on_error: bool = False,
+    ) -> list[bool]:
+        """Load raw-block payloads into caller-provided memory objects.
+
+        Args:
+            encoded_keys: Ordered encoded raw-block keys to load.
+            objs: Destination memory objects. Buffers must remain valid until
+                this method returns.
+            raise_on_error: If true, re-raise the first load exception instead
+                of logging it and returning ``False`` for that key.
+
+        Returns:
+            A list of per-key load success booleans aligned with
+            ``encoded_keys``.
+
+        Raises:
+            ValueError: If either sequence is empty or the sequence lengths do
+                not match.
+            Exception: Re-raises load errors when ``raise_on_error`` is true.
+        """
+        if not encoded_keys or not objs:
+            raise ValueError("encoded_keys and objs must be non-empty")
+        if len(encoded_keys) != len(objs):
+            raise ValueError("encoded_keys and objs must have the same length")
+
+        with self._lock:
+            items = [
+                (encoded_key, self._index.get(encoded_key))
+                for encoded_key in encoded_keys
+            ]
+            self._inflight_io_count += 1
+
+        results = [False] * len(encoded_keys)
+        try:
+            raw_dev = self._rawdev()
+            for i, (encoded_key, entry) in enumerate(items):
+                if entry is None:
+                    continue
+                try:
+                    payload_len = int(entry.size)
+                    total_len = (
+                        round_up(payload_len, self.block_align)
+                        if self.use_odirect
+                        else payload_len
+                    )
+                    buf = memoryview(objs[i].byte_array)
+                    try:
+                        buf = buf.cast("B")
+                    except Exception:
+                        pass
+
+                    direct_view = self._build_direct_odirect_view(
+                        memory_obj=objs[i],
+                        payload_len=payload_len,
+                        total_len=total_len,
+                        buffer_len=len(buf),
+                        zero_tail=False,
+                    )
+                    if direct_view is not None:
+                        raw_dev.pread_into(
+                            entry.offset + self.header_bytes,
+                            direct_view,
+                            total_len if len(direct_view) >= total_len else payload_len,
+                            total_len,
+                        )
+                    else:
+                        raw_dev.pread_into(
+                            entry.offset + self.header_bytes,
+                            buf,
+                            payload_len,
+                            total_len,
+                        )
+                    objs[i].metadata.cached_positions = entry.meta.cached_positions
+                    results[i] = True
+                except Exception as e:
+                    if raise_on_error:
+                        raise
+                    logger.error("RawBlockCore load failed for %s: %s", encoded_key, e)
+        finally:
+            with self._lock:
+                self._inflight_io_count -= 1
+                self._last_io_ts = time.monotonic()
+        return results
+
+    def unlock_many(self, encoded_keys: Sequence[str]) -> None:
+        """Release L2 lock references for encoded keys.
+
+        Args:
+            encoded_keys: Encoded raw-block keys whose lock refcounts should be
+                decremented. Missing keys and underflow are treated as no-ops.
+        """
+        with self._lock:
+            for encoded_key in encoded_keys:
+                refcnt = self._lock_refcnt.get(encoded_key, 0)
+                if refcnt <= 1:
+                    self._lock_refcnt.pop(encoded_key, None)
+                else:
+                    self._lock_refcnt[encoded_key] = refcnt - 1
+
+    def delete_many(
+        self,
+        encoded_keys: Sequence[str],
+        *,
+        force: bool = False,
+    ) -> list[bool]:
+        """Delete indexed keys and recycle their slots when allowed.
+
+        Args:
+            encoded_keys: Ordered encoded raw-block keys to delete.
+            force: If true, delete locked keys as well. Normal MP eviction uses
+                false so locked entries are preserved.
+
+        Returns:
+            A list of per-key deletion booleans aligned with ``encoded_keys``.
+        """
+        deleted: list[bool] = []
+        with self._lock:
+            for encoded_key in encoded_keys:
+                existed = encoded_key in self._index or encoded_key in self._inflight
+                entry = self._index.get(encoded_key)
+                locked = self._lock_refcnt.get(encoded_key, 0) > 0
+                if entry is not None and locked and not force:
+                    deleted.append(False)
+                    continue
+
+                removed_entry = self._index.pop(encoded_key, None)
+                inflight = self._inflight.get(encoded_key)
+                if inflight is not None:
+                    inflight.canceled = True
+                self._lock_refcnt.pop(encoded_key, None)
+                if removed_entry is not None:
+                    self._append_free_slot_locked(
+                        self._offset_to_slot(int(removed_entry.offset))
+                    )
+                    self._meta_dirty_total += 1
+                deleted.append(
+                    existed and (removed_entry is not None or inflight is not None)
+                )
+        return deleted
+
+    def usage(self) -> tuple[float, float]:
+        """Return current raw-block slot usage fractions.
+
+        Returns:
+            ``(current_usage, projected_usage)``. Raw-block has no separate
+            projected value, so both values are identical. ``(-1.0, -1.0)``
+            indicates that usable capacity is unknown.
+        """
+        with self._lock:
+            usable_capacity = self._max_slots * self.slot_bytes
+            if usable_capacity <= 0:
+                return (-1.0, -1.0)
+            used_slots = len(self._index) + len(self._inflight)
+            usage = (used_slots * self.slot_bytes) / usable_capacity
+            return (usage, usage)
+
+    def checkpoint_now(self) -> None:
+        """Synchronously write a metadata checkpoint."""
+        self._checkpoint_once(force=True)
+
+    def apply_loaded_state(self, data: dict[str, Any]) -> bool:
+        """Validate and apply a recovered metadata checkpoint payload.
+
+        Args:
+            data: Decoded checkpoint dictionary.
+
+        Returns:
+            True when the payload shape and layout match this core and all
+            valid entries were applied. Invalid per-entry records are skipped.
+        """
+        return self._apply_loaded_state(data)
+
+    def report_status(self) -> dict:
+        """Return raw-block health, layout, metadata, and in-flight counters."""
+        with self._lock:
+            return {
+                "is_healthy": not self._closed,
+                "type": "RawBlockCore",
+                "key_namespace": self.key_namespace,
+                "device_path": self.device_path,
+                "block_align": self.block_align,
+                "header_bytes": self.header_bytes,
+                "slot_bytes": self.slot_bytes,
+                "meta_total_bytes": self.meta_total_bytes,
+                "usable_capacity_bytes": self._max_slots * self.slot_bytes,
+                "indexed_key_count": len(self._index),
+                "inflight_key_count": len(self._inflight),
+                "locked_key_count": sum(
+                    1 for refcnt in self._lock_refcnt.values() if refcnt > 0
+                ),
+                "free_slot_count": len(self._free_slots),
+                "next_slot": self._next_slot,
+                "max_slots": self._max_slots,
+                "metadata_seq": self._meta_seq,
+                "metadata_dirty_total": self._meta_dirty_total,
+                "metadata_persisted": self._meta_persisted,
+                "inflight_io_count": self._inflight_io_count,
+                "use_odirect": self.use_odirect,
+                "enable_zero_copy": self.enable_zero_copy,
+                "io_engine": self.io_engine,
+                "iouring_queue_depth": self.iouring_queue_depth,
+            }
+
+    def close(self) -> None:
+        """Stop checkpointing, write a final checkpoint, and close the device."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        self._meta_stop_evt.set()
+        if self._meta_thread is not None:
+            self._meta_thread.join(timeout=5)
+            self._meta_thread = None
+
+        try:
+            self._checkpoint_once(force=True)
+        except Exception as e:
+            logger.warning("RawBlockCore final checkpoint failed: %s", e)
+
+        if self._raw is not None:
+            try:
+                self._raw.close()
+            except Exception as e:
+                logger.warning(
+                    "Failed to close raw block device %s: %s", self.device_path, e
+                )
+            finally:
+                self._raw = None
+
+    def _cleanup_after_init_failure(self) -> None:
+        """Close resources that may have been opened before init failed."""
+        self._meta_stop_evt.set()
+        if self._meta_thread is not None:
+            self._meta_thread.join(timeout=5)
+            self._meta_thread = None
+        if self._raw is not None:
+            try:
+                self._raw.close()
+            except Exception as e:
+                logger.warning(
+                    "Failed to close raw block device %s: %s", self.device_path, e
+                )
+            finally:
+                self._raw = None
+        self._closed = True
+
+    def _build_direct_odirect_view(
+        self,
+        memory_obj: MemoryObj,
+        payload_len: int,
+        total_len: int,
+        buffer_len: int,
+        *,
+        zero_tail: bool,
+    ) -> Optional[memoryview]:
+        """Build an aligned memoryview for direct O_DIRECT I/O when possible.
+
+        Args:
+            memory_obj: Memory object whose backing allocation may be aligned.
+            payload_len: Logical payload length in bytes.
+            total_len: I/O length after any O_DIRECT padding.
+            buffer_len: Available buffer length in bytes.
+            zero_tail: Whether to zero any padded tail bytes before writing.
+
+        Returns:
+            A direct memoryview over the allocation, or None when the memory
+            object is unsuitable for direct I/O.
+        """
+        if not self.use_odirect or not self.enable_zero_copy:
+            return None
+
+        ptr_val = getattr(memory_obj, "data_ptr", None)
+        if callable(ptr_val):
+            try:
+                ptr_val = ptr_val()
+            except Exception:
+                ptr_val = None
+        if ptr_val is None:
+            return None
+        if buffer_len <= 0:
+            return None
+
+        ptr = int(ptr_val)
+        if ptr <= 0 or ptr % self.block_align != 0:
+            return None
+        if buffer_len < payload_len:
+            return None
+
+        view_len = min(buffer_len, total_len)
+        if view_len < payload_len:
+            return None
+
+        try:
+            raw = (ctypes.c_ubyte * view_len).from_address(ptr)
+            view = memoryview(raw)
+            if zero_tail and total_len > payload_len and view_len >= total_len:
+                ctypes.memset(ptr + payload_len, 0, total_len - payload_len)
+            return view
+        except Exception:
+            return None
+
+    def _prepare_write_payload(self, memory_obj: MemoryObj) -> tuple[Any, int, int]:
+        """Prepare the payload buffer and lengths for a raw-block write.
+
+        Args:
+            memory_obj: Source object to persist.
+
+        Returns:
+            A tuple of ``(buffer, payload_len, total_len)`` where ``total_len``
+            includes any O_DIRECT padding.
+
+        Raises:
+            RuntimeError: If the aligned payload would exceed slot capacity.
+        """
+        buf = memory_obj.byte_array
+        if hasattr(buf, "cast"):
+            buf = buf.cast("B")
+        payload_len = len(memory_obj.byte_array)
+        total_len = payload_len
+        if self.use_odirect:
+            total_len = round_up(payload_len, self.block_align)
+            if total_len > (self.slot_bytes - self.header_bytes):
+                raise RuntimeError(
+                    f"O_DIRECT payload {total_len} exceeds slot capacity"
+                )
+            direct_view = self._build_direct_odirect_view(
+                memory_obj=memory_obj,
+                payload_len=payload_len,
+                total_len=total_len,
+                buffer_len=len(buf),
+                zero_tail=True,
+            )
+            if direct_view is not None:
+                buf = direct_view
+        return buf, payload_len, total_len
+
+    def _write_one(
+        self, key: RawBlockKeySpec, memory_obj: MemoryObj, offset: int
+    ) -> bool:
+        """Write one object header and payload into a raw-block slot.
+
+        Args:
+            key: Raw-block key spec with the slot-header identity.
+            memory_obj: Source object to write.
+            offset: Slot byte offset on the raw device.
+
+        Returns:
+            True when both header and payload writes complete; false otherwise.
+        """
+        try:
+            header = self._encode_header(key.slot_identity, len(memory_obj.byte_array))
+            buf, payload_len, total_len = self._prepare_write_payload(memory_obj)
+
+            with self._lock:
+                self._inflight_io_count += 1
+            try:
+                raw_dev = self._rawdev()
+                hdr_total = (
+                    round_up(len(header), self.block_align)
+                    if self.use_odirect
+                    else len(header)
+                )
+                raw_dev.pwrite_from_buffer(offset, header, len(header), hdr_total)
+                raw_dev.pwrite_from_buffer(
+                    offset + self.header_bytes,
+                    buf,
+                    payload_len,
+                    total_len,
+                )
+            finally:
+                with self._lock:
+                    self._inflight_io_count -= 1
+                    self._last_io_ts = time.monotonic()
+            return True
+        except Exception as e:
+            logger.error("RawBlockCore write failed for %s: %s", key.encoded, e)
+            return False
+
+    def _encode_header(self, slot_identity: int, payload_len: int) -> bytes:
+        """Encode a fixed-size raw-block slot header."""
+        hdr = bytearray(self.header_bytes)
+        hdr[0:8] = b"LMCBLK01"
+        hdr[8:16] = int(slot_identity & ((1 << 64) - 1)).to_bytes(
+            8,
+            "little",
+            signed=False,
+        )
+        hdr[16:24] = int(payload_len).to_bytes(8, "little", signed=False)
+        return bytes(hdr)
+
+    def _decode_slot_header(self, hdr: bytes) -> Optional[tuple[int, int]]:
+        """Decode a raw-block slot header into identity and payload length."""
+        if len(hdr) < 24 or hdr[0:8] != b"LMCBLK01":
+            return None
+        slot_identity = int.from_bytes(hdr[8:16], "little", signed=False)
+        payload_len = int.from_bytes(hdr[16:24], "little", signed=False)
+        return slot_identity, payload_len
+
+    def _read_slot_header(self, offset: int) -> Optional[tuple[int, int]]:
+        """Read and decode the slot header at a raw-device offset."""
+        buf = bytearray(self.header_bytes)
+        try:
+            with self._lock:
+                self._inflight_io_count += 1
+            self._rawdev().pread_into(offset, buf, self.header_bytes, self.header_bytes)
+            return self._decode_slot_header(buf)
+        except Exception:
+            return None
+        finally:
+            with self._lock:
+                self._inflight_io_count -= 1
+                self._last_io_ts = time.monotonic()
+
+    def _ensure_capacity_and_layout(self) -> None:
+        """Open the device if needed and compute metadata/data layout."""
+        if self._effective_capacity_bytes > 0 and self._max_slots > 0:
+            return
+
+        device_size = int(self._rawdev().size_bytes())
+        requested = self.capacity_bytes if self.capacity_bytes > 0 else device_size
+        self._effective_capacity_bytes = min(requested, device_size)
+        self.capacity_bytes = self._effective_capacity_bytes
+
+        if self.meta_total_bytes >= self._effective_capacity_bytes:
+            raise RuntimeError("metadata region exceeds usable device capacity")
+
+        self._data_base_offset = self.meta_total_bytes
+        data_bytes = self._effective_capacity_bytes - self._data_base_offset
+        self._max_slots = data_bytes // self.slot_bytes
+        if self._max_slots <= 0:
+            raise RuntimeError(
+                "raw block capacity too small for slot size after metadata"
+            )
+
+    def _slot_to_offset(self, slot: int) -> int:
+        """Convert a data-slot index to its byte offset."""
+        return self._data_base_offset + slot * self.slot_bytes
+
+    def _offset_to_slot(self, offset: int) -> int:
+        """Convert a data-slot byte offset to its slot index."""
+        return (offset - self._data_base_offset) // self.slot_bytes
+
+    def _allocate_slot_locked(self) -> int:
+        """Allocate a slot offset while ``self._lock`` is held."""
+        self._ensure_capacity_and_layout()
+        if self._free_slots:
+            return self._slot_to_offset(self._free_slots.pop())
+        if self._next_slot < self._max_slots:
+            slot = self._next_slot
+            self._next_slot += 1
+            return self._slot_to_offset(slot)
+        raise RuntimeError("No free slots available")
+
+    def _append_free_slot_locked(self, slot: int) -> None:
+        """Add a slot to the free list while ``self._lock`` is held."""
+        if slot < 0 or slot >= self._max_slots:
+            return
+        if slot in self._free_slots:
+            return
+        self._free_slots.append(slot)
+
+    def _checkpoint_loop(self) -> None:
+        """Periodically checkpoint dirty metadata until shutdown."""
+        interval = max(1, self.meta_checkpoint_interval_sec)
+        while not self._meta_stop_evt.wait(interval):
+            try:
+                self._checkpoint_once(force=False)
+            except Exception as e:
+                logger.warning("Periodic raw-block metadata checkpoint failed: %s", e)
+
+    def _meta_payload_capacity(self) -> int:
+        """Return usable bytes in one metadata checkpoint payload area."""
+        return self._meta_container_bytes - self.block_align
+
+    def _meta_container_offsets(self) -> list[int]:
+        """Return byte offsets for mirrored metadata checkpoint containers."""
+        return [
+            idx * self._meta_container_bytes for idx in range(self._meta_copy_count)
+        ]
+
+    def _read_meta_header(self, container_offset: int) -> Optional[dict[str, int]]:
+        """Read and validate a metadata checkpoint header."""
+        buf = bytearray(self.block_align)
+        try:
+            self._rawdev().pread_into(
+                container_offset, buf, self.block_align, self.block_align
+            )
+        except Exception:
+            return None
+
+        hdr = bytes(buf[: _META_HEADER_STRUCT.size])
+        magic, version, seq, payload_len, crc = _META_HEADER_STRUCT.unpack(hdr)
+        if magic != self.meta_magic or version != self.meta_version:
+            return None
+
+        payload_cap = self._meta_payload_capacity()
+        if payload_len <= 0 or payload_len > payload_cap:
+            return None
+        return {
+            "seq": int(seq),
+            "payload_len": int(payload_len),
+            "crc": int(crc),
+            "container_offset": int(container_offset),
+        }
+
+    def _load_meta_payload(self, header: dict[str, int]) -> Optional[bytes]:
+        """Load and CRC-validate a checkpoint payload for a metadata header."""
+        payload_len = int(header["payload_len"])
+        payload_off = int(header["container_offset"]) + self.block_align
+        total_len = round_up(payload_len, self.block_align)
+        buf = bytearray(total_len)
+        try:
+            self._rawdev().pread_into(payload_off, buf, payload_len, total_len)
+        except Exception:
+            return None
+
+        payload = bytes(buf[:payload_len])
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        if crc != int(header["crc"]):
+            return None
+        return payload
+
+    def _select_latest_checkpoint(
+        self,
+    ) -> tuple[Optional[dict[str, int]], Optional[bytes]]:
+        """Return the newest valid checkpoint header and payload."""
+        best_header: Optional[dict[str, int]] = None
+        best_payload: Optional[bytes] = None
+        for offset in self._meta_container_offsets():
+            header = self._read_meta_header(offset)
+            if header is None:
+                continue
+            payload = self._load_meta_payload(header)
+            if payload is None:
+                continue
+            if best_header is None or int(header["seq"]) > int(best_header["seq"]):
+                best_header = header
+                best_payload = payload
+        return best_header, best_payload
+
+    def _snapshot_state(self) -> tuple[dict[str, Any], int]:
+        """Build a JSON-serializable checkpoint state snapshot."""
+        with self._lock:
+            dirty_total = self._meta_dirty_total
+            snapshot = {
+                "version": 1,
+                "device_path": self.device_path,
+                "capacity_bytes": self.capacity_bytes,
+                "block_align": self.block_align,
+                "header_bytes": self.header_bytes,
+                "slot_bytes": self.slot_bytes,
+                "meta_total_bytes": self.meta_total_bytes,
+                "meta_magic": self.meta_magic_text,
+                "meta_version": self.meta_version,
+                "data_base_offset": self._data_base_offset,
+                "next_slot": self._next_slot,
+                "free_slots": list(self._free_slots),
+                "entries": {
+                    encoded_key: {
+                        "offset": entry.offset,
+                        "size": entry.meta.size,
+                        "shape": list(entry.meta.shape)
+                        if entry.meta.shape is not None
+                        else None,
+                        "dtype": self._checkpoint_dtype_name(entry.meta.dtype),
+                        "fmt": (
+                            entry.meta.fmt.name
+                            if entry.meta.fmt is not None
+                            and hasattr(entry.meta.fmt, "name")
+                            else str(entry.meta.fmt)
+                            if entry.meta.fmt is not None
+                            else None
+                        ),
+                        "cached_positions": (
+                            entry.meta.cached_positions.tolist()
+                            if entry.meta.cached_positions is not None
+                            and hasattr(entry.meta.cached_positions, "tolist")
+                            else None
+                        ),
+                    }
+                    for encoded_key, entry in self._index.items()
+                },
+            }
+        return snapshot, dirty_total
+
+    def _checkpoint_dtype_name(self, dtype: torch.dtype | None) -> str | None:
+        """Return a durable checkpoint string for a torch dtype.
+
+        Args:
+            dtype: Torch dtype from recovered or live memory metadata.
+
+        Returns:
+            Stable LMCache dtype name when known, ``str(dtype)`` for unknown
+            torch dtypes, or None when no dtype is available.
+        """
+        if dtype is None:
+            return None
+        return TORCH_DTYPE_TO_STR_DTYPE.get(dtype, str(dtype))
+
+    def _write_checkpoint(self, payload: bytes, dirty_total_snapshot: int) -> bool:
+        """Write one checkpoint copy and advance persisted metadata counters."""
+        payload_cap = self._meta_payload_capacity()
+        if len(payload) > payload_cap:
+            logger.warning(
+                "RawBlockCore metadata payload too large (%d > %d), "
+                "skipping checkpoint",
+                len(payload),
+                payload_cap,
+            )
+            return False
+
+        next_seq = self._meta_seq + 1
+        target_idx = int((next_seq - 1) % self._meta_copy_count)
+        target = self._meta_container_offsets()[target_idx]
+
+        payload_len = len(payload)
+        payload_total_len = round_up(payload_len, self.block_align)
+        payload_off = target + self.block_align
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+        header_block = bytearray(self.block_align)
+        header_block[: _META_HEADER_STRUCT.size] = _META_HEADER_STRUCT.pack(
+            self.meta_magic,
+            self.meta_version,
+            int(next_seq),
+            int(payload_len),
+            int(crc),
+        )
+
+        raw = self._rawdev()
+        raw.pwrite_from_buffer(payload_off, payload, payload_len, payload_total_len)
+        raw.pwrite_from_buffer(target, header_block, self.block_align, self.block_align)
+
+        with self._lock:
+            self._meta_seq = int(next_seq)
+            self._meta_persisted = max(self._meta_persisted, int(dirty_total_snapshot))
+        return True
+
+    def _checkpoint_once(self, force: bool) -> bool:
+        """Write a metadata checkpoint when dirty and sufficiently idle."""
+        with self._lock:
+            dirty = self._meta_dirty_total > self._meta_persisted
+            idle_ok = self._inflight_io_count == 0 and (
+                time.monotonic() - self._last_io_ts
+            ) >= (self.meta_idle_quiet_ms / 1000.0)
+
+        if not dirty:
+            return False
+        if not force and not idle_ok:
+            return False
+
+        snapshot, dirty_total_snapshot = self._snapshot_state()
+        payload = json.dumps(snapshot, separators=(",", ":"), ensure_ascii=True).encode(
+            "utf-8"
+        )
+        return self._write_checkpoint(payload, dirty_total_snapshot)
+
+    def _is_valid_checkpoint_entry(self, offset: int, size: int) -> bool:
+        """Return whether a checkpoint entry references a valid data slot."""
+        if offset < self._data_base_offset:
+            return False
+        rel = offset - self._data_base_offset
+        if rel % self.slot_bytes != 0:
+            return False
+        slot = rel // self.slot_bytes
+        if slot < 0 or slot >= self._max_slots:
+            return False
+        return 0 < size <= (self.slot_bytes - self.header_bytes)
+
+    def _apply_loaded_state(self, data: dict[str, Any]) -> bool:
+        """Apply decoded checkpoint state after validating layout fields."""
+        if not isinstance(data, dict):
+            return False
+        if int(data.get("version", 0)) != 1:
+            return False
+        if data.get("device_path") and data.get("device_path") != self.device_path:
+            logger.warning("Device metadata device_path mismatch; ignoring metadata")
+            return False
+        if int(data.get("slot_bytes", self.slot_bytes)) != self.slot_bytes:
+            logger.warning("Device metadata slot_bytes mismatch; ignoring metadata")
+            return False
+        if (
+            int(data.get("meta_total_bytes", self.meta_total_bytes))
+            != self.meta_total_bytes
+        ):
+            logger.warning(
+                "Device metadata meta_total_bytes mismatch; ignoring metadata"
+            )
+            return False
+        if str(data.get("meta_magic", self.meta_magic_text)) != self.meta_magic_text:
+            logger.warning("Device metadata meta_magic mismatch; ignoring metadata")
+            return False
+        if int(data.get("meta_version", self.meta_version)) != self.meta_version:
+            logger.warning("Device metadata meta_version mismatch; ignoring metadata")
+            return False
+
+        try:
+            next_slot = int(data.get("next_slot", 0))
+        except Exception:
+            logger.warning("Device metadata next_slot is invalid; ignoring metadata")
+            return False
+        if next_slot < 0 or next_slot > self._max_slots:
+            logger.warning(
+                "Device metadata next_slot out of range (%d); ignoring metadata",
+                next_slot,
+            )
+            return False
+
+        raw_free_slots = data.get("free_slots", [])
+        if not isinstance(raw_free_slots, list):
+            logger.warning("Device metadata free_slots is invalid; ignoring metadata")
+            return False
+        free_slots: list[int] = []
+        seen_slots: set[int] = set()
+        for raw_slot in raw_free_slots:
+            try:
+                slot = int(raw_slot)
+            except Exception:
+                logger.warning(
+                    "Device metadata free_slots contains non-integer; ignoring metadata"
+                )
+                return False
+            if slot < 0 or slot >= self._max_slots:
+                logger.warning(
+                    "Device metadata free_slots contains out-of-range slot %d; "
+                    "ignoring metadata",
+                    slot,
+                )
+                return False
+            if slot in seen_slots:
+                continue
+            seen_slots.add(slot)
+            free_slots.append(slot)
+
+        with self._lock:
+            self._next_slot = next_slot
+            self._free_slots = free_slots
+            self._index.clear()
+            self._lock_refcnt.clear()
+
+            entries = data.get("entries", {})
+            if isinstance(entries, dict):
+                for encoded_key, entry in entries.items():
+                    if not isinstance(entry, dict):
+                        continue
+
+                    offset = int(entry.get("offset", 0))
+                    size = int(entry.get("size", 0))
+                    shape_list = entry.get("shape")
+                    fmt_name = entry.get("fmt")
+                    cached_positions_list = entry.get("cached_positions")
+                    dtype_name = entry.get("dtype")
+
+                    if not self._is_valid_checkpoint_entry(offset, size):
+                        continue
+
+                    shape = (
+                        torch.Size(list(shape_list)) if shape_list is not None else None
+                    )
+                    fmt = (
+                        MemoryFormat[fmt_name]
+                        if isinstance(fmt_name, str)
+                        and fmt_name in MemoryFormat.__members__
+                        else MemoryFormat.UNDEFINED
+                    )
+                    cached_positions = (
+                        torch.tensor(cached_positions_list, dtype=torch.long)
+                        if cached_positions_list is not None
+                        else None
+                    )
+                    dtype = self._recover_checkpoint_dtype(
+                        str(encoded_key),
+                        dtype_name,
+                    )
+
+                    meta = DiskCacheMetadata(
+                        path=f"{self.device_path}@{offset}",
+                        size=size,
+                        shape=shape,
+                        dtype=dtype,
+                        cached_positions=cached_positions,
+                        fmt=fmt,
+                        pin_count=0,
+                    )
+                    self._index[encoded_key] = _Entry(
+                        offset=offset, size=size, meta=meta
+                    )
+
+            used_slots = {
+                self._offset_to_slot(int(entry.offset))
+                for entry in self._index.values()
+            }
+            self._free_slots = [
+                slot for slot in self._free_slots if slot not in used_slots
+            ]
+
+            self._meta_dirty_total = 0
+            self._meta_persisted = 0
+
+        if self.meta_verify_on_load:
+            self._validate_loaded_entries()
+        return True
+
+    def _recover_checkpoint_dtype(
+        self,
+        encoded_key: str,
+        dtype_name: Any,
+    ) -> torch.dtype | None:
+        """Recover checkpoint dtype from entry metadata or legacy key strings.
+
+        Args:
+            encoded_key: Encoded raw-block key from the checkpoint entry.
+            dtype_name: Raw dtype value stored in the checkpoint entry.
+
+        Returns:
+            A torch dtype when recovery succeeds, otherwise None.
+        """
+        if isinstance(dtype_name, str):
+            dtype = STR_DTYPE_TO_TORCH_DTYPE.get(dtype_name)
+            if dtype is not None:
+                return dtype
+
+            torch_prefix = "torch."
+            if dtype_name.startswith(torch_prefix):
+                dtype_attr = dtype_name.removeprefix(torch_prefix)
+                dtype = STR_DTYPE_TO_TORCH_DTYPE.get(dtype_attr)
+                if dtype is not None:
+                    return dtype
+                torch_dtype = getattr(torch, dtype_attr, None)
+                if isinstance(torch_dtype, torch.dtype):
+                    return torch_dtype
+
+        if self.key_namespace != "legacy":
+            return None
+
+        try:
+            return decode_legacy_key(encoded_key).dtype
+        except Exception:
+            logger.debug(
+                "Unable to recover dtype from legacy raw-block key %s",
+                encoded_key,
+                exc_info=True,
+            )
+            return None
+
+    def _validate_loaded_entries(self) -> None:
+        """Drop recovered entries whose slot headers do not match metadata."""
+        to_drop: list[str] = []
+        with self._lock:
+            items = list(self._index.items())
+
+        for encoded_key, entry in items:
+            slot_hdr = self._read_slot_header(int(entry.offset))
+            if slot_hdr is None:
+                to_drop.append(encoded_key)
+                continue
+            try:
+                expected_identity = slot_identity_from_encoded_key(
+                    encoded_key,
+                    self.key_namespace,
+                )
+            except Exception:
+                to_drop.append(encoded_key)
+                continue
+            slot_identity, payload_len = slot_hdr
+            if int(slot_identity) != int(expected_identity):
+                to_drop.append(encoded_key)
+                continue
+            if int(payload_len) != int(entry.size):
+                to_drop.append(encoded_key)
+
+        if not to_drop:
+            return
+
+        with self._lock:
+            for encoded_key in to_drop:
+                removed_entry = self._index.pop(encoded_key, None)
+                self._lock_refcnt.pop(encoded_key, None)
+                if removed_entry is not None:
+                    self._append_free_slot_locked(
+                        self._offset_to_slot(int(removed_entry.offset))
+                    )
+            self._meta_dirty_total += 1
+
+        logger.warning(
+            "RawBlockCore dropped %d stale metadata entries after "
+            "slot-header validation",
+            len(to_drop),
+        )
+
+    def _load_checkpoint_from_device(self) -> None:
+        """Load the newest valid checkpoint from the raw device if present."""
+        header, payload = self._select_latest_checkpoint()
+        if header is None:
+            logger.info("RawBlockCore: no valid on-device metadata checkpoint found")
+            return
+        if payload is None:
+            logger.warning("RawBlockCore: checkpoint header had no payload")
+            return
+        try:
+            data = json.loads(payload.decode("utf-8"))
+        except Exception:
+            logger.warning("RawBlockCore: failed to decode metadata payload")
+            return
+        if not self.apply_loaded_state(data):
+            logger.warning("RawBlockCore: metadata payload rejected by checks")
+            return
+        self._meta_seq = int(header["seq"])
+        logger.info(
+            "RawBlockCore loaded checkpoint (entries=%d next_slot=%d seq=%d device=%s)",
+            len(self._index),
+            self._next_slot,
+            self._meta_seq,
+            self.device_path,
+        )

--- a/lmcache/v1/storage_backend/raw_block/key_codec.py
+++ b/lmcache/v1/storage_backend/raw_block/key_codec.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from typing import Literal
+import hashlib
+import urllib.parse
+
+# First Party
+from lmcache.utils import CacheEngineKey, LayerCacheEngineKey, parse_cache_key
+from lmcache.v1.distributed.api import ObjectKey
+
+RawBlockKeyNamespace = Literal["legacy", "object"]
+
+_KEY_SEP = "@"
+_UINT64_MASK = (1 << 64) - 1
+
+
+@dataclass(frozen=True)
+class RawBlockKeySpec:
+    """Encoded raw-block key plus stable slot-header identity."""
+
+    encoded: str
+    slot_identity: int
+
+
+def object_key_to_string(key: ObjectKey) -> str:
+    """Serialize an ObjectKey using raw-block's reversible key shape.
+
+    Args:
+        key: Object key supplied by the MP storage layer.
+
+    Returns:
+        A stable string containing model name, KV rank, chunk hash, and
+        optional cache salt.
+
+    Raises:
+        AttributeError: If ``key`` does not expose the ObjectKey fields.
+    """
+    safe_model = urllib.parse.quote(key.model_name, safe="")
+    base = f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    if key.cache_salt:
+        return f"{base}{_KEY_SEP}{key.cache_salt}"
+    return base
+
+
+def decode_object_key(encoded: str) -> ObjectKey:
+    """Deserialize an ObjectKey from raw-block's reversible encoding.
+
+    Args:
+        encoded: Encoded key string produced by ``object_key_to_string``.
+
+    Returns:
+        The reconstructed ``ObjectKey``.
+
+    Raises:
+        ValueError: If the encoded string has an unexpected shape or invalid
+            hexadecimal chunk hash.
+    """
+    parts = encoded.split(_KEY_SEP)
+    if len(parts) == 3:
+        safe_model, kv_rank_str, chunk_hash_hex = parts
+        cache_salt = ""
+    elif len(parts) == 4:
+        safe_model, kv_rank_str, chunk_hash_hex, cache_salt = parts
+    else:
+        raise ValueError(f"Invalid raw-block ObjectKey encoding: {encoded!r}")
+
+    return ObjectKey(
+        chunk_hash=bytes.fromhex(chunk_hash_hex),
+        model_name=urllib.parse.unquote(safe_model),
+        kv_rank=int(kv_rank_str, 16),
+        cache_salt=cache_salt,
+    )
+
+
+def encode_object_key(key: ObjectKey) -> RawBlockKeySpec:
+    """Encode an MP ObjectKey for raw-block storage.
+
+    Args:
+        key: Object key supplied by the MP storage layer.
+
+    Returns:
+        Encoded key and deterministic slot-header identity.
+    """
+    encoded = object_key_to_string(key)
+    return RawBlockKeySpec(
+        encoded=encoded,
+        slot_identity=_object_slot_identity(encoded),
+    )
+
+
+def decode_legacy_key(encoded: str) -> CacheEngineKey | LayerCacheEngineKey:
+    """Deserialize a legacy non-MP cache key string.
+
+    Args:
+        encoded: String produced by ``CacheEngineKey.to_string`` or
+            ``LayerCacheEngineKey.to_string``.
+
+    Returns:
+        Parsed legacy cache key.
+
+    Raises:
+        TypeError: If parsing returns an unsupported key type.
+    """
+    parsed = parse_cache_key(encoded)
+    if not isinstance(parsed, (CacheEngineKey, LayerCacheEngineKey)):
+        raise TypeError(
+            "parse_cache_key returned unsupported key type "
+            f"{type(parsed).__name__} for {encoded!r}"
+        )
+    return parsed
+
+
+def encode_legacy_key(key: CacheEngineKey | LayerCacheEngineKey) -> RawBlockKeySpec:
+    """Encode a legacy non-MP cache key for raw-block storage.
+
+    Args:
+        key: Legacy cache key from the non-MP storage plugin path.
+
+    Returns:
+        Encoded key and slot-header identity derived from the chunk hash.
+    """
+    return RawBlockKeySpec(
+        encoded=key.to_string(),
+        slot_identity=int(key.chunk_hash) & _UINT64_MASK,
+    )
+
+
+def slot_identity_from_encoded_key(
+    encoded: str,
+    namespace: RawBlockKeyNamespace,
+) -> int:
+    """Return the stable slot-header identity for an encoded key.
+
+    Args:
+        encoded: Encoded raw-block key string.
+        namespace: Key namespace used when the key was encoded.
+
+    Returns:
+        Unsigned 64-bit identity stored in the per-slot header.
+
+    Raises:
+        ValueError: If ``namespace`` is unsupported.
+        TypeError: If legacy key parsing returns an unsupported key type.
+    """
+    if namespace == "legacy":
+        key = decode_legacy_key(encoded)
+        return int(key.chunk_hash) & _UINT64_MASK
+    if namespace == "object":
+        return _object_slot_identity(encoded)
+    raise ValueError(f"Unsupported raw-block key namespace: {namespace!r}")
+
+
+def _object_slot_identity(encoded: str) -> int:
+    """Return the stable 64-bit slot identity for an encoded ObjectKey.
+
+    Args:
+        encoded: Raw-block ObjectKey string produced by ``object_key_to_string``.
+
+    Returns:
+        Unsigned 64-bit identity stored in the raw-block slot header.
+    """
+    digest = hashlib.blake2b(encoded.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "little", signed=False)

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -111,7 +111,7 @@ spec:
         name: string
     # Option B: Raw escape hatch for other adapter types
     raw:
-      type: string              # adapter type name (nixl_store, fs, mock, etc.)
+      type: string              # adapter type name (nixl_store, fs, mock, raw_block, etc.)
       config: map[string]any    # type-specific config as free-form map
 
   # -- Resources (auto-computed, no user input needed) --
@@ -346,7 +346,7 @@ OnEvent(LMCacheEngine create/update/delete):
 
 ## Future Extensibility
 
-- **L2 backends:** The RESP (Redis/Valkey) adapter is natively supported with typed CRD fields and Secret-based auth injection. Other adapter types (nixl_store, fs, mock, mooncake_store) can be configured via the `raw` escape hatch. Currently only a single L2 adapter is supported at a time. LMCache MP mode is designed to support multiple adapters in cascade, but this is not yet fully tested — once validated, the operator will support multiple adapters.
+- **L2 backends:** The RESP (Redis/Valkey) adapter is natively supported with typed CRD fields and Secret-based auth injection. Other adapter types (nixl_store, fs, mock, mooncake_store, raw_block) can be configured via the `raw` escape hatch. Currently only a single L2 adapter is supported at a time. LMCache MP mode is designed to support multiple adapters in cascade, but this is not yet fully tested — once validated, the operator will support multiple adapters.
 - **Blend mode:** Future `LMCacheEngine` field `blend.enabled` to switch entrypoint from `server.py` to `blend_server.py` (deferred from v1alpha1).
 - **Update strategy:** Future `spec.updateStrategy` field for `RollingUpdate`/`OnDelete` control on the DaemonSet.
 - **Additional CRDs:** `LMCacheKeyManager` (global key management), `LMCacheMonitor` (engine state monitoring), `LMCacheFederation` (cross-cluster P2P topology).

--- a/operator/README.md
+++ b/operator/README.md
@@ -257,7 +257,7 @@ spec:
 
 ### L2 Storage: Other Adapters (Raw Escape Hatch)
 
-For adapter types not yet natively supported by the operator (e.g. `nixl_store`, `fs`, `mock`), use the `raw` escape hatch. The JSON is passed through to `--l2-adapter` as-is:
+For adapter types not yet natively supported by the operator (e.g. `nixl_store`, `fs`, `mock`, `raw_block`), use the `raw` escape hatch. The JSON is passed through to `--l2-adapter` as-is:
 
 ```yaml
 spec:
@@ -271,6 +271,27 @@ spec:
           use_direct_io: "false"
         pool_size: 64
 ```
+
+Example `raw_block` configuration via the same escape hatch:
+
+```yaml
+spec:
+  l2Backend:
+    raw:
+      type: raw_block
+      config:
+        device_path: "/dev/nvme0n1"
+        slot_bytes: 1048576
+        block_align: 4096
+        header_bytes: 4096
+        meta_total_bytes: 268435456
+        use_odirect: true
+        num_store_workers: 2
+        num_lookup_workers: 1
+        num_load_workers: 4
+```
+
+Use an unmounted raw block device or a dedicated file path reserved for LMCache. With `use_odirect: true`, the LMCache server's `--l1-align-bytes` setting must be at least `block_align`.
 
 > [!NOTE]
 > Currently only a single L2 adapter is supported at a time. While LMCache multiprocess mode is designed to support multiple L2 adapters in cascade, this functionality is not yet fully tested. Once the multi-adapter pipeline is validated and performance is confirmed, the operator will be updated to support multiple adapters.

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -1,29 +1,50 @@
 # LMCache Rust Raw Block I/O
 
-This crate provides raw block I/O for LMCache via Rust + PyO3.
+This crate provides the low-level raw device I/O layer for LMCache via Rust +
+PyO3. It is used by both:
 
-## What Changed vs `origin/dev`
+- the legacy non-MP `RustRawBlockBackend`
+- the MP `raw_block` L2 adapter (`RawBlockL2Adapter`) via `RawBlockCore`
 
-1. `RustRawBlockBackend` can use aligned Python buffer memory directly in O_DIRECT paths (no extra Python-side payload copy on the fast path).
-2. O_DIRECT tail handling uses a hybrid path:
-   - direct write/read for aligned prefix
-   - bounce buffer only for the final padded tail block
-3. `LocalCPUBackend` alignment can be auto-driven by rust raw block config for O_DIRECT compatibility:
-   - `rust_raw_block.block_align`
-   - `rust_raw_block.align_local_cpu_allocator`
-   - `local_cpu.pinned_align_bytes` (explicit override)
-4. Benchmark harness reliability improvements:
-   - skip `truncate()` for real block devices (`/dev/...`)
-   - unique manifest per run (avoid stale-index reuse)
-   - timeout guard for local disk completion waits (scales with `num_ops`)
-5. **io_uring support**: Added asynchronous I/O backend using Linux io_uring API:
-   - Dedicated worker thread drives the io_uring submission/completion loop
-   - Batch write, read support to reduce syscall overhead and improve throughput
-   - Fixed buffer registration for true zero-copy I/O operations
+The Rust crate intentionally stays narrow: it owns the raw device handle and
+exposes blocking `pwrite_from_buffer` / `pread_into` primitives. Slotting,
+checkpointing, recovery, and MP task orchestration all live in Python.
+
+## I/O Engines
+
+`RawBlockDevice` accepts `io_engine`:
+
+- `posix` (default): synchronous Linux `pread` / `pwrite`.
+- `io_uring`: direct Rust io_uring syscall path using the existing worker,
+  batch, and `wait_iouring` machinery.
+
+`use_iouring=True` remains accepted for backward compatibility. If `io_engine`
+is explicitly set, it wins over the legacy flag.
+
+## MP Mode Integration
+
+In MP mode, the stack looks like this:
+
+```text
+StoreController / PrefetchController
+                |
+                v
+        RawBlockL2Adapter
+                |
+                v
+           RawBlockCore
+                |
+                v
+         lmcache_rust_raw_block_io
+                |
+                v
+         raw device / file
+```
+
+This split lets LMCache reuse the same on-device metadata and recovery model in
+both non-MP and MP mode without duplicating the raw-block implementation.
 
 ## Zero-Copy Data Path
-
-### Synchronous Path (pread/pwrite)
 
 ```text
 LMCache LocalCPUBackend (aligned pinned CPU tensor)
@@ -41,54 +62,6 @@ RawBlockDevice::pwrite_from_buffer / pread_into
 Block device or file
 ```
 
-### Asynchronous Path (io_uring)
-
-```text
-LMCache LocalCPUBackend (aligned pinned CPU tensor)
-                 |
-                 |  Python buffer / memoryview (no payload memcpy)
-                 v
-RustRawBlockBackend (PyO3 boundary)
-                 |
-                 |  enqueue to worker thread queue
-                 v
-io_uring worker thread (batching & submission)
-                 |
-                 |  direct pointer path when O_DIRECT constraints are met
-                 |  and fixed buffer path for true zero-copy
-                 v
-io_uring submission queue (kernel)
-                 |
-                 v
-Block device or file
-```
-
-```text
-Python Thread(s)              Worker Thread (io_uring)
-===============               =======================
-batched_write() /  --push-->   [queue]
-batched_read()                [worker loop]
-    |                               |
-    |                               v
-    |                         process queue
-    |                               |
-    v                               v
-[IoCompletion]  <--signal--   submit to kernel
-    |                               |
-wait_iouring() GIL-release    completions
-    |                               |
-    v                               v
-wait() non-blocking           wake up waiters
-```
-
-### Fixed Buffer Zero-Copy (io_uring)
-
-io_uring with registered fixed buffers:
-- Buffers are pre-registered with the kernel via `register_fixed_buffers()`
-- Eliminates memory copies between user and kernel space
-- Avoids kernel pin/unpin overhead on each I/O operation
-- Particularly beneficial for repeated I/O operations on the same buffers
-
 ## How To Compare Performance
 
 To compare `local_disk` vs `rust_raw_block` on a real NVMe device:
@@ -103,48 +76,8 @@ No fixed numbers are included here because results are host/device/workload depe
 
 ## Limitations
 
-- Linux only (`pread` / `pwrite`, O_DIRECT semantics, io_uring).
+- Linux only (`pread` / `pwrite`, O_DIRECT semantics).
 - O_DIRECT requires aligned offset, size, and user buffer address.
-- io_uring backend requires Linux kernel 5.1+.
-
-## io_uring Dependencies
-
-The io_uring backend requires specific kernel configuration and versions:
-
-### Kernel Version
-
-- **Minimum version**: Linux kernel 5.1+
-- **Recommended version**: Linux kernel 5.19+ for full feature support
-
-### Kernel Configuration
-
-The following kernel configuration options must be enabled:
-
-```
-CONFIG_IO_URING=y
-```
-
-To check if io_uring is enabled on your system:
-
-```bash
-# Check kernel config
-grep -i uring /boot/config-$(uname -r)
-
-# Or check the presence of io_uring setup function in kernel's symbol table
-grep io_uring_setup /proc/kallsyms
-```
-
-### Rust io-uring Crate
-
-- **Crate version**: `io-uring = "0.7"`
-- **Source**: [io-uring crate on crates.io](https://crates.io/crates/io-uring)
-
-The crate provides safe Rust bindings to the Linux io_uring API and is included in the project's `Cargo.toml`:
-
-```toml
-[dependencies]
-io-uring = "0.7"
-```
 
 ## Build
 
@@ -156,8 +89,6 @@ maturin develop --release
 
 ## Minimal Usage
 
-### Synchronous I/O (pread/pwrite)
-
 ```python
 from lmcache_rust_raw_block_io import RawBlockDevice
 
@@ -168,44 +99,51 @@ buf = bytearray(4096)
 dev.pread_into(offset=0, out=buf, payload_len=5, total_len=4096)
 ```
 
-### Asynchronous I/O (io_uring)
+io_uring:
 
 ```python
-from lmcache_rust_raw_block_io import RawBlockDevice
-
-# Create device with io_uring enabled
 dev = RawBlockDevice(
     "/dev/nvme0n1",
-    writable=True,
+    True,
     use_odirect=True,
     alignment=4096,
-    use_iouring=True
+    io_engine="io_uring",
+    iouring_queue_depth=256,
 )
-
-buf1 = bytearray(4096)
-buf2 = bytearray(4096)
-buffer_ptrs = [ctypes.addressof(ctypes.c_char.from_buffer(buf1)), ctypes.addressof(ctypes.c_char.from_buffer(buf2))]
-buffer_sizes = [len(buf1), len(buf2)]
-dev.register_fixed_buffers(buffer_ptrs, buffer_sizes)
-
-offsets = [0, 4096]
-buffers = [buf1, buf2]
-lens = [4096, 4096]
-# Batched write submit multiple writes at once
-batch_id = dev.batched_write(offsets, buffers, lens)
-
-# Wait for all in-flight I/O to complete
-dev.wait_iouring(batch_id)
-
-# Single read using io_uring
-buf = bytearray(4096)
-dev.read_uring(offset=0, data=buf, payload_len=5, total_len=4096)
-
-# Batched read submit multiple reads at once
-batch_id = dev.batched_read(offsets, buffers, lens)
-
-# Wait for all in-flight I/O to complete
-dev.wait_iouring(batch_id)
-
-dev.close()
 ```
+
+## MP Adapter Example
+
+To use the MP adapter from `lmcache server`, pass a `raw_block` L2 adapter
+config:
+
+```bash
+lmcache server \
+  --l1-size-gb 10 \
+  --eviction-policy LRU \
+  --l1-align-bytes 4096 \
+  --l2-adapter '{
+    "type": "raw_block",
+    "device_path": "/dev/nvme0n1",
+    "slot_bytes": 1048576,
+    "block_align": 4096,
+    "header_bytes": 4096,
+    "meta_total_bytes": 268435456,
+    "use_odirect": true,
+    "io_engine": "io_uring",
+    "num_store_workers": 2,
+    "num_lookup_workers": 1,
+    "num_load_workers": 4
+  }'
+```
+
+Notes:
+
+- `device_path` should point to an unmounted raw block device or a dedicated
+  file used only by LMCache.
+- With `use_odirect=true`, LMCache MP L1 alignment must be at least
+  `block_align`.
+- Restart recovery uses the metadata checkpoint region on the same device.
+- Raw-block slot reclamation is driven by the shared/global L2 eviction
+  controller or explicit `delete()` calls.
+- `raw_block` remains the adapter type for both supported engines.

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -47,6 +47,19 @@ const O_DIRECT: i32 = libc::O_DIRECT;
 const O_DIRECT: i32 = 0;
 const RING_SIZE: usize = 256;
 
+fn parse_use_iouring(io_engine: Option<String>, use_iouring: bool) -> PyResult<bool> {
+    match io_engine {
+        Some(engine) if !engine.is_empty() => match engine.as_str() {
+            "posix" => Ok(false),
+            "io_uring" => Ok(true),
+            other => Err(PyValueError::new_err(format!(
+                "io_engine must be one of posix, io_uring; got {other}"
+            ))),
+        },
+        _ => Ok(use_iouring),
+    }
+}
+
 ///Per batch tracking for in flight I/O operation
 type BatchTracking = (Arc<AtomicU64>, Arc<Condvar>);
 
@@ -389,7 +402,11 @@ impl RawBlockDevice {
         use_odirect: bool,
         alignment: usize,
         use_iouring: bool,
+        io_engine: Option<String>,
+        iouring_queue_depth: usize,
     ) -> PyResult<Self> {
+        let use_iouring = parse_use_iouring(io_engine, use_iouring)?;
+        let iouring_queue_depth = iouring_queue_depth.max(1);
         let cpath = CString::new(path).map_err(|_| PyValueError::new_err("path contains NUL"))?;
         let mut flags = if writable {
             libc::O_RDWR
@@ -419,7 +436,7 @@ impl RawBlockDevice {
             next_batch_id_opt,
             batch_in_flight_opt,
         ) = if use_iouring {
-            let ring = IoUring::new(RING_SIZE as u32)
+            let ring = IoUring::new(iouring_queue_depth as u32)
                 .map_err(|e| PyRuntimeError::new_err(format!("io_uring init failed: {}", e)))?;
             let ring = Arc::new(Mutex::new(ring));
             let queue = Arc::new(Mutex::new(Vec::<IoSubmission>::new()));
@@ -440,6 +457,7 @@ impl RawBlockDevice {
             let in_flight_count_clone = Arc::clone(&in_flight_count);
             let in_flight_cvar_clone = Arc::clone(&in_flight_cvar);
             let batch_in_flight_clone = Arc::clone(&batch_in_flight);
+            let ring_size = iouring_queue_depth;
 
             // Worker thread that handles io_uring submissions and completions.
             //
@@ -640,7 +658,7 @@ impl RawBlockDevice {
 
                         let mut ring = ring_clone.lock().unwrap();
 
-                        let available = RING_SIZE - ring.submission().len();
+                        let available = ring_size - ring.submission().len();
                         let to_submit_count = std::cmp::min(available, batch_len);
 
                         if to_submit_count < batch_len {
@@ -948,16 +966,35 @@ impl RawBlockDevice {
 impl RawBlockDevice {
     #[new]
     #[pyo3(
-        signature = (path, writable, use_odirect = false, use_iouring = false, alignment = 4096)
+        signature = (
+            path,
+            writable,
+            use_odirect = false,
+            use_iouring = false,
+            alignment = 4096,
+            io_engine = None,
+            iouring_queue_depth = RING_SIZE
+        )
     )]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         path: String,
         writable: bool,
         use_odirect: bool,
         use_iouring: bool,
         alignment: usize,
+        io_engine: Option<String>,
+        iouring_queue_depth: usize,
     ) -> PyResult<Self> {
-        Self::new_internal(path, writable, use_odirect, alignment, use_iouring)
+        Self::new_internal(
+            path,
+            writable,
+            use_odirect,
+            alignment,
+            use_iouring,
+            io_engine,
+            iouring_queue_depth,
+        )
     }
 
     // Expose cached size to Python.

--- a/tests/v1/distributed/conftest.py
+++ b/tests/v1/distributed/conftest.py
@@ -2,3 +2,90 @@
 """
 Shared fixtures for distributed module tests.
 """
+
+# Future
+from __future__ import annotations
+
+# Standard
+from importlib.util import find_spec
+from typing import Any, cast
+import sys
+import types
+
+if find_spec("lmcache.native_storage_ops") is None:
+
+    class Bitmap:
+        """Small Python Bitmap fallback for source-only distributed tests."""
+
+        def __init__(self, size: int, first_n: int = 0) -> None:
+            self._size = int(size)
+            self._bits = {i for i in range(min(int(first_n), self._size))}
+
+        def set(self, index: int) -> None:
+            """Set one bit by index."""
+            index = int(index)
+            if index < 0 or index >= self._size:
+                raise IndexError(index)
+            self._bits.add(index)
+
+        def test(self, index: int) -> bool:
+            """Return whether one bit is set."""
+            return int(index) in self._bits
+
+        def get_indices_list(self) -> list[int]:
+            """Return set bit indices in ascending order."""
+            return sorted(self._bits)
+
+        def popcount(self) -> int:
+            """Return the number of set bits."""
+            return len(self._bits)
+
+        def count_leading_ones(self) -> int:
+            """Return the length of the leading contiguous set-bit prefix."""
+            count = 0
+            while count in self._bits:
+                count += 1
+            return count
+
+        def gather(self, values):
+            """Return values selected by set bit indices."""
+            return [values[i] for i in self.get_indices_list()]
+
+        def __and__(self, other: "Bitmap") -> "Bitmap":
+            size = min(self._size, other._size)
+            result = Bitmap(size)
+            result._bits = {i for i in self._bits & other._bits if i < size}
+            return result
+
+        def __iand__(self, other: "Bitmap") -> "Bitmap":
+            self._bits &= other._bits
+            self._bits = {i for i in self._bits if i < self._size}
+            return self
+
+        def __or__(self, other: "Bitmap") -> "Bitmap":
+            size = max(self._size, other._size)
+            result = Bitmap(size)
+            result._bits = set(self._bits | other._bits)
+            return result
+
+        def __ior__(self, other: "Bitmap") -> "Bitmap":
+            self._size = max(self._size, other._size)
+            self._bits |= other._bits
+            return self
+
+        def __invert__(self) -> "Bitmap":
+            result = Bitmap(self._size)
+            result._bits = set(range(self._size)) - self._bits
+            return result
+
+        def __str__(self) -> str:
+            return "".join("1" if i in self._bits else "0" for i in range(self._size))
+
+    class TTLLock:
+        """Minimal TTLLock fallback for tests that only import the symbol."""
+
+    fallback_module = types.ModuleType("lmcache.native_storage_ops")
+    fallback_module_any = cast(Any, fallback_module)
+    fallback_module_any.Bitmap = Bitmap
+    fallback_module_any.TTLLock = TTLLock
+    sys.modules["lmcache.native_storage_ops"] = fallback_module

--- a/tests/v1/distributed/test_l2_adapter_factory.py
+++ b/tests/v1/distributed/test_l2_adapter_factory.py
@@ -5,6 +5,8 @@ PluginL2AdapterConfig.
 """
 
 # Standard
+import os
+import tempfile
 import types
 
 # Third Party
@@ -21,7 +23,21 @@ from lmcache.v1.distributed.l2_adapters.factory import (
 )
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 from lmcache.v1.distributed.l2_adapters.plugin_l2_adapter import PluginL2AdapterConfig
+from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
+    RawBlockL2AdapterConfig,
+)
 from lmcache.v1.platform import create_event_notifier
+
+
+def _has_raw_block_ext() -> bool:
+    try:
+        # Third Party
+        import lmcache_rust_raw_block_io  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
 
 # =========================================================
 # Helpers
@@ -70,6 +86,16 @@ class TestFactoryRegistry:
         name = get_type_name_for_config(config)
         assert name == "mock"
 
+    def test_raw_block_factory_is_registered(self):
+        config = RawBlockL2AdapterConfig(
+            device_path="/tmp/raw-block-dev",
+            slot_bytes=64 * 1024,
+            use_odirect=False,
+            meta_enable_periodic=False,
+        )
+        name = get_type_name_for_config(config)
+        assert name == "raw_block"
+
     def test_create_mock_via_registry(self):
         """create_l2_adapter_from_registry creates a
         MockL2Adapter."""
@@ -85,6 +111,32 @@ class TestFactoryRegistry:
         adapter = create_l2_adapter_from_registry(config)
         assert isinstance(adapter, MockL2Adapter)
         adapter.close()
+
+    @pytest.mark.skipif(
+        not _has_raw_block_ext(),
+        reason="lmcache_rust_raw_block_io extension not installed",
+    )
+    def test_create_raw_block_via_registry(self):
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
+            RawBlockL2Adapter,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            dev_path = os.path.join(td, "dev.bin")
+            with open(dev_path, "wb") as f:
+                f.truncate(8 * 1024 * 1024)
+
+            config = RawBlockL2AdapterConfig(
+                device_path=dev_path,
+                slot_bytes=64 * 1024,
+                use_odirect=False,
+                meta_total_bytes=1 * 1024 * 1024,
+                meta_enable_periodic=False,
+            )
+            adapter = create_l2_adapter_from_registry(config)
+            assert isinstance(adapter, RawBlockL2Adapter)
+            adapter.close()
 
     def test_duplicate_factory_raises(self):
         """Registering the same factory name twice should

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from unittest.mock import patch
+import os
+import select
+import tempfile
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
+    RawBlockL2Adapter,
+    RawBlockL2AdapterConfig,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+
+
+def _has_ext() -> bool:
+    try:
+        # Third Party
+        import lmcache_rust_raw_block_io  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+requires_raw_block_ext = pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+
+
+class _RecordingListener(L2AdapterListener):
+    def __init__(self):
+        self.stored: list[list[ObjectKey]] = []
+        self.accessed: list[list[ObjectKey]] = []
+        self.deleted: list[list[ObjectKey]] = []
+
+    def on_l2_keys_stored(self, keys: list[ObjectKey]):
+        self.stored.append(list(keys))
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]):
+        self.accessed.append(list(keys))
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]):
+        self.deleted.append(list(keys))
+
+
+class _FailingListener(L2AdapterListener):
+    def on_l2_keys_stored(self, keys: list[ObjectKey]):
+        del keys
+        raise RuntimeError("store listener failed")
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]):
+        raise RuntimeError("access listener failed")
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]):
+        del keys
+        raise RuntimeError("delete listener failed")
+
+
+def _create_object_key(chunk_id: int, model_name: str = "test_model") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name=model_name,
+        kv_rank=0,
+    )
+
+
+def _create_memory_obj(size: int = 1024, fill_value: float = 0.0) -> TensorMemoryObj:
+    raw_data = torch.empty(size, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def _create_complex_memory_obj(
+    size: int = 1024,
+    fill_value: complex = 0j,
+) -> TensorMemoryObj:
+    raw_data = torch.empty(size, dtype=torch.complex64)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.complex64,
+        address=0,
+        phy_size=raw_data.numel() * raw_data.element_size(),
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def _wait_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if events:
+        try:
+            os.eventfd_read(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+def _make_config(
+    device_path: str,
+    *,
+    slot_bytes: int = 64 * 1024,
+    capacity_bytes: int = 0,
+) -> RawBlockL2AdapterConfig:
+    return RawBlockL2AdapterConfig(
+        device_path=device_path,
+        slot_bytes=slot_bytes,
+        capacity_bytes=capacity_bytes,
+        use_odirect=False,
+        block_align=4096,
+        header_bytes=4096,
+        meta_total_bytes=1 * 1024 * 1024,
+        meta_enable_periodic=False,
+        num_store_workers=2,
+        num_lookup_workers=1,
+        num_load_workers=2,
+    )
+
+
+def _config_dict(**overrides) -> dict[str, object]:
+    config: dict[str, object] = {
+        "device_path": "/tmp/raw-block-test-device",
+        "slot_bytes": 64 * 1024,
+        "use_odirect": False,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_raw_block_l2_adapter_config_default_io_engine():
+    config = RawBlockL2AdapterConfig.from_dict(_config_dict())
+
+    assert config.io_engine == "posix"
+
+
+@pytest.mark.parametrize("io_engine", ["posix", "io_uring"])
+def test_raw_block_l2_adapter_config_accepts_io_engine_values(io_engine):
+    config = RawBlockL2AdapterConfig.from_dict(_config_dict(io_engine=io_engine))
+
+    assert config.io_engine == io_engine
+
+
+def test_raw_block_l2_adapter_config_rejects_invalid_io_engine():
+    with pytest.raises(ValueError, match="io_engine"):
+        RawBlockL2AdapterConfig.from_dict(_config_dict(io_engine="uring"))
+
+
+@pytest.mark.parametrize("legacy_key", ["use_iouring", "use_uring"])
+def test_raw_block_l2_adapter_config_legacy_use_uring_maps_to_iouring(legacy_key):
+    config = RawBlockL2AdapterConfig.from_dict(_config_dict(**{legacy_key: True}))
+
+    assert config.io_engine == "io_uring"
+
+
+def test_raw_block_l2_adapter_config_explicit_io_engine_wins_over_legacy_flag():
+    config = RawBlockL2AdapterConfig.from_dict(
+        _config_dict(io_engine="posix", use_iouring=True)
+    )
+
+    assert config.io_engine == "posix"
+
+
+def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
+    with pytest.raises(ValueError, match="iouring_queue_depth"):
+        RawBlockL2AdapterConfig.from_dict(_config_dict(iouring_queue_depth=0))
+
+
+def _run_store(adapter: RawBlockL2Adapter, keys, objects) -> bool:
+    task_id = adapter.submit_store_task(keys, objects)
+    assert _wait_event_fd(adapter.get_store_event_fd())
+    completed = adapter.pop_completed_store_tasks()
+    assert task_id in completed
+    return completed[task_id]
+
+
+def _run_lookup(adapter: RawBlockL2Adapter, keys):
+    task_id = adapter.submit_lookup_and_lock_task(keys)
+    assert _wait_event_fd(adapter.get_lookup_and_lock_event_fd())
+    return task_id, adapter.query_lookup_and_lock_result(task_id)
+
+
+def _run_load(adapter: RawBlockL2Adapter, keys, objects):
+    task_id = adapter.submit_load_task(keys, objects)
+    assert _wait_event_fd(adapter.get_load_event_fd())
+    return task_id, adapter.query_load_result(task_id)
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_store_lookup_load_roundtrip():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        try:
+            key1 = _create_object_key(1)
+            key_miss = _create_object_key(2)
+            key3 = _create_object_key(3)
+            obj1 = _create_memory_obj(fill_value=1.0)
+            obj3 = _create_memory_obj(fill_value=3.0)
+
+            assert _run_store(adapter, [key1, key3], [obj1, obj3]) is True
+
+            lookup_task_id, lookup_bitmap = _run_lookup(
+                adapter,
+                [key1, key_miss, key3],
+            )
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == [0, 2]
+            assert adapter.query_lookup_and_lock_result(lookup_task_id) is None
+
+            load_buffers = [
+                _create_memory_obj(fill_value=0.0),
+                _create_memory_obj(fill_value=0.0),
+                _create_memory_obj(fill_value=0.0),
+            ]
+            load_task_id, load_bitmap = _run_load(
+                adapter,
+                [key1, key_miss, key3],
+                load_buffers,
+            )
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0, 2]
+            assert adapter.query_load_result(load_task_id) is None
+            assert torch.equal(load_buffers[0].tensor, obj1.tensor)
+            assert torch.equal(load_buffers[2].tensor, obj3.tensor)
+            assert torch.count_nonzero(load_buffers[1].tensor) == 0
+
+            adapter.submit_unlock([key1, key_miss, key3])
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_delete_respects_lock_until_unlock():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        try:
+            key = _create_object_key(11)
+            obj = _create_memory_obj(fill_value=11.0)
+            assert _run_store(adapter, [key], [obj]) is True
+
+            _, bitmap = _run_lookup(adapter, [key])
+            assert bitmap is not None
+            assert bitmap.get_indices_list() == [0]
+
+            adapter.delete([key])
+            _, still_present = _run_lookup(adapter, [key])
+            assert still_present is not None
+            assert still_present.get_indices_list() == [0]
+            adapter.submit_unlock([key, key])
+
+            adapter.delete([key])
+            _, after_delete = _run_lookup(adapter, [key])
+            assert after_delete is not None
+            assert after_delete.get_indices_list() == []
+            adapter.submit_unlock([key])
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_uses_global_eviction_accounting():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        slot_bytes = 64 * 1024
+        capacity_bytes = (1 * 1024 * 1024) + slot_bytes
+        adapter = RawBlockL2Adapter(
+            _make_config(
+                dev_path,
+                slot_bytes=slot_bytes,
+                capacity_bytes=capacity_bytes,
+            )
+        )
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+
+        try:
+            key1 = _create_object_key(21)
+            key2 = _create_object_key(22)
+            obj1 = _create_memory_obj(fill_value=21.0)
+            obj2 = _create_memory_obj(fill_value=22.0)
+
+            assert _run_store(adapter, [key1], [obj1]) is True
+            assert _run_store(adapter, [key2], [obj2]) is False
+
+            assert listener.stored == [[key1]]
+            assert listener.deleted == []
+
+            usage = adapter.get_usage()
+            assert usage.total_bytes_used == slot_bytes
+            assert usage.total_capacity_bytes == slot_bytes
+            assert 0.0 < usage.usage_fraction <= 1.0
+            assert adapter.supports_global_eviction is True
+
+            status = adapter.report_status()
+            assert status["is_healthy"] is True
+            assert status["type"] == "RawBlockL2Adapter"
+            assert status["core"]["usable_capacity_bytes"] == slot_bytes
+
+            _, bitmap1 = _run_lookup(adapter, [key1])
+            assert bitmap1 is not None
+            assert bitmap1.get_indices_list() == [0]
+            _, bitmap2 = _run_lookup(adapter, [key2])
+            assert bitmap2 is not None
+            assert bitmap2.get_indices_list() == []
+            adapter.submit_unlock([key1, key2])
+
+            adapter.delete([key1])
+            assert listener.deleted[-1] == [key1]
+            assert adapter.get_usage().total_bytes_used == 0
+
+            assert _run_store(adapter, [key2], [obj2]) is True
+            assert listener.stored[-1] == [key2]
+            _, bitmap_after_delete = _run_lookup(adapter, [key1, key2])
+            assert bitmap_after_delete is not None
+            assert bitmap_after_delete.get_indices_list() == [1]
+            adapter.submit_unlock([key1, key2])
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_does_not_notify_duplicate_store():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+
+        try:
+            key = _create_object_key(25)
+            obj = _create_memory_obj(fill_value=25.0)
+
+            assert _run_store(adapter, [key], [obj]) is True
+            assert _run_store(adapter, [key], [obj]) is True
+
+            assert listener.stored == [[key]]
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_listener_errors_do_not_block_eventfds():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        adapter.register_listener(_FailingListener())
+
+        try:
+            key = _create_object_key(29)
+            obj = _create_memory_obj(fill_value=29.0)
+
+            store_task_id = adapter.submit_store_task([key], [obj])
+            assert _wait_event_fd(adapter.get_store_event_fd())
+            assert adapter.pop_completed_store_tasks()[store_task_id] is True
+
+            load_buffer = _create_memory_obj(fill_value=0.0)
+            load_task_id = adapter.submit_load_task([key], [load_buffer])
+            assert _wait_event_fd(adapter.get_load_event_fd())
+            load_bitmap = adapter.query_load_result(load_task_id)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0]
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_recovery_from_checkpoint():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        config = _make_config(dev_path)
+        key = _create_object_key(31)
+        obj = _create_memory_obj(fill_value=31.0)
+
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            assert _run_store(adapter1, [key], [obj]) is True
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            _, lookup_bitmap = _run_lookup(adapter2, [key])
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == [0]
+
+            load_buffer = _create_memory_obj(fill_value=0.0)
+            _, load_bitmap = _run_load(adapter2, [key], [load_buffer])
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0]
+            assert torch.equal(load_buffer.tensor, obj.tensor)
+            adapter2.submit_unlock([key])
+        finally:
+            adapter2.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_recovers_unknown_checkpoint_dtype():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        config = _make_config(dev_path)
+        key = _create_object_key(35)
+        obj = _create_complex_memory_obj(fill_value=1 + 2j)
+
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            assert _run_store(adapter1, [key], [obj]) is True
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            load_buffer = _create_complex_memory_obj(fill_value=0j)
+            _, load_bitmap = _run_load(adapter2, [key], [load_buffer])
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0]
+            assert load_buffer.metadata.dtype is torch.complex64
+            assert torch.equal(load_buffer.tensor, obj.tensor)
+        finally:
+            adapter2.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        try:
+            keys = [_create_object_key(41), _create_object_key(42)]
+            objects = [_create_memory_obj(), _create_memory_obj()]
+
+            with patch.object(
+                adapter, "_run_lookup_task", side_effect=RuntimeError("lookup failed")
+            ):
+                lookup_task_id = adapter.submit_lookup_and_lock_task(keys)
+                assert _wait_event_fd(adapter.get_lookup_and_lock_event_fd())
+                lookup_bitmap = adapter.query_lookup_and_lock_result(lookup_task_id)
+            assert lookup_bitmap is not None
+            assert str(lookup_bitmap) == "00"
+
+            with patch.object(
+                adapter, "_run_load_task", side_effect=RuntimeError("load failed")
+            ):
+                load_task_id = adapter.submit_load_task(keys, objects)
+                assert _wait_event_fd(adapter.get_load_event_fd())
+                load_bitmap = adapter.query_load_result(load_task_id)
+            assert load_bitmap is not None
+            assert str(load_bitmap) == "00"
+        finally:
+            adapter.close()

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -12,10 +12,14 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.config import EvictionConfig
 from lmcache.v1.distributed.internal_api import L2AdapterListener
 from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
     RawBlockL2Adapter,
     RawBlockL2AdapterConfig,
+)
+from lmcache.v1.distributed.storage_controllers.eviction_controller import (
+    L2AdapterEvictionState,
 )
 from lmcache.v1.memory_management import (
     MemoryFormat,
@@ -68,11 +72,16 @@ class _FailingListener(L2AdapterListener):
         raise RuntimeError("delete listener failed")
 
 
-def _create_object_key(chunk_id: int, model_name: str = "test_model") -> ObjectKey:
+def _create_object_key(
+    chunk_id: int,
+    model_name: str = "test_model",
+    cache_salt: str = "",
+) -> ObjectKey:
     return ObjectKey(
         chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
         model_name=model_name,
         kv_rank=0,
+        cache_salt=cache_salt,
     )
 
 
@@ -399,6 +408,10 @@ def test_raw_block_l2_adapter_listener_errors_do_not_block_eventfds():
             load_bitmap = adapter.query_load_result(load_task_id)
             assert load_bitmap is not None
             assert load_bitmap.get_indices_list() == [0]
+            adapter.delete([key])
+            _, after_delete = _run_lookup(adapter, [key])
+            assert after_delete is not None
+            assert after_delete.get_indices_list() == []
         finally:
             adapter.close()
 
@@ -432,6 +445,74 @@ def test_raw_block_l2_adapter_recovery_from_checkpoint():
             assert load_bitmap.get_indices_list() == [0]
             assert torch.equal(load_buffer.tensor, obj.tensor)
             adapter2.submit_unlock([key])
+        finally:
+            adapter2.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_recovery_seeds_usage_by_cache_salt():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        slot_bytes = 64 * 1024
+        config = _make_config(dev_path, slot_bytes=slot_bytes)
+        key = _create_object_key(33, cache_salt="u1")
+        obj = _create_memory_obj(fill_value=33.0)
+
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            assert _run_store(adapter1, [key], [obj]) is True
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            usage = adapter2.get_usage()
+            assert usage.total_bytes_used == slot_bytes
+            assert dict(usage.bytes_by_cache_salt) == {"u1": slot_bytes}
+
+            adapter2.delete([key])
+            usage = adapter2.get_usage()
+            assert usage.total_bytes_used == 0
+            assert dict(usage.bytes_by_cache_salt) == {}
+        finally:
+            adapter2.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_recovered_keys_seed_l2_eviction_state():
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        config = _make_config(dev_path)
+        key = _create_object_key(34)
+        obj = _create_memory_obj(fill_value=34.0)
+
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            assert _run_store(adapter1, [key], [obj]) is True
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            state = L2AdapterEvictionState(
+                adapter2,
+                EvictionConfig(eviction_policy="LRU", eviction_ratio=1.0),
+            )
+            assert state.eviction_policy.get_eviction_candidates(1) == [key]
+
+            actions = state.eviction_policy.get_eviction_actions(1.0)
+            assert len(actions) == 1
+            assert actions[0].keys == [key]
+            adapter2.delete(actions[0].keys)
+
+            assert adapter2.get_usage().total_bytes_used == 0
+            assert state.eviction_policy.get_eviction_candidates(1) == []
         finally:
             adapter2.close()
 

--- a/tests/v1/storage_backend/test_raw_block_key_codec.py
+++ b/tests/v1/storage_backend/test_raw_block_key_codec.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.storage_backend.raw_block.key_codec import (
+    decode_object_key,
+    object_key_to_string,
+)
+
+
+def test_raw_block_object_key_codec_preserves_sep_literal() -> None:
+    """Object-key encoding must not treat literal -SEP- as a slash escape."""
+    key = ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(123),
+        model_name="my-SEP-model",
+        kv_rank=1,
+        cache_salt="tenant",
+    )
+
+    decoded = decode_object_key(object_key_to_string(key))
+
+    assert decoded == key
+
+
+def test_raw_block_object_key_codec_roundtrips_slash_and_sep() -> None:
+    """Object-key encoding must round-trip slashes and literal -SEP- strings."""
+    key = ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(456),
+        model_name="org/model-SEP-name",
+        kv_rank=2,
+    )
+
+    encoded = object_key_to_string(key)
+    decoded = decode_object_key(encoded)
+
+    assert "%2F" in encoded
+    assert decoded == key

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -22,7 +22,12 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import AdHocMemoryAllocator, MemoryFormat
+from lmcache.v1.memory_management import (
+    AdHocMemoryAllocator,
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
@@ -30,7 +35,11 @@ from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
     _DEFAULT_META_VERSION,
     RustRawBlockBackend,
 )
-from lmcache.v1.storage_backend.raw_block import RawBlockCore, RawBlockCoreConfig
+from lmcache.v1.storage_backend.raw_block import (
+    RawBlockCore,
+    RawBlockCoreConfig,
+    RawBlockKeySpec,
+)
 
 
 def _has_ext() -> bool:
@@ -41,6 +50,75 @@ def _has_ext() -> bool:
         return True
     except Exception:
         return False
+
+
+class _FakeRawBlockDevice:
+    def __init__(self, path: str, *, size_bytes: int, **kwargs):
+        del path, kwargs
+        self._data = bytearray(size_bytes)
+
+    def size_bytes(self):
+        return len(self._data)
+
+    def pread_into(self, offset, out, payload_len, total_len=None):
+        del total_len
+        out[:payload_len] = self._data[offset : offset + payload_len]
+
+    def pwrite_from_buffer(self, offset, data, payload_len=None, total_len=None):
+        del total_len
+        length = len(data) if payload_len is None else payload_len
+        self._data[offset : offset + length] = bytes(memoryview(data)[:length])
+
+    def close(self):
+        return None
+
+
+def _install_fake_raw_block_device(monkeypatch, *, size_bytes: int = 64 * 1024):
+    def create_fake_device(path: str, **kwargs):
+        return _FakeRawBlockDevice(path, size_bytes=size_bytes, **kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "lmcache_rust_raw_block_io",
+        types.SimpleNamespace(RawBlockDevice=create_fake_device),
+    )
+
+
+def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
+    return RawBlockCore(
+        RawBlockCoreConfig(
+            device_path="/tmp/raw-block-boundary-test",
+            capacity_bytes=64 * 1024,
+            block_align=4096,
+            header_bytes=4096,
+            slot_bytes=8192,
+            use_odirect=use_odirect,
+            enable_zero_copy=True,
+            meta_total_bytes=16 * 1024,
+            meta_magic=b"LMCIDX01",
+            meta_version=1,
+            meta_checkpoint_interval_sec=60,
+            meta_idle_quiet_ms=100,
+            meta_enable_periodic=False,
+            meta_verify_on_load=True,
+            io_engine="posix",
+            iouring_queue_depth=256,
+        ),
+        key_namespace="object",
+    )
+
+
+def _make_byte_obj(size: int) -> TensorMemoryObj:
+    raw_data = torch.empty(size, dtype=torch.uint8)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.uint8,
+        address=0,
+        phy_size=size,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
 
 
 def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
@@ -101,6 +179,52 @@ def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
                 "iouring_queue_depth": 512,
             }
         ]
+    finally:
+        core.close()
+
+
+def test_raw_block_core_non_odirect_rejects_payload_over_slot_capacity(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False)
+    try:
+        payload_capacity = core.slot_bytes - core.header_bytes
+        exact_key = RawBlockKeySpec(encoded="exact", slot_identity=1)
+        too_large_key = RawBlockKeySpec(encoded="too-large", slot_identity=2)
+
+        exact = core.put_many([exact_key], [_make_byte_obj(payload_capacity)])
+        assert exact.results == [True]
+        assert core.contains_key("exact") is True
+
+        too_large = core.put_many(
+            [too_large_key],
+            [_make_byte_obj(payload_capacity + 1)],
+        )
+        assert too_large.results == [False]
+        assert core.contains_key("too-large") is False
+    finally:
+        core.close()
+
+
+def test_raw_block_core_odirect_prepare_payload_boundaries(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=True)
+    try:
+        payload_capacity = core.slot_bytes - core.header_bytes
+
+        _, payload_len, total_len = core._prepare_write_payload(
+            _make_byte_obj(payload_capacity)
+        )
+        assert payload_len == payload_capacity
+        assert total_len == payload_capacity
+
+        _, payload_len, total_len = core._prepare_write_payload(
+            _make_byte_obj(payload_capacity - 1)
+        )
+        assert payload_len == payload_capacity - 1
+        assert total_len == payload_capacity
+
+        with pytest.raises(RuntimeError, match="slot capacity"):
+            core._prepare_write_payload(_make_byte_obj(payload_capacity + 1))
     finally:
         core.close()
 

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -9,9 +9,11 @@ from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import struct
+import sys
 import tempfile
 import threading
 import time
+import types
 
 # Third Party
 import pytest
@@ -28,6 +30,7 @@ from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
     _DEFAULT_META_VERSION,
     RustRawBlockBackend,
 )
+from lmcache.v1.storage_backend.raw_block import RawBlockCore, RawBlockCoreConfig
 
 
 def _has_ext() -> bool:
@@ -38,6 +41,99 @@ def _has_ext() -> bool:
         return True
     except Exception:
         return False
+
+
+def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class FakeRawBlockDevice:
+        def __init__(self, path: str, **kwargs):
+            calls.append({"path": path, **kwargs})
+
+        def size_bytes(self):
+            return 2 * 1024 * 1024
+
+        def pread_into(self, offset, out, payload_len, total_len=None):
+            del offset, total_len
+            out[:payload_len] = b"\x00" * payload_len
+
+        def pwrite_from_buffer(self, offset, data, payload_len=None, total_len=None):
+            del offset, data, payload_len, total_len
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "lmcache_rust_raw_block_io",
+        types.SimpleNamespace(RawBlockDevice=FakeRawBlockDevice),
+    )
+
+    core = RawBlockCore(
+        RawBlockCoreConfig(
+            device_path="/tmp/raw-block-engine-test",
+            capacity_bytes=0,
+            block_align=4096,
+            header_bytes=4096,
+            slot_bytes=8192,
+            use_odirect=False,
+            enable_zero_copy=True,
+            meta_total_bytes=16 * 1024,
+            meta_magic=b"LMCIDX01",
+            meta_version=1,
+            meta_checkpoint_interval_sec=60,
+            meta_idle_quiet_ms=100,
+            meta_enable_periodic=False,
+            meta_verify_on_load=True,
+            io_engine="io_uring",
+            iouring_queue_depth=512,
+        ),
+        key_namespace="legacy",
+    )
+    try:
+        assert calls == [
+            {
+                "path": "/tmp/raw-block-engine-test",
+                "writable": True,
+                "use_odirect": False,
+                "alignment": 4096,
+                "io_engine": "io_uring",
+                "iouring_queue_depth": 512,
+            }
+        ]
+    finally:
+        core.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+@pytest.mark.parametrize("io_engine", ["posix", "io_uring"])
+def test_raw_block_device_all_io_engines_roundtrip_on_tmp_file(io_engine):
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as td:
+        dev_path = os.path.join(td, f"raw-block-{io_engine}.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(1024 * 1024)
+
+        dev = RawBlockDevice(
+            dev_path,
+            writable=True,
+            use_odirect=False,
+            alignment=4096,
+            io_engine=io_engine,
+        )
+
+        try:
+            payload = bytearray(f"raw-block-{io_engine}".encode())
+            out = bytearray(len(payload))
+            dev.pwrite_from_buffer(4096, payload, len(payload), len(payload))
+            dev.pread_into(4096, out, len(out), len(out))
+            assert out == payload
+        finally:
+            dev.close()
 
 
 @pytest.fixture
@@ -249,6 +345,174 @@ def test_rust_raw_block_backend_batched_get_non_blocking_prefix_stop(
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
+def test_rust_raw_block_backend_pin_and_contains_are_idempotent(
+    memory_allocator, loop_in_thread
+):
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_pin_idempotent",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        try:
+            key = CacheEngineKey("test_model", 1, 0, 4242, torch.bfloat16)
+            allocator = AdHocMemoryAllocator(device="cpu")
+            obj = allocator.allocate(
+                [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+            )
+            assert obj is not None
+
+            futs = backend.batched_submit_put_task([key], [obj])
+            assert futs is not None
+            futs[0].result(timeout=10)
+            obj.ref_count_down()
+
+            encoded_key = key.to_string()
+            assert backend.contains(key, pin=True) is True
+            assert backend.lock_refcount(encoded_key) == 1
+            assert backend.contains(key, pin=True) is True
+            assert backend.lock_refcount(encoded_key) == 1
+            assert backend.pin(key) is True
+            assert backend.lock_refcount(encoded_key) == 1
+
+            assert backend.unpin(key) is True
+            assert backend.lock_refcount(encoded_key) == 0
+            assert backend.unpin(key) is True
+            assert backend.lock_refcount(encoded_key) == 0
+
+            barrier = threading.Barrier(8)
+            pin_results: list[bool] = []
+            result_lock = threading.Lock()
+
+            def pin_concurrently() -> None:
+                barrier.wait(timeout=5)
+                pinned = backend.pin(key)
+                with result_lock:
+                    pin_results.append(pinned)
+
+            threads = [
+                threading.Thread(target=pin_concurrently, daemon=True) for _ in range(8)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=5)
+
+            assert pin_results == [True] * 8
+            assert backend.lock_refcount(encoded_key) == 1
+
+            assert backend.unpin(key) is True
+            assert backend.lock_refcount(encoded_key) == 0
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_close_is_thread_safe(memory_allocator, loop_in_thread):
+    """Concurrent close calls should not double-clean raw-block resources."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_concurrent_close",
+        )
+        config.storage_plugins = []
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+
+        errors: list[BaseException] = []
+        errors_lock = threading.Lock()
+
+        def close_backend() -> None:
+            try:
+                backend.close()
+            except BaseException as e:
+                with errors_lock:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=close_backend) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert errors == []
+        backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
 def test_rust_raw_block_backend_batched_get_resets_inflight_on_rawdev_error(
     memory_allocator, loop_in_thread
 ):
@@ -308,10 +572,12 @@ def test_rust_raw_block_backend_batched_get_resets_inflight_on_rawdev_error(
             futs[0].result(timeout=10)
             obj.ref_count_down()
 
-            with patch.object(backend, "_rawdev", side_effect=RuntimeError("boom")):
+            with patch.object(
+                backend._core, "_rawdev", side_effect=RuntimeError("boom")
+            ):
                 with pytest.raises(RuntimeError, match="boom"):
                     backend.get_blocking(key)
-            assert backend._inflight_io_count == 0
+            assert backend.inflight_io_count() == 0
         finally:
             backend.close()
 
@@ -381,7 +647,7 @@ def test_rust_raw_block_backend_batched_get_handles_allocator_exhaustion(
             with patch.object(local_cpu, "allocate", return_value=None):
                 assert backend.get_blocking(key) is None
                 assert backend.batched_get_blocking([key]) == [None]
-            assert backend._inflight_io_count == 0
+            assert backend.inflight_io_count() == 0
         finally:
             backend.close()
 
@@ -459,12 +725,12 @@ def test_rust_raw_block_backend_batched_get_releases_allocation_on_read_error(
             raw_dev = MagicMock()
             raw_dev.pread_into.side_effect = OSError("read failed")
             with patch.object(local_cpu, "allocate", return_value=leaked_obj):
-                with patch.object(backend, "_rawdev", return_value=raw_dev):
+                with patch.object(backend._core, "_rawdev", return_value=raw_dev):
                     with pytest.raises(OSError, match="read failed"):
                         backend.get_blocking(key)
 
             assert leaked_obj.get_ref_count() == 0
-            assert backend._inflight_io_count == 0
+            assert backend.inflight_io_count() == 0
         finally:
             backend.close()
 
@@ -555,13 +821,13 @@ def test_rust_raw_block_backend_batched_get_releases_loaded_prefix_on_read_error
             with patch.object(
                 local_cpu, "allocate", side_effect=[loaded_obj, failed_obj]
             ):
-                with patch.object(backend, "_rawdev", return_value=raw_dev):
+                with patch.object(backend._core, "_rawdev", return_value=raw_dev):
                     with pytest.raises(OSError, match="read failed"):
                         backend.batched_get_blocking([key1, key2])
 
             assert loaded_obj.get_ref_count() == 0
             assert failed_obj.get_ref_count() == 0
-            assert backend._inflight_io_count == 0
+            assert backend.inflight_io_count() == 0
         finally:
             backend.close()
 
@@ -569,8 +835,8 @@ def test_rust_raw_block_backend_batched_get_releases_loaded_prefix_on_read_error
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
-def test_rust_raw_block_backend_eviction_lru(memory_allocator, loop_in_thread):
-    """Test LRU eviction when capacity is exceeded."""
+def test_rust_raw_block_backend_rejects_when_full(memory_allocator, loop_in_thread):
+    """Test that raw-block writes fail when no slot has been freed."""
     with tempfile.TemporaryDirectory() as td:
         dev_path = os.path.join(td, "dev.bin")
         with open(dev_path, "wb") as f:
@@ -646,17 +912,15 @@ def test_rust_raw_block_backend_eviction_lru(memory_allocator, loop_in_thread):
             f1.result(timeout=10)
             f2.result(timeout=10)
 
-            # Touch k1 so k2 becomes LRU
             assert backend.get_blocking(k1) is not None
 
             f3 = backend.batched_submit_put_task([k3], [o3])[0]
-            f3.result(timeout=10)
+            with pytest.raises(RuntimeError, match="Failed to persist raw-block key"):
+                f3.result(timeout=10)
 
-            # k2 should be evicted
-            assert backend.contains(k2) is False
-            assert backend.get_blocking(k2) is None
             assert backend.get_blocking(k1) is not None
-            assert backend.get_blocking(k3) is not None
+            assert backend.get_blocking(k2) is not None
+            assert backend.contains(k3) is False
         finally:
             backend.close()
 
@@ -799,10 +1063,9 @@ def test_rust_raw_block_backend_data_offsets_start_after_metadata(
             assert futs is not None
             futs[0].result(timeout=10)
 
-            with backend._lock:
-                entry = backend._index.get(key)
-                assert entry is not None
-                assert entry.offset >= 8 * 1024 * 1024
+            entry_offset = backend.entry_offset(key)
+            assert entry_offset is not None
+            assert entry_offset >= 8 * 1024 * 1024
         finally:
             backend.close()
 
@@ -872,7 +1135,7 @@ def test_rust_raw_block_backend_ignores_torn_newer_checkpoint(
             fut = backend1.batched_submit_put_task([key], [obj])[0]
             fut.result(timeout=10)
         finally:
-            torn_offset = backend1._meta_container_offsets()[1]
+            torn_offset = backend1.metadata_container_offsets()[1]
             backend1.close()
 
         # Corrupt the newer checkpoint copy with invalid CRC.
@@ -955,10 +1218,10 @@ def test_rust_raw_block_backend_skips_invalid_checkpoint_entries(
         try:
             entries = {}
             for chunk_hash, (offset, size) in {
-                1: (backend._data_base_offset - backend.slot_bytes, 1024),
-                2: (backend._data_base_offset + 1, 1024),
+                1: (backend.data_base_offset - backend.slot_bytes, 1024),
+                2: (backend.data_base_offset + 1, 1024),
                 3: (
-                    backend._data_base_offset,
+                    backend.data_base_offset,
                     backend.slot_bytes - backend.header_bytes + 1,
                 ),
             }.items():
@@ -972,7 +1235,7 @@ def test_rust_raw_block_backend_skips_invalid_checkpoint_entries(
                     "cached_positions": None,
                 }
 
-            applied = backend._apply_loaded_state(
+            applied = backend.apply_loaded_state(
                 {
                     "version": 1,
                     "device_path": dev_path,
@@ -983,15 +1246,104 @@ def test_rust_raw_block_backend_skips_invalid_checkpoint_entries(
                     "meta_total_bytes": backend.meta_total_bytes,
                     "meta_magic": backend.meta_magic_text,
                     "meta_version": backend.meta_version,
-                    "data_base_offset": backend._data_base_offset,
+                    "data_base_offset": backend.data_base_offset,
                     "next_slot": 0,
                     "free_slots": [],
-                    "lru_keys": [],
                     "entries": entries,
                 }
             )
             assert applied is True
-            assert backend._index == {}
+            assert backend.indexed_key_count() == 0
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_recovers_legacy_key_dtype(
+    memory_allocator, loop_in_thread
+):
+    """Checkpoint recovery should fall back to dtype encoded in legacy keys."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        base_cfg = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_legacy_dtype",
+        )
+        base_cfg.storage_plugins = []
+        base_cfg.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.slot_bytes": 1 * 1024 * 1024,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+            "rust_raw_block.meta_verify_on_load": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=base_cfg,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend = RustRawBlockBackend(
+            config=base_cfg,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        try:
+            key = CacheEngineKey("test_model", 1, 0, 99, torch.bfloat16)
+            applied = backend.apply_loaded_state(
+                {
+                    "version": 1,
+                    "device_path": dev_path,
+                    "capacity_bytes": backend.capacity_bytes,
+                    "block_align": backend.block_align,
+                    "header_bytes": backend.header_bytes,
+                    "slot_bytes": backend.slot_bytes,
+                    "meta_total_bytes": backend.meta_total_bytes,
+                    "meta_magic": backend.meta_magic_text,
+                    "meta_version": backend.meta_version,
+                    "data_base_offset": backend.data_base_offset,
+                    "next_slot": 1,
+                    "free_slots": [],
+                    # Older checkpoints may include this key; recovery ignores it.
+                    "lru_keys": [key.to_string()],
+                    "entries": {
+                        key.to_string(): {
+                            "offset": backend.data_base_offset,
+                            "size": 1024,
+                            "shape": [512],
+                            "dtype": "torch.bfloat16",
+                            "fmt": MemoryFormat.KV_2LTD.name,
+                            "cached_positions": None,
+                        }
+                    },
+                }
+            )
+
+            assert applied is True
+            loaded = backend.batched_get_blocking([key])
+            assert loaded[0] is not None
+            assert loaded[0].metadata.dtype is torch.bfloat16
         finally:
             backend.close()
 
@@ -1131,7 +1483,7 @@ def test_rust_raw_block_backend_tp4_comprehensive_io(memory_allocator, loop_in_t
         device_paths = [os.path.join(td, f"device{i}.bin") for i in range(TP)]
         for p in device_paths:
             with open(p, "wb") as f:
-                f.truncate(512 * 1024 * 1024)
+                f.truncate(1024 * 1024 * 1024)
 
         config = LMCacheEngineConfig.from_defaults(
             chunk_size=256,
@@ -1533,146 +1885,54 @@ def test_rust_raw_block_backend_uring_put_get_roundtrip(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
 def test_rust_raw_block_backend_close_with_inflight(memory_allocator, loop_in_thread):
-    """Test that closing the backend while writes are queued / inflight
-    is handled gracefully (uring)."""
+    """Test that RawBlockDevice close handles queued / inflight io_uring writes."""
+    del memory_allocator, loop_in_thread
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
     NUM_OPS = 128
 
     with tempfile.TemporaryDirectory() as td:
         dev_path = os.path.join(td, "dev.bin")
         with open(dev_path, "wb") as f:
-            f.truncate(1024 * 1024 * 1024)  # 1G
+            f.truncate(16 * 1024 * 1024)
 
-        config = LMCacheEngineConfig.from_defaults(
-            chunk_size=256,
-            local_cpu=True,
-            max_local_cpu_size=1,
-            lmcache_instance_id="test_rust_raw_block_uring",
+        writer = RawBlockDevice(
+            dev_path,
+            writable=True,
+            use_odirect=False,
+            alignment=4096,
+            io_engine="io_uring",
         )
-        config.storage_plugins = []
-        config.extra_config = {
-            "rust_raw_block.device_path": dev_path,
-            "rust_raw_block.block_align": 4096,
-            "rust_raw_block.header_bytes": 4096,
-            "rust_raw_block.use_uring": True,
-            "rust_raw_block.use_odirect": True,
-        }
-        metadata = LMCacheMetadata(
-            model_name="test_model",
-            world_size=1,
-            local_world_size=1,
-            worker_id=0,
-            local_worker_id=0,
-            kv_dtype=torch.bfloat16,
-            kv_shape=(4, 2, 256, 8, 128),
-            chunk_size=256,
+        payload_len = 4096
+        offsets: list[int] = []
+        buffers: list[bytearray] = []
+        total_lens: list[int] = []
+
+        for i in range(NUM_OPS):
+            payload = bytearray([i % 251]) * payload_len
+            offsets.append(i * payload_len)
+            buffers.append(payload)
+            total_lens.append(payload_len)
+
+        writer.batched_write(offsets, buffers, total_lens)
+        time.sleep(0.001)
+        writer.close()
+
+        reader = RawBlockDevice(
+            dev_path,
+            writable=False,
+            use_odirect=False,
+            alignment=4096,
+            io_engine="posix",
         )
-
-        local_cpu = LocalCPUBackend(
-            config=config,
-            metadata=metadata,
-            dst_device="cpu",
-        )
-        backend = RustRawBlockBackend(
-            config=config,
-            metadata=metadata,
-            local_cpu_backend=local_cpu,
-            loop=loop_in_thread,
-            dst_device="cpu",
-        )
-
-        # Dummy raw that simulates few operations.
-        class DummyRaw:
-            def __init__(self):
-                self._inner = backend._rawdev()
-
-            def batched_write(self, offsets, buffers, total_lens):
-                return self._inner.batched_write(offsets, buffers, total_lens)
-
-            def read_uring(self, offset, data, payload_len, total_len):
-                return self._inner.read_uring(offset, data, payload_len, total_len)
-
-            def wait_iouring(self, batch_id):
-                self._inner.wait_iouring(batch_id)
-
-            def __getattr__(self, name):
-                return getattr(self._inner, name)
-
-            def close(self):
-                self._inner.close()
-
-        backend._raw = DummyRaw()
-
         try:
-            allocator = local_cpu.memory_allocator
-
-            # Create keys and memory objects with unique data patterns
-            keys = []
-            objs = []
-            expected_data = []
-            offsets = []
-            buffers = []
-            total_lens = []
-
-            for i in range(NUM_OPS):
-                key = CacheEngineKey("test_model", 1, 0, i, torch.bfloat16)
-                keys.append(key)
-
-                obj = allocator.allocate(
-                    [torch.Size([2, 16, 8, 128])],
-                    [torch.bfloat16],
-                    fmt=MemoryFormat.KV_T2D,
-                )
-                assert obj is not None
-                assert obj.tensor is not None
-
-                obj.tensor.fill_(float(i + 1))
-                expected_data.append(bytes(obj.byte_array))
-                objs.append(obj)
-
-                offset = i * len(obj.byte_array)
-                total_len = len(obj.byte_array)
-                buf = obj.byte_array
-                offsets.append(offset)
-                buffers.append(buf)
-                total_lens.append(total_len)
-            backend._raw.batched_write(offsets, buffers, total_lens)
-            time.sleep(0.001)
-            # close while writes may still be in progress.
-            backend.close()
-
-            backend = RustRawBlockBackend(
-                config=config,
-                metadata=metadata,
-                local_cpu_backend=local_cpu,
-                loop=loop_in_thread,
-                dst_device="cpu",
-            )
-            # Read back and verify data integrity
-            for i, key in enumerate(keys):
-                obj = allocator.allocate(
-                    [torch.Size([2, 16, 8, 128])],
-                    [torch.bfloat16],
-                    fmt=MemoryFormat.KV_T2D,
-                )
-                assert obj is not None
-                assert obj.tensor is not None
-
-                offset = i * len(obj.byte_array)
-                total_len = len(obj.byte_array)
-                buf = obj.byte_array
-                backend._raw.read_uring(offset, buf, total_len, total_len)
-                actual_data = bytes(obj.byte_array)
-                assert actual_data == expected_data[i], (
-                    f"Data mismatch for key {i}: "
-                    f"expected first bytes {expected_data[i][:16]}, "
-                    f"got {actual_data[:16]}"
-                )
-
+            for i, expected in enumerate(buffers):
+                actual = bytearray(payload_len)
+                reader.pread_into(i * payload_len, actual, payload_len, payload_len)
+                assert actual == expected
         finally:
-            try:
-                backend.close()
-            except Exception:
-                pass
+            reader.close()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION

This PR adds multiprocess `raw_block` L2 adapter support without changing the MP request flow.

It extracts a shared `RawBlockCore` from the original `RustRawBlockBackend` and reuses the existing raw-device Rust I/O path and on-device metadata/checkpoint format, adds a built-in `RawBlockL2Adapter` for `--l2-adapter
  '{"type":"raw_block", ...}'`, and rewires the non-MP backend to the shared core while preserving the existing non-MP prefix semantics.

  Concretely, this PR:
  - adds `RawBlockCore` and shared key codec under `lmcache/v1/storage_backend/raw_block/`
  - adds `RawBlockL2Adapter` plus config/factory registration for MP mode
  - keeps restart recovery semantics and locked-entry handling inside the shared core
  - preserves plain raw-block behavior only: no FDP, no placement hints, no NVMe control path
  - updates MP/raw-block/operator docs and adds targeted tests for the adapter, factory, and non-MP wrapper

  **Notes for reviewers**:

  This is intentionally the minimum MP integration cut for raw-block:

  Validation:
  - Focused regression/unit tests:
    `python -m pytest -q tests/v1/distributed/test_mock_l2_adapter.py tests/v1/distributed/test_l2_adapter_factory.py tests/v1/distributed/test_raw_block_l2_adapter.py tests/v1/distributed/test_native_connector_l2_adapter.py`
    Result: `170 passed, 67 warnings`
  - MP e2e on raw block:
    Model: `Qwen/Qwen2.5-14B-Instruct`
    vLLM: `0.19.1`
    TP: `2`
    L2: `raw_block` on `/dev/nvme5n1p1`
    Store policy: `skip_l1`
    Benchmark: `benchmarks/long_doc_qa/long_doc_qa.py`
    Result: warmup `6/6` success, query `6/6` success
    Warmup mean TTFT: `0.555s`
    Warmup round time: `5.317s`
    Query mean TTFT: `1.215s`
    Query round time: `7.051s` ( It seems we have bunch of room to optimize this path)
    L2 evidence: LMCache logged `78/78 prefix hits (0 L1, 78 L2)` on the query-round prefetches, and final adapter status reported `indexed_key_count=508` on `/dev/nvme5n1p1`
  - For the local vLLM `0.19.1` validation above, the connector was launched with `kv_connector_extra_config={"lmcache.mp.port":6555}`

  This benchmark was used as a functional validation of MP raw-block store/lookup/load under a larger model, not as a tuned performance claim. The query round successfully came from L2, but this particular configuration is not yet
  optimized for lower TTFT than the warmup round.

  **If applicable**:

  - [x] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a new durable raw-device storage path and refactors the existing raw-block backend onto a new shared core, affecting persistence/recovery, eviction/locking semantics, and low-level I/O behavior.
> 
> **Overview**
> Adds a built-in MP `raw_block` L2 adapter that persists objects into fixed-size slots on a raw device/file, with async store/lookup/load via worker pools + eventfds and listener notifications (including internal slot-recycle deletions).
> 
> Extracts the raw-block durability logic into a shared `RawBlockCore` (device I/O, slot allocation/LRU, lock refcounts, checkpoints/recovery, key encoding) and rewires the legacy `RustRawBlockBackend` to use this core while preserving its prefix-hit semantics.
> 
> Extends `L2AdapterListener` callbacks to optionally carry `object_sizes`, updates eviction listener plumbing and tests accordingly, and adds docs/operator guidance plus new unit tests for the adapter, key codec, and factory registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468947d92607cf8e24dbc01a16294432a96d1f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->