### PR TITLE
[Chore][docs] daily drift check — multi-process mode (2026-04-24)

### DIFF
--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -56,10 +56,13 @@ which adds CacheBlend operations (``CB_REGISTER_KV_CACHE``,
 cache reuse across document paragraphs.
 
 **``http_server.py``** -- Wraps ``run_cache_server()`` (from ``server.py``)
-inside a FastAPI application.  Adds ``/api/healthcheck`` for Kubernetes probes,
-``POST /api/clear-cache`` for clearing all KV cache data in L1 (CPU) memory,
-and ``/api/status`` for inspecting detailed internal state.
-The ZMQ server runs as part of the same process.
+inside a FastAPI application.  Endpoints are contributed by modules under
+``http_apis/`` and auto-registered via ``HTTPAPIRegistry``: ``GET /`` (basic
+liveness), ``GET /api/healthcheck`` for Kubernetes probes, ``POST /api/clear-cache``
+for clearing all KV cache data in L1 (CPU) memory, and ``GET /api/status``
+for inspecting detailed internal state.  The ZMQ server runs as part of the
+same process, and any configured runtime plugins are spawned by
+``MPRuntimePluginLauncher`` during FastAPI startup.
 
 ZMQ Protocol
 ------------
@@ -144,6 +147,9 @@ Each config module exposes a composable triple:
 
     parser = argparse.ArgumentParser(...)
     add_mp_server_args(parser)        # from multiprocess/config.py
+                                      # includes runtime-plugin args
+                                      # (--runtime-plugin-locations,
+                                      #  --runtime-plugin-config)
     add_storage_manager_args(parser)  # from distributed/config.py
       # which internally calls add_l2_adapters_args(parser)
     add_observability_args(parser)    # from mp_observability/config.py
@@ -311,13 +317,25 @@ How to Extend
 Adding a new L2 adapter
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+Create a new ``*_l2_adapter.py`` module under
+``lmcache/v1/distributed/l2_adapters/`` — ``__init__.py`` auto-discovers
+modules matching that suffix via ``pkgutil`` and imports them lazily on
+first use, so no other files need to be modified.
+
 1. Create a config class subclassing ``L2AdapterConfigBase`` with
    ``from_dict()`` and ``help()`` methods.
-2. Call ``register_l2_adapter_type("my_adapter", MyAdapterConfig)`` at module
-   level.
-3. Create an adapter class implementing ``L2AdapterInterface``.
-4. Add an ``isinstance()`` branch in ``create_l2_adapter()``
-   (``l2_adapters/__init__.py``).
+2. Create an adapter class implementing ``L2AdapterInterface``, and
+   a small factory function
+   ``(config, l1_memory_desc) -> L2AdapterInterface``.
+3. At module level, self-register both the config and the factory:
+
+   .. code-block:: python
+
+       register_l2_adapter_type("my_adapter", MyAdapterConfig)
+       register_l2_adapter_factory("my_adapter", _create_my_adapter)
+
+See ``mock_l2_adapter.py`` or ``s3_l2_adapter.py`` for reference
+implementations.
 
 Adding an observability subscriber
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -362,6 +380,14 @@ Key Source Files
      - BlendEngineV2 (extends MPCacheEngine)
    * - ``lmcache/v1/multiprocess/http_server.py``
      - FastAPI wrapper with health check and many other useful APIs
+   * - ``lmcache/v1/multiprocess/http_api_registry.py``
+     - ``HTTPAPIRegistry`` that auto-discovers routers in ``http_apis/``
+   * - ``lmcache/v1/multiprocess/http_apis/``
+     - Extensible HTTP endpoints (``/``, ``/api/healthcheck``,
+       ``/api/clear-cache``, ``/api/status``)
+   * - ``lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py``
+     - ``MPRuntimePluginLauncher`` that spawns runtime plugins with the
+       full server config serialized into environment variables
    * - ``lmcache/v1/multiprocess/protocols/base.py``
      - RequestType, HandlerType, ProtocolDefinition
    * - ``lmcache/v1/distributed/storage_manager.py``

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -52,6 +52,17 @@ Source: ``lmcache/v1/multiprocess/config.py``
        ``default`` uses MPCacheEngine; ``blend`` uses BlendEngineV2
        for cross-request KV reuse.
        Choices: ``default``, ``blend``.
+   * - ``--runtime-plugin-locations``
+     - ``[]``
+     - Zero or more paths to runtime plugin scripts or directories to
+       launch alongside the server. Plugins are spawned by
+       ``MPRuntimePluginLauncher`` and receive the full server config
+       via the ``LMCACHE_RUNTIME_PLUGIN_CONFIG`` environment variable.
+   * - ``--runtime-plugin-config``
+     - ``"{}"``
+     - JSON string of extra key-value config forwarded to runtime
+       plugins via ``LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG``. Example:
+       ``'{"plugin.frontend.heartbeat_url": "http://localhost:5000/heartbeat"}'``.
 
 Lookup Hash Logging
 -------------------
@@ -223,7 +234,9 @@ L2 adapters are configured via repeatable ``--l2-adapter <JSON>`` arguments.
 Each JSON object must include a ``"type"`` field that selects the adapter type.
 The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
-Registered adapter types: ``nixl_store``, ``fs``, ``mock``.
+Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
+``fs_native``, ``mock``, ``mooncake_store``, ``s3``, ``resp``, ``plugin``,
+``native_plugin``.
 
 ``nixl_store`` -- NIXL-based persistent storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,6 +303,34 @@ Example:
 .. code-block:: bash
 
     --l2-adapter '{"type": "mock", "max_size_gb": 256, "mock_bandwidth_gb": 10}'
+
+``s3`` -- S3-compatible object store
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+S3-backed L2 adapter using the AWS CRT (Common Runtime) for high-throughput
+transfers to AWS S3 or any S3-compatible endpoint. See
+:doc:`l2_storage` for details.
+
+Fields:
+
+- ``s3_endpoint`` *(required)*: Bucket URL, either ``"s3://<bucket>"`` or
+  the bare host form.
+- ``s3_region`` *(required)*: AWS region string.
+- ``s3_num_io_threads`` *(optional, default ``64``)*: CRT I/O threads.
+- ``s3_prefer_http2`` *(optional, default ``true``)*: Negotiate HTTP/2 via ALPN.
+- ``s3_enable_s3express`` *(optional, default ``false``)*: Enable S3 Express signing.
+- ``disable_tls`` *(optional, default ``false``)*: Bypass TLS (for
+  non-AWS HTTP endpoints).
+- ``aws_access_key_id`` / ``aws_secret_access_key`` *(optional)*:
+  Static credentials; omit to use the default credential provider chain.
+- ``max_capacity_gb`` *(optional, default ``0.0``)*: Aggregate capacity
+  used by ``get_usage()``. A value of ``0`` disables aggregate eviction.
+
+Example:
+
+.. code-block:: bash
+
+    --l2-adapter '{"type": "s3", "s3_endpoint": "s3://my-bucket", "s3_region": "us-west-2"}'
 
 Multiple adapters (cascade)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -273,6 +273,47 @@ etc.), see `Mooncake <https://github.com/kvcache-ai/Mooncake>`_ .
   LMCache L1 memory is enabled and that the descriptor has a non-zero pointer
   and size.
 
