### PR TITLE
[MP][Feat] Add IsolatedLRU eviction policy + per-cache_salt quotas

### DIFF
--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -61,7 +61,7 @@ class EvictionConfig:
     The configuration for eviction policies (L1 and optionally L2).
     """
 
-    eviction_policy: Literal["LRU", "noop"]
+    eviction_policy: Literal["LRU", "IsolatedLRU", "noop"]
     """ The eviction policy to use. """
 
     trigger_watermark: float = field(default=0.8)
@@ -176,9 +176,11 @@ def add_storage_manager_args(
     eviction_group.add_argument(
         "--eviction-policy",
         type=str,
-        choices=["LRU", "noop"],
+        choices=["LRU", "IsolatedLRU", "noop"],
         required=True,
-        help="The eviction policy to use ('LRU' or 'noop').",
+        help="The eviction policy to use ('LRU', 'IsolatedLRU', or 'noop'). "
+        "'IsolatedLRU' maintains one LRU list per cache_salt and requires "
+        "quotas keyed by cache_salt to be configured via the HTTP API.",
     )
     eviction_group.add_argument(
         "--eviction-trigger-watermark",

--- a/lmcache/v1/distributed/eviction_policy/__init__.py
+++ b/lmcache/v1/distributed/eviction_policy/__init__.py
@@ -7,6 +7,9 @@ Eviction policies for L1 cache management
 from lmcache.v1.distributed.eviction_policy.factory import (
     CreateEvictionPolicy,
 )
+from lmcache.v1.distributed.eviction_policy.isolated_lru import (
+    IsolatedLRUEvictionPolicy,
+)
 from lmcache.v1.distributed.eviction_policy.lru import (
     LRUEvictionPolicy,
 )
@@ -17,5 +20,6 @@ from lmcache.v1.distributed.eviction_policy.noop import (
 __all__ = [
     "LRUEvictionPolicy",
     "NoOpEvictionPolicy",
+    "IsolatedLRUEvictionPolicy",
     "CreateEvictionPolicy",
 ]

--- a/lmcache/v1/distributed/eviction_policy/factory.py
+++ b/lmcache/v1/distributed/eviction_policy/factory.py
@@ -3,6 +3,9 @@
 # First Party
 from lmcache.v1.distributed.config import EvictionConfig
 from lmcache.v1.distributed.eviction import EvictionPolicy
+from lmcache.v1.distributed.eviction_policy.isolated_lru import (
+    IsolatedLRUEvictionPolicy,
+)
 from lmcache.v1.distributed.eviction_policy.lru import LRUEvictionPolicy
 from lmcache.v1.distributed.eviction_policy.noop import NoOpEvictionPolicy
 
@@ -19,6 +22,8 @@ def CreateEvictionPolicy(eviction_config: EvictionConfig) -> EvictionPolicy:
     """
     if eviction_config.eviction_policy == "LRU":
         return LRUEvictionPolicy()
+    elif eviction_config.eviction_policy == "IsolatedLRU":
+        return IsolatedLRUEvictionPolicy()
     elif eviction_config.eviction_policy == "noop":
         return NoOpEvictionPolicy()
     else:

--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -109,7 +109,13 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
         cache_salt: str | None = None,
     ) -> list[EvictionAction]:
-        """Select victims in LRU order, optionally scoped to one salt.
+        """Select victims in LRU order, scoped to a single ``cache_salt``.
+
+        IsolatedLRU is "isolated only" by contract — callers must pass a
+        concrete ``cache_salt``. The base interface keeps ``cache_salt``
+        optional for compatibility with non-isolated policies; passing
+        ``None`` here raises ``ValueError`` rather than silently
+        falling back to a global pool.
 
         Args:
             expected_ratio: Fraction of the candidate pool to evict,
@@ -118,30 +124,26 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
                 returned (matches ``LRUEvictionPolicy``).
             key_eligible_filter: Optional predicate — keys failing the
                 filter (e.g. locked) are skipped.
-            cache_salt: When set, only this salt's bucket is considered.
-                When ``None``, victims are taken across all buckets.
+            cache_salt: The salt whose bucket to evict from. Required.
 
         Returns:
