### PR TITLE
[MP] Introduce common http apis

### DIFF
--- a/docs/design/v1/multiprocess/mp_runtime_plugin.md
+++ b/docs/design/v1/multiprocess/mp_runtime_plugin.md
@@ -62,11 +62,14 @@ expected by `RuntimePluginLauncher`:
 | `configs_dict` | `dict` | Aggregated config sections |
 | `to_json()` | `str` | Serialize `configs_dict` + `extra_config` to JSON string |
 
-### `_safe_asdict` / `_make_json_safe`
+### `safe_asdict` / `make_json_safe`
 
-Helper functions that convert dataclass instances to dicts while
-handling non-serializable fields (e.g. `pathlib.Path`) by falling
-back to `str()`.
+Public helpers in `lmcache.v1.utils.json_utils` that convert
+dataclass instances to dicts while handling non-serializable
+fields (e.g. `pathlib.Path`) by falling back to `str()`.
+`safe_asdict` operates on dataclass instances; `make_json_safe`
+recursively sanitizes arbitrary values (dicts, lists, tuples,
+primitives) and is also reused by the `/conf` HTTP endpoint.
 
 ### `RuntimePluginLauncher` (base)
 
@@ -130,7 +133,7 @@ sequenceDiagram
     participant P as Plugin Process
 
     S->>MPL: init(runtime_plugin_config, mp_config, storage_config, ...)
-    MPL->>MPL: _safe_asdict() each config
+    MPL->>MPL: safe_asdict() each config
     MPL->>MPL: Build _MPPluginConfig wrapper
     MPL->>RPL: init(config=wrapper, role=None)
 

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -12,6 +12,15 @@ New endpoints are registered automatically from
 exposes a module-level ``router`` (a :class:`fastapi.APIRouter`) is
 discovered at startup.
 
+A subset of routes defined under
+``lmcache/v1/internal_api_server/common/`` is also exposed on this HTTP
+server. The module
+``lmcache/v1/multiprocess/http_apis/common_api.py`` aggregates those
+routers (skipping modules listed in ``_MP_INCOMPATIBLE_MODULES``, such as
+``run_script_api``) and forwards them to the auto-discovery pipeline.
+Adding a new compatible module under ``internal_api_server/common``
+therefore requires no wiring changes on the MP side.
+
 .. contents::
    :local:
    :depth: 2
@@ -47,9 +56,15 @@ All examples below assume the server is reachable at
 Endpoints
 ---------
 
+The table below groups the routes by purpose. Paths under ``/api/`` are
+the operational surface (health, status, cache control). Routes without
+the ``/api/`` prefix are inherited from the shared
+``internal_api_server`` package and kept at their original paths for
+compatibility with the vLLM-embedded API server.
+
 .. list-table::
    :header-rows: 1
-   :widths: 10 30 60
+   :widths: 10 35 55
 
    * - Method
      - Path
@@ -66,6 +81,43 @@ Endpoints
    * - POST
      - ``/api/clear-cache``
      - Force-clear all KV data in L1 (CPU) memory.
+   * - GET
+     - ``/conf``
+     - Dump merged server configurations (mp, storage_manager,
+       observability).
+   * - GET
+     - ``/version``
+     - Full version descriptor (package version + commit id).
+   * - GET
+     - ``/lmc_version``
+     - LMCache package version string.
+   * - GET
+     - ``/commit_id``
+     - Current build commit id.
+   * - GET
+     - ``/env``
+     - Dump process environment variables (JSON, plain text).
+   * - GET
+     - ``/loglevel``
+     - List or inspect logger levels; also accepts ``level`` to mutate.
+   * - GET
+     - ``/metrics``
+     - Prometheus exposition format.
+   * - POST
+     - ``/metrics/reset``
+     - Reset all observability metrics to their initial state.
+   * - GET
+     - ``/threads``
+     - Enumerate active Python threads and their stack traces.
+   * - GET
+     - ``/periodic-threads``
+     - List registered periodic threads with summary counts.
+   * - GET
+     - ``/periodic-threads/{thread_name}``
+     - Detailed status for a single periodic thread.
+   * - GET
+     - ``/periodic-threads-health``
+     - Quick health check for critical/high-level periodic threads.
 
 ``GET /``
 ~~~~~~~~~
@@ -234,6 +286,291 @@ The request body is ignored.
 
     curl -s -X POST http://localhost:8080/api/clear-cache
 
