### PR TITLE
fix: ref-count leak in LocalCPUBackend batched eviction + PagedTensor invalidate

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1765,7 +1765,11 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
             if not memory_obj.is_valid():
                 logger.warning("Trying to free an invalidated MemoryObj")
                 continue
-            # memory_obj.invalidate()
+            # PATCH: invalidate MemoryObj on free so stale references see is_valid=False
+            # instead of silently pointing at a page that may have been re-allocated.
+            # PinMemoryAllocator.batched_free already invalidates; this brings
+            # PagedTensorMemoryAllocator in line with that contract.
+            memory_obj.invalidate()
             if memory_obj.meta.shapes != self.shapes:
                 page_idx = memory_obj.meta.address
                 memory_obj.raw_data = self.paged_buffers[page_idx]

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -661,20 +661,22 @@ class LocalCPUBackend(AllocatorBackendInterface):
                         wait_other_requests = False
                         for evict_key in evict_keys:
                             evict_key_all_layer = evict_key.split_layers(batch_size)
-
-                            # TODO(Jiayi): batched allocate is not supported through
-                            # `batched_remove`. Therefore, features like usage tracking
-                            # is not supported.
-                            old_mem_objs = []
+                            # PATCH: drop ref via ref_count_down() instead of calling
+                            # allocator.batched_free() directly. The memory_management
+                            # module docstring says: "this function shouldn't be explicitly
+                            # called. Instead, use `ref_count_down` to decrease ref count."
+                            # Skipping it leaks MemoryObj wrappers (ref_count stuck at 1)
+                            # and can corrupt buffers if any other holder still references
+                            # them at eviction time.
+                            evicted_count = 0
                             for key in evict_key_all_layer:
-                                old_mem_objs.append(self.hot_cache[key])
-                                self.cache_policy.update_on_force_evict(key)
-                                self.hot_cache.pop(key, None)
-
-                            self.memory_allocator.batched_free(old_mem_objs)
-
+                                memory_obj = self.hot_cache.pop(key, None)
+                                if memory_obj is not None:
+                                    self.cache_policy.update_on_force_evict(key)
+                                    memory_obj.ref_count_down()
+                                    evicted_count += 1
                             logger.debug(
-                                f"Evicting {len(old_mem_objs)} chunks from cpu memory"
+                                f"Evicting {evicted_count} chunks from cpu memory"
                             )
                     else:
                         self.stats_monitor.update_local_cpu_evict_failed_count(


### PR DESCRIPTION
## Summary

Two related ref-count correctness fixes in the LocalCPUBackend eviction path:

1. **`local_cpu_backend.batched_remove`** was calling `memory_allocator.batched_free()` directly, bypassing the `MemoryObj` ref-count contract that the module's own docstring establishes ("this function shouldn't be explicitly called. Instead, use `ref_count_down` to decrease ref count."). Single-key `remove()` already honors this contract; batched eviction now does too.

2. **`PagedTensorMemoryAllocator.batched_free`** had `memory_obj.invalidate()` commented out. `PinMemoryAllocator.batched_free` (line 1465) invalidates. Uncommenting brings the paged allocator in line with the pin allocator's contract.

Each commit is independently landable and can be reviewed separately.

## Why this matters

Under sustained workloads that hit the CPU cap and trigger batched eviction, both bugs surface:

**Bug #1 consequences:**
- `MemoryObj` wrappers stuck at `ref_count=1` after eviction. Underlying bytes return to the allocator pool, but the Python wrapper never reaches `ref_count=0`, so `PinMonitor` and usage counters stay elevated. Accumulates over time.
- If another holder had `ref_count_up`'d the chunk (in-flight `get_blocking()` reader racing with eviction), `batched_free()` forcibly releases its bytes while the reader still thinks it's valid. The new path respects both `pin_count` and `ref_count`.

**Bug #2 consequences:**
- After `batched_free`, the evicted `MemoryObj`'s `is_valid()` still returns `True` and its `raw_data` still points at the underlying buffer. If a stale reference survives past eviction, the reader reads-through to bytes that may have already been re-allocated to a new store. Correctness hazard.

## Evidence

Observed on **GLM-5.1 NVFP4 (MLA)** on 8×B200 under `conc=32`, 20K-token random prompts:

| config | RSS growth rate | notes |
|---|---|---|
| unpatched LMCache | ~30 GB/hr | + container self-terminates at ~15 min under pressure |
| **this PR (patches 1+2)** | **~13 GB/hr** | **56% reduction; survived full 35-min soak** |
| no LMCache (sglang baseline) | ~7 GB/hr | baseline leak rate is sglang-intrinsic, not LMCache |

The ~6 GB/hr LMCache-attributable residual after these two patches is likely additional ref-count paths we haven't reviewed. The dominant contributor was batched eviction.

MLA/compressed-latent models (GLM-5.1, DeepSeek-V2) surface this first because their KV chunks are larger and fill the CPU cap in seconds. MHA users would see the same pattern on longer timescales.

## Testing

Manually verified by:
1. Running `sglang.bench_serving --dataset-name random --random-input-len 20000 --random-output-len 1024 --num-prompts 2400 --max-concurrency 32 --request-rate 2` against sglang+LMCache on 8×B200
2. Sampling cgroup memory every 10s during the run
3. Comparing slope with and without the patches

Suggest adding a unit test for `batched_remove` that asserts `ref_count` reaches 0 after eviction — happy to add in a follow-up if maintainers want.

## Files changed

- `lmcache/v1/storage_backend/local_cpu_backend.py` (+14 / -12)
- `lmcache/v1/memory_management.py` (+5 / -1)

Both are small, localized changes. No test file changes (happy to add if requested).

## Notes

- `PagedTensorMemoryAllocator.free` (non-batched, line ~1738) also has `invalidate()` commented out. I left it alone in this PR since it's not on the observed hot path, but a follow-up could normalize it for consistency.
- No performance impact from invalidate() (single bool write). Batched-eviction path loses one lock acquisition worth of coalescing on `PinMemoryAllocator` under heavy eviction; <5% theoretical hit in that case, unmeasurable in our runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cache eviction/free paths; while localized, incorrect behavior could cause memory leaks or use-after-free-style stale reads under concurrency if assumptions about ref/pin counts differ.
> 
> **Overview**
> Fixes batched eviction in `LocalCPUBackend.batched_allocate` to **decrement `MemoryObj` refs via `ref_count_down()`** (after removing keys) instead of directly calling `memory_allocator.batched_free()`, aligning batched removal with the module’s ref-count contract and avoiding leaked wrappers/stale buffer releases.
> 
> Updates `PagedTensorMemoryAllocator.batched_free` to **invalidate freed `MemoryObj`s** so any stale references reliably observe `is_valid=False` rather than continuing to point at pages that may be reallocated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619e6bb6f9c5bb1bcf5b7227b71d731f4cc7f09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->