### PR TITLE
[MP]: Use unified c_ops backend import and fix gpu_kv_format_name property

### DIFF
--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -41,7 +41,7 @@ from lmcache.v1.multiprocess.custom_types import (
 # fallback) is handled once in ``lmcache/__init__.py`` via ``_get_backend``,
 # which aliases the chosen module as ``lmcache.c_ops`` in ``sys.modules``.
 # Importing it here transparently works in both CUDA and CPU-only envs.
-import lmcache.c_ops as lmc_ops  # noqa: E402
+import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -33,14 +33,15 @@ from lmcache.v1.gpu_connector.utils import (
     is_mla,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
-
-if torch.cuda.is_available():
-    import lmcache.c_ops as lmc_ops
-
-# First Party
 from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
+
+# Backend selection (c_ops when CUDA is available, otherwise a pure-Python
+# fallback) is handled once in ``lmcache/__init__.py`` via ``_get_backend``,
+# which aliases the chosen module as ``lmcache.c_ops`` in ``sys.modules``.
+# Importing it here transparently works in both CUDA and CPU-only envs.
+import lmcache.c_ops as lmc_ops  # noqa: E402
 
 logger = init_logger(__name__)
 
@@ -241,6 +242,7 @@ class GPUCacheContext:
         """Returns the KV layer groups manager."""
         return self.kv_layer_groups_manager_
 
+    @property
     def gpu_kv_format_name(self) -> str:
         """Returns the GPU KV format enum name (e.g. ``'NL_X_TWO_NB_BS_NH_HS'``)."""
         return self.gpu_kv_format_.name


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR applies two small fixes to `lmcache/v1/multiprocess/gpu_context.py`:

1. Use the unified backend selection from `lmcache/__init__.py` by importing
   `lmcache.c_ops` unconditionally. The CUDA vs pure-Python fallback is
   already aliased into `sys.modules` by `_get_backend`, so the previous
   `if torch.cuda.is_available():` guard is redundant and makes the CPU-only
   path diverge from the rest of the codebase.
2. Decorate `GPUCacheContext.gpu_kv_format_name` with `@property` so callers
   (e.g. server metadata accessors) receive the enum name string directly,
   consistent with the other metadata accessors on `GPUCacheContext`.

**Special notes for your reviewers**:

⚠️ **Breaking change**: `GPUCacheContext.gpu_kv_format_name` is changed from a
method to a `@property`. Any existing caller that invokes it as
`ctx.gpu_kv_format_name()` must be updated to access it as
`ctx.gpu_kv_format_name`. A quick search in this repo shows no such callers
today, but downstream users of this public interface should update
accordingly.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
