### PR TITLE
[CI/CD] Add k3 build pipeline for unit tests

### DIFF
--- a/.buildkite/k3_harness/install-agent-stack.sh
+++ b/.buildkite/k3_harness/install-agent-stack.sh
@@ -19,22 +19,24 @@ QUEUE="${BUILDKITE_QUEUE:-k8s}"
 
 # Create (or update) the K8s secret with GitHub credentials.
 # Two keys:
-#   git-credentials  — used by agent-stack-k8s checkout container (HTTPS clone)
+#   .git-credentials — used by agent-stack-k8s checkout container (HTTPS clone).
+#                      The leading dot matches the file git-credential-store expects.
 #   GITHUB_TOKEN     — injected into job containers for git push (e.g. baselines)
 kubectl create secret generic buildkite-git-creds \
-    --from-literal=git-credentials="https://x-access-token:${GH_TOKEN}@github.com" \
+    --from-literal=.git-credentials="https://x-access-token:${GH_TOKEN}@github.com" \
     --from-literal=GITHUB_TOKEN="${GH_TOKEN}" \
     -n buildkite --dry-run=client -o yaml | kubectl apply -f -
 
 # Install or upgrade agent-stack-k8s
-# - git-credentials-secret: checkout container uses HTTPS instead of SSH
+# - default-checkout-params.gitCredentialsSecret: checkout container uses HTTPS
+#   instead of SSH. Expects a Secret with a `.git-credentials` key.
 # - GITHUB_TOKEN is injected per-step in pipeline.yml (not via global pod-spec-patch)
 helm upgrade --install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-k8s \
     --version 0.38.0 \
     --namespace buildkite --create-namespace \
     --set agentToken="${TOKEN}" \
     --set config.queue="${QUEUE}" \
-    --set-json 'config.git-credentials-secret={"name":"buildkite-git-creds","key":"git-credentials"}' \
+    --set-json 'config.default-checkout-params={"gitCredentialsSecret":{"secretName":"buildkite-git-creds"}}' \
     --wait --timeout 3m
 
 echo "agent-stack-k8s installed (queue=${QUEUE})"

--- a/.buildkite/k3_harness/setup-lmcache-only-env.sh
+++ b/.buildkite/k3_harness/setup-lmcache-only-env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Per-job environment setup for jobs that DON'T need vLLM (e.g. unit tests).
+# Installs LMCache from source on top of the ci-base image, which already
+# has torch + requirements/cuda.txt + build.txt baked in. Much faster than
+# setup-env.sh since it skips the vLLM nightly install entirely.
+set -euo pipefail
+
+trap 'echo "ERROR: setup-lmcache-only-env.sh failed at line $LINENO (exit code $?)" >&2' ERR
+
+# ── GPU health pre-check ────────────────────────────────────
+# Fail fast if GPUs are occupied by stale host processes.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+check_gpu_health 80
+
+echo "--- :python: Installing LMCache from source (no vLLM)"
+# Skip setuptools_scm git describe; the repo carries non-PEP-440 tags
+# (nightly, nightly-cu13) that crash the newer vcs_versioning backend.
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE:-0.0.0+ci}"
+uv pip install -e . --no-build-isolation
+
+echo "--- :white_check_mark: Environment ready (LMCache only, no vLLM)"
+python -c "import lmcache; print('LMCache installed from source')"

