### PR TITLE
[Core] Add hidden state support

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -298,6 +298,7 @@ class ReqMeta:
         load_spec: Optional[LoadSpec] = None,
         discard_partial_chunks: bool = True,
         save_decode_cache: bool = False,
+        skip_mm_storage: bool = False,
     ) -> Optional["ReqMeta"]:
         """Create the request metadata from a request tracker.
 
@@ -308,6 +309,9 @@ class ReqMeta:
             load_spec (Optional[LoadSpec]): the load spec for KV cache loading.
             discard_partial_chunks (bool): whether to discard partial chunks.
             save_decode_cache (bool): whether to save the cache in decode phase.
+            skip_mm_storage (bool): if True, limit storage to the contiguous
+                text-only prefix before any multimodal tokens. Useful for
+                random/varying multimodal inputs where mm KV is rarely reused.
 
         Returns:
             the request metadata if we need to perform load/save
@@ -356,6 +360,16 @@ class ReqMeta:
             )
         else:
             num_tokens_to_save = input_token_len
+
+        # Limit storage to the text-only prefix before any multimodal tokens.
+        # Multimodal KV with varying mm content (e.g., random images) is rarely
+        # reused across requests, so storing it wastes CPU bandwidth.
+        if skip_mm_storage and tracker.mm_positions:
+            first_mm_offset = min(p.offset for p in tracker.mm_positions)
+            first_mm_offset = (
+                first_mm_offset // lmcache_chunk_size * lmcache_chunk_size
+            )
+            num_tokens_to_save = min(num_tokens_to_save, first_mm_offset)
 
         # If we need to save, update the number of saved tokens
         if not skip_save:
@@ -1469,6 +1483,7 @@ class LMCacheConnectorV1Impl:
                 load_spec=load_spec,
                 discard_partial_chunks=self._discard_partial_chunks,
                 save_decode_cache=self.config.save_decode_cache,
+                skip_mm_storage=self.config.skip_mm_storage,
             )
             if req_meta is not None:
                 meta.add_request(req_meta)
@@ -1515,6 +1530,7 @@ class LMCacheConnectorV1Impl:
                     load_spec=load_spec,
                     discard_partial_chunks=self._discard_partial_chunks,
                     save_decode_cache=self.config.save_decode_cache,
+                    skip_mm_storage=self.config.skip_mm_storage,
                 )
                 if req_meta is not None:
                     meta.add_request(req_meta)
@@ -1638,6 +1654,7 @@ class LMCacheConnectorV1Impl:
                 load_spec=load_spec,
                 discard_partial_chunks=self._discard_partial_chunks,
                 save_decode_cache=self.config.save_decode_cache,
+                skip_mm_storage=self.config.skip_mm_storage,
             )
             if req_meta is not None:
                 meta.add_request(req_meta)

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -380,12 +380,12 @@ class ReqMeta:
             if first_mm_offset < num_tokens_to_save:
                 max_save_tokens = first_mm_offset
 
-        # If we need to save, update the number of saved tokens
+        # If we need to save, advance num_saved_tokens to the full aligned
+        # range so subsequent iterations skip these tokens via
+        # skip_leading_tokens.  max_save_tokens caps only the current
+        # iteration's store_mask, not the progress tracker.
         if not skip_save:
-            effective_save = (
-                max_save_tokens if max_save_tokens is not None else num_tokens_to_save
-            )
-            tracker.num_saved_tokens = effective_save
+            tracker.num_saved_tokens = num_tokens_to_save
         save_spec = SaveSpec(skip_leading_tokens, not skip_save, max_save_tokens)
 
         # Calculate the token ids and slot mappings for load and save

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -74,6 +74,11 @@ class SaveSpec:
     skip_leading_tokens: int
     # Whether the scheduler allow us to save the tokens
     can_save: bool
+    # Optional cap on how many tokens to save (storage path only).
+    # When set, tokens at index >= max_save_tokens are masked out before
+    # storing.  Leaves the load path unaffected so that token_ids remains
+    # the full length expected by start_load_kv.
+    max_save_tokens: Optional[int] = None
 
 
 @dataclass
@@ -364,15 +369,23 @@ class ReqMeta:
         # Limit storage to the text-only prefix before any multimodal tokens.
         # Multimodal KV with varying mm content (e.g., random images) is rarely
         # reused across requests, so storing it wastes CPU bandwidth.
+        # Apply only to the save path: leave token_ids/load path full so
+        # subsequent retrieves can address up to lmcache_cached_tokens
+        # without indexing past the end.
+        max_save_tokens: Optional[int] = None
         if skip_mm_storage and tracker.mm_positions:
             first_mm_offset = min(p.offset for p in tracker.mm_positions)
             first_mm_offset = first_mm_offset // lmcache_chunk_size * lmcache_chunk_size
-            num_tokens_to_save = min(num_tokens_to_save, first_mm_offset)
+            if first_mm_offset < num_tokens_to_save:
+                max_save_tokens = first_mm_offset
 
         # If we need to save, update the number of saved tokens
         if not skip_save:
-            tracker.num_saved_tokens = num_tokens_to_save
-        save_spec = SaveSpec(skip_leading_tokens, not skip_save)
+            effective_save = (
+                max_save_tokens if max_save_tokens is not None else num_tokens_to_save
+            )
+            tracker.num_saved_tokens = effective_save
+        save_spec = SaveSpec(skip_leading_tokens, not skip_save, max_save_tokens)
 
         # Calculate the token ids and slot mappings for load and save
         token_ids = input_token_ids[:num_tokens_to_save]
@@ -1144,6 +1157,10 @@ class LMCacheConnectorV1Impl:
 
             store_mask = torch.ones(len(token_ids), dtype=torch.bool)
             store_mask[:skip_leading_tokens] = False
+            # Cap on storage extent (e.g. skip_mm_storage clamps trailing
+            # tokens beyond the text-only prefix).  Load path is unaffected.
+            if save_spec.max_save_tokens is not None:
+                store_mask[save_spec.max_save_tokens :] = False
 
             logger.debug(
                 "Storing KV cache for %d out of %d tokens "

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -366,9 +366,7 @@ class ReqMeta:
         # reused across requests, so storing it wastes CPU bandwidth.
         if skip_mm_storage and tracker.mm_positions:
             first_mm_offset = min(p.offset for p in tracker.mm_positions)
-            first_mm_offset = (
-                first_mm_offset // lmcache_chunk_size * lmcache_chunk_size
-            )
+            first_mm_offset = first_mm_offset // lmcache_chunk_size * lmcache_chunk_size
             num_tokens_to_save = min(num_tokens_to_save, first_mm_offset)
 
         # If we need to save, update the number of saved tokens
@@ -870,7 +868,6 @@ class LMCacheConnectorV1Impl:
                         slot_mapping[:lmcache_cached_tokens],
                     )
                     self._invalid_block_ids.update(missing_blocks)
-
 
     def record_failed_blocks(
         self,

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -74,10 +74,11 @@ class SaveSpec:
     skip_leading_tokens: int
     # Whether the scheduler allow us to save the tokens
     can_save: bool
-    # Optional cap on how many tokens to save (storage path only).
-    # When set, tokens at index >= max_save_tokens are masked out before
-    # storing.  Leaves the load path unaffected so that token_ids remains
-    # the full length expected by start_load_kv.
+    # Upper bound (token index) for the storage path; tokens at index
+    # >= max_save_tokens are masked out of store_mask.  Leaves the load
+    # path (token_ids length) unaffected so retrieves can still address
+    # the full chunk-aligned sequence.  Used by skip_mm_storage to cap
+    # storage at the text-only prefix before any multimodal token.
     max_save_tokens: Optional[int] = None
 
 
@@ -1164,10 +1165,11 @@ class LMCacheConnectorV1Impl:
 
             logger.debug(
                 "Storing KV cache for %d out of %d tokens "
-                "(skip_leading_tokens=%d) for request %s",
-                len(token_ids) - skip_leading_tokens,
+                "(skip_leading_tokens=%d, max_save_tokens=%s) for request %s",
+                int(store_mask.sum().item()),
                 len(token_ids),
                 skip_leading_tokens,
+                save_spec.max_save_tokens,
                 request.req_id,
             )
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -857,6 +857,7 @@ class LMCacheConnectorV1Impl:
                     )
                     self._invalid_block_ids.update(missing_blocks)
 
+
     def record_failed_blocks(
         self,
         request_id: str,

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -396,6 +396,22 @@ class CacheEngineKey:
             s += "@" + "@".join(tags)
         return s
 
+    def to_hs_key(self) -> "CacheEngineKey":
+        """Derive a parallel key for hidden-state storage.
+
+        Returns:
+            A new ``CacheEngineKey`` with ``:hs`` appended to ``model_name``.
+            All other fields (``chunk_hash``, ``world_size``, etc.) are copied.
+        """
+        return CacheEngineKey(
+            model_name=self.model_name + ":hs",
+            world_size=self.world_size,
+            worker_id=self.worker_id,
+            chunk_hash=self.chunk_hash,
+            dtype=self.dtype,
+            request_configs=self.request_configs,
+        )
+
     def split_layers(self, num_layers: int) -> List["LayerCacheEngineKey"]:
         """Split the key into multiple keys for each layer"""
         keys = []

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -569,7 +569,7 @@ class LMCacheEngine:
         tokens: Union[torch.Tensor, list[int]],
         mask: Optional[torch.Tensor] = None,
         hidden_states: Optional[torch.Tensor] = None,
-        **kwargs,
+        request_configs: Optional[dict] = None,
     ) -> None:
         """Store hidden states alongside KV cache using the same chunk keys.
 
