### PR TITLE
[Observability] Add L1/L2 state metrics for MP mode

### DIFF
--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -286,28 +286,28 @@ Live state of the L1 memory pool and the in-flight L2 store / prefetch-load
 queues.  These metrics are useful for capacity planning, sizing L1, and
 spotting backpressure on individual L2 adapters.
 
-The three "in-flight" metrics are OTel `UpDownCounter` instruments — the
-controllers call `.add(+1)` on submission and `.add(-1)` on completion (or
-on shutdown cleanup), and the SDK maintains the per-attribute running total
-internally.  Prometheus renders an `UpDownCounter` as a gauge.  L1 memory
-usage is a true `ObservableGauge` because L1Manager already maintains the
-running byte total — there is no event to subscribe to.
+All four metrics are OTel `ObservableGauge` instruments registered via the
+shared `register_gauge` helper.  At scrape time, OTel invokes the
+registered callback, which iterates the controller's live in-flight state
+and returns one observation per adapter that currently has work.
+Adapters with no in-flight work emit no datapoint for that scrape.
 
-All three in-flight metrics carry two attributes that disambiguate
-adapters even when more than one is registered with the same backend type:
+The three in-flight metrics carry two attributes that disambiguate
+adapters even when more than one is registered with the same backend type
+— same shape as the existing `lmcache_mp.l2_store_completed` counter:
 
 - `l2_name` — the registered adapter type (e.g. `"fs"`, `"mock"`,
-  `"nixl_store"`).  Same string used in the existing `L2_*` counters.
+  `"nixl_store"`).
 - `adapter_index` — position in the `StoreController`/`PrefetchController`
   adapter list.  Distinguishes two adapters of the same type (e.g.
   `fs[0]` and `fs[1]`).
 
