### PR TITLE
fix(disk): defer cache-policy hit update until load succeeds in get_blocking()

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -404,33 +404,34 @@ class LocalDiskBackend(StorageBackendInterface):
         :returns: A ``MemoryObj`` containing the loaded KV data, or ``None``
             if the key is not present or the load fails.
         """
-        self.disk_lock.acquire()
-        if key not in self.dict:
-            self.disk_lock.release()
-            return None
+        with self.disk_lock:
+            if key not in self.dict:
+                return None
 
-        disk_meta = self.dict[key]
-        path = disk_meta.path
-        dtype = disk_meta.dtype
-        shape = disk_meta.shape
-        fmt = disk_meta.fmt
-        assert dtype is not None
-        assert shape is not None
+            disk_meta = self.dict[key]
+            path = disk_meta.path
+            dtype = disk_meta.dtype
+            shape = disk_meta.shape
+            fmt = disk_meta.fmt
+            assert dtype is not None
+            assert shape is not None
 
-        self.disk_lock.release()
+        # Load is performed outside the lock: it can block for a non-trivial
+        # amount of time (CPU staging pool allocation + memcpy from disk) and
+        # must not hold disk_lock while waiting, or concurrent insert/evict
+        # operations would deadlock.
         memory_obj = self.load_bytes_from_disk(
             key, path, dtype=dtype, shape=shape, fmt=fmt
         )
 
         if memory_obj is not None:
-            # Update cache recency only after the load succeeds; calling
-            # update_on_hit() before confirming success would record a phantom
-            # hit and skew eviction order when load_bytes_from_disk() returns
-            # None (e.g. CPU staging pool exhausted after PR #3006).
-            self.disk_lock.acquire()
-            if key in self.dict:
-                self.cache_policy.update_on_hit(key, self.dict)
-            self.disk_lock.release()
+            # Re-acquire the lock to update the eviction policy.  The key
+            # membership check guards against the entry being evicted between
+            # the two lock regions — in that case the policy state is already
+            # consistent and no update is needed.
+            with self.disk_lock:
+                if key in self.dict:
+                    self.cache_policy.update_on_hit(key, self.dict)
 
         return memory_obj
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -394,15 +394,20 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
     ) -> Optional[MemoryObj]:
         """