@@ -582,7 +582,8 @@ class LMCacheEngine:
             mask: Boolean mask (same semantics as ``store()``).
             hidden_states: CPU tensor of shape ``[num_tokens, hidden_dim]``.
                 If ``None``, this is a no-op.
-            **kwargs: Passed to ``token_database.process_tokens()``.
+            request_configs: Forwarded to ``token_database.process_tokens()``
+                for tag-aware chunk hashing.
         """
         if hidden_states is None:
             return
@@ -594,8 +595,6 @@ class LMCacheEngine:
         if self._is_passive():
             logger.debug("rank=%s ignore HS store", self.metadata.worker_id)
             return
-
-        request_configs = kwargs.get("request_configs")
         hs_keys: list[CacheEngineKey] = []
         hs_objs: list[MemoryObj] = []
         partial = False
@@ -606,6 +605,12 @@ class LMCacheEngine:
             request_configs=request_configs,
         ):
             hs_key = key.to_hs_key()
+            # Skip chunks already in storage (mirrors KV store()).  Concurrent
+            # requests sharing a token prefix would otherwise redundantly
+            # allocate, copy, and put identical entries.
+            if self.storage_manager.contains(hs_key, self.retrieve_locations):
+                continue
+
             hs_chunk = hidden_states[start:end].contiguous()
             hs_shape = torch.Size(list(hs_chunk.shape))
             hs_dtype = hs_chunk.dtype
@@ -646,14 +651,15 @@ class LMCacheEngine:
         self,
         tokens: Union[torch.Tensor, list[int]],
         mask: Optional[torch.Tensor] = None,
-        **kwargs,
+        request_configs: Optional[dict] = None,
     ) -> Optional[torch.Tensor]:
         """Retrieve hidden states stored alongside KV cache.
 
         Args:
             tokens: Token IDs for chunk boundary computation.
             mask: Boolean mask (same semantics as ``retrieve()``).