+``s3`` -- S3-compatible object store
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An L2 adapter that stores KV cache objects as S3 objects using the AWS
+Common Runtime (CRT).  Works with AWS S3, S3 Express One Zone, and any
+S3-compatible endpoint (MinIO, Ceph RGW, etc.).
+
+**Required fields:**
+
+- ``s3_endpoint``: Bucket URL -- either ``"s3://<bucket>"`` or the bare host form
+  (used for non-AWS endpoints).
+- ``s3_region``: AWS region string (e.g. ``"us-west-2"``).
+
+**Optional fields:**
+
+- ``s3_num_io_threads`` (int, default ``64``): Number of CRT I/O threads.
+- ``s3_prefer_http2`` (bool, default ``true``): Negotiate HTTP/2 via ALPN.
+- ``s3_enable_s3express`` (bool, default ``false``): Enable S3 Express signing
+  for S3 Express One Zone buckets.
+- ``disable_tls`` (bool, default ``false``): Bypass TLS when pointing at a
+  plain-HTTP endpoint (e.g. a local MinIO).
+- ``aws_access_key_id`` / ``aws_secret_access_key`` (string): Static
+  credentials; omit both to use the AWS default credential provider chain
+  (environment, EC2 instance profile, etc.).
+- ``max_capacity_gb`` (float, default ``0.0``): Aggregate capacity used by
+  ``get_usage()``.  A value of ``0`` disables aggregate eviction
+  (``usage_fraction == -1.0``).
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # AWS S3 with default credentials
+    --l2-adapter '{"type": "s3", "s3_endpoint": "s3://my-bucket", "s3_region": "us-west-2"}'
+
+    # Static credentials, HTTP/2 disabled
+    --l2-adapter '{"type": "s3", "s3_endpoint": "s3://my-bucket", "s3_region": "us-west-2", "s3_prefer_http2": false, "aws_access_key_id": "AKIA...", "aws_secret_access_key": "..."}'
+
+    # Local MinIO over plain HTTP
+    --l2-adapter '{"type": "s3", "s3_endpoint": "minio.local:9000", "s3_region": "us-east-1", "disable_tls": true, "aws_access_key_id": "minio", "aws_secret_access_key": "minio123"}'
+
 ``mock`` -- Mock adapter for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -490,6 +531,12 @@ drops by ``eviction_ratio``.
    * - ``mock``
      - Full support. Useful for testing eviction behaviour without
        real storage hardware.