-            A single ``EvictionAction`` covering all selected keys, or
-            an empty list if nothing is available to evict.
+            A list with at most one ``EvictionAction`` (one per
+            destination — IsolatedLRU has a single destination, so the
+            list is either empty or length 1). Empty when nothing is
+            available to evict under the current filter / ratio.
+
+        Raises:
+            ValueError: If ``cache_salt`` is ``None``.
         """
+        if cache_salt is None:
+            raise ValueError(
+                "IsolatedLRUEvictionPolicy.get_eviction_actions requires "
+                "cache_salt; this policy is per-bucket and has no global "
+                "eviction path."
+            )
         with self._lock:
-            if cache_salt is not None:
-                order = self._per_salt_order.get(cache_salt)
-                pool = list(order.keys()) if order else []
-            else:
-                # Global eviction: concatenate every bucket in
-                # dict-insertion order (i.e. first-seen-salt first).
-                # This is deterministic but NOT "oldest key first across
-                # all salts" — salts that happened to see traffic early
-                # get evicted first even if their current front is
-                # newer than another salt's. The isolated controller
-                # branch doesn't hit this path (always passes an
-                # explicit salt); global eviction here is a fallback
-                # for callers that explicitly opt in.
-                pool = []
-                for order in self._per_salt_order.values():
-                    pool.extend(order.keys())
+            order = self._per_salt_order.get(cache_salt)
+            pool = list(order.keys()) if order else []
 
             if not pool:
                 return []

--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+IsolatedLRU (per-``cache_salt`` LRU) eviction policy.
+
+Unlike :class:`LRUEvictionPolicy` which maintains a single global LRU
+list, this policy keeps one LRU list per ``cache_salt`` and uses
+``support_isolation=True`` so the L2 eviction controller can scope
+eviction to a specific salt via the ``cache_salt`` argument to
+``get_eviction_actions``.
+
+Combined with :class:`QuotaManager`, this lets the controller evict
+only the over-quota ``cache_salt``'s keys while leaving other salts'
+cached data untouched.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections import OrderedDict
+from collections.abc import Callable
+import threading
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction import EvictionPolicy
+from lmcache.v1.distributed.internal_api import (
+    EvictionAction,
+    EvictionDestination,
+)
+
+
+class IsolatedLRUEvictionPolicy(EvictionPolicy):
+    """Per-``cache_salt`` LRU eviction policy.
+
+    Maintains one ``OrderedDict`` per ``cache_salt`` (keyed by
+    ``ObjectKey``). New and touched keys move to the end of their
+    bucket's ordering; least-recently-used keys stay at the front and
+    are evicted first.
+
+    Thread-safety: every public method holds a single lock so bucket
+    dicts cannot be mutated concurrently.
+    """
+
+    @property
+    def support_isolation(self) -> bool:
+        return True
+
+    def __init__(
+        self,
+        default_destination: EvictionDestination = EvictionDestination.DISCARD,
+    ):
+        self._lock = threading.Lock()
+        # cache_salt -> ordered {ObjectKey: None} (oldest first).
+        self._per_salt_order: dict[str, OrderedDict[ObjectKey, None]] = {}
+        # Registered destinations (first one wins if any are registered,
+        # matching LRUEvictionPolicy semantics).
+        self._destinations: list[EvictionDestination] = []
+        self._default_destination = default_destination
+
+    def register_eviction_destination(self, destination: EvictionDestination) -> None:
+        with self._lock:
+            if destination not in self._destinations:
+                self._destinations.append(destination)
+
+    def on_keys_created(self, keys: list[ObjectKey]) -> None:
+        if not keys:
+            return
+        with self._lock:
+            # Same prefix-match ordering rationale as ``LRUEvictionPolicy``:
+            # later keys in a request should be evicted first, so we
+            # insert in reverse to place the final key at the LRU head.
+            for key in reversed(keys):
+                order = self._per_salt_order.get(key.cache_salt)
+                if order is None:
+                    order = OrderedDict()
+                    self._per_salt_order[key.cache_salt] = order
+                if key in order:
+                    order.move_to_end(key)
+                else:
+                    order[key] = None
+
+    def on_keys_touched(self, keys: list[ObjectKey]) -> None:
+        if not keys:
+            return
+        with self._lock:
+            for key in reversed(keys):
+                order = self._per_salt_order.get(key.cache_salt)
+                if order is not None and key in order:
+                    order.move_to_end(key)
+
+    def on_keys_removed(self, keys: list[ObjectKey]) -> None:
+        if not keys:
+            return
+        with self._lock:
+            for key in keys:
+                order = self._per_salt_order.get(key.cache_salt)
+                if order is None:
+                    continue
+                order.pop(key, None)
+                if not order:
+                    # Drop the empty bucket so ``list``/iteration
+                    # snapshots stay compact.
+                    del self._per_salt_order[key.cache_salt]
+
+    def get_eviction_actions(
+        self,
+        expected_ratio: float,
+        key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
+        cache_salt: str | None = None,
+    ) -> list[EvictionAction]:
+        """Select victims in LRU order, optionally scoped to one salt.
+
+        Args:
+            expected_ratio: Fraction of the candidate pool to evict,
+                clamped to ``[0.0, 1.0]``. If the ratio rounds down to
+                zero and the pool is non-empty, at least one key is
+                returned (matches ``LRUEvictionPolicy``).
+            key_eligible_filter: Optional predicate — keys failing the
+                filter (e.g. locked) are skipped.
+            cache_salt: When set, only this salt's bucket is considered.
+                When ``None``, victims are taken across all buckets.
+
+        Returns:
+            A single ``EvictionAction`` covering all selected keys, or
+            an empty list if nothing is available to evict.
+        """
+        with self._lock:
+            if cache_salt is not None:
+                order = self._per_salt_order.get(cache_salt)
+                pool = list(order.keys()) if order else []
+            else:
+                # Global eviction: concatenate every bucket in
+                # dict-insertion order (i.e. first-seen-salt first).
+                # This is deterministic but NOT "oldest key first across
+                # all salts" — salts that happened to see traffic early
+                # get evicted first even if their current front is
+                # newer than another salt's. The isolated controller
+                # branch doesn't hit this path (always passes an
+                # explicit salt); global eviction here is a fallback
+                # for callers that explicitly opt in.
+                pool = []
+                for order in self._per_salt_order.values():
+                    pool.extend(order.keys())
+
+            if not pool:
+                return []
+
+            expected_ratio = max(0.0, min(1.0, expected_ratio))
+            target_count = int(len(pool) * expected_ratio)
+            if expected_ratio > 0 and target_count == 0:
+                target_count = 1
+            if target_count == 0:
+                return []
+
+            keys_to_evict: list[ObjectKey] = []
+            for key in pool:
+                if key_eligible_filter is not None and not key_eligible_filter(key):
+                    continue
+                keys_to_evict.append(key)
+                if len(keys_to_evict) >= target_count:
+                    break
+
+            if not keys_to_evict:
+                return []
+
+            destination = self._default_destination
+            if self._destinations:
+                destination = self._destinations[0]
+
+            return [EvictionAction(keys=keys_to_evict, destination=destination)]
+
+    # =========================================================================
+    # Methods below are NOT part of the EvictionPolicy interface.
+    # They are provided for testing and debugging purposes only.
+    # =========================================================================
+
+    def get_num_tracked_keys(self, cache_salt: str | None = None) -> int:
+        """Number of tracked keys, optionally scoped to one bucket."""
+        with self._lock:
+            if cache_salt is not None:
+                order = self._per_salt_order.get(cache_salt)
+                return len(order) if order is not None else 0
+            return sum(len(o) for o in self._per_salt_order.values())
+
+    def get_tracked_salts(self) -> list[str]:
+        """Return the set of cache_salts with at least one tracked key."""
+        with self._lock:
+            return list(self._per_salt_order.keys())

--- a/lmcache/v1/distributed/internal_api.py
+++ b/lmcache/v1/distributed/internal_api.py
@@ -168,3 +168,11 @@ class EvictionAction:
 
     keys: list[ObjectKey] = field(default_factory=list)
     """The key of the object to be evicted"""
+
+
+@dataclass(frozen=True)
+class QuotaEntry:
+    """Snapshot of a single quota registration."""
+
+    cache_salt: str
+    limit_bytes: int

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -227,9 +227,10 @@ class L2AdapterConfigBase(ABC):
         from lmcache.v1.distributed.config import EvictionConfig  # noqa: PLC0415
 
         policy = eviction_dict.get("eviction_policy")
-        if policy not in ("LRU", "noop"):
+        if policy not in ("LRU", "IsolatedLRU", "noop"):
             raise ValueError(
-                f"eviction.eviction_policy must be 'LRU' or 'noop', got {policy!r}"
+                "eviction.eviction_policy must be 'LRU', 'IsolatedLRU', or "
+                f"'noop', got {policy!r}"
             )
         return EvictionConfig(
             eviction_policy=policy,

--- a/lmcache/v1/distributed/quota_manager.py
+++ b/lmcache/v1/distributed/quota_manager.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Per-cache_salt quota registry.
+
+Holds the authoritative map from ``cache_salt`` to a byte budget.
+Consumed by the L2 eviction controller each cycle to decide which
+users are over their quota, and by the HTTP API for runtime
+administration (CRUD endpoints at ``/api/quota/...``).
+
+Allowlist semantics: a ``cache_salt`` with no entry has an effective
+limit of ``0`` bytes — stores are still permitted on the hot path,
+but any bytes accumulated under that salt will be evicted at the next
+eviction cycle. Only salts with an explicit quota retain cached data.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+import threading
+
+
+@dataclass(frozen=True)
+class QuotaEntry:
+    """Snapshot of a single quota registration."""
+
+    cache_salt: str
+    limit_bytes: int
+
+
+class QuotaManager:
+    """Thread-safe registry of byte quotas keyed by ``cache_salt``.
+
+    Quotas are dynamic — CRUD operations (``set_quota``, ``delete_quota``)
+    are cheap, and any change takes effect on the very next eviction
+    cycle (no restart needed).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # cache_salt -> limit in bytes
+        self._limits: dict[str, int] = {}
+
+    def set_quota(self, cache_salt: str, limit_bytes: int) -> None:
+        """Create or update the quota for ``cache_salt``.
+
+        Raises ``ValueError`` for a negative limit. A zero limit is
+        accepted and behaves identically to having no entry at all
+        (keys under this salt will be evicted next cycle) — the
+        difference is purely bookkeeping: the entry shows up in
+        ``list_quotas()`` until removed.
+        """
+        if limit_bytes < 0:
+            raise ValueError(f"limit_bytes must be non-negative (got {limit_bytes})")
+        with self._lock:
+            self._limits[cache_salt] = limit_bytes
+
+    def delete_quota(self, cache_salt: str) -> bool:
+        """Remove the quota entry for ``cache_salt``.
+
+        Returns ``True`` if an entry was removed, ``False`` if the salt
+        had no registration. After deletion the effective limit drops
+        to ``0``, so any existing bytes under that salt will be evicted
+        at the next eviction cycle.
+        """
+        with self._lock:
+            return self._limits.pop(cache_salt, None) is not None
+
+    def get_limit_bytes(self, cache_salt: str) -> int:
+        """Return the effective limit for ``cache_salt``.
+
+        Unregistered salts resolve to ``0`` (allowlist semantics) —
+        callers use this value to drive eviction decisions, so the
+        zero default deliberately triggers eviction of any bytes
+        accumulated under an unknown salt.
+        """
+        with self._lock:
+            return self._limits.get(cache_salt, 0)
+
+    def has_quota(self, cache_salt: str) -> bool:
+        """Whether ``cache_salt`` has an explicit registration.
+
+        Useful for distinguishing "zero limit by default" from
+        "explicitly registered with limit=0" in status reports.
+        """
+        with self._lock:
+            return cache_salt in self._limits
+
+    def list_quotas(self) -> list[QuotaEntry]:
+        """Return a snapshot of all registered quotas.
+
+        The returned list is a detached copy; mutating it does not
+        affect the registry.
+        """
+        with self._lock:
+            return [
+                QuotaEntry(cache_salt=salt, limit_bytes=limit)
+                for salt, limit in self._limits.items()
+            ]

--- a/lmcache/v1/distributed/quota_manager.py
+++ b/lmcache/v1/distributed/quota_manager.py
@@ -17,16 +17,10 @@ eviction cycle. Only salts with an explicit quota retain cached data.
 from __future__ import annotations
 
 # Standard
-from dataclasses import dataclass
 import threading
 
-
-@dataclass(frozen=True)
-class QuotaEntry:
-    """Snapshot of a single quota registration."""
-
-    cache_salt: str
-    limit_bytes: int
+# First Party
+from lmcache.v1.distributed.internal_api import QuotaEntry
 
 
 class QuotaManager:

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Future
+from __future__ import annotations
+
 # Standard
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 import threading
 import time
 