-            **kwargs: Passed to ``token_database.process_tokens()``.
+            request_configs: Forwarded to ``token_database.process_tokens()``
+                for tag-aware chunk hashing.
 
         Returns:
             A contiguous CPU tensor of shape ``[num_tokens, hidden_dim]``,
@@ -662,7 +668,6 @@ class LMCacheEngine:
         if not self.is_healthy() or self.storage_manager is None:
             return None
 
-        request_configs = kwargs.get("request_configs")
         chunks: list[tuple[int, int, torch.Tensor]] = []
 
         for start, end, key in self.token_database.process_tokens(

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -563,6 +563,106 @@ class LMCacheEngine:
             store_stats.put_time * 1000,
         )
 
+    @torch.inference_mode()
+    def store_hidden_states(
+        self,
+        tokens: Union[torch.Tensor, list[int]],
+        mask: Optional[torch.Tensor] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> None:
+        """Store hidden states alongside KV cache using the same chunk keys.
+
+        Hidden states are stored as separate entries with a derived key
+        (``CacheEngineKey.to_hs_key()``).  Unlike KV store, this does not
+        use the GPU connector — the caller is expected to pass a CPU tensor.
+
+        Args:
+            tokens: Token IDs for chunk boundary computation.
+            mask: Boolean mask (same semantics as ``store()``).
+            hidden_states: CPU tensor of shape ``[num_tokens, hidden_dim]``.
+                If ``None``, this is a no-op.
+            **kwargs: Passed to ``token_database.process_tokens()``.
+        """
+        if hidden_states is None:
+            return
+        if not self.is_healthy() or self.storage_manager is None or self.is_frozen():
+            return
+
+        request_configs = kwargs.get("request_configs")
+        hs_keys: list[CacheEngineKey] = []
+        hs_objs: list[MemoryObj] = []
+
+        for start, end, key in self.token_database.process_tokens(
+            tokens, mask=mask, request_configs=request_configs,
+        ):
+            hs_key = key.to_hs_key()
+            hs_chunk = hidden_states[start:end].contiguous()
+            hs_shape = torch.Size(list(hs_chunk.shape))
+            hs_dtype = hs_chunk.dtype
+
+            memory_obj = self.storage_manager.allocate(
+                hs_shape, hs_dtype, fmt=MemoryFormat.HS_TD,
+                eviction=True, busy_loop=False,
+            )
+            if memory_obj is None:
+                logger.warning("CPU memory pressure, skipping HS store")
+                break
+            memory_obj.tensor[:] = hs_chunk
+            hs_keys.append(hs_key)
+            hs_objs.append(memory_obj)
+
+        if hs_keys:
+            self.storage_manager.batched_put(
+                hs_keys, hs_objs, location=self.store_location,
+            )
+            logger.debug("Stored hidden states for %d chunks", len(hs_keys))
+
+    @torch.inference_mode()
+    def retrieve_hidden_states(
+        self,
+        tokens: Union[torch.Tensor, list[int]],
+        mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Optional[torch.Tensor]:
+        """Retrieve hidden states stored alongside KV cache.
+
+        Args:
+            tokens: Token IDs for chunk boundary computation.
+            mask: Boolean mask (same semantics as ``retrieve()``).
+            **kwargs: Passed to ``token_database.process_tokens()``.
+
+        Returns:
+            A contiguous CPU tensor of shape ``[num_tokens, hidden_dim]``,
+            or ``None`` if any chunk is missing.
+        """
+        if not self.is_healthy() or self.storage_manager is None:
+            return None
+
+        request_configs = kwargs.get("request_configs")
+        chunks: list[tuple[int, int, torch.Tensor]] = []
+
+        for start, end, key in self.token_database.process_tokens(
+            tokens, mask=mask, request_configs=request_configs,
+        ):
+            hs_key = key.to_hs_key()
+            memory_obj = self.storage_manager.get(hs_key)
+            if memory_obj is None:
+                logger.debug("HS chunk miss for hash %s", hs_key.chunk_hash)
+                return None
+            chunks.append((start, end, memory_obj.tensor.clone()))
+            memory_obj.ref_count_down()
+
+        if not chunks:
+            return None
+
+        total_tokens = max(end for _, end, _ in chunks)
+        hidden_dim = chunks[0][2].shape[-1]
+        result = torch.zeros(total_tokens, hidden_dim, dtype=chunks[0][2].dtype)
+        for start, end, tensor in chunks:
+            result[start:end] = tensor
+        return result
+
     @_lmcache_nvtx_annotate
     @torch.inference_mode()
     def store_layer(

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -588,6 +588,12 @@ class LMCacheEngine:
             return
         if not self.is_healthy() or self.storage_manager is None or self.is_frozen():
             return
+        # Match KV store(): on multi-GPU save_only_first_rank setups, only the
+        # primary rank performs storage so non-primary ranks don't redundantly
+        # write the same hidden states.
+        if self._is_passive():
+            logger.debug("rank=%s ignore HS store", self.metadata.worker_id)
+            return
 
         request_configs = kwargs.get("request_configs")
         hs_keys: list[CacheEngineKey] = []
@@ -665,7 +671,12 @@ class LMCacheEngine:
             request_configs=request_configs,
         ):
             hs_key = key.to_hs_key()
-            memory_obj = self.storage_manager.get(hs_key)
+            # Honour configured retrieve_locations so PD deployments with
+            # asymmetric store/retrieve targets search the intended subset
+            # only, matching the existing KV retrieve path.
+            memory_obj = self.storage_manager.get(
+                hs_key, search_range=self.retrieve_locations
+            )
             if memory_obj is None:
                 logger.debug("HS chunk miss for hash %s", hs_key.chunk_hash)
                 return None

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -592,9 +592,12 @@ class LMCacheEngine:
         request_configs = kwargs.get("request_configs")
         hs_keys: list[CacheEngineKey] = []
         hs_objs: list[MemoryObj] = []
+        partial = False
 
         for start, end, key in self.token_database.process_tokens(
-            tokens, mask=mask, request_configs=request_configs,
+            tokens,
+            mask=mask,
+            request_configs=request_configs,
         ):
             hs_key = key.to_hs_key()
             hs_chunk = hidden_states[start:end].contiguous()
@@ -602,19 +605,33 @@ class LMCacheEngine:
             hs_dtype = hs_chunk.dtype
 
             memory_obj = self.storage_manager.allocate(
-                hs_shape, hs_dtype, fmt=MemoryFormat.HS_TD,
-                eviction=True, busy_loop=False,
+                hs_shape,
+                hs_dtype,
+                fmt=MemoryFormat.HS_TD,
+                eviction=True,
+                busy_loop=False,
             )
             if memory_obj is None:
                 logger.warning("CPU memory pressure, skipping HS store")
+                partial = True
                 break
             memory_obj.tensor[:] = hs_chunk
             hs_keys.append(hs_key)
             hs_objs.append(memory_obj)
 
+        # retrieve_hidden_states is all-or-nothing: any missing chunk causes
+        # the whole retrieve to return None.  Drop a partial allocation
+        # instead of writing orphaned, unreachable entries to storage.
+        if partial:
+            for obj in hs_objs:
+                obj.ref_count_down()
+            return
+
         if hs_keys:
             self.storage_manager.batched_put(
-                hs_keys, hs_objs, location=self.store_location,
+                hs_keys,
+                hs_objs,
+                location=self.store_location,
             )
             logger.debug("Stored hidden states for %d chunks", len(hs_keys))
 
@@ -643,7 +660,9 @@ class LMCacheEngine:
         chunks: list[tuple[int, int, torch.Tensor]] = []
 
         for start, end, key in self.token_database.process_tokens(
-            tokens, mask=mask, request_configs=request_configs,
+            tokens,
+            mask=mask,
+            request_configs=request_configs,
         ):
             hs_key = key.to_hs_key()
             memory_obj = self.storage_manager.get(hs_key)

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -294,6 +294,11 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default": False,
         "env_converter": _to_bool,
     },
+    "skip_mm_storage": {
+        "type": bool,
+        "default": False,
+        "env_converter": _to_bool,
+    },
     "blocking_timeout_secs": {"type": int, "default": 10, "env_converter": int},
     "external_lookup_client": {
         "type": Optional[str],

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -70,6 +70,10 @@ class MemoryFormat(Enum):
     """[1, num_layers, num_tokens, aligned_head_size]
     """
 
+    HS_TD = auto()
+    """[num_tokens, hidden_dim] — per-token hidden states
+    """
+
     def token_dim(self) -> int:
         if self == MemoryFormat.KV_2LTD:
             return 2
@@ -83,6 +87,8 @@ class MemoryFormat(Enum):
             return 0
         elif self == MemoryFormat.KV_MLA_FMT:
             return 2
+        elif self == MemoryFormat.HS_TD:
+            return 0
         return 0
 
 
@@ -2108,6 +2114,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
             MemoryFormat.KV_2TD,
             MemoryFormat.KV_T2D,
             MemoryFormat.KV_MLA_FMT,
+            MemoryFormat.HS_TD,
         ]:
             with self.host_mem_lock:
                 return self.pin_allocator.allocate(shapes, dtypes, fmt, str(self))
@@ -2132,6 +2139,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
             MemoryFormat.KV_2TD,
             MemoryFormat.KV_T2D,
             MemoryFormat.KV_MLA_FMT,
+            MemoryFormat.HS_TD,
         ]:
             with self.host_mem_lock:
                 return self.pin_allocator.batched_allocate(
@@ -2150,6 +2158,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
             MemoryFormat.KV_2TD,
             MemoryFormat.KV_T2D,
             MemoryFormat.KV_MLA_FMT,
+            MemoryFormat.HS_TD,
         ]:
             with self.host_mem_lock:
                 self.pin_allocator.free(memory_obj)