+   * - ``s3``
+     - ``delete`` removes objects from the bucket and frees aggregate
+       byte accounting. ``get_usage`` reports ``usage_fraction == -1.0``
+       when ``max_capacity_gb`` is ``0`` (disabled); set a non-zero
+       ``max_capacity_gb`` to enable the watermark-triggered eviction
+       controller.
    * - ``mooncake_store``
      - No eviction support (native connector adapter).
    * - ``fs``


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

Aligns `docs/source/mp/` with recent changes on `dev` since the last drift-check PR (#3076, merged 2026-04-21). Scope: `docs/source/mp/configuration.rst`, `docs/source/mp/l2_storage.rst`, `docs/source/mp/architecture.rst` (+124 / −10).

### Fresh drift (commits in the last ~72 h)

**New S3 L2 adapter — #3064 (2026-04-24)**

The `s3` adapter self-registers at import time but is not mentioned in user docs.

- Evidence: [`lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py#L983`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py#L983) (`register_l2_adapter_type("s3", S3L2AdapterConfig)`) and config class at [`L135-L234`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py#L135-L234).
- Doc locations: `docs/source/mp/configuration.rst` (`Registered adapter types` line + `L2 Adapters` subsections) and `docs/source/mp/l2_storage.rst` (`Adapter Types` + `L2 Eviction` adapter-support table).
- Fix: add an `s3` subsection to both docs, extend the registered-types list, add an `s3` row to the L2-eviction adapter-support table.

**Runtime plugin CLI flags — #2956 (2026-04-22)**

`--runtime-plugin-locations` and `--runtime-plugin-config` were added to the MP server argparse group but are not in the configuration reference.

- Evidence: [`lmcache/v1/multiprocess/config.py#L153-L169`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/multiprocess/config.py#L153-L169).
- Doc location: `docs/source/mp/configuration.rst` "MP Server" table.
- Fix: add both flags with defaults and the env var they populate.

**HTTP server extensibility refactor — #3017 (2026-04-23)**

`http_server.py` no longer hardcodes endpoints; it uses `HTTPAPIRegistry` to auto-discover routers in `http_apis/`, adds a new `GET /` liveness endpoint, and launches `MPRuntimePluginLauncher` during FastAPI startup.

- Evidence: [`lmcache/v1/multiprocess/http_server.py#L116-L120`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/multiprocess/http_server.py#L116-L120) (registry wiring) and [`#L80-L96`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/multiprocess/http_server.py#L80-L96) (plugin launcher). Routers at [`lmcache/v1/multiprocess/http_apis/`](https://github.com/LMCache/LMCache/tree/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/multiprocess/http_apis).
- Doc location: `docs/source/mp/architecture.rst` "Server Variants" (`http_server.py` paragraph) and "Key Source Files" table.
- Fix: reword the `http_server.py` paragraph, add `http_api_registry.py`, `http_apis/`, and `mp_runtime_plugin_launcher.py` to Key Source Files.

### Pre-existing drift (touched for coherence)

**Stale "Adding a new L2 adapter" extension guide**

`docs/source/mp/architecture.rst` currently instructs developers to add an `isinstance()` branch in `create_l2_adapter()` (`l2_adapters/__init__.py`). The actual flow is factory-based, auto-discovered via `pkgutil`, and requires no edits to other files.

- Evidence: [`lmcache/v1/distributed/l2_adapters/__init__.py#L28-L58`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/distributed/l2_adapters/__init__.py#L28-L58) and [`factory.py#L62-L81`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/lmcache/v1/distributed/l2_adapters/factory.py#L62-L81). Mirrored design doc at [`docs/design/v1/distributed/l2_adapters/overall.md#L491-L509`](https://github.com/LMCache/LMCache/blob/b016774674df7a65f8389afc1440590233d70253/docs/design/v1/distributed/l2_adapters/overall.md#L491-L509) is already correct.
- Fix: rewrite to `register_l2_adapter_type` + `register_l2_adapter_factory`.

**Incomplete "Registered adapter types" list in `configuration.rst`**

Listed only `nixl_store, fs, mock`. Actual registered set (from `grep -rn "register_l2_adapter_type" lmcache/v1/distributed/l2_adapters/`): `fs, fs_native, mock, mooncake_store, native_plugin, nixl_store, nixl_store_dynamic, plugin, resp, s3`.

### `docs/design/`

No new drift observed this run — the mirrored design docs under `docs/design/v1/distributed/l2_adapters/` already describe the factory + pkgutil pattern correctly.

## Proposed fix

Applied in this PR. Surgical doc edits only — no code touched.

## Notes for reviewers

- The three "fresh drift" items are direct consequences of #3064 / #3017 / #2956 landing after the previous drift-check PR (#3076) merged on 2026-04-21.
- The "pre-existing drift" items would have been caught earlier but were adjacent to the architecture.rst edits needed for #3017, so they're bundled here for coherence. Happy to split them out if preferred.
- This was **auto-generated by the daily drift-check routine** and needs human review before merge.

## Test plan

- [ ] Sphinx builds `docs/` without new warnings.
- [ ] Eyeball the rendered `mp/configuration.rst` "Registered adapter types" list and new `s3` subsection.
- [ ] Eyeball the rendered `mp/l2_storage.rst` `s3` section and the L2 eviction adapter-support table.
- [ ] Eyeball the rendered `mp/architecture.rst` "Server Variants" paragraph for `http_server.py` and the updated "Adding a new L2 adapter" extension guide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcsChsuGQpcZC4BUaamrsz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only changes documentation, but inaccuracies could mislead users configuring runtime plugins, HTTP endpoints, or L2 adapters.
> 
> **Overview**
> Aligns `docs/source/mp/` with recent multiprocess changes by documenting the HTTP server’s new `HTTPAPIRegistry`/`http_apis/` extensibility, `GET /` liveness, and runtime plugin startup via `MPRuntimePluginLauncher`.
> 
> Extends the configuration reference with `--runtime-plugin-locations` and `--runtime-plugin-config`, and updates L2 adapter docs to include the new `s3` adapter (fields/examples plus eviction behavior) and to refresh the “Adding a new L2 adapter” guide to the current self-registration + factory pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa02f122eaae6fb6407bd97eb3554c88c7f1af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->