+``GET /conf``
+~~~~~~~~~~~~~
+
+Returns every server-side configuration object registered on
+``app.state.configs`` (typically ``mp``, ``storage_manager`` and
+``observability``) as a single indented JSON document. Dataclasses are
+serialized via ``safe_asdict``; other values go through ``make_json_safe``.
+Useful for confirming what the process actually loaded — including
+environment overrides — without restarting.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "mp": {
+        "http_host": "0.0.0.0",
+        "http_port": 8080,
+        "...": "..."
+      },
+      "storage_manager": {
+        "...": "..."
+      },
+      "observability": {
+        "...": "..."
+      }
+    }
+
+**Response** (``503 Service Unavailable``) when configs are not wired
+onto ``app.state`` yet:
+
+.. code-block:: json
+
+    {
+      "error": "configs not initialized"
+    }
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/conf | jq
+
+``GET /version``
+~~~~~~~~~~~~~~~~
+
+Returns the full version descriptor (package version combined with the
+current commit id), formatted by ``lmcache.utils.get_version()``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    "0.3.x+<commit-id>"
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/version
+
+``GET /lmc_version``
+~~~~~~~~~~~~~~~~~~~~
+
+Returns the raw LMCache package version string (``lmcache.utils.VERSION``).
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/lmc_version
+
+``GET /commit_id``
+~~~~~~~~~~~~~~~~~~
+
+Returns the git commit id baked into the build (``lmcache.utils.COMMIT_ID``).
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/commit_id
+
+``GET /env``
+~~~~~~~~~~~~
+
+Dumps the process environment variables as a sorted, pretty-printed
+JSON document. Response ``Content-Type`` is ``text/plain`` so it can be
+piped directly to a terminal.
+
+.. warning::
+
+   The payload may contain secrets injected via environment
+   variables. Restrict network access to this endpoint in production.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/env
+
+``GET /loglevel``
+~~~~~~~~~~~~~~~~~
+
+Inspect or mutate Python logger levels at runtime. All responses are
+``text/plain``. The endpoint has three modes driven by query parameters:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Query
+     - Behavior
+   * - (no params)
+     - List every logger registered with :mod:`logging` and its level.
+   * - ``?logger_name=<name>``
+     - Return the effective level of the named logger.
+   * - ``?logger_name=<name>&level=<LEVEL>``
+     - Set the named logger (and its handlers) to ``LEVEL``
+       (``DEBUG``/``INFO``/``WARNING``/``ERROR``/``CRITICAL``).
+       Returns ``400`` on an unknown level.
+
+**Examples:**
+
+.. code-block:: bash
+
+    # list everything
+    curl -s http://localhost:8080/loglevel
+
+    # read one
+    curl -s 'http://localhost:8080/loglevel?logger_name=lmcache'
+
+    # elevate to DEBUG
+    curl -s 'http://localhost:8080/loglevel?logger_name=lmcache&level=DEBUG'
+
+``GET /metrics``
+~~~~~~~~~~~~~~~~
+
+Prometheus exposition format for every metric registered on the default
+``prometheus_client`` registry. Scrape this directly from Prometheus.
+See :doc:`observability` for the list of exported metrics.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/metrics
+
+``POST /metrics/reset``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Resets all LMCache observability metrics to their initial state
+(``reset_observability_metrics``). Intended for test harnesses and
+benchmarks — not for production.
+
+**Response** (``200 OK``):
+
+.. code-block:: text
+
+    ok
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s -X POST http://localhost:8080/metrics/reset
+
+``GET /threads``
+~~~~~~~~~~~~~~~~
+
+Enumerate active Python threads in the server process along with their
+stack traces, plus a total-count summary. Useful for live debugging of
+hangs or runaway workers.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Query
+     - Behavior
+   * - ``?name=<substr>``
+     - Keep only threads whose name contains ``<substr>``
+       (case-insensitive).
+   * - ``?thread_id=<int>``
+     - Keep only the thread with the matching ``ident``.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s 'http://localhost:8080/threads?name=periodic'
+
+``GET /periodic-threads``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns a JSON snapshot of the
+:class:`~lmcache.v1.periodic_thread.PeriodicThreadRegistry`: counts by
+level plus per-thread status (last run timestamp, latest summary, etc.).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Query
+     - Behavior
+   * - ``?level=critical|high|medium|low``
+     - Only include threads at the given level. ``400`` on unknown.
+   * - ``?running_only=true``
+     - Only include threads currently running.
+   * - ``?active_only=true``
+     - Only include threads considered active (recent tick).
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "summary": {
+        "total_count": 4,
+        "running_count": 4,
+        "active_count": 4,
+        "by_level": {"critical": 1, "high": 2, "medium": 1, "low": 0}
+      },
+      "threads": [
+        {"name": "...", "level": "high", "is_running": true, "...": "..."}
+      ]
+    }
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s 'http://localhost:8080/periodic-threads?level=critical' | jq
+
+``GET /periodic-threads/{thread_name}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Detailed status for a single periodic thread (``404`` if not found).
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/periodic-threads/storage-flush | jq
+
+``GET /periodic-threads-health``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fast health check covering only ``critical`` and ``high`` level periodic
+threads. A thread is flagged unhealthy when it is marked running but has
+not ticked within its expected interval.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "healthy": true,
+      "unhealthy_count": 0,
+      "unhealthy_threads": []
+    }
+
+When something is lagging:
+
+.. code-block:: json
+
+    {
+      "healthy": false,
+      "unhealthy_count": 1,
+      "unhealthy_threads": [
+        {
+          "name": "storage-flush",
+          "level": "critical",
+          "last_run_ago": 42.5,
+          "interval": 5.0
+        }
+      ]
+    }
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/periodic-threads-health
+
 Adding New Endpoints
 --------------------
 