@@ -2175,6 +2184,7 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
             MemoryFormat.KV_2TD,
             MemoryFormat.KV_T2D,
             MemoryFormat.KV_MLA_FMT,
+            MemoryFormat.HS_TD,
         ]:
             with self.host_mem_lock:
                 self.pin_allocator.batched_free(memory_objs)

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -436,13 +436,22 @@ class StorageManager:
         self,
         key: CacheEngineKey,
         location: Optional[str] = None,
+        search_range: Optional[List[str]] = None,
     ) -> Optional[MemoryObj]:
         """
         Blocking function to get the memory object from the storages.
+
+        :param location: If specified, only search this exact backend name.
+        :param search_range: If specified, only search backends whose names
+            appear in this list. Mirrors ``contains()`` semantics so callers
+            holding a configured ``retrieve_locations`` list can pass it
+            directly.
         """
 
         # Search all backends for blocking get
-        for backend_name, backend in self.get_active_storage_backends(location):
+        for backend_name, backend in self.get_active_storage_backends(
+            location, search_range
+        ):
             # TODO(Jiayi): need to make sure all memory_objs returned
             # are allocated by the allocator backend.
             memory_obj = backend.get_blocking(key)

--- a/tests/v1/test_hidden_state_offload.py
+++ b/tests/v1/test_hidden_state_offload.py
@@ -2,10 +2,24 @@
 """Tests for hidden state offload alongside KV cache in LMCache."""
 
 # Third Party