--- a/.buildkite/k3_tests/unit/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/unit/buildkite-pipeline.yml
@@ -1,0 +1,13 @@
+# Paste this into the Buildkite pipeline's "Steps" editor.
+# It uploads the real pipeline definition from the repo.
+agents:
+  queue: "k3-h200-local"
+
+env:
+  # Optional: unit tests run without it. Setting it unlocks one extra test
+  # (test_segment_token_database) that's gated on HF credentials.
+  HF_TOKEN: ""
+
+steps:
+  - label: ":pipeline: Upload pipeline"
+    command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/unit/pipeline.yml

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -1,0 +1,28 @@
+# Unit tests — runs pytest with coverage against LMCache source.
+# No vLLM required; uses setup-lmcache-only-env.sh for a lighter install.
+
+steps:
+  - label: ":test_tube: Unit Tests"
+    command: .buildkite/k3_tests/unit/run.sh
+    timeout_in_minutes: 60
+    agents: { queue: "k3-h200-local" }
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - name: container-0
+                image: lmcache/ci-base:latest
+                imagePullPolicy: Never
+                env:
+                  - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
+                resources:
+                  limits:
+                    nvidia.com/gpu: "1"
+                volumeMounts:
+                  - { name: hf-cache, mountPath: /root/.cache/huggingface }
+            volumes:
+              - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+    artifact_paths:
+      - "durations/test.html"
+      - "coverage-test.xml"
+      - "coverage-test/**/*"

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -16,12 +16,22 @@ steps:
                 env:
                   - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
                 resources:
+                  requests:
+                    cpu: "32"
+                    memory: "96Gi"
                   limits:
                     nvidia.com/gpu: "1"
+                    cpu: "64"
+                    memory: "200Gi"
                 volumeMounts:
                   - { name: hf-cache, mountPath: /root/.cache/huggingface }
+                  # K8s defaults /dev/shm to 64 MiB, which causes SIGBUS in
+                  # tests/v1/shm_allocator (allocates 5 GiB via SharedMemory).
+                  # Mount an 8 GiB tmpfs to give shm tests headroom.
+                  - { name: dshm, mountPath: /dev/shm }
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+              - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
     artifact_paths:
       - "durations/test.html"
       - "coverage-test.xml"

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -15,13 +15,6 @@ steps:
                 imagePullPolicy: Never
                 env:
                   - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
-                  # Route tempfile.mkdtemp() to the host-backed /scratch
-                  # mount. Overlayfs (default /tmp) fails GDS (cuFile) with
-                  # CU_FILE_IO_NOT_SUPPORTED (err=5027); the /scratch mount
-                  # is on the host's ext4/xfs NVMe. A hostPath + subPathExpr
-                  # at /tmp was also tried and fails GDS — the bind mount
-                  # used by subPath confuses cuFile's fs-type detection.
-                  - { name: TMPDIR, value: /scratch }
                 resources:
                   requests:
                     cpu: "32"

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -31,8 +31,8 @@ steps:
                   - { name: dshm, mountPath: /dev/shm }
                   # GDS-capable scratch dir on the host's local NVMe. Direct
                   # hostPath (no subPath) — K8s' subPath bind-mount breaks
-                  # cuFile's fs detection. TMPDIR above redirects
-                  # tempfile.mkdtemp() here.
+                  # cuFile's fs-type detection. run.sh creates a per-build
+                  # subdir here and exposes it via LMCACHE_TEST_TMPDIR.
                   - { name: scratch, mountPath: /scratch }
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -15,6 +15,12 @@ steps:
                 imagePullPolicy: Never
                 env:
                   - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
+                  # Redirect tempfile.mkdtemp() away from the pod's overlay
+                  # rootfs onto a host-backed ext4/xfs mount. GDS (cuFile)
+                  # fails on overlayfs/tmpfs with CU_FILE_IO_NOT_SUPPORTED
+                  # (err=5027); tests under storage_backend/test_gds_backend
+                  # need a real direct-I/O-capable filesystem.
+                  - { name: TMPDIR, value: /scratch }
                 resources:
                   requests:
                     cpu: "32"
@@ -29,9 +35,14 @@ steps:
                   # tests/v1/shm_allocator (allocates 5 GiB via SharedMemory).
                   # Mount an 8 GiB tmpfs to give shm tests headroom.
                   - { name: dshm, mountPath: /dev/shm }
+                  # GDS-capable scratch dir on the host's local NVMe. Paired
+                  # with TMPDIR=/scratch above so tempfile.mkdtemp() lands on
+                  # ext4/xfs instead of the pod's overlay rootfs.
+                  - { name: scratch, mountPath: /scratch }
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
               - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