@@ -249,6 +586,13 @@ Endpoints are auto-discovered from
 The :class:`~lmcache.v1.multiprocess.http_api_registry.HTTPAPIRegistry`
 will pick the module up automatically at startup — no central
 registration list to edit.
+
+If the route is generic enough to be shared with the vLLM-embedded API
+server, add it under ``lmcache/v1/internal_api_server/common/`` instead.
+It will be picked up on the MP side via ``common_api.py`` unless its
+module name is listed in ``_MP_INCOMPATIBLE_MODULES`` there (used for
+modules that require vLLM-specific ``app.state`` attributes, e.g.
+``run_script_api``).
 
 When adding a new endpoint, please also add a matching section to this
 page documenting the endpoint's purpose, request/response schema, and

--- a/lmcache/v1/multiprocess/http_apis/common_api.py
+++ b/lmcache/v1/multiprocess/http_apis/common_api.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Aggregate HTTP routes exposed by ``lmcache.v1.internal_api_server.common``.
+
+This module discovers every ``*_api`` sub-module under the
+``internal_api_server/common`` package and merges their ``router``
+attributes into a single :class:`~fastapi.APIRouter` named
+``router`` so that :class:`HTTPAPIRegistry` picks it up through the
+standard ``http_apis`` auto-discovery mechanism.
+
+Adding a new API module under ``internal_api_server/common`` requires
+no changes here: it is registered automatically.
+"""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+from fastapi import APIRouter
+
+# First Party
+from lmcache.v1 import internal_api_server
+from lmcache.v1.utils.router_discovery import discover_api_routers
+
+router = APIRouter()
+
+_common_path = Path(internal_api_server.__file__).parent / "common"
+_common_package = f"{internal_api_server.__name__}.common"
+
+for _discovered in discover_api_routers(_common_path, _common_package):
+    router.include_router(_discovered)

--- a/lmcache/v1/multiprocess/http_apis/common_api.py
+++ b/lmcache/v1/multiprocess/http_apis/common_api.py
@@ -9,6 +9,14 @@ standard ``http_apis`` auto-discovery mechanism.
 
 Adding a new API module under ``internal_api_server/common`` requires
 no changes here: it is registered automatically.
+
+Note:
+    Some modules under ``internal_api_server/common`` target the
+    vLLM-embedded API server and rely on attributes that only exist
+    on that server's ``app.state`` (e.g. ``lmcache_adapter``).  Such
+    modules are listed in ``_MP_INCOMPATIBLE_MODULES`` and skipped
+    here so they don't raise misleading 500s when invoked on the
+    multiprocess HTTP server.
 """
 
 # Standard
@@ -23,8 +31,16 @@ from lmcache.v1.utils.router_discovery import discover_api_routers
 
 router = APIRouter()
 