+import pytest
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import (
+    CacheEngineKey,
+    mock_up_broadcast_fn,
+    mock_up_broadcast_object_fn,
+)
+from lmcache.v1.cache_engine import LMCacheEngineBuilder
+from lmcache.v1.config import LMCacheEngineConfig
+
+# Local
+from .utils import (
+    create_gpu_connector,
+    dumb_metadata,
+    generate_tokens,
+)
 
 # ---------------------------------------------------------------------------
 # CacheEngineKey.to_hs_key()
@@ -89,3 +103,111 @@ def test_hs_key_does_not_collide_with_kv_key():
     assert len(d) == 2
     assert d[key] == "kv"
     assert d[hs_key] == "hs"
+
+
+# ---------------------------------------------------------------------------
+# store_hidden_states / retrieve_hidden_states roundtrip
+# ---------------------------------------------------------------------------
+
+
+def _build_engine(autorelease_v1, chunk_size: int = 64):
+    cfg = LMCacheEngineConfig.from_legacy(
+        chunk_size=chunk_size,
+        remote_url=None,
+        save_unfull_chunk=True,
+    )
+    kv_shape = (32, 2, chunk_size, 8, 128)
+    connector = create_gpu_connector(1024, 32)
+    return autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            dumb_metadata(kv_shape),
+            connector,
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="LMCacheEngine init currently requires CUDA-capable GPU connector",
+)
+def test_store_then_retrieve_hidden_states_roundtrip(autorelease_v1):
+    chunk_size = 64
+    num_tokens = 192  # exactly 3 full chunks
+    hidden_dim = 16
+
+    engine = _build_engine(autorelease_v1, chunk_size=chunk_size)
+    tokens = generate_tokens(num_tokens, device="cuda")
+    hidden_states = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16)
+
+    engine.store_hidden_states(tokens, hidden_states=hidden_states)
+    retrieved = engine.retrieve_hidden_states(tokens)
+
+    assert retrieved is not None
+    assert retrieved.shape == hidden_states.shape
+    assert torch.equal(retrieved, hidden_states)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="LMCacheEngine init currently requires CUDA-capable GPU connector",
+)
+def test_store_hidden_states_none_is_noop(autorelease_v1):
+    """Passing hidden_states=None should be a silent no-op."""
+    engine = _build_engine(autorelease_v1)
+    tokens = generate_tokens(128, device="cuda")
+    # No raise; nothing stored.
+    engine.store_hidden_states(tokens, hidden_states=None)
+    assert engine.retrieve_hidden_states(tokens) is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="LMCacheEngine init currently requires CUDA-capable GPU connector",
+)
+def test_retrieve_hidden_states_returns_none_on_miss(autorelease_v1):
+    """Retrieving without a prior store should return None (not crash)."""
+    engine = _build_engine(autorelease_v1)
+    tokens = generate_tokens(128, device="cuda")
+    assert engine.retrieve_hidden_states(tokens) is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="LMCacheEngine init currently requires CUDA-capable GPU connector",
+)
+def test_retrieve_hidden_states_partial_returns_none(autorelease_v1):
+    """If only the first chunk's tokens were stored, retrieving a longer
+    sequence must return None (all-or-nothing semantics)."""
+    chunk_size = 64
+    hidden_dim = 16
+
+    engine = _build_engine(autorelease_v1, chunk_size=chunk_size)
+    short_tokens = generate_tokens(chunk_size, device="cuda")
+    long_tokens = torch.cat([short_tokens, generate_tokens(chunk_size, device="cuda")])
+    short_hs = torch.randn(chunk_size, hidden_dim, dtype=torch.bfloat16)
+
+    engine.store_hidden_states(short_tokens, hidden_states=short_hs)
+    # First chunk is stored, second is not -> overall miss.
+    assert engine.retrieve_hidden_states(long_tokens) is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="LMCacheEngine init currently requires CUDA-capable GPU connector",
+)
+def test_store_hidden_states_skipped_when_frozen(autorelease_v1):
+    """In freeze mode, store_hidden_states must not write anything."""
+    engine = _build_engine(autorelease_v1)
+    tokens = generate_tokens(128, device="cuda")
+    hs = torch.randn(128, 16, dtype=torch.bfloat16)
+
+    engine.freeze(True)
+    try:
+        engine.store_hidden_states(tokens, hidden_states=hs)
+    finally:
+        engine.freeze(False)
+    assert engine.retrieve_hidden_states(tokens) is None

