### PR TITLE
fix(#3104): use per-instance FastAPI app to fix 503 on cache endpoints in TP=1 non-MP mode

### DIFF
--- a/lmcache/v1/internal_api_server/api_server.py
+++ b/lmcache/v1/internal_api_server/api_server.py
@@ -21,23 +21,20 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+
+def _build_app() -> FastAPI:
+    """Create a fresh FastAPI app with all internal API routes registered."""
+    new_app = FastAPI()
+    APIRegistry(new_app).register_all_apis()
+    return new_app
+
+
 # Module-level app kept for backward compatibility with existing tests that
 # import `app` directly. Production code no longer relies on this shared
 # singleton; each InternalAPIServer owns its own FastAPI app so that
 # multiple instances in the same process (e.g. scheduler + worker in TP=1
 # non-MP mode) do not overwrite each other's app.state.lmcache_adapter.
-app = FastAPI()
-
-# Automatically register common, vllm, and controller APIs
-registry = APIRegistry(app)
-registry.register_all_apis(categories=["common", "vllm", "controller"])
-
-
-def _build_app() -> FastAPI:
-    """Create a fresh FastAPI app with all internal API routes registered."""
-    new_app = FastAPI()
-    APIRegistry(new_app).register_all_apis(categories=["common", "vllm", "controller"])
-    return new_app
+app = _build_app()
 
 
 class InternalAPIServer:

--- a/lmcache/v1/internal_api_server/api_server.py
+++ b/lmcache/v1/internal_api_server/api_server.py
@@ -21,11 +21,23 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# Module-level app kept for backward compatibility with existing tests that
+# import `app` directly. Production code no longer relies on this shared
+# singleton; each InternalAPIServer owns its own FastAPI app so that
+# multiple instances in the same process (e.g. scheduler + worker in TP=1
+# non-MP mode) do not overwrite each other's app.state.lmcache_adapter.
 app = FastAPI()
 
 # Automatically register common, vllm, and controller APIs
 registry = APIRegistry(app)
 registry.register_all_apis(categories=["common", "vllm", "controller"])
+
+
+def _build_app() -> FastAPI:
+    """Create a fresh FastAPI app with all internal API routes registered."""
+    new_app = FastAPI()
+    APIRegistry(new_app).register_all_apis(categories=["common", "vllm", "controller"])
+    return new_app
 
 
 class InternalAPIServer:
@@ -64,8 +76,10 @@ class InternalAPIServer:
             self.enable = False
             return
 
+        self.app = _build_app()
+
         uvicorn_config = {
-            "app": app,
+            "app": self.app,
             "host": config.internal_api_server_host,
             "loop": "uvloop",
             "http": "httptools",
@@ -92,7 +106,7 @@ class InternalAPIServer:
             uvicorn_config["port"] = self.port
 
         self.server = uvicorn.Server(uvicorn.Config(**uvicorn_config))
-        app.state.lmcache_adapter = lmcache_manager
+        self.app.state.lmcache_adapter = lmcache_manager
 
     async def run(self):
         logger.info(f"Running LMCache internal API server on {self.server_log_info}")

--- a/tests/v1/internal_api_server/test_per_instance_app.py
+++ b/tests/v1/internal_api_server/test_per_instance_app.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #3104.
+
+In TP=1 non-MP vLLM mode, scheduler and worker are initialized in the
+same Python process and both construct ``InternalAPIServer``. Prior to
+the fix, the module-level ``app`` was shared across all instances, so
+the later-initialized scheduler (whose ``lmcache_engine`` is ``None``)
+overwrote the worker's ``app.state.lmcache_adapter``, causing every
+cache endpoint on the worker port to return 503.
+
+This test verifies that each ``InternalAPIServer`` owns its own
+FastAPI app and the adapters do not clobber each other.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+from fastapi.testclient import TestClient
+
+# First Party
+from lmcache.v1.cache_engine import LMCacheEngine
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.internal_api_server.api_server import InternalAPIServer
+from lmcache.v1.metadata import LMCacheMetadata
+
+
+def _make_config(port_start: int) -> LMCacheEngineConfig:
+    cfg = LMCacheEngineConfig.from_defaults(chunk_size=256, local_cpu=True)
+    cfg.internal_api_server_enabled = True
+    cfg.internal_api_server_port_start = port_start
+    cfg.internal_api_server_socket_path_prefix = None
+    return cfg
+
+
+def _make_worker_manager(cfg: LMCacheEngineConfig) -> MagicMock:
+    """Mock LMCacheManager representing a worker (engine present)."""
+    metadata = LMCacheMetadata(
+        model_name="test_model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=None,
+        kv_shape=(1, 2, 256, 8, 128),
+    )
+    engine = MagicMock(spec=LMCacheEngine)
+    engine.config = cfg
+    engine.metadata = metadata
+    engine.clear.return_value = 7
+
+    manager = MagicMock()
+    manager.lmcache_engine = engine
+    manager.config = cfg
+    return manager
+
+
+def _make_scheduler_manager(cfg: LMCacheEngineConfig) -> MagicMock:
+    """Mock LMCacheManager representing a scheduler (no engine)."""
+    manager = MagicMock()
+    manager.lmcache_engine = None
+    manager.config = cfg
+    return manager
+
+
+def test_scheduler_does_not_overwrite_worker_adapter():
+    """Scheduler initialized after worker must not break worker endpoints."""
+    cfg = _make_config(port_start=17000)
+
+    worker_manager = _make_worker_manager(cfg)
+    worker_server = InternalAPIServer(worker_manager)
+
+    # Scheduler comes up after worker in TP=1 non-MP mode.
+    scheduler_manager = _make_scheduler_manager(cfg)
+    scheduler_server = InternalAPIServer(scheduler_manager)
+
+    # Each server must own a distinct FastAPI app.
+    assert worker_server.app is not scheduler_server.app
+
+    # Worker's adapter is still its own manager, not overwritten by
+    # the scheduler's manager (which has lmcache_engine=None).
+    assert worker_server.app.state.lmcache_adapter is worker_manager
+    assert scheduler_server.app.state.lmcache_adapter is scheduler_manager
+
+    # Worker cache endpoint works (returns 200 instead of 503).
+    with TestClient(worker_server.app) as client:
+        response = client.delete("/cache/clear")
+    assert response.status_code == 200
+    assert response.json()["num_removed"] == 7
+
+    # Scheduler endpoint correctly reports engine unavailable (503),
+    # because the scheduler genuinely has no engine.
+    with TestClient(scheduler_server.app) as client:
+        response = client.delete("/cache/clear")
+    assert response.status_code == 503
+
+
+def test_worker_after_scheduler_still_works():
+    """Reverse order: worker initialized after scheduler also stays healthy."""
+    cfg = _make_config(port_start=17100)
+
+    scheduler_manager = _make_scheduler_manager(cfg)
+    scheduler_server = InternalAPIServer(scheduler_manager)
+
+    worker_manager = _make_worker_manager(cfg)
+    worker_server = InternalAPIServer(worker_manager)
+
+    assert worker_server.app is not scheduler_server.app
+    assert worker_server.app.state.lmcache_adapter is worker_manager
+    assert scheduler_server.app.state.lmcache_adapter is scheduler_manager
+
+    with TestClient(worker_server.app) as client:
+        response = client.delete("/cache/clear")
+    assert response.status_code == 200
+    assert response.json()["num_removed"] == 7

--- a/tests/v1/internal_api_server/test_per_instance_app.py
+++ b/tests/v1/internal_api_server/test_per_instance_app.py
@@ -63,7 +63,7 @@ def _make_scheduler_manager(cfg: LMCacheEngineConfig) -> MagicMock:
     return manager
 
 
-def test_scheduler_does_not_overwrite_worker_adapter():
+def test_scheduler_does_not_overwrite_worker_adapter() -> None:
     """Scheduler initialized after worker must not break worker endpoints."""
     cfg = _make_config(port_start=17000)
 
@@ -95,7 +95,7 @@ def test_scheduler_does_not_overwrite_worker_adapter():
     assert response.status_code == 503
 
 
-def test_worker_after_scheduler_still_works():
+def test_worker_after_scheduler_still_works() -> None:
     """Reverse order: worker initialized after scheduler also stays healthy."""
     cfg = _make_config(port_start=17100)
 


### PR DESCRIPTION

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix:#3104

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is localized to internal API server initialization to avoid shared `app.state` across instances, plus a regression test; main risk is unintended differences in route registration or app lifecycle when multiple servers are created in-process.
> 
> **Overview**
> Fixes a bug where multiple `InternalAPIServer` instances in the same process shared a module-level FastAPI `app`, causing later initialization (e.g. scheduler with no engine) to overwrite `app.state.lmcache_adapter` and return 503s on worker cache endpoints.
> 
> `InternalAPIServer` now builds and owns its own FastAPI app via `_build_app()` (while keeping a module-level `app` only for backward compatibility), and a new regression test verifies adapters don’t clobber each other and `/cache/clear` behaves correctly for worker vs scheduler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a15468dd6b0ffc35c7a4a307be17d39bb5084d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->