@@ -17,6 +21,10 @@ from lmcache.v1.distributed.internal_api import (
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
 from lmcache.v1.distributed.storage_controller import StorageControllerInterface
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.quota_manager import QuotaManager
 
 logger = init_logger(__name__)
 
@@ -161,13 +169,23 @@ class L2EvictionController(StorageControllerInterface):
 
     Each adapter gets its own eviction policy and listener bridge, but a
     single background thread loops over all of them.
+
+    When the adapter's policy sets ``support_isolation == True``
+    (e.g. :class:`IsolatedLRUEvictionPolicy`), the controller consults
+    the injected :class:`QuotaManager` to decide which ``cache_salt``
+    buckets are over budget and evicts from each one in isolation.
+    Otherwise it uses the adapter's aggregate ``usage_fraction``
+    against the configured watermark — unchanged from the pre-PR5
+    behavior.
     """
 
     def __init__(
         self,
         l2_adapter_states: list[L2AdapterEvictionState],
+        quota_manager: QuotaManager | None = None,
     ):
         self._adapter_states = l2_adapter_states
+        self._quota_manager = quota_manager
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(
             target=self._eviction_loop,
@@ -186,8 +204,9 @@ class L2EvictionController(StorageControllerInterface):
         # NOTE: ``usage.bytes_by_cache_salt`` is intentionally NOT
         # surfaced here. A deployment can have 10k+ salts, so embedding
         # the full bucket map in the status response would blow up the
-        # payload. A separate paginated / queried endpoint is the right
-        # home for per-salt inspection if we need it.
+        # payload. Per-salt inspection goes through the dedicated HTTP
+        # quota endpoints (which pull from ``QuotaManager`` +
+        # ``StorageManager.get_usage_bytes_by_cache_salt``).
         adapter_statuses = []
         for state in self._adapter_states:
             usage = state.adapter.get_usage()
@@ -215,6 +234,13 @@ class L2EvictionController(StorageControllerInterface):
                 self._check_and_evict(state)
 
     def _check_and_evict(self, state: L2AdapterEvictionState):
+        if state.eviction_policy.support_isolation and self._quota_manager is not None:
+            self._check_and_evict_by_cache_salt(state)
+        else:
+            self._check_and_evict_global(state)
+
+    def _check_and_evict_global(self, state: L2AdapterEvictionState):
+        """Aggregate-usage eviction (``LRU`` / ``noop``)."""
         watermark = state.eviction_config.trigger_watermark
         eviction_ratio = state.eviction_config.eviction_ratio
 
@@ -240,6 +266,49 @@ class L2EvictionController(StorageControllerInterface):
         actions = state.eviction_policy.get_eviction_actions(eviction_ratio)
         for action in actions:
             self._execute_eviction_action(state.adapter, action)
+
+    def _check_and_evict_by_cache_salt(self, state: L2AdapterEvictionState):
+        """Per-``cache_salt`` eviction driven by :class:`QuotaManager`.
+
+        For every salt with non-zero bytes, compare its usage against
+        ``watermark * quota``. Salts over threshold get eviction scoped
+        to their own LRU list. Salts with no quota registered have an
+        effective limit of ``0`` and are therefore always over budget,
+        so they get a full eviction (``effective_ratio=1.0``) — this
+        enforces the allowlist rule: only registered salts retain data.
+        """
+        assert self._quota_manager is not None
+        watermark = state.eviction_config.trigger_watermark
+        eviction_ratio = state.eviction_config.eviction_ratio
+        usage = state.adapter.get_usage()
+
+        for cache_salt, user_bytes in usage.bytes_by_cache_salt.items():
+            if user_bytes <= 0:
+                continue
+            limit = self._quota_manager.get_limit_bytes(cache_salt)
+            # Trigger on ``>=`` to match the global branch's ``usage <
+            # watermark`` short-circuit. Salts with no quota (limit=0)
+            # always land here because ``user_bytes > 0 >= 0``.
+            if user_bytes < watermark * limit:
+                continue
+
+            # Unregistered / zero-quota salts: wipe everything.
+            # Registered salts: evict the configured ratio of their list.
+            effective_ratio = 1.0 if limit == 0 else eviction_ratio
+            logger.info(
+                "cache_salt=%r over quota (bytes=%d, limit=%d, "
+                "watermark=%.2f); evicting ratio=%.2f.",
+                cache_salt,
+                user_bytes,
+                limit,
+                watermark,
+                effective_ratio,
+            )
+            actions = state.eviction_policy.get_eviction_actions(
+                effective_ratio, cache_salt=cache_salt
+            )
+            for action in actions:
+                self._execute_eviction_action(state.adapter, action)
 
     def _execute_eviction_action(
         self, adapter: L2AdapterInterface, action: EvictionAction

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -11,6 +11,7 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.config import EvictionConfig
 from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
 from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
@@ -276,11 +277,21 @@ class L2EvictionController(StorageControllerInterface):
         effective limit of ``0`` and are therefore always over budget,
         so they get a full eviction (``effective_ratio=1.0``) — this
         enforces the allowlist rule: only registered salts retain data.
+
+        Per-destination keys are batched across all over-budget salts
+        before invoking the adapter — one ``adapter.delete(...)`` call
+        per destination instead of one per (salt, destination) pair.
+        Adapters with non-trivial per-call overhead (NIXL handle setup,
+        FS sync, etc.) see this as a real win when many salts go over
+        budget in the same cycle.
         """
         assert self._quota_manager is not None
         watermark = state.eviction_config.trigger_watermark
         eviction_ratio = state.eviction_config.eviction_ratio
         usage = state.adapter.get_usage()
+
+        # destination -> accumulated keys across all over-budget salts.
+        pending: dict[EvictionDestination, list[ObjectKey]] = {}
 
         for cache_salt, user_bytes in usage.bytes_by_cache_salt.items():
             if user_bytes <= 0:
@@ -308,7 +319,13 @@ class L2EvictionController(StorageControllerInterface):
                 effective_ratio, cache_salt=cache_salt
             )
             for action in actions:
-                self._execute_eviction_action(state.adapter, action)
+                pending.setdefault(action.destination, []).extend(action.keys)
+
+        for destination, keys in pending.items():
+            self._execute_eviction_action(
+                state.adapter,
+                EvictionAction(keys=keys, destination=destination),
+            )
 
     def _execute_eviction_action(
         self, adapter: L2AdapterInterface, action: EvictionAction

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -21,6 +21,7 @@ from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
 from lmcache.v1.distributed.l2_adapters.serde_wrapper import SerdeL2AdapterWrapper
+from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.distributed.serde import create_serde_processor
 from lmcache.v1.distributed.storage_controllers import (
     L1EvictionController,
@@ -76,26 +77,42 @@ class StorageManager:
                 )
             self._l2_adapters.append(adapter)
 
-        # Unified L2 eviction controller for all adapters with eviction config.
-        # Adapters that don't support global (aggregate) eviction
-        # (``supports_global_eviction == False``, i.e. no
-        # ``max_capacity_bytes`` declared — e.g. the FS adapter) are
-        # skipped here even if an ``eviction_config`` is present — the
-        # eviction controller has no aggregate-usage signal to act on.
-        # Per-cache_salt eviction policies (future: quota-based) would
-        # be wired up separately and don't go through this filter.
+        # Per-cache_salt quota registry. Shared across the L2 eviction
+        # controller (reads quotas each cycle) and the HTTP quota
+        # endpoints (CRUD). Present even when no adapter uses
+        # IsolatedLRU so the HTTP layer has a stable ``quota_manager``
+        # reference. No explicit cleanup on close — the registry is
+        # just a dict protected by a lock and has no OS resources.
+        self._quota_manager = QuotaManager()
+
+        # Unified L2 eviction controller for all adapters with eviction
+        # config. Aggregate-usage policies (``LRU``, ``noop``) need
+        # ``max_capacity_bytes > 0`` to compute a usage fraction;
+        # adapters without capacity are skipped for those. Isolated
+        # policies (``IsolatedLRU``) operate on per cache_salt byte
+        # counts which the base class tracks regardless of capacity,
+        # so they are wired up unconditionally.
+        #
+        # CAVEAT: IsolatedLRU on an adapter whose ``_notify_keys_stored``
+        # never fires (or whose ``delete()`` is a no-op) will log
+        # "triggering eviction" each cycle but have no observable
+        # effect. The FS adapter in particular is both unbounded and
+        # delete-less; configuring IsolatedLRU there is allowed but
+        # produces zero eviction activity.
         l2_eviction_states: list[L2AdapterEvictionState] = []
         for adapter, ac in zip(
             self._l2_adapters, config.l2_adapter_config.adapters, strict=True
         ):
             if ac.eviction_config is None:
                 continue
-            if not adapter.supports_global_eviction:
+            policy_name = ac.eviction_config.eviction_policy
+            if policy_name != "IsolatedLRU" and not adapter.supports_global_eviction:
                 logger.warning(
-                    "L2 adapter %s has eviction_config but does not support "
-                    "global eviction (max_capacity_bytes=0); skipping "
-                    "aggregate-usage eviction setup.",
+                    "L2 adapter %s configured with '%s' eviction but does "
+                    "not support global eviction (max_capacity_bytes=0); "
+                    "skipping aggregate-usage eviction setup.",
                     type(adapter).__name__,
+                    policy_name,
                 )
                 continue
             l2_eviction_states.append(
@@ -104,7 +121,9 @@ class StorageManager:
                     eviction_config=ac.eviction_config,
                 )
             )
