### PR TITLE
 [CI/CD] Fix nightly Docker build broken by nightly-cu13 tag

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -175,6 +175,9 @@ jobs:
           # for setuptools-scm
           fetch-depth: 0
 
+      - name: Remove non-release tags
+        run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$' | xargs -r git tag -d
+
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 


### PR DESCRIPTION
 Summary

  The nightly-build job was crashing in python3 setup.py bdist_wheel because setuptools_scm found the nightly-cu13 release tag (created earlier in the
  same workflow run), couldn't parse it against the semver tag_regex, and raised AssertionError. The nightly-wheels job already strips non-release tags
   before building; apply the same step to nightly-build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that deletes local non-release git tags before building to prevent `setuptools-scm` version parsing failures.
> 
> **Overview**
> Fixes the nightly container image workflow by deleting any non-semver git tags after checkout in `nightly-build`, mirroring the existing tag cleanup used in `nightly-wheels`.
> 
> This prevents newly-created nightly tags (e.g. `nightly-cu13`) from breaking build steps that rely on `setuptools-scm` tag parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a801fe8ee6901c82be16a086e708bd28307207fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->