### PR TITLE
[Docs] Replace removed Qwen3-8B-Instruct in quickstart

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -54,7 +54,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
             .. code-block:: bash
 
-               vllm serve Qwen/Qwen3-8B-Instruct \
+               vllm serve Qwen/Qwen3-8B \
                    --port 8000 --kv-transfer-config \
                    '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
 
@@ -68,7 +68,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
                curl http://localhost:8000/v1/completions \
                  -H "Content-Type: application/json" \
                  -d '{
-                   "model": "Qwen/Qwen3-8B-Instruct",
+                   "model": "Qwen/Qwen3-8B",
                    "prompt": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts",
                    "max_tokens": 100,
                    "temperature": 0.7
@@ -81,7 +81,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
                curl http://localhost:8000/v1/completions \
                  -H "Content-Type: application/json" \
                  -d '{
-                   "model": "Qwen/Qwen3-8B-Instruct",
+                   "model": "Qwen/Qwen3-8B",
                    "prompt": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts (MoE) models",
                    "max_tokens": 100,
                    "temperature": 0.7
@@ -123,7 +123,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
                # The chunk size here is only for illustration purpose, use default one (256) later
                LMCACHE_CHUNK_SIZE=8 \
-               vllm serve Qwen/Qwen3-8B-Instruct \
+               vllm serve Qwen/Qwen3-8B \
                    --port 8000 --kv-transfer-config \
                    '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'
 
@@ -154,7 +154,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
                curl http://localhost:8000/v1/completions \
                  -H "Content-Type: application/json" \
                  -d '{
-                   "model": "Qwen/Qwen3-8B-Instruct",
+                   "model": "Qwen/Qwen3-8B",
                    "prompt": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts",
                    "max_tokens": 100,
                    "temperature": 0.7
@@ -167,7 +167,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
                curl http://localhost:8000/v1/completions \
                  -H "Content-Type: application/json" \
                  -d '{
-                   "model": "Qwen/Qwen3-8B-Instruct",
+                   "model": "Qwen/Qwen3-8B",
                    "prompt": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts (MoE) models",
                    "max_tokens": 100,
                    "temperature": 0.7
@@ -221,7 +221,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
          export LMCACHE_CONFIG_FILE=$PWD/lmc_config.yaml
 
          python -m sglang.launch_server \
-           --model-path Qwen/Qwen3-14B \
+           --model-path Qwen/Qwen3-8B \
            --host 0.0.0.0 \
            --port 30000 \
            --enable-lmcache
@@ -239,7 +239,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
          curl http://localhost:30000/v1/chat/completions \
            -H "Content-Type: application/json" \
            -d '{
-             "model": "Qwen/Qwen3-14B",
+             "model": "Qwen/Qwen3-8B",
              "messages": [{"role": "user", "content": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts"}],
              "max_tokens": 100,
              "temperature": 0.7
@@ -252,7 +252,7 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
          curl http://localhost:30000/v1/chat/completions \
            -H "Content-Type: application/json" \
            -d '{
-             "model": "Qwen/Qwen3-14B",
+             "model": "Qwen/Qwen3-8B",
              "messages": [{"role": "user", "content": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts (MoE) models"}],
              "max_tokens": 100,
              "temperature": 0.7


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The quickstart guide still references `Qwen/Qwen3-8B-Instruct` in the vLLM launch command and sample completion requests, but that model is no longer available. This PR updates those examples to use `Qwen/Qwen3-8B` instead so the quickstart remains runnable end to end.

```bash
LMCACHE_CHUNK_SIZE=8 \
vllm serve Qwen/Qwen3-8B-Instruct \
    --port 8000 --kv-transfer-config \
    '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}'

# error log
(APIServer pid=2502393) Traceback (most recent call last):
(APIServer pid=2502393)   File "/root/seven/lmcache/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_http.py", line 761, in hf_raise_for_status
(APIServer pid=2502393)     response.raise_for_status()
(APIServer pid=2502393)   File "/root/seven/lmcache/.venv/lib/python3.12/site-packages/httpx/_models.py", line 829, in raise_for_status
(APIServer pid=2502393)     raise HTTPStatusError(message, request=request, response=self)
(APIServer pid=2502393) httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://huggingface.co/Qwen/Qwen3-8B-Instruct/resolve/main/config.json'
(APIServer pid=2502393) For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
```

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates example model names; no runtime code paths are affected.
> 
> **Overview**
> Updates `docs/source/getting_started/quickstart.rst` to replace all quickstart commands and sample requests that referenced the removed `Qwen/Qwen3-8B-Instruct` (and the SGLang example’s `Qwen/Qwen3-14B`) with `Qwen/Qwen3-8B`, keeping the guide runnable end-to-end.
> 
> Also fixes a minor formatting issue in the “Next Steps” list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc44adbcfa2f76fc3ebe80804bb9010af8bbf82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->