### PR TITLE
Add macos ci check

### DIFF
--- a/.github/scripts/macos_smoke_test.sh
+++ b/.github/scripts/macos_smoke_test.sh
@@ -4,8 +4,11 @@
 # macOS basic-compatibility smoke test for the lmcache multiprocess
 # server. Verifies that:
 #   1) `lmcache --help` works (CLI entry point is importable)
-#   2) `lmcache server` can launch the ZMQ + HTTP server on CPU
-#   3) the HTTP server answers GET / and GET /healthcheck
+#   2) common C++ extensions (native_storage_ops / lmcache_redis /
+#      lmcache_fs) load on macOS, exercising the PipeNotifier fallback
+#      in csrc/storage_backends/event_notifier.h
+#   3) `lmcache server` can launch the ZMQ + HTTP server on CPU
+#   4) the HTTP server answers GET / and GET /healthcheck
 #
 # This script is intentionally minimal — it does not exercise any
 # GPU / CUDA / vLLM code paths. It is meant to be a fast regression
@@ -31,6 +34,21 @@ python -c "import torch; print('torch', torch.__version__, 'cuda', torch.cuda.is
 
 echo "==> Step 1: lmcache CLI help"
 lmcache --help >/dev/null
+
+echo "==> Step 1.5: import common C++ extensions (CPU-only build)"
+# Mirrors the verify step in .github/workflows/build_cpu_artifacts.yml
+# on the macOS axis: makes sure NO_GPU_EXT=1 produced loadable .so's
+# and that c_ops resolves to the python_ops_fallback shim.
+python -c "
+import sys
+import lmcache
+import lmcache.native_storage_ops  # noqa: F401
+import lmcache.lmcache_redis  # noqa: F401
+import lmcache.lmcache_fs  # noqa: F401
+import lmcache.c_ops  # noqa: F401
+assert lmcache.torch_device_type == 'cpu', lmcache.torch_device_type
+assert sys.modules['lmcache.c_ops'].__name__ == 'lmcache.python_ops_fallback'
+"
 
 echo "==> Step 2: launch 'lmcache server' on ${HTTP_HOST}:${HTTP_PORT} (zmq ${ZMQ_PORT})"
 rm -f "${LOG_FILE}"

--- a/.github/scripts/macos_smoke_test.sh
+++ b/.github/scripts/macos_smoke_test.sh
@@ -5,7 +5,7 @@
 # server. Verifies that:
 #   1) `lmcache --help` works (CLI entry point is importable)
 #   2) `lmcache server` can launch the ZMQ + HTTP server on CPU
-#   3) the HTTP server answers GET / and GET /api/healthcheck
+#   3) the HTTP server answers GET / and GET /healthcheck
 #
 # This script is intentionally minimal — it does not exercise any
 # GPU / CUDA / vLLM code paths. It is meant to be a fast regression