+# Modules that depend on vLLM-specific ``app.state`` attributes and
+# therefore cannot run on the multiprocess HTTP server.
+_MP_INCOMPATIBLE_MODULES = frozenset({"run_script_api"})
+
 _common_path = Path(internal_api_server.__file__).parent / "common"
 _common_package = f"{internal_api_server.__name__}.common"
 
-for _discovered in discover_api_routers(_common_path, _common_package):
+for _discovered in discover_api_routers(
+    _common_path,
+    _common_package,
+    exclude=_MP_INCOMPATIBLE_MODULES,
+):
     router.include_router(_discovered)

--- a/lmcache/v1/multiprocess/http_apis/conf_api.py
+++ b/lmcache/v1/multiprocess/http_apis/conf_api.py
@@ -52,7 +52,7 @@ async def conf(request: Request) -> Any:
         )
     result = {}
     for name, cfg in configs.items():
-        if is_dataclass(cfg):
+        if is_dataclass(cfg) and not isinstance(cfg, type):
             result[name] = safe_asdict(cfg)
         else:
             result[name] = make_json_safe(cfg)

--- a/lmcache/v1/multiprocess/http_apis/conf_api.py
+++ b/lmcache/v1/multiprocess/http_apis/conf_api.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from dataclasses import asdict
+from dataclasses import is_dataclass
 from typing import Any
 import json
 
 # Third Party
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+
+# First Party
+from lmcache.v1.utils.json_utils import make_json_safe, safe_asdict
 
 router = APIRouter()
 
@@ -22,22 +25,23 @@ class _IndentedJSONResponse(JSONResponse):
         ).encode("utf-8")
 
 
-def _make_json_safe(obj: Any) -> Any:
-    """Recursively ensure all values are JSON-serializable."""
-    if isinstance(obj, dict):
-        return {k: _make_json_safe(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_make_json_safe(v) for v in obj]
-    if isinstance(obj, (str, int, float, bool, type(None))):
-        return obj
-    return str(obj)
-
-
 @router.get("/conf")
 async def conf(request: Request) -> Any:
     """
     Return all server configurations (mp, storage_manager,
     observability) as a single JSON object.
+
+    Args:
+        request (Request): The incoming HTTP request; its
+            ``app.state.configs`` mapping is serialized.
+
+    Returns:
+        Any: A JSON response whose body is a dict keyed by
+        config name. Returns HTTP 503 if ``configs`` is not
+        initialized yet.
+
+    Exceptions:
+        None.
     """
     configs = getattr(request.app.state, "configs", None)
     if configs is None:
@@ -47,8 +51,8 @@ async def conf(request: Request) -> Any:
         )
     result = {}
     for name, cfg in configs.items():
-        if hasattr(cfg, "__dataclass_fields__"):
-            result[name] = _make_json_safe(asdict(cfg))
+        if is_dataclass(cfg):
+            result[name] = safe_asdict(cfg)
         else:
-            result[name] = _make_json_safe(cfg)
+            result[name] = make_json_safe(cfg)
     return _IndentedJSONResponse(content=result)

--- a/lmcache/v1/multiprocess/http_apis/conf_api.py
+++ b/lmcache/v1/multiprocess/http_apis/conf_api.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from dataclasses import asdict
+from typing import Any
+import json
+
+# Third Party
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+class _IndentedJSONResponse(JSONResponse):
+    """JSONResponse with indented output for readability."""
+
+    def render(self, content: Any) -> bytes:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            indent=2,
+        ).encode("utf-8")
+
+
+def _make_json_safe(obj: Any) -> Any:
+    """Recursively ensure all values are JSON-serializable."""
+    if isinstance(obj, dict):
+        return {k: _make_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_make_json_safe(v) for v in obj]
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    return str(obj)
+
+
+@router.get("/conf")
+async def conf(request: Request) -> Any:
+    """
+    Return all server configurations (mp, storage_manager,
+    observability) as a single JSON object.
+    """
+    configs = getattr(request.app.state, "configs", None)
+    if configs is None:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "configs not initialized"},
+        )
+    result = {}
+    for name, cfg in configs.items():
+        if hasattr(cfg, "__dataclass_fields__"):
+            result[name] = _make_json_safe(asdict(cfg))
+        else:
+            result[name] = _make_json_safe(cfg)
+    return _IndentedJSONResponse(content=result)