-| OTel metric name | Prometheus name | Type | Source | Calculation |
+| OTel metric name | Prometheus name | Type | Source of truth | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.l1_memory_usage_bytes` | `lmcache_mp_l1_memory_usage_bytes` | ObservableGauge | `L1Manager._memory_manager.get_memory_usage()[0]` | Bytes currently held in L1 at scrape time |
-| `lmcache_mp.num_inflight_l2_stores` | `lmcache_mp_num_inflight_l2_stores` | UpDownCounter (attrs: `l2_name`, `adapter_index`) | `StoreController._in_flight_tasks` add/remove sites | `+1` per submitted store task, `-1` per completion or cleanup |
-| `lmcache_mp.num_inflight_l2_loads` | `lmcache_mp_num_inflight_l2_loads` | UpDownCounter (attrs: `l2_name`, `adapter_index`) | `PrefetchController.pending_load_tasks` add/remove sites | `+1` per submitted per-adapter load task, `-1` per completion or cleanup |
-| `lmcache_mp.inflight_load_memory_usage_bytes` | `lmcache_mp_inflight_load_memory_usage_bytes` | UpDownCounter (attrs: `l2_name`, `adapter_index`) | `PrefetchController.load_bytes_by_adapter` add/remove sites | `+reserved_bytes` per submitted per-adapter load task, `-reserved_bytes` per completion or cleanup |
+| `lmcache_mp.l1_memory_usage_bytes` | `lmcache_mp_l1_memory_usage_bytes` | ObservableGauge | `L1Manager.get_memory_usage()` | Bytes currently held in L1 at scrape time |
+| `lmcache_mp.num_inflight_l2_stores` | `lmcache_mp_num_inflight_l2_stores` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `StoreController.get_inflight_count_by_adapter()` | Snapshot of in-flight L2 store tasks grouped by adapter |
+| `lmcache_mp.num_inflight_l2_loads` | `lmcache_mp_num_inflight_l2_loads` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `PrefetchController.get_inflight_load_state_by_adapter()` | Per-adapter count from the same snapshot |
+| `lmcache_mp.inflight_load_memory_usage_bytes` | `lmcache_mp_inflight_load_memory_usage_bytes` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `PrefetchController.get_inflight_load_state_by_adapter()` | Per-adapter reserved bytes from the same snapshot |
 
 **What `l1_memory_usage_bytes` answers:** How full is the L1 cache? Helps
 size L1 against working set and detect leaks (steadily climbing without
@@ -328,14 +328,25 @@ prefetch reservations are crowding out cacheable data.
 
 > **Bytes attribution.** A single prefetch request may load from multiple
 > adapters.  The byte count is split per-adapter via the request's
-> `load_plan` bitmap × per-key `MemoryObj.size` so each in-flight byte is
-> attributed to exactly one `(l2_name, adapter_index)` pair — sums across
-> adapters are not double-counted.
+> `load_plan` bitmap × per-key `MemoryObj.size` (precomputed at submit
+> time and stored on `InFlightPrefetchRequest.load_bytes_by_adapter`) so
+> each in-flight byte is attributed to exactly one `(l2_name,
+> adapter_index)` pair — sums across adapters are not double-counted.
 
-> **Bookkeeping invariant.** Reserved bytes are recorded on the request
-> at submit time (`InFlightPrefetchRequest.load_bytes_by_adapter`) and
-> popped at completion, so the decrement always matches the increment
-> regardless of how many keys actually loaded successfully.
+> **Singleton dispatch.** L1Manager / StoreController / PrefetchController
+> are singletons in MP mode.  Each controller registers its gauge once
+> (guarded by a class-level `_gauge_registered` flag) and the callback
+> dispatches via a class-level `_gauge_target` so the most recently
+> constructed instance owns the reported values.  This is invisible in
+> production (one instance per process); it matters in tests that create
+> multiple controllers.
+
+> **Thread safety.** Callbacks run on the OTel reader thread and read
+> state mutated by the controller's background loop thread.  Snapshots
+> use `dict.copy()`, which is implemented in C and atomic under the
+> CPython GIL — concurrent mutation cannot crash the snapshot, though it
+> may briefly see a state that is one mutation stale.  Acceptable for a
+> 10-second scrape cadence.
 
 ---
 

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -280,6 +280,65 @@ point-in-time state snapshots that do not correspond to discrete events.
 
 ---
 
+## L1 / L2 State Metrics
+
+Live state of the L1 memory pool and the in-flight L2 store / prefetch-load
+queues.  These metrics are useful for capacity planning, sizing L1, and
+spotting backpressure on individual L2 adapters.
+
+The three "in-flight" metrics are OTel `UpDownCounter` instruments — the
+controllers call `.add(+1)` on submission and `.add(-1)` on completion (or
+on shutdown cleanup), and the SDK maintains the per-attribute running total
+internally.  Prometheus renders an `UpDownCounter` as a gauge.  L1 memory
+usage is a true `ObservableGauge` because L1Manager already maintains the
+running byte total — there is no event to subscribe to.
+
+All three in-flight metrics carry two attributes that disambiguate
+adapters even when more than one is registered with the same backend type:
+
+- `l2_name` — the registered adapter type (e.g. `"fs"`, `"mock"`,
+  `"nixl_store"`).  Same string used in the existing `L2_*` counters.
+- `adapter_index` — position in the `StoreController`/`PrefetchController`
+  adapter list.  Distinguishes two adapters of the same type (e.g.
+  `fs[0]` and `fs[1]`).
+
+| OTel metric name | Prometheus name | Type | Source | Calculation |
+|---|---|---|---|---|
+| `lmcache_mp.l1_memory_usage_bytes` | `lmcache_mp_l1_memory_usage_bytes` | ObservableGauge | `L1Manager._memory_manager.get_memory_usage()[0]` | Bytes currently held in L1 at scrape time |
+| `lmcache_mp.num_inflight_l2_stores` | `lmcache_mp_num_inflight_l2_stores` | UpDownCounter (attrs: `l2_name`, `adapter_index`) | `StoreController._in_flight_tasks` add/remove sites | `+1` per submitted store task, `-1` per completion or cleanup |
+| `lmcache_mp.num_inflight_l2_loads` | `lmcache_mp_num_inflight_l2_loads` | UpDownCounter (attrs: `l2_name`, `adapter_index`) | `PrefetchController.pending_load_tasks` add/remove sites | `+1` per submitted per-adapter load task, `-1` per completion or cleanup |
+| `lmcache_mp.inflight_load_memory_usage_bytes` | `lmcache_mp_inflight_load_memory_usage_bytes` | UpDownCounter (attrs: `l2_name`, `adapter_index`) | `PrefetchController.load_bytes_by_adapter` add/remove sites | `+reserved_bytes` per submitted per-adapter load task, `-reserved_bytes` per completion or cleanup |
+
+**What `l1_memory_usage_bytes` answers:** How full is the L1 cache? Helps
+size L1 against working set and detect leaks (steadily climbing without
+plateauing).
+
+**What `num_inflight_l2_stores` answers:** Are L2 stores piling up on a
+particular adapter? Sustained non-zero values indicate the adapter cannot
+keep up with the L1 → L2 write rate.
+
+**What `num_inflight_l2_loads` answers:** Are L2 → L1 prefetch loads
+backing up? Pair with `num_inflight_l2_stores` to see whether read or
+write traffic dominates a given backend.
+
+**What `inflight_load_memory_usage_bytes` answers:** How much L1 capacity
+is currently *reserved but not yet filled* by in-flight prefetches? Rising
+in-flight bytes alongside rising `l1_memory_usage_bytes` is a signal that
+prefetch reservations are crowding out cacheable data.
+
+> **Bytes attribution.** A single prefetch request may load from multiple
+> adapters.  The byte count is split per-adapter via the request's
+> `load_plan` bitmap × per-key `MemoryObj.size` so each in-flight byte is
+> attributed to exactly one `(l2_name, adapter_index)` pair — sums across
+> adapters are not double-counted.
+
+> **Bookkeeping invariant.** Reserved bytes are recorded on the request
+> at submit time (`InFlightPrefetchRequest.load_bytes_by_adapter`) and
+> popped at completion, so the decrement always matches the increment
+> regardless of how many keys actually loaded successfully.
+
+---
+
 ## Cache Blending (CB) Metrics
 
 Metrics for Cache Blending operations use the `lmcache_blend.` prefix (distinct from the

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -412,6 +412,16 @@ Observable Gauges
 Point-in-time state snapshots registered via ``register_gauge``
 (pull-based OTel observable gauges).
 
+The three in-flight metrics carry two attributes that distinguish
+adapters even when more than one is registered with the same backend
+type — same shape as ``lmcache_mp.l2_store_completed``:
+
+- ``l2_name`` — the registered adapter type (e.g. ``"fs"``,
+  ``"nixl_store"``, ``"mooncake_store"``).
+- ``adapter_index`` — position in the controller's adapter list.
+
+Adapters with no in-flight work emit no datapoint for that scrape.
+
 .. list-table::
    :header-rows: 1
    :widths: 40 15 45
@@ -423,6 +433,29 @@ Point-in-time state snapshots registered via ``register_gauge``
      - ObservableGauge
      - Number of prefetch jobs currently in-flight. A sustained high
        value may indicate slow L2 backends or polling delays.
+   * - ``lmcache_mp.l1_memory_usage_bytes``
+     - ObservableGauge
+     - Bytes currently held in L1.  Rising without plateauing typically
+       indicates a leak; saturating at the configured ``--l1-size-gb``
+       indicates working set exceeds capacity.
+   * - ``lmcache_mp.num_inflight_l2_stores``
+     - ObservableGauge (attrs: ``l2_name``, ``adapter_index``)
+     - L2 store tasks currently executing, per adapter.  Sustained
+       non-zero values indicate the adapter cannot keep up with the
+       L1 → L2 write rate.
+   * - ``lmcache_mp.num_inflight_l2_loads``
+     - ObservableGauge (attrs: ``l2_name``, ``adapter_index``)
+     - L2 → L1 prefetch load tasks currently executing, per adapter.
+       Pair with ``num_inflight_l2_stores`` to see whether read or write
+       traffic dominates a given backend.
+   * - ``lmcache_mp.inflight_load_memory_usage_bytes``
+     - ObservableGauge (attrs: ``l2_name``, ``adapter_index``)
+     - L1 bytes reserved by in-flight L2 → L1 prefetch loads, per
+       adapter.  Rising in-flight bytes alongside rising
+       ``l1_memory_usage_bytes`` is a signal that prefetch reservations
+       are crowding out cacheable data.  Per-adapter byte attribution
+       follows each request's ``load_plan`` bitmap, so summing across
+       adapters never double-counts.
 
 Prometheus Scrape Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -19,6 +19,7 @@ from lmcache.v1.distributed.memory_manager import L1MemoryManager
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.mp_observability.otel_init import register_gauge
 
 logger = init_logger(__name__)
 
@@ -114,6 +115,32 @@ def _validate_extra_count(extra_count: int) -> int:
 # Main classes
 
 
+def _register_l1_memory_usage_gauge() -> None:
+    """Register the L1 memory usage gauge exactly once per process.
+
+    L1Manager is a singleton in MP mode (one per cache server process), so
+    a single OTel ObservableGauge with a single callback is the correct
+    shape.  Tests that construct multiple L1Manager instances would
+    otherwise stack multiple callbacks on the same metric name with the
+    same (empty) attribute set, leaving the reported value undefined.
+    The callback dispatches via the class-level ``_gauge_target`` so the
+    most recently constructed L1Manager owns the reported value.
+    """
+    if L1Manager._gauge_registered:
+        return
+    L1Manager._gauge_registered = True
+    register_gauge(
+        "lmcache.l1_manager",
+        "lmcache_mp.l1_memory_usage_bytes",
+        "Bytes currently held in L1 cache",
+        lambda: (
+            L1Manager._gauge_target._memory_manager.get_memory_usage()[0]
+            if L1Manager._gauge_target is not None
+            else 0
+        ),
+    )
+
+
 class L1Manager:
     """
     Object lifecycle state machine for L1 cache
@@ -157,6 +184,11 @@ class L1Manager:
     For every operation on list of keys, the operation is atomic
     """
 
+    # Class-level state for the singleton ``lmcache_mp.l1_memory_usage_bytes``
+    # gauge.  See ``_register_l1_memory_usage_gauge``.
+    _gauge_registered: bool = False
+    _gauge_target: "L1Manager | None" = None
+
     def __init__(self, config: L1ManagerConfig):
         self._lock = threading.Lock()
 
@@ -170,6 +202,9 @@ class L1Manager:
         self._registered_listeners: list[L1ManagerListener] = []
 
         self._event_bus = get_event_bus()
+
+        L1Manager._gauge_target = self
+        _register_l1_memory_usage_gauge()
 
     def register_listener(self, listener: L1ManagerListener) -> None:
         """Register a listener for L1Manager events.

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -158,42 +158,12 @@ class L1Manager:
     For every operation on list of keys, the operation is atomic
     """
 
-    # Class-level state for the singleton ``lmcache_mp.l1_memory_usage_bytes``
-    # gauge.  See ``_ensure_memory_usage_gauge_registered``.
+    # Singleton dispatch for ``lmcache_mp.l1_memory_usage_bytes``: tests may
+    # construct multiple L1Managers but the OTel SDK only honors the first
+    # gauge registration, so the callback reads from the most recently built
+    # instance via ``_gauge_target``.
     _gauge_registered: bool = False
     _gauge_target: "L1Manager | None" = None
-
-    @classmethod
-    def _ensure_memory_usage_gauge_registered(cls) -> None:
-        """Register ``lmcache_mp.l1_memory_usage_bytes`` exactly once per
-        process.
-
-        L1Manager is a singleton in MP mode (one per cache server
-        process), so a single OTel ObservableGauge with a single callback
-        is the correct shape.  Tests that construct multiple L1Manager
-        instances would otherwise stack multiple callbacks on the same
-        metric name with the same (empty) attribute set, leaving the
-        reported value undefined.  The callback dispatches via
-        ``_gauge_target`` so the most recently constructed L1Manager owns
-        the reported value.
-        """
-        if cls._gauge_registered:
-            return
-        cls._gauge_registered = True
-        register_gauge(
-            "lmcache.l1_manager",
-            "lmcache_mp.l1_memory_usage_bytes",
-            "Bytes currently held in L1 cache",
-            cls._read_current_memory_usage_bytes,
-        )
-
-    @classmethod
-    def _read_current_memory_usage_bytes(cls) -> int:
-        """Gauge callback: return the current L1 instance's used bytes."""
-        target = cls._gauge_target
-        if target is None:
-            return 0
-        return target.get_memory_usage()[0]
 
     def __init__(self, config: L1ManagerConfig):
         self._lock = threading.Lock()
@@ -210,7 +180,18 @@ class L1Manager:
         self._event_bus = get_event_bus()
 
         L1Manager._gauge_target = self
-        L1Manager._ensure_memory_usage_gauge_registered()
+        if not L1Manager._gauge_registered:
+            L1Manager._gauge_registered = True
+            register_gauge(
+                "lmcache.l1_manager",
+                "lmcache_mp.l1_memory_usage_bytes",
+                "Bytes currently held in L1 cache",
+                lambda: (
+                    L1Manager._gauge_target.get_memory_usage()[0]
+                    if L1Manager._gauge_target is not None
+                    else 0
+                ),
+            )
 
     def register_listener(self, listener: L1ManagerListener) -> None:
         """Register a listener for L1Manager events.

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -115,32 +115,6 @@ def _validate_extra_count(extra_count: int) -> int:
 # Main classes
 
 
-def _register_l1_memory_usage_gauge() -> None:
-    """Register the L1 memory usage gauge exactly once per process.
-
-    L1Manager is a singleton in MP mode (one per cache server process), so
-    a single OTel ObservableGauge with a single callback is the correct
-    shape.  Tests that construct multiple L1Manager instances would
-    otherwise stack multiple callbacks on the same metric name with the
-    same (empty) attribute set, leaving the reported value undefined.
-    The callback dispatches via the class-level ``_gauge_target`` so the
-    most recently constructed L1Manager owns the reported value.
-    """
-    if L1Manager._gauge_registered:
-        return
-    L1Manager._gauge_registered = True
-    register_gauge(
-        "lmcache.l1_manager",
-        "lmcache_mp.l1_memory_usage_bytes",
-        "Bytes currently held in L1 cache",
-        lambda: (
-            L1Manager._gauge_target._memory_manager.get_memory_usage()[0]
-            if L1Manager._gauge_target is not None
-            else 0
-        ),
-    )
-
-
 class L1Manager:
     """
     Object lifecycle state machine for L1 cache
@@ -185,9 +159,41 @@ class L1Manager:
     """
 
     # Class-level state for the singleton ``lmcache_mp.l1_memory_usage_bytes``
-    # gauge.  See ``_register_l1_memory_usage_gauge``.
+    # gauge.  See ``_ensure_memory_usage_gauge_registered``.
     _gauge_registered: bool = False
     _gauge_target: "L1Manager | None" = None
+
+    @classmethod
+    def _ensure_memory_usage_gauge_registered(cls) -> None:
+        """Register ``lmcache_mp.l1_memory_usage_bytes`` exactly once per
+        process.
+
+        L1Manager is a singleton in MP mode (one per cache server
+        process), so a single OTel ObservableGauge with a single callback
+        is the correct shape.  Tests that construct multiple L1Manager
+        instances would otherwise stack multiple callbacks on the same
+        metric name with the same (empty) attribute set, leaving the
+        reported value undefined.  The callback dispatches via
+        ``_gauge_target`` so the most recently constructed L1Manager owns
+        the reported value.
+        """
+        if cls._gauge_registered:
+            return
+        cls._gauge_registered = True
+        register_gauge(
+            "lmcache.l1_manager",
+            "lmcache_mp.l1_memory_usage_bytes",
+            "Bytes currently held in L1 cache",
+            cls._read_current_memory_usage_bytes,
+        )
+
+    @classmethod
+    def _read_current_memory_usage_bytes(cls) -> int:
+        """Gauge callback: return the current L1 instance's used bytes."""
+        target = cls._gauge_target
+        if target is None:
+            return 0
+        return target.get_memory_usage()[0]
 
     def __init__(self, config: L1ManagerConfig):
         self._lock = threading.Lock()
@@ -204,7 +210,7 @@ class L1Manager:
         self._event_bus = get_event_bus()
 
         L1Manager._gauge_target = self
-        _register_l1_memory_usage_gauge()
+        L1Manager._ensure_memory_usage_gauge_registered()
 
     def register_listener(self, listener: L1ManagerListener) -> None:
         """Register a listener for L1Manager events.

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -20,6 +20,9 @@ import os
 import select
 import threading
 
+# Third Party
+from opentelemetry import metrics
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
@@ -154,6 +157,11 @@ class InFlightPrefetchRequest:
     load_plan: dict[int, Bitmap] = field(default_factory=dict)
     # Load phase: adapter_idx -> task_id (removed as results arrive)
     pending_load_tasks: dict[int, L2TaskId] = field(default_factory=dict)
+    # Load phase: adapter_idx -> reserved bytes (mirrors pending_load_tasks
+    # so the inflight_load_memory_usage_bytes counter can be decremented by
+    # the same amount it was incremented at submit time, regardless of how
+    # many keys actually load).
+    load_bytes_by_adapter: dict[int, int] = field(default_factory=dict)
     # Load phase: adapter_idx -> bitmap (populated as results arrive)
     load_results: dict[int, Bitmap] = field(default_factory=dict)
     # Load phase: keys that were write-reserved in L1
@@ -240,6 +248,17 @@ class PrefetchController(StorageControllerInterface):
             self._load_efd_to_adapter[adapter.get_load_event_fd()] = i
 
         self._event_bus = get_event_bus()
+
+        meter = metrics.get_meter("lmcache.l2_prefetch")
+        self._inflight_loads_counter = meter.create_up_down_counter(
+            "lmcache_mp.num_inflight_l2_loads",
+            description="L2 -> L1 prefetch load tasks currently executing, per adapter",
+        )
+        self._inflight_load_bytes_counter = meter.create_up_down_counter(
+            "lmcache_mp.inflight_load_memory_usage_bytes",
+            description="L1 bytes reserved by in-flight L2 -> L1 prefetch "
+            "loads, per adapter",
+        )
 
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(
@@ -629,6 +648,13 @@ class PrefetchController(StorageControllerInterface):
                 if per_adapter_objs
                 else 0
             )
+            request.load_bytes_by_adapter[adapter_idx] = total_bytes
+            attrs = {
+                "l2_name": self._adapter_descriptors[adapter_idx].type_name,
+                "adapter_index": adapter_idx,
+            }
+            self._inflight_loads_counter.add(1, attrs)
+            self._inflight_load_bytes_counter.add(total_bytes, attrs)
 
             self._event_bus.publish(
                 Event(
@@ -734,6 +760,13 @@ class PrefetchController(StorageControllerInterface):
                 continue
             request.load_results[adapter_idx] = result
             del request.pending_load_tasks[adapter_idx]
+            reserved_bytes = request.load_bytes_by_adapter.pop(adapter_idx, 0)
+            attrs = {
+                "l2_name": self._adapter_descriptors[adapter_idx].type_name,
+                "adapter_index": adapter_idx,
+            }
+            self._inflight_loads_counter.add(-1, attrs)
+            self._inflight_load_bytes_counter.add(-reserved_bytes, attrs)
 
             self._event_bus.publish(
                 Event(
@@ -875,6 +908,14 @@ class PrefetchController(StorageControllerInterface):
                 self._unlock_all_plan_keys(request)
             elif request.phase == PrefetchPhase.LOOKUP:
                 self._unlock_all_lookups(request)
+            for adapter_idx, reserved_bytes in request.load_bytes_by_adapter.items():
+                attrs = {
+                    "l2_name": self._adapter_descriptors[adapter_idx].type_name,
+                    "adapter_index": adapter_idx,
+                }
+                self._inflight_loads_counter.add(-1, attrs)
+                self._inflight_load_bytes_counter.add(-reserved_bytes, attrs)
+            request.load_bytes_by_adapter.clear()
             logger.warning(
                 "Cleaning up in-flight prefetch request %d (%d keys).",
                 request.request_id,

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -159,10 +159,8 @@ class InFlightPrefetchRequest:
     load_plan: dict[int, Bitmap] = field(default_factory=dict)
     # Load phase: adapter_idx -> task_id (removed as results arrive)
     pending_load_tasks: dict[int, L2TaskId] = field(default_factory=dict)
-    # Load phase: adapter_idx -> reserved bytes (mirrors pending_load_tasks
-    # so the inflight_load_memory_usage_bytes counter can be decremented by
-    # the same amount it was incremented at submit time, regardless of how
-    # many keys actually load).
+    # Load phase: adapter_idx -> L1 bytes reserved for that adapter's
+    # in-flight load.  Read by the inflight_load_memory_usage_bytes gauge.
     load_bytes_by_adapter: dict[int, int] = field(default_factory=dict)
     # Load phase: adapter_idx -> bitmap (populated as results arrive)
     load_results: dict[int, Bitmap] = field(default_factory=dict)
@@ -197,8 +195,10 @@ class PrefetchController(StorageControllerInterface):
         max_in_flight: Maximum number of concurrent prefetch requests.
     """
 
-    # Class-level state for the singleton in-flight load gauges.  See
-    # ``_ensure_inflight_load_gauges_registered``.
+    # Singleton dispatch for the in-flight load gauges: tests may construct
+    # multiple controllers but the OTel SDK only honors the first gauge
+    # registration, so the callbacks read from the most recently built
+    # instance via ``_gauge_target``.
     _gauges_registered: bool = False
     _gauge_target: "PrefetchController | None" = None
 
@@ -257,7 +257,28 @@ class PrefetchController(StorageControllerInterface):
         self._event_bus = get_event_bus()
 
         PrefetchController._gauge_target = self
-        PrefetchController._ensure_inflight_load_gauges_registered()
+        if not PrefetchController._gauges_registered:
+            PrefetchController._gauges_registered = True
+            register_gauge(
+                "lmcache.l2_prefetch",
+                "lmcache_mp.num_inflight_l2_loads",
+                "L2 -> L1 prefetch load tasks currently executing, per adapter",
+                lambda: (
+                    PrefetchController._gauge_target.get_inflight_loads_observations()
+                    if PrefetchController._gauge_target is not None
+                    else []
+                ),
+            )
+            register_gauge(
+                "lmcache.l2_prefetch",
+                "lmcache_mp.inflight_load_memory_usage_bytes",
+                "L1 bytes reserved by in-flight L2 -> L1 prefetch loads, per adapter",
+                lambda: (
+                    PrefetchController._gauge_target.get_inflight_load_bytes_observations()
+                    if PrefetchController._gauge_target is not None
+                    else []
+                ),
+            )
 
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(
@@ -378,135 +399,51 @@ class PrefetchController(StorageControllerInterface):
             "num_l2_adapters": len(self._l2_adapters),
         }
 
-    def get_inflight_load_state_by_adapter(self) -> dict[int, tuple[int, int]]:
-        """Snapshot of in-flight L2 -> L1 load (count, bytes) per adapter.
-
-        Read by the ``lmcache_mp.num_inflight_l2_loads`` and
-        ``lmcache_mp.inflight_load_memory_usage_bytes`` observable gauge
-        callbacks at scrape time.
-
-        Per-adapter byte attribution follows the request's load_plan
-        bitmap: each in-flight byte is attributed to exactly the adapter
-        actually loading it, so summing across adapters never
-        double-counts.
-
-        Thread safety:
-            ``self._in_flight_requests`` and each request's
-            ``load_bytes_by_adapter`` are mutated only on the background
-            prefetch loop thread.  ``dict.copy()`` is implemented in C
-            and atomic under the CPython GIL, so taking a snapshot from
-            another thread (e.g. the OTel reader thread) cannot crash —
-            in the worst case it sees a state that is one mutation
-            stale, which is acceptable for an observability gauge polled
-            on a 10-second cadence.
-
-        Returns:
-            Mapping from ``adapter_index`` to ``(count, bytes)`` where
-            ``count`` is the number of in-flight load tasks targeting
-            that adapter and ``bytes`` is the L1 reservation pinned by
-            those loads.  Adapters with no in-flight work are absent.
+    def _snapshot_inflight_loads(self) -> dict[int, tuple[int, int]]:
+        """``{adapter_idx: (count, reserved_bytes)}`` for in-flight L2 -> L1
+        loads, computed via GIL-atomic ``dict.copy()`` snapshots so the
+        OTel reader thread can call this concurrently with the prefetch
+        loop without locking.
         """
         counts: dict[int, int] = defaultdict(int)
         bytes_by_adapter: dict[int, int] = defaultdict(int)
         for request in self._in_flight_requests.copy().values():
-            load_bytes = request.load_bytes_by_adapter.copy()
-            for adapter_idx, reserved_bytes in load_bytes.items():
-                counts[adapter_idx] += 1
-                bytes_by_adapter[adapter_idx] += reserved_bytes
+            for idx, reserved in request.load_bytes_by_adapter.copy().items():
+                counts[idx] += 1
+                bytes_by_adapter[idx] += reserved
         return {idx: (counts[idx], bytes_by_adapter[idx]) for idx in counts}
 
     def get_inflight_loads_observations(
         self,
     ) -> list[tuple[int | float, dict[str, object]]]:
-        """Snapshot in the shape expected by ``register_gauge`` for the
-        ``num_inflight_l2_loads`` gauge.
-
-        Each tuple is ``(count, attributes)`` for one adapter that
-        currently has in-flight load tasks.
-        """
+        """Per-adapter ``(count, attributes)`` for the
+        ``lmcache_mp.num_inflight_l2_loads`` gauge."""
         return [
             (
                 count,
                 {
-                    "l2_name": self._adapter_descriptors[adapter_idx].type_name,
-                    "adapter_index": adapter_idx,
+                    "l2_name": self._adapter_descriptors[idx].type_name,
+                    "adapter_index": idx,
                 },
             )
-            for adapter_idx, (count, _) in (
-                self.get_inflight_load_state_by_adapter().items()
-            )
+            for idx, (count, _) in self._snapshot_inflight_loads().items()
         ]
 
     def get_inflight_load_bytes_observations(
         self,
     ) -> list[tuple[int | float, dict[str, object]]]:
-        """Snapshot in the shape expected by ``register_gauge`` for the
-        ``inflight_load_memory_usage_bytes`` gauge.
-
-        Each tuple is ``(reserved_bytes, attributes)`` for one adapter
-        with in-flight loads.  Adapters without in-flight loads are
-        omitted.
-        """
+        """Per-adapter ``(reserved_bytes, attributes)`` for the
+        ``lmcache_mp.inflight_load_memory_usage_bytes`` gauge."""
         return [
             (
                 reserved_bytes,
                 {
-                    "l2_name": self._adapter_descriptors[adapter_idx].type_name,
-                    "adapter_index": adapter_idx,
+                    "l2_name": self._adapter_descriptors[idx].type_name,
+                    "adapter_index": idx,
                 },
             )
-            for adapter_idx, (_, reserved_bytes) in (
-                self.get_inflight_load_state_by_adapter().items()
-            )
+            for idx, (_, reserved_bytes) in self._snapshot_inflight_loads().items()
         ]
-
-    @classmethod
-    def _ensure_inflight_load_gauges_registered(cls) -> None:
-        """Register the two in-flight load gauges exactly once per process.
-
-        PrefetchController is a singleton in MP mode (one per cache server
-        process), so each gauge has a single OTel instrument with a
-        single callback.  Tests that construct multiple PrefetchController
-        instances would otherwise stack registrations on the same
-        instrument names; the callback dispatches via ``_gauge_target``
-        so the most recently constructed controller owns the reported
-        values.
-        """
-        if cls._gauges_registered:
-            return
-        cls._gauges_registered = True
-        register_gauge(
-            "lmcache.l2_prefetch",
-            "lmcache_mp.num_inflight_l2_loads",
-            "L2 -> L1 prefetch load tasks currently executing, per adapter",
-            cls._read_inflight_loads_observations,
-        )
-        register_gauge(
-            "lmcache.l2_prefetch",
-            "lmcache_mp.inflight_load_memory_usage_bytes",
-            "L1 bytes reserved by in-flight L2 -> L1 prefetch loads, per adapter",
-            cls._read_inflight_load_bytes_observations,
-        )
-
-    @classmethod
-    def _read_inflight_loads_observations(
-        cls,
-    ) -> list[tuple[int | float, dict[str, object]]]:
-        """Gauge callback: dispatch to the current target instance."""
-        target = cls._gauge_target
-        if target is None:
-            return []
-        return target.get_inflight_loads_observations()
-
-    @classmethod
-    def _read_inflight_load_bytes_observations(
-        cls,
-    ) -> list[tuple[int | float, dict[str, object]]]:
-        """Gauge callback: dispatch to the current target instance."""
-        target = cls._gauge_target
-        if target is None:
-            return []
-        return target.get_inflight_load_bytes_observations()
 
     # =========================================================================
     # Lifecycle

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -13,15 +13,13 @@ The controller runs a background thread with an event-driven loop that:
 """
 
 # Standard
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Iterable
 import enum
 import os
 import select
 import threading
-
-# Third Party
-from opentelemetry import metrics
 
 # First Party
 from lmcache.logging import init_logger
@@ -40,6 +38,7 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.mp_observability.otel_init import register_gauge
 
 logger = init_logger(__name__)
 
@@ -195,6 +194,11 @@ class PrefetchController(StorageControllerInterface):
         max_in_flight: Maximum number of concurrent prefetch requests.
     """
 
+    # Class-level state for the singleton in-flight load gauges.  See
+    # ``_ensure_inflight_load_gauges_registered``.
+    _gauges_registered: bool = False
+    _gauge_target: "PrefetchController | None" = None
+
     def __init__(
         self,
         l1_manager: L1Manager,
@@ -249,16 +253,8 @@ class PrefetchController(StorageControllerInterface):
 
         self._event_bus = get_event_bus()
 
-        meter = metrics.get_meter("lmcache.l2_prefetch")
-        self._inflight_loads_counter = meter.create_up_down_counter(
-            "lmcache_mp.num_inflight_l2_loads",
-            description="L2 -> L1 prefetch load tasks currently executing, per adapter",
-        )
-        self._inflight_load_bytes_counter = meter.create_up_down_counter(
-            "lmcache_mp.inflight_load_memory_usage_bytes",
-            description="L1 bytes reserved by in-flight L2 -> L1 prefetch "
-            "loads, per adapter",
-        )
+        PrefetchController._gauge_target = self
+        PrefetchController._ensure_inflight_load_gauges_registered()
 
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(
@@ -378,6 +374,136 @@ class PrefetchController(StorageControllerInterface):
             "completed_results_count": completed_results_count,
             "num_l2_adapters": len(self._l2_adapters),
         }
+
+    def get_inflight_load_state_by_adapter(self) -> dict[int, tuple[int, int]]:
+        """Snapshot of in-flight L2 -> L1 load (count, bytes) per adapter.
+
+        Read by the ``lmcache_mp.num_inflight_l2_loads`` and
+        ``lmcache_mp.inflight_load_memory_usage_bytes`` observable gauge
+        callbacks at scrape time.
+
+        Per-adapter byte attribution follows the request's load_plan
+        bitmap: each in-flight byte is attributed to exactly the adapter
+        actually loading it, so summing across adapters never
+        double-counts.
+
+        Thread safety:
+            ``self._in_flight_requests`` and each request's
+            ``load_bytes_by_adapter`` are mutated only on the background
+            prefetch loop thread.  ``dict.copy()`` is implemented in C
+            and atomic under the CPython GIL, so taking a snapshot from
+            another thread (e.g. the OTel reader thread) cannot crash —
+            in the worst case it sees a state that is one mutation
+            stale, which is acceptable for an observability gauge polled
+            on a 10-second cadence.
+
+        Returns:
+            Mapping from ``adapter_index`` to ``(count, bytes)`` where
+            ``count`` is the number of in-flight load tasks targeting
+            that adapter and ``bytes`` is the L1 reservation pinned by
+            those loads.  Adapters with no in-flight work are absent.
+        """
+        counts: dict[int, int] = defaultdict(int)
+        bytes_by_adapter: dict[int, int] = defaultdict(int)
+        for request in self._in_flight_requests.copy().values():
+            load_bytes = request.load_bytes_by_adapter.copy()
+            for adapter_idx, reserved_bytes in load_bytes.items():
+                counts[adapter_idx] += 1
+                bytes_by_adapter[adapter_idx] += reserved_bytes
+        return {idx: (counts[idx], bytes_by_adapter[idx]) for idx in counts}
+
+    def get_inflight_loads_observations(
+        self,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Snapshot in the shape expected by ``register_gauge`` for the
+        ``num_inflight_l2_loads`` gauge.
+
+        Each tuple is ``(count, attributes)`` for one adapter that
+        currently has in-flight load tasks.
+        """
+        return [
+            (
+                count,
+                {
+                    "l2_name": self._adapter_descriptors[adapter_idx].type_name,
+                    "adapter_index": adapter_idx,
+                },
+            )
+            for adapter_idx, (count, _) in (
+                self.get_inflight_load_state_by_adapter().items()
+            )
+        ]
+
+    def get_inflight_load_bytes_observations(
+        self,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Snapshot in the shape expected by ``register_gauge`` for the
+        ``inflight_load_memory_usage_bytes`` gauge.
+
+        Each tuple is ``(reserved_bytes, attributes)`` for one adapter
+        with in-flight loads.  Adapters without in-flight loads are
+        omitted.
+        """
+        return [
+            (
+                reserved_bytes,
+                {
+                    "l2_name": self._adapter_descriptors[adapter_idx].type_name,
+                    "adapter_index": adapter_idx,
+                },
+            )
+            for adapter_idx, (_, reserved_bytes) in (
+                self.get_inflight_load_state_by_adapter().items()
+            )
+        ]
+
+    @classmethod
+    def _ensure_inflight_load_gauges_registered(cls) -> None:
+        """Register the two in-flight load gauges exactly once per process.
+
+        PrefetchController is a singleton in MP mode (one per cache server
+        process), so each gauge has a single OTel instrument with a
+        single callback.  Tests that construct multiple PrefetchController
+        instances would otherwise stack registrations on the same
+        instrument names; the callback dispatches via ``_gauge_target``
+        so the most recently constructed controller owns the reported
+        values.
+        """
+        if cls._gauges_registered:
+            return
+        cls._gauges_registered = True
+        register_gauge(
+            "lmcache.l2_prefetch",
+            "lmcache_mp.num_inflight_l2_loads",
+            "L2 -> L1 prefetch load tasks currently executing, per adapter",
+            cls._read_inflight_loads_observations,
+        )
+        register_gauge(
+            "lmcache.l2_prefetch",
+            "lmcache_mp.inflight_load_memory_usage_bytes",
+            "L1 bytes reserved by in-flight L2 -> L1 prefetch loads, per adapter",
+            cls._read_inflight_load_bytes_observations,
+        )
+
+    @classmethod
+    def _read_inflight_loads_observations(
+        cls,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Gauge callback: dispatch to the current target instance."""
+        target = cls._gauge_target
+        if target is None:
+            return []
+        return target.get_inflight_loads_observations()
+
+    @classmethod
+    def _read_inflight_load_bytes_observations(
+        cls,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Gauge callback: dispatch to the current target instance."""
+        target = cls._gauge_target
+        if target is None:
+            return []
+        return target.get_inflight_load_bytes_observations()
 
     # =========================================================================
     # Lifecycle
@@ -649,12 +775,6 @@ class PrefetchController(StorageControllerInterface):
                 else 0
             )
             request.load_bytes_by_adapter[adapter_idx] = total_bytes
-            attrs = {
-                "l2_name": self._adapter_descriptors[adapter_idx].type_name,
-                "adapter_index": adapter_idx,
-            }
-            self._inflight_loads_counter.add(1, attrs)
-            self._inflight_load_bytes_counter.add(total_bytes, attrs)
 
             self._event_bus.publish(
                 Event(
@@ -760,13 +880,7 @@ class PrefetchController(StorageControllerInterface):
                 continue
             request.load_results[adapter_idx] = result
             del request.pending_load_tasks[adapter_idx]
-            reserved_bytes = request.load_bytes_by_adapter.pop(adapter_idx, 0)
-            attrs = {
-                "l2_name": self._adapter_descriptors[adapter_idx].type_name,
-                "adapter_index": adapter_idx,
-            }
-            self._inflight_loads_counter.add(-1, attrs)
-            self._inflight_load_bytes_counter.add(-reserved_bytes, attrs)
+            request.load_bytes_by_adapter.pop(adapter_idx, None)
 
             self._event_bus.publish(
                 Event(
@@ -908,14 +1022,6 @@ class PrefetchController(StorageControllerInterface):
                 self._unlock_all_plan_keys(request)
             elif request.phase == PrefetchPhase.LOOKUP:
                 self._unlock_all_lookups(request)
-            for adapter_idx, reserved_bytes in request.load_bytes_by_adapter.items():
-                attrs = {
-                    "l2_name": self._adapter_descriptors[adapter_idx].type_name,
-                    "adapter_index": adapter_idx,
-                }
-                self._inflight_loads_counter.add(-1, attrs)
-                self._inflight_load_bytes_counter.add(-reserved_bytes, attrs)
-            request.load_bytes_by_adapter.clear()
             logger.warning(
                 "Cleaning up in-flight prefetch request %d (%d keys).",
                 request.request_id,

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -17,9 +17,6 @@ import os
 import select
 import threading
 
-# Third Party
-from opentelemetry import metrics
-
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import ObjectKey
@@ -34,6 +31,7 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
 )
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.mp_observability.otel_init import register_gauge
 
 logger = init_logger(__name__)
 
@@ -203,6 +201,11 @@ class StoreController(StorageControllerInterface):
         policy: The store policy for deciding targets and deletions.
     """
 
+    # Class-level state for the singleton ``lmcache_mp.num_inflight_l2_stores``
+    # gauge.  See ``_ensure_inflight_stores_gauge_registered``.
+    _gauge_registered: bool = False
+    _gauge_target: "StoreController | None" = None
+
     def __init__(
         self,
         l1_manager: L1Manager,
@@ -219,12 +222,6 @@ class StoreController(StorageControllerInterface):
         self._l1_manager.register_listener(self._listener)
         self._event_bus = get_event_bus()
 
-        meter = metrics.get_meter("lmcache.l2_store")
-        self._inflight_stores_counter = meter.create_up_down_counter(
-            "lmcache_mp.num_inflight_l2_stores",
-            description="L2 store tasks currently executing, per adapter",
-        )
-
         # (adapter_index, task_id) -> InFlightStoreTask
         # Composite key is needed because task IDs are only unique
         # within a single adapter, not across adapters.
@@ -232,6 +229,9 @@ class StoreController(StorageControllerInterface):
 
         # Shadow counter for status reporting (updated in background loop)
         self._status_in_flight_count: int = 0
+
+        StoreController._gauge_target = self
+        StoreController._ensure_inflight_stores_gauge_registered()
 
         # Map eventfd -> adapter index for quick lookup in poll results
         self._efd_to_adapter_index: dict[int, int] = {}
@@ -274,6 +274,86 @@ class StoreController(StorageControllerInterface):
             "in_flight_task_count": self._status_in_flight_count,
             "num_l2_adapters": len(self._l2_adapters),
         }
+
+    def get_inflight_count_by_adapter(self) -> dict[int, int]:
+        """Snapshot of in-flight L2 store tasks grouped by adapter index.
+
+        Read by the ``lmcache_mp.num_inflight_l2_stores`` observable
+        gauge callback at scrape time.  The returned dict is a fresh
+        snapshot — callers may use it freely.
+
+        Thread safety:
+            ``self._in_flight_tasks`` is mutated only on the background
+            store loop thread.  ``dict.copy()`` is implemented in C and
+            atomic under the CPython GIL, so taking a snapshot from any
+            other thread (e.g. the OTel reader thread) cannot crash even
+            though it may briefly see a stale state by one mutation.
+
+        Returns:
+            Mapping from ``adapter_index`` to the count of in-flight
+            store tasks targeting that adapter.  Adapters with no
+            in-flight work are absent from the dict.
+        """
+        snapshot = self._in_flight_tasks.copy()
+        counts: dict[int, int] = defaultdict(int)
+        for adapter_index, _ in snapshot:
+            counts[adapter_index] += 1
+        return dict(counts)
+
+    def get_inflight_stores_observations(
+        self,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Snapshot in the shape expected by ``register_gauge``.
+
+        Each tuple is ``(count, attributes)`` for a single adapter that
+        currently has in-flight store tasks.  Adapters with zero
+        in-flight tasks are omitted.
+        """
+        return [
+            (
+                count,
+                {
+                    "l2_name": self._adapter_descriptors[adapter_index].type_name,
+                    "adapter_index": adapter_index,
+                },
+            )
+            for adapter_index, count in self.get_inflight_count_by_adapter().items()
+        ]
+
+    @classmethod
+    def _ensure_inflight_stores_gauge_registered(cls) -> None:
+        """Register ``lmcache_mp.num_inflight_l2_stores`` exactly once per
+        process.
+
+        StoreController is a singleton in MP mode (one per cache server
+        process), so a single OTel ObservableGauge with a single callback
+        is the correct shape.  Tests that construct multiple
+        StoreController instances would otherwise stack registrations on
+        the same instrument name (the OTel SDK honors only the first), so
+        the gauge would keep reporting from a stopped controller after a
+        new one is created.  The callback dispatches via ``_gauge_target``
+        so the most recently constructed controller owns the reported
+        values.
+        """
+        if cls._gauge_registered:
+            return
+        cls._gauge_registered = True
+        register_gauge(
+            "lmcache.l2_store",
+            "lmcache_mp.num_inflight_l2_stores",
+            "L2 store tasks currently executing, per adapter",
+            cls._read_inflight_stores_observations,
+        )
+
+    @classmethod
+    def _read_inflight_stores_observations(
+        cls,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Gauge callback: dispatch to the current target instance."""
+        target = cls._gauge_target
+        if target is None:
+            return []
+        return target.get_inflight_stores_observations()
 
     # Private methods
 
@@ -413,13 +493,6 @@ class StoreController(StorageControllerInterface):
                 read_locked_keys=list(successful_keys),
             )
             self._status_in_flight_count += 1
-            self._inflight_stores_counter.add(
-                1,
-                {
-                    "l2_name": self._adapter_descriptors[adapter_index].type_name,
-                    "adapter_index": adapter_index,
-                },
-            )
 
             # All objects for a single store task share one layout (L1
             # allocates uniform MemoryObjs per chunk), so total bytes is
@@ -488,13 +561,6 @@ class StoreController(StorageControllerInterface):
         l1_mgr.finish_read(task.read_locked_keys)
         del self._in_flight_tasks[task_key]
         self._status_in_flight_count -= 1
-        self._inflight_stores_counter.add(
-            -1,
-            {
-                "l2_name": self._adapter_descriptors[adapter_index].type_name,
-                "adapter_index": adapter_index,
-            },
-        )
 
         l2_name = self._adapter_descriptors[adapter_index].type_name
         if success:
@@ -553,11 +619,4 @@ class StoreController(StorageControllerInterface):
                 len(task.read_locked_keys),
             )
             l1_mgr.finish_read(task.read_locked_keys)
-            self._inflight_stores_counter.add(
-                -1,
-                {
-                    "l2_name": self._adapter_descriptors[adapter_index].type_name,
-                    "adapter_index": adapter_index,
-                },
-            )
         self._in_flight_tasks.clear()

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -17,6 +17,9 @@ import os
 import select
 import threading
 
+# Third Party
+from opentelemetry import metrics
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import ObjectKey
@@ -216,6 +219,12 @@ class StoreController(StorageControllerInterface):
         self._l1_manager.register_listener(self._listener)
         self._event_bus = get_event_bus()
 
+        meter = metrics.get_meter("lmcache.l2_store")
+        self._inflight_stores_counter = meter.create_up_down_counter(
+            "lmcache_mp.num_inflight_l2_stores",
+            description="L2 store tasks currently executing, per adapter",
+        )
+
         # (adapter_index, task_id) -> InFlightStoreTask
         # Composite key is needed because task IDs are only unique
         # within a single adapter, not across adapters.
@@ -404,6 +413,13 @@ class StoreController(StorageControllerInterface):
                 read_locked_keys=list(successful_keys),
             )
             self._status_in_flight_count += 1
+            self._inflight_stores_counter.add(
+                1,
+                {
+                    "l2_name": self._adapter_descriptors[adapter_index].type_name,
+                    "adapter_index": adapter_index,
+                },
+            )
 
             # All objects for a single store task share one layout (L1
             # allocates uniform MemoryObjs per chunk), so total bytes is
@@ -472,6 +488,13 @@ class StoreController(StorageControllerInterface):
         l1_mgr.finish_read(task.read_locked_keys)
         del self._in_flight_tasks[task_key]
         self._status_in_flight_count -= 1
+        self._inflight_stores_counter.add(
+            -1,
+            {
+                "l2_name": self._adapter_descriptors[adapter_index].type_name,
+                "adapter_index": adapter_index,
+            },
+        )
 
         l2_name = self._adapter_descriptors[adapter_index].type_name
         if success:
@@ -530,4 +553,11 @@ class StoreController(StorageControllerInterface):
                 len(task.read_locked_keys),
             )
             l1_mgr.finish_read(task.read_locked_keys)
+            self._inflight_stores_counter.add(
+                -1,
+                {
+                    "l2_name": self._adapter_descriptors[adapter_index].type_name,
+                    "adapter_index": adapter_index,
+                },
+            )
         self._in_flight_tasks.clear()

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -209,8 +209,10 @@ class StoreController(StorageControllerInterface):
         policy: The store policy for deciding targets and deletions.
     """
 
-    # Class-level state for the singleton ``lmcache_mp.num_inflight_l2_stores``
-    # gauge.  See ``_ensure_inflight_stores_gauge_registered``.
+    # Singleton dispatch for ``lmcache_mp.num_inflight_l2_stores``: tests may
+    # construct multiple controllers but the OTel SDK only honors the first
+    # gauge registration, so the callback reads from the most recently built
+    # instance via ``_gauge_target``.
     _gauge_registered: bool = False
     _gauge_target: "StoreController | None" = None
 
@@ -239,7 +241,18 @@ class StoreController(StorageControllerInterface):
         self._status_in_flight_count: int = 0
 
         StoreController._gauge_target = self
-        StoreController._ensure_inflight_stores_gauge_registered()
+        if not StoreController._gauge_registered:
+            StoreController._gauge_registered = True
+            register_gauge(
+                "lmcache.l2_store",
+                "lmcache_mp.num_inflight_l2_stores",
+                "L2 store tasks currently executing, per adapter",
+                lambda: (
+                    StoreController._gauge_target.get_inflight_stores_observations()
+                    if StoreController._gauge_target is not None
+                    else []
+                ),
+            )
 
         # Map eventfd -> adapter index for quick lookup in poll results
         self._efd_to_adapter_index: dict[int, int] = {}
@@ -283,85 +296,30 @@ class StoreController(StorageControllerInterface):
             "num_l2_adapters": len(self._l2_adapters),
         }
 
-    def get_inflight_count_by_adapter(self) -> dict[int, int]:
-        """Snapshot of in-flight L2 store tasks grouped by adapter index.
-
-        Read by the ``lmcache_mp.num_inflight_l2_stores`` observable
-        gauge callback at scrape time.  The returned dict is a fresh
-        snapshot — callers may use it freely.
-
-        Thread safety:
-            ``self._in_flight_tasks`` is mutated only on the background
-            store loop thread.  ``dict.copy()`` is implemented in C and
-            atomic under the CPython GIL, so taking a snapshot from any
-            other thread (e.g. the OTel reader thread) cannot crash even
-            though it may briefly see a stale state by one mutation.
-
-        Returns:
-            Mapping from ``adapter_index`` to the count of in-flight
-            store tasks targeting that adapter.  Adapters with no
-            in-flight work are absent from the dict.
-        """
-        snapshot = self._in_flight_tasks.copy()
-        counts: dict[int, int] = defaultdict(int)
-        for adapter_index, _ in snapshot:
-            counts[adapter_index] += 1
-        return dict(counts)
-
     def get_inflight_stores_observations(
         self,
     ) -> list[tuple[int | float, dict[str, object]]]:
-        """Snapshot in the shape expected by ``register_gauge``.
+        """Per-adapter ``(count, attributes)`` snapshot for the
+        ``lmcache_mp.num_inflight_l2_stores`` gauge.
 
-        Each tuple is ``(count, attributes)`` for a single adapter that
-        currently has in-flight store tasks.  Adapters with zero
-        in-flight tasks are omitted.
+        ``dict.copy()`` is GIL-atomic in CPython, so reading from the
+        OTel reader thread while the store loop mutates is safe; the
+        snapshot may be one mutation stale, which is fine at the 10 s
+        scrape cadence.
         """
+        counts: dict[int, int] = defaultdict(int)
+        for adapter_index, _ in self._in_flight_tasks.copy():
+            counts[adapter_index] += 1
         return [
             (
                 count,
                 {
-                    "l2_name": self._adapter_descriptors[adapter_index].type_name,
-                    "adapter_index": adapter_index,
+                    "l2_name": self._adapter_descriptors[idx].type_name,
+                    "adapter_index": idx,
                 },
             )
-            for adapter_index, count in self.get_inflight_count_by_adapter().items()
+            for idx, count in counts.items()
         ]
-
-    @classmethod
-    def _ensure_inflight_stores_gauge_registered(cls) -> None:
-        """Register ``lmcache_mp.num_inflight_l2_stores`` exactly once per
-        process.
-
-        StoreController is a singleton in MP mode (one per cache server
-        process), so a single OTel ObservableGauge with a single callback
-        is the correct shape.  Tests that construct multiple
-        StoreController instances would otherwise stack registrations on
-        the same instrument name (the OTel SDK honors only the first), so
-        the gauge would keep reporting from a stopped controller after a
-        new one is created.  The callback dispatches via ``_gauge_target``
-        so the most recently constructed controller owns the reported
-        values.
-        """
-        if cls._gauge_registered:
-            return
-        cls._gauge_registered = True
-        register_gauge(
-            "lmcache.l2_store",
-            "lmcache_mp.num_inflight_l2_stores",
-            "L2 store tasks currently executing, per adapter",
-            cls._read_inflight_stores_observations,
-        )
-
-    @classmethod
-    def _read_inflight_stores_observations(
-        cls,
-    ) -> list[tuple[int | float, dict[str, object]]]:
-        """Gauge callback: dispatch to the current target instance."""
-        target = cls._gauge_target
-        if target is None:
-            return []
-        return target.get_inflight_stores_observations()
 
     # Private methods
 

--- a/lmcache/v1/mp_observability/otel_init.py
+++ b/lmcache/v1/mp_observability/otel_init.py
@@ -151,28 +151,53 @@ def register_gauge(
     meter_name: str,
     gauge_name: str,
     description: str,
-    func: Callable[[], int | float],
+    func: Callable[[], int | float]
+    | Callable[[], list[tuple[int | float, dict[str, object]]]],
 ) -> None:
     """Register an OTel observable gauge with a callback.
 
     This is a convenience wrapper that hides the OTel boilerplate.
     If OTel is not available, the call is silently ignored.
 
+    Two callback shapes are accepted:
+
+    - **Single value (no attributes).** ``func`` returns ``int`` / ``float``
+      and the gauge emits one datapoint per scrape with no attributes.
+      Use this for whole-process metrics like
+      ``lmcache_mp.active_prefetch_jobs``.
+    - **Per-attribute-set values.** ``func`` returns a list of
+      ``(value, attrs)`` tuples; the gauge emits one datapoint per tuple
+      with the given attributes.  Use this for per-adapter or per-tier
+      metrics that share a name but vary by attribute.  An empty list
+      reports no datapoints (the metric simply does not appear in the
+      next scrape, which is the correct shape when there is nothing to
+      observe).
+
     Args:
         meter_name: OTel meter name (e.g. ``lmcache.mp_engine``).
         gauge_name: Metric name (e.g.
             ``lmcache_mp.active_prefetch_jobs``).
         description: Human-readable description of the gauge.
-        func: Zero-arg callable returning the current value.
+        func: Zero-arg callable.  Either a function returning the current
+            scalar value, or a function returning a list of
+            ``(value, attrs)`` tuples for tagged observations.
     """
     try:
         # Third Party
         from opentelemetry import metrics as otel_metrics
 
+        def _callback(_options):
+            result = func()
+            if isinstance(result, list):
+                return [
+                    otel_metrics.Observation(value, attrs) for value, attrs in result
+                ]
+            return [otel_metrics.Observation(result)]
+
         meter = otel_metrics.get_meter(meter_name)
         meter.create_observable_gauge(
             gauge_name,
-            callbacks=[lambda _: [otel_metrics.Observation(func())]],
+            callbacks=[_callback],
             description=description,
         )
     except ImportError:

--- a/tests/v1/distributed/test_l1_l2_state_metrics.py
+++ b/tests/v1/distributed/test_l1_l2_state_metrics.py
@@ -334,13 +334,17 @@ class TestNumInflightL2Loads:
         ctrl.stop()
         adapter.close()
 
-    def test_cleanup_decrements_counters_on_shutdown(self, l1_manager):
+    def test_no_leak_after_shutdown_with_inflight_loads(self, l1_manager):
         # When the controller is stopped while a load is still in flight,
-        # ``_cleanup_in_flight_requests`` must decrement the counters so
-        # they return to baseline.  We use a slow MockL2Adapter (bandwidth
-        # set at construction, since ``_bandwidth_byte_ps`` is computed
-        # once in ``__init__``) and assert via the metric snapshot that
-        # the load is observably in-flight before calling ``stop()``.
+        # the gauges must report 0 after shutdown — the in-flight request
+        # tracking dict is cleared in ``_cleanup_in_flight_requests``, and
+        # the observable gauge callbacks read live state, so an empty
+        # tracking dict naturally yields zero observations.  We use a
+        # slow MockL2Adapter (bandwidth set at construction, since
+        # ``_bandwidth_byte_ps`` is computed once in ``__init__``) and
+        # assert via the metric snapshot that the load is observably
+        # in-flight before calling ``stop()`` — otherwise the test
+        # could pass via the normal completion path instead.
         slow_gb = 0.001  # 1 MB/s — a 200 KB key takes ~200 ms.
         adapter = make_adapter(bandwidth_gb=slow_gb)
         adapter_index = 0

--- a/tests/v1/distributed/test_l1_l2_state_metrics.py
+++ b/tests/v1/distributed/test_l1_l2_state_metrics.py
@@ -72,8 +72,8 @@ def make_layout() -> MemoryLayoutDesc:
     )
 
 
-def make_adapter() -> MockL2Adapter:
-    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+def make_adapter(bandwidth_gb: float = 10.0) -> MockL2Adapter:
+    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=bandwidth_gb)
     return MockL2Adapter(config)
 
 
@@ -335,17 +335,20 @@ class TestNumInflightL2Loads:
         adapter.close()
 
     def test_cleanup_decrements_counters_on_shutdown(self, l1_manager):
-        # If the controller is stopped with in-flight loads, _cleanup
-        # must decrement the counters so they return to baseline.
-        adapter = make_adapter()
-        # Use an absurdly slow mock bandwidth so the load is still
-        # in-flight when we stop().
-        adapter._config.mock_bandwidth_gb = 0.0001  # type: ignore[attr-defined]
+        # When the controller is stopped while a load is still in flight,
+        # ``_cleanup_in_flight_requests`` must decrement the counters so
+        # they return to baseline.  We use a slow MockL2Adapter (bandwidth
+        # set at construction, since ``_bandwidth_byte_ps`` is computed
+        # once in ``__init__``) and assert via the metric snapshot that
+        # the load is observably in-flight before calling ``stop()``.
+        slow_gb = 0.001  # 1 MB/s — a 200 KB key takes ~200 ms.
+        adapter = make_adapter(bandwidth_gb=slow_gb)
         adapter_index = 0
         attrs = {"l2_name": "mock", "adapter_index": adapter_index}
         layout = make_layout()
         keys = [make_object_key(400 + i) for i in range(4)]
 
+        # Seed L2 (also slow at this bandwidth, so allow plenty of time).
         store_keys_in_l2(adapter, keys, layout)
 
         ctrl = PrefetchController(
@@ -360,10 +363,25 @@ class TestNumInflightL2Loads:
         before_bytes = _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)
 
         ctrl.submit_prefetch_request(keys, layout)
-        # Don't wait for completion; stop() should clean up regardless.
+
+        # Wait until the load is actually in flight on this adapter; only
+        # then is ``_cleanup_in_flight_requests`` the path that brings the
+        # counters back down.  Without this wait, the test could pass via
+        # the normal completion path instead.
+        assert wait_for_condition(
+            lambda: (
+                _value_for("lmcache_mp.num_inflight_l2_loads", attrs) > before_loads
+            ),
+            timeout=10.0,
+        ), "Load never entered the in-flight state"
+        assert (
+            _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)
+            > before_bytes
+        )
+
+        # Stop while the load is still in flight; cleanup must decrement.
         ctrl.stop()
 
-        # After cleanup the counters must be back at baseline.
         assert _value_for("lmcache_mp.num_inflight_l2_loads", attrs) == before_loads
         assert (
             _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)

--- a/tests/v1/distributed/test_l1_l2_state_metrics.py
+++ b/tests/v1/distributed/test_l1_l2_state_metrics.py
@@ -1,15 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
-Integration tests for the four L1/L2 state metrics:
-
-- ``lmcache_mp.l1_memory_usage_bytes`` (ObservableGauge on L1Manager)
-- ``lmcache_mp.num_inflight_l2_stores`` (UpDownCounter on StoreController)
-- ``lmcache_mp.num_inflight_l2_loads`` (UpDownCounter on PrefetchController)
-- ``lmcache_mp.inflight_load_memory_usage_bytes`` (UpDownCounter on PrefetchController)
+"""Integration tests for the four L1/L2 state metrics.
 
 Drives real controllers through real state changes and reads back values
-from a process-shared ``InMemoryMetricReader``.  Tests assert on deltas to
-remain robust against earlier tests that already exercised the meters.
+via a process-shared ``InMemoryMetricReader``.  Assertions are on deltas
+so prior tests that exercised the meters don't poison the baseline.
 """
 
 # Standard
@@ -42,9 +36,8 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
 )
 from lmcache.v1.memory_management import MemoryObjMetadata, TensorMemoryObj
 
-# Shared module-scope MeterProvider with an InMemoryMetricReader.  The
-# import itself sets the global MeterProvider; controllers constructed
-# below all bind their instruments to this reader.
+# Importing this sets the process-wide MeterProvider with an
+# InMemoryMetricReader; controllers bind their instruments to it.
 from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
 
 pytestmark = pytest.mark.skipif(
@@ -135,11 +128,7 @@ def store_keys_in_l2(
 
 
 def _read_points_by_attrs() -> dict[str, dict[tuple, float]]:
-    """Snapshot all sum/gauge data points from the shared reader.
-
-    Returns ``{metric_name: {sorted_attrs_tuple: value}}``.  Histogram
-    points are skipped (they don't have ``.value``).
-    """
+    """``{metric: {sorted_attrs_tuple: value}}`` from the shared reader."""
     data = _reader.get_metrics_data()
     result: dict[str, dict[tuple, float]] = {}
     if data is None:
@@ -335,16 +324,11 @@ class TestNumInflightL2Loads:
         adapter.close()
 
     def test_no_leak_after_shutdown_with_inflight_loads(self, l1_manager):
-        # When the controller is stopped while a load is still in flight,
-        # the gauges must report 0 after shutdown — the in-flight request
-        # tracking dict is cleared in ``_cleanup_in_flight_requests``, and
-        # the observable gauge callbacks read live state, so an empty
-        # tracking dict naturally yields zero observations.  We use a
-        # slow MockL2Adapter (bandwidth set at construction, since
-        # ``_bandwidth_byte_ps`` is computed once in ``__init__``) and
-        # assert via the metric snapshot that the load is observably
-        # in-flight before calling ``stop()`` — otherwise the test
-        # could pass via the normal completion path instead.
+        # Slow adapter so the load is still in flight when stop() runs;
+        # the gauge callback reads live state, so once cleanup clears the
+        # in-flight dict the gauges naturally report 0.  We assert via
+        # the metric that the load is observably in-flight before calling
+        # stop(), otherwise the test could pass via normal completion.
         slow_gb = 0.001  # 1 MB/s — a 200 KB key takes ~200 ms.
         adapter = make_adapter(bandwidth_gb=slow_gb)
         adapter_index = 0

--- a/tests/v1/distributed/test_l1_l2_state_metrics.py
+++ b/tests/v1/distributed/test_l1_l2_state_metrics.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Integration tests for the four L1/L2 state metrics:
+
+- ``lmcache_mp.l1_memory_usage_bytes`` (ObservableGauge on L1Manager)
+- ``lmcache_mp.num_inflight_l2_stores`` (UpDownCounter on StoreController)
+- ``lmcache_mp.num_inflight_l2_loads`` (UpDownCounter on PrefetchController)
+- ``lmcache_mp.inflight_load_memory_usage_bytes`` (UpDownCounter on PrefetchController)
+
+Drives real controllers through real state changes and reads back values
+from a process-shared ``InMemoryMetricReader``.  Tests assert on deltas to
+remain robust against earlier tests that already exercised the meters.
+"""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+    PrefetchController,
+)
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    DefaultPrefetchPolicy,
+)
+from lmcache.v1.distributed.storage_controllers.store_controller import (
+    StoreController,
+)
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+    DefaultStorePolicy,
+)
+from lmcache.v1.memory_management import MemoryObjMetadata, TensorMemoryObj
+
+# Shared module-scope MeterProvider with an InMemoryMetricReader.  The
+# import itself sets the global MeterProvider; controllers constructed
+# below all bind their instruments to this reader.
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available"
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_object_key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def make_layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([100, 2, 512])],
+        dtypes=[torch.bfloat16],
+    )
+
+
+def make_adapter() -> MockL2Adapter:
+    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+    return MockL2Adapter(config)
+
+
+def make_descriptor(index: int) -> AdapterDescriptor:
+    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+    return AdapterDescriptor(index=index, config=config)
+
+
+def wait_for_condition(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def write_keys_to_l1(
+    l1_manager: L1Manager,
+    keys: list[ObjectKey],
+    layout: MemoryLayoutDesc,
+) -> list[ObjectKey]:
+    results = l1_manager.reserve_write(
+        keys=keys,
+        is_temporary=[False] * len(keys),
+        layout_desc=layout,
+        mode="new",
+    )
+    written = [k for k, (e, m) in results.items() if m is not None]
+    if written:
+        l1_manager.finish_write(written)
+    return written
+
+
+def store_keys_in_l2(
+    adapter: MockL2Adapter,
+    keys: list[ObjectKey],
+    layout: MemoryLayoutDesc,
+) -> None:
+    """Push test data into L2 directly so subsequent prefetches hit."""
+    if not keys:
+        return
+    objs = []
+    for _ in keys:
+        tensor = torch.randn(layout.shapes[0], dtype=layout.dtypes[0])
+        metadata = MemoryObjMetadata(
+            shape=layout.shapes[0],
+            dtype=layout.dtypes[0],
+            address=0,
+            phy_size=tensor.nelement() * tensor.element_size(),
+            ref_count=0,
+        )
+        obj = TensorMemoryObj(raw_data=tensor, metadata=metadata, parent_allocator=None)
+        objs.append(obj)
+    adapter.submit_store_task(keys, objs)  # type: ignore[arg-type]
+    assert wait_for_condition(
+        lambda: all(adapter.debug_has_key(k) for k in keys),
+    ), "Failed to seed L2 with test data"
+
+
+def _read_points_by_attrs() -> dict[str, dict[tuple, float]]:
+    """Snapshot all sum/gauge data points from the shared reader.
+
+    Returns ``{metric_name: {sorted_attrs_tuple: value}}``.  Histogram
+    points are skipped (they don't have ``.value``).
+    """
+    data = _reader.get_metrics_data()
+    result: dict[str, dict[tuple, float]] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue
+                    key = tuple(sorted(dict(dp.attributes).items()))
+                    result.setdefault(metric.name, {})[key] = dp.value
+    return result
+
+
+def _value_for(metric: str, attrs: dict | None = None) -> float:
+    """Look up the current value of ``metric`` for the exact attribute set."""
+    snapshot = _read_points_by_attrs().get(metric, {})
+    key = tuple(sorted((attrs or {}).items()))
+    return snapshot.get(key, 0)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def l1_manager():
+    config = L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(
+            size_in_bytes=128 * 1024 * 1024,
+            use_lazy=True,
+            init_size_in_bytes=64 * 1024 * 1024,
+            align_bytes=0x1000,
+        ),
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+    mgr = L1Manager(config)
+    yield mgr
+    mgr.close()
+
+
+# =============================================================================
+# L1 memory usage gauge
+# =============================================================================
+
+
+class TestL1MemoryUsageGauge:
+    """``lmcache_mp.l1_memory_usage_bytes`` reports current L1 usage."""
+
+    def test_gauge_reports_zero_initially(self, l1_manager):
+        # A fresh L1 with no writes should report 0 used bytes.
+        before = _value_for("lmcache_mp.l1_memory_usage_bytes")
+        assert before == 0
+
+    def test_gauge_grows_after_writes(self, l1_manager):
+        before = _value_for("lmcache_mp.l1_memory_usage_bytes")
+
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        after = _value_for("lmcache_mp.l1_memory_usage_bytes")
+        assert after > before, "Gauge should reflect bytes written to L1"
+
+
+# =============================================================================
+# StoreController in-flight counter
+# =============================================================================
+
+
+class TestNumInflightL2Stores:
+    """``lmcache_mp.num_inflight_l2_stores`` per (l2_name, adapter_index)."""
+
+    def test_counter_balances_to_zero_after_store_cycle(self, l1_manager):
+        adapter = make_adapter()
+        adapter_index = 0
+        attrs = {"l2_name": "mock", "adapter_index": adapter_index}
+
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(adapter_index)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+
+        before = _value_for("lmcache_mp.num_inflight_l2_stores", attrs)
+
+        layout = make_layout()
+        keys = [make_object_key(100 + i) for i in range(2)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        # Every store must complete and decrement back to the baseline.
+        assert wait_for_condition(lambda: adapter.debug_get_stored_object_count() == 2)
+        assert wait_for_condition(
+            lambda: _value_for("lmcache_mp.num_inflight_l2_stores", attrs) == before
+        )
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_counter_uses_per_adapter_attribution(self, l1_manager):
+        # Two adapters of the same backend type get distinct datapoints
+        # via adapter_index; their counters return to zero independently.
+        adapters = [make_adapter(), make_adapter()]
+        descriptors = [make_descriptor(0), make_descriptor(1)]
+        attrs0 = {"l2_name": "mock", "adapter_index": 0}
+        attrs1 = {"l2_name": "mock", "adapter_index": 1}
+
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=adapters,  # type: ignore[arg-type]
+            adapter_descriptors=descriptors,
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+
+        before0 = _value_for("lmcache_mp.num_inflight_l2_stores", attrs0)
+        before1 = _value_for("lmcache_mp.num_inflight_l2_stores", attrs1)
+
+        layout = make_layout()
+        keys = [make_object_key(200 + i) for i in range(3)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        # Both adapters should have stored every key (DefaultStorePolicy
+        # writes to all) and counters should return to baseline.
+        assert wait_for_condition(
+            lambda: adapters[0].debug_get_stored_object_count() == 3
+            and adapters[1].debug_get_stored_object_count() == 3
+        )
+        assert wait_for_condition(
+            lambda: (
+                _value_for("lmcache_mp.num_inflight_l2_stores", attrs0) == before0
+                and _value_for("lmcache_mp.num_inflight_l2_stores", attrs1) == before1
+            )
+        )
+
+        ctrl.stop()
+        for a in adapters:
+            a.close()
+
+
+# =============================================================================
+# PrefetchController in-flight counters
+# =============================================================================
+
+
+class TestNumInflightL2Loads:
+    """``num_inflight_l2_loads`` and ``inflight_load_memory_usage_bytes``
+    return to baseline after a successful prefetch cycle."""
+
+    def test_load_counters_balance_to_zero(self, l1_manager):
+        adapter = make_adapter()
+        adapter_index = 0
+        attrs = {"l2_name": "mock", "adapter_index": adapter_index}
+        layout = make_layout()
+        keys = [make_object_key(300 + i) for i in range(4)]
+
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(adapter_index)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        before_loads = _value_for("lmcache_mp.num_inflight_l2_loads", attrs)
+        before_bytes = _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+
+        # Wait for the request to fully resolve, then the counters should
+        # come back to where they started.
+        assert wait_for_condition(
+            lambda: ctrl.query_prefetch_result(req_id) is not None
+        )
+        assert wait_for_condition(
+            lambda: (
+                _value_for("lmcache_mp.num_inflight_l2_loads", attrs) == before_loads
+                and _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)
+                == before_bytes
+            )
+        )
+
+        # Release any read locks so teardown is clean.
+        l1_manager.finish_read(keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_cleanup_decrements_counters_on_shutdown(self, l1_manager):
+        # If the controller is stopped with in-flight loads, _cleanup
+        # must decrement the counters so they return to baseline.
+        adapter = make_adapter()
+        # Use an absurdly slow mock bandwidth so the load is still
+        # in-flight when we stop().
+        adapter._config.mock_bandwidth_gb = 0.0001  # type: ignore[attr-defined]
+        adapter_index = 0
+        attrs = {"l2_name": "mock", "adapter_index": adapter_index}
+        layout = make_layout()
+        keys = [make_object_key(400 + i) for i in range(4)]
+
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(adapter_index)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        before_loads = _value_for("lmcache_mp.num_inflight_l2_loads", attrs)
+        before_bytes = _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)
+
+        ctrl.submit_prefetch_request(keys, layout)
+        # Don't wait for completion; stop() should clean up regardless.
+        ctrl.stop()
+
+        # After cleanup the counters must be back at baseline.
+        assert _value_for("lmcache_mp.num_inflight_l2_loads", attrs) == before_loads
+        assert (
+            _value_for("lmcache_mp.inflight_load_memory_usage_bytes", attrs)
+            == before_bytes
+        )
+
+        adapter.close()


### PR DESCRIPTION
Adds four metrics that surface live capacity and queue state for the MP cache server, addressing the operator/customer ask for visibility beyond per-event counters.

- lmcache_mp.l1_memory_usage_bytes (ObservableGauge): bytes currently held in L1.  Registered once via a class-level singleton guard so multi-instance test contexts don't stack stale callbacks.
- lmcache_mp.num_inflight_l2_stores (UpDownCounter, l2_name + adapter_index): in-flight L2 store tasks per adapter.
- lmcache_mp.num_inflight_l2_loads (UpDownCounter, l2_name + adapter_index): in-flight L2->L1 prefetch loads per adapter.
- lmcache_mp.inflight_load_memory_usage_bytes (UpDownCounter, l2_name + adapter_index): L1 bytes reserved by in-flight prefetches per adapter.

Per-adapter byte attribution uses the request's load_plan bitmap (each byte attributed to exactly one adapter, no double counting).  A new load_bytes_by_adapter field on InFlightPrefetchRequest mirrors pending_load_tasks so the decrement always matches the increment, even when loads partially fail.  Cleanup paths in both controllers decrement explicitly so counters return to baseline at server shutdown.

Adds integration tests under tests/v1/distributed/ exercising the full balance, per-adapter attribution, and shutdown-cleanup paths via InMemoryMetricReader.  Updates docs/design/v1/mp_observability/METRICS.md with a new "L1 / L2 State Metrics" section.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core L1/L2 controller code paths and adds cross-thread metric callbacks; while behavior is additive, incorrect snapshots/accounting could impact performance or observability accuracy under load.
> 
> **Overview**
> Adds **four new MP-mode state metrics** as OTel `ObservableGauge`s to expose live cache capacity and backpressure: `lmcache_mp.l1_memory_usage_bytes`, `lmcache_mp.num_inflight_l2_stores`, `lmcache_mp.num_inflight_l2_loads`, and `lmcache_mp.inflight_load_memory_usage_bytes` (the latter three tagged by `l2_name` + `adapter_index`).
> 
> Implements gauge registration + per-adapter observation callbacks in `L1Manager`, `StoreController`, and `PrefetchController`, including singleton-style dispatch to avoid stale callbacks in tests and per-adapter byte accounting for in-flight prefetch loads. Updates `register_gauge` to support callbacks returning multiple attributed observations, adds integration tests using an in-process `InMemoryMetricReader`, and documents the new metrics in both the design doc and MP observability docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b42598e32c76b85299f4333a3c2303286ad0c9ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->