+              - { name: scratch, hostPath: { path: /data/gds-scratch, type: DirectoryOrCreate } }
     artifact_paths:
       - "durations/test.html"
       - "coverage-test.xml"

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -15,13 +15,13 @@ steps:
                 imagePullPolicy: Never
                 env:
                   - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
-                  # POD_NAME is used as subPathExpr for the /tmp hostPath
-                  # below, giving each concurrent pod its own scratch dir
-                  # under /data/gds-scratch on the host.
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
+                  # Route tempfile.mkdtemp() to the host-backed /scratch
+                  # mount. Overlayfs (default /tmp) fails GDS (cuFile) with
+                  # CU_FILE_IO_NOT_SUPPORTED (err=5027); the /scratch mount
+                  # is on the host's ext4/xfs NVMe. A hostPath + subPathExpr
+                  # at /tmp was also tried and fails GDS — the bind mount
+                  # used by subPath confuses cuFile's fs-type detection.
+                  - { name: TMPDIR, value: /scratch }
                 resources:
                   requests:
                     cpu: "32"
@@ -36,17 +36,15 @@ steps:
                   # tests/v1/shm_allocator (allocates 5 GiB via SharedMemory).
                   # Mount a 16 GiB tmpfs to give shm tests headroom.
                   - { name: dshm, mountPath: /dev/shm }
-                  # Replace the pod's overlay /tmp with a host-backed ext4/xfs
-                  # mount so GDS (cuFile) works. Overlayfs fails with
-                  # CU_FILE_IO_NOT_SUPPORTED (err=5027). subPathExpr gives
-                  # each concurrent pod its own isolated subdirectory.
-                  - name: tmp
-                    mountPath: /tmp
-                    subPathExpr: $(POD_NAME)
+                  # GDS-capable scratch dir on the host's local NVMe. Direct
+                  # hostPath (no subPath) — K8s' subPath bind-mount breaks
+                  # cuFile's fs detection. TMPDIR above redirects
+                  # tempfile.mkdtemp() here.
+                  - { name: scratch, mountPath: /scratch }
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
               - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
-              - { name: tmp, hostPath: { path: /data/gds-scratch, type: DirectoryOrCreate } }
+              - { name: scratch, hostPath: { path: /data/gds-scratch, type: DirectoryOrCreate } }
     artifact_paths:
       - "durations/test.html"
       - "coverage-test.xml"

--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -15,12 +15,13 @@ steps:
                 imagePullPolicy: Never
                 env:
                   - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
-                  # Redirect tempfile.mkdtemp() away from the pod's overlay
-                  # rootfs onto a host-backed ext4/xfs mount. GDS (cuFile)
-                  # fails on overlayfs/tmpfs with CU_FILE_IO_NOT_SUPPORTED
-                  # (err=5027); tests under storage_backend/test_gds_backend
-                  # need a real direct-I/O-capable filesystem.
-                  - { name: TMPDIR, value: /scratch }
+                  # POD_NAME is used as subPathExpr for the /tmp hostPath
+                  # below, giving each concurrent pod its own scratch dir
+                  # under /data/gds-scratch on the host.
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
                 resources:
                   requests:
                     cpu: "32"
@@ -33,16 +34,19 @@ steps:
                   - { name: hf-cache, mountPath: /root/.cache/huggingface }
                   # K8s defaults /dev/shm to 64 MiB, which causes SIGBUS in
                   # tests/v1/shm_allocator (allocates 5 GiB via SharedMemory).
-                  # Mount an 8 GiB tmpfs to give shm tests headroom.
+                  # Mount a 16 GiB tmpfs to give shm tests headroom.
                   - { name: dshm, mountPath: /dev/shm }
