### PR TITLE
[Chore][docs] daily drift check — multi-process mode (2026-04-28)

### DIFF
--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -274,6 +274,55 @@ demand via ``rate(lmcache_mp_l2_store_completed_total{l2_name="..."}[1m])``
 (and the equivalent for loads).  No separate ``*_iops`` metric is exported;
 keeping the raw counter lets dashboard users pick their own window.
 
+Failure & Health Counters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Health-monitoring counters emitted on the dedicated ``lmcache_mp.health``
+OTel meter. Driven by the ``L1FailureMetricsSubscriber`` and
+``L2FailureMetricsSubscriber``, which are registered automatically when
+metrics are enabled. All three counters carry ``model_name`` (extracted
+from each ``ObjectKey``) so operators can slice per-model on the
+Prometheus ``/metrics`` endpoint.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Metric
+     - Type
+     - Description
+   * - ``lmcache_mp.l1_allocation_failure``
+     - Counter
+     - L1 memory allocation failures (OOM) during ``reserve_write``.
+       Tagged by ``during`` ∈ {``l1_store``, ``l2_prefetch``} to
+       distinguish user-initiated stores from prefetch-triggered
+       allocations, plus ``model_name``.
+   * - ``lmcache_mp.l1_read_failure``
+     - Counter
+     - L1 ``reserve_read`` failures. Tagged by ``during`` ∈
+       {``l2_store``, ``l1_retrieve``}, ``reason`` ∈ {``not_found``,
+       ``write_locked``}, plus ``model_name``. **Post-lookup anomaly
+       counter**, not a cache-miss counter — in MP mode ``reserve_read``
+       is only called after a successful lookup, so any non-zero value
+       indicates a lookup/reserve race or unexpected eviction and should
+       stay near zero in healthy operation.
+   * - ``lmcache_mp.l2_prefetch_failure``
+     - Counter
+     - Keys that L2 reported present at lookup but failed to land in L1.
+       Tagged by ``reason`` ∈ {``l1_oom``, ``not_found``} plus
+       ``model_name``. ``l1_oom`` means L1 had no room to receive the
+       prefetched object; ``not_found`` means the adapter returned no
+       data despite a positive lookup (e.g. concurrent delete).
+
+A ``reason=serde_failure`` value will be added to ``l2_prefetch_failure``
+as an additive, non-breaking extension once L2 adapters distinguish
+deserialization errors from missing objects — no dashboard migration
+needed when that lands.
+
+For the full design rationale (including which event types drive each
+counter and why ``lmcache_instance_id`` is deferred), see
+``docs/design/v1/mp_observability/METRICS.md`` in the source tree.
+
 Lookup Hit-Rate Metrics
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

Aligns `docs/source/mp/observability.rst` with the L1/L2 failure-counter surface added in #3112 (merged 2026-04-27). Scope: one section added (+49 / −0).

### `docs/source/` (user-facing)

**Missing user-facing surface for L1/L2 failure health counters — #3112 (2026-04-27)**

#3112 added three new health-monitoring counters on a dedicated `lmcache_mp.health` OTel meter, registered automatically when metrics are enabled. The design doc `docs/design/v1/mp_observability/METRICS.md` was updated in the same PR but the user-facing reference (`docs/source/mp/observability.rst`) was not, so users currently have no documented surface for these counters.

Counters and tag schemas:

| OTel metric | Tags |
| --- | --- |
| `lmcache_mp.l1_allocation_failure` | `during` ∈ {`l1_store`, `l2_prefetch`}, `model_name` |
| `lmcache_mp.l1_read_failure` | `during` ∈ {`l2_store`, `l1_retrieve`}, `reason` ∈ {`not_found`, `write_locked`}, `model_name` |
| `lmcache_mp.l2_prefetch_failure` | `reason` ∈ {`l1_oom`, `not_found`}, `model_name` |

**Evidence:**