-        self._l2_eviction_controller = L2EvictionController(l2_eviction_states)
+        self._l2_eviction_controller = L2EvictionController(
+            l2_eviction_states, quota_manager=self._quota_manager
+        )
         self._l2_eviction_controller.start()
 
         adapter_descriptors = [
@@ -546,6 +565,31 @@ class StorageManager:
             keys (list[ObjectKey]): List of object keys to touch.
         """
         self._l1_manager.touch_keys(keys)
+
+    @property
+    def quota_manager(self) -> QuotaManager:
+        """Per-cache_salt quota registry.
+
+        Exposed so the HTTP layer can serve CRUD endpoints without
+        reaching into private state. Always non-``None`` — the
+        storage manager creates the registry at construction time.
+        """
+        return self._quota_manager
+
+    def get_usage_bytes_by_cache_salt(self) -> dict[str, int]:
+        """Aggregate ``cache_salt`` byte usage across every L2 adapter.
+
+        Used by the HTTP quota endpoints to report ``current_usage_gb``
+        alongside the configured limit. Aggregation is a simple sum:
+        each adapter tracks the same salt independently so the totals
+        are additive.
+        """
+        totals: dict[str, int] = {}
+        for adapter in self._l2_adapters:
+            snap = adapter.get_usage().bytes_by_cache_salt
+            for salt, used in snap.items():
+                totals[salt] = totals.get(salt, 0) + used
+        return totals
 
     def clear(self, force: bool = False):
         """

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -92,13 +92,6 @@ class StorageManager:
         # policies (``IsolatedLRU``) operate on per cache_salt byte
         # counts which the base class tracks regardless of capacity,
         # so they are wired up unconditionally.
-        #
-        # CAVEAT: IsolatedLRU on an adapter whose ``_notify_keys_stored``
-        # never fires (or whose ``delete()`` is a no-op) will log
-        # "triggering eviction" each cycle but have no observable
-        # effect. The FS adapter in particular is both unbounded and
-        # delete-less; configuring IsolatedLRU there is allowed but
-        # produces zero eviction activity.
         l2_eviction_states: list[L2AdapterEvictionState] = []
         for adapter, ac in zip(
             self._l2_adapters, config.l2_adapter_config.adapters, strict=True

--- a/lmcache/v1/multiprocess/http_apis/quota_api.py
+++ b/lmcache/v1/multiprocess/http_apis/quota_api.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Per-``cache_salt`` quota management endpoints.
+
+The adapter's ``IsolatedLRU`` eviction policy uses these quotas to
+scope per-bucket eviction decisions. Quotas are soft: setting a limit
+does not reject writes — any over-budget bucket is evicted at the
+next eviction cycle (~1s). Removing or never setting a quota leaves
+the bucket at an effective limit of ``0`` bytes, so its data is
+cleared next cycle (allowlist semantics).
+"""
+
+# Standard
+from typing import Any
+import math
+
+# Third Party
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+# ``cache_salt=""`` (un-salted / anonymous traffic) cannot appear in a
+# URL path parameter, so the API accepts this sentinel in its place.
+#
+# COLLISION CAVEAT: a user who legitimately stores data with
+# ``cache_salt="_default"`` cannot be managed via this HTTP API
+# distinctly from anonymous traffic — both map to the same path
+# parameter. Deployments that want to manage such a user should set
+# ``cache_salt`` to any other value (e.g. ``"default"`` without the
+# underscore, or a tenant prefix).
+_DEFAULT_SALT_SENTINEL = "_default"
+
+
+def _unescape_salt(path_salt: str) -> str:
+    """Translate the URL sentinel back to the empty-string salt."""
+    return "" if path_salt == _DEFAULT_SALT_SENTINEL else path_salt
+
+
+def _escape_salt(salt: str) -> str:
+    """Translate the empty-string salt to the URL sentinel."""
+    return _DEFAULT_SALT_SENTINEL if salt == "" else salt
+
+
+def _gb(n_bytes: int) -> float:
+    """Convert bytes → GB for the JSON payload."""
+    return n_bytes / (1024**3)
+
+
+def _get_storage_manager(request: Request) -> Any:
+    """Resolve the shared ``StorageManager`` or return a 503 response.
+
+    Returns either the ``StorageManager`` instance or a
+    ``JSONResponse`` (503) ready to be returned directly from the
+    endpoint — keeps the endpoint bodies short.
+    """
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "engine not initialized"},
+        )
+    return engine.storage_manager
+
+
+@router.put("/api/quota/{cache_salt}")
+async def set_quota(cache_salt: str, request: Request) -> Any:
+    """Create or update a quota for the given ``cache_salt``.
+
+    Body: ``{"limit_gb": <float>}`` (required, non-negative).
+    """
+    sm = _get_storage_manager(request)
+    if isinstance(sm, JSONResponse):
+        return sm
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"error": "invalid JSON body"})
+    if not isinstance(body, dict) or "limit_gb" not in body:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "body must be {'limit_gb': <float>}"},
+        )
+    try:
+        limit_gb = float(body["limit_gb"])
+    except (TypeError, ValueError):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "limit_gb must be numeric"},
+        )
+    if not math.isfinite(limit_gb):
+        # ``nan`` / ``inf`` would propagate to an int() cast below that
+        # raises OverflowError / ValueError (reported as a 500). Reject
+        # here so the error surfaces as a clean 400.
+        return JSONResponse(
+            status_code=400,
+            content={"error": "limit_gb must be finite"},
+        )
+    if limit_gb < 0:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "limit_gb must be non-negative"},
+        )
+
+    salt = _unescape_salt(cache_salt)
+    try:
+        sm.quota_manager.set_quota(salt, int(limit_gb * (1024**3)))
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+    return {
+        "cache_salt": _escape_salt(salt),
+        "limit_gb": limit_gb,
+        "status": "ok",
+    }
+
+
+@router.get("/api/quota/{cache_salt}")
+async def get_quota(cache_salt: str, request: Request) -> Any:
+    """Read the current quota + live usage for a single salt."""
+    sm = _get_storage_manager(request)
+    if isinstance(sm, JSONResponse):
+        return sm
+
+    salt = _unescape_salt(cache_salt)
+    exists = sm.quota_manager.has_quota(salt)
+    limit_bytes = sm.quota_manager.get_limit_bytes(salt)
+    usage_bytes = sm.get_usage_bytes_by_cache_salt().get(salt, 0)
+    return {
+        "cache_salt": _escape_salt(salt),
+        "limit_gb": _gb(limit_bytes),
+        "current_usage_gb": _gb(usage_bytes),
+        "exists": exists,
+    }
+
+
+@router.delete("/api/quota/{cache_salt}")
+async def delete_quota(cache_salt: str, request: Request) -> Any:
+    """Remove a salt's quota entry.
+
+    Any bytes still cached under this salt become over-budget on the
+    next eviction cycle (effective limit drops to 0) and will be
+    evicted.
+    """
+    sm = _get_storage_manager(request)
+    if isinstance(sm, JSONResponse):
+        return sm
+
+    salt = _unescape_salt(cache_salt)
+    removed = sm.quota_manager.delete_quota(salt)
+    return {
+        "cache_salt": _escape_salt(salt),
+        "status": "removed" if removed else "not_found",
+    }
+
+
+@router.get("/api/quota")
+async def list_quotas(request: Request) -> Any:
+    """List every registered quota alongside its live usage."""
+    sm = _get_storage_manager(request)
+    if isinstance(sm, JSONResponse):
+        return sm
+
+    usage_map = sm.get_usage_bytes_by_cache_salt()
+    users: dict[str, dict[str, float]] = {}
+    for entry in sm.quota_manager.list_quotas():
+        used_bytes = usage_map.get(entry.cache_salt, 0)
+        users[_escape_salt(entry.cache_salt)] = {
+            "limit_gb": _gb(entry.limit_bytes),
+            "current_usage_gb": _gb(used_bytes),
+        }
+    return {"users": users}

--- a/tests/v1/distributed/test_cache_salt_l2_eviction.py
+++ b/tests/v1/distributed/test_cache_salt_l2_eviction.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Integration tests for L2 eviction scoped by ``cache_salt``.
+
+Drives :class:`L2EvictionController` end-to-end against a real
+:class:`MockL2Adapter` with :class:`IsolatedLRUEvictionPolicy` and a
+:class:`QuotaManager`, covering:
+
+* over-budget salts get evicted; within-budget salts are left alone
+* unregistered salts (no quota entry) have effective limit 0 and are
+  wiped on the next eviction cycle
+* salt isolation: touching alice's keys doesn't move bob's
+"""
+
+# Standard
+import os
+import select
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.config import EvictionConfig
+from lmcache.v1.distributed.eviction import L2EvictionPolicy
+from lmcache.v1.distributed.eviction_policy.isolated_lru import (
+    IsolatedLRUEvictionPolicy,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.distributed.storage_controllers.eviction_controller import (
+    L2AdapterEvictionState,
+    L2EvictionController,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _key(chunk_id: int, cache_salt: str) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+def _memory_obj(n_floats: int = 128) -> TensorMemoryObj:
+    """Small (~0.5 KB with 128 floats) tensor so quotas fit comfortably
+    inside the mock adapter's 1 MB capacity."""
+    raw = torch.empty(n_floats, dtype=torch.float32)
+    raw.fill_(1.0)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([n_floats]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=n_floats * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw, metadata, parent_allocator=None)
+
+
+def _wait_fd(fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if not events:
+        return False
+    try:
+        os.eventfd_read(fd)
+    except BlockingIOError:
+        pass
+    return True
+
+
+def _store_sync(adapter: MockL2Adapter, key: ObjectKey, obj: TensorMemoryObj):
+    """Submit a store and wait for it to land in the base-class
+    accounting (``_notify_keys_stored`` fires in ``_execute_store_in_the_loop``)."""
+    adapter.submit_store_task([key], [obj])
+    assert _wait_fd(adapter.get_store_event_fd()), "store event timed out"
+    adapter.pop_completed_store_tasks()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_lru_setup():
+    """Mock adapter + IsolatedLRU policy + QuotaManager wired through a
+    controller — same topology as production, minus the background
+    thread. Tests drive eviction synchronously via
+    ``_check_and_evict`` so they don't race the 1-second loop."""
+    adapter_config = MockL2AdapterConfig(
+        max_size_gb=0.001,  # 1 MB — big enough for salted traffic
+        mock_bandwidth_gb=10.0,
+    )
+    adapter = MockL2Adapter(adapter_config)
+
+    policy = IsolatedLRUEvictionPolicy()
+    # Wire the adapter → policy bridge so on_keys_* updates fire on
+    # store / delete / access events. Normally StorageManager does
+    # this; the test sets up its own bridge so the controller sees
+    # accurate per-bucket LRU state.
+    adapter.register_listener(L2EvictionPolicy(policy))
+
+    eviction_config = EvictionConfig(
+        eviction_policy="IsolatedLRU",
+        trigger_watermark=0.8,
+        eviction_ratio=0.5,
+    )
+    state = L2AdapterEvictionState(adapter=adapter, eviction_config=eviction_config)
+    # L2AdapterEvictionState creates its own policy internally; swap in
+    # the one we made to observe it from the test side. The listener
+    # it attached is stale, but the policy reference the controller
+    # uses is the one on ``state``.
+    state.eviction_policy = policy
+
+    qm = QuotaManager()
+    controller = L2EvictionController([state], quota_manager=qm)
+    # Don't call ``controller.start()`` — the test drives
+    # ``_check_and_evict`` directly so timing is deterministic.
+
+    yield adapter, policy, qm, controller, state
+    adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOverQuotaEviction:
+    def test_over_budget_salt_gets_evicted(self, isolated_lru_setup):
+        """Alice exceeds 50% of her 2 KB quota (watermark=0.8) — the
+        controller evicts enough of her keys to bring her below."""
+        adapter, policy, qm, controller, state = isolated_lru_setup
+
+        # 2 KB quota; watermark 0.8 → threshold 1.6 KB; eviction
+        # ratio 0.5 → evict half of alice's keys.
+        qm.set_quota("alice", 2 * 1024)
+        qm.set_quota("bob", 10 * 1024)  # plenty of headroom
+
+        for i in range(4):
+            _store_sync(adapter, _key(i, "alice"), _memory_obj())
+        _store_sync(adapter, _key(100, "bob"), _memory_obj())
+
+        before = adapter.get_usage().bytes_by_cache_salt
+        assert before["alice"] > 0.8 * (2 * 1024)
+        assert before["bob"] < 0.8 * (10 * 1024)
+
+        controller._check_and_evict(state)
+
+        after = adapter.get_usage().bytes_by_cache_salt
+        assert after.get("alice", 0) < before["alice"], (
+            "alice's bytes should have dropped"
+        )
+        assert after["bob"] == before["bob"], (
+            "bob was within quota — nothing should have moved"
+        )
+
+    def test_unregistered_salt_gets_wiped(self, isolated_lru_setup):
+        """A salt with no quota entry is fully evicted on the next
+        cycle (allowlist semantics)."""
+        adapter, policy, qm, controller, state = isolated_lru_setup
+
+        # Only alice is registered.
+        qm.set_quota("alice", 10 * 1024)
+
+        _store_sync(adapter, _key(1, "alice"), _memory_obj())
+        _store_sync(adapter, _key(2, "stranger"), _memory_obj())
+        _store_sync(adapter, _key(3, "stranger"), _memory_obj())
+
+        controller._check_and_evict(state)
+
+        after = adapter.get_usage().bytes_by_cache_salt
+        assert "stranger" not in after, (
+            "unregistered salt should have been fully evicted"
+        )
+        assert after.get("alice", 0) > 0, "alice was under quota"
+
+    def test_under_budget_does_nothing(self, isolated_lru_setup):
+        """Nobody is over threshold → no eviction, accounting is
+        stable across the cycle."""
+        adapter, policy, qm, controller, state = isolated_lru_setup
+        qm.set_quota("alice", 10 * 1024)
+
+        _store_sync(adapter, _key(1, "alice"), _memory_obj())
+        before = dict(adapter.get_usage().bytes_by_cache_salt)
+
+        controller._check_and_evict(state)
+
+        after = dict(adapter.get_usage().bytes_by_cache_salt)
+        assert after == before
+
+
+class TestSaltIsolation:
+    def test_alice_over_quota_does_not_touch_bob(self, isolated_lru_setup):
+        """Scoped eviction — only alice's keys are candidates, even
+        though bob has some keys that are globally older."""
+        adapter, policy, qm, controller, state = isolated_lru_setup
+
+        qm.set_quota("alice", 2 * 1024)
+        qm.set_quota("bob", 10 * 1024)
+
+        # bob goes first → bob's keys are older globally.
+        for i in range(2):
+            _store_sync(adapter, _key(100 + i, "bob"), _memory_obj())
+        for i in range(4):
+            _store_sync(adapter, _key(i, "alice"), _memory_obj())
+
+        controller._check_and_evict(state)
+
+        after = adapter.get_usage().bytes_by_cache_salt
+        assert after["bob"] == 2 * 512, (
+            "bob should still have both keys — scoped eviction "
+            "shouldn't leak into his bucket"
+        )
+
+
+class TestPolicyDispatch:
+    def test_lru_policy_ignores_quota_manager(self, isolated_lru_setup):
+        """Sanity check: even if a QuotaManager is wired in, a
+        non-isolation policy falls through to the aggregate
+        watermark branch. Here that branch is a no-op (adapter well
+        under global capacity)."""
+        adapter, policy, qm, controller, state = isolated_lru_setup
+
+        # Swap the state's policy for one without isolation support.
+        # First Party
+        from lmcache.v1.distributed.eviction_policy.lru import (
+            LRUEvictionPolicy,
+        )
+
+        state.eviction_policy = LRUEvictionPolicy()
+        adapter.register_listener(L2EvictionPolicy(state.eviction_policy))
+
+        # Set a quota that would normally trigger eviction.
+        qm.set_quota("alice", 1)  # 1 byte limit
+
+        _store_sync(adapter, _key(1, "alice"), _memory_obj())
+        before = dict(adapter.get_usage().bytes_by_cache_salt)
+        controller._check_and_evict(state)
+        after = dict(adapter.get_usage().bytes_by_cache_salt)
+
+        # LRU policy doesn't look at the quota → under aggregate
+        # watermark → no eviction.
+        assert after == before
+
+    def test_isolated_lru_without_quota_manager_falls_through_to_global(
+        self, isolated_lru_setup
+    ):
+        """Defensive: IsolatedLRU configured on a controller that wasn't
+        given a QuotaManager falls through to the aggregate-watermark
+        branch. This path is unreachable through normal ``StorageManager``
+        wiring (which always creates a QuotaManager) but exists as a
+        safety fallback."""
+        adapter, policy, _qm, _controller, state = isolated_lru_setup
+
+        # Build a fresh controller without a QuotaManager.
+        no_qm_controller = L2EvictionController([state], quota_manager=None)
+
+        _store_sync(adapter, _key(1, "alice"), _memory_obj())
+        before = dict(adapter.get_usage().bytes_by_cache_salt)
+
+        # Even with IsolatedLRU policy, no quota_manager → global branch.
+        # Adapter is well under capacity → no eviction.
+        no_qm_controller._check_and_evict(state)
+
+        after = dict(adapter.get_usage().bytes_by_cache_salt)
+        assert after == before

--- a/tests/v1/distributed/test_isolated_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_isolated_lru_eviction_policy.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :class:`IsolatedLRUEvictionPolicy`.
+"""
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction_policy.isolated_lru import (
+    IsolatedLRUEvictionPolicy,
+)
+from lmcache.v1.distributed.internal_api import EvictionDestination
+
+
+def _key(chunk_id: int, cache_salt: str = "") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="m",
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+class TestSupportIsolation:
+    def test_support_isolation_is_true(self):
+        """``IsolatedLRUEvictionPolicy`` reports isolation support so
+        the controller routes to the by-cache_salt eviction branch."""
+        assert IsolatedLRUEvictionPolicy().support_isolation is True
+
+
+class TestPerSaltTracking:
+    def test_keys_bucketed_by_salt(self):
+        """Each ``cache_salt`` lives in its own LRU list; buckets do
+        not bleed into each other."""
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(1, "alice"), _key(2, "bob"), _key(3, "alice")])
+        assert p.get_num_tracked_keys("alice") == 2
+        assert p.get_num_tracked_keys("bob") == 1
+        assert p.get_num_tracked_keys("charlie") == 0
+        assert sorted(p.get_tracked_salts()) == ["alice", "bob"]
+
+    def test_empty_bucket_dropped_after_removal(self):
+        """When a bucket empties the policy forgets the salt entirely
+        — keeps status / list snapshots compact."""
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(1, "alice")])
+        p.on_keys_removed([_key(1, "alice")])
+        assert "alice" not in p.get_tracked_salts()
+
+    def test_touch_updates_order(self):
+        """Touching a key moves it to MRU. After ``on_keys_created``
+        the reversed-insertion rule leaves ``k2`` as LRU (first out).
+        Touching ``k2`` must promote it so ``k1`` becomes the LRU
+        victim — this specifically exercises ``move_to_end`` on an
+        existing entry (a no-op touch on the already-MRU key would
+        pass the test trivially and hide bugs in the touch path)."""
+        p = IsolatedLRUEvictionPolicy()
+        k1 = _key(1, "alice")
+        k2 = _key(2, "alice")
+        p.on_keys_created([k1, k2])
+        # Default LRU order now: [k2 (oldest), k1 (newest)].
+        p.on_keys_touched([k2])
+        # Expected after touch: [k1 (oldest), k2 (newest)].
+        actions = p.get_eviction_actions(expected_ratio=0.5, cache_salt="alice")
+        evicted = actions[0].keys
+        assert evicted == [k1], (
+            f"k1 should be LRU after touching k2; got {[k.chunk_hash for k in evicted]}"
+        )
+
+
+class TestScopedEviction:
+    def test_scoped_eviction_stays_in_bucket(self):
+        """Eviction scoped to a salt only returns keys from that
+        bucket — other salts' data is untouched."""
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(1, "alice"), _key(2, "bob"), _key(3, "alice")])
+        actions = p.get_eviction_actions(expected_ratio=1.0, cache_salt="alice")
+        assert len(actions) == 1
+        evicted_salts = {k.cache_salt for k in actions[0].keys}
+        assert evicted_salts == {"alice"}
+        assert len(actions[0].keys) == 2
+
+    def test_scoped_eviction_empty_bucket_returns_empty(self):
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(1, "alice")])
+        # No bob bucket yet.
+        actions = p.get_eviction_actions(expected_ratio=1.0, cache_salt="bob")
+        assert actions == []
+
+    def test_global_eviction_spans_all_buckets(self):
+        """``cache_salt=None`` falls back to global eviction across
+        every bucket (useful for emergency cleanup)."""
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(1, "alice"), _key(2, "bob"), _key(3, "alice")])
+        actions = p.get_eviction_actions(expected_ratio=1.0, cache_salt=None)
+        assert len(actions) == 1
+        assert len(actions[0].keys) == 3
+
+
+class TestEvictionAmount:
+    def test_at_least_one_when_ratio_positive(self):
+        """Matches ``LRUEvictionPolicy`` — a positive ratio that rounds
+        to zero still yields one eviction so the caller makes forward
+        progress."""
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(i, "alice") for i in range(3)])
+        actions = p.get_eviction_actions(expected_ratio=0.01, cache_salt="alice")
+        assert len(actions[0].keys) == 1
+
+    def test_zero_ratio_evicts_nothing(self):
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(i, "alice") for i in range(3)])
+        assert p.get_eviction_actions(expected_ratio=0.0, cache_salt="alice") == []
+
+    def test_eviction_destination_default_is_discard(self):
+        p = IsolatedLRUEvictionPolicy()
+        p.on_keys_created([_key(1, "alice")])
+        actions = p.get_eviction_actions(expected_ratio=1.0, cache_salt="alice")
+        assert actions[0].destination == EvictionDestination.DISCARD
+
+    def test_key_eligible_filter_skips_locked_keys(self):
+        """The filter is useful for skipping pinned / locked keys. Any
+        key for which the filter returns False should be bypassed when
+        choosing victims."""
+        p = IsolatedLRUEvictionPolicy()
+        k1 = _key(1, "alice")
+        k2 = _key(2, "alice")
+        p.on_keys_created([k1, k2])
+        # Only allow k2 to be evicted.
+        actions = p.get_eviction_actions(
+            expected_ratio=1.0,
+            cache_salt="alice",
+            key_eligible_filter=lambda k: k == k2,
+        )
+        assert actions[0].keys == [k2]