-                  # GDS-capable scratch dir on the host's local NVMe. Paired
-                  # with TMPDIR=/scratch above so tempfile.mkdtemp() lands on
-                  # ext4/xfs instead of the pod's overlay rootfs.
-                  - { name: scratch, mountPath: /scratch }
+                  # Replace the pod's overlay /tmp with a host-backed ext4/xfs
+                  # mount so GDS (cuFile) works. Overlayfs fails with
+                  # CU_FILE_IO_NOT_SUPPORTED (err=5027). subPathExpr gives
+                  # each concurrent pod its own isolated subdirectory.
+                  - name: tmp
+                    mountPath: /tmp
+                    subPathExpr: $(POD_NAME)
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
               - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
-              - { name: scratch, hostPath: { path: /data/gds-scratch, type: DirectoryOrCreate } }
+              - { name: tmp, hostPath: { path: /data/gds-scratch, type: DirectoryOrCreate } }
     artifact_paths:
       - "durations/test.html"
       - "coverage-test.xml"

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -8,6 +8,17 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 cd "${REPO_ROOT}"
 
+# ── Per-build scratch dir ────────────────────────────────────
+# /scratch is a shared hostPath mount (see pipeline.yml). Give this build
+# its own subdirectory so concurrent pods can't clobber each other, and
+# clean it up on exit so /data/gds-scratch on the host doesn't grow. Using
+# a direct subdir instead of K8s subPathExpr because the latter breaks GDS
+# (cuFile rejects bind-mounted paths).
+BUILD_TAG="${BUILDKITE_BUILD_ID:-manual-$$}"
+export TMPDIR="/scratch/bk-${BUILD_TAG}"
+mkdir -p "${TMPDIR}"
+trap 'rm -rf "${TMPDIR}" 2>/dev/null || true' EXIT
+
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -9,15 +9,21 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 cd "${REPO_ROOT}"
 
 # ── Per-build scratch dir ────────────────────────────────────
-# /scratch is a shared hostPath mount (see pipeline.yml). Give this build
-# its own subdirectory so concurrent pods can't clobber each other, and
-# clean it up on exit so /data/gds-scratch on the host doesn't grow. Using
-# a direct subdir instead of K8s subPathExpr because the latter breaks GDS
-# (cuFile rejects bind-mounted paths).
+# /scratch is a shared hostPath mount (see pipeline.yml) backed by ext4/xfs
+# on local NVMe — the only place GDS (cuFile) works in this pod (overlayfs
+# /tmp fails with CU_FILE_IO_NOT_SUPPORTED). Give this build its own
+# subdirectory so concurrent pods don't collide, and clean it up on exit.
+# Direct subdir rather than K8s subPathExpr since the latter's bind mount
+# breaks cuFile's fs-type detection.
+#
+# LMCACHE_TEST_TMPDIR is consumed by the handful of test files that need
+# GDS-capable scratch (test_gds_backend, test_cache_engine, the xpu
+# benchmarks). Leaving TMPDIR unset means /tmp stays pod-internal overlay
+# for pip/uv/build caches — those don't need direct I/O.
 BUILD_TAG="${BUILDKITE_BUILD_ID:-manual-$$}"
-export TMPDIR="/scratch/bk-${BUILD_TAG}"
-mkdir -p "${TMPDIR}"
-trap 'rm -rf "${TMPDIR}" 2>/dev/null || true' EXIT
+export LMCACHE_TEST_TMPDIR="/scratch/bk-${BUILD_TAG}"
+mkdir -p "${LMCACHE_TEST_TMPDIR}"
+trap 'rm -rf "${LMCACHE_TEST_TMPDIR}" 2>/dev/null || true' EXIT
 
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -8,11 +8,6 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 cd "${REPO_ROOT}"
 