-        Blocking get function.
+        Load a cached KV chunk from disk synchronously.
+
+        The cache policy is updated only after a successful load so that a
+        failed load (``load_bytes_from_disk`` returning ``None``) does not
+        record a phantom cache hit and skew future eviction decisions.
+
+        :param key: The cache key identifying the KV chunk.
+        :returns: A ``MemoryObj`` containing the loaded KV data, or ``None``
+            if the key is not present or the load fails.
         """
         self.disk_lock.acquire()
         if key not in self.dict:
             self.disk_lock.release()
             return None
-
-        # Update cache recency
-        self.cache_policy.update_on_hit(key, self.dict)
 
         disk_meta = self.dict[key]
         path = disk_meta.path
@@ -416,6 +421,16 @@ class LocalDiskBackend(StorageBackendInterface):
         memory_obj = self.load_bytes_from_disk(
             key, path, dtype=dtype, shape=shape, fmt=fmt
         )
+
+        if memory_obj is not None:
+            # Update cache recency only after the load succeeds; calling
+            # update_on_hit() before confirming success would record a phantom
+            # hit and skew eviction order when load_bytes_from_disk() returns
+            # None (e.g. CPU staging pool exhausted after PR #3006).
+            self.disk_lock.acquire()
+            if key in self.dict:
+                self.cache_policy.update_on_hit(key, self.dict)
+            self.disk_lock.release()
 
         return memory_obj
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import shutil
@@ -10,9 +11,10 @@ import pytest
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import CacheEngineKey, DiskCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -377,3 +379,90 @@ class TestParseLocalDisk:
 
     def test_empty_string(self):
         assert _parse_local_disk("") is None
+
+
+class TestGetBlockingCachePolicyUpdate:
+    """Regression tests for phantom cache hit in get_blocking() (issue #3015).
+
+    ``get_blocking()`` must call ``cache_policy.update_on_hit()`` only when
+    ``load_bytes_from_disk()`` returns a valid ``MemoryObj``.  Calling it
+    before confirming load success records a phantom hit that skews future
+    eviction decisions.
+    """
+
+    def _inject_key(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+        shape: torch.Size,
+        dtype: torch.dtype,
+    ) -> None:
+        """Insert a key into backend.dict without writing anything to disk."""
+        meta = DiskCacheMetadata(
+            path="/nonexistent/path.pt",
+            size=0,
+            shape=shape,
+            dtype=dtype,
+            cached_positions=None,
+            fmt=MemoryFormat.KV_2LTD,
+            pin_count=0,
+        )
+        with backend.disk_lock:
+            backend.dict[key] = meta
+            backend.cache_policy.update_on_put(key)
+
+    def test_no_phantom_hit_when_load_fails(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """update_on_hit must NOT be called when load_bytes_from_disk returns None."""
+        key = create_test_key(101)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
+
+        with patch.object(
+            local_disk_backend, "load_bytes_from_disk", return_value=None
+        ):
+            with patch.object(
+                local_disk_backend.cache_policy, "update_on_hit"
+            ) as mock_update:
+                result = local_disk_backend.get_blocking(key)
+
+        assert result is None
+        mock_update.assert_not_called()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_updates_cache_policy_on_successful_load(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """update_on_hit must be called exactly once when the load succeeds."""
+        key = create_test_key(102)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
+
+        fake_memory_obj = MagicMock(spec=MemoryObj)
+        with patch.object(
+            local_disk_backend, "load_bytes_from_disk", return_value=fake_memory_obj
+        ):
+            with patch.object(
+                local_disk_backend.cache_policy, "update_on_hit"
+            ) as mock_update:
+                result = local_disk_backend.get_blocking(key)
+
+        assert result is fake_memory_obj
+        mock_update.assert_called_once_with(key, local_disk_backend.dict)
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_key_absent_returns_none_without_policy_update(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """get_blocking must return None immediately when the key is not cached."""
+        key = create_test_key(103)
+
+        with patch.object(
+            local_disk_backend.cache_policy, "update_on_hit"
+        ) as mock_update:
+            result = local_disk_backend.get_blocking(key)
+
+        assert result is None
+        mock_update.assert_not_called()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## Summary

Fixes #3015.

`LocalDiskBackend.get_blocking()` called `cache_policy.update_on_hit()` **before** `load_bytes_from_disk()` confirmed that data was actually loaded. When `load_bytes_from_disk()` returns `None` (e.g. after the CPU staging pool is exhausted — the graceful-failure path introduced by PR #3006), the policy has already recorded a hit that never delivered data: a **phantom hit**.

The phantom hit inflates the key's recency/frequency score, shielding it from eviction even though the load failed. Under repeated pool exhaustion the same keys accumulate phantom hits and silently distort eviction order.

## Root Cause

```python
# Before this fix (local_disk_backend.py)
def get_blocking(self, key):
    self.disk_lock.acquire()
    ...
    self.cache_policy.update_on_hit(key, self.dict)  # ← recorded BEFORE load
    ...
    self.disk_lock.release()
    memory_obj = self.load_bytes_from_disk(...)       # ← may return None
    return memory_obj
```

## Fix

Move `update_on_hit()` to after `load_bytes_from_disk()` returns, gated on `memory_obj is not None`. Re-acquire `disk_lock` for the update (so concurrent eviction threads cannot observe a partially-updated `OrderedDict`), and guard with `key in self.dict` in case the entry was evicted concurrently during the lock-free disk I/O window.

```python
# After this fix
self.disk_lock.release()
memory_obj = self.load_bytes_from_disk(key, path, dtype=dtype, shape=shape, fmt=fmt)

if memory_obj is not None:
    self.disk_lock.acquire()
    if key in self.dict:
        self.cache_policy.update_on_hit(key, self.dict)
    self.disk_lock.release()

return memory_obj
```

## Tests

Three new regression tests in `tests/v1/storage_backend/test_local_disk_backend.py` (`TestGetBlockingCachePolicyUpdate`):

| Test | Scenario | Expected |
|------|----------|----------|
| `test_no_phantom_hit_when_load_fails` | `load_bytes_from_disk` returns `None` | `update_on_hit` NOT called |
| `test_updates_cache_policy_on_successful_load` | load returns a valid `MemoryObj` | `update_on_hit` called exactly once |
| `test_key_absent_returns_none_without_policy_update` | key not in cache | `update_on_hit` NOT called |

## Scope

This PR fixes only `get_blocking()`. `batched_get_non_blocking()` has a similar pattern (line 467) but the async path delivers data via a `disk_worker` callback, making the fix more involved; that can be addressed in a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change scoped to synchronous disk reads plus new unit tests; minimal risk beyond potentially altering eviction ordering to match actual successful loads.
> 
> **Overview**
> Fixes `LocalDiskBackend.get_blocking()` to **defer `cache_policy.update_on_hit()` until after `load_bytes_from_disk()` succeeds**, preventing eviction policy “phantom hits” when a disk load returns `None`.
> 
> The method now releases `disk_lock` during the potentially slow disk/CPU-staging load and then re-acquires it conditionally to update recency only if the key still exists. Adds targeted regression tests asserting no policy update on missing keys or failed loads, and exactly one update on successful loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9d401434d33433aab0b48fa6283a4e87b77686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->