### PR TITLE
[MP]: Add batch operations and per-op worker pools to Mooncake L2 adapter  

### DIFF
--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -7,11 +7,14 @@
 #include <unistd.h>
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <condition_variable>
+#include <cstdio>
 #include <mutex>
 #include <queue>
 #include <stdexcept>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 namespace lmcache {
@@ -260,6 +263,47 @@ class ConnectorBase : public IStorageConnector {
     (void)key;
     return false;  // no-op default for backward compat with plugins
   }
+  virtual size_t choose_num_tiles(Op op, size_t num_items) const {
+    (void)op;
+    return std::min<size_t>(num_workers_, num_items);
+  }
+  virtual void do_batch_get(ConnectionType& conn, const Request& req) {
+    for (size_t i = 0; i < req.keys.size(); ++i) {
+      try {
+        do_single_get(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+                      req.batch_chunk_num_bytes);
+        req.batch->per_key_results[req.start_idx + i] = 1;
+      } catch (const std::exception& e) {
+        req.batch->per_key_results[req.start_idx + i] = 0;
+        fprintf(stderr, "[LMCache GET] key %s failed: %s\n",
+                req.keys[i].c_str(), e.what());
+      }
+    }
+  }
+  virtual void do_batch_set(ConnectionType& conn, const Request& req) {
+    for (size_t i = 0; i < req.keys.size(); ++i) {
+      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+                    req.batch_chunk_num_bytes);
+    }
+  }
+  virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+    for (size_t i = 0; i < req.keys.size(); ++i) {
+      bool exists = do_single_exists(conn, req.keys[i]);
+      req.batch->per_key_results[req.start_idx + i] = exists ? 1 : 0;
+    }
+  }
+  virtual void do_batch_delete(ConnectionType& conn, const Request& req) {
+    for (size_t i = 0; i < req.keys.size(); ++i) {
+      try {
+        bool deleted = do_single_delete(conn, req.keys[i]);
+        req.batch->per_key_results[req.start_idx + i] = deleted ? 1 : 0;
+      } catch (const std::exception& e) {
+        req.batch->per_key_results[req.start_idx + i] = 0;
+        fprintf(stderr, "[LMCache DELETE] key %s failed: %s\n",
+                req.keys[i].c_str(), e.what());
+      }
+    }
+  }
   virtual void shutdown_connections() {}
   virtual void on_workers_stopped() {}
 
