### PR TITLE
[CI][fix] use existing NGC base image tags for cu12.9 and cu13.0 builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -572,7 +572,7 @@ jobs:
             - name: Build lmcache/vllm-openai container image (cu12.9)
               run: |
                 docker build \
-                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
                 --build-arg CUDA_VERSION=12.9 \
                 --target image-release \
                 --tag lmcache/vllm-openai:latest --tag lmcache/vllm-openai:${{ env.LATEST_TAG }} \
@@ -607,7 +607,7 @@ jobs:
             - name: Build lmcache/standalone container image (cu12.9)
               run: |
                 docker build \
-                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
                 --build-arg CUDA_VERSION=12.9 \
                 --target lmcache-final \
                 --tag lmcache/standalone:latest --tag lmcache/standalone:${{ env.LATEST_TAG }} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@
 
 ARG CUDA_VERSION=12.9
 ARG UBUNTU_VERSION=24.04
-ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+ARG NGC_VERSION=25.05
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:${NGC_VERSION}-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
 # Prepare basic build environment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 
 ARG CUDA_VERSION=12.9
 ARG UBUNTU_VERSION=24.04
-ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
 # Prepare basic build environment

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -3,7 +3,8 @@
 
 ARG CUDA_VERSION=12.9
 ARG UBUNTU_VERSION=24.04
-ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+ARG NGC_VERSION=25.05
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:${NGC_VERSION}-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
 # Prepare basic build environment


### PR DESCRIPTION

  Description:

  Summary

  - The NGC tag 25.06-cuda12.9-devel-ubuntu24.04 does not exist, causing container image builds to fail
  - Switch cu12.9 base image to 25.05-cuda12.9 (confirmed available on nvcr.io) in both docker/Dockerfile and publish.yml
  - cu13.0 builds already use 25.09-cuda13.0 which is available — no change needed

  Root cause

  docker build failed immediately at the FROM layer because nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 has not been published by
  NVIDIA yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Docker/CI base image tags for CUDA 12.9 to a published NGC version, impacting build/release pipeline but not runtime logic.
> 
> **Overview**
> Fixes failing CUDA 12.9 container builds by switching the NGC `cuda-dl-base` tag from `25.06` to the known-published `25.05`.
> 
> Updates `publish.yml` to pass the corrected `BASE_IMAGE` for cu12.9 images, and refactors both `docker/Dockerfile` and `docker/Dockerfile.standalone` to introduce an explicit `NGC_VERSION` arg used to compose `BASE_IMAGE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c84b77d746a88ac783b9f8b5eec794d3451347f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->