### PR TITLE
[Observability] num_chunks_loaded counter

### DIFF
--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -85,7 +85,7 @@ to correlate START/END pairs.
 | `MP_STORE_START` | `device`, `engine_id`, `model_name` | `str`, `int`, `str` |
 | `MP_STORE_END` | `device`, `stored_count`, `engine_id`, `model_name`, `total_bytes` | `str`, `int`, `int`, `str`, `int` |
 | `MP_RETRIEVE_START` | `device`, `engine_id`, `model_name` | `str`, `int`, `str` |
-| `MP_RETRIEVE_END` | `device`, `retrieved_count`, `engine_id`, `model_name`, `total_bytes` | `str`, `int`, `int`, `str`, `int` |
+| `MP_RETRIEVE_END` | `device`, `retrieved_count`, `engine_id`, `model_name`, `cache_salt`, `total_bytes` | `str`, `int`, `int`, `str`, `str`, `int` |
 | `MP_LOOKUP_PREFETCH_START` | *(none)* | — |
 | `MP_LOOKUP_PREFETCH_END` | `found_count`, `requested_tokens`, `hit_tokens`, `model_name`, `cache_salt` | `int`, `int`, `int`, `str`, `str` |
 | `MP_LOOKUP` | `request_id`, `chunk_hashes`, `model_name`, `chunk_size`, `seq_len`, `dtypes`, `shapes` | `str`, `list[str]`, `str`, `int`, `int`, `list[str]`, `list[list[int]]` |

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -87,7 +87,7 @@ to correlate START/END pairs.
 | `MP_RETRIEVE_START` | `device`, `engine_id`, `model_name` | `str`, `int`, `str` |
 | `MP_RETRIEVE_END` | `device`, `retrieved_count`, `engine_id`, `model_name`, `total_bytes` | `str`, `int`, `int`, `str`, `int` |
 | `MP_LOOKUP_PREFETCH_START` | *(none)* | — |
-| `MP_LOOKUP_PREFETCH_END` | `found_count`, `requested_tokens`, `hit_tokens` | `int`, `int`, `int` |
+| `MP_LOOKUP_PREFETCH_END` | `found_count`, `requested_tokens`, `hit_tokens`, `model_name`, `cache_salt` | `int`, `int`, `int`, `str`, `str` |
 | `MP_LOOKUP` | `request_id`, `chunk_hashes`, `model_name`, `chunk_size`, `seq_len`, `dtypes`, `shapes` | `str`, `list[str]`, `str`, `int`, `int`, `list[str]`, `list[list[int]]` |
 | `MP_VLLM_BLOCK_ALLOCATION` | `instance_id`, `model_name`, `records` | `int`, `str`, `list[BlockAllocationRecord]` (each has `req_id: str`, `new_block_ids: list[int]`, `new_token_ids: list[int]`) |
 | `MP_VLLM_END_SESSION` | `request_id` | `str` |
@@ -104,6 +104,13 @@ know `chunk_size`:
   empty `chunk_hashes`).  Sub-chunk trailing tokens are excluded — they
   cannot hit at chunk granularity.
 - `hit_tokens = found_count * chunk_size`.