--- a/tests/v1/distributed/test_isolated_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_isolated_lru_eviction_policy.py
@@ -3,6 +3,9 @@
 Unit tests for :class:`IsolatedLRUEvictionPolicy`.
 """
 
+# Third Party
+import pytest
+
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.eviction_policy.isolated_lru import (
@@ -86,14 +89,14 @@ class TestScopedEviction:
         actions = p.get_eviction_actions(expected_ratio=1.0, cache_salt="bob")
         assert actions == []
 
-    def test_global_eviction_spans_all_buckets(self):
-        """``cache_salt=None`` falls back to global eviction across
-        every bucket (useful for emergency cleanup)."""
+    def test_missing_cache_salt_raises(self):
+        """``IsolatedLRU`` is per-bucket only — calling without an
+        explicit ``cache_salt`` raises ``ValueError`` rather than
+        silently falling back to a global pool."""
         p = IsolatedLRUEvictionPolicy()
-        p.on_keys_created([_key(1, "alice"), _key(2, "bob"), _key(3, "alice")])
-        actions = p.get_eviction_actions(expected_ratio=1.0, cache_salt=None)
-        assert len(actions) == 1
-        assert len(actions[0].keys) == 3
+        p.on_keys_created([_key(1, "alice")])
+        with pytest.raises(ValueError, match="cache_salt"):
+            p.get_eviction_actions(expected_ratio=1.0, cache_salt=None)
 
 
 class TestEvictionAmount:

--- a/tests/v1/distributed/test_l2_adapter_base.py
+++ b/tests/v1/distributed/test_l2_adapter_base.py
@@ -128,7 +128,7 @@ class TestSupportsGlobalEviction:
 
 
 class TestBaseAccounting:
-    def test_store_increments_aggregate_and_per_user(self):
+    def test_store_increments_aggregate_and_by_cache_salt(self):
         a = _StubAdapter(max_capacity_bytes=10_000)
         k_alice = _make_key(1, salt="alice")
         k_bob = _make_key(2, salt="bob")
@@ -138,7 +138,7 @@ class TestBaseAccounting:
         assert u.total_bytes_used == 350
         assert u.bytes_by_cache_salt == {"alice": 150, "bob": 200}
 
-    def test_delete_decrements_aggregate_and_per_user(self):
+    def test_delete_decrements_aggregate_and_by_cache_salt(self):
         a = _StubAdapter(max_capacity_bytes=10_000)
         k_alice = _make_key(1, salt="alice")
         k_bob = _make_key(2, salt="bob")
@@ -148,10 +148,10 @@ class TestBaseAccounting:
         assert u.total_bytes_used == 200
         assert u.bytes_by_cache_salt == {"bob": 200}
 
-    def test_per_user_bucket_dropped_when_zero(self):
-        """Per-user bookkeeping should not retain stale ``0`` entries — it
-        keeps the snapshot compact and avoids memory growth across many
-        short-lived users."""
+    def test_cache_salt_bucket_dropped_when_zero(self):
+        """Per-``cache_salt`` bookkeeping should not retain stale ``0``
+        entries — it keeps the snapshot compact and avoids memory
+        growth across many short-lived salts."""
         a = _StubAdapter(max_capacity_bytes=10_000)
         k = _make_key(1, salt="alice")
         a._notify_keys_stored([k], [100])
@@ -203,7 +203,7 @@ class TestBaseAccounting:
         assert u.total_bytes_used == 0  # clamped, not -400
         assert u.usage_fraction == 0.0  # not the -1 sentinel
 
-    def test_get_usage_returns_immutable_per_user_view(self):
+    def test_get_usage_returns_immutable_by_cache_salt_view(self):
         """``bytes_by_cache_salt`` is a read-only ``Mapping`` so a caller
         cannot mutate the snapshot or the adapter's live state."""
         a = _StubAdapter(max_capacity_bytes=10_000)