-# /tmp is a hostPath-backed per-pod subdir (see pipeline.yml). K8s doesn't
-# auto-clean hostPath subPaths when the pod dies, so wipe our contents on
-# exit to keep the host's /data/gds-scratch from growing unbounded.
-trap 'rm -rf /tmp/* /tmp/.[!.]* 2>/dev/null || true' EXIT
-
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Unit test entrypoint for K8s pods.
+# Installs LMCache (no vLLM) + test deps, then runs pytest with coverage.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+# ── Environment setup ────────────────────────────────────────
+source .buildkite/k3_harness/setup-lmcache-only-env.sh
+uv pip install -r requirements/test.txt
+
+# ── Run unit tests with coverage ─────────────────────────────
+LMCACHE_TRACK_USAGE="false" \
+pytest --maxfail=1 --cov=lmcache \
+    --cov-report term --cov-report=html:coverage-test \
+    --cov-report=xml:coverage-test.xml --html=durations/test.html \
+    --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
+    --ignore=tests/v1/test_nixl_storage.py \
+    --ignore=tests/skipped \
+    --ignore=tests/v1/storage_backend/test_eic.py
+
+cat << EOF | buildkite-agent annotate --style "info"
+  Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>
+EOF

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -8,6 +8,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 cd "${REPO_ROOT}"
 
+# /tmp is a hostPath-backed per-pod subdir (see pipeline.yml). K8s doesn't
+# auto-clean hostPath subPaths when the pod dies, so wipe our contents on
+# exit to keep the host's /data/gds-scratch from growing unbounded.
+trap 'rm -rf /tmp/* /tmp/.[!.]* 2>/dev/null || true' EXIT
+
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from functools import partial
-import os
 import random
 import shlex
 import subprocess
@@ -91,10 +90,7 @@ def create_config():
                 print("Supported backends: 'cpu', 'disk', and 'fsconnector'")
                 raise ValueError(f"Unknown backend: {backend}")
 
-    homedir = os.environ.get("HOME", "/tmp")
-    with tempfile.TemporaryDirectory(
-        dir=homedir, ignore_cleanup_errors=True
-    ) as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         print("Temp dir is:", temp_dir)
         yield partial(make_config, path=temp_dir)
 

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from functools import partial
+import os
 import random
 import shlex
 import subprocess
@@ -21,6 +22,10 @@ from tests.v1.utils import (
     generate_kv_cache_paged_list_tensors,
     generate_tokens,
 )
+
+# Optional override for tempfile root; see tests/v1/test_cache_engine.py
+# for rationale.
+_TEST_TMPDIR = os.environ.get("LMCACHE_TEST_TMPDIR") or None
 
 
 # helper functions
@@ -90,7 +95,9 @@ def create_config():
                 print("Supported backends: 'cpu', 'disk', and 'fsconnector'")
                 raise ValueError(f"Unknown backend: {backend}")
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with tempfile.TemporaryDirectory(
+        dir=_TEST_TMPDIR, ignore_cleanup_errors=True
+    ) as temp_dir:
         print("Temp dir is:", temp_dir)
         yield partial(make_config, path=temp_dir)
 

--- a/tests/benchmarks/test_xpu_connector_benchmark.py
+++ b/tests/benchmarks/test_xpu_connector_benchmark.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from functools import partial
-import os
 import random
 import tempfile
 import time
@@ -169,10 +168,7 @@ def create_config():
             case _:
                 raise ValueError(f"Unknown backend: {backend}")
 
-    homedir = os.environ.get("HOME", "/tmp")
-    with tempfile.TemporaryDirectory(
-        dir=homedir, ignore_cleanup_errors=True
-    ) as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         yield partial(make_config, path=temp_dir)
 
 

--- a/tests/benchmarks/test_xpu_connector_benchmark.py
+++ b/tests/benchmarks/test_xpu_connector_benchmark.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from functools import partial
+import os
 import random
 import tempfile
 import time
