### PR TITLE
[MP] Introduce EventNotifier to replace direct os.eventfd usage

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/plugin.md
+++ b/docs/design/v1/distributed/l2_adapters/plugin.md
@@ -129,8 +129,9 @@ A plugin adapter class **should**:
 1. Create its own asyncio event loop and background thread if it needs
    async I/O (the framework does **not** provide a loop to L2 adapters,
    unlike the old Connector-based architecture).
-2. Use `os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)` for the three
-   event fds.
+2. Use `create_event_notifier()` from `lmcache.v1.platform` for the
+   three event fds (cross-platform: `os.eventfd` on Linux,
+   `os.pipe` fallback elsewhere).
 3. Clean up all resources (event fds, threads, connections) in `close()`.
 
 ---
@@ -172,17 +173,18 @@ This pattern is identical to the one used by `MockL2Adapter` and
 
 ```python
 # my_plugin/adapter.py
-import asyncio, os, threading
+import asyncio, threading
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface, L2TaskId,
 )
+from lmcache.v1.platform import create_event_notifier
 
 class MyL2Adapter(L2AdapterInterface):
     def __init__(self, host="localhost", **_kw):
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
         # ... set up connection to `host`, background thread, etc.
 
     # implement all abstract methods ...

--- a/docs/design/v1/platform/event_notifier.md
+++ b/docs/design/v1/platform/event_notifier.md
@@ -1,0 +1,206 @@
+# Cross-Platform Event Notification
+
+Location: `lmcache/v1/platform/event_notifier.py`
+(re-exported from the `lmcache.v1.platform` package)
+
+## Background
+
+LMCache's multiprocess / distributed runtime uses a large number of
+**pollable file descriptors** to wake background loops from other
+threads:
+
+- `mq.MessageQueueServer._output_efd` — notify the poller that a
+  response frame is ready on the thread-pool output queue.
+- `StoreListener._event_fd` — notify the store-controller loop that
+  L1 has finished writing new keys.
+- `PrefetchController._submission_efd` — notify the prefetch loop of
+  a newly submitted request.
+- Every `L2Adapter` exposes three event fds
+  (`get_store_event_fd()`, `get_lookup_and_lock_event_fd()`,
+  `get_load_event_fd()`) so controllers can `select.poll()` across
+  all adapters in a single loop.
+
+Previously these were all raw `os.eventfd(...)`. `os.eventfd` is a
+Linux-only syscall, which blocks the MP/distributed stack from
+running on macOS (and any other non-Linux POSIX system).
+
+## Goals
+
+1. Let the exact same code paths run on Linux (using `eventfd`) and
+   on macOS / other POSIX (using a self-pipe).
+2. Keep the call-site diff small — existing sites should look as
+   close as possible to the `os.eventfd(...)` version they replace.
+3. No global state, no monkey-patching of `os`, no hidden
+   process-wide registries.
+4. Give callers a single abstraction rather than each module doing
+   its own `hasattr(os, "eventfd")` dance.
+
+## Non-Goals
+
+- Cross-process signaling. `EventNotifier` is for in-process
+  thread-to-thread wake-ups. The fd is created in one process and
+  never shared via IPC.
+- Counting semaphore semantics. `notify()` is a **binary signal**;
+  coalescing is expected.
+
+## Design
+
+### Public API
+
+```python
+# lmcache/v1/platform/event_notifier.py
+# (re-exported via `lmcache.v1.platform` for short imports)
+
+class EventNotifier(ABC):
+    def fileno(self) -> int: ...      # poll-able fd
+    def notify(self) -> None: ...     # signal (idempotent)
+    def consume(self) -> None: ...    # drain (non-blocking)
+    def close(self) -> None: ...      # idempotent
+
+    def __enter__(self) -> "EventNotifier": ...
+    def __exit__(self, *exc) -> None: ...
+
+def create_event_notifier() -> EventNotifier: ...
+def consume_fd(fd: int) -> None: ...
+```
+
+Two concrete implementations:
+
+| Implementation    | Backend      | Selected when                    |
+|-------------------|--------------|----------------------------------|
+| `EventfdNotifier` | `os.eventfd` | `HAS_EVENTFD` (Linux + Py 3.10+) |
+| `PipeNotifier`    | `os.pipe`    | otherwise (macOS / other POSIX)  |
+
+Selection is centralized in `create_event_notifier()`; callers never
+branch on the platform. `HAS_EVENTFD` is defined as
+`hasattr(os, "eventfd")` in `lmcache/v1/platform/event_notifier.py`
+and re-exported from the `lmcache.v1.platform` package — the single
+source of truth for platform capability detection.
+
+On non-Linux platforms the `EventfdNotifier` symbol still exists as
+a placeholder whose `__init__` raises `RuntimeError`, so
+`isinstance(..., EventfdNotifier)` checks in tests stay valid.
+
+`consume_fd(fd)` is a module-level helper for callers that only have
+a raw fd (typical case: a controller that received an fd via
+`adapter.get_store_event_fd()` and wants to drain it after
+`poll()`). It dispatches to the right syscall based on the same
+`HAS_EVENTFD` flag.
+
+### Semantics
+
+`EventNotifier` models a **binary signal**:
+
+- After `notify()`, the fd is readable via `select.poll()`.
+- `consume()` drains all pending signals so the fd is no longer
+  readable.
+- Multiple `notify()` calls before a `consume()` are coalesced.
+  Callers must not rely on a counter — they must re-check the
+  underlying work queue after being woken.
+- `consume()` is non-blocking and safe to call on an unsignaled fd.
+- `close()` is idempotent.
+
+### Exception contract
+
+`consume()` and the module-level `consume_fd(fd)` helper **only
+swallow `BlockingIOError`** (i.e. "no data pending on a non-blocking
+fd"). Every other `OSError` subclass — most importantly `EBADF` from
+a stale or already-closed fd — propagates to the caller so caller
+bugs surface instead of being silently absorbed.
+
+`notify()` swallows `BlockingIOError` in `PipeNotifier` because a
+full pipe means a signal is *already* pending, which is the
+post-condition we want. On `EventfdNotifier`, the counter only
+blocks on overflow (max `2**64 - 2`), which we treat as unreachable
+in practice.
+
+`close()` is fully idempotent and swallows any `OSError` during
+`os.close`, since there is nothing a caller could do about it.
+
+### Backend Differences
+
+**`EventfdNotifier`** (Linux) wraps a single eventfd opened with
+`EFD_NONBLOCK | EFD_CLOEXEC`. `notify()` writes `1`, `consume()`
+reads the 8-byte counter.
+
+**`PipeNotifier`** (macOS / other POSIX) wraps an `os.pipe()` pair.
+Since Python 3.4 (PEP 446) `os.pipe()` already sets `FD_CLOEXEC`,
+so `__init__` only needs to flip both ends to non-blocking via
+`os.set_blocking(fd, False)` — a portable API that avoids pulling
+in `fcntl` and is friendlier to a future Windows pipe backend. If
+either `set_blocking` call fails, both fds are closed before the
+error propagates so no descriptors leak.
+
+`notify()` writes a single `\x01` byte; `consume()` drains the read
+end in a loop. If the pipe buffer is full, `notify()` is a no-op —
+the signal is already pending. Both `PipeNotifier.consume()` and
+the module-level `consume_fd()` treat an empty read (`b''`, i.e.
+the write end was closed) as "drained" and stop looping, so a dead
+pipe can never spin a background event loop.
+
+### Architecture
+
+```mermaid
+graph LR
+  Caller -->|create_event_notifier| Factory
+  Factory -->|HAS_EVENTFD| EventfdNotifier
+  Factory -->|fallback| PipeNotifier
+  EventfdNotifier -->|os.eventfd| Kernel
+  PipeNotifier -->|os.pipe| Kernel
+```
+
+## Call-Site Migration
+
+Before (Linux-only):
+
+```python
+import os
+self._event_fd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+...
+os.eventfd_write(self._event_fd, 1)
+...
+os.eventfd_read(self._event_fd)
+...
+os.close(self._event_fd)
+```
+
+After (cross-platform):
+
+```python
+from lmcache.v1.platform import create_event_notifier
+
+self._event_fd = create_event_notifier()
+...
+self._event_fd.notify()
+...
+self._event_fd.consume()        # or: consume_fd(raw_fd)
+...
+self._event_fd.close()
+```
+
+The field name (`_event_fd`, `_output_efd`, `_submission_efd`, etc.)
+is kept deliberately — the variable is still "the thing you poll
+on", and reusing the name keeps the diff focused on the semantic
+change.
+
+## Testing
+
+Unit tests live in `tests/v1/test_event_notifier.py`. They cover:
+
+- **`TestEventNotifierAPI`** — platform-agnostic contract:
+  factory returns an `EventNotifier` subclass; `fileno()` returns a
+  valid fd; `notify()` makes the fd readable and `consume()` clears
+  it; multiple `notify()` calls coalesce; `consume()` and `close()`
+  are idempotent; context-manager usage.
+- **`TestPipeNotifier`** — pipe-specific: both read/write fds are
+  released by `close()`; pipe-full triggers the `BlockingIOError`
+  swallow path in `notify()`; many create/close cycles do not leak
+  fds; fd is pollable.
+- **`TestConsumeFd`** — the `consume_fd(raw_fd)` utility drains a
+  signaled fd and is a no-op on an unsignaled one.
+- **`TestBackendSelection`** — asserts the factory picks
+  `EventfdNotifier` when `HAS_EVENTFD` and `PipeNotifier` otherwise.
+- **`TestForcedPipeFallback`** — on Linux CI the factory would
+  normally return `EventfdNotifier`; this class `monkeypatch`es
+  `HAS_EVENTFD` to `False` so the pipe fallback (and `consume_fd`'s
+  pipe branch) is exercised on every platform.

--- a/docs/source/developer_guide/extending_lmcache/storage_plugins.rst
+++ b/docs/source/developer_guide/extending_lmcache/storage_plugins.rst
@@ -149,7 +149,8 @@ A plugin adapter class **must**:
 A plugin adapter class **should**:
 
 1. Create its own asyncio event loop and background thread if it needs async I/O.
-2. Use ``os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)`` for the three event fds.
+2. Use ``create_event_notifier()`` from ``lmcache.v1.platform`` for the three event fds
+   (cross-platform: ``os.eventfd`` on Linux, ``os.pipe`` fallback elsewhere).
 3. Clean up all resources (event fds, threads, connections) in ``close()``.
 
 Loading Flow
@@ -192,7 +193,6 @@ Minimal Example
 
     # my_plugin/adapter.py
     import asyncio
-    import os
     import threading
 
     from lmcache.native_storage_ops import Bitmap
@@ -200,27 +200,22 @@ Minimal Example
         L2AdapterInterface,
         L2TaskId,
     )
+    from lmcache.v1.platform import create_event_notifier
 
 
     class MyL2Adapter(L2AdapterInterface):
         def __init__(self, params, **_kw):
-            self._store_efd = os.eventfd(
-                0, os.EFD_NONBLOCK | os.EFD_CLOEXEC
-            )
-            self._lookup_efd = os.eventfd(
-                0, os.EFD_NONBLOCK | os.EFD_CLOEXEC
-            )
-            self._load_efd = os.eventfd(
-                0, os.EFD_NONBLOCK | os.EFD_CLOEXEC
-            )
+            self._store_efd = create_event_notifier()
+            self._lookup_efd = create_event_notifier()
+            self._load_efd = create_event_notifier()
             # ... set up connection, background thread, etc.
 
         # implement all abstract methods ...
 
         def close(self) -> None:
-            os.close(self._store_efd)
-            os.close(self._lookup_efd)
-            os.close(self._load_efd)
+            self._store_efd.close()
+            self._lookup_efd.close()
+            self._load_efd.close()
 
 Launch via CLI:
 

--- a/examples/lmc_external_l2_adapter/src/lmc_external_l2_adapter/adapter.py
+++ b/examples/lmc_external_l2_adapter/src/lmc_external_l2_adapter/adapter.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from typing import Any, Union
 import asyncio
 import copy
-import os
 import threading
 import time
 
@@ -34,6 +33,7 @@ from lmcache.v1.memory_management import (
     MemoryObj,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -119,9 +119,9 @@ class InMemoryL2Adapter(L2AdapterInterface):
         self._bw_bps = bw
         self._cur_size = 0
 
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         self._objects: dict[ObjectKey, MemoryObj] = {}
         self._key_queue: list[ObjectKey] = []
@@ -146,13 +146,13 @@ class InMemoryL2Adapter(L2AdapterInterface):
     # ---- event fd ------------------------------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     # ---- store ---------------------------------------------
 
@@ -243,9 +243,9 @@ class InMemoryL2Adapter(L2AdapterInterface):
             self._loop.call_soon_threadsafe(self._loop.stop)
 
         self._thread.join()
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
 
     # ---- helpers -------------------------------------------
 
@@ -301,7 +301,7 @@ class InMemoryL2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._done_store[tid] = ok
-        os.eventfd_write(self._store_efd, 1)
+        self._store_efd.notify()
 
     def _do_lookup(
         self,
@@ -316,7 +316,7 @@ class InMemoryL2Adapter(L2AdapterInterface):
             self._locked[k] += 1
         with self._lock:
             self._done_lookup[tid] = bm
-        os.eventfd_write(self._lookup_efd, 1)
+        self._lookup_efd.notify()
 
     async def _do_load(
         self,
@@ -344,4 +344,4 @@ class InMemoryL2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._done_load[tid] = bm
-        os.eventfd_write(self._load_efd, 1)
+        self._load_efd.notify()

--- a/examples/lmc_external_l2_adapter/tests/test_plugin.py
+++ b/examples/lmc_external_l2_adapter/tests/test_plugin.py
@@ -15,7 +15,6 @@ Validates that:
 # Standard
 from typing import TYPE_CHECKING
 import json
-import os
 import platform
 import select
 
@@ -33,6 +32,7 @@ from lmcache.v1.distributed.l2_adapters.factory import (
 )
 from lmcache.v1.distributed.l2_adapters.plugin_l2_adapter import PluginL2AdapterConfig
 from lmcache.v1.memory_management import TensorMemoryObj
+from lmcache.v1.platform import consume_fd
 
 if TYPE_CHECKING:
     pass
@@ -139,7 +139,7 @@ def _wait_event_fd(fd: int, timeout: float = 5.0) -> bool:
     events = poll.poll(timeout * 1000)
     if events:
         try:
-            os.eventfd_read(fd)
+            consume_fd(fd)
         except BlockingIOError:
             pass
         return True

--- a/lmcache/v1/check/check_mode_test_l2_adapter.py
+++ b/lmcache/v1/check/check_mode_test_l2_adapter.py
@@ -3,7 +3,6 @@
 
 # Standard
 import argparse
-import os
 import select
 import time
 
@@ -29,6 +28,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd
 
 _POLL_TIMEOUT_MS = 100000
 
@@ -91,7 +91,7 @@ def _wait_event_fd(efd: int, timeout_ms: int = _POLL_TIMEOUT_MS) -> bool:
     events = poll.poll(timeout_ms)
     if events:
         try:
-            os.eventfd_read(efd)
+            consume_fd(efd)
         except BlockingIOError:
             pass
         return True

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -42,6 +42,7 @@ from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -279,9 +280,9 @@ class FSL2Adapter(L2AdapterInterface):
             stat = os.statvfs(self._base_path)
             self._os_disk_bs = stat.f_bsize
 
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         # Task bookkeeping
         self._next_task_id: L2TaskId = 0
@@ -310,13 +311,13 @@ class FSL2Adapter(L2AdapterInterface):
     # ------------------------------------------------------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     # ------------------------------------------------------------------
     # Store Interface
@@ -444,9 +445,9 @@ class FSL2Adapter(L2AdapterInterface):
         self._loop_thread.join()
         self._loop.close()
 
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
         logger.info("FSL2Adapter closed")
 
     # ------------------------------------------------------------------
@@ -627,7 +628,7 @@ class FSL2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_store_tasks[task_id] = success
-        os.eventfd_write(self._store_efd, 1)
+        self._store_efd.notify()
 
     # ---- lookup ---------------------------------------------------------
 
@@ -644,7 +645,7 @@ class FSL2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_lookup_tasks[task_id] = bitmap
-        os.eventfd_write(self._lookup_efd, 1)
+        self._lookup_efd.notify()
 
     # ---- load -----------------------------------------------------------
 
@@ -731,7 +732,7 @@ class FSL2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_load_tasks[task_id] = bitmap
-        os.eventfd_write(self._load_efd, 1)
+        self._load_efd.notify()
 
 
 # Self-register config type and adapter factory

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Optional
 import asyncio
 import copy
-import os
 import threading
 import time
 
@@ -30,6 +29,7 @@ from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
 from lmcache.v1.memory_management import MemoryObj, TensorMemoryObj
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -114,9 +114,9 @@ class MockL2Adapter(L2AdapterInterface):
         self._config = config
         self._bandwidth_byte_ps = int(config.mock_bandwidth_gb * (1024**3))
 
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         self._memory_objects: dict[ObjectKey, MemoryObj] = {}
         self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
@@ -139,13 +139,13 @@ class MockL2Adapter(L2AdapterInterface):
     # --------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     # --------------------
     # Store Interface
@@ -268,9 +268,9 @@ class MockL2Adapter(L2AdapterInterface):
         self._loop_thread.join()
         self._loop.close()
 
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
 
     ##################
     # Debug / test-only functions
@@ -370,7 +370,7 @@ class MockL2Adapter(L2AdapterInterface):
 
     def _signal_store_event(self) -> None:
         """Signal the store event fd to notify completion."""
-        os.eventfd_write(self._store_efd, 1)
+        self._store_efd.notify()
 
     async def _execute_store_in_the_loop(
         self,
@@ -441,7 +441,7 @@ class MockL2Adapter(L2AdapterInterface):
 
     def _signal_lookup_event(self) -> None:
         """Signal the lookup event fd to notify completion."""
-        os.eventfd_write(self._lookup_efd, 1)
+        self._lookup_efd.notify()
 
     def _execute_lookup_in_the_loop(
         self, keys: list[ObjectKey], task_id: L2TaskId
@@ -458,7 +458,7 @@ class MockL2Adapter(L2AdapterInterface):
 
     def _signal_load_event(self) -> None:
         """Signal the load event fd to notify completion."""
-        os.eventfd_write(self._load_efd, 1)
+        self._load_efd.notify()
 
     async def _execute_load_in_loop(
         self,

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 # Standard
 from collections import defaultdict
 from typing import Any
-import os
 import select
 import threading
 
@@ -36,6 +35,7 @@ from lmcache.v1.distributed.l2_adapters.base import (
     L2TaskId,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -109,11 +109,11 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         self._client = native_client
         self._client_fd: int = int(native_client.event_fd())
 
-        # 3 distinct Python eventfds for the L2 adapter
+        # 3 distinct cross-platform notifiers for the L2 adapter
         # interface
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         # Pending ops: native future_id →
         #   (op_type, task_id, num_keys, keys_for_locking)
@@ -168,13 +168,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     # ---------------------------------------------------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     # ---------------------------------------------------------------
     # Store Interface
@@ -344,9 +344,9 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         self._client.close()
 
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
 
     # ---------------------------------------------------------------
     # Internal helpers
@@ -439,7 +439,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                 else:
                                     keys_stored.append(key)
                                     sizes_stored.append(0)
-                        os.eventfd_write(self._store_efd, 1)
+                        self._store_efd.notify()
 
                     elif op_type == self._OP_LOOKUP:
                         bitmap = Bitmap(num_keys)
@@ -450,7 +450,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                     if lookup_keys is not None:
                                         self._locked_keys[lookup_keys[i]] += 1
                         self._completed_lookups[task_id] = bitmap
-                        os.eventfd_write(self._lookup_efd, 1)
+                        self._lookup_efd.notify()
 
                     elif op_type == self._OP_LOAD:
                         bitmap = Bitmap(num_keys)
@@ -470,7 +470,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                 loaded_keys.extend(lookup_keys)
                         keys_accessed.extend(loaded_keys)
                         self._completed_loads[task_id] = bitmap
-                        os.eventfd_write(self._load_efd, 1)
+                        self._load_efd.notify()
 
                     elif op_type == self._OP_DELETE:
                         if result_bools is not None and lookup_keys is not None:

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -54,6 +54,7 @@ from lmcache.v1.distributed.l2_adapters.nixl_store_l2_adapter import (
     NixlStoreObj,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -346,9 +347,9 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=int(max_capacity_gb * (1024**3)))
         self._config = config
 
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         # Cache data structures
         self._memory_objects: dict[ObjectKey, NixlStoreObj] = {}
@@ -382,13 +383,13 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
     # --------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     #####################
     # Store Interface
@@ -554,9 +555,9 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
 
         self.nixl_agent.close()
 
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
 
     ##################
     # Helper functions
@@ -572,13 +573,13 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         return task_id
 
     def _signal_store_event(self) -> None:
-        os.eventfd_write(self._store_efd, 1)
+        self._store_efd.notify()
 
     def _signal_lookup_event(self) -> None:
-        os.eventfd_write(self._lookup_efd, 1)
+        self._lookup_efd.notify()
 
     def _signal_load_event(self) -> None:
-        os.eventfd_write(self._load_efd, 1)
+        self._load_efd.notify()
 
     async def _execute_store_in_the_loop(
         self,

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -34,6 +34,7 @@ from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -447,9 +448,9 @@ class NixlStoreL2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=max_capacity_bytes)
         self._config = config
 
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         # Cache data structures
         self._memory_objects: dict[ObjectKey, NixlStoreObj] = {}
@@ -471,13 +472,13 @@ class NixlStoreL2Adapter(L2AdapterInterface):
     # --------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     #####################
     # Store Interface
@@ -599,9 +600,9 @@ class NixlStoreL2Adapter(L2AdapterInterface):
         self._loop_thread.join()
         self._loop.close()
 
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
 
     #####################
     # Eviction Interface
@@ -698,7 +699,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
 
     def _signal_store_event(self) -> None:
         """Signal the store event fd to notify completion."""
-        os.eventfd_write(self._store_efd, 1)
+        self._store_efd.notify()
 
     async def _execute_store_in_the_loop(
         self,
@@ -802,7 +803,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
 
     def _signal_lookup_event(self) -> None:
         """Signal the lookup event fd to notify completion."""
-        os.eventfd_write(self._lookup_efd, 1)
+        self._lookup_efd.notify()
 
     def _execute_lookup_in_the_loop(
         self, keys: list[ObjectKey], task_id: L2TaskId
@@ -831,7 +832,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
 
     def _signal_load_event(self) -> None:
         """Signal the load event fd to notify completion."""
-        os.eventfd_write(self._load_efd, 1)
+        self._load_efd.notify()
 
     async def _execute_load_in_loop(
         self,

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, Optional
 from urllib.parse import quote as url_quote
 import asyncio
 import ctypes
-import os
 import threading
 
 if TYPE_CHECKING:
@@ -47,6 +46,7 @@ from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -321,10 +321,10 @@ class S3L2Adapter(L2AdapterInterface):
             signing_config=signing_config,
         )
 
-        # 3 distinct eventfds for the L2 interface.
-        self._store_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._lookup_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
-        self._load_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        # 3 distinct cross-platform notifiers for the L2 interface.
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
 
         self._next_task_id: L2TaskId = 0
         self._completed_store_tasks: dict[L2TaskId, bool] = {}
@@ -377,13 +377,13 @@ class S3L2Adapter(L2AdapterInterface):
     # ------------------------------------------------------------------
 
     def get_store_event_fd(self) -> int:
-        return self._store_efd
+        return self._store_efd.fileno()
 
     def get_lookup_and_lock_event_fd(self) -> int:
-        return self._lookup_efd
+        return self._lookup_efd.fileno()
 
     def get_load_event_fd(self) -> int:
-        return self._load_efd
+        return self._load_efd.fileno()
 
     # ------------------------------------------------------------------
     # Store Interface
@@ -404,7 +404,7 @@ class S3L2Adapter(L2AdapterInterface):
                 disabled = False
 
         if disabled:
-            os.eventfd_write(self._store_efd, 1)
+            self._store_efd.notify()
             return task_id
 
         asyncio.run_coroutine_threadsafe(
@@ -434,7 +434,7 @@ class S3L2Adapter(L2AdapterInterface):
                 disabled = False
 
         if disabled:
-            os.eventfd_write(self._lookup_efd, 1)
+            self._lookup_efd.notify()
             return task_id
 
         asyncio.run_coroutine_threadsafe(
@@ -476,7 +476,7 @@ class S3L2Adapter(L2AdapterInterface):
                 disabled = False
 
         if disabled:
-            os.eventfd_write(self._load_efd, 1)
+            self._load_efd.notify()
             return task_id
 
         asyncio.run_coroutine_threadsafe(
@@ -576,9 +576,9 @@ class S3L2Adapter(L2AdapterInterface):
         except Exception:
             pass
 
-        os.close(self._store_efd)
-        os.close(self._lookup_efd)
-        os.close(self._load_efd)
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
 
         # Drop awscrt references so their native event loops / host
         # resolver threads / epoll fds can be reaped immediately rather
@@ -814,7 +814,7 @@ class S3L2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_store_tasks[task_id] = success
-        os.eventfd_write(self._store_efd, 1)
+        self._store_efd.notify()
 
         if newly_stored_keys:
             self._notify_keys_stored(newly_stored_keys, newly_stored_sizes)
@@ -892,7 +892,7 @@ class S3L2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_lookup_tasks[task_id] = bitmap
-        os.eventfd_write(self._lookup_efd, 1)
+        self._lookup_efd.notify()
 
         accessed = [keys[i] for i in range(len(keys)) if bitmap.test(i)]
         if accessed:
@@ -935,7 +935,7 @@ class S3L2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_load_tasks[task_id] = bitmap
-        os.eventfd_write(self._load_efd, 1)
+        self._load_efd.notify()
 
     async def _execute_delete(
         self, keys: list[ObjectKey]

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -16,7 +16,6 @@ The controller runs a background thread with an event-driven loop that:
 from dataclasses import dataclass, field
 from typing import Iterable
 import enum
-import os
 import select
 import threading
 
@@ -37,6 +36,10 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.platform import (
+    consume_fd,
+    create_event_notifier,
+)
 
 logger = init_logger(__name__)
 
@@ -219,7 +222,7 @@ class PrefetchController(StorageControllerInterface):
             tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int]
         ] = []
         self._next_request_id: PrefetchRequestId = 0
-        self._submission_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._submission_efd = create_event_notifier()
 
         # Thread-safe lookup results (background -> external)
         self._lookup_results_lock = threading.Lock()
@@ -286,7 +289,7 @@ class PrefetchController(StorageControllerInterface):
             request_id = self._next_request_id
             self._next_request_id += 1
             self._submission_queue.append((request_id, keys, layout_desc, extra_count))
-        os.eventfd_write(self._submission_efd, 1)
+        self._submission_efd.notify()
         return request_id
 
     def query_lookup_result(self, request_id: PrefetchRequestId) -> int | None:
@@ -377,10 +380,10 @@ class PrefetchController(StorageControllerInterface):
         L2 locks) before returning.
         """
         self._stop_flag.set()
-        os.eventfd_write(self._submission_efd, 1)
+        self._submission_efd.notify()
         self._thread.join()
         self._cleanup_in_flight_requests()
-        os.close(self._submission_efd)
+        self._submission_efd.close()
 
     # =========================================================================
     # Background loop
@@ -396,7 +399,8 @@ class PrefetchController(StorageControllerInterface):
         - Each L2 adapter's load eventfd (completed loads).
         """
         poller = select.poll()
-        poller.register(self._submission_efd, select.POLLIN)
+        submission_fd = self._submission_efd.fileno()
+        poller.register(submission_fd, select.POLLIN)
         for efd in self._lookup_efd_to_adapter:
             poller.register(efd, select.POLLIN)
         for efd in self._load_efd_to_adapter:
@@ -413,12 +417,12 @@ class PrefetchController(StorageControllerInterface):
                     continue
 
                 try:
-                    os.eventfd_read(fd)
+                    consume_fd(fd)
                 except (OSError, BlockingIOError):
                     pass
 
                 try:
-                    if fd == self._submission_efd:
+                    if fd == submission_fd:
                         self._drain_submission_queue()
                     elif fd in self._lookup_efd_to_adapter:
                         signaled_adapters[PrefetchPhase.LOOKUP].add(

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -13,7 +13,6 @@ The controller runs a background thread with an event-driven loop that:
 from collections import defaultdict
 from dataclasses import dataclass
 import enum
-import os
 import select
 import threading
 
@@ -31,6 +30,10 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
 )
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.platform import (
+    consume_fd,
+    create_event_notifier,
+)
 
 logger = init_logger(__name__)
 
@@ -72,16 +75,21 @@ class StoreListener(L1ManagerListener):
     def __init__(self) -> None:
         self._pending_keys: list[ObjectKey] = []
         self._lock = threading.Lock()
-        self._event_fd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._event_fd = create_event_notifier()
 
     def get_event_fd(self) -> int:
         """
-        Return the eventfd that is signaled when new keys are available.
+        Return the notifier fd that is signaled when new keys are
+        available.
 
         Returns:
-            int: The eventfd file descriptor.
+            int: The readable file descriptor for poller registration.
         """
-        return self._event_fd
+        return self._event_fd.fileno()
+
+    def notify(self) -> None:
+        """Signal the notifier to wake any blocked poll() waiter."""
+        self._event_fd.notify()
 
     def pop_pending_keys(self) -> list[ObjectKey]:
         """
@@ -107,7 +115,7 @@ class StoreListener(L1ManagerListener):
 
     def on_l1_keys_write_finished(self, keys: list[ObjectKey]) -> None:
         """
-        Enqueue keys and signal the eventfd.
+        Enqueue keys and signal the notifier.
 
         Called inside L1Manager's lock. Must be fast and must not
         call any L1Manager methods (would deadlock).
@@ -117,7 +125,7 @@ class StoreListener(L1ManagerListener):
         """
         with self._lock:
             self._pending_keys.extend(keys)
-        os.eventfd_write(self._event_fd, 1)
+        self._event_fd.notify()
 
     def on_l1_keys_reserved_read(self, keys: list[ObjectKey]) -> None:
         pass
@@ -140,8 +148,8 @@ class StoreListener(L1ManagerListener):
         pass
 
     def close(self) -> None:
-        """Close the eventfd."""
-        os.close(self._event_fd)
+        """Close the notifier."""
+        self._event_fd.close()
 
 
 class StorePhase(enum.Enum):
@@ -250,7 +258,7 @@ class StoreController(StorageControllerInterface):
         """
         self._stop_flag.set()
         # Wake up the poll loop so it can exit promptly
-        os.eventfd_write(self._listener.get_event_fd(), 1)
+        self._listener.notify()
         self._thread.join()
         self._cleanup_in_flight_tasks()
         self._listener.close()
@@ -296,9 +304,9 @@ class StoreController(StorageControllerInterface):
                 if not (events & select.POLLIN):
                     continue
 
-                # Consume the eventfd value
+                # Consume the notifier value
                 try:
-                    os.eventfd_read(fd)
+                    consume_fd(fd)
                 except (OSError, BlockingIOError):
                     pass
 

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -4,7 +4,6 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, Optional, TypeVar, get_type_hints
 import inspect
-import os
 import queue
 import threading
 import uuid
@@ -30,6 +29,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_payload_classes,
     get_response_class,
 )
+from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
 
@@ -351,16 +351,17 @@ class MessageQueueServer:
         self.ctx = context
         self.socket = self.ctx.socket(zmq.ROUTER)
         self.socket.bind(bind_url)
-        # Use eventfd instead of zmq PUSH/PULL sockets because blocking
-        # handler callbacks run on ThreadPoolExecutor threads, and zmq
-        # sockets are not thread-safe. eventfd_write() is atomic.
-        self._output_efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        # Use a cross-platform Notifier instead of zmq PUSH/PULL sockets
+        # because blocking handler callbacks run on ThreadPoolExecutor
+        # threads, and zmq sockets are not thread-safe. Notifier.notify()
+        # is atomic (eventfd on Linux, self-pipe elsewhere).
+        self._output_efd = create_event_notifier()
         self.output_queue: queue.Queue = queue.Queue()
 
         # Poller
         self.poller = zmq.Poller()
         self.poller.register(self.socket, zmq.POLLIN)
-        self.poller.register(self._output_efd, zmq.POLLIN)
+        self.poller.register(self._output_efd.fileno(), zmq.POLLIN)
 
         # Main loop thread
         self.is_finished = threading.Event()
@@ -427,7 +428,7 @@ class MessageQueueServer:
                 )
 
                 self.output_queue.put(frames_to_send)
-                os.eventfd_write(self._output_efd, 1)
+                self._output_efd.notify()
 
             except Exception:
                 logger.exception("Error in blocking handler")
@@ -453,10 +454,11 @@ class MessageQueueServer:
                 raise ValueError("Unknown handler type")
 
     def _main_loop(self):
+        output_fd = self._output_efd.fileno()
         while not self.is_finished.is_set():
             socks = dict(self.poller.poll(1000))
             inbound_state = socks.get(self.socket, None)
-            outbound_state = socks.get(self._output_efd, None)
+            outbound_state = socks.get(output_fd, None)
 
             # Process the incoming requests
             if inbound_state and inbound_state & zmq.POLLIN:
@@ -486,8 +488,8 @@ class MessageQueueServer:
 
             # Send the responses
             if outbound_state and outbound_state & zmq.POLLIN:
-                # Consume the eventfd counter (resets atomically)
-                os.eventfd_read(self._output_efd)
+                # Consume the notifier counter (resets atomically)
+                self._output_efd.consume()
 
                 # Process the output tasks
                 try:
@@ -729,4 +731,4 @@ class MessageQueueServer:
         self.socket.close()
         for pool in self.extra_pools:
             pool.shutdown(wait=False)
-        os.close(self._output_efd)
+        self._output_efd.close()

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-platform abstraction layer for LMCache.
+
+This package centralizes platform-specific primitives. It currently
+exposes :class:`EventNotifier` -- a thin wake-up primitive used to
+signal background loops from other threads.  On Linux it is backed by
+``os.eventfd``; on macOS / other POSIX systems it falls back to
+``os.pipe``.  Callers never touch ``os.eventfd`` directly.
+"""
+
+# First Party
+from lmcache.v1.platform.event_notifier import HAS_EVENTFD as HAS_EVENTFD
+from lmcache.v1.platform.event_notifier import EventfdNotifier as EventfdNotifier
+from lmcache.v1.platform.event_notifier import EventNotifier as EventNotifier
+from lmcache.v1.platform.event_notifier import PipeNotifier as PipeNotifier
+from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
+from lmcache.v1.platform.event_notifier import (
+    create_event_notifier as create_event_notifier,
+)

--- a/lmcache/v1/platform/event_notifier.py
+++ b/lmcache/v1/platform/event_notifier.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-platform event notification abstraction.
+
+Provides a unified ``EventNotifier`` interface for signaling between
+threads using poll-able file descriptors.  On Linux (Python 3.10+),
+uses ``os.eventfd``; on other platforms (macOS, etc.), falls back to
+``os.pipe`` with non-blocking I/O.
+
+Usage::
+
+    from lmcache.v1.platform import create_event_notifier
+
+    notifier = create_event_notifier()
+    notifier.notify()          # signal
+    notifier.consume()         # drain
+    fd = notifier.fileno()     # for select.poll()
+    notifier.close()           # release resources
+
+Or as a context manager::
+
+    with create_event_notifier() as notifier:
+        notifier.notify()
+        notifier.consume()
+
+Exception contract:
+    ``consume()`` / ``consume_fd()`` only swallow
+    :class:`BlockingIOError` (i.e. "no data pending").  All other
+    :class:`OSError` subclasses - most importantly ``EBADF`` from a
+    stale / closed fd - propagate to the caller so bugs surface
+    instead of being silently absorbed.
+"""
+
+# Standard
+from abc import ABC, abstractmethod
+from types import TracebackType
+import os
+
+#: True when :func:`os.eventfd` is available (Linux + Python 3.10+).
+#: Single source of truth for platform capability detection; exposed
+#: via :mod:`lmcache.v1.platform` for external callers.
+HAS_EVENTFD: bool = hasattr(os, "eventfd")
+
+
+class EventNotifier(ABC):
+    """Abstract base class for cross-platform event notification.
+
+    An ``EventNotifier`` models a **binary signal**: calling
+    ``notify()`` makes the notifier readable via ``poll()``/
+    ``select()``, and ``consume()`` resets it.  Multiple
+    ``notify()`` calls before a ``consume()`` are coalesced.
+    """
+
+    @abstractmethod
+    def fileno(self) -> int:
+        """Return a poll-able file descriptor.
+
+        The fd becomes readable after ``notify()`` is called.
+        """
+
+    @abstractmethod
+    def notify(self) -> None:
+        """Signal the notifier (idempotent if already signaled)."""
+
+    @abstractmethod
+    def consume(self) -> None:
+        """Consume the pending signal (non-blocking).
+
+        Only :class:`BlockingIOError` (no data pending) is
+        swallowed; other OS errors propagate.
+        """
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release underlying OS resources.  Idempotent."""
+
+    # Context manager support
+
+    def __enter__(self) -> "EventNotifier":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+if HAS_EVENTFD:
+
+    class EventfdNotifier(EventNotifier):
+        """Linux eventfd-based notifier (Python 3.10+).
+
+        Invariants:
+            ``self._efd`` holds the live eventfd while open and is
+            set to ``-1`` once :meth:`close` has released it.  All
+            other methods treat ``-1`` as "already closed".
+        """
+
+        def __init__(self) -> None:
+            self._efd: int = os.eventfd(
+                0,
+                os.EFD_NONBLOCK | os.EFD_CLOEXEC,
+            )
+
+        def fileno(self) -> int:
+            return self._efd
+
+        def notify(self) -> None:
+            os.eventfd_write(self._efd, 1)
+
+        def consume(self) -> None:
+            try:
+                os.eventfd_read(self._efd)
+            except BlockingIOError:
+                pass  # no pending signal
+
+        def close(self) -> None:
+            if self._efd >= 0:
+                try:
+                    os.close(self._efd)
+                except OSError:
+                    pass
+                self._efd = -1
+else:
+
+    class EventfdNotifier(EventNotifier):  # type: ignore[no-redef]
+        """Placeholder - eventfd unavailable on this platform."""
+
+        def __init__(self) -> None:
+            raise RuntimeError(
+                "EventfdNotifier requires os.eventfd (Linux + "
+                "Python 3.10+); use PipeNotifier instead."
+            )
+
+        def fileno(self) -> int:  # pragma: no cover
+            raise RuntimeError("unreachable")
+
+        def notify(self) -> None:  # pragma: no cover
+            raise RuntimeError("unreachable")
+
+        def consume(self) -> None:  # pragma: no cover
+            raise RuntimeError("unreachable")
+
+        def close(self) -> None:  # pragma: no cover
+            raise RuntimeError("unreachable")
+
+
+class PipeNotifier(EventNotifier):
+    """Pipe-based fallback notifier for non-Linux platforms.
+
+    Invariants:
+        ``self._read_fd`` / ``self._write_fd`` hold the live pipe
+        ends while open and are both set to ``-1`` once
+        :meth:`close` has released them.
+    """
+
+    def __init__(self) -> None:
+        # ``os.pipe()`` on Python 3.4+ creates descriptors with
+        # ``FD_CLOEXEC`` already set (PEP 446), so we only need to
+        # flip them to non-blocking.  ``os.set_blocking`` is the
+        # portable way to do this and improves future portability
+        # (e.g. to Windows pipes).
+        r, w = os.pipe()
+        try:
+            os.set_blocking(r, False)
+            os.set_blocking(w, False)
+        except OSError:
+            os.close(r)
+            os.close(w)
+            raise
+        self._read_fd: int = r
+        self._write_fd: int = w
+
+    def fileno(self) -> int:
+        return self._read_fd
+
+    def notify(self) -> None:
+        try:
+            os.write(self._write_fd, b"\x01")
+        except BlockingIOError:
+            pass  # pipe buffer full - signal already pending
+
+    def consume(self) -> None:
+        while True:
+            try:
+                # ``os.read`` returns ``b''`` at EOF (write end
+                # closed); treat that as drained so background
+                # loops cannot spin forever on a dead pipe.
+                if not os.read(self._read_fd, 4096):
+                    return
+            except BlockingIOError:
+                return  # drained
+
+    def close(self) -> None:
+        for attr in ("_read_fd", "_write_fd"):
+            fd = getattr(self, attr, -1)
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                setattr(self, attr, -1)
+
+
+def create_event_notifier() -> EventNotifier:
+    """Create a platform-appropriate EventNotifier.
+
+    On Linux (Python 3.10+), returns an ``EventfdNotifier``.
+    On other platforms, returns a ``PipeNotifier``.
+    """
+    if HAS_EVENTFD:
+        return EventfdNotifier()
+    return PipeNotifier()
+
+
+def consume_fd(fd: int) -> None:
+    """Consume a pending signal from a raw file descriptor.
+
+    This is a convenience function for code that only has a
+    raw fd (e.g., obtained from ``adapter.get_store_event_fd()``)
+    and needs to drain it after ``poll()`` reports it readable.
+
+    On Linux, uses ``os.eventfd_read()``; on other platforms,
+    drains all bytes via ``os.read()``.
+
+    Only :class:`BlockingIOError` (no data pending) is swallowed;
+    other OS errors propagate.
+    """
+    if HAS_EVENTFD:
+        try:
+            os.eventfd_read(fd)
+        except BlockingIOError:
+            pass
+        return
+    while True:
+        try:
+            if not os.read(fd, 4096):
+                return  # EOF -- write end closed; stop draining
+        except BlockingIOError:
+            return

--- a/tests/v1/distributed/test_l2_adapter_factory.py
+++ b/tests/v1/distributed/test_l2_adapter_factory.py
@@ -5,7 +5,6 @@ PluginL2AdapterConfig.
 """
 
 # Standard
-import os
 import types
 
 # Third Party
@@ -22,6 +21,7 @@ from lmcache.v1.distributed.l2_adapters.factory import (
 )
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 from lmcache.v1.distributed.l2_adapters.plugin_l2_adapter import PluginL2AdapterConfig
+from lmcache.v1.platform import create_event_notifier
 
 # =========================================================
 # Helpers
@@ -836,11 +836,11 @@ class _FakeLMCacheFSClient:
         self.relative_tmp_dir = relative_tmp_dir
         self.use_odirect = use_odirect
         self.read_ahead_size = read_ahead_size
-        self._efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._efd = create_event_notifier()
         self._closed = False
 
     def event_fd(self):
-        return self._efd
+        return self._efd.fileno()
 
     def submit_batch_get(self, keys, memoryviews):
         return 0
@@ -857,7 +857,7 @@ class _FakeLMCacheFSClient:
     def close(self):
         if not self._closed:
             self._closed = True
-            os.close(self._efd)
+            self._efd.close()
 
 
 class TestFSNativeAdapterFactory:

--- a/tests/v1/distributed/test_mock_l2_adapter.py
+++ b/tests/v1/distributed/test_mock_l2_adapter.py
@@ -7,7 +7,6 @@ Tests only use public methods and do not access private fields.
 """
 
 # Standard
-import os
 import select
 import time
 
@@ -27,6 +26,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd
 
 
 class _RecordingListener(L2AdapterListener):
@@ -88,7 +88,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     if events:
         # Read and consume the event
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -37,6 +37,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd
 
 # =============================================================================
 # Helpers
@@ -118,7 +119,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 10.0) -> bool:
     events = poll.poll(timeout * 1000)
     if events:
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -8,7 +8,6 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
 
 # Standard
 import ctypes
-import os
 import select
 import threading
 
@@ -27,6 +26,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd, create_event_notifier
 
 # =============================================================================
 # Mock Native Connector (simulates the pybind C++ IStorageConnector interface)
@@ -48,7 +48,7 @@ class MockNativeConnector:
     """
 
     def __init__(self):
-        self._efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        self._efd = create_event_notifier()
         self._store: dict[str, bytes] = {}
         self._next_id = 1
         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
@@ -56,7 +56,7 @@ class MockNativeConnector:
         self._closed = False
 
     def event_fd(self) -> int:
-        return self._efd
+        return self._efd.fileno()
 
     def submit_batch_set(self, keys: list[str], memoryviews: list) -> int:
         with self._lock:
@@ -127,7 +127,7 @@ class MockNativeConnector:
     def drain_completions(self) -> list[tuple[int, bool, str, list[bool] | None]]:
         # Drain the eventfd
         try:
-            os.eventfd_read(self._efd)
+            self._efd.consume()
         except BlockingIOError:
             pass
 
@@ -139,7 +139,7 @@ class MockNativeConnector:
     def close(self):
         if not self._closed:
             self._closed = True
-            os.close(self._efd)
+            self._efd.close()
 
     def _push_completion(
         self, fid: int, ok: bool, error: str, result_bools: list[bool] | None
@@ -148,7 +148,7 @@ class MockNativeConnector:
             self._completions.append((fid, ok, error, result_bools))
         # Signal the eventfd
         try:
-            os.eventfd_write(self._efd, 1)
+            self._efd.notify()
         except OSError:
             pass
 
@@ -186,7 +186,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     events = poll.poll(timeout * 1000)
     if events:
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True
@@ -1207,11 +1207,11 @@ class TestDeleteBackwardCompatibility:
             """Mock connector that only has the 6 original methods."""
 
             def __init__(self):
-                self._efd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+                self._efd = create_event_notifier()
                 self._closed = False
 
             def event_fd(self) -> int:
-                return self._efd
+                return self._efd.fileno()
 
             def submit_batch_get(self, keys, memoryviews):
                 return 0
@@ -1228,7 +1228,7 @@ class TestDeleteBackwardCompatibility:
             def close(self):
                 if not self._closed:
                     self._closed = True
-                    os.close(self._efd)
+                    self._efd.close()
 
         client = NoDeleteConnector()
         adp = NativeConnectorL2Adapter(client)

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -35,6 +35,7 @@ from lmcache.v1.memory_management import (  # noqa: E402
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd  # noqa: E402
 
 
 class _RecordingListener(L2AdapterListener):
@@ -110,7 +111,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     events = poll.poll(timeout * 1000)
     if events:
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/distributed/test_nixl_store_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_l2_adapter.py
@@ -7,7 +7,6 @@ Tests only use public methods and do not access private fields.
 """
 
 # Standard
-import os
 import select
 import shutil
 import tempfile
@@ -55,6 +54,7 @@ from lmcache.v1.memory_management import (  # noqa: E402
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd  # noqa: E402
 
 # =============================================================================
 # Constants
@@ -121,7 +121,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     events = poll.poll(timeout * 1000)  # timeout in milliseconds
     if events:
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/distributed/test_resp_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_resp_l2_adapter_integration.py
@@ -22,6 +22,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd
 
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.environ.get("REDIS_PORT", "6399"))
@@ -90,7 +91,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 10.0) -> bool:
     events = poll.poll(timeout * 1000)
     if events:
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -8,7 +8,6 @@ routes PUT/GET/HEAD/DELETE against a shared dict.  No network required.
 
 # Standard
 from concurrent.futures import Future as ConcurrentFuture
-import os
 import select
 import threading
 import time
@@ -31,6 +30,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.platform import consume_fd
 
 # =============================================================================
 # Fake awscrt.s3.S3Request
@@ -266,7 +266,7 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     events = poll.poll(timeout * 1000)
     if events:
         try:
-            os.eventfd_read(event_fd)
+            consume_fd(event_fd)
         except BlockingIOError:
             pass
         return True

--- a/tests/v1/test_event_notifier.py
+++ b/tests/v1/test_event_notifier.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import os
+import select
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform import (
+    HAS_EVENTFD,
+    EventfdNotifier,
+    EventNotifier,
+    PipeNotifier,
+    consume_fd,
+    create_event_notifier,
+)
+from lmcache.v1.platform import event_notifier as _canonical_ev_mod
+
+
+class TestEventNotifierAPI:
+    """Test the public API on the current platform."""
+
+    def test_create_returns_event_notifier(self):
+        """Factory returns an EventNotifier subclass."""
+        n = create_event_notifier()
+        try:
+            assert isinstance(n, EventNotifier)
+        finally:
+            n.close()
+
+    def test_fileno_is_nonnegative(self):
+        """fileno() returns a valid fd."""
+        n = create_event_notifier()
+        try:
+            assert n.fileno() >= 0
+        finally:
+            n.close()
+
+    def test_notify_then_consume(self):
+        """notify() makes the fd readable; consume() drains it."""
+        n = create_event_notifier()
+        try:
+            n.notify()
+            poller = select.poll()
+            poller.register(n.fileno(), select.POLLIN)
+            events = poller.poll(100)
+            assert len(events) > 0
+            n.consume()
+        finally:
+            n.close()
+
+    def test_multiple_notify_single_consume(self):
+        """Multiple notify() calls are coalesced by one consume()."""
+        n = create_event_notifier()
+        try:
+            n.notify()
+            n.notify()
+            n.notify()
+            n.consume()
+            # After consume, fd should not be readable
+            poller = select.poll()
+            poller.register(n.fileno(), select.POLLIN)
+            events = poller.poll(50)
+            assert len(events) == 0
+        finally:
+            n.close()
+
+    def test_consume_without_notify_is_noop(self):
+        """consume() without prior notify() does not block or raise."""
+        n = create_event_notifier()
+        try:
+            n.consume()  # should not block or raise
+        finally:
+            n.close()
+
+    def test_close_is_idempotent(self):
+        """Calling close() twice does not raise."""
+        n = create_event_notifier()
+        n.close()
+        n.close()  # should not raise
+
+    def test_context_manager(self):
+        """EventNotifier works as a context manager."""
+        with create_event_notifier() as n:
+            n.notify()
+            n.consume()
+            assert n.fileno() >= 0
+
+
+class TestPipeNotifier:
+    """Force the pipe-based fallback path."""
+
+    def test_both_fds_closed(self):
+        """close() releases both read and write fds."""
+        n = PipeNotifier()
+        r = n.fileno()
+        # Second fd via notify/consume cycle: after close, both must be gone.
+        n.notify()
+        n.consume()
+        n.close()
+        with pytest.raises(OSError):
+            os.fstat(r)
+
+    def test_notify_when_pipe_full_is_noop(self):
+        """notify() does not raise when pipe buffer is full."""
+        n = PipeNotifier()
+        try:
+            # A POSIX pipe's capacity is at most 1 MiB on current
+            # Linux/macOS kernels and each notify() writes a single
+            # byte, so (1 << 21) iterations comfortably saturate it
+            # while keeping the test fast - notify() itself swallows
+            # BlockingIOError once the buffer is full.
+            for _ in range(1 << 21):
+                n.notify()
+            # Still a no-op once the pipe is saturated.
+            n.notify()
+        finally:
+            n.close()
+
+    def test_pollable(self):
+        """PipeNotifier fd is pollable with select.poll."""
+        n = PipeNotifier()
+        try:
+            n.notify()
+            poller = select.poll()
+            poller.register(n.fileno(), select.POLLIN)
+            events = poller.poll(100)
+            assert len(events) > 0
+        finally:
+            n.close()
+
+    def test_multiple_create_close_cycles(self):
+        """Create and close multiple notifiers without leaking."""
+        for _ in range(20):
+            n = PipeNotifier()
+            n.notify()
+            n.consume()
+            n.close()
+
+
+class TestPipeEOF:
+    """Regression test: pipe EOF must not spin the drain loop.
+
+    ``os.read`` returns ``b''`` (not ``BlockingIOError``) when the
+    write end is closed.  Both ``PipeNotifier.consume`` and the
+    module-level ``consume_fd`` helper share this drain loop, so
+    they must treat an empty read as "drained" -- otherwise a dead
+    pipe would hang a background event loop.
+    """
+
+    def test_consume_fd_returns_on_pipe_eof(self, monkeypatch):
+        """consume_fd() returns when the pipe write end is closed."""
+        monkeypatch.setattr(_canonical_ev_mod, "HAS_EVENTFD", False)
+        r, w = os.pipe()
+        os.set_blocking(r, False)
+        try:
+            os.close(w)  # write end closed -> read end at EOF
+            consume_fd(r)  # must return promptly, not hang
+        finally:
+            os.close(r)
+
+
+class TestConsumeFd:
+    """Test the consume_fd utility function."""
+
+    def test_consume_fd_after_notify(self):
+        """consume_fd() drains a notifier's fd."""
+        n = create_event_notifier()
+        try:
+            n.notify()
+            consume_fd(n.fileno())
+            # After consume, fd should not be readable
+            poller = select.poll()
+            poller.register(n.fileno(), select.POLLIN)
+            events = poller.poll(50)
+            assert len(events) == 0
+        finally:
+            n.close()
+
+    def test_consume_fd_without_signal(self):
+        """consume_fd() on unsignaled fd does not block."""
+        n = create_event_notifier()
+        try:
+            consume_fd(n.fileno())  # should not block
+        finally:
+            n.close()
+
+
+class TestBackendSelection:
+    """Validate which concrete backend the factory picks."""
+
+    def test_factory_matches_platform_capability(self):
+        """create_event_notifier() picks the backend for this OS."""
+        n = create_event_notifier()
+        try:
+            if HAS_EVENTFD:
+                assert isinstance(n, EventfdNotifier)
+            else:
+                assert isinstance(n, PipeNotifier)
+        finally:
+            n.close()
+
+
+class TestForcedPipeFallback:
+    """Exercise the pipe fallback even when eventfd is available.
+
+    On Linux CI ``create_event_notifier()`` would normally return
+    an ``EventfdNotifier``; monkeypatch ``HAS_EVENTFD`` to force
+    the pipe path so the non-Linux code is covered on every OS.
+    """
+
+    @pytest.fixture
+    def force_pipe(self, monkeypatch):
+        monkeypatch.setattr(_canonical_ev_mod, "HAS_EVENTFD", False)
+        yield
+
+    def test_factory_returns_pipe_notifier(self, force_pipe):
+        n = create_event_notifier()
+        try:
+            assert isinstance(n, PipeNotifier)
+        finally:
+            n.close()
+
+    def test_notify_consume_roundtrip(self, force_pipe):
+        n = create_event_notifier()
+        try:
+            n.notify()
+            poller = select.poll()
+            poller.register(n.fileno(), select.POLLIN)
+            assert poller.poll(100)
+            n.consume()
+            assert not poller.poll(50)
+        finally:
+            n.close()
+
+    def test_consume_fd_uses_pipe_path(self, force_pipe):
+        n = create_event_notifier()
+        try:
+            n.notify()
+            consume_fd(n.fileno())
+            poller = select.poll()
+            poller.register(n.fileno(), select.POLLIN)
+            assert not poller.poll(50)
+        finally:
+            n.close()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Replaces low-level wakeup primitives across multiprocess/distributed controllers and L2 adapters, so subtle signaling/FD lifecycle differences could impact background loop liveness or cause missed wakeups, especially on non-Linux via pipe fallback.
> 
> **Overview**
> Introduces `lmcache.v1.platform.EventNotifier` plus `create_event_notifier()`/`consume_fd()` to replace direct `os.eventfd*` usage, enabling the MP/distributed stack to run on non-Linux POSIX via an `os.pipe` fallback.
> 
> Migrates wakeup signaling throughout the runtime (L2 adapters, `StoreController`/`PrefetchController`, and `MessageQueueServer`) from raw fds to notifier objects (`notify()`/`consume()`/`close()`), while keeping poll/select registration on `fileno()`.
> 
> Adds dedicated unit coverage for backend selection and notifier semantics, and updates plugin/developer docs and the external adapter example/tests to use the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8b519b77bc8cc2cf170d2b8e63e6e6079f5923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->