+- `model_name` and `cache_salt` are captured at lookup time from
+  `IPCCacheEngineKey` and surface as OTel attributes on the
+  `lmcache_mp.lookup_*_tokens` counters so the hit rate can be sliced
+  per model and per tenant / isolation domain on the dashboard.
+  `cache_salt` may have high cardinality (e.g. one entry per tenant);
+  operators can drop the label at scrape time with a `metric_relabel_configs`
+  rule if storage cost matters.
 
 Together they drive the `lmcache_mp.lookup_*_tokens` counters used to
 compute the L1+L2 token-level hit rate.  See

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -284,11 +284,14 @@ distinct from any scheduler-scoped id used elsewhere.
 
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.num_chunks_loaded` | `lmcache_mp_num_chunks_loaded_total` | Counter (attr: `worker_id`) | `MP_RETRIEVE_END` | `+retrieved_count` per event |
+| `lmcache_mp.num_chunks_loaded` | `lmcache_mp_num_chunks_loaded_total` | Counter (attrs: `worker_id`, `model_name`, `cache_salt`) | `MP_RETRIEVE_END` | `+retrieved_count` per event |
 
 **What it answers:** How many LMCache chunks is each vLLM worker loading
 from LMCache into its engine?  Compare across workers to spot uneven
-demand or underserved ranks.
+demand or underserved ranks.  Slice by `model_name` to see per-model
+load volume in multi-model deployments, or by `cache_salt` for per-tenant
+attribution (note: `cache_salt` can be high-cardinality — drop it at
+scrape time with `metric_relabel_configs` if storage cost matters).
 
 ---
 

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -169,16 +169,26 @@ ratio is the fraction of tokens requested by a lookup that were served from
 either L1 or L2.  L0 (GPU prefix cache) is intentionally excluded — it is
 vLLM-owned and not observable from LMCache.
 
+Both counters carry `model_name` and `cache_salt` OTel attributes (captured
+at lookup time from `IPCCacheEngineKey`), enabling per-model and per-tenant
+slicing of the hit rate.  `cache_salt` can be high-cardinality; drop it at
+scrape time with `metric_relabel_configs` if storage cost matters.
+
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.lookup_requested_tokens` | `lmcache_mp_lookup_requested_tokens_total` | Counter | `MP_LOOKUP_PREFETCH_END` | `+requested_tokens` |
-| `lmcache_mp.lookup_hit_tokens` | `lmcache_mp_lookup_hit_tokens_total` | Counter | `MP_LOOKUP_PREFETCH_END` | `+hit_tokens` |
+| `lmcache_mp.lookup_requested_tokens` | `lmcache_mp_lookup_requested_tokens_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+requested_tokens` |
+| `lmcache_mp.lookup_hit_tokens` | `lmcache_mp_lookup_hit_tokens_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+hit_tokens` |
 
 **What it answers:** What fraction of tokens requested by a lookup were served from cache (L1 or L2)?
 
 ```promql
+# Aggregate hit rate (all models, all salts):
 rate(lmcache_mp_lookup_hit_tokens_total[5m])
 / rate(lmcache_mp_lookup_requested_tokens_total[5m])
+
+# Per-model hit rate:
+sum(rate(lmcache_mp_lookup_hit_tokens_total[5m])) by (model_name)
+/ sum(rate(lmcache_mp_lookup_requested_tokens_total[5m])) by (model_name)
 ```
 
 > **Note:** Both counters are driven by the *same* event, so they always

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -225,6 +225,22 @@ Are some workers or GPUs underperforming?
 
 ---
 
