### PR TITLE
[DO NOT MERGE] sanity check on correctness test

### DIFF
--- a/.buildkite/k3_tests/correctness/scripts/run-correctness.sh
+++ b/.buildkite/k3_tests/correctness/scripts/run-correctness.sh
@@ -143,7 +143,6 @@ vllm serve "${MODEL}" \
     --enforce-eager \
     --attention-backend FLASH_ATTN \
     --gpu-memory-utilization 0.8 \
-    --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}' \
     >>"${VLLM_LOG}" 2>&1 &
 VLLM_PID=$!
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks CI correctness test server startup flags and does not change runtime library code.
> 
> **Overview**
> The K8s correctness script now starts the LMCache-backed `vllm serve` process **without** the explicit `--kv-transfer-config` (`LMCacheConnectorV1` / `kv_both`) argument, relying on `LMCACHE_CONFIG_FILE` alone for LMCache setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75c3e7599e4defc5d2d24af3c2ef39eaf4155c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->