- Subscriber definitions and meter name (`lmcache_mp.health`):
  - [`lmcache/v1/mp_observability/subscribers/metrics/l1_failures.py#L36-L57`](https://github.com/LMCache/LMCache/blob/f8ffd8f06d7c252cef52e82387ab730f71a2f050/lmcache/v1/mp_observability/subscribers/metrics/l1_failures.py#L36-L57)
  - [`lmcache/v1/mp_observability/subscribers/metrics/l2_failures.py#L36-L48`](https://github.com/LMCache/LMCache/blob/f8ffd8f06d7c252cef52e82387ab730f71a2f050/lmcache/v1/mp_observability/subscribers/metrics/l2_failures.py#L36-L48)
- Auto-registration when metrics are enabled: [`lmcache/v1/mp_observability/config.py#L324-L351`](https://github.com/LMCache/LMCache/blob/f8ffd8f06d7c252cef52e82387ab730f71a2f050/lmcache/v1/mp_observability/config.py#L324-L351) (lines 344, 347)
- Mirrored design doc (already correct): [`docs/design/v1/mp_observability/METRICS.md#L120-L127`](https://github.com/LMCache/LMCache/blob/f8ffd8f06d7c252cef52e82387ab730f71a2f050/docs/design/v1/mp_observability/METRICS.md#L120-L127) and [`#L219-L225`](https://github.com/LMCache/LMCache/blob/f8ffd8f06d7c252cef52e82387ab730f71a2f050/docs/design/v1/mp_observability/METRICS.md#L219-L225)
- Stale doc location (no mention prior to this PR): `docs/source/mp/observability.rst` (`grep -nE "l1_allocation_failure|l1_read_failure|l2_prefetch_failure" docs/source/mp/observability.rst` → 0 matches).

### `docs/design/`

No new drift observed this run — the mirrored design docs under `docs/design/v1/mp_observability/METRICS.md` and `EVENTS.md` already cover the new failure counters and their source events correctly.

### Other commits checked, no drift

- **#3128** (Common HTTP APIs) — `docs/source/mp/http_api.rst` and `docs/design/v1/multiprocess/mp_runtime_plugin.md` were updated in the same PR; cross-checked the documented endpoint table against `lmcache/v1/multiprocess/http_apis/` + `lmcache/v1/internal_api_server/common/` registrations and they match.
- **#3144** (EventNotifier replaces `os.eventfd`) — `docs/source/developer_guide/extending_lmcache/storage_plugins.rst` and `docs/design/v1/platform/event_notifier.md` were updated in the same PR; the `create_event_notifier()` example matches `lmcache/v1/platform/event_notifier.py`.
- **#3124** (Per-adapter L1↔L2 throughput metrics) — `docs/source/mp/observability.rst` was updated in the same PR.
- **#3142** (unified c_ops backend / `gpu_kv_format_name` fix) — 12-line code change in `gpu_context.py`; only design-doc reference is in `docs/design/cli/commands/describe.md` and matches.
- **#3131** (MP HTTP endpoints docs) — already a docs PR; no drift introduced.
- **#2635** (io_uring for Rust raw block backend) — module-local doc updates only (`rust/raw_block/README.md`, `benchmarks/storage_backend_io/README.md`); not referenced from `docs/source/mp/`.

## Proposed fix

Applied in this PR. Surgical doc edit only — added a `Failure & Health Counters` subsection to `docs/source/mp/observability.rst`, slotted between `L2 Metrics` and `Lookup Hit-Rate Metrics`, mirroring the design doc's structure and cross-linking back to `docs/design/v1/mp_observability/METRICS.md` for the full rationale.

## Notes for reviewers

- This was **auto-generated by the daily drift-check routine** and needs human review before merge.
- One drift item this run (vs. five in the previous one); consistent with the prior drift-check PR #3132 having recently cleared the backlog.
- No code changes — the new counters are already wired up and emitting. This PR just makes them discoverable on the user-facing observability reference.

## Test plan

- [ ] Sphinx builds `docs/` without new warnings.
- [ ] Eyeball the rendered `mp/observability.rst` "Failure & Health Counters" table.
- [ ] Confirm the documented metric names match a live `lmcache server` Prometheus scrape: `curl -s :9090/metrics | grep -E 'l1_allocation_failure|l1_read_failure|l2_prefetch_failure'`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011eCSKvkz4WqfgdE5YcjKNR)_