--- a/tests/v1/distributed/test_mock_l2_adapter.py
+++ b/tests/v1/distributed/test_mock_l2_adapter.py
@@ -736,10 +736,10 @@ class TestEvictionInterface:
 
     def test_bytes_by_cache_salt_populated_from_cache_salt(self, adapter):
         """End-to-end: storing keys with different ``cache_salt`` values
-        should drive the per-user byte buckets in ``AdapterUsage`` —
-        proves the salt actually flows through the real adapter into the
-        base-class accounting (not just verified by the stub tests)."""
-        # Two keys per user so we know the totals are summed, not
+        should drive the byte buckets in ``AdapterUsage`` — proves the
+        salt actually flows through the real adapter into the base-class
+        accounting (not just verified by the stub tests)."""
+        # Two keys per cache_salt so we know the totals are summed, not
         # just per-key-overwritten.
         alice_keys = [
             ObjectKey(

--- a/tests/v1/distributed/test_quota_manager.py
+++ b/tests/v1/distributed/test_quota_manager.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for :class:`QuotaManager`.
+"""
+
+# Standard
+import threading
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.quota_manager import QuotaEntry, QuotaManager
+
+
+class TestQuotaManagerBasics:
+    def test_unregistered_salt_limit_is_zero(self):
+        """Allowlist semantics — anything unregistered has limit 0."""
+        qm = QuotaManager()
+        assert qm.get_limit_bytes("alice") == 0
+        assert not qm.has_quota("alice")
+
+    def test_set_and_get(self):
+        qm = QuotaManager()
+        qm.set_quota("alice", 1024)
+        assert qm.get_limit_bytes("alice") == 1024
+        assert qm.has_quota("alice")
+
+    def test_set_overwrites(self):
+        qm = QuotaManager()
+        qm.set_quota("alice", 1024)
+        qm.set_quota("alice", 2048)
+        assert qm.get_limit_bytes("alice") == 2048
+
+    def test_delete_returns_true_when_present(self):
+        qm = QuotaManager()
+        qm.set_quota("alice", 1024)
+        assert qm.delete_quota("alice") is True
+        assert not qm.has_quota("alice")
+        assert qm.get_limit_bytes("alice") == 0
+
+    def test_delete_returns_false_when_absent(self):
+        qm = QuotaManager()
+        assert qm.delete_quota("alice") is False
+
+    def test_zero_limit_is_registered_and_distinguishable(self):
+        """A zero limit IS a registration — ``has_quota`` returns True,
+        so the entry shows up in ``list_quotas``. Evaluating the quota
+        still yields 0, so the salt behaves like an unregistered one
+        for eviction purposes."""
+        qm = QuotaManager()
+        qm.set_quota("alice", 0)
+        assert qm.has_quota("alice")
+        assert qm.get_limit_bytes("alice") == 0
+        entries = qm.list_quotas()
+        assert QuotaEntry(cache_salt="alice", limit_bytes=0) in entries
+
+    def test_reject_negative_limit(self):
+        qm = QuotaManager()
+        with pytest.raises(ValueError, match="non-negative"):
+            qm.set_quota("alice", -1)
+
+    def test_empty_salt_is_a_valid_key(self):
+        """``cache_salt=""`` is a real bucket (anonymous traffic) — the
+        registry treats it like any other key."""
+        qm = QuotaManager()
+        qm.set_quota("", 512)
+        assert qm.has_quota("")
+        assert qm.get_limit_bytes("") == 512
+
+
+class TestQuotaManagerList:
+    def test_list_returns_snapshot(self):
+        qm = QuotaManager()
+        qm.set_quota("alice", 1)
+        entries = qm.list_quotas()
+        # Mutating the snapshot must not affect the registry.
+        entries.clear()
+        assert qm.has_quota("alice")
+
+    def test_list_is_complete(self):
+        qm = QuotaManager()
+        qm.set_quota("alice", 100)
+        qm.set_quota("bob", 200)
+        qm.set_quota("", 50)
+        got = {(e.cache_salt, e.limit_bytes) for e in qm.list_quotas()}
+        assert got == {("alice", 100), ("bob", 200), ("", 50)}
+
+
+class TestQuotaManagerThreadSafety:
+    def test_concurrent_writes_do_not_corrupt(self):
+        """Every write must land intact under contention."""
+        qm = QuotaManager()
+        n_writers = 8
+        per_writer = 50
+        barrier = threading.Barrier(n_writers)
+
+        def writer(worker_id: int) -> None:
+            barrier.wait()
+            for i in range(per_writer):
+                qm.set_quota(f"user-{worker_id}-{i}", worker_id * 1000 + i)
+
+        threads = [threading.Thread(target=writer, args=(w,)) for w in range(n_writers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(qm.list_quotas()) == n_writers * per_writer
+        # Spot-check a few values.
+        assert qm.get_limit_bytes("user-3-7") == 3007
+        assert qm.get_limit_bytes("user-0-0") == 0
+
+    def test_concurrent_read_write(self):
+        """Readers must never see a corrupted value."""
+        qm = QuotaManager()
+        qm.set_quota("alice", 1024)
+        stop = threading.Event()
+        errors: list[str] = []
+
+        def reader():
+            while not stop.is_set():
+                v = qm.get_limit_bytes("alice")
+                if v not in (1024, 2048):
+                    errors.append(f"unexpected {v}")
+                    return
+
+        def writer():
+            for _ in range(1000):
+                qm.set_quota("alice", 2048)
+                qm.set_quota("alice", 1024)
+
+        t_r = threading.Thread(target=reader)
+        t_w = threading.Thread(target=writer)
+        t_r.start()
+        t_w.start()
+        t_w.join()
+        stop.set()
+        t_r.join()
+        assert not errors, errors
+
+    def test_concurrent_set_and_delete_on_same_key(self):
+        """A set racing with a delete must leave the registry in a
+        self-consistent state — either set wins (entry present) or
+        delete wins (entry absent). Neither path should crash or leak
+        a half-applied write."""
+        qm = QuotaManager()
+        iters = 500
+
+        def setter():
+            for _ in range(iters):
+                qm.set_quota("alice", 1024)
+
+        def deleter():
+            for _ in range(iters):
+                qm.delete_quota("alice")
+
+        t1 = threading.Thread(target=setter)
+        t2 = threading.Thread(target=deleter)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        # Final state is either present-with-1024 or absent. Anything
+        # else (KeyError mid-read, partial write, etc.) would have
+        # surfaced during the run.
+        final = qm.get_limit_bytes("alice")
+        assert final in (0, 1024)
+
+
+class TestQuotaManagerEdgeCases:
+    def test_very_large_limit(self):
+        """Well inside a 64-bit int — shouldn't overflow or round."""
+        qm = QuotaManager()
+        big = 2**60
+        qm.set_quota("alice", big)
+        assert qm.get_limit_bytes("alice") == big
+
+    def test_delete_then_read_returns_zero(self):
+        """After deletion the salt is indistinguishable from an
+        unregistered one — limit is the allowlist default of 0."""
+        qm = QuotaManager()
+        qm.set_quota("alice", 1024)
+        qm.delete_quota("alice")
+        assert qm.get_limit_bytes("alice") == 0
+        assert not qm.has_quota("alice")
+
+    def test_many_salts(self):
+        """Sanity: large registries don't trip a size limit."""
+        qm = QuotaManager()
+        for i in range(10_000):
+            qm.set_quota(f"user-{i}", i)
+        assert len(qm.list_quotas()) == 10_000
+        assert qm.get_limit_bytes("user-9999") == 9999

--- a/tests/v1/multiprocess/test_http_quota_endpoints.py
+++ b/tests/v1/multiprocess/test_http_quota_endpoints.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for the quota CRUD HTTP endpoints.
+
+Uses ``fastapi.testclient.TestClient`` against the module's ``app``
+with a hand-built stub engine on ``app.state.engine`` — bypasses the
+lifespan so we don't spin up the full ZMQ cache server. The stub
+exposes just the two attributes the endpoints touch:
+``storage_manager.quota_manager`` and
+``storage_manager.get_usage_bytes_by_cache_salt()``.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.multiprocess.http_server import app
+
+
+@pytest.fixture
+def client():
+    """TestClient with a stub engine wired to app.state.
+
+    Each test gets a fresh QuotaManager + usage map — there is no
+    cross-test state leakage because the fixture reassigns both.
+    """
+    usage_map: dict[str, int] = {}
+
+    stub_engine = MagicMock()
+    stub_engine.storage_manager.quota_manager = QuotaManager()
+    stub_engine.storage_manager.get_usage_bytes_by_cache_salt.return_value = usage_map
+
+    app.state.engine = stub_engine
+    # ``TestClient`` without the context manager skips lifespan startup/shutdown,
+    # which is exactly what we want here.
+    c = TestClient(app)
+    yield c, stub_engine, usage_map
+    # Clear the engine so later tests don't accidentally reuse the stub.
+    if hasattr(app.state, "engine"):
+        delattr(app.state, "engine")
+
+
+@pytest.fixture
+def no_engine_client():
+    """Client with no engine on ``app.state`` — exercises the 503 path."""
+    if hasattr(app.state, "engine"):
+        delattr(app.state, "engine")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/quota/{salt}
+# ---------------------------------------------------------------------------
+
+
+class TestPutQuota:
+    def test_set_quota_for_named_salt(self, client):
+        c, engine, _ = client
+        resp = c.put("/api/quota/alice", json={"limit_gb": 2.0})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"cache_salt": "alice", "limit_gb": 2.0, "status": "ok"}
+        assert engine.storage_manager.quota_manager.get_limit_bytes("alice") == int(
+            2.0 * (1024**3)
+        )
+
+    def test_set_quota_sentinel_maps_to_empty_salt(self, client):
+        """`_default` in the URL must resolve to the empty-string salt
+        in the registry — un-salted traffic doesn't have its own
+        distinct path parameter."""
+        c, engine, _ = client
+        resp = c.put("/api/quota/_default", json={"limit_gb": 1.0})
+        assert resp.status_code == 200
+        assert engine.storage_manager.quota_manager.has_quota("")
+        assert not engine.storage_manager.quota_manager.has_quota("_default")
+        assert resp.json()["cache_salt"] == "_default"
+
+    def test_overwrite_existing_quota(self, client):
+        c, engine, _ = client
+        c.put("/api/quota/alice", json={"limit_gb": 1.0})
+        resp = c.put("/api/quota/alice", json={"limit_gb": 5.0})
+        assert resp.status_code == 200
+        assert engine.storage_manager.quota_manager.get_limit_bytes("alice") == int(
+            5.0 * (1024**3)
+        )
+
+    def test_missing_limit_gb_is_400(self, client):
+        c, _, _ = client
+        resp = c.put("/api/quota/alice", json={})
+        assert resp.status_code == 400
+        assert "limit_gb" in resp.json()["error"]
+
+    def test_non_numeric_limit_is_400(self, client):
+        c, _, _ = client
+        resp = c.put("/api/quota/alice", json={"limit_gb": "huge"})
+        assert resp.status_code == 400
+        assert "numeric" in resp.json()["error"]
+
+    def test_negative_limit_is_400(self, client):
+        c, _, _ = client
+        resp = c.put("/api/quota/alice", json={"limit_gb": -1.0})
+        assert resp.status_code == 400
+        assert "non-negative" in resp.json()["error"]
+
+    def test_nan_limit_is_400(self, client):
+        """``nan`` would propagate to ``int()`` below and raise a 500;
+        reject it cleanly at parse time.
+
+        Strict JSON doesn't allow ``NaN``, but Python's ``json.loads``
+        accepts it as an extension — so a client that uses the same
+        library (including anyone who calls ``json.dumps(allow_nan=True)``)
+        can send it. Use a raw ``content=`` body to bypass the
+        strict-JSON serializer in the test client.
+        """
+        c, _, _ = client
+        resp = c.put(
+            "/api/quota/alice",
+            content=b'{"limit_gb": NaN}',
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert "finite" in resp.json()["error"]
+
+    def test_inf_limit_is_400(self, client):
+        """Same rationale as NaN — ``Infinity`` is a Python json
+        extension, so a malicious client can still send it."""
+        c, _, _ = client
+        resp = c.put(
+            "/api/quota/alice",
+            content=b'{"limit_gb": Infinity}',
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert "finite" in resp.json()["error"]
+
+    def test_zero_limit_is_accepted(self, client):
+        """Zero is a valid limit — it registers the salt but evaluates
+        to ``0`` bytes (same effective behavior as no entry, but the
+        entry shows up in list_quotas)."""
+        c, engine, _ = client
+        resp = c.put("/api/quota/alice", json={"limit_gb": 0.0})
+        assert resp.status_code == 200
+        qm = engine.storage_manager.quota_manager
+        assert qm.has_quota("alice")
+        assert qm.get_limit_bytes("alice") == 0
+
+    def test_503_when_engine_not_initialized(self, no_engine_client):
+        resp = no_engine_client.put("/api/quota/alice", json={"limit_gb": 1.0})
+        assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /api/quota/{salt}
+# ---------------------------------------------------------------------------
+
+
+class TestGetQuota:
+    def test_reports_limit_and_usage(self, client):
+        c, engine, usage_map = client
+        engine.storage_manager.quota_manager.set_quota("alice", int(2.0 * (1024**3)))
+        usage_map["alice"] = int(1.3 * (1024**3))
+        resp = c.get("/api/quota/alice")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cache_salt"] == "alice"
+        assert body["exists"] is True
+        assert body["limit_gb"] == pytest.approx(2.0)
+        assert body["current_usage_gb"] == pytest.approx(1.3)
+
+    def test_reports_zero_for_unknown_salt(self, client):
+        """Allowlist semantics — unknown salt returns ``exists=False``
+        and limit/usage of 0."""
+        c, _, _ = client
+        resp = c.get("/api/quota/charlie")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["exists"] is False
+        assert body["limit_gb"] == 0.0
+        assert body["current_usage_gb"] == 0.0
+
+    def test_sentinel_reads_empty_salt_entry(self, client):
+        c, engine, usage_map = client
+        engine.storage_manager.quota_manager.set_quota("", 512)
+        usage_map[""] = 128
+        resp = c.get("/api/quota/_default")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cache_salt"] == "_default"
+        assert body["exists"] is True
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/quota/{salt}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteQuota:
+    def test_delete_existing_salt(self, client):
+        c, engine, _ = client
+        engine.storage_manager.quota_manager.set_quota("alice", 1024)
+        resp = c.delete("/api/quota/alice")
+        assert resp.status_code == 200
+        assert resp.json() == {"cache_salt": "alice", "status": "removed"}
+        assert not engine.storage_manager.quota_manager.has_quota("alice")
+
+    def test_delete_missing_salt_returns_not_found(self, client):
+        c, _, _ = client
+        resp = c.delete("/api/quota/charlie")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_found"
+
+    def test_delete_sentinel_removes_empty_salt_entry(self, client):
+        c, engine, _ = client
+        engine.storage_manager.quota_manager.set_quota("", 512)
+        resp = c.delete("/api/quota/_default")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "cache_salt": "_default",
+            "status": "removed",
+        }
+        assert not engine.storage_manager.quota_manager.has_quota("")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/quota
+# ---------------------------------------------------------------------------
+
+
+class TestListQuotas:
+    def test_list_empty_registry(self, client):
+        c, _, _ = client
+        resp = c.get("/api/quota")
+        assert resp.status_code == 200
+        assert resp.json() == {"users": {}}
+
+    def test_list_reports_usage_for_each_salt(self, client):
+        c, engine, usage_map = client
+        qm = engine.storage_manager.quota_manager
+        qm.set_quota("alice", int(2.0 * (1024**3)))
+        qm.set_quota("bob", int(5.0 * (1024**3)))
+        qm.set_quota("", 512)
+        usage_map.update({"alice": int(1.3 * (1024**3)), "bob": 0})
+        resp = c.get("/api/quota")
+        assert resp.status_code == 200
+        users = resp.json()["users"]
+        assert set(users) == {"alice", "bob", "_default"}
+        assert users["alice"]["limit_gb"] == pytest.approx(2.0)
+        assert users["alice"]["current_usage_gb"] == pytest.approx(1.3)
+        assert users["bob"]["current_usage_gb"] == 0.0
+        # The empty-salt entry appears under its URL sentinel.
+        assert "_default" in users


### PR DESCRIPTION
## Summary

Adds multi-tenant quota support to the L2 eviction path. A single `cache_salt` (i.e. a user) cannot evict another salt's cached data under the new `IsolatedLRU` policy; quotas are configured dynamically via HTTP, with no restart needed.

Stacks on #3045 (already merged) which added `AdapterUsage.bytes_by_cache_salt` byte accounting.

## What it adds

- **`IsolatedLRUEvictionPolicy`** — one LRU list per `cache_salt`. `support_isolation=True` routes the `L2EvictionController` to the per-bucket eviction branch; `get_eviction_actions(cache_salt=...)` scopes victim selection to a single bucket.
- **`QuotaManager`** — thread-safe `{cache_salt: limit_bytes}` registry. Shared by the controller (reader) and the HTTP endpoints (CRUD). Allowlist semantics: unregistered salts have effective limit 0 and are wiped on the next eviction cycle.
- **`L2EvictionController`** — dispatches on `policy.support_isolation`. Per-salt branch compares `user_bytes` vs `watermark * limit` for every salt with non-zero bytes; unregistered salts always land over-budget (`limit=0`) and get a full-ratio eviction.
- **HTTP quota endpoints** (`http_apis/quota_api.py`):
  - `PUT/GET/DELETE /api/quota/{cache_salt}`
  - `GET /api/quota`
  - `_default` URL sentinel maps to the empty-string salt.
  - `math.isfinite` rejects NaN / Infinity before they propagate to `int()`.
- **`StorageManager`** exposes `quota_manager` and `get_usage_bytes_by_cache_salt()` (aggregated across adapters). Adapter filter allows `IsolatedLRU` on adapters without `supports_global_eviction` since the per-salt branch operates on the base class's byte counts regardless of adapter capacity.

## Usage

```bash
# Enable the policy:
--eviction-policy IsolatedLRU

# Configure a 2GB quota for user 'alice':
curl -X PUT http://HOST:PORT/api/quota/alice \
     -H 'Content-Type: application/json' \
     -d '{"limit_gb": 2.0}'

# List all quotas:
curl http://HOST:PORT/api/quota
```

## Tests

- `test_quota_manager.py` — CRUD + thread-safety (concurrent writes, read-write race, set/delete race on same key).
- `test_isolated_lru_eviction_policy.py` — per-salt bucketing, scoped vs global eviction, locked-key filter.
- `test_cache_salt_l2_eviction.py` — end-to-end with a real adapter: over-budget salt evicted, unregistered salt wiped, other salts untouched.
- `test_http_quota_endpoints.py` — TestClient-driven CRUD + validation paths (non-numeric / negative / NaN / inf / missing body) + `_default` sentinel round-trip.

All 880 tests in `tests/v1/distributed/` + `tests/v1/multiprocess/` pass locally; pre-commit clean.

## Drive-by

Two test names / docstrings in the merged PR #3045 test files renamed from `per_user` → `by_cache_salt` / `cache_salt` for terminology consistency with this feature. Happy to split out if preferred.

## Test plan

- [ ] CI green on `tests/v1/distributed/` + `tests/v1/multiprocess/`
- [ ] Smoke test: start MP server with `--eviction-policy IsolatedLRU`, set quota for a salt via HTTP, exceed it, observe eviction scoped to that salt
- [ ] Verify `_default` sentinel round-trips for un-salted traffic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L2 eviction behavior by adding quota-driven, per-`cache_salt` eviction (including allowlist semantics where unregistered salts are fully evicted), which can impact cache retention and eviction rates in production. Also introduces new HTTP endpoints for runtime quota CRUD that must be deployed/secured correctly.
> 
> **Overview**
> Adds a new `IsolatedLRU` eviction mode that keeps separate LRU lists per `cache_salt` and updates config/CLI parsing and the eviction-policy factory to support selecting it.
> 
> Extends `L2EvictionController` to dispatch to a new quota-driven per-salt eviction path when the policy supports isolation, using a new thread-safe `QuotaManager` registry (unregistered salts default to an effective quota of 0 and are wiped on the next eviction cycle).
> 
> Exposes quota administration via new FastAPI endpoints under `/api/quota` (PUT/GET/DELETE + list) and wires `StorageManager` to always create/expose a shared `quota_manager` plus an aggregate `get_usage_bytes_by_cache_salt()` helper. Adds unit/integration tests covering the new policy, quota manager semantics/thread-safety, controller behavior, and HTTP validation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c37b549754b4076b29c61765f41dea3df13cb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->