+## Engine Counters
+
+Worker-scoped counters tied to what the MP server delivers back to each
+vLLM worker.  Labeled by `worker_id` — the vLLM worker instance id,
+distinct from any scheduler-scoped id used elsewhere.
+
+| OTel metric name | Prometheus name | Type | Source event | Calculation |
+|---|---|---|---|---|
+| `lmcache_mp.num_chunks_loaded` | `lmcache_mp_num_chunks_loaded_total` | Counter (attr: `worker_id`) | `MP_RETRIEVE_END` | `+retrieved_count` per event |
+
+**What it answers:** How many LMCache chunks is each vLLM worker loading
+from LMCache into its engine?  Compare across workers to spot uneven
+demand or underserved ranks.
+
+---
+
 ## MPCacheEngine Observable Gauges
 
 These metrics are registered directly via `register_gauge` (pull-based OTel

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -433,9 +433,12 @@ appear on other metrics.
      - Type
      - Description
    * - ``lmcache_mp.num_chunks_loaded``
-     - Counter (attr: ``worker_id``)
+     - Counter (attrs: ``worker_id``, ``model_name``, ``cache_salt``)
      - Total number of LMCache chunks loaded into the engine, summed
-       over all ``retrieve()`` completions and labeled per vLLM worker.
+       over all ``retrieve()`` completions.  Sliceable per worker, per
+       model, and per tenant / isolation domain (``cache_salt``).
+       ``cache_salt`` may be high-cardinality; drop it at scrape time
+       with ``metric_relabel_configs`` if storage cost matters.
 
 Observable Gauges
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -359,6 +359,26 @@ per-GPU slicing in Prometheus (e.g.
      - Histogram
      - CPU→GPU (L1→L0) load throughput in GB/s per sampled request.
 
+Engine Counters
+~~~~~~~~~~~~~~~
+
+Worker-scoped counters tied to what the MP server delivers back to each
+vLLM worker via ``retrieve()``.  Labeled by ``worker_id`` (the vLLM
+worker instance id) — distinct from any scheduler-scoped id that may
+appear on other metrics.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 25 35
+
+   * - Metric
+     - Type
+     - Description
+   * - ``lmcache_mp.num_chunks_loaded``
+     - Counter (attr: ``worker_id``)
+     - Total number of LMCache chunks loaded into the engine, summed
+       over all ``retrieve()`` completions and labeled per vLLM worker.
+
 Observable Gauges
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -289,11 +289,11 @@ intentionally excluded — it is vLLM-owned and not observable from LMCache.
      - Type
      - Description
    * - ``lmcache_mp.lookup_requested_tokens``
-     - Counter
+     - Counter (attrs: ``model_name``, ``cache_salt``)
      - Total tokens submitted for lookup (denominator of the L1+L2
        token-level hit rate). Only chunk-aligned tokens are counted.
    * - ``lmcache_mp.lookup_hit_tokens``
-     - Counter
+     - Counter (attrs: ``model_name``, ``cache_salt``)
      - Total tokens found in L1 or L2 during lookup (numerator of the
        L1+L2 token-level hit rate). Counts the contiguous prefix hit only.
 
@@ -301,12 +301,23 @@ Both counters are driven by the same event (``MP_LOOKUP_PREFETCH_END``),
 so they always advance together per completed lookup. Early-exit lookups
 contribute ``0`` to both, and abandoned lookups contribute to neither.
 
+The ``model_name`` and ``cache_salt`` attributes are captured at lookup
+time from ``IPCCacheEngineKey`` so dashboards can compute per-model or
+per-tenant hit rate. ``cache_salt`` can be high-cardinality (one entry
+per tenant or isolation domain); drop it at scrape time with
+``metric_relabel_configs`` if storage cost matters.
+
 **PromQL for hit rate:**
 
 .. code-block:: promql
 
+    # Aggregate (all models, all salts):
     rate(lmcache_mp_lookup_hit_tokens_total[5m])
     / rate(lmcache_mp_lookup_requested_tokens_total[5m])
+
+    # Per-model:
+    sum(rate(lmcache_mp_lookup_hit_tokens_total[5m])) by (model_name)
+    / sum(rate(lmcache_mp_lookup_requested_tokens_total[5m])) by (model_name)
 
 L0 (GPU) Block Lifecycle Histograms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -325,6 +325,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         # First Party
         from lmcache.v1.mp_observability.subscribers.metrics import (
             BlendMetricsSubscriber,
+            EngineMetricsSubscriber,
             L0L1ThroughputSubscriber,
             L0LifecycleSubscriber,
             L1LifecycleSubscriber,
@@ -343,6 +344,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         bus.register_subscriber(LookupMetricsSubscriber())
         bus.register_subscriber(SMMetricsSubscriber())
         bus.register_subscriber(BlendMetricsSubscriber())
+        bus.register_subscriber(EngineMetricsSubscriber())
 
     if obs_config.logging_enabled:
         # First Party

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -4,6 +4,9 @@
 from lmcache.v1.mp_observability.subscribers.metrics.cb_server import (
     BlendMetricsSubscriber,
 )
+from lmcache.v1.mp_observability.subscribers.metrics.engine import (
+    EngineMetricsSubscriber,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.l0_l1_throughput import (
     L0L1ThroughputSubscriber,
 )
@@ -22,6 +25,7 @@ from lmcache.v1.mp_observability.subscribers.metrics.sm import SMMetricsSubscrib
 
 __all__ = [
     "BlendMetricsSubscriber",
+    "EngineMetricsSubscriber",
     "L0L1ThroughputSubscriber",
     "L0LifecycleSubscriber",
     "L1LifecycleSubscriber",

--- a/lmcache/v1/mp_observability/subscribers/metrics/engine.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/engine.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Worker-side engine metrics subscriber.
+
+Emits counters tied to what the MP server delivers back to each vLLM
+worker.  Today the only metric is ``lmcache_mp.num_chunks_loaded``;
+future worker-scoped counters (e.g., bytes loaded, blocks touched) would
+land here too.
+"""
+
+# Future
+from __future__ import annotations
+
+# Third Party
+from opentelemetry import metrics
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+
+
+class EngineMetricsSubscriber(EventSubscriber):
+    """Maintains OTel counters tied to the MP server's retrieve path
+    (worker-side; ``worker_id`` = vLLM worker instance id).
+
+    Metrics:
+    - ``lmcache_mp.num_chunks_loaded`` — chunks loaded from LMCache into
+      the engine via ``retrieve()`` (attr: ``worker_id``).
+
+    ``worker_id`` on this metric names the vLLM **worker** instance id and
+    is distinct from any scheduler-scoped ``scheduler_id`` attribute used
+    elsewhere — the two IDs come from different vLLM processes and should
+    not be cross-joined on dashboards.
+    """
+
+    def __init__(self) -> None:
+        meter = metrics.get_meter("lmcache_mp.engine")
+        self._num_chunks_loaded = meter.create_counter(
+            "lmcache_mp.num_chunks_loaded",
+            description=(
+                "Total number of LMCache chunks loaded into the engine "
+                "(summed across all retrieve operations)."
+            ),
+        )
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {
+            EventType.MP_RETRIEVE_END: self._on_retrieve_end,
+        }
+
+    def _on_retrieve_end(self, event: Event) -> None:
+        retrieved_count = int(event.metadata.get("retrieved_count", 0))
+        if retrieved_count <= 0:
+            return
+        # MP_RETRIEVE_END carries the worker's instance_id under the
+        # ``engine_id`` key; re-emit as ``worker_id`` so the attribute
+        # name disambiguates from any scheduler-side id used elsewhere.
+        engine_id = event.metadata.get("engine_id")
+        attrs: dict[str, str] = {}
+        if engine_id is not None:
+            attrs["worker_id"] = str(engine_id)
+        self._num_chunks_loaded.add(retrieved_count, attributes=attrs)

--- a/lmcache/v1/mp_observability/subscribers/metrics/engine.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/engine.py
@@ -25,7 +25,8 @@ class EngineMetricsSubscriber(EventSubscriber):
 
     Metrics:
     - ``lmcache_mp.num_chunks_loaded`` — chunks loaded from LMCache into
-      the engine via ``retrieve()`` (attr: ``worker_id``).
+      the engine via ``retrieve()`` (attrs: ``worker_id``, ``model_name``,
+      ``cache_salt``).
 
     ``worker_id`` on this metric names the vLLM **worker** instance id and
     is distinct from any scheduler-scoped ``scheduler_id`` attribute used
@@ -55,8 +56,14 @@ class EngineMetricsSubscriber(EventSubscriber):
         # MP_RETRIEVE_END carries the worker's instance_id under the
         # ``engine_id`` key; re-emit as ``worker_id`` so the attribute
         # name disambiguates from any scheduler-side id used elsewhere.
-        engine_id = event.metadata.get("engine_id")
         attrs: dict[str, str] = {}
+        engine_id = event.metadata.get("engine_id")
         if engine_id is not None:
             attrs["worker_id"] = str(engine_id)
+        model_name = event.metadata.get("model_name")
+        if model_name is not None:
+            attrs["model_name"] = str(model_name)
+        cache_salt = event.metadata.get("cache_salt")
+        if cache_salt is not None:
+            attrs["cache_salt"] = str(cache_salt)
         self._num_chunks_loaded.add(retrieved_count, attributes=attrs)

--- a/lmcache/v1/mp_observability/subscribers/metrics/lookup.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/lookup.py
@@ -10,12 +10,19 @@ here):
     rate(lmcache_mp_lookup_hit_tokens_total[5m])
     / rate(lmcache_mp_lookup_requested_tokens_total[5m])
 
+Both counters carry ``model_name`` and ``cache_salt`` attributes so the
+ratio can be sliced per model and per tenant / isolation domain on the
+dashboard.
+
 See ``docs/design/v1/mp_observability/L1_L2_HIT_RATE_PLAN.md`` for the full
 rationale behind co-locating numerator and denominator on a single event.
 """
 
 # Future
 from __future__ import annotations
+
+# Standard
+from typing import Any
 
 # Third Party
 from opentelemetry import metrics
@@ -25,10 +32,27 @@ from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
 
 
+def _lookup_attrs(event: Event) -> dict[str, Any]:
+    """Build ``{"model_name": ..., "cache_salt": ...}`` from the event.
+
+    Missing fields are dropped from the returned dict so future emission
+    sites that haven't been updated to populate them won't crash; the
+    counter just records without that label dimension.
+    """
+    attrs: dict[str, Any] = {}
+    model_name = event.metadata.get("model_name")
+    if model_name is not None:
+        attrs["model_name"] = str(model_name)
+    cache_salt = event.metadata.get("cache_salt")
+    if cache_salt is not None:
+        attrs["cache_salt"] = str(cache_salt)
+    return attrs
+
+
 class LookupMetricsSubscriber(EventSubscriber):
     """Maintains OTel counters for L1+L2 token-level cache hit rate.
 
-    Metrics:
+    Metrics (both labeled by ``model_name`` and ``cache_salt``):
     - ``lmcache_mp.lookup_requested_tokens`` — tokens submitted for lookup
       (denominator).  Counts only the chunk-aligned portion; sub-chunk
       trailing tokens are excluded because they cannot hit by design.
@@ -64,5 +88,6 @@ class LookupMetricsSubscriber(EventSubscriber):
         }
 
     def _on_lookup_prefetch_end(self, event: Event) -> None:
-        self._requested_tokens.add(event.metadata["requested_tokens"])
-        self._hit_tokens.add(event.metadata["hit_tokens"])
+        attrs = _lookup_attrs(event)
+        self._requested_tokens.add(event.metadata["requested_tokens"], attributes=attrs)
+        self._hit_tokens.add(event.metadata["hit_tokens"], attributes=attrs)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -601,6 +601,7 @@ class MPCacheEngine:
                             "device": str(gpu_context.device),
                             "engine_id": instance_id,
                             "model_name": model_name,
+                            "cache_salt": key.cache_salt,
                             "total_bytes": total_bytes,
                         },
                     ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -161,6 +161,12 @@ class _PrefetchJob:
     # or chunk_hashes is empty).  Consumed at ``MP_LOOKUP_PREFETCH_END``
     # emission time in ``query_prefetch_status``.
     requested_tokens: int
+    # Captured at lookup time so the ``MP_LOOKUP_PREFETCH_END`` event can
+    # carry them as labels.  ``model_name`` lets dashboards slice hit rate
+    # per model in multi-model deployments; ``cache_salt`` slices per
+    # tenant / isolation domain (an empty string means no salt set).
+    model_name: str = ""
+    cache_salt: str = ""
 
 
 # Main class for the mp cache engine
@@ -676,6 +682,8 @@ class MPCacheEngine:
                     world_size=1,
                     request_id=key.request_id,
                     requested_tokens=0,
+                    model_name=model_name,
+                    cache_salt=key.cache_salt,
                 )
             )
             return
@@ -697,6 +705,8 @@ class MPCacheEngine:
                     world_size=1,
                     request_id=key.request_id,
                     requested_tokens=0,
+                    model_name=model_name,
+                    cache_salt=key.cache_salt,
                 )
             )
             return
@@ -748,6 +758,8 @@ class MPCacheEngine:
                 world_size=key.world_size,
                 request_id=key.request_id,
                 requested_tokens=requested_tokens,
+                model_name=model_name,
+                cache_salt=key.cache_salt,
             )
         )
 
@@ -829,6 +841,8 @@ class MPCacheEngine:
                     "found_count": found_count,
                     "requested_tokens": job.requested_tokens,
                     "hit_tokens": found_count * self.chunk_size,
+                    "model_name": job.model_name,
+                    "cache_salt": job.cache_salt,
                 },
             )
         )

--- a/tests/v1/mp_observability/subscribers/metrics/test_engine.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_engine.py
@@ -29,6 +29,7 @@ def _retrieve_end(
     retrieved_count: int,
     engine_id: int = 0,
     model_name: str = "test-model",
+    cache_salt: str = "",
     device: str = "cuda:0",
 ) -> Event:
     return Event(
@@ -39,8 +40,24 @@ def _retrieve_end(
             "device": device,
             "engine_id": engine_id,
             "model_name": model_name,
+            "cache_salt": cache_salt,
             "total_bytes": 0,
         },
+    )
+
+
+def _attrs(
+    worker_id: str, model_name: str = "test-model", cache_salt: str = ""
+) -> tuple:
+    """Build the sorted-tuple attribute key the subscriber emits."""
+    return tuple(
+        sorted(
+            {
+                "worker_id": worker_id,
+                "model_name": model_name,
+                "cache_salt": cache_salt,
+            }.items()
+        )
     )
 
 
@@ -96,7 +113,7 @@ class TestNumChunksLoaded:
         subscriber._on_retrieve_end(_retrieve_end(retrieved_count=8, engine_id=3))
         after = _read_counter_by_attrs()
 
-        key = (("worker_id", "3"),)
+        key = _attrs(worker_id="3")
         assert after.get(key, 0) == before.get(key, 0) + 8
 
     def test_different_workers_are_independent(self, subscriber):
@@ -106,10 +123,59 @@ class TestNumChunksLoaded:
         subscriber._on_retrieve_end(_retrieve_end(retrieved_count=3, engine_id=0))
         after = _read_counter_by_attrs()
 
-        worker_0 = (("worker_id", "0"),)
-        worker_1 = (("worker_id", "1"),)
+        worker_0 = _attrs(worker_id="0")
+        worker_1 = _attrs(worker_id="1")
         assert after.get(worker_0, 0) == before.get(worker_0, 0) + 8
         assert after.get(worker_1, 0) == before.get(worker_1, 0) + 7
+
+    def test_carries_model_name_and_cache_salt(self, subscriber):
+        before = _read_counter_by_attrs()
+        subscriber._on_retrieve_end(
+            _retrieve_end(
+                retrieved_count=4,
+                engine_id=2,
+                model_name="llama-3.1-8b",
+                cache_salt="tenant-A",
+            )
+        )
+        after = _read_counter_by_attrs()
+        key = _attrs(worker_id="2", model_name="llama-3.1-8b", cache_salt="tenant-A")
+        assert after.get(key, 0) == before.get(key, 0) + 4
+
+    def test_different_models_or_salts_accumulate_independently(self, subscriber):
+        before = _read_counter_by_attrs()
+        # Same worker, different (model, salt) pairs.
+        subscriber._on_retrieve_end(
+            _retrieve_end(
+                retrieved_count=5,
+                engine_id=0,
+                model_name="model-A",
+                cache_salt="salt-1",
+            )
+        )
+        subscriber._on_retrieve_end(
+            _retrieve_end(
+                retrieved_count=3,
+                engine_id=0,
+                model_name="model-A",
+                cache_salt="salt-2",
+            )
+        )
+        subscriber._on_retrieve_end(
+            _retrieve_end(
+                retrieved_count=7,
+                engine_id=0,
+                model_name="model-B",
+                cache_salt="salt-1",
+            )
+        )
+        after = _read_counter_by_attrs()
+        a1 = _attrs(worker_id="0", model_name="model-A", cache_salt="salt-1")
+        a2 = _attrs(worker_id="0", model_name="model-A", cache_salt="salt-2")
+        b1 = _attrs(worker_id="0", model_name="model-B", cache_salt="salt-1")
+        assert after.get(a1, 0) == before.get(a1, 0) + 5
+        assert after.get(a2, 0) == before.get(a2, 0) + 3
+        assert after.get(b1, 0) == before.get(b1, 0) + 7
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +188,7 @@ class TestEdgeCases:
         before = _read_counter_by_attrs()
         subscriber._on_retrieve_end(_retrieve_end(retrieved_count=0, engine_id=4))
         after = _read_counter_by_attrs()
-        key = (("worker_id", "4"),)
+        key = _attrs(worker_id="4")
         assert after.get(key, 0) == before.get(key, 0)
 
     def test_missing_engine_id_still_records_without_attr(self, subscriber):
@@ -159,5 +225,5 @@ class TestEventBusIntegration:
         bus.stop()
         after = _read_counter_by_attrs()
 
-        key = (("worker_id", "9"),)
+        key = _attrs(worker_id="9")
         assert after.get(key, 0) == before.get(key, 0) + 12

--- a/tests/v1/mp_observability/subscribers/metrics/test_engine.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_engine.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for EngineMetricsSubscriber."""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
+from lmcache.v1.mp_observability.subscribers.metrics.engine import (
+    EngineMetricsSubscriber,
+)
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+
+_DRAIN_WAIT = 0.15
+_METRIC = "lmcache_mp.num_chunks_loaded"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _retrieve_end(
+    retrieved_count: int,
+    engine_id: int = 0,
+    model_name: str = "test-model",
+    device: str = "cuda:0",
+) -> Event:
+    return Event(
+        event_type=EventType.MP_RETRIEVE_END,
+        session_id="req-1",
+        metadata={
+            "retrieved_count": retrieved_count,
+            "device": device,
+            "engine_id": engine_id,
+            "model_name": model_name,
+            "total_bytes": 0,
+        },
+    )
+
+
+def _read_counter_by_attrs() -> dict[tuple, int]:
+    data = _reader.get_metrics_data()
+    result: dict[tuple, int] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                if metric.name != _METRIC:
+                    continue
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue
+                    key = tuple(sorted(dict(dp.attributes).items()))
+                    result[key] = int(dp.value)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subscriber():
+    return EngineMetricsSubscriber()
+
+
+# ---------------------------------------------------------------------------
+# Subscription surface
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptions:
+    def test_subscribes_to_retrieve_end_only(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.MP_RETRIEVE_END in subs
+        # Store path is not of interest here; the counter is load-only.
+        assert EventType.MP_STORE_END not in subs
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestNumChunksLoaded:
+    def test_single_retrieve_adds_retrieved_count(self, subscriber):
+        before = _read_counter_by_attrs()
+        subscriber._on_retrieve_end(_retrieve_end(retrieved_count=8, engine_id=3))
+        after = _read_counter_by_attrs()
+
+        key = (("worker_id", "3"),)
+        assert after.get(key, 0) == before.get(key, 0) + 8
+
+    def test_different_workers_are_independent(self, subscriber):
+        before = _read_counter_by_attrs()
+        subscriber._on_retrieve_end(_retrieve_end(retrieved_count=5, engine_id=0))
+        subscriber._on_retrieve_end(_retrieve_end(retrieved_count=7, engine_id=1))
+        subscriber._on_retrieve_end(_retrieve_end(retrieved_count=3, engine_id=0))
+        after = _read_counter_by_attrs()
+
+        worker_0 = (("worker_id", "0"),)
+        worker_1 = (("worker_id", "1"),)
+        assert after.get(worker_0, 0) == before.get(worker_0, 0) + 8
+        assert after.get(worker_1, 0) == before.get(worker_1, 0) + 7
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_zero_count_is_noop(self, subscriber):
+        before = _read_counter_by_attrs()
+        subscriber._on_retrieve_end(_retrieve_end(retrieved_count=0, engine_id=4))
+        after = _read_counter_by_attrs()
+        key = (("worker_id", "4"),)
+        assert after.get(key, 0) == before.get(key, 0)
+
+    def test_missing_engine_id_still_records_without_attr(self, subscriber):
+        # Some future emission site may forget engine_id; we should
+        # record the count anyway (so operators notice the total) but
+        # drop the worker_id attribute.
+        before = _read_counter_by_attrs()
+        subscriber._on_retrieve_end(
+            Event(
+                event_type=EventType.MP_RETRIEVE_END,
+                metadata={"retrieved_count": 2},
+            )
+        )
+        after = _read_counter_by_attrs()
+        empty_key: tuple = ()
+        assert after.get(empty_key, 0) == before.get(empty_key, 0) + 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via EventBus
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusIntegration:
+    def test_retrieve_end_via_bus_increments_counter(self):
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        sub = EngineMetricsSubscriber()
+        bus.register_subscriber(sub)
+
+        before = _read_counter_by_attrs()
+        bus.start()
+        bus.publish(_retrieve_end(retrieved_count=12, engine_id=9))
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+        after = _read_counter_by_attrs()
+
+        key = (("worker_id", "9"),)
+        assert after.get(key, 0) == before.get(key, 0) + 12

--- a/tests/v1/mp_observability/subscribers/metrics/test_lookup.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_lookup.py
@@ -32,7 +32,7 @@ _DRAIN_WAIT = 0.15
 
 
 def _read_counters() -> dict[str, int]:
-    """Snapshot all counter values from the module-level reader."""
+    """Snapshot counter values, summed across attribute combinations."""
     data = _reader.get_metrics_data()
     result: dict[str, int] = {}
     if data is None:
@@ -40,10 +40,32 @@ def _read_counters() -> dict[str, int]:
     for resource_metrics in data.resource_metrics:
         for scope_metrics in resource_metrics.scope_metrics:
             for metric in scope_metrics.metrics:
+                total = 0
+                any_value = False
                 for dp in metric.data.data_points:
                     if not hasattr(dp, "value"):
                         continue  # skip histogram data points
-                    result[metric.name] = int(dp.value)
+                    total += int(dp.value)
+                    any_value = True
+                if any_value:
+                    result[metric.name] = total
+    return result
+
+
+def _read_counters_by_attrs() -> dict[str, dict[tuple, int]]:
+    """Snapshot counter values keyed by (metric_name, sorted-attrs-tuple)."""
+    data = _reader.get_metrics_data()
+    result: dict[str, dict[tuple, int]] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue
+                    key = tuple(sorted(dict(dp.attributes).items()))
+                    result.setdefault(metric.name, {})[key] = int(dp.value)
     return result
 
 
@@ -225,3 +247,116 @@ class TestLookupMetricsSubscriptions:
         # to lookups that will never fire END (abandoned, early-exit).
         assert EventType.MP_LOOKUP_PREFETCH_START not in subs
         assert len(subs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-(model_name, cache_salt) label slicing
+# ---------------------------------------------------------------------------
+
+
+class TestLookupAttributeLabels:
+    def test_carries_model_name_and_cache_salt(self, bus, subscriber):
+        bus.start()
+        before = _read_counters_by_attrs()
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id="req-labeled",
+                metadata={
+                    "found_count": 2,
+                    "requested_tokens": 1024,
+                    "hit_tokens": 768,
+                    "model_name": "llama-3.1-8b",
+                    "cache_salt": "tenant-A",
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        after = _read_counters_by_attrs()
+        attr_key = (
+            ("cache_salt", "tenant-A"),
+            ("model_name", "llama-3.1-8b"),
+        )
+        before_req = before.get("lmcache_mp.lookup_requested_tokens", {}).get(
+            attr_key, 0
+        )
+        before_hit = before.get("lmcache_mp.lookup_hit_tokens", {}).get(attr_key, 0)
+        after_req = after.get("lmcache_mp.lookup_requested_tokens", {}).get(attr_key, 0)
+        after_hit = after.get("lmcache_mp.lookup_hit_tokens", {}).get(attr_key, 0)
+        assert after_req == before_req + 1024
+        assert after_hit == before_hit + 768
+
+    def test_different_models_accumulate_independently(self, bus, subscriber):
+        bus.start()
+        before = _read_counters_by_attrs()
+        # 2 lookups on model-A, 1 on model-B, all same salt.
+        for _ in range(2):
+            bus.publish(
+                Event(
+                    event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                    session_id="x",
+                    metadata={
+                        "found_count": 1,
+                        "requested_tokens": 256,
+                        "hit_tokens": 256,
+                        "model_name": "model-A",
+                        "cache_salt": "salt-1",
+                    },
+                )
+            )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id="y",
+                metadata={
+                    "found_count": 1,
+                    "requested_tokens": 256,
+                    "hit_tokens": 256,
+                    "model_name": "model-B",
+                    "cache_salt": "salt-1",
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        after = _read_counters_by_attrs()
+        a_key = (("cache_salt", "salt-1"), ("model_name", "model-A"))
+        b_key = (("cache_salt", "salt-1"), ("model_name", "model-B"))
+        req = "lmcache_mp.lookup_requested_tokens"
+        assert (
+            after.get(req, {}).get(a_key, 0) == before.get(req, {}).get(a_key, 0) + 512
+        )
+        assert (
+            after.get(req, {}).get(b_key, 0) == before.get(req, {}).get(b_key, 0) + 256
+        )
+
+    def test_missing_labels_record_without_attrs(self, bus, subscriber):
+        # Older event producers may not populate model_name / cache_salt;
+        # the counter should still record under the empty-attrs bucket
+        # rather than crashing.
+        bus.start()
+        before = _read_counters_by_attrs()
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id="legacy",
+                metadata={
+                    "found_count": 1,
+                    "requested_tokens": 128,
+                    "hit_tokens": 128,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        after = _read_counters_by_attrs()
+        empty_key: tuple = ()
+        req = "lmcache_mp.lookup_requested_tokens"
+        assert (
+            after.get(req, {}).get(empty_key, 0)
+            == before.get(req, {}).get(empty_key, 0) + 128
+        )


### PR DESCRIPTION
Introduces a worker-scoped counter that ticks +retrieved_count on every MP_RETRIEVE_END event, labeled by worker_id.  Lets dashboards track per- worker load volume and spot uneven demand across vLLM ranks.

- New EngineMetricsSubscriber (subscribers/metrics/engine.py).  Reads engine_id from the existing MP_RETRIEVE_END metadata and emits it as worker_id on the counter, making the attribute name distinct from any scheduler-scoped id that may appear on other metrics.
- Registered in init_observability().
- New tests cover single-retrieve, multi-worker independence, zero-count noop, missing-engine_id fallback, and EventBus end-to-end.
- Docs: new "Engine Counters" section in METRICS.md and observability.rst.

No changes to the server.py emission site — MP_RETRIEVE_END already carries retrieved_count and engine_id.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new OTel counters and expands event/metric label dimensions (`model_name`, `cache_salt`, `worker_id`), which can affect metric cardinality and dashboard expectations but does not change core caching behavior.
> 
> **Overview**
> Adds a new worker-scoped metric, `lmcache_mp.num_chunks_loaded`, emitted on each `MP_RETRIEVE_END` to track per-vLLM-worker chunk load volume (attributes: `worker_id`, `model_name`, `cache_salt`), and registers the new `EngineMetricsSubscriber` in observability initialization.
> 
> Extends MP observability metadata/contracts so `MP_RETRIEVE_END` and `MP_LOOKUP_PREFETCH_END` carry `cache_salt` (and lookup end also carries `model_name`), and updates `LookupMetricsSubscriber` (and tests) so the hit-rate token counters are labeled by `model_name`/`cache_salt` with a backward-compatible fallback when labels are missing.
> 
> Updates design/user docs to document the new engine counter and the additional lookup/retrieve label dimensions, including guidance on potentially high-cardinality `cache_salt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6099f48a5ae3825fcc7ca2fb5a4315b9af844584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->