@@ -280,9 +324,11 @@ class ConnectorBase : public IStorageConnector {
   // returns: (batch_future_id, batch_state, num_tiles, tile_size)
   std::tuple<uint64_t, std::shared_ptr<BatchState>, size_t, size_t>
   prepare_batch_operation(size_t num_items, Op op) {
-    // divide work evenly between workers into tiles
-    size_t num_tiles =
-        std::min<size_t>(num_workers_, num_items);  // avoid empty tiles
+    size_t num_tiles = choose_num_tiles(op, num_items);
+    if (num_tiles == 0 || num_tiles > num_items) {
+      throw std::runtime_error(
+          "choose_num_tiles must return a value in [1, num_items]");
+    }
     size_t tile_size = (num_items + num_tiles - 1) / num_tiles;  // round up
 
     // create shared batch state
@@ -405,54 +451,22 @@ class ConnectorBase : public IStorageConnector {
         try {
           switch (req.op) {
             case Op::BATCH_TILE_GET:
-              for (size_t i = 0; i < req.keys.size(); ++i) {
-                try {
-                  do_single_get(conn, req.keys[i], req.buf_ptrs[i],
-                                req.buf_lens[i], req.batch_chunk_num_bytes);
-                  // 1 = success (key loaded OK)
-                  req.batch->per_key_results[req.start_idx + i] = 1;
-                } catch (const std::exception& e) {
-                  // Per-key error tolerance: record failure
-                  // but continue processing remaining keys
-                  req.batch->per_key_results[req.start_idx + i] = 0;
-                  fprintf(stderr, "[LMCache GET] key %s failed: %s\n",
-                          req.keys[i].c_str(), e.what());
-                }
-              }
+              do_batch_get(conn, req);
               comp.ok = true;
               break;
 
             case Op::BATCH_TILE_SET:
-              for (size_t i = 0; i < req.keys.size(); ++i) {
-                do_single_set(conn, req.keys[i], req.buf_ptrs[i],
-                              req.buf_lens[i], req.batch_chunk_num_bytes);
-              }
+              do_batch_set(conn, req);
               comp.ok = true;
               break;
 
             case Op::BATCH_TILE_EXISTS:
-              for (size_t i = 0; i < req.keys.size(); ++i) {
-                bool exists = do_single_exists(conn, req.keys[i]);
-                // Write result as uint8_t (0/1) to avoid vector<bool> data race
-                req.batch->per_key_results[req.start_idx + i] = exists ? 1 : 0;
-              }
+              do_batch_exists(conn, req);
               comp.ok = true;
               break;
 
             case Op::BATCH_TILE_DELETE:
-              for (size_t i = 0; i < req.keys.size(); ++i) {
-                try {
-                  bool deleted = do_single_delete(conn, req.keys[i]);
-                  req.batch->per_key_results[req.start_idx + i] =
-                      deleted ? 1 : 0;
-                } catch (const std::exception& e) {
-                  // Per-key error tolerance: record failure
-                  // but continue processing remaining keys
-                  req.batch->per_key_results[req.start_idx + i] = 0;
-                  fprintf(stderr, "[LMCache DELETE] key %s failed: %s\n",
-                          req.keys[i].c_str(), e.what());
-                }
-              }
+              do_batch_delete(conn, req);
               comp.ok = true;
               break;
           }

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -20,6 +20,13 @@
 namespace lmcache {
 namespace connector {
 
+struct WorkerPoolConfig {
+  bool enable_separate_pools{false};
+  int lookup_workers{0};
+  int retrieve_workers{0};
+  int store_workers{0};
+};
+
 /*
 this base needs to have at least four methods be overridden by the derived
 class:
@@ -37,9 +44,20 @@ for an example
 template <typename ConnectionType>
 class ConnectorBase : public IStorageConnector {
  public:
-  ConnectorBase(int num_workers) : num_workers_(num_workers) {
+  ConnectorBase(int num_workers)
+      : ConnectorBase(num_workers, WorkerPoolConfig{}) {}
+
+  ConnectorBase(int num_workers, WorkerPoolConfig worker_pool_config)
+      : num_workers_(num_workers), worker_pool_config_(worker_pool_config) {
     if (num_workers_ <= 0) {
       throw std::runtime_error("num_workers must be > 0");
+    }
+    if (worker_pool_config_.enable_separate_pools &&
+        (worker_pool_config_.lookup_workers <= 0 ||
+         worker_pool_config_.retrieve_workers <= 0 ||
+         worker_pool_config_.store_workers <= 0)) {
+      throw std::runtime_error(
+          "separate worker pools require positive worker counts");
     }
 
     // create eventfd for async notification
@@ -91,6 +109,9 @@ class ConnectorBase : public IStorageConnector {
     size_t num_items = keys.size();
     auto [batch_future_id, batch_state, num_tiles, tile_size] =
         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+
+    // pre-allocate per-key results for error tolerance
+    batch_state->per_key_results.assign(num_items, 0);
 
     // fan out work to threads
     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
@@ -206,6 +227,11 @@ class ConnectorBase : public IStorageConnector {
     // Signal all worker threads to stop
     stop_.store(true, std::memory_order_release);
     req_cv_.notify_all();
+    if (worker_pool_config_.enable_separate_pools) {
+      lookup_lane_.cv.notify_all();
+      retrieve_lane_.cv.notify_all();
+      store_lane_.cv.notify_all();
+    }
 
     // Shutdown all connections (derived class specific)
     shutdown_connections();
@@ -215,6 +241,11 @@ class ConnectorBase : public IStorageConnector {
       if (worker.joinable()) {
         worker.join();
       }
+    }
+    if (worker_pool_config_.enable_separate_pools) {
+      join_lane_workers(lookup_lane_);
+      join_lane_workers(retrieve_lane_);
+      join_lane_workers(store_lane_);
     }
 
     // Derived cleanup that must only run after workers have stopped.
@@ -233,6 +264,11 @@ class ConnectorBase : public IStorageConnector {
         requests_.pop();
       }
     }
+    if (worker_pool_config_.enable_separate_pools) {
+      clear_lane_queue(lookup_lane_);
+      clear_lane_queue(retrieve_lane_);
+      clear_lane_queue(store_lane_);
+    }
     {
       std::lock_guard<std::mutex> lk(comp_mu_);
       while (!completions_.empty()) {
@@ -244,6 +280,13 @@ class ConnectorBase : public IStorageConnector {
  protected:
   // call this at the END of your derived class constructor
   void start_workers() {
+    if (worker_pool_config_.enable_separate_pools) {
+      start_lane_workers(lookup_lane_, worker_pool_config_.lookup_workers);
+      start_lane_workers(retrieve_lane_, worker_pool_config_.retrieve_workers);
+      start_lane_workers(store_lane_, worker_pool_config_.store_workers);
+      return;
+    }
+
     workers_.reserve(static_cast<size_t>(num_workers_));
     for (int i = 0; i < num_workers_; i++) {
       workers_.emplace_back([this]() { this->worker_loop(); });
@@ -264,8 +307,7 @@ class ConnectorBase : public IStorageConnector {
     return false;  // no-op default for backward compat with plugins
   }
   virtual size_t choose_num_tiles(Op op, size_t num_items) const {
-    (void)op;
-    return std::min<size_t>(num_workers_, num_items);
+    return std::min<size_t>(worker_count_for_op(op), num_items);
   }
   virtual void do_batch_get(ConnectionType& conn, const Request& req) {
     for (size_t i = 0; i < req.keys.size(); ++i) {
@@ -282,8 +324,16 @@ class ConnectorBase : public IStorageConnector {
   }
   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
     for (size_t i = 0; i < req.keys.size(); ++i) {
-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
-                    req.batch_chunk_num_bytes);
+      try {
+        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+                      req.batch_chunk_num_bytes);
+        req.batch->per_key_results[req.start_idx + i] = 1;
+      } catch (const std::exception& e) {
+        req.batch->per_key_results[req.start_idx + i] = 0;
+        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
+                req.keys[i].c_str(), e.what());
+        req.batch->any_failed.store(true, std::memory_order_relaxed);
+      }
     }
   }
   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
@@ -309,7 +359,30 @@ class ConnectorBase : public IStorageConnector {
 
   bool is_stopping() const { return stop_.load(std::memory_order_acquire); }
 
+  int worker_count_for_op(Op op) const {
+    if (!worker_pool_config_.enable_separate_pools) {
+      return num_workers_;
+    }
+    switch (op) {
+      case Op::BATCH_TILE_EXISTS:
+        return worker_pool_config_.lookup_workers;
+      case Op::BATCH_TILE_GET:
+        return worker_pool_config_.retrieve_workers;
+      case Op::BATCH_TILE_SET:
+      case Op::BATCH_TILE_DELETE:
+        return worker_pool_config_.store_workers;
+    }
+    return num_workers_;
+  }
+
  private:
+  struct WorkerLane {
+    std::mutex mu;
+    std::condition_variable cv;
+    std::queue<Request> requests;
+    std::vector<std::thread> workers;
+  };
+
   void validate_batch_inputs(const std::vector<std::string>& keys,
                              const std::vector<void*>& bufs,
                              const std::vector<size_t>& lens) {
@@ -368,6 +441,16 @@ class ConnectorBase : public IStorageConnector {
   }
 
   void enqueue_request(Request&& req) {
+    if (worker_pool_config_.enable_separate_pools) {
+      WorkerLane& lane = lane_for_op(req.op);
+      {
+        std::lock_guard<std::mutex> lk(lane.mu);
+        lane.requests.push(std::move(req));
+      }
+      lane.cv.notify_one();
+      return;
+    }
+
     {
       std::lock_guard<std::mutex> lk(req_mu_);
       requests_.push(std::move(req));
@@ -423,7 +506,51 @@ class ConnectorBase : public IStorageConnector {
     }
   }
 
-  void worker_loop() {
+  WorkerLane& lane_for_op(Op op) {
+    switch (op) {
+      case Op::BATCH_TILE_EXISTS:
+        return lookup_lane_;
+      case Op::BATCH_TILE_GET:
+        return retrieve_lane_;
+      case Op::BATCH_TILE_SET:
+      case Op::BATCH_TILE_DELETE:
+        return store_lane_;
+      default:
+        throw std::runtime_error("invalid Op type");
+    }
+  }
+
+  void start_lane_workers(WorkerLane& lane, int num_workers) {
+    lane.workers.reserve(static_cast<size_t>(num_workers));
+    WorkerLane* lane_ptr = &lane;
+    for (int i = 0; i < num_workers; i++) {
+      lane.workers.emplace_back([this, lane_ptr]() {
+        this->worker_loop_for_queue(lane_ptr->mu, lane_ptr->cv,
+                                    lane_ptr->requests);
+      });
+    }
+  }
+
+  void join_lane_workers(WorkerLane& lane) {
+    for (auto& worker : lane.workers) {
+      if (worker.joinable()) {
+        worker.join();
+      }
+    }
+  }
+
+  void clear_lane_queue(WorkerLane& lane) {
+    std::lock_guard<std::mutex> lk(lane.mu);
+    while (!lane.requests.empty()) {
+      lane.requests.pop();
+    }
+  }
+
+  void worker_loop() { worker_loop_for_queue(req_mu_, req_cv_, requests_); }
+
+  void worker_loop_for_queue(std::mutex& req_mu,
+                             std::condition_variable& req_cv,
+                             std::queue<Request>& requests) {
     try {
       // create connection (derived class specific)
       ConnectionType conn = create_connection();
@@ -433,15 +560,15 @@ class ConnectorBase : public IStorageConnector {
 
         // 1. grab a request from the submission queue
         {
-          std::unique_lock<std::mutex> lk(req_mu_);
-          req_cv_.wait(lk, [&] {
-            return stop_.load(std::memory_order_acquire) || !requests_.empty();
+          std::unique_lock<std::mutex> lk(req_mu);
+          req_cv.wait(lk, [&] {
+            return stop_.load(std::memory_order_acquire) || !requests.empty();
           });
-          if (stop_.load(std::memory_order_acquire) && requests_.empty()) {
+          if (stop_.load(std::memory_order_acquire) && requests.empty()) {
             break;  // exit loop
           }
-          req = std::move(requests_.front());
-          requests_.pop();
+          req = std::move(requests.front());
+          requests.pop();
         }
 
         Completion comp;
@@ -515,6 +642,7 @@ class ConnectorBase : public IStorageConnector {
       // for batch exists and batch get, move per-key results
       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
           req.batch->batch_op == Op::BATCH_TILE_GET ||
+          req.batch->batch_op == Op::BATCH_TILE_SET ||
           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
         batch_comp.result_bytes = std::move(req.batch->per_key_results);
       }
@@ -524,6 +652,7 @@ class ConnectorBase : public IStorageConnector {
 
  protected:
   int num_workers_;
+  WorkerPoolConfig worker_pool_config_;
 
   std::atomic<bool> stop_{false};
   std::atomic<bool> closed_{false};
@@ -547,6 +676,9 @@ class ConnectorBase : public IStorageConnector {
   std::queue<Completion> completions_;
 
   std::vector<std::thread> workers_;
+  WorkerLane lookup_lane_;
+  WorkerLane retrieve_lane_;
+  WorkerLane store_lane_;
 };
 
 }  // namespace connector

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -110,9 +110,6 @@ class ConnectorBase : public IStorageConnector {
     auto [batch_future_id, batch_state, num_tiles, tile_size] =
         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
 
-    // pre-allocate per-key results for error tolerance
-    batch_state->per_key_results.assign(num_items, 0);
-
     // fan out work to threads
     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
       auto tile_req = create_tile_request(
@@ -319,35 +316,19 @@ class ConnectorBase : public IStorageConnector {
         req.batch->per_key_results[req.start_idx + i] = 0;
         fprintf(stderr, "[LMCache GET] key %s failed: %s\n",
                 req.keys[i].c_str(), e.what());
-        req.batch->any_failed.store(true, std::memory_order_relaxed);
       }
     }
   }
   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
     for (size_t i = 0; i < req.keys.size(); ++i) {
-      try {
-        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
-                      req.batch_chunk_num_bytes);
-        req.batch->per_key_results[req.start_idx + i] = 1;
-      } catch (const std::exception& e) {
-        req.batch->per_key_results[req.start_idx + i] = 0;
-        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
-                req.keys[i].c_str(), e.what());
-        req.batch->any_failed.store(true, std::memory_order_relaxed);
-      }
+      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+                    req.batch_chunk_num_bytes);
     }
   }
   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
     for (size_t i = 0; i < req.keys.size(); ++i) {
-      try {
-        bool exists = do_single_exists(conn, req.keys[i]);
-        req.batch->per_key_results[req.start_idx + i] = exists ? 1 : 0;
-      } catch (const std::exception& e) {
-        req.batch->per_key_results[req.start_idx + i] = 0;
-        fprintf(stderr, "[LMCache EXISTS] key %s failed: %s\n",
-                req.keys[i].c_str(), e.what());
-        req.batch->any_failed.store(true, std::memory_order_relaxed);
-      }
+      bool exists = do_single_exists(conn, req.keys[i]);
+      req.batch->per_key_results[req.start_idx + i] = exists ? 1 : 0;
     }
   }
   virtual void do_batch_delete(ConnectionType& conn, const Request& req) {
@@ -359,7 +340,6 @@ class ConnectorBase : public IStorageConnector {
         req.batch->per_key_results[req.start_idx + i] = 0;
         fprintf(stderr, "[LMCache DELETE] key %s failed: %s\n",
                 req.keys[i].c_str(), e.what());
-        req.batch->any_failed.store(true, std::memory_order_relaxed);
       }
     }
   }

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -319,6 +319,7 @@ class ConnectorBase : public IStorageConnector {
         req.batch->per_key_results[req.start_idx + i] = 0;
         fprintf(stderr, "[LMCache GET] key %s failed: %s\n",
                 req.keys[i].c_str(), e.what());
+        req.batch->any_failed.store(true, std::memory_order_relaxed);
       }
     }
   }
@@ -351,6 +352,7 @@ class ConnectorBase : public IStorageConnector {
         req.batch->per_key_results[req.start_idx + i] = 0;
         fprintf(stderr, "[LMCache DELETE] key %s failed: %s\n",
                 req.keys[i].c_str(), e.what());
+        req.batch->any_failed.store(true, std::memory_order_relaxed);
       }
     }
   }

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -631,7 +631,6 @@ class ConnectorBase : public IStorageConnector {
       // for batch exists and batch get, move per-key results
       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
           req.batch->batch_op == Op::BATCH_TILE_GET ||
-          req.batch->batch_op == Op::BATCH_TILE_SET ||
           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
         batch_comp.result_bytes = std::move(req.batch->per_key_results);
       }

--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -339,8 +339,15 @@ class ConnectorBase : public IStorageConnector {
   }
   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
     for (size_t i = 0; i < req.keys.size(); ++i) {
-      bool exists = do_single_exists(conn, req.keys[i]);
-      req.batch->per_key_results[req.start_idx + i] = exists ? 1 : 0;
+      try {
+        bool exists = do_single_exists(conn, req.keys[i]);
+        req.batch->per_key_results[req.start_idx + i] = exists ? 1 : 0;
+      } catch (const std::exception& e) {
+        req.batch->per_key_results[req.start_idx + i] = 0;
+        fprintf(stderr, "[LMCache EXISTS] key %s failed: %s\n",
+                req.keys[i].c_str(), e.what());
+        req.batch->any_failed.store(true, std::memory_order_relaxed);
+      }
     }
   }
   virtual void do_batch_delete(ConnectionType& conn, const Request& req) {

--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -105,7 +105,7 @@ void MooncakeConnector::do_single_get(WorkerMooncakeConn& conn,
   (void)chunk_size;
   ensure_registered(buf, len);
   int64_t bytes_read = conn.client->get_into(key, buf, len);
-  if (bytes_read < 0) {
+  if (bytes_read <= 0) {
     throw std::runtime_error("Mooncake get_into failed for key: " + key);
   }
 }
@@ -152,7 +152,7 @@ void MooncakeConnector::do_batch_get(WorkerMooncakeConn& conn,
   ensure_batch_result_size(results, req.keys.size(), "batch_get_into");
 
   for (size_t i = 0; i < results.size(); ++i) {
-    if (results[i] < 0) {
+    if (results[i] <= 0) {
       req.batch->per_key_results[req.start_idx + i] = 0;
       fprintf(stderr,
               "[LMCache GET] key %s failed: Mooncake batch_get_into "

--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -143,8 +143,16 @@ size_t MooncakeConnector::choose_num_tiles(Op op, size_t num_items) const {
 
 void MooncakeConnector::do_batch_get(WorkerMooncakeConn& conn,
                                      const Request& req) {
+  // Keep GET tolerant at per-key granularity: registration failures should
+  // only zero that key. Keep the no-failure path on Mooncake's batch API, and
+  // fall back to ConnectorBase's singleton-style handling on error.
   for (size_t i = 0; i < req.buf_ptrs.size(); ++i) {
-    ensure_registered(req.buf_ptrs[i], req.buf_lens[i]);
+    try {
+      ensure_registered(req.buf_ptrs[i], req.buf_lens[i]);
+    } catch (const std::exception&) {
+      ConnectorBase<WorkerMooncakeConn>::do_batch_get(conn, req);
+      return;
+    }
   }
 
   auto results =
@@ -182,7 +190,6 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
               req.keys[i].c_str(), static_cast<long long>(results[i]));
       throw std::runtime_error("Mooncake batch_put_from failed for key: " +
                                req.keys[i]);
-      continue;
     }
   }
 }
@@ -201,7 +208,6 @@ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
               req.keys[i].c_str(), static_cast<long long>(results[i]));
       throw std::runtime_error("Mooncake batchIsExist failed for key: " +
                                req.keys[i]);
-      continue;
     }
     req.batch->per_key_results[req.start_idx + i] = results[i] == 1 ? 1 : 0;
   }

--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -17,6 +17,21 @@
 namespace lmcache {
 namespace connector {
 
+namespace {
+
+template <typename T>
+void ensure_batch_result_size(const std::vector<T>& results, size_t expected,
+                              const char* op_name) {
+  if (results.size() != expected) {
+    throw std::runtime_error(std::string("Mooncake ") + op_name +
+                             " returned " + std::to_string(results.size()) +
+                             " results for " + std::to_string(expected) +
+                             " keys");
+  }
+}
+
+}  // namespace
+
 MooncakeConnector::MooncakeConnector(ConfigDict config, int num_workers,
                                      L1RegistrationConfig l1_registration)
     : ConnectorBase(num_workers),
@@ -88,7 +103,67 @@ bool MooncakeConnector::do_single_exists(WorkerMooncakeConn& conn,
   return result == 1;
 }
 
-void MooncakeConnector::on_workers_stopped() { unregister_all_buffers(); }
+size_t MooncakeConnector::choose_num_tiles(Op op, size_t num_items) const {
+  (void)op;
+  (void)num_items;
+  return 1;
+}
+
+void MooncakeConnector::do_batch_get(WorkerMooncakeConn& conn,
+                                     const Request& req) {
+  for (size_t i = 0; i < req.buf_ptrs.size(); ++i) {
+    ensure_registered(req.buf_ptrs[i], req.buf_lens[i]);
+  }
+
+  auto results =
+      conn.client->batch_get_into(req.keys, req.buf_ptrs, req.buf_lens);
+  ensure_batch_result_size(results, req.keys.size(), "batch_get_into");
+
+  for (size_t i = 0; i < results.size(); ++i) {
+    if (results[i] < 0) {
+      req.batch->per_key_results[req.start_idx + i] = 0;
+      fprintf(stderr,
+              "[LMCache GET] key %s failed: Mooncake batch_get_into "
+              "returned %lld\n",
+              req.keys[i].c_str(), static_cast<long long>(results[i]));
+      continue;
+    }
+    req.batch->per_key_results[req.start_idx + i] = 1;
+  }
+}
+
+void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+                                     const Request& req) {
+  for (size_t i = 0; i < req.buf_ptrs.size(); ++i) {
+    ensure_registered(req.buf_ptrs[i], req.buf_lens[i]);
+  }
+
+  auto results = conn.client->batch_put_from(req.keys, req.buf_ptrs,
+                                             req.buf_lens);
+  ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+
+  for (size_t i = 0; i < results.size(); ++i) {
+    if (results[i] != 0) {
+      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+                               req.keys[i]);
+    }
+  }
+}
+
+void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+                                        const Request& req) {
+  auto results = conn.client->batchIsExist(req.keys);
+  ensure_batch_result_size(results, req.keys.size(), "batchIsExist");
+
+  for (size_t i = 0; i < results.size(); ++i) {
+    if (results[i] < 0) {
+      throw std::runtime_error("Mooncake batchIsExist failed for key: " +
+                               req.keys[i]);
+    }
+    req.batch->per_key_results[req.start_idx + i] =
+        results[i] == 1 ? 1 : 0;
+  }
+}
 
 void MooncakeConnector::ensure_registered(const void* buf, size_t len) {
   if (!l1_registration_.is_valid()) {

--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -158,7 +158,6 @@ void MooncakeConnector::do_batch_get(WorkerMooncakeConn& conn,
               "[LMCache GET] key %s failed: Mooncake batch_get_into "
               "returned %lld\n",
               req.keys[i].c_str(), static_cast<long long>(results[i]));
-      req.batch->any_failed.store(true, std::memory_order_relaxed);
       continue;
     }
     req.batch->per_key_results[req.start_idx + i] = 1;
@@ -177,15 +176,14 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
 
   for (size_t i = 0; i < results.size(); ++i) {
     if (results[i] != 0) {
-      req.batch->per_key_results[req.start_idx + i] = 0;
       fprintf(stderr,
               "[LMCache SET] key %s failed: Mooncake batch_put_from "
               "returned %lld\n",
               req.keys[i].c_str(), static_cast<long long>(results[i]));
-      req.batch->any_failed.store(true, std::memory_order_relaxed);
+      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+                               req.keys[i]);
       continue;
     }
-    req.batch->per_key_results[req.start_idx + i] = 1;
   }
 }
 
@@ -201,7 +199,8 @@ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
               "[LMCache EXISTS] key %s failed: Mooncake batchIsExist "
               "returned %lld\n",
               req.keys[i].c_str(), static_cast<long long>(results[i]));
-      req.batch->any_failed.store(true, std::memory_order_relaxed);
+      throw std::runtime_error("Mooncake batchIsExist failed for key: " +
+                               req.keys[i]);
       continue;
     }
     req.batch->per_key_results[req.start_idx + i] = results[i] == 1 ? 1 : 0;

--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -23,18 +23,46 @@ template <typename T>
 void ensure_batch_result_size(const std::vector<T>& results, size_t expected,
                               const char* op_name) {
   if (results.size() != expected) {
-    throw std::runtime_error(std::string("Mooncake ") + op_name +
-                             " returned " + std::to_string(results.size()) +
-                             " results for " + std::to_string(expected) +
-                             " keys");
+    throw std::runtime_error(std::string("Mooncake ") + op_name + " returned " +
+                             std::to_string(results.size()) + " results for " +
+                             std::to_string(expected) + " keys");
   }
+}
+
+WorkerPoolConfig make_worker_pool_config(int lookup_workers,
+                                         int retrieve_workers,
+                                         int store_workers) {
+  const bool enable_separate_pools =
+      lookup_workers != 0 || retrieve_workers != 0 || store_workers != 0;
+  if (!enable_separate_pools) {
+    return WorkerPoolConfig{};
+  }
+  if (lookup_workers < 0 || retrieve_workers < 0 || store_workers < 0) {
+    throw std::runtime_error("Mooncake worker counts must be positive");
+  }
+  if (lookup_workers == 0 || retrieve_workers == 0 || store_workers == 0) {
+    throw std::runtime_error(
+        "lookup_workers, retrieve_workers, and store_workers must all be set "
+        "together");
+  }
+
+  WorkerPoolConfig config;
+  config.enable_separate_pools = true;
+  config.lookup_workers = lookup_workers;
+  config.retrieve_workers = retrieve_workers;
+  config.store_workers = store_workers;
+  return config;
 }
 
 }  // namespace
 
 MooncakeConnector::MooncakeConnector(ConfigDict config, int num_workers,
-                                     L1RegistrationConfig l1_registration)
-    : ConnectorBase(num_workers),
+                                     L1RegistrationConfig l1_registration,
+                                     int lookup_workers, int retrieve_workers,
+                                     int store_workers)
+    : ConnectorBase(num_workers,
+                    make_worker_pool_config(lookup_workers, retrieve_workers,
+                                            store_workers)),
       config_(std::move(config)),
       l1_registration_(l1_registration) {
   // Create a RealClient via the static factory.
@@ -103,9 +131,13 @@ bool MooncakeConnector::do_single_exists(WorkerMooncakeConn& conn,
   return result == 1;
 }
 
+void MooncakeConnector::on_workers_stopped() { unregister_all_buffers(); }
+
 size_t MooncakeConnector::choose_num_tiles(Op op, size_t num_items) const {
   (void)op;
   (void)num_items;
+  // Mooncake's batch APIs already parallelize internally. Keep each LMCache
+  // batch as one tile so we do not split a single backend batch across workers.
   return 1;
 }
 
@@ -126,6 +158,7 @@ void MooncakeConnector::do_batch_get(WorkerMooncakeConn& conn,
               "[LMCache GET] key %s failed: Mooncake batch_get_into "
               "returned %lld\n",
               req.keys[i].c_str(), static_cast<long long>(results[i]));
+      req.batch->any_failed.store(true, std::memory_order_relaxed);
       continue;
     }
     req.batch->per_key_results[req.start_idx + i] = 1;
@@ -138,15 +171,21 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
     ensure_registered(req.buf_ptrs[i], req.buf_lens[i]);
   }
 
-  auto results = conn.client->batch_put_from(req.keys, req.buf_ptrs,
-                                             req.buf_lens);
+  auto results =
+      conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
 
   for (size_t i = 0; i < results.size(); ++i) {
     if (results[i] != 0) {
-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
-                               req.keys[i]);
+      req.batch->per_key_results[req.start_idx + i] = 0;
+      fprintf(stderr,
+              "[LMCache SET] key %s failed: Mooncake batch_put_from "
+              "returned %lld\n",
+              req.keys[i].c_str(), static_cast<long long>(results[i]));
+      req.batch->any_failed.store(true, std::memory_order_relaxed);
+      continue;
     }
+    req.batch->per_key_results[req.start_idx + i] = 1;
   }
 }
 
@@ -157,11 +196,15 @@ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
 
   for (size_t i = 0; i < results.size(); ++i) {
     if (results[i] < 0) {
-      throw std::runtime_error("Mooncake batchIsExist failed for key: " +
-                               req.keys[i]);
+      req.batch->per_key_results[req.start_idx + i] = 0;
+      fprintf(stderr,
+              "[LMCache EXISTS] key %s failed: Mooncake batchIsExist "
+              "returned %lld\n",
+              req.keys[i].c_str(), static_cast<long long>(results[i]));
+      req.batch->any_failed.store(true, std::memory_order_relaxed);
+      continue;
     }
-    req.batch->per_key_results[req.start_idx + i] =
-        results[i] == 1 ? 1 : 0;
+    req.batch->per_key_results[req.start_idx + i] = results[i] == 1 ? 1 : 0;
   }
 }
 

--- a/csrc/storage_backends/mooncake/connector.h
+++ b/csrc/storage_backends/mooncake/connector.h
@@ -42,7 +42,9 @@ struct L1RegistrationConfig {
 class MooncakeConnector : public ConnectorBase<WorkerMooncakeConn> {
  public:
   MooncakeConnector(ConfigDict config, int num_workers,
-                    L1RegistrationConfig l1_registration = {});
+                    L1RegistrationConfig l1_registration = {},
+                    int lookup_workers = 0, int retrieve_workers = 0,
+                    int store_workers = 0);
   ~MooncakeConnector() override;
 
  protected:

--- a/csrc/storage_backends/mooncake/connector.h
+++ b/csrc/storage_backends/mooncake/connector.h
@@ -58,6 +58,14 @@ class MooncakeConnector : public ConnectorBase<WorkerMooncakeConn> {
                         const std::string& key) override;
   void on_workers_stopped() override;
 
+  size_t choose_num_tiles(Op op, size_t num_items) const override;
+
+  void do_batch_get(WorkerMooncakeConn& conn, const Request& req) override;
+
+  void do_batch_set(WorkerMooncakeConn& conn, const Request& req) override;
+
+  void do_batch_exists(WorkerMooncakeConn& conn, const Request& req) override;
+
  private:
   void ensure_registered(const void* buf, size_t len);
   void preregister_l1_memory(std::uintptr_t base, size_t size);

--- a/csrc/storage_backends/mooncake/pybind.cpp
+++ b/csrc/storage_backends/mooncake/pybind.cpp
@@ -1,10 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <stdexcept>
+#include <string>
+#include <utility>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "../connector_pybind_utils.h"
 #include "connector.h"
 
 namespace py = pybind11;
+
+namespace {
+
+int parse_optional_worker_count(const py::object& value, const char* arg_name) {
+  if (value.is_none()) {
+    return 0;
+  }
+  int count = value.cast<int>();
+  if (count <= 0) {
+    throw std::runtime_error(std::string(arg_name) +
+                             " must be a positive integer or None");
+  }
+  return count;
+}
+
+}  // namespace
 
 PYBIND11_MODULE(lmcache_mooncake, m) {
   py::class_<lmcache::connector::L1RegistrationConfig>(m,
@@ -16,10 +36,22 @@ PYBIND11_MODULE(lmcache_mooncake, m) {
       .def_readwrite("size", &lmcache::connector::L1RegistrationConfig::size);
 
   py::class_<lmcache::connector::MooncakeConnector>(m, "LMCacheMooncakeClient")
-      .def(py::init<lmcache::connector::ConfigDict, int,
-                    lmcache::connector::L1RegistrationConfig>(),
+      .def(py::init([](lmcache::connector::ConfigDict config, int num_workers,
+                       lmcache::connector::L1RegistrationConfig l1_registration,
+                       py::object lookup_workers, py::object retrieve_workers,
+                       py::object store_workers) {
+             return new lmcache::connector::MooncakeConnector(
+                 std::move(config), num_workers, l1_registration,
+                 parse_optional_worker_count(lookup_workers, "lookup_workers"),
+                 parse_optional_worker_count(retrieve_workers,
+                                             "retrieve_workers"),
+                 parse_optional_worker_count(store_workers, "store_workers"));
+           }),
            py::arg("config"), py::arg("num_workers"),
            py::arg("l1_registration") =
-               lmcache::connector::L1RegistrationConfig{})
+               lmcache::connector::L1RegistrationConfig{},
+           py::arg("lookup_workers") = py::none(),
+           py::arg("retrieve_workers") = py::none(),
+           py::arg("store_workers") = py::none())
           LMCACHE_BIND_CONNECTOR_METHODS(lmcache::connector::MooncakeConnector);
 }

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -231,32 +231,59 @@ If the Mooncake headers are not installed in the system include path
 
 **LMCache-specific fields:**
 
-- ``num_workers``: Number of C++ worker threads (default ``4``, must
-  be > 0).
+- ``num_workers``: Number of C++ worker threads for the shared pool
+  (default ``4``, must be > 0).  Only used when per-operation worker
+  counts are not set.
+
+- ``lookup_workers``, ``retrieve_workers``, ``store_workers``
+  (``int``, optional): Per-operation worker thread counts.  When set,
+  the adapter allocates three independent thread pools so that
+  different operation types cannot block each other:
+
+  - ``lookup_workers`` — threads for ``EXISTS`` operations.
+  - ``retrieve_workers`` — threads for ``GET`` / load operations.
+  - ``store_workers`` — threads for ``SET`` / put operations.
+
+  All three must be set together (or all left unset).  When set, the
+  shared ``num_workers`` pool is **not used**.
 
 **Mooncake fields:**
 
 All other keys in the JSON config (except ``type``, ``num_workers``,
-and ``eviction``) are forwarded **as-is** to Mooncake's
+``lookup_workers``, ``retrieve_workers``, ``store_workers``, and
+``eviction``) are forwarded **as-is** to Mooncake's
 ``setup_internal(ConfigDict)``.  Refer to the
 `Mooncake documentation <https://github.com/kvcache-ai/Mooncake>`_
 for available setup keys (e.g., ``local_hostname``,
-``metadata_server``, ``master_server_address``, ``protocol``,
-``device_name``, ``global_segment_size``).
+``metadata_server``, ``master_server_addr``, ``protocol``,
+``rdma_devices``, ``global_segment_size``).
 
 **Configuration example:**
 
 .. code-block:: bash
 
+    # Shared pool (default)
     --l2-adapter '{
       "type": "mooncake_store",
       "num_workers": 4,
       "local_hostname": "node01",
       "metadata_server": "http://localhost:8080/metadata",
-      "master_server_address": "localhost:50051",
+      "master_server_addr": "localhost:50051",
       "protocol": "tcp",
-      "local_buffer_size": "3221225472"
+      "local_buffer_size": "3221225472",
       "global_segment_size": "3221225472"
+    }'
+
+    # Per-operation pools (GET-heavy workload)
+    --l2-adapter '{
+      "type": "mooncake_store",
+      "lookup_workers": 2,
+      "retrieve_workers": 16,
+      "store_workers": 4,
+      "local_hostname": "node01",
+      "metadata_server": "http://localhost:8080/metadata",
+      "master_server_addr": "localhost:50051",
+      "protocol": "tcp"
     }'
 
 For full Mooncake setup instructions (master service, metadata server,

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -129,9 +129,7 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
         if value is None:
             return None
         if not isinstance(value, int):
-            raise TypeError(
-                f"{key} must be an integer, got {type(value).__name__}"
-            )
+            raise ValueError(f"{key} must be an integer, got {type(value).__name__}")
         return value
 
     @staticmethod

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 # Standard
 from typing import (
     TYPE_CHECKING,
-    Dict,
-    Optional,
 )
 
 if TYPE_CHECKING:
@@ -76,11 +74,11 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
 
     def __init__(
         self,
-        setup_config: Dict[str, str],
+        setup_config: dict[str, str],
         num_workers: int = 4,
-        lookup_workers: Optional[int] = None,
-        retrieve_workers: Optional[int] = None,
-        store_workers: Optional[int] = None,
+        lookup_workers: int | None = None,
+        retrieve_workers: int | None = None,
+        store_workers: int | None = None,
     ):
         super().__init__()
         self.num_workers = self._validate_num_workers(num_workers)
@@ -89,7 +87,7 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
             retrieve_workers,
             store_workers,
         )
-        self.setup_config: Dict[str, str] = dict(setup_config)
+        self.setup_config: dict[str, str] = dict(setup_config)
         self.lookup_workers = lookup_workers
         self.retrieve_workers = retrieve_workers
         self.store_workers = store_workers
@@ -110,7 +108,7 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
 
         # Everything except LMCache-only keys is
         # forwarded to mooncake as str values.
-        setup: Dict[str, str] = {}
+        setup: dict[str, str] = {}
         for k, v in d.items():
             if k in _LMCACHE_ONLY_KEYS:
                 continue
@@ -126,7 +124,7 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
         )
 
     @staticmethod
-    def _parse_optional_worker_count(d: dict[str, object], key: str) -> Optional[int]:
+    def _parse_optional_worker_count(d: dict[str, object], key: str) -> int | None:
         value = d.get(key)
         if value is None:
             return None
@@ -142,9 +140,9 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
 
     @staticmethod
     def _validate_per_op_worker_counts(
-        lookup_workers: Optional[int],
-        retrieve_workers: Optional[int],
-        store_workers: Optional[int],
+        lookup_workers: int | None,
+        retrieve_workers: int | None,
+        store_workers: int | None,
     ) -> None:
         values = {
             "lookup_workers": lookup_workers,
@@ -185,7 +183,7 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
 
 def _create_mooncake_store_l2_adapter(
     config: L2AdapterConfigBase,
-    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+    l1_memory_desc: "L1MemoryDesc | None" = None,
 ) -> L2AdapterInterface:
     """Create a NativeConnectorL2Adapter backed by the
     C++ Mooncake Store connector.

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -34,7 +34,14 @@ from lmcache.v1.distributed.l2_adapters.factory import (
 logger = init_logger(__name__)
 
 # Keys consumed only by LMCache (never sent to mooncake).
-_LMCACHE_ONLY_KEYS = {"type", "num_workers", "eviction"}
+_LMCACHE_ONLY_KEYS = {
+    "type",
+    "num_workers",
+    "eviction",
+    "lookup_workers",
+    "retrieve_workers",
+    "store_workers",
+}
 
 
 class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
@@ -48,23 +55,43 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
     defaults for any mooncake keys — that is mooncake's
     responsibility.
 
-    ``num_workers`` is the only LMCache-specific knob.
+    ``num_workers`` and optional per-operation worker counts are
+    LMCache-specific knobs.
     """
 
     def __init__(
         self,
         setup_config: Dict[str, str],
         num_workers: int = 4,
+        lookup_workers: Optional[int] = None,
+        retrieve_workers: Optional[int] = None,
+        store_workers: Optional[int] = None,
     ):
         super().__init__()
+        self.num_workers = self._validate_num_workers(num_workers)
+        self._validate_per_op_worker_counts(
+            lookup_workers,
+            retrieve_workers,
+            store_workers,
+        )
         self.setup_config: Dict[str, str] = dict(setup_config)
-        self.num_workers = num_workers
+        self.lookup_workers = lookup_workers
+        self.retrieve_workers = retrieve_workers
+        self.store_workers = store_workers
 
     @classmethod
-    def from_dict(cls, d: dict) -> "MooncakeStoreL2AdapterConfig":
-        num_workers = d.get("num_workers", 4)
-        if not isinstance(num_workers, int) or num_workers <= 0:
-            raise ValueError("num_workers must be a positive integer")
+    def from_dict(cls, d: dict[str, object]) -> "MooncakeStoreL2AdapterConfig":
+        num_workers: int = 4
+        if "num_workers" in d:
+            num_workers = cls._validate_num_workers(d["num_workers"])
+        lookup_workers = cls._parse_optional_worker_count(d, "lookup_workers")
+        retrieve_workers = cls._parse_optional_worker_count(d, "retrieve_workers")
+        store_workers = cls._parse_optional_worker_count(d, "store_workers")
+        cls._validate_per_op_worker_counts(
+            lookup_workers,
+            retrieve_workers,
+            store_workers,
+        )
 
         # Everything except LMCache-only keys is
         # forwarded to mooncake as str values.
@@ -78,7 +105,45 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
         return cls(
             setup_config=setup,
             num_workers=num_workers,
+            lookup_workers=lookup_workers,
+            retrieve_workers=retrieve_workers,
+            store_workers=store_workers,
         )
+
+    @staticmethod
+    def _parse_optional_worker_count(d: dict[str, object], key: str) -> Optional[int]:
+        value = d.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{key} must be a positive integer")
+        return value
+
+    @staticmethod
+    def _validate_num_workers(raw: object) -> int:
+        if not isinstance(raw, int) or raw <= 0:
+            raise ValueError("num_workers must be a positive integer")
+        return raw
+
+    @staticmethod
+    def _validate_per_op_worker_counts(
+        lookup_workers: Optional[int],
+        retrieve_workers: Optional[int],
+        store_workers: Optional[int],
+    ) -> None:
+        values = {
+            "lookup_workers": lookup_workers,
+            "retrieve_workers": retrieve_workers,
+            "store_workers": store_workers,
+        }
+        specified = [name for name, value in values.items() if value is not None]
+        if not specified:
+            return
+        if len(specified) != len(values):
+            raise ValueError(
+                "lookup_workers, retrieve_workers, and store_workers must "
+                "all be set together"
+            )
 
     @classmethod
     def help(cls) -> str:
@@ -93,7 +158,13 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
             "Refer to mooncake documentation for "
             "available setup keys.\n"
             "- num_workers (int): C++ worker threads "
-            "(default 4, >0)"
+            "(default 4, >0)\n"
+            "- lookup_workers (int): EXISTS worker threads (>0); must be set "
+            "together with retrieve_workers and store_workers\n"
+            "- retrieve_workers (int): GET/load worker threads (>0); must be "
+            "set together with lookup_workers and store_workers\n"
+            "- store_workers (int): SET/put worker threads (>0); must be set "
+            "together with lookup_workers and retrieve_workers"
         )
 
 
@@ -134,7 +205,8 @@ def _create_mooncake_store_l2_adapter(
         NativeConnectorL2Adapter,
     )
 
-    assert isinstance(config, MooncakeStoreL2AdapterConfig)
+    if not isinstance(config, MooncakeStoreL2AdapterConfig):
+        raise ValueError(f"Expected MooncakeStoreL2AdapterConfig, got {type(config)}")
     l1_registration = L1RegistrationConfig()
     if config.setup_config.get("protocol") == "rdma":
         if l1_memory_desc is None:
@@ -153,14 +225,33 @@ def _create_mooncake_store_l2_adapter(
             l1_registration.base = l1_memory_desc.ptr
             l1_registration.size = l1_memory_desc.size
 
-    native_client = LMCacheMooncakeClient(
-        config=config.setup_config,
-        num_workers=config.num_workers,
-        l1_registration=l1_registration,
-    )
+    native_client_kwargs = {
+        "config": config.setup_config,
+        "num_workers": config.num_workers,
+        "l1_registration": l1_registration,
+    }
+    if (
+        config.lookup_workers is not None
+        or config.retrieve_workers is not None
+        or config.store_workers is not None
+    ):
+        native_client_kwargs.update(
+            {
+                "lookup_workers": config.lookup_workers,
+                "retrieve_workers": config.retrieve_workers,
+                "store_workers": config.store_workers,
+            }
+        )
+
+    native_client = LMCacheMooncakeClient(**native_client_kwargs)
     logger.info(
-        "Created Mooncake Store L2 adapter (workers=%d, preregister_l1_memory=%s)",
+        "Created Mooncake Store L2 adapter "
+        "(workers=%d, lookup_workers=%s, retrieve_workers=%s, "
+        "store_workers=%s, preregister_l1_memory=%s)",
         config.num_workers,
+        config.lookup_workers,
+        config.retrieve_workers,
+        config.store_workers,
         l1_registration.enabled and l1_registration.size > 0,
     )
     return NativeConnectorL2Adapter(native_client)

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -128,8 +128,10 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
         value = d.get(key)
         if value is None:
             return None
-        if not isinstance(value, int) or value <= 0:
-            raise ValueError(f"{key} must be a positive integer")
+        if not isinstance(value, int):
+            raise TypeError(
+                f"{key} must be an integer, got {type(value).__name__}"
+            )
         return value
 
     @staticmethod
@@ -157,6 +159,10 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
                 "lookup_workers, retrieve_workers, and store_workers must "
                 "all be set together"
             )
+        for name in specified:
+            value = values[name]
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
 
     @classmethod
     def help(cls) -> str:

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -48,15 +48,30 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
     """Config for an L2 adapter backed by the native
     C++ Mooncake Store connector.
 
-    ``setup_config`` is a string-to-string dict that is
-    forwarded **as-is** to mooncake's
+    ``setup_config`` is a string-to-string dict forwarded
+    **as-is** to mooncake's
     ``RealClient::setup_internal(ConfigDict)``.
     LMCache does NOT interpret, validate, or fill in
     defaults for any mooncake keys — that is mooncake's
     responsibility.
 
-    ``num_workers`` and optional per-operation worker counts are
-    LMCache-specific knobs.
+    Fields:
+        setup_config: Mooncake SDK configuration forwarded
+            as-is to ``RealClient::setup_internal()``.
+        num_workers: Shared worker thread count (default 4,
+            must be > 0).  Ignored when per-operation
+            worker counts are set.
+        lookup_workers: Optional dedicated worker count
+            for EXISTS operations.  Must be set together
+            with ``retrieve_workers`` and
+            ``store_workers``.
+        retrieve_workers: Optional dedicated worker count
+            for GET/load operations.  Must be set together
+            with ``lookup_workers`` and
+            ``store_workers``.
+        store_workers: Optional dedicated worker count for
+            SET/put operations.  Must be set together with
+            ``lookup_workers`` and ``retrieve_workers``.
     """
 
     def __init__(

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -650,7 +650,10 @@ class TestMooncakeStoreIntegration:
         )
         self.adapter = create_l2_adapter(config)
         yield
-        self.adapter.close()
+        adapter = self.adapter
+        self.adapter = None
+        if adapter is not None:
+            adapter.close()
 
     def test_event_fds_are_distinct(self):
         """Each operation should have a distinct event fd."""
@@ -826,6 +829,13 @@ class TestMooncakeStoreIntegration:
         """Store and load RDMA-preregistered objects backed by an explicit L1 buffer."""
         # First Party
         from lmcache.v1.distributed.l2_adapters import create_l2_adapter
+
+        # The class-level autouse fixture creates a default TCP adapter.
+        # Keep this RDMA-only test isolated so Mooncake master cannot allocate
+        # the object on an active TCP segment while the client has only RDMA
+        # transport installed.
+        self.adapter.close()
+        self.adapter = None
 
         page_size = 4096
         obj_size_bytes = page_size * 16

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -285,7 +285,13 @@ class TestMooncakeStoreL2AdapterConfig:
     @pytest.mark.parametrize("value", [0, -1, "four"])
     def test_from_dict_invalid_per_op_workers(self, field: str, value: Any):
         """Invalid per-operation worker counts should raise ValueError."""
-        d = {"type": "mooncake_store", field: value}
+        d = {
+            "type": "mooncake_store",
+            "lookup_workers": 2,
+            "retrieve_workers": 4,
+            "store_workers": 2,
+            field: value,
+        }
         with pytest.raises(ValueError, match=field):
             MooncakeStoreL2AdapterConfig.from_dict(d)
 

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -8,9 +8,11 @@ extension is not available.
 """
 
 # Standard
-from typing import Any
+from typing import Any, cast
 import os
 import select
+import sys
+import types
 
 # Third Party
 import pytest
@@ -169,6 +171,26 @@ class TestMooncakeStoreL2AdapterConfig:
         assert "num_workers" not in config.setup_config
         assert config.setup_config["local_hostname"] == "10.0.0.1"
 
+    def test_from_dict_with_per_op_workers(self):
+        """Per-operation worker counts should be parsed and excluded."""
+        d = {
+            "type": "mooncake_store",
+            "num_workers": 16,
+            "lookup_workers": 4,
+            "retrieve_workers": 16,
+            "store_workers": 4,
+            "local_hostname": "10.0.0.1",
+        }
+        config = MooncakeStoreL2AdapterConfig.from_dict(d)
+
+        assert config.lookup_workers == 4
+        assert config.retrieve_workers == 16
+        assert config.store_workers == 4
+        assert "lookup_workers" not in config.setup_config
+        assert "retrieve_workers" not in config.setup_config
+        assert "store_workers" not in config.setup_config
+        assert config.setup_config["local_hostname"] == "10.0.0.1"
+
     def test_from_dict_forwards_boolean_mooncake_keys_as_strings(self):
         """Non-LMCache boolean keys should be forwarded as strings."""
         config = MooncakeStoreL2AdapterConfig.from_dict(
@@ -193,12 +215,15 @@ class TestMooncakeStoreL2AdapterConfig:
         assert config.setup_config["experimental_key"] == "enabled"
 
     def test_from_dict_strips_lmcache_only_keys(self):
-        """LMCache-only keys (type, num_workers, eviction) should
+        """LMCache-only keys should
         not appear in setup_config."""
         d = {
             "type": "mooncake_store",
             "num_workers": 2,
             "eviction": "lru",
+            "lookup_workers": 3,
+            "retrieve_workers": 5,
+            "store_workers": 2,
             "local_hostname": "host1",
         }
         config = MooncakeStoreL2AdapterConfig.from_dict(d)
@@ -206,6 +231,9 @@ class TestMooncakeStoreL2AdapterConfig:
         assert "type" not in config.setup_config
         assert "num_workers" not in config.setup_config
         assert "eviction" not in config.setup_config
+        assert "lookup_workers" not in config.setup_config
+        assert "retrieve_workers" not in config.setup_config
+        assert "store_workers" not in config.setup_config
         assert config.setup_config["local_hostname"] == "host1"
 
     def test_from_dict_converts_values_to_str(self):
@@ -249,6 +277,54 @@ class TestMooncakeStoreL2AdapterConfig:
         d = {"type": "mooncake_store", "num_workers": "four"}
         with pytest.raises(ValueError, match="num_workers"):
             MooncakeStoreL2AdapterConfig.from_dict(d)
+
+    @pytest.mark.parametrize(
+        "field",
+        ["lookup_workers", "retrieve_workers", "store_workers"],
+    )
+    @pytest.mark.parametrize("value", [0, -1, "four"])
+    def test_from_dict_invalid_per_op_workers(self, field: str, value: Any):
+        """Invalid per-operation worker counts should raise ValueError."""
+        d = {"type": "mooncake_store", field: value}
+        with pytest.raises(ValueError, match=field):
+            MooncakeStoreL2AdapterConfig.from_dict(d)
+
+    @pytest.mark.parametrize(
+        "config_dict",
+        [
+            {"type": "mooncake_store", "lookup_workers": 2},
+            {"type": "mooncake_store", "retrieve_workers": 2},
+            {"type": "mooncake_store", "store_workers": 2},
+            {
+                "type": "mooncake_store",
+                "lookup_workers": 2,
+                "retrieve_workers": 4,
+            },
+            {
+                "type": "mooncake_store",
+                "lookup_workers": 2,
+                "store_workers": 4,
+            },
+            {
+                "type": "mooncake_store",
+                "retrieve_workers": 2,
+                "store_workers": 4,
+            },
+        ],
+    )
+    def test_from_dict_requires_all_per_op_workers(self, config_dict: dict):
+        """Separate worker pools require all per-operation counts."""
+        with pytest.raises(ValueError, match="must all be set together"):
+            MooncakeStoreL2AdapterConfig.from_dict(config_dict)
+
+    def test_constructor_requires_all_per_op_workers(self):
+        """Direct construction should reject partial per-operation worker counts."""
+        with pytest.raises(ValueError, match="must all be set together"):
+            MooncakeStoreL2AdapterConfig(
+                setup_config={},
+                lookup_workers=2,
+                retrieve_workers=4,
+            )
 
     def test_constructor_copies_setup_config(self):
         """Constructor should copy the setup_config dict."""
@@ -298,19 +374,37 @@ class TestMooncakeStoreRegistration:
             create_l2_adapter_from_registry(config)
 
 
-@requires_mooncake
+def _install_fake_mooncake_extension(
+    monkeypatch: pytest.MonkeyPatch,
+    client_cls: type,
+) -> None:
+    """Install a fake lmcache_mooncake module for factory unit tests."""
+
+    class FakeL1RegistrationConfig:
+        def __init__(self):
+            self.enabled = False
+            self.base = 0
+            self.size = 0
+
+    fake_module = types.ModuleType("lmcache.lmcache_mooncake")
+    fake_module_any = cast(Any, fake_module)
+    fake_module_any.L1RegistrationConfig = FakeL1RegistrationConfig
+    fake_module_any.LMCacheMooncakeClient = client_cls
+    monkeypatch.setitem(sys.modules, "lmcache.lmcache_mooncake", fake_module)
+
+
 class TestMooncakeStoreL1RegistrationFactory:
     """Tests for Mooncake TCP/RDMA L1 registration factory behavior.
 
     RDMA creation must receive a valid L1 memory descriptor; TCP creation
     must not enable preregistration even if a descriptor is provided.
+    Uses a fake native extension so these tests do not require Mooncake.
     """
 
     def test_factory_passes_disabled_l1_registration_for_tcp(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         # First Party
-        from lmcache import lmcache_mooncake
         from lmcache.v1.distributed.l2_adapters import native_connector_l2_adapter
 
         captured: dict[str, Any] = {}
@@ -326,11 +420,7 @@ class TestMooncakeStoreL1RegistrationFactory:
                 captured["num_workers"] = num_workers
                 captured["l1_registration"] = l1_registration
 
-        monkeypatch.setattr(
-            lmcache_mooncake,
-            "LMCacheMooncakeClient",
-            FakeClient,
-        )
+        _install_fake_mooncake_extension(monkeypatch, FakeClient)
         monkeypatch.setattr(
             native_connector_l2_adapter,
             "NativeConnectorL2Adapter",
@@ -366,7 +456,6 @@ class TestMooncakeStoreL1RegistrationFactory:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         # First Party
-        from lmcache import lmcache_mooncake
         from lmcache.v1.distributed.l2_adapters import native_connector_l2_adapter
 
         captured: dict[str, Any] = {}
@@ -382,11 +471,7 @@ class TestMooncakeStoreL1RegistrationFactory:
                 captured["num_workers"] = num_workers
                 captured["l1_registration"] = l1_registration
 
-        monkeypatch.setattr(
-            lmcache_mooncake,
-            "LMCacheMooncakeClient",
-            FakeClient,
-        )
+        _install_fake_mooncake_extension(monkeypatch, FakeClient)
         monkeypatch.setattr(
             native_connector_l2_adapter,
             "NativeConnectorL2Adapter",
@@ -418,7 +503,65 @@ class TestMooncakeStoreL1RegistrationFactory:
         assert registration.base == l1_desc.ptr
         assert registration.size == l1_desc.size
 
-    def test_factory_requires_l1_memory_descriptor_for_rdma(self):
+    def test_factory_passes_per_op_worker_counts(self, monkeypatch: pytest.MonkeyPatch):
+        # First Party
+        from lmcache.v1.distributed.l2_adapters import native_connector_l2_adapter
+
+        captured: dict[str, Any] = {}
+
+        class FakeClient:
+            def __init__(
+                self,
+                config: dict[str, str],
+                num_workers: int,
+                l1_registration,
+                lookup_workers=None,
+                retrieve_workers=None,
+                store_workers=None,
+            ):
+                captured["config"] = config
+                captured["num_workers"] = num_workers
+                captured["l1_registration"] = l1_registration
+                captured["lookup_workers"] = lookup_workers
+                captured["retrieve_workers"] = retrieve_workers
+                captured["store_workers"] = store_workers
+
+        _install_fake_mooncake_extension(monkeypatch, FakeClient)
+        monkeypatch.setattr(
+            native_connector_l2_adapter,
+            "NativeConnectorL2Adapter",
+            lambda client: ("wrapped", client),
+        )
+
+        config = MooncakeStoreL2AdapterConfig.from_dict(
+            {
+                "type": "mooncake_store",
+                "local_hostname": "127.0.0.1",
+                "num_workers": 16,
+                "lookup_workers": 4,
+                "retrieve_workers": 16,
+                "store_workers": 4,
+                "protocol": "tcp",
+            }
+        )
+
+        adapter = mooncake_store_module._create_mooncake_store_l2_adapter(config)
+        wrapped_adapter: Any = adapter
+
+        assert wrapped_adapter[0] == "wrapped"
+        assert captured["config"] == config.setup_config
+        assert captured["num_workers"] == 16
+        assert captured["lookup_workers"] == 4
+        assert captured["retrieve_workers"] == 16
+        assert captured["store_workers"] == 4
+
+    def test_factory_requires_l1_memory_descriptor_for_rdma(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeClient:
+            pass
+
+        _install_fake_mooncake_extension(monkeypatch, FakeClient)
         config = MooncakeStoreL2AdapterConfig.from_dict(
             {
                 "type": "mooncake_store",
@@ -430,7 +573,13 @@ class TestMooncakeStoreL1RegistrationFactory:
         with pytest.raises(ValueError, match="no L1 memory descriptor"):
             mooncake_store_module._create_mooncake_store_l2_adapter(config)
 
-    def test_factory_rejects_invalid_l1_memory_descriptor_for_rdma(self):
+    def test_factory_rejects_invalid_l1_memory_descriptor_for_rdma(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeClient:
+            pass
+
+        _install_fake_mooncake_extension(monkeypatch, FakeClient)
         config = MooncakeStoreL2AdapterConfig.from_dict(
             {
                 "type": "mooncake_store",
@@ -692,10 +841,10 @@ class TestMooncakeStoreIntegration:
                 "type": "mooncake_store",
                 "local_hostname": MOONCAKE_LOCAL_HOSTNAME,
                 "metadata_server": MOONCAKE_METADATA_SERVER,
-                "master_server_address": MOONCAKE_MASTER_SERVER_ADDRESS,
+                "master_server_addr": MOONCAKE_MASTER_SERVER_ADDRESS,
                 "num_workers": 2,
                 "protocol": "rdma",
-                "device_name": MOONCAKE_DEVICE_NAME,
+                "rdma_devices": MOONCAKE_DEVICE_NAME,
             }
         )
         adapter = create_l2_adapter(config, l1_memory_desc=l1_desc)


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements batch operations (`do_batch_get/do_batch_set/do_batch_delete`) in the `MooncakeConnector`, replacing per-key RPC calls with single batched calls. This reduces RPC overhead and improves throughput for L2 cache lookups, retrievals, and stores.
                                                                                                                                                                                                       
Also adds per-operation worker pool configuration (`lookup_workers, retrieve_workers, store_workers`) to the MooncakeStore L2 adapter, allowing each operation type to use an independently-sized worker pool to avoid head-of-line blocking.              
 <details>                                                                                                                                                                                            
  <summary>Benchmark: per-operation vs shared worker pool (mixed pressure)</summary>                                                                                                                   

<details>                                                                                                                                                                                                       
<summary>Script</summary>                                                                                                                                                               
                                                                                                                                                                                                       
  ```python
#!/usr/bin/env python3
"""Benchmark Mooncake L2 adapter latency with mixed operation pressure.

Run from the LMCache repo root, or pass --repo-root.  The config can be a JSON
string or a JSON file path.  Example:

  python bench_mooncake_multiworkers.py \
    --config-json '{"type":"mooncake_store","local_hostname":"192.168.0.139",...}' \
    --num-keys 1024 \
    --batch-size 16 \
    --value-size-bytes 1048576 \
    --warmup 20 \
    --iters 200 \
    --stores-per-round 4
"""

from __future__ import annotations

import argparse
import json
import os
import select
import statistics
import sys
import time
from pathlib import Path
from typing import Any


def _add_repo_to_path(repo_root: str) -> None:
    if repo_root not in sys.path:
        sys.path.insert(0, repo_root)


def _load_config(config_json: str | None, config_file: str | None) -> dict[str, Any]:
    if config_file:
        with open(config_file, encoding="utf-8") as f:
            return json.load(f)
    if config_json:
        return json.loads(config_json)
    raise ValueError("pass either --config-json or --config-file")


def _wait_any_event(fds: dict[int, str], timeout_s: float) -> list[str]:
    poll = select.poll()
    for fd in fds:
        poll.register(fd, select.POLLIN)
    events = poll.poll(int(timeout_s * 1000))
    ready: list[str] = []
    for fd, _event in events:
        try:
            os.eventfd_read(fd)
        except BlockingIOError:
            pass
        ready.append(fds[fd])
    return ready


def _percentiles(values_ms: list[float]) -> dict[str, float]:
    if not values_ms:
        return {
            "count": 0,
            "avg": 0.0,
            "p50": 0.0,
            "p90": 0.0,
            "p95": 0.0,
            "p99": 0.0,
        }
    values = sorted(values_ms)

    def pct(p: float) -> float:
        if len(values) == 1:
            return values[0]
        idx = int(round((len(values) - 1) * p))
        return values[min(idx, len(values) - 1)]

    return {
        "count": float(len(values)),
        "avg": statistics.fmean(values),
        "p50": pct(0.50),
        "p90": pct(0.90),
        "p95": pct(0.95),
        "p99": pct(0.99),
    }


def _format_bytes(num_bytes: int) -> str:
    value = float(num_bytes)
    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
        if value < 1024 or unit == "TiB":
            return "%.2f %s" % (value, unit)
        value /= 1024
    return "%d B" % num_bytes


def _print_title(title: str) -> None:
    line = "=" * len(title)
    print("\n%s\n%s\n%s" % (line, title, line))


def _print_section(title: str) -> None:
    print("\n%s\n%s" % (title, "-" * len(title)))


def _print_kv_table(rows: list[tuple[str, str]]) -> None:
    width = max(len(key) for key, _value in rows)
    for key, value in rows:
        print("  %-*s : %s" % (width, key, value))


def _print_config(config: dict[str, Any]) -> None:
    rows = []
    for key in sorted(config):
        value = config[key]
        if key in {"lookup_workers", "retrieve_workers", "store_workers"}:
            rows.append((key, str(value)))
        elif key == "num_workers":
            rows.append((key, str(value)))
        elif key in {"type", "protocol", "metadata_server", "local_hostname"}:
            rows.append((key, str(value)))
    hidden = len(config) - len(rows)
    if hidden > 0:
        rows.append(("other_config_keys", str(hidden)))
    _print_kv_table(rows)


def _print_latency_table(title: str, latencies: dict[str, list[float]]) -> None:
    _print_section(title)
    print(
        "  %-10s %8s %11s %11s %11s %11s %11s"
        % ("op", "count", "avg ms", "p50 ms", "p90 ms", "p95 ms", "p99 ms")
    )
    print("  " + "-" * 78)
    for op in ("store", "lookup", "load"):
        if op not in latencies or not latencies[op]:
            continue
        stats = _percentiles(latencies[op])
        print(
            "  %-10s %8d %11.3f %11.3f %11.3f %11.3f %11.3f"
            % (
                op,
                int(stats["count"]),
                stats["avg"],
                stats["p50"],
                stats["p90"],
                stats["p95"],
                stats["p99"],
            )
        )


def _create_object_key(chunk_id: int, model_name: str):
    from lmcache.v1.distributed.api import ObjectKey

    return ObjectKey(
        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
        model_name=model_name,
        kv_rank=0,
    )


class L1Arena:
    def __init__(self, num_slots: int, value_size_bytes: int):
        import torch
        from lmcache.v1.distributed.internal_api import L1MemoryDesc

        if value_size_bytes % 4 != 0:
            raise ValueError("--value-size-bytes must be divisible by 4")
        self.num_slots = num_slots
        self.value_size_bytes = value_size_bytes
        self.buffer = torch.empty(num_slots * value_size_bytes, dtype=torch.uint8)
        self.desc = L1MemoryDesc(
            ptr=self.buffer.data_ptr(),
            size=self.buffer.numel() * self.buffer.element_size(),
            align_bytes=4096,
        )

    def obj(self, slot: int, fill_value: float = 0.0):
        return _create_memory_obj_from_l1_slot(self, slot, fill_value)


def _create_memory_obj_from_l1_slot(arena: L1Arena, slot: int, fill_value: float):
    import torch
    from lmcache.v1.memory_management import (
        MemoryFormat,
        MemoryObjMetadata,
        TensorMemoryObj,
    )

    if slot < 0 or slot >= arena.num_slots:
        raise ValueError("L1 arena slot out of range")
    offset = slot * arena.value_size_bytes
    raw_data = arena.buffer[offset : offset + arena.value_size_bytes].view(
        torch.float32
    )
    raw_data.fill_(fill_value)
    metadata = MemoryObjMetadata(
        shape=torch.Size([arena.value_size_bytes // 4]),
        dtype=torch.float32,
        address=offset,
        phy_size=arena.value_size_bytes,
        fmt=MemoryFormat.KV_2LTD,
        ref_count=1,
    )
    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)


def _make_adapter(config_dict: dict[str, Any], l1_memory_desc):
    from lmcache.v1.distributed.l2_adapters import create_l2_adapter
    from lmcache.v1.distributed.l2_adapters.mooncake_store_l2_adapter import (
        MooncakeStoreL2AdapterConfig,
    )

    config = MooncakeStoreL2AdapterConfig.from_dict(config_dict)
    return create_l2_adapter(config, l1_memory_desc=l1_memory_desc)


def _submit_store(adapter, keys, objs) -> int:
    return int(adapter.submit_store_task(keys, objs))


def _submit_lookup(adapter, keys) -> int:
    return int(adapter.submit_lookup_and_lock_task(keys))


def _submit_load(adapter, keys, objs) -> int:
    return int(adapter.submit_load_task(keys, objs))


def _drain_until_done(
    adapter,
    pending: dict[tuple[str, int], float],
    latencies: dict[str, list[float]],
    timeout_s: float,
) -> None:
    fds = {
        adapter.get_store_event_fd(): "store",
        adapter.get_lookup_and_lock_event_fd(): "lookup",
        adapter.get_load_event_fd(): "load",
    }
    deadline = time.perf_counter() + timeout_s

    while pending:
        remaining = deadline - time.perf_counter()
        if remaining <= 0:
            raise TimeoutError("timed out with %d pending tasks" % len(pending))
        for op in _wait_any_event(fds, remaining):
            now = time.perf_counter()
            if op == "store":
                for task_id, ok in adapter.pop_completed_store_tasks().items():
                    start = pending.pop(("store", int(task_id)), None)
                    if start is not None and ok:
                        latencies["store"].append((now - start) * 1000)
            elif op == "lookup":
                for op_name, task_id in list(pending):
                    if op_name != "lookup":
                        continue
                    bitmap = adapter.query_lookup_and_lock_result(task_id)
                    if bitmap is not None:
                        start = pending.pop(("lookup", task_id))
                        latencies["lookup"].append((now - start) * 1000)
            elif op == "load":
                for op_name, task_id in list(pending):
                    if op_name != "load":
                        continue
                    bitmap = adapter.query_load_result(task_id)
                    if bitmap is not None:
                        start = pending.pop(("load", task_id))
                        latencies["load"].append((now - start) * 1000)


def _prefill(adapter, keys, objs, batch_size: int, timeout_s: float) -> None:
    print("Prefilling %d keys..." % len(keys), flush=True)
    latencies = {"store": [], "lookup": [], "load": []}
    for start in range(0, len(keys), batch_size):
        end = min(start + batch_size, len(keys))
        pending = {
            ("store", _submit_store(adapter, keys[start:end], objs[start:end])): (
                time.perf_counter()
            )
        }
        _drain_until_done(adapter, pending, latencies, timeout_s)


def _run_pure_read(
    adapter,
    keys,
    batch_size: int,
    load_slots: list,
    warmup: int,
    iters: int,
    timeout_s: float,
) -> dict[str, list[float]]:
    latencies = {"store": [], "lookup": [], "load": []}
    total = warmup + iters
    for i in range(total):
        start = (i * batch_size) % len(keys)
        batch_keys = keys[start : start + batch_size]
        if len(batch_keys) < batch_size:
            batch_keys = batch_keys + keys[: batch_size - len(batch_keys)]
        load_objs = load_slots[: len(batch_keys)]
        pending: dict[tuple[str, int], float] = {}

        lookup_start = time.perf_counter()
        pending[("lookup", _submit_lookup(adapter, batch_keys))] = lookup_start
        load_start = time.perf_counter()
        pending[("load", _submit_load(adapter, batch_keys, load_objs))] = load_start

        round_latencies = {"store": [], "lookup": [], "load": []}
        _drain_until_done(adapter, pending, round_latencies, timeout_s)
        adapter.submit_unlock(batch_keys)
        if i >= warmup:
            latencies["lookup"].extend(round_latencies["lookup"])
            latencies["load"].extend(round_latencies["load"])
    return latencies


def _run_mixed_pressure(
    adapter,
    keys,
    store_objs,
    batch_size: int,
    load_slots: list,
    stores_per_round: int,
    warmup: int,
    iters: int,
    timeout_s: float,
) -> dict[str, list[float]]:
    latencies = {"store": [], "lookup": [], "load": []}
    total = warmup + iters
    for i in range(total):
        pending: dict[tuple[str, int], float] = {}
        offset = (i * batch_size * max(1, stores_per_round)) % len(keys)

        for j in range(stores_per_round):
            start = (offset + j * batch_size) % len(keys)
            batch_keys = keys[start : start + batch_size]
            batch_objs = store_objs[start : start + batch_size]
            if len(batch_keys) < batch_size:
                need = batch_size - len(batch_keys)
                batch_keys = batch_keys + keys[:need]
                batch_objs = batch_objs + store_objs[:need]
            pending[("store", _submit_store(adapter, batch_keys, batch_objs))] = (
                time.perf_counter()
            )

        read_start = (offset + stores_per_round * batch_size) % len(keys)
        read_keys = keys[read_start : read_start + batch_size]
        if len(read_keys) < batch_size:
            read_keys = read_keys + keys[: batch_size - len(read_keys)]
        load_objs = load_slots[: len(read_keys)]
        pending[("lookup", _submit_lookup(adapter, read_keys))] = time.perf_counter()
        pending[("load", _submit_load(adapter, read_keys, load_objs))] = (
            time.perf_counter()
        )

        round_latencies = {"store": [], "lookup": [], "load": []}
        _drain_until_done(adapter, pending, round_latencies, timeout_s)
        adapter.submit_unlock(read_keys)
        if i >= warmup:
            for op, values in round_latencies.items():
                latencies[op].extend(values)
    return latencies


def main() -> int:
    parser = argparse.ArgumentParser()
    parser.add_argument("--repo-root", default="/home/fcz/LMCache")
    parser.add_argument("--config-json")
    parser.add_argument("--config-file")
    parser.add_argument("--num-keys", type=int, default=1024)
    parser.add_argument("--batch-size", type=int, default=16)
    parser.add_argument("--value-size-bytes", type=int, default=1024 * 1024)
    parser.add_argument("--warmup", type=int, default=20)
    parser.add_argument("--iters", type=int, default=200)
    parser.add_argument("--stores-per-round", type=int, default=4)
    parser.add_argument("--timeout-s", type=float, default=120.0)
    parser.add_argument("--model-name", default="bench_mooncake_multiworkers")
    args = parser.parse_args()

    repo_root = str(Path(args.repo_root).resolve())
    _add_repo_to_path(repo_root)
    config = _load_config(args.config_json, args.config_file)

    keys = [_create_object_key(i, args.model_name) for i in range(args.num_keys)]
    arena_slots = args.num_keys + args.batch_size
    arena = L1Arena(arena_slots, args.value_size_bytes)
    store_objs = [
        arena.obj(i, float((i % 251) + 1)) for i in range(args.num_keys)
    ]
    load_slots = [
        arena.obj(args.num_keys + i, 0.0) for i in range(args.batch_size)
    ]


    adapter = _make_adapter(config, arena.desc)
    try:
        _prefill(adapter, keys, store_objs, args.batch_size, args.timeout_s)

        pure = _run_pure_read(
            adapter,
            keys,
            args.batch_size,
            load_slots,
            args.warmup,
            args.iters,
            args.timeout_s,
        )

        mixed = _run_mixed_pressure(
            adapter,
            keys,
            store_objs,
            args.batch_size,
            load_slots,
            args.stores_per_round,
            args.warmup,
            args.iters,
            args.timeout_s,
        )
        _print_title("Mooncake Multiworker Benchmark")
        _print_section("Adapter config")
        _print_config(config)
        _print_section("Workload")
        _print_kv_table(
            [
                ("num_keys", str(args.num_keys)),
                ("batch_size", str(args.batch_size)),
                ("value_size", _format_bytes(args.value_size_bytes)),
                ("warmup_iters", str(args.warmup)),
                ("measured_iters", str(args.iters)),
                ("stores_per_round", str(args.stores_per_round)),
                ("l1_slots", str(arena_slots)),
                ("l1_memory", _format_bytes(arena.desc.size)),
            ]
        )
        _print_latency_table("Pure read: lookup + load", pure)
        _print_latency_table(
            "Mixed pressure: stores queued before lookup + load", mixed
        )
    finally:
        adapter.close()
    return 0


if __name__ == "__main__":
    raise SystemExit(main())

```           
</details>

Pre-allocates an L1 arena, prefills keys to L2, then runs two scenarios: 

  1. **Pure read**: each iteration submits one `lookup` + one `load` concurrently.                                              
  2. **Mixed pressure**: each iteration submits N concurrent `store` batches first, then one `lookup` + `load` — reads compete with in-flight writes for worker pool slots.

Latency is measured per-op via eventfd polling. Percentiles are computed across all measured iterations after warmup. 

Mixed pressure results (1 MiB values, batch_size=16, 4 concurrent stores per round): 
  
  | Config | Op | avg ms | p99 ms |                                                                                                                                                                    
  |--------|-----|--------|--------|                                                                                                                                                                   
  | shared 16 workers | lookup | 2.34 | 108.76 |                                                                                                                                                       
  | shared 16 workers | load | 3.96 | 110.28 |                                                                                                                                                         
  | per-op (5+5+6) | lookup | **1.10** | **0.36** |                                                                                                                                                    
  | per-op (5+5+6) | load | **3.19** | **67.16** |                                                                                                                                                     
                                                                                                                                                                                                       
  Per-operation pools reduce lookup p99 by **300x** (108.76ms → 0.36ms) and load p99 by **1.6x** (110.28ms → 67.16ms). Pure-read performance is unchanged between the two configs.
</details> 

**Special notes for your reviewers**:
 - Batch methods follow the existing `do_batch_*` pattern in `ConnectorBase`, with consistent `any_failed` flagging across all three operations. 
 - The per-operation worker counts default to the global `num_workers` value when not explicitly set, so this is backward-compatible.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connector threading/queueing and Mooncake I/O paths (batching + optional separate thread pools), which could affect concurrency, shutdown behavior, and error handling under load.
> 
> **Overview**
> **Mooncake L2 now uses backend batch APIs and can isolate work by operation type.** `ConnectorBase` gains optional *separate per-op worker lanes* (`lookup`/`retrieve`/`store`), plus overridable `choose_num_tiles` and `do_batch_*` hooks so connectors can control tiling and implement true batch execution.
> 
> `MooncakeConnector` switches GET/SET/EXISTS execution to Mooncake’s `batch_*` calls (keeping per-key tolerance for GET), forces each LMCache batch to a single tile, and adds constructor/plumbing for per-op worker counts. Python/pybind, adapter config/factory, docs, and tests are updated to accept/validate `lookup_workers`/`retrieve_workers`/`store_workers` (all-or-nothing) and to unit-test factory behavior via a fake Mooncake extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e287ffe5a011e2782e7b3b2e2a6cf728fa500c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->