### PR TITLE
Add support for `AZURE_BLOB` NIXL backend

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/nixl_store.md
+++ b/docs/design/v1/distributed/l2_adapters/nixl_store.md
@@ -9,7 +9,7 @@ two variants:
 
 | Adapter | Type name | Storage mode | Persist | Backends |
 |---|---|---|---|---|
-| `NixlStoreL2Adapter` | `nixl_store` | Static (pre-allocated files) | Not supported | GDS, GDS_MT, POSIX, HF3FS, OBJ |
+| `NixlStoreL2Adapter` | `nixl_store` | Static (pre-allocated files) | Not supported | GDS, GDS_MT, POSIX, HF3FS, OBJ, AZURE_BLOB |
 | `DynamicNixlStoreL2Adapter` | `nixl_store_dynamic` | Dynamic (per-operation files) | Supported (default on) | GDS, GDS_MT, POSIX, HF3FS |
 
 The **static** adapter pre-allocates all storage files at init and registers

--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -169,6 +169,6 @@ Example ``lmcache-config.yaml`` for AZURE_BLOB backend with dynamic mode:
     nixl_pool_size: 0
     nixl_presence_cache: False
     nixl_async_put: False
-      nixl_backend_params:
-        account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
-        container_name: <your_container_name>
+    nixl_backend_params:
+      account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
+      container_name: <your_container_name>

--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -47,13 +47,13 @@ Key settings:
 
 - ``nixl_path``: directory under which the storage files will be saved (e.g. /mnt/nixl/). Needed for NIXL backends that store to file.
 
-- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS" and "GDS_MT" backends - for "POSIX", "HF3FS" & "OBJ", must be "cpu".
+- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS", "GDS_MT", and "OBJ" backends - for "POSIX", "HF3FS" & "AZURE_BLOB", must be "cpu".
 
 - ``nixl_backend``: configuration of which nixl backend to use for storage.
 
 .. note::
 
-    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ"].
+    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ", "AZURE_BLOB"].
 
     Backend specific params should be provided via ``extra_config.nixl_backend_params``. Please refer to NIXL documentation for specifics.
 
@@ -95,6 +95,22 @@ Example ``lmcache-config.yaml`` for POSIX backend using liburing:
       nixl_backend_params:
         use_uring: "true"
 
+Example ``lmcache-config.yaml`` for AZURE_BLOB backend to offload using Azure Blob Storage API:
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    nixl_buffer_size: 1073741824 # 1GB
+    nixl_buffer_device: cpu
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: AZURE_BLOB
+      nixl_pool_size: 64
+      nixl_path: /mnt/nixl/cache/
+      nixl_backend_params:
+        account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
+        container_name: <your_container_name>
+
 Dynamic Mode
 ~~~~~~~~~~~~~
 
@@ -105,7 +121,7 @@ In order to use dynamic mode, extra_config.nixl_pool_size should be set to 0.
 Restrictions
 ^^^^^^^^^^^^
 
-- Dynamic mode is currently only supported for nixl OBJ backend.
+- Dynamic mode is currently only supported for nixl OBJ and AZURE_BLOB backends.
 - save_unfull_chunk must be set to False.
 
 Example ``lmcache-config.yaml`` for OBJ backend with dynamic mode:
@@ -133,3 +149,26 @@ Example ``lmcache-config.yaml`` for OBJ backend with dynamic mode:
       region: <your_region>
       endpoint_override: https://url-to-object-storage
       ca_bundle: path to self-signed certificate # remove this line if not using self-signed certificate
+
+
+Example ``lmcache-config.yaml`` for AZURE_BLOB backend with dynamic mode:
+
+.. code-block:: yaml
+
+  chunk_size: 256
+  local_cpu: False
+  save_unfull_chunk: False
+  enable_async_loading: False # set to True to test async loading
+  # buffer size has to be divisible by chunk size
+  # 2880MiB is divisible by 256 token chunk for Qwen3-4B/8B/32B
+  nixl_buffer_size: 3019898880
+  nixl_buffer_device: cpu
+  extra_config:
+    enable_nixl_storage: true
+    nixl_backend: AZURE_BLOB
+    nixl_pool_size: 0
+    nixl_presence_cache: False
+    nixl_async_put: False
+      nixl_backend_params:
+        account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
+        container_name: <your_container_name>

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -243,7 +243,7 @@ Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
 
 Fields:
 
-- ``backend`` *(required)*: One of ``POSIX``, ``GDS``, ``GDS_MT``, ``HF3FS``, ``OBJ``.
+- ``backend`` *(required)*: One of ``POSIX``, ``GDS``, ``GDS_MT``, ``HF3FS``, ``OBJ``, ``AZURE_BLOB``.
 - ``backend_params`` *(required for file-based backends)*: Dict of string
   key-value pairs.  File-based backends (``GDS``, ``GDS_MT``, ``POSIX``,
   ``HF3FS``) require ``file_path`` and ``use_direct_io``.
@@ -267,6 +267,10 @@ Examples:
 
     # OBJ backend (object store -- no file_path needed)
     --l2-adapter '{"type": "nixl_store", "backend": "OBJ", "backend_params": {}, "pool_size": 32}'
