### PR TITLE
[CI/CD] Skip flaky test_p2p_backend_with_controller

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,5 +105,6 @@ jobs:
             --ignore=tests/v1/mp_observability/ \
             --ignore=tests/skipped \
             --ignore=tests/cli/commands/trace \
-            --ignore=tests/v1/storage_backend/test_eic.py
+            --ignore=tests/v1/storage_backend/test_eic.py \
+            --ignore=tests/v1/storage_backend/test_p2p_backend_with_controller.py
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `tests/v1/storage_backend/test_p2p_backend_with_controller.py` test sometimes blocks the GitHub test workflow. This PR adds it to the `--ignore` list in the non-CUDA unit test step so CI runs are no longer stuck on it.

**Special notes for your reviewers**:

Minimal change -- one additional `--ignore` line in `.github/workflows/test.yml`. The test remains in the repo and can still be run locally; only the GitHub Actions `Test` workflow skips it.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just excludes a single test from the non-CUDA pytest run; it could reduce coverage in CI if the test was catching regressions.
> 
> **Overview**
> Updates the GitHub Actions `Test` workflow to skip `tests/v1/storage_backend/test_p2p_backend_with_controller.py` in the non-CUDA `pytest` step, preventing CI runs from hanging on this flaky test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd99a50d92a02cf8da7e05105b110f7bd21fa370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->