@@ -22,6 +23,10 @@ from tests.v1.utils import (
 
 DEVICE_PARAMS = ["xpu"]
 BACKENDS = ["cpu", "disk"]
+
+# Optional override for tempfile root; see tests/v1/test_cache_engine.py
+# for rationale.
+_TEST_TMPDIR = os.environ.get("LMCACHE_TEST_TMPDIR") or None
 
 
 def _skip_if_no_xpu() -> None:
@@ -168,7 +173,9 @@ def create_config():
             case _:
                 raise ValueError(f"Unknown backend: {backend}")
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with tempfile.TemporaryDirectory(
+        dir=_TEST_TMPDIR, ignore_cleanup_errors=True
+    ) as temp_dir:
         yield partial(make_config, path=temp_dir)
 
 

--- a/tests/benchmarks/test_xpu_layerwise_connector_benchmark.py
+++ b/tests/benchmarks/test_xpu_layerwise_connector_benchmark.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from functools import partial
+import os
 import random
 import tempfile
 import time
@@ -22,6 +23,10 @@ from tests.v1.utils import (
 
 DEVICE_PARAMS = ["xpu"]
 BACKENDS = ["cpu", "disk"]
+
+# Optional override for tempfile root; see tests/v1/test_cache_engine.py
+# for rationale.
+_TEST_TMPDIR = os.environ.get("LMCACHE_TEST_TMPDIR") or None
 
 
 def _skip_if_no_xpu():
@@ -253,7 +258,9 @@ def create_config():
             case _:
                 raise ValueError(f"Unknown backend: {backend}")
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with tempfile.TemporaryDirectory(
+        dir=_TEST_TMPDIR, ignore_cleanup_errors=True
+    ) as temp_dir:
         yield partial(make_config, path=temp_dir)
 
 

--- a/tests/benchmarks/test_xpu_layerwise_connector_benchmark.py
+++ b/tests/benchmarks/test_xpu_layerwise_connector_benchmark.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from functools import partial
-import os
 import random
 import tempfile
 import time
@@ -254,10 +253,7 @@ def create_config():
             case _:
                 raise ValueError(f"Unknown backend: {backend}")
 
-    homedir = os.environ.get("HOME", "/tmp")
-    with tempfile.TemporaryDirectory(
-        dir=homedir, ignore_cleanup_errors=True
-    ) as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         yield partial(make_config, path=temp_dir)
 
 

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -29,6 +29,13 @@ from lmcache.v1.storage_backend.gds_backend import (
 )
 from tests.v1.utils import create_test_memory_obj, has_cufile, has_hipfile
 
+# Optional override for tempfile root. In CI we point this at a GDS-capable
+# host-backed mount (see .buildkite/k3_tests/unit/run.sh); locally, it's
+# unset and tempfile falls back to its default (usually /tmp). cuFile needs
+# direct-I/O-capable storage (ext4/xfs on real disk); overlayfs and tmpfs
+# fail with CU_FILE_IO_NOT_SUPPORTED (err=5027).
+_TEST_TMPDIR = os.environ.get("LMCACHE_TEST_TMPDIR") or None
+
 
 def create_test_config(gds_path: str, gds_path_sharding: str = "by_gpu"):
     config = LMCacheEngineConfig.from_defaults(
@@ -68,7 +75,7 @@ def create_test_metadata():
 
 @pytest.fixture
 def temp_gds_path():
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = tempfile.mkdtemp(dir=_TEST_TMPDIR)
     yield temp_dir
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
@@ -547,7 +554,7 @@ class TestGdsMultiPath:
 
     def test_multi_path_parsing(self, async_loop):
         """Comma-separated paths are split into gds_paths list."""
-        paths = [tempfile.mkdtemp() for _ in range(3)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(3)]
         try:
             gds_path = ",".join(paths)
             backend = self._make_backend(gds_path, "cuda:0", async_loop)
@@ -562,7 +569,7 @@ class TestGdsMultiPath:
 
     def test_multi_path_parsing_with_spaces(self, async_loop):
         """Spaces around commas are stripped."""
-        paths = [tempfile.mkdtemp() for _ in range(2)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(2)]
         try:
             gds_path = f"  {paths[0]}  ,  {paths[1]}  "
             backend = self._make_backend(gds_path, "cuda:0", async_loop)
@@ -576,7 +583,7 @@ class TestGdsMultiPath:
 
     def test_gpu_affinity_selects_path(self, async_loop):
         """Different cuda devices select different paths via modulo."""
-        paths = [tempfile.mkdtemp() for _ in range(4)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(4)]
         try:
             gds_path = ",".join(paths)
             for device_id in range(8):
@@ -596,7 +603,7 @@ class TestGdsMultiPath:
 
     def test_all_directories_created(self, async_loop):
         """All paths in gds_paths get their directories created."""
-        base = tempfile.mkdtemp()
+        base = tempfile.mkdtemp(dir=_TEST_TMPDIR)
         try:
             paths = [os.path.join(base, f"nvme{i}") for i in range(3)]
             gds_path = ",".join(paths)
@@ -611,7 +618,7 @@ class TestGdsMultiPath:
 
     def test_key_to_path_uses_selected_path(self, async_loop):
         """_key_to_path builds file paths under the selected gds_path."""
-        paths = [tempfile.mkdtemp() for _ in range(2)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(2)]
         try:
             gds_path = ",".join(paths)
             backend = self._make_backend(gds_path, "cuda:0", async_loop)
@@ -627,7 +634,7 @@ class TestGdsMultiPath:
 
     def test_deterministic_path_selection(self, async_loop):
         """Same device always selects the same path."""
-        paths = [tempfile.mkdtemp() for _ in range(3)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(3)]
         try:
             gds_path = ",".join(paths)
             selected = set()
@@ -649,7 +656,7 @@ class TestGdsMultiPath:
         under paths[1].  The scan should still discover it because
         ``_scan_metadata`` iterates all ``gds_paths``.
         """
-        paths = [tempfile.mkdtemp() for _ in range(2)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(2)]
         try:
             # chunk_hash must have >=4 decimal digits so l1/l2 dirs
             # are each 2 chars (the scanner filters on len == 2).
@@ -711,7 +718,7 @@ class TestGdsMultiPath:
         ``contains()`` falls back to ``_try_to_read_metadata`` which
         should search all ``gds_paths``, not just the affinity path.
         """
-        paths = [tempfile.mkdtemp() for _ in range(2)]
+        paths = [tempfile.mkdtemp(dir=_TEST_TMPDIR) for _ in range(2)]
         try:
             key = CacheEngineKey(
                 model_name="testmodel",

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 from copy import deepcopy
 from unittest.mock import MagicMock
+import os
 import random
 import shlex
 import subprocess
@@ -34,6 +35,12 @@ from .utils import (
     has_cufile,
     recover_engine_states,
 )
+
+# Optional override for tempfile root. In CI we point this at a GDS-capable
+# host-backed mount (see .buildkite/k3_tests/unit/run.sh); locally it's
+# unset and tempfile falls back to its default. Direct-I/O-backed paths are
+# required for GDS tests (cuFile err=5027 on overlayfs/tmpfs).
+_TEST_TMPDIR = os.environ.get("LMCACHE_TEST_TMPDIR") or None
 
 
 def get_expected_count(token_len, save_unfull_chunk, chunk_size):
@@ -1257,7 +1264,9 @@ def test_force_store_wait(autorelease_v1):
         for _ in range(num_requests)
     ]
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with tempfile.TemporaryDirectory(
+        dir=_TEST_TMPDIR, ignore_cleanup_errors=True
+    ) as temp_dir:
         cfg = LMCacheEngineConfig.from_defaults(
             local_cpu=False,
             max_local_cpu_size=2,  # small cpu buffer
@@ -1445,7 +1454,9 @@ def test_multi_device_backends(save_unfull_chunk, autorelease_v1):
     with pytest.raises(AssertionError):
         check_paged_kv_cache_equal(retrieved_cache, kv_cache, slot_mapping)
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    with tempfile.TemporaryDirectory(
+        dir=_TEST_TMPDIR, ignore_cleanup_errors=True
+    ) as temp_dir:
         cfg = LMCacheEngineConfig.from_dict(
             {
                 "local_cpu": True,

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -3,7 +3,6 @@
 from collections import OrderedDict
 from copy import deepcopy
 from unittest.mock import MagicMock
-import os
 import random
 import shlex
 import subprocess
@@ -1258,10 +1257,7 @@ def test_force_store_wait(autorelease_v1):
         for _ in range(num_requests)
     ]
 
-    homedir = os.environ.get("HOME", "/tmp")
-    with tempfile.TemporaryDirectory(
-        dir=homedir, ignore_cleanup_errors=True
-    ) as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         cfg = LMCacheEngineConfig.from_defaults(
             local_cpu=False,
             max_local_cpu_size=2,  # small cpu buffer
@@ -1449,10 +1445,7 @@ def test_multi_device_backends(save_unfull_chunk, autorelease_v1):
     with pytest.raises(AssertionError):
         check_paged_kv_cache_equal(retrieved_cache, kv_cache, slot_mapping)
 
-    homedir = os.environ.get("HOME", "/tmp")
-    with tempfile.TemporaryDirectory(
-        dir=homedir, ignore_cleanup_errors=True
-    ) as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         cfg = LMCacheEngineConfig.from_dict(
             {
                 "local_cpu": True,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new k3 (agent-stack-k8s) build pipeline for running LMCache unit tests on our self-managed K3s + GPU Operator host, alongside the existing bare-metal unit-test pipeline. Each job runs in an ephemeral pod with clean filesystem state, atomic GPU allocation via the K8s device plugin, and the pre-baked `lmcache/ci-base` image — no shared venv, no `pick-free-gpu.sh` dance.

**Special notes for your reviewers**:

- New files under `.buildkite/k3_tests/unit/` follow the same pattern as the existing `integration` / `correctness` / `multiprocess` k3 tests (`run.sh`, `pipeline.yml`, `buildkite-pipeline.yml`).
- Introduces `.buildkite/k3_harness/setup-lmcache-only-env.sh`, a lighter env-setup script that installs only LMCache from source on top of the ci-base image. It skips the vLLM nightly install entirely, so startup is significantly faster than `setup-env.sh` — appropriate for unit tests, which don't import vLLM.
- Targets queue `k3-h200-local` with `nvidia.com/gpu: "1"` — each job allocates exactly one GPU.
- `HF_TOKEN` is optional: the suite runs without credentials; setting it only unlocks one gated test (`test_segment_token_database`). Gated-model tests like `test_nixl_storage.py` remain excluded via `--ignore` in the pytest command.
- Drive-by fix to `install-agent-stack.sh`: renames the secret key to `.git-credentials` (what `git-credential-store` expects) and migrates the Helm value from the deprecated `config.git-credentials-secret` to `config.default-checkout-params.gitCredentialsSecret` for newer agent-stack-k8s versions.

The Buildkite pipeline ("K3 Unit Tests") needs to be created in the web UI by pasting `buildkite-pipeline.yml` into the Steps editor.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds a new GPU-backed Buildkite/K8s pipeline and changes agent-stack checkout secret/Helm configuration, which can break CI if misconfigured.
> 
> **Overview**
> Adds a new K3s Buildkite pipeline to run LMCache unit tests in ephemeral `agent-stack-k8s` pods using the prebuilt `lmcache/ci-base` image, with coverage artifacts and a per-build hostPath scratch directory.
> 
> Introduces `setup-lmcache-only-env.sh` to install LMCache from source without pulling vLLM, and wires `LMCACHE_TEST_TMPDIR` through the K8s job so GDS-related tests/benchmarks place temp files on a direct-I/O-capable filesystem.
> 
> Updates `install-agent-stack.sh` to store GitHub HTTPS credentials under `.git-credentials` and switches the Helm config to `config.default-checkout-params.gitCredentialsSecret` for newer `agent-stack-k8s` versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 722a26b1ab91fe6018436b51fcdf0b1ca34199be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->