+
+    # AZURE_BLOB backend
+    --l2-adapter '{"type": "nixl_store", "backend": "AZURE_BLOB", "backend_params": {"account_url": "https://<account_name>.blob.core.windows.net", "container_name": "<container_name>"}, "pool_size": 32}'
+
 
 ``fs`` -- File-system backed storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -44,7 +44,7 @@ high-performance storage I/O.
 **Required fields:**
 
 - ``backend``: Storage backend -- one of ``POSIX``, ``GDS``, ``GDS_MT``,
-  ``HF3FS``, ``OBJ``.
+  ``HF3FS``, ``OBJ``, ``AZURE_BLOB``.
 - ``pool_size``: Number of storage descriptors to pre-allocate (must be > 0).
 
 **Backend-specific parameters (``backend_params``):**
@@ -54,7 +54,7 @@ File-based backends (``GDS``, ``GDS_MT``, ``POSIX``, ``HF3FS``) require:
 - ``file_path``: Directory path for storing L2 data.
 - ``use_direct_io``: ``"true"`` or ``"false"`` -- whether to use direct I/O.
 
-The ``OBJ`` backend (object store) does not require ``file_path``.
+The ``OBJ`` and ``AZURE_BLOB`` backends (object stores) do not require ``file_path``.
 
 **Backend descriptions:**
 
@@ -75,6 +75,8 @@ The ``OBJ`` backend (object store) does not require ``file_path``.
      - Shared file system backend (e.g., for distributed/networked storage).
    * - ``OBJ``
      - Object store backend.  No local file path required.
+   * - ``AZURE_BLOB``
+     - Object store backend for Azure Blob Storage.  No local file path required.
 
 **Configuration examples:**
 
@@ -95,6 +97,9 @@ The ``OBJ`` backend (object store) does not require ``file_path``.
     # OBJ backend
     --l2-adapter '{"type": "nixl_store", "backend": "OBJ", "backend_params": {}, "pool_size": 32}'
 
+    # AZURE_BLOB backend
+    --l2-adapter '{"type": "nixl_store", "backend": "AZURE_BLOB", "backend_params": {"account_url": "https://<account_name>.blob.core.windows.net", "container_name": "<container_name>"}, "pool_size": 32}'
+
 ``nixl_store_dynamic`` -- NIXL-based dynamic storage with persist/recover
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -108,7 +113,7 @@ per-operation instead of pre-allocating them at init. This enables:
 .. note::
 
    Only file-based backends are supported (``POSIX``, ``GDS``, ``GDS_MT``,
-   ``HF3FS``). The ``OBJ`` backend is not supported yet.
+   ``HF3FS``). The ``OBJ`` and ``AZURE_BLOB`` backends are not supported yet.
 
 **Required fields:**
 

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -157,7 +157,7 @@ class NixlStorageAgent:
         Args:
             device: Device type of the L1 memory buffer (e.g. "cpu", "cuda").
             backend: Nixl storage backend to use. One of: GDS, GDS_MT, POSIX,
-                HF3FS (file-based) or OBJ (object-based).
+                HF3FS (file-based) or OBJ, AZURE_BLOB (object-based).
             backend_params: Backend-specific parameters. File-based backends
                 require "file_path" and "use_direct_io" keys.
             pool_size: Number of storage descriptor slots to pre-allocate.
@@ -199,7 +199,7 @@ class NixlStorageAgent:
                 use_direct_io=str(self.backend_params["use_direct_io"]).lower()
                 == "true",
             )
-        elif self.backend in ["OBJ"]:
+        elif self.backend in ["OBJ", "AZURE_BLOB"]:
             self.pool = NixlObjPool(num_total_objs=self.pool_size)
             self.init_storage_handlers_object(
                 page_size=l1_memory_desc.align_bytes,
@@ -901,6 +901,7 @@ _VALID_NIXL_BACKENDS = (
     "POSIX",
     "HF3FS",
     "OBJ",
+    "AZURE_BLOB",
 )
 _FILE_BACKENDS = ("GDS", "GDS_MT", "POSIX", "HF3FS")
 
@@ -911,7 +912,7 @@ class NixlStoreL2AdapterConfig(L2AdapterConfigBase):
 
     Fields:
     - backend: Nixl storage backend
-      (GDS, GDS_MT, POSIX, HF3FS, OBJ).
+      (GDS, GDS_MT, POSIX, HF3FS, OBJ, AZURE_BLOB).
     - backend_params: Backend-specific parameters as a
       dict of string key-value pairs. For file-based
       backends (GDS, GDS_MT, POSIX, HF3FS), must include

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -70,15 +70,17 @@ class NixlStorageConfig:
 
     @staticmethod
     def validate_nixl_backend(dynamic_storage: bool, backend: str, device: str):
-        if dynamic_storage:  # For now only supports OBJ backend
+        if dynamic_storage:  # For now only supports OBJ and AZURE_BLOB backend
             if backend in ("OBJ",):
                 return device == "cpu" or device == "cuda"
+            elif backend in ("AZURE_BLOB",):
+                return device == "cpu"
             else:
                 return False
         else:
             if backend in ("GDS", "GDS_MT", "OBJ"):
                 return device == "cpu" or device == "cuda"
-            elif backend in ("POSIX", "HF3FS"):
+            elif backend in ("POSIX", "HF3FS", "AZURE_BLOB"):
                 return device == "cpu"
             else:
                 return False
@@ -434,7 +436,7 @@ class NixlDynamicStorageAgent(NixlStorageAgent):
     ):
         super().__init__(allocator, device, backend, backend_params)
 
-        if backend == "OBJ":
+        if backend in ("OBJ", "AZURE_BLOB"):
             self.mem_type = "OBJ"
         else:
             # Already validated in validate_nixl_backend
@@ -684,7 +686,7 @@ class NixlStaticStorageBackend(NixlStorageBackend):
     def createPool(backend: str, size: int, path: str, use_direct_io: bool):
         if backend in ("GDS", "GDS_MT", "POSIX", "HF3FS"):
             return NixlFilePool(size, path, use_direct_io)
-        elif backend in ("OBJ"):
+        elif backend in ("OBJ", "AZURE_BLOB"):
             return NixlObjectPool(size)
         else:
             raise ValueError(f"Unsupported NIXL backend: {backend}")


### PR DESCRIPTION
**What this PR does / why we need it**:

The NIXL plugin uses Azure Blob Storage as an object store backend instead of S3. It is designed as a drop-in replacement for the OBJ backend, behaving functionally the same and only differing by required configurations. Currently, it only supports CPU to object store offloading. There is currently no GPU direct support. See NIXL documentation [here](https://github.com/ai-dynamo/nixl/blob/main/src/plugins/azure_blob/README.md) to learn more.

Most of the work was allow listing the `AZURE_BLOB` plugin in code paths where the `OBJ` plugin was configured. Specifically, the PR updated the following LMCache interfaces to plumb through `AZURE_BLOB` support:

* KV cache offloading with the NIXL storage backend for both static and dynamic pools
* L2 storage for `nixl_store`. Note it was not added to the `nixl_store_dynamic` because the `OBJ` plugin was not supported there either

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**Special notes for your reviewers**:
In terms of testing, I did not see any unit tests specifically targeting the `OBJ` NIXL plugin that I could follow for the `AZURE_BLOB` plugin. So mainly focused on manually testing (see details below). Let me know if there is any specific unit tests you'd like to see added or other scenarios to try out. Happy to do it.

I have not done any in-depth performance testing on the offloading either; I plan to do that soon, but figured it should not block being able to access offloading to Azure Blob as part of LMCache and any changes required related to perf would happen in the NIXL integration itself. 

**Testing: Static pool NIXL storage backend for single process KV cache offloading**
I used the configuration in the PR and spun up vLLM using it e.g.,:
```
AZURE_LOG_LEVEL=verbose LMCACHE_CONFIG_FILE="az-config.yaml"  PYTHONHASHSEED=0 vllm serve Qwen/Qwen3-8B --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
```
I confirmed that KV results were being written to the configured Azure storage container and also confirmed with repeated prompts (while the same vLLM process was still running) API calls were made to check for existence and retrieve the KV results.

**Testing: Dynamic pool NIXL storage backend for single process KV cache offloading**
I used the configuration in the PR and spun up vLLM similar to the static pool. I confirmed that the KV results were being written to the configured Azure storage container. I also confirmed when a new instance of vLLM was launched it would read the KV results from Azure storage that were previously stored instead of writing new results when reusing the same prompt.

**Testing: Static pool NIXL L2 storage for MP server**
Ran the LMCache server:
```
AZURE_LOG_LEVEL=verbose PYTHONHASHSEED=0 python -c "from lmcache.cli.main import main; main()" server --l1-size-gb 1 --eviction-policy LRU --l2-adapter '{"type": "nixl_store", "backend": "AZURE_BLOB", "backend_params": {"account_url": "https://account-name.blob.core.windows.net", "container_name": "container-name"}, "pool_size": 10000}'
```
Connected vLLM to it:
```
PYTHONHASHSEED=0 vllm serve Qwen/Qwen3-8B --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both"}'
```
And confirmed that KV results were being written to Azure Storage as an L2 storage option and confirmed results were being read for Azure Storage when needed (e.g., a previously used prompt's KV results were evicted from L1 but had been stored in Azure storage as L2).



**If applicable**:

- [X] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands supported storage backends and changes backend/device validation and pool selection logic in NIXL data paths; incorrect config values could cause runtime failures or CPU-only fallbacks.
> 
> **Overview**
> Adds support for the NIXL `AZURE_BLOB` plugin as an object-store backend, treating it alongside `OBJ` for static `nixl_store` L2 storage and for the NIXL KV-cache storage backend (including dynamic mode).
> 
> Updates backend allowlists and device compatibility checks to permit `AZURE_BLOB` (CPU-only in dynamic mode; CPU-only for file-like paths), and extends user docs/CLI examples to document the new backend and required Azure configuration parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae4ec0cabc86cb2fb76d2574767d22c904043ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->