### PR TITLE
[DO-NOT-MERGE][CI/CD] Use compat mode to avoid GDS UT flaky faiures

### DIFF
--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -15,6 +15,15 @@ steps:
                 imagePullPolicy: Never
                 env:
                   - { name: CUDA_LAUNCH_BLOCKING, value: "1" }
+                  # Force cuFile into POSIX-fallback mode. The host runs the
+                  # k3s master, so we can't reboot to swap proprietary NVIDIA
+                  # kernel modules for the open variant that nvidia-fs needs.
+                  # Compat mode routes cuFile through pread/pwrite + staging
+                  # buffer — API surface is identical, only DMA performance
+                  # is sacrificed. Unit tests validate backend correctness,
+                  # not GDS throughput, so this is a clean trade.
+                  - { name: CUFILE_FORCE_COMPAT_MODE, value: "true" }
+                  - { name: CUFILE_ALLOW_COMPAT_MODE, value: "true" }
                 resources:
                   requests:
                     cpu: "32"


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets `CUFILE_FORCE_COMPAT_MODE=true` (plus the legacy `CUFILE_ALLOW_COMPAT_MODE=true`) in the k3 unit-test pod spec so `tests/v1/storage_backend/test_gds_backend.py` passes without requiring the `nvidia-fs` kernel module on the CI host.

The full native-GDS path needs NVIDIA's *open* kernel modules (proprietary modules fail to link against GPL-only symbols in `nvidia_fs` on recent kernels), and switching driver variants on the host requires a reboot. Our k3 CI host also serves as the k3s master, so a reboot would take the whole cluster offline. Compat mode routes `cuFile` calls through `pread`/`pwrite` + a staging buffer — the API surface and results are identical, only DMA-from-storage performance is sacrificed. Unit tests validate backend correctness rather than GDS throughput, so this is a clean trade-off.

**Special notes for your reviewers**:

- Change is isolated to `.buildkite/k3_tests/unit/pipeline.yml` (pod `env` only). No test or source changes.
- The existing `/scratch` hostPath + `LMCACHE_TEST_TMPDIR` plumbing stays — still useful for large writes landing on local NVMe rather than overlay, just no longer load-bearing for GDS.
- If/when the k3 host is rebooted for another reason, we can switch to open kernel modules + real nvidia-fs and drop these env vars.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only environment variable changes that affect test execution/performance but not production code or data paths.
> 
> **Overview**
> Unit-test CI now sets `CUFILE_FORCE_COMPAT_MODE=true` and `CUFILE_ALLOW_COMPAT_MODE=true` in the k3 Buildkite pod spec, forcing cuFile to use the POSIX fallback path.
> 
> This avoids reliance on the host `nvidia-fs` kernel module (native GDS) and reduces flakiness in GDS backend unit tests at the cost of storage DMA performance during CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1623d1fc931e89044d89d5ade95f75e1338e2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->