--- a/tests/v1/test_hidden_state_offload.py
+++ b/tests/v1/test_hidden_state_offload.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for hidden state offload alongside KV cache in LMCache."""
 
+# Third Party
 import torch
 
+# First Party
 from lmcache.utils import CacheEngineKey
-
 
 # ---------------------------------------------------------------------------
 # CacheEngineKey.to_hs_key()

--- a/tests/v1/test_hidden_state_offload.py
+++ b/tests/v1/test_hidden_state_offload.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for hidden state offload alongside KV cache in LMCache."""
+
+import torch
+
+from lmcache.utils import CacheEngineKey
+
+
+# ---------------------------------------------------------------------------
+# CacheEngineKey.to_hs_key()
+# ---------------------------------------------------------------------------
+
+
+def test_to_hs_key_produces_distinct_key():
+    key = CacheEngineKey(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=12345,
+        dtype=torch.bfloat16,
+    )
+    hs_key = key.to_hs_key()
+
+    assert hs_key.model_name == "test-model:hs"
+    assert hs_key.chunk_hash == key.chunk_hash
+    assert hs_key.world_size == key.world_size
+    assert hs_key.worker_id == key.worker_id
+    assert hs_key != key
+    assert hash(hs_key) != hash(key)
+
+
+def test_to_hs_key_preserves_request_configs():
+    key = CacheEngineKey(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=99999,
+        dtype=torch.bfloat16,
+        request_configs={"lmcache.tag.user": "alice"},
+    )
+    hs_key = key.to_hs_key()
+    assert hs_key.request_configs == key.request_configs
+    assert hs_key.tags == key.tags
+
+
+def test_to_hs_key_is_idempotent_hash():
+    key = CacheEngineKey(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=42,
+        dtype=torch.bfloat16,
+    )
+    hs_key1 = key.to_hs_key()
+    hs_key2 = key.to_hs_key()
+    assert hs_key1 == hs_key2
+    assert hash(hs_key1) == hash(hs_key2)
+
+
+def test_to_hs_key_string_representation():
+    key = CacheEngineKey(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=42,
+        dtype=torch.bfloat16,
+    )
+    hs_key = key.to_hs_key()
+    assert ":hs" in hs_key.to_string()
+    assert hs_key.to_string() != key.to_string()
+
+
+def test_hs_key_does_not_collide_with_kv_key():
+    """HS and KV keys for the same chunk must never match in a hash table."""
+    key = CacheEngineKey(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=12345,
+        dtype=torch.bfloat16,
+    )
+    hs_key = key.to_hs_key()
+
+    # Must not be equal
+    assert hs_key != key
+    # Must not collide in dict/set
+    d = {key: "kv", hs_key: "hs"}
+    assert len(d) == 2
+    assert d[key] == "kv"
+    assert d[hs_key] == "hs"

--- a/tests/v1/test_skip_mm_storage.py
+++ b/tests/v1/test_skip_mm_storage.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the ``skip_mm_storage`` option in ReqMeta.from_request_tracker.
 
