### PR TITLE
 [CI] add missing egress endpoint to nightly Docker build

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -158,6 +158,7 @@ jobs:
               releases.astral.sh:443
               download.pytorch.org:443
               download-r2.pytorch.org:443
+              pypi.nvidia.com:443
 
       - name: Login to DockerHub
         if: vars.DOCKERHUB_USERNAME != ''


### PR DESCRIPTION
 Description:
   The nightly image-build target installs vLLM nightly wheels, which pull NVIDIA CUDA libraries
   (e.g. nvidia-cudnn-cu12) from pypi.nvidia.com. This host was not in the Harden Runner
  allowlist for the nightly-build job, causing the build to fail with Connection refused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk allowlist-only change to CI networking; the main impact is permitting outbound access to `pypi.nvidia.com` during the nightly image build, which could slightly broaden external dependency surface.
> 
> **Overview**
> Fixes nightly Docker image build failures by **adding `pypi.nvidia.com:443` to the Harden Runner egress allowlist** in `.github/workflows/nightly_build.yml`, enabling installs of NVIDIA CUDA-related wheels pulled during the nightly image build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c27fb211ed62d7628811623753a479d3c46e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->