### PR TITLE
[Misc] Add .gitignore to rust/raw_block

### DIFF
--- a/rust/raw_block/.gitignore
+++ b/rust/raw_block/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock


### PR DESCRIPTION
**What this PR does / why we need it**:

  Adds `rust/raw_block/.gitignore` to ignore local Rust build artifacts for the raw block crate:

  - `target/`
  - `Cargo.lock`

  This keeps generated build output and local lockfile changes out of the working tree.

  **Special notes for your reviewers**:

  This is a gitignore-only change. No runtime behavior is affected.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a gitignore-only change and does not affect runtime behavior or shipped artifacts.
> 
> **Overview**
> Adds `rust/raw_block/.gitignore` to ignore local Rust build artifacts (`target/`) and `Cargo.lock`, keeping generated outputs and local lockfile changes out of the working tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81d48b8c3ad3bf13e726da281caf76328a4107d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->