-When set, storage is limited to the contiguous text-only prefix before the
-first multimodal token, so KV for varying mm content is not written to CPU.
+When set, the save path is capped to the contiguous text-only prefix before
+the first multimodal token while the load path remains unaffected.
 """
 
 # Standard
@@ -43,10 +43,12 @@ def test_no_mm_positions_is_noop():
         tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
     )
     assert meta is not None
+    # Full chunk-aligned token set on the load path; no save cap needed.
     assert len(meta.token_ids) == 512
+    assert meta.save_spec.max_save_tokens is None
 
 
-def test_skip_mm_storage_truncates_to_first_mm_offset():
+def test_skip_mm_storage_caps_save_at_first_mm_offset():
     # System prompt: 0..127, image: 128..15999, query: 16000..16399
     mm_positions = [_FakePlaceholderRange(offset=128, length=15872)]
     tracker = _make_tracker(prompt_len=16400, mm_positions=mm_positions)
@@ -55,7 +57,11 @@ def test_skip_mm_storage_truncates_to_first_mm_offset():
         tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
     )
     assert meta is not None
-    assert len(meta.token_ids) == 128
+    # Load path keeps the full chunk-aligned sequence so retrieve()
+    # can index up to lmcache_cached_tokens without going out of range.
+    assert len(meta.token_ids) == 16400 // 64 * 64
+    # Save path is capped at the first mm offset.
+    assert meta.save_spec.max_save_tokens == 128
 
 
 def test_skip_mm_storage_off_stores_everything():
@@ -66,8 +72,8 @@ def test_skip_mm_storage_off_stores_everything():
         tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=False
     )
     assert meta is not None
-    # Without the flag, we store as much as chunk-aligned full input
     assert len(meta.token_ids) == 16400 // 64 * 64
+    assert meta.save_spec.max_save_tokens is None
 
 
 def test_skip_mm_storage_aligns_to_chunk_size():
@@ -79,11 +85,11 @@ def test_skip_mm_storage_aligns_to_chunk_size():
         tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
     )
     assert meta is not None
-    assert len(meta.token_ids) == 128
+    assert meta.save_spec.max_save_tokens == 128
 
 
 def test_skip_mm_storage_picks_first_of_multiple_mm_ranges():
-    # Two images: at 200 and at 800; we should clamp to 200 (chunk-aligned to 192)
+    # Two images: at 200 and at 800; we cap to 200 (chunk-aligned to 192)
     mm_positions = [
         _FakePlaceholderRange(offset=800, length=400),
         _FakePlaceholderRange(offset=200, length=400),
@@ -94,18 +100,30 @@ def test_skip_mm_storage_picks_first_of_multiple_mm_ranges():
         tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
     )
     assert meta is not None
-    # min offset = 200, aligned floor to 64 -> 192
-    assert len(meta.token_ids) == 192
+    assert meta.save_spec.max_save_tokens == 192
 
 
-def test_skip_mm_storage_zero_offset_skips_save():
-    # mm token starts at position 0 -> nothing to save
+def test_skip_mm_storage_zero_offset_caps_to_zero():
+    # mm token starts at position 0 -> save cap is 0 (nothing stored).
     mm_positions = [_FakePlaceholderRange(offset=0, length=2000)]
     tracker = _make_tracker(prompt_len=2000, mm_positions=mm_positions)
 
     meta = ReqMeta.from_request_tracker(
         tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
     )
-    # token_ids should be empty since no text prefix before mm
-    if meta is not None:
-        assert len(meta.token_ids) == 0
+    assert meta is not None
+    assert meta.save_spec.max_save_tokens == 0
+
+
+def test_load_path_unaffected_by_skip_mm_storage():
+    """Regression: token_ids must remain full-length so load can index into it."""
+    mm_positions = [_FakePlaceholderRange(offset=128, length=15872)]
+    tracker = _make_tracker(prompt_len=16400, mm_positions=mm_positions)
+
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
+    )
+    assert meta is not None
+    # If a prior lookup found 16320 cached tokens, tokens[:16320] must
+    # not silently shrink below that.
+    assert len(meta.token_ids) >= 16320

--- a/tests/v1/test_skip_mm_storage.py
+++ b/tests/v1/test_skip_mm_storage.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the ``skip_mm_storage`` option in ReqMeta.from_request_tracker.
+
+When set, storage is limited to the contiguous text-only prefix before the
+first multimodal token, so KV for varying mm content is not written to CPU.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+from lmcache.integration.vllm.vllm_v1_adapter import ReqMeta, RequestTracker
+
+
+@dataclass
+class _FakePlaceholderRange:
+    offset: int
+    length: int
+
+
+def _make_tracker(prompt_len: int, mm_positions=None) -> RequestTracker:
+    return RequestTracker(
+        req_id="test-req",
+        prompt_len=prompt_len,
+        token_ids=list(range(prompt_len)),
+        allocated_block_ids=list(range(prompt_len // 16 + 1)),
+        num_saved_tokens=0,
+        mm_positions=mm_positions,
+    )
+
+
+def test_no_mm_positions_is_noop():
+    tracker = _make_tracker(prompt_len=512)
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
+    )
+    assert meta is not None
+    assert len(meta.token_ids) == 512
+
+
+def test_skip_mm_storage_truncates_to_first_mm_offset():
+    # System prompt: 0..127, image: 128..15999, query: 16000..16399
+    mm_positions = [_FakePlaceholderRange(offset=128, length=15872)]
+    tracker = _make_tracker(prompt_len=16400, mm_positions=mm_positions)
+
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
+    )
+    assert meta is not None
+    assert len(meta.token_ids) == 128
+
+
+def test_skip_mm_storage_off_stores_everything():
+    mm_positions = [_FakePlaceholderRange(offset=128, length=15872)]
+    tracker = _make_tracker(prompt_len=16400, mm_positions=mm_positions)
+
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=False
+    )
+    assert meta is not None
+    # Without the flag, we store as much as chunk-aligned full input
+    assert len(meta.token_ids) == 16400 // 64 * 64
+
+
+def test_skip_mm_storage_aligns_to_chunk_size():
+    # First mm token at 130, chunk_size=64 -> aligned floor = 128
+    mm_positions = [_FakePlaceholderRange(offset=130, length=1000)]
+    tracker = _make_tracker(prompt_len=2000, mm_positions=mm_positions)
+
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
+    )
+    assert meta is not None
+    assert len(meta.token_ids) == 128
+
+
+def test_skip_mm_storage_picks_first_of_multiple_mm_ranges():
+    # Two images: at 200 and at 800; we should clamp to 200 (chunk-aligned to 192)
+    mm_positions = [
+        _FakePlaceholderRange(offset=800, length=400),
+        _FakePlaceholderRange(offset=200, length=400),
+    ]
+    tracker = _make_tracker(prompt_len=2000, mm_positions=mm_positions)
+
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
+    )
+    assert meta is not None
+    # min offset = 200, aligned floor to 64 -> 192
+    assert len(meta.token_ids) == 192
+
+
+def test_skip_mm_storage_zero_offset_skips_save():
+    # mm token starts at position 0 -> nothing to save
+    mm_positions = [_FakePlaceholderRange(offset=0, length=2000)]
+    tracker = _make_tracker(prompt_len=2000, mm_positions=mm_positions)
+
+    meta = ReqMeta.from_request_tracker(
+        tracker, block_size=16, lmcache_chunk_size=64, skip_mm_storage=True
+    )
+    # token_ids should be empty since no text prefix before mm
+    if meta is not None:
+        assert len(meta.token_ids) == 0

--- a/tests/v1/test_skip_mm_storage.py
+++ b/tests/v1/test_skip_mm_storage.py
@@ -5,10 +5,10 @@ When set, storage is limited to the contiguous text-only prefix before the
 first multimodal token, so KV for varying mm content is not written to CPU.
 """
 