--- a/.github/scripts/macos_smoke_test.sh
+++ b/.github/scripts/macos_smoke_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# macOS basic-compatibility smoke test for the lmcache multiprocess
+# server. Verifies that:
+#   1) `lmcache --help` works (CLI entry point is importable)
+#   2) `lmcache server` can launch the ZMQ + HTTP server on CPU
+#   3) the HTTP server answers GET / and GET /api/healthcheck
+#
+# This script is intentionally minimal — it does not exercise any
+# GPU / CUDA / vLLM code paths. It is meant to be a fast regression
+# signal against accidental Linux-only imports or filesystem usage
+# (e.g. /dev/shm, librt, eventfd, fcntl at import time).
+
+set -euo pipefail
+
+HTTP_HOST="127.0.0.1"
+HTTP_PORT="${LMCACHE_HTTP_PORT:-18080}"
+ZMQ_PORT="${LMCACHE_ZMQ_PORT:-15555}"
+LOG_FILE="${LMCACHE_LOG_FILE:-/tmp/lmcache_server.log}"
+# GitHub macOS runners are noticeably slower than local macs on cold
+# `import torch / fastapi / opentelemetry` chains, so budget enough
+# wall-clock for the first HTTP hit after `lmcache server` starts.
+STARTUP_TIMEOUT="${LMCACHE_STARTUP_TIMEOUT:-180}"
+
+echo "==> Environment"
+uname -a || true
+sw_vers || true
+python --version
+python -c "import torch; print('torch', torch.__version__, 'cuda', torch.cuda.is_available())"
+
+echo "==> Step 1: lmcache CLI help"
+lmcache --help >/dev/null
+
+echo "==> Step 2: launch 'lmcache server' on ${HTTP_HOST}:${HTTP_PORT} (zmq ${ZMQ_PORT})"
+rm -f "${LOG_FILE}"
+# Run the server in the background. Using `setsid`-like behavior via
+# a subshell so we can kill the whole process group cleanly.
+(
+  lmcache server \
+    --host "${HTTP_HOST}" \
+    --port "${ZMQ_PORT}" \
+    --http-host "${HTTP_HOST}" \
+    --http-port "${HTTP_PORT}" \
+    --l1-size-gb "${LMCACHE_L1_SIZE_GB:-1}" \
+    --eviction-policy "${LMCACHE_EVICTION_POLICY:-LRU}" \
+    --no-l1-use-lazy \
+    >"${LOG_FILE}" 2>&1
+) &
+SERVER_PID=$!
+
+cleanup() {
+  echo "==> Cleanup: stopping server (pid=${SERVER_PID})"
+  if kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    # Give it a moment to exit; escalate if needed.
+    for _ in $(seq 1 10); do
+      kill -0 "${SERVER_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    kill -9 "${SERVER_PID}" 2>/dev/null || true
+  fi
+  if [[ -f "${LOG_FILE}" ]]; then
+    echo "==> Last 100 lines of server log:"
+    tail -n 100 "${LOG_FILE}" || true
+  fi
+}
+trap cleanup EXIT
+
+echo "==> Step 3: wait for HTTP endpoint (timeout=${STARTUP_TIMEOUT}s)"
+READY=0
+for i in $(seq 1 "${STARTUP_TIMEOUT}"); do
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    echo "!! lmcache server exited prematurely after ${i}s"
+    break
+  fi
+  if curl -fsS --max-time 2 "http://${HTTP_HOST}:${HTTP_PORT}/" >/dev/null 2>&1; then
+    READY=1
+    echo "==> Server reachable after ${i}s"
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${READY}" != "1" ]]; then
+  echo "!! lmcache server did not become ready within ${STARTUP_TIMEOUT}s"
+  exit 1
+fi
+
+echo "==> Step 4: curl GET /"
+ROOT_BODY="$(curl -fsS "http://${HTTP_HOST}:${HTTP_PORT}/")"
+echo "    body: ${ROOT_BODY}"
+echo "${ROOT_BODY}" | grep -q '"status"' || {
+  echo "!! GET / did not return expected status field"
+  exit 1
+}
+
+echo "==> Step 5: curl GET /healthcheck"
+HEALTH_BODY="$(curl -fsS "http://${HTTP_HOST}:${HTTP_PORT}/healthcheck")"
+echo "    body: ${HEALTH_BODY}"
+echo "${HEALTH_BODY}" | grep -q '"status"[[:space:]]*:[[:space:]]*"healthy"' || {
+  echo "!! GET /healthcheck did not report healthy"
+  exit 1
+}
+
+echo "==> macOS smoke test passed."

--- a/.github/workflows/macos_compat.yml
+++ b/.github/workflows/macos_compat.yml
@@ -1,10 +1,13 @@
 name: macOS Compat
 
 # Smoke test that verifies the lmcache multiprocess server can be
-# installed and launched on macOS (no CUDA, C++/CUDA extensions skipped
-# via NO_CUDA_EXT=1), and that both the HTTP endpoint and the `lmcache`
-# CLI are usable. This is a "best-effort basic compatibility" check —
-# it does not cover GPU / CUDA / vLLM code paths.
+# installed and launched on macOS (GPU backend skipped via NO_GPU_EXT=1;
+# common C++ extensions — native_storage_ops / lmcache_redis /
+# lmcache_fs — are still built so the cross-platform PipeNotifier
+# fallback in csrc/storage_backends/event_notifier.h is exercised),
+# and that both the HTTP endpoint and the `lmcache` CLI are usable.
+# This is a "best-effort basic compatibility" check — it does not
+# cover GPU / CUDA / vLLM code paths.
 
 on:
   workflow_call:
@@ -105,9 +108,12 @@ jobs:
             pyproject.toml
             requirements/*.txt
 
-      - name: Install lmcache (no CUDA ext, no vLLM)
+      - name: Install lmcache (CPU-only, common C++ ext, no vLLM)
         env:
-          NO_CUDA_EXT: "1"
+          # NO_GPU_EXT=1: build common C++ extensions (native_storage_ops,
+          # lmcache_redis, lmcache_fs) but skip the CUDA / ROCm / SYCL
+          # backend. Mirrors build_cpu_artifacts.yml on the macOS axis.
+          NO_GPU_EXT: "1"
           # Pin a synthetic version so setuptools-scm never inspects
           # git tags. Defense-in-depth on top of pyproject.toml's
           # tag_regex; harmless if tag_regex already filters tags.

--- a/.github/workflows/macos_compat.yml
+++ b/.github/workflows/macos_compat.yml
@@ -1,0 +1,141 @@
+name: macOS Compat
+
+# Smoke test that verifies the lmcache multiprocess server can be
+# installed and launched on macOS (no CUDA, C++/CUDA extensions skipped
+# via NO_CUDA_EXT=1), and that both the HTTP endpoint and the `lmcache`
+# CLI are usable. This is a "best-effort basic compatibility" check —
+# it does not cover GPU / CUDA / vLLM code paths.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "dev"
+      - "release-**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+# Single source of truth for the smoke-script contract. The script
+# (.github/scripts/macos_smoke_test.sh) reads these from the env, and
+# the failure-artifact upload step below references LMCACHE_LOG_FILE.
+env:
+  LMCACHE_HTTP_PORT: "18080"
+  LMCACHE_ZMQ_PORT: "15555"
+  LMCACHE_LOG_FILE: "/tmp/lmcache_server.log"
+  LMCACHE_STARTUP_TIMEOUT: "180"
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      lmcache: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.lmcache == 'true' }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 2
+
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            lmcache:
+              - 'lmcache/**'
+              - 'pyproject.toml'
+              - 'setup.py'
+              - 'requirements/**.txt'
+              - '.github/workflows/macos_compat.yml'
+              - '.github/scripts/macos_smoke_test.sh'
+              - '!operator/**'
+
+  macos-smoke:
+    needs: changes
+    if: needs.changes.outputs.lmcache == 'true'
+    name: "macOS smoke: py${{ matrix.python }} on ${{ matrix.platform }}"
+    runs-on: "${{ matrix.platform }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.11"
+          - "3.12"
+        platform:
+          # macos-latest is Apple Silicon (arm64); macos-13 is the last
+          # GitHub-hosted Intel runner. Keep both until macos-13 is
+          # retired by GitHub.
+          - "macos-latest"
+          - "macos-13"
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # Shallow clone is enough; SETUPTOOLS_SCM_PRETEND_VERSION
+          # below avoids any git-tag resolution by setuptools-scm.
+          fetch-depth: 1
+
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements/*.txt
+
+      - name: Install lmcache (no CUDA ext, no vLLM)
+        env:
+          NO_CUDA_EXT: "1"
+          # Pin a synthetic version so setuptools-scm never inspects
+          # git tags. Defense-in-depth on top of pyproject.toml's
+          # tag_regex; harmless if tag_regex already filters tags.
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev0"
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/build.txt
+          # Pure-Python deps. macOS wheels exist for everything in
+          # common.txt; we explicitly skip requirements/cuda13_core.txt
+          # (the default core file picked by setup.py) since cupy and
+          # nixl are CUDA/Linux-only.
+          python -m pip install torch
+          python -m pip install -r requirements/common.txt
+          # CLI entry points eagerly import openai / matplotlib (e.g.
+          # lmcache.cli.commands.bench), so cli.txt is needed for the
+          # `lmcache --help` step inside the smoke script.
+          python -m pip install -r requirements/cli.txt
+          # Install lmcache itself with --no-deps so setup.py's
+          # install_requires (which appends cuda13_core.txt by default)
+          # cannot drag CUDA-only wheels onto macOS.
+          python -m pip install -e . --no-deps --no-build-isolation
+
+      - name: Run macOS smoke test
+        run: |
+          chmod +x .github/scripts/macos_smoke_test.sh
+          .github/scripts/macos_smoke_test.sh
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lmcache-server-log-${{ matrix.platform }}-py${{ matrix.python }}
+          path: ${{ env.LMCACHE_LOG_FILE }}
+          if-no-files-found: ignore

--- a/.github/workflows/macos_compat.yml
+++ b/.github/workflows/macos_compat.yml
@@ -41,7 +41,10 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      lmcache: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.lmcache == 'true' }}
+      # workflow_call / workflow_dispatch bypass the paths-filter (which
+      # only runs for push / pull_request). Treat both as "always run"
+      # so callers don't get a silently-skipped job.
+      lmcache: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || steps.filter.outputs.lmcache == 'true' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         if: github.event_name == 'push'

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -3,13 +3,14 @@
 
 #include "connector_interface.h"
 #include "connector_types.h"
-#include <sys/eventfd.h>
+#include "event_notifier.h"
 #include <unistd.h>
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <condition_variable>
 #include <cstdio>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <stdexcept>
@@ -64,13 +65,9 @@ class ConnectorBase : public IStorageConnector {
       }
     }
 
-    // create eventfd for async notification
-    // EFD_NONBLOCK: read() and write() are non-blocking
-    // EFD_CLOEXEC: close on exec
-    efd_ = ::eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-    if (efd_ < 0) {
-      throw std::runtime_error("failed to create eventfd");
-    }
+    // Cross-platform poll-able wakeup fd (eventfd on Linux,
+    // self-pipe on macOS). See event_notifier.h.
+    notifier_ = make_event_notifier();
   }
 
   virtual ~ConnectorBase() { close(); }
@@ -78,7 +75,7 @@ class ConnectorBase : public IStorageConnector {
   ConnectorBase(const ConnectorBase&) = delete;
   ConnectorBase& operator=(const ConnectorBase&) = delete;
 
-  int event_fd() const override { return efd_; }
+  int event_fd() const override { return notifier_->fileno(); }
 
   uint64_t submit_batch_get(const std::vector<std::string>& keys,
                             const std::vector<void*>& bufs,
@@ -205,8 +202,7 @@ class ConnectorBase : public IStorageConnector {
           signaled_.store(false, std::memory_order_release);
           if (!completions_.empty() &&
               !signaled_.exchange(true, std::memory_order_acq_rel)) {
-            uint64_t x = 1;
-            ::write(efd_, &x, sizeof(x));
+            notifier_->notify();
           }
           break;
         }
@@ -248,10 +244,9 @@ class ConnectorBase : public IStorageConnector {
     // Derived cleanup that must only run after workers have stopped.
     on_workers_stopped();
 
-    // Close eventfd
-    if (efd_ >= 0) {
-      ::close(efd_);
-      efd_ = -1;
+    // Close wakeup fd
+    if (notifier_) {
+      notifier_->close();
     }
 
     // Clear queues (no GIL needed - python guarantees buffers stay alive)
@@ -461,44 +456,12 @@ class ConnectorBase : public IStorageConnector {
     signal_eventfd_();
   }
 
-  void drain_eventfd_() {
-    // loop to consume all writes that happened since last drain
-    for (;;) {
-      uint64_t x;
-      ssize_t r = ::read(efd_, &x, sizeof(x));
-      if (r == static_cast<ssize_t>(sizeof(x))) {
-        continue;  // keep draining
-      }
-      if (r < 0) {
-        if (errno == EINTR) {
-          continue;  // retry on EINTR
-        }
-        if (errno == EAGAIN) {
-          break;  // drained (no more data)
-        }
-      }
-      break;
-    }
-  }
+  void drain_eventfd_() { notifier_->consume(); }
 
   void signal_eventfd_() {
     bool already_signaled = signaled_.exchange(true, std::memory_order_acq_rel);
     if (already_signaled) return;  // only one signal at a time
-
-    uint64_t x = 1;
-    for (;;) {
-      ssize_t w = ::write(efd_, &x, sizeof(x));
-      if (w == static_cast<ssize_t>(sizeof(x))) {
-        return;  // success
-      }
-      if (w < 0) {
-        if (errno == EINTR) {
-          continue;  // retry on EINTR
-        }
-        throw std::runtime_error("eventfd write failed unexpectedly");
-      }
-      throw std::runtime_error("partial write to eventfd");
-    }
+    notifier_->notify();
   }
 
   static const std::unordered_map<std::string, std::vector<Op>>&
@@ -668,9 +631,9 @@ class ConnectorBase : public IStorageConnector {
   std::atomic<uint64_t> next_future_id_{1};
 
  private:
-  int efd_ = -1;
+  std::unique_ptr<EventNotifier> notifier_;
 
-  // treat eventfd as a binary wakeup flag:
+  // treat wakeup fd as a binary wakeup flag:
   // true: Python has been signaled (or will be)
   // false: Python is asleep, no wakeup pending
   std::atomic<bool> signaled_{false};

--- a/csrc/storage_backends/event_notifier.h
+++ b/csrc/storage_backends/event_notifier.h
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// Cross-platform event notification abstraction (C++ mirror of
+// lmcache/v1/platform/event_notifier.py). Provides a unified
+// EventNotifier interface for signaling between threads using a
+// poll-able file descriptor.
+//
+// On Linux we use eventfd(2); on macOS / other POSIX we fall back
+// to a self-pipe with non-blocking I/O. Connector code stays
+// platform-agnostic — only this header has #if branches.
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+
+#if defined(__linux__)
+  #include <sys/eventfd.h>
+#endif
+
+namespace lmcache {
+namespace connector {
+
+// Abstract base: a binary signal that a listener can poll() on.
+// notify() makes fileno() readable; consume() resets it. Multiple
+// notify() calls before a consume() are coalesced.
+class EventNotifier {
+ public:
+  virtual ~EventNotifier() = default;
+
+  // Poll-able file descriptor. Becomes readable after notify().
+  virtual int fileno() const = 0;
+
+  // Signal the notifier (idempotent if already signaled).
+  virtual void notify() = 0;
+
+  // Consume any pending signal (non-blocking). EAGAIN/EWOULDBLOCK
+  // is the only swallowed error; other OS errors propagate.
+  virtual void consume() = 0;
+
+  // Release underlying OS resources. Idempotent.
+  virtual void close() = 0;
+
+  EventNotifier() = default;
+  EventNotifier(const EventNotifier&) = delete;
+  EventNotifier& operator=(const EventNotifier&) = delete;
+};
+
+#if defined(__linux__)
+
+// Linux eventfd-based notifier.
+class EventfdNotifier final : public EventNotifier {
+ public:
+  EventfdNotifier() {
+    efd_ = ::eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    if (efd_ < 0) {
+      throw std::runtime_error("failed to create eventfd");
+    }
+  }
+
+  ~EventfdNotifier() override { close(); }
+
+  int fileno() const override { return efd_; }
+
+  void notify() override {
+    uint64_t one = 1;
+    for (;;) {
+      ssize_t w = ::write(efd_, &one, sizeof(one));
+      if (w == static_cast<ssize_t>(sizeof(one))) return;
+      if (w < 0) {
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+        throw std::runtime_error("eventfd write failed unexpectedly");
+      }
+      throw std::runtime_error("partial write to eventfd");
+    }
+  }
+
+  void consume() override {
+    for (;;) {
+      uint64_t x;
+      ssize_t r = ::read(efd_, &x, sizeof(x));
+      if (r == static_cast<ssize_t>(sizeof(x))) continue;
+      if (r < 0 && errno == EINTR) continue;
+      break;  // drained or non-EINTR error (EAGAIN expected)
+    }
+  }
+
+  void close() override {
+    if (efd_ >= 0) {
+      ::close(efd_);
+      efd_ = -1;
+    }
+  }
+
+ private:
+  int efd_ = -1;
+};
+
+#endif  // __linux__
+
+// Pipe-based fallback notifier (macOS / other POSIX).
+class PipeNotifier final : public EventNotifier {
+ public:
+  PipeNotifier() {
+    int fds[2];
+    if (::pipe(fds) != 0) {
+      throw std::runtime_error("failed to create pipe");
+    }
+    for (int i = 0; i < 2; ++i) {
+      int flags = ::fcntl(fds[i], F_GETFL, 0);
+      if (flags < 0 || ::fcntl(fds[i], F_SETFL, flags | O_NONBLOCK) < 0 ||
+          ::fcntl(fds[i], F_SETFD, FD_CLOEXEC) < 0) {
+        ::close(fds[0]);
+        ::close(fds[1]);
+        throw std::runtime_error("failed to configure pipe fd flags");
+      }
+    }
+    read_fd_ = fds[0];
+    write_fd_ = fds[1];
+  }
+
+  ~PipeNotifier() override { close(); }
+
+  int fileno() const override { return read_fd_; }
+
+  void notify() override {
+    const uint8_t one = 1;
+    for (;;) {
+      ssize_t w = ::write(write_fd_, &one, sizeof(one));
+      if (w == 1) return;
+      if (w < 0) {
+        if (errno == EINTR) continue;
+        // Pipe full = signal already pending; readers will see it.
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+        throw std::runtime_error("pipe write failed unexpectedly");
+      }
+    }
+  }
+
+  void consume() override {
+    uint8_t buf[256];
+    for (;;) {
+      ssize_t r = ::read(read_fd_, buf, sizeof(buf));
+      if (r > 0) continue;
+      if (r < 0 && errno == EINTR) continue;
+      break;  // drained, EOF, or EAGAIN
+    }
+  }
+
+  void close() override {
+    if (read_fd_ >= 0) {
+      ::close(read_fd_);
+      read_fd_ = -1;
+    }
+    if (write_fd_ >= 0) {
+      ::close(write_fd_);
+      write_fd_ = -1;
+    }
+  }
+
+ private:
+  int read_fd_ = -1;
+  int write_fd_ = -1;
+};
+
+// Factory: returns the platform-appropriate notifier.
+inline std::unique_ptr<EventNotifier> make_event_notifier() {
+#if defined(__linux__)
+  return std::unique_ptr<EventNotifier>(new EventfdNotifier());
+#else
+  return std::unique_ptr<EventNotifier>(new PipeNotifier());
+#endif
+}
+
+}  // namespace connector
+}  // namespace lmcache


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The macos ci test passed.

<img width="2604" height="1724" alt="Clipboard_Screenshot_1777202031" src="https://github.com/user-attachments/assets/3e888440-29a3-4e7d-8e6e-6f7959aaf610" />


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds early-import monkey patches for `torch.cuda`, `cupy`, and `os.eventfd`, which can affect runtime behavior across platforms if any code relies on real CUDA/eventfd semantics. Also updates packaging/build selection logic, so mis-detection could change which native extensions are built/installed.
> 
> **Overview**
> Adds a new GitHub Actions *macOS compatibility* workflow that installs LMCache in CPU-only mode on both Intel and Apple Silicon (Python 3.11/3.12) and runs a smoke script that starts `lmcache server` and validates the HTTP endpoints.
> 
> Introduces a new `lmcache.v1.platform` shim layer that is imported at `lmcache` package import time to provide cross-platform fallbacks: a pipe-based `os.eventfd` implementation, a fake `cupy` module for CPU-only environments, and no-op stubs for key `torch.cuda` APIs.
> 
> Tightens macOS/CPU-only robustness by catching `AssertionError` during vLLM `NONE_HASH` initialization, and updates `setup.py` so `NO_CUDA_EXT=1` builds CPU-only C++ extensions (instead of treating it like an sdist/no-extension build).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f02c68a105f86ce4d83c17363ea30eea54eb9a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->