--- a/lmcache/v1/multiprocess/http_apis/conf_api.py
+++ b/lmcache/v1/multiprocess/http_apis/conf_api.py
@@ -21,6 +21,7 @@ class _IndentedJSONResponse(JSONResponse):
         return json.dumps(
             content,
             ensure_ascii=False,
+            allow_nan=False,
             indent=2,
         ).encode("utf-8")
 

--- a/lmcache/v1/multiprocess/http_apis/version_api.py
+++ b/lmcache/v1/multiprocess/http_apis/version_api.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# First Party
+from lmcache.v1.internal_api_server.vllm.version_api import (
+    router,
+)
+
+__all__ = ["router"]

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -139,6 +139,7 @@ def run_http_server(
     _configs["storage_manager"] = storage_manager_config
     _configs["observability"] = obs_config
     _configs["http"] = http_config
+    app.state.configs = _configs
 
     config = uvicorn.Config(
         app=app,

--- a/lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py
+++ b/lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py
@@ -12,7 +12,7 @@ via the LMCACHE_RUNTIME_PLUGIN_CONFIG environment variable.
 """
 
 # Standard
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 import json
 
@@ -21,6 +21,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.plugin.runtime_plugin_launcher import (
     RuntimePluginLauncher,
 )
+from lmcache.v1.utils.json_utils import make_json_safe, safe_asdict
 
 if TYPE_CHECKING:
     # First Party
@@ -29,28 +30,6 @@ if TYPE_CHECKING:
     )
 
 logger = init_logger(__name__)
-
-
-def _safe_asdict(obj: Any) -> dict[str, Any]:
-    """Convert a dataclass to dict, falling back to str()
-    for non-serializable fields."""
-    # Verify it's a dataclass instance at runtime
-    if not hasattr(obj, "__dataclass_fields__"):
-        raise TypeError("Expected a dataclass instance, got %s" % type(obj).__name__)
-    raw = asdict(obj)
-    return _make_json_safe(raw)  # type: ignore[return-value]
-
-
-def _make_json_safe(obj: Any) -> Any:
-    """Recursively ensure all values are JSON-serializable."""
-    if isinstance(obj, dict):
-        return {k: _make_json_safe(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_make_json_safe(v) for v in obj]
-    if isinstance(obj, (str, int, float, bool, type(None))):
-        return obj
-    # Fallback: convert to string representation
-    return str(obj)
 
 
 @dataclass
@@ -66,7 +45,7 @@ class _MPPluginConfig:
     def to_json(self) -> str:
         merged = dict(self.configs_dict)
         if self.extra_config:
-            merged["runtime_plugin_extra_config"] = _make_json_safe(self.extra_config)
+            merged["runtime_plugin_extra_config"] = make_json_safe(self.extra_config)
         return json.dumps(merged)
 
 
@@ -106,7 +85,7 @@ class MPRuntimePluginLauncher:
         # Build the aggregated JSON dict from all configs
         aggregated: dict = {}
         for name, cfg in configs.items():
-            aggregated[name] = _safe_asdict(cfg)
+            aggregated[name] = safe_asdict(cfg)
 
         wrapper = _MPPluginConfig(
             runtime_plugin_locations=runtime_plugin_config.locations,

--- a/lmcache/v1/utils/json_utils.py
+++ b/lmcache/v1/utils/json_utils.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for serializing arbitrary Python values to
+JSON-compatible structures.
+
+These utilities are used by HTTP API endpoints and runtime
+plugin launchers that need to emit server configs (which are
+dataclasses potentially containing non-JSON-native values) as
+plain JSON payloads.
+"""
+
+# Standard
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+
+def make_json_safe(obj: Any) -> Any:
+    """Recursively convert ``obj`` into a JSON-serializable value.
+
+    Dicts, lists and tuples are traversed; primitive JSON types are
+    returned unchanged; any other value falls back to ``str(obj)``.
+
+    Args:
+        obj: Arbitrary Python object to sanitize.
+
+    Returns:
+        A value composed solely of ``dict`` / ``list`` /
+        ``str`` / ``int`` / ``float`` / ``bool`` / ``None``.
+
+    Exceptions:
+        None.
+    """
+    if isinstance(obj, dict):
+        return {k: make_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [make_json_safe(v) for v in obj]
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    return str(obj)
+
+
+def safe_asdict(obj: Any) -> dict[str, Any]:
+    """Convert a dataclass instance to a JSON-safe ``dict``.
+
+    Args:
+        obj: A dataclass instance.
+
+    Returns:
+        Dictionary with all fields recursively sanitized via
+        :func:`make_json_safe`.
+
+    Exceptions:
+        TypeError: If ``obj`` is not a dataclass instance.
+    """
+    if not is_dataclass(obj) or isinstance(obj, type):
+        raise TypeError("Expected a dataclass instance, got %s" % type(obj).__name__)
+    return make_json_safe(asdict(obj))  # type: ignore[return-value]

--- a/lmcache/v1/utils/router_discovery.py
+++ b/lmcache/v1/utils/router_discovery.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from pathlib import Path
-from typing import List
+from typing import Iterable, List, Optional
 import importlib
 import pkgutil
 
@@ -18,6 +18,7 @@ def discover_api_routers(
     search_path: Path,
     package_name: str,
     suffix: str = "_api",
+    exclude: Optional[Iterable[str]] = None,
 ) -> List[APIRouter]:
     """Scan *search_path* for modules whose name ends with *suffix*
     and return every ``router`` attribute that is an
@@ -30,13 +31,20 @@ def discover_api_routers(
             :func:`importlib.import_module`).
         suffix: Only modules whose name ends with this string
             are considered.  Defaults to ``"_api"``.
+        exclude: Optional iterable of module base names to skip
+            (e.g. ``{"run_script_api"}``).  Useful when a host
+            package only wants a subset of the available routers.
 
     Returns:
         A list of discovered :class:`~fastapi.APIRouter` instances.
     """
+    excluded = set(exclude or ())
     routers: List[APIRouter] = []
     for _, module_name, _ in pkgutil.iter_modules([str(search_path)]):
         if not module_name.endswith(suffix):
+            continue
+        if module_name in excluded:
+            logger.info("Skipping excluded API module: %s", module_name)
             continue
         full_name = f"{package_name}.{module_name}"
         module = importlib.import_module(full_name)

--- a/tests/v1/multiprocess/http_apis/test_common_api.py
+++ b/tests/v1/multiprocess/http_apis/test_common_api.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for common_api.py — the aggregation layer that pulls in
+``internal_api_server/common`` routers while excluding
+vLLM-specific modules.
+
+Covers:
+- ``run_script_api`` is NOT registered on the mp HTTP server.
+- Other common endpoints (env, loglevel, metrics, …) ARE present.
+"""
+
+# Third Party
+from fastapi import FastAPI
+
+# First Party
+from lmcache.v1.multiprocess.http_api_registry import HTTPAPIRegistry
+
+
+def _app_with_all_apis() -> FastAPI:
+    app = FastAPI()
+    registry = HTTPAPIRegistry(app)
+    registry.register_all_apis()
+    return app
+
+
+class TestCommonApiAggregation:
+    def test_run_script_endpoint_excluded(self):
+        """/run_script must NOT be registered on the mp server."""
+        app = _app_with_all_apis()
+        paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/run_script" not in paths
+
+    def test_common_env_endpoint_present(self):
+        """/env from env_api should be registered."""
+        app = _app_with_all_apis()
+        paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/env" in paths
+
+    def test_common_loglevel_endpoint_present(self):
+        """/loglevel from loglevel_api should be registered."""
+        app = _app_with_all_apis()
+        paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/loglevel" in paths
+
+    def test_conf_endpoint_present(self):
+        """/conf from conf_api should be registered."""
+        app = _app_with_all_apis()
+        paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/conf" in paths

--- a/tests/v1/multiprocess/http_apis/test_conf_api.py
+++ b/tests/v1/multiprocess/http_apis/test_conf_api.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the ``/conf`` endpoint exposed by conf_api.
+
+Covers:
+- Dataclass configs serialized with nested values.
+- Plain-dict configs merged via ``make_json_safe``.
+- Missing ``app.state.configs`` returns HTTP 503.
+- Response body is valid JSON and is indented for readability.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+
+# Third Party
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.http_apis.conf_api import router as conf_router
+
+
+@dataclass
+class _FakeMPConfig:
+    host: str = "0.0.0.0"
+    port: int = 9000
+    path: Path = Path("/tmp/mp")
+
+
+@dataclass
+class _FakeStorageConfig:
+    backend: str = "local"
+    capacity: int = 1024
+    tags: list = field(default_factory=lambda: ["a", "b"])
+
+
+def _make_app(configs):
+    app = FastAPI()
+    app.include_router(conf_router)
+    if configs is not None:
+        app.state.configs = configs
+    return app
+
+
+class TestConfEndpoint:
+    def test_dataclass_configs_serialized(self):
+        app = _make_app(
+            {
+                "mp": _FakeMPConfig(host="1.2.3.4", port=8000),
+                "storage": _FakeStorageConfig(backend="redis"),
+            }
+        )
+        client = TestClient(app)
+        resp = client.get("/conf")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mp"] == {
+            "host": "1.2.3.4",
+            "port": 8000,
+            "path": "/tmp/mp",
+        }
+        assert body["storage"]["backend"] == "redis"
+        assert body["storage"]["capacity"] == 1024
+        assert body["storage"]["tags"] == ["a", "b"]
+
+    def test_plain_dict_config_merged(self):
+        """Non-dataclass values still go through make_json_safe."""
+        app = _make_app({"extra": {"k": Path("/v")}})
+        client = TestClient(app)
+
+        body = client.get("/conf").json()
+        assert body == {"extra": {"k": "/v"}}
+
+    def test_returns_503_when_configs_missing(self):
+        """/conf returns 503 if app.state.configs is absent."""
+        client = TestClient(_make_app(configs=None))
+        resp = client.get("/conf")
+
+        assert resp.status_code == 503
+        assert resp.json() == {"error": "configs not initialized"}
+
+    def test_response_is_indented_json(self):
+        """Indented JSON renderer keeps the payload human-readable."""
+        app = _make_app({"mp": _FakeMPConfig()})
+        client = TestClient(app)
+
+        raw = client.get("/conf").text
+        # Indented output has newlines and 2-space indentation.
+        assert "\n" in raw
+        assert '  "mp"' in raw
+        # And the body is still valid JSON.
+        assert json.loads(raw)["mp"]["host"] == "0.0.0.0"
+
+    def test_empty_configs_returns_empty_object(self):
+        client = TestClient(_make_app(configs={}))
+        resp = client.get("/conf")
+
+        assert resp.status_code == 200
+        assert resp.json() == {}
+
+
+@pytest.mark.parametrize(
+    "configs,expected_key",
+    [
+        ({"only": _FakeMPConfig()}, "only"),
+        ({"a": _FakeMPConfig(), "b": _FakeStorageConfig()}, "b"),
+    ],
+)
+def test_arbitrary_config_keys_round_trip(configs, expected_key):
+    client = TestClient(_make_app(configs))
+    body = client.get("/conf").json()
+    assert expected_key in body

--- a/tests/v1/multiprocess/test_http_api_registry.py
+++ b/tests/v1/multiprocess/test_http_api_registry.py
@@ -113,6 +113,56 @@ class TestDiscoverApiRouters:
 
         assert len(routers) == 0
 
+    def test_exclude_filters_named_modules(self, tmp_path):
+        """Modules whose base name is listed in ``exclude`` are skipped."""
+        (tmp_path / "keep_api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        (tmp_path / "drop_api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        (tmp_path / "__init__.py").write_text("")
+
+        sys.path.insert(0, str(tmp_path.parent))
+        try:
+            routers = discover_api_routers(
+                tmp_path,
+                pkg_name := tmp_path.name,
+                exclude={"drop_api"},
+            )
+        finally:
+            sys.path.pop(0)
+            for key in list(sys.modules):
+                if key.startswith(pkg_name):
+                    del sys.modules[key]
+
+        assert len(routers) == 1
+
+    def test_exclude_none_is_default(self, tmp_path):
+        """Passing ``exclude=None`` keeps all discoverable modules."""
+        (tmp_path / "a_api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        (tmp_path / "b_api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        (tmp_path / "__init__.py").write_text("")
+
+        sys.path.insert(0, str(tmp_path.parent))
+        try:
+            routers = discover_api_routers(
+                tmp_path,
+                pkg_name := tmp_path.name,
+                exclude=None,
+            )
+        finally:
+            sys.path.pop(0)
+            for key in list(sys.modules):
+                if key.startswith(pkg_name):
+                    del sys.modules[key]
+
+        assert len(routers) == 2
+
 
 # ------------------------------------------------------------------ #
 #  HTTPAPIRegistry integration

--- a/tests/v1/test_json_utils.py
+++ b/tests/v1/test_json_utils.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for lmcache.v1.utils.json_utils.
+
+Covers make_json_safe (recursive sanitization) and safe_asdict
+(dataclass -> JSON-safe dict) across primitive, container,
+nested, non-serializable, and invalid-input scenarios.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.utils.json_utils import make_json_safe, safe_asdict
+
+# ---------------------------------------------------------------- #
+#  make_json_safe
+# ---------------------------------------------------------------- #
+
+
+class TestMakeJsonSafe:
+    @pytest.mark.parametrize(
+        "value",
+        ["s", 1, 1.5, True, False, None],
+    )
+    def test_primitives_unchanged(self, value: Any):
+        """JSON-native primitives are returned unchanged."""
+        assert make_json_safe(value) == value
+        assert type(make_json_safe(value)) is type(value)
+
+    def test_dict_recursively_sanitized(self):
+        obj = {"a": 1, "b": Path("/tmp/x"), "c": {"d": (1, 2)}}
+        result = make_json_safe(obj)
+        assert result == {"a": 1, "b": "/tmp/x", "c": {"d": [1, 2]}}
+
+    def test_tuple_becomes_list(self):
+        assert make_json_safe((1, 2, 3)) == [1, 2, 3]
+
+    def test_list_recursively_sanitized(self):
+        assert make_json_safe([1, Path("/a"), [Path("/b")]]) == [
+            1,
+            "/a",
+            ["/b"],
+        ]
+
+    def test_non_serializable_falls_back_to_str(self):
+        class Opaque:
+            def __str__(self) -> str:
+                return "opaque-repr"
+
+        assert make_json_safe(Opaque()) == "opaque-repr"
+
+    def test_nested_mixed_structures(self):
+        obj = {"items": [{"p": Path("/x")}, (Path("/y"),)]}
+        assert make_json_safe(obj) == {
+            "items": [{"p": "/x"}, ["/y"]],
+        }
+
+
+# ---------------------------------------------------------------- #
+#  safe_asdict
+# ---------------------------------------------------------------- #
+
+
+@dataclass
+class _FakeCfg:
+    name: str = "n"
+    port: int = 8080
+    path: Path = Path("/tmp/cfg")
+    nested: dict = field(default_factory=lambda: {"k": Path("/v")})
+
+
+@dataclass
+class _EmptyCfg:
+    pass
+
+
+class TestSafeAsdict:
+    def test_dataclass_converted_with_non_serializable_fields(self):
+        result = safe_asdict(_FakeCfg())
+        assert result == {
+            "name": "n",
+            "port": 8080,
+            "path": "/tmp/cfg",
+            "nested": {"k": "/v"},
+        }
+
+    def test_empty_dataclass(self):
+        assert safe_asdict(_EmptyCfg()) == {}
+
+    def test_non_dataclass_raises(self):
+        with pytest.raises(TypeError, match="Expected a dataclass"):
+            safe_asdict({"not": "a dataclass"})
+
+    def test_dataclass_class_rejected(self):
+        """A dataclass *type* (not instance) must be rejected."""
+        with pytest.raises(TypeError, match="Expected a dataclass"):
+            safe_asdict(_FakeCfg)
+
+    @pytest.mark.parametrize("bad", [None, 42, "str", [1, 2]])
+    def test_primitive_inputs_rejected(self, bad: Any):
+        with pytest.raises(TypeError, match="Expected a dataclass"):
+            safe_asdict(bad)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the multiprocess HTTP server surface area by exposing additional diagnostic/operational endpoints (e.g. `/env`, `/loglevel`, `/threads`), which can leak sensitive data if not properly network-restricted. Also changes router auto-discovery behavior via an `exclude` filter, so misconfiguration could hide or unintentionally expose routes.
> 
> **Overview**
> Exposes a shared set of *common* HTTP endpoints on the multiprocess server by adding `common_api.py`, which aggregates routers from `lmcache.v1.internal_api_server.common` while skipping MP-incompatible modules (e.g. `run_script_api`).
> 
> Adds a new `GET /conf` endpoint that dumps `app.state.configs` as indented JSON, and wires `app.state.configs` in `http_server.py` so the runtime-loaded configs are inspectable.
> 
> Refactors JSON sanitization into reusable `lmcache.v1.utils.json_utils` (`safe_asdict`, `make_json_safe`) and updates the MP runtime plugin launcher to use it; extends `discover_api_routers` to support an `exclude` list, with new unit tests and updated docs for the expanded MP HTTP API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e724caffc5937da2904fca900fa228bf71426208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->