+# Standard
 from dataclasses import dataclass
 
-import torch
-
+# First Party
 from lmcache.integration.vllm.vllm_v1_adapter import ReqMeta, RequestTracker
 
 

--- a/tests/v1/test_skip_mm_storage.py
+++ b/tests/v1/test_skip_mm_storage.py
@@ -8,8 +8,16 @@ first multimodal token, so KV for varying mm content is not written to CPU.
 # Standard
 from dataclasses import dataclass
 
+# Third Party
+import pytest
+
+pytest.importorskip("vllm")
+
 # First Party
-from lmcache.integration.vllm.vllm_v1_adapter import ReqMeta, RequestTracker
+from lmcache.integration.vllm.vllm_v1_adapter import (  # noqa: E402
+    ReqMeta,
+    RequestTracker,
+)
 
 
 @dataclass


### PR DESCRIPTION
## Add hidden state store/retrieve alongside KV cache

### Problem

When LMCache restores KV cache from CPU, the serving engine skips prefill for cached tokens. However, some downstream consumers (e.g., multi-stage pipelines, cross-attention layers) need the **full-sequence hidden states** from the prefill, not just KV. Without HS restore, these consumers receive partial hidden states and produce incorrect output.

### Solution

Add general-purpose hidden state store/retrieve to LMCache, using the same chunk-based token hash mechanism as KV:

- **`CacheEngineKey.to_hs_key()`** — derives a parallel key with `:hs` model_name suffix so HS entries don't collide with KV entries but share the same `chunk_hash`
- **`MemoryFormat.HS_TD`** — new memory format for `[num_tokens, hidden_dim]` tensors, routed through the pinned memory allocator like existing KV formats
- **`LMCacheEngine.store_hidden_states()`** — stores HS chunks to CPU storage using the same `token_database.process_tokens()` chunking as KV (guarantees identical chunk boundaries)
- **`LMCacheEngine.retrieve_hidden_states()`** — retrieves HS chunks and assembles into a contiguous CPU tensor
- **`_enable_hs_offload` config flag** — opt-in via `kv_connector_extra_config["lmcache.enable_hidden_state_offload"]` so vanilla vLLM is completely unaffected

### Key Design Decisions

- **HS bypasses GPU connector entirely** — HS tensors are already on CPU, so no `multi_layer_kv_transfer` or CUDA kernel needed
- **Parallel keys, not modified MemoryObj** — HS uses separate `CacheEngineKey` entries (`:hs` suffix) rather than extending the KV MemoryObj format, keeping backward compatibility
- **Same chunk boundaries as KV** — `store_hidden_states` reuses `token_database.process_tokens()`, so HS and KV chunks are always aligned
- **Opt-in flag** — `_enable_hs_offload` defaults to `False`. No impact on existing users

### Changes

| File | Change |
|---|---|
| `lmcache/utils.py` | `CacheEngineKey.to_hs_key()` method |
| `lmcache/v1/memory_management.py` | `MemoryFormat.HS_TD` enum + allocator/free support |
| `lmcache/v1/cache_engine.py` | `store_hidden_states()` and `retrieve_hidden_states()` |
| `lmcache/integration/vllm/vllm_v1_adapter.py` | `_enable_hs_offload` config flag |
| `tests/v1/test_hidden_state_offload.py` | Unit tests for key derivation and store/retrieve roundtrip |

### Related

- Companion PR: vllm-project/vllm-omni#1330 (wires store/restore from the model runner side)

### Testing

- Unit tests: key derivation (distinct, idempotent, preserves configs, no KV collision), store/retrieve roundtrip (single chunk, multi-chunk), missing returns None
- E2E verified with vllm-omni (Qwen3-Omni-30B, 2×A100, 20K input tokens): both `prefix_caching=true` and `prefix_caching=false` paths produce correct full-sequence HS after KV restore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new storage paths and memory formats (hidden-state offload and configurable multimodal save masking) that affect cache persistence and retrieval behavior; mistakes could cause cache misses or increased memory pressure but changes are largely additive and opt-in.
> 
> **Overview**
> **Adds hidden-state offload support alongside KV cache.** Introduces `CacheEngineKey.to_hs_key()` and a new `MemoryFormat.HS_TD`, plus `LMCacheEngine.store_hidden_states()`/`retrieve_hidden_states()` to chunk, store, and reconstruct per-token hidden states using the same token-hash boundaries as KV while keeping HS entries separate from KV keys.
> 
> **Improves vLLM integration controls around what gets stored.** Adds `skip_mm_storage` config and plumbing through `ReqMeta`/`SaveSpec` to cap KV storage to the text-only prefix before multimodal tokens (without shrinking the load path), and extends `StorageManager.get()` to accept a backend `search_range` for retrieve-location-aware HS fetches. Includes new unit tests covering HS roundtrips/key separation and `skip_mm_storage` masking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943b49312e7c839836350641c8ebaa9b0c192642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->