### PR TITLE
[Refactor] Unify discover+normalize and add EngineType to REGISTER

### DIFF
--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -2,10 +2,12 @@
 
 ## Invariant
 
-> **`discover_gpu_kv_format` is the only place that parses KV-cache layout.**
-> Every other module queries KV-cache information via helpers in
-> `lmcache/v1/gpu_connector/utils.py` that accept a `GPUKVFormat`
-> argument.
+> **`normalize_kv_and_discover_format` is the only place that parses
+> KV-cache layout.** It also returns the canonical (post-permute) form
+> of the kv_caches alongside the format, so callers never need a
+> separate normalization step. Every other module queries KV-cache
+> information via helpers in `lmcache/v1/gpu_connector/utils.py` that
+> accept a `GPUKVFormat` argument.
 
 "Layout parsing" means: list-nesting depth, tensor-dimension ordering,
 HND vs NHD, MLA vs MHA, per-layer vs cross-layer. All of that is
@@ -30,11 +32,14 @@ are responsible for unwrapping to this form before calling any helper.
 ## Adding a new format
 
 1. Add the enum value in `csrc/mem_kernels.cuh` and `csrc/pybind.cpp`.
-2. Extend `discover_gpu_kv_format` to detect it. The dispatch keys off
-   `(list_depth, tensor_ndim)` — both are computed once in a single
-   descent via the private `_list_depth_tensor_dim` probe, so new
-   detection branches only need to add a shape check, not re-walk the
-   structure.
+2. Extend `normalize_kv_and_discover_format` to detect it. The dispatch
+   keys off `(list_depth, tensor_ndim)` — both are computed once in a
+   single descent via the private `_list_depth_tensor_dim` probe, so
+   new detection branches only need to add a shape check, not re-walk
+   the structure. If the engine produces a tensor whose shape needs
+   reshape-via-hints (e.g. TRT-LLM's 4-D bare tensor that must be
+   `view`'d as 6-D), put the reshape inside this function in the
+   engine-keyed branch — *before* the permute step.
 3. Add a branch in every `utils.py` helper that raises "Unknown GPU KV
    Format" — the exhaustive chain makes it mechanical.
 4. Add a row in `tests/v1/gpu_connector/test_utils_shape_desc.py`.
@@ -52,7 +57,7 @@ a `GPUKVFormat`. Nothing else may index raw shapes.
 
 | Helper | Returns |
 |---|---|
-| `discover_gpu_kv_format(kv_caches, engine, layout_hints)` | `GPUKVFormat` — the one parser. |
+| `normalize_kv_and_discover_format(kv_caches, engine, layout_hints)` | `tuple[GPUKVFormat, DiscoverableKVCache]` — the one parser. Returns the canonical (permuted-to-contiguous) kv_caches alongside the detected format; callers must use the returned tensor structure for subsequent operations. |
 
 ### Scalar accessors
 
@@ -87,7 +92,7 @@ helper.
 
 | Helper | Returns | Notes |
 |---|---|---|
-| `attempt_permute_to_contiguous_view(kv)` | `DiscoverableKVCache` | Recursive, metadata-only. No-op if already contiguous; raises `ValueError` for non-permutation-recoverable cases (slicing, `as_strided`). **Never copies.** Walks the full structure and permutes every tensor leaf. |
+| `attempt_permute_to_contiguous_view(kv)` | `DiscoverableKVCache` | Recursive, metadata-only. No-op if already contiguous; raises `ValueError` for non-permutation-recoverable cases (slicing, `as_strided`). **Never copies.** Walks the full structure and permutes every tensor leaf. Called internally by `normalize_kv_and_discover_format`; remains public only for callers that handle a tensor *outside* the discover flow (`GPUConnectorInterface.initialize_kvcaches_ptr`, `CudaIPCWrapper.__init__`). |
 
 ## Forbidden outside `utils.py`
 
@@ -96,8 +101,9 @@ helper.
   dimensions.
 - Hand-rolled list-depth probing (`while isinstance(x, list): depth +=
   1; x = x[0]`). There is no public depth helper and there shouldn't
-  be one — `discover_gpu_kv_format` encapsulates the descent, and
-  downstream code only ever needs the resulting `GPUKVFormat`.
+  be one — `normalize_kv_and_discover_format` encapsulates the
+  descent, and downstream code only ever needs the resulting
+  `GPUKVFormat`.
 - Wrapping a tensor with `[tensor]` to adapt to a helper's list-depth
   expectation — the accessors take `layer_idx` directly.
 - Hand-rolled pointer assembly (`[t.data_ptr() for t in kv_caches]`) —
@@ -108,7 +114,9 @@ helper.
   use `attempt_permute_to_contiguous_view` which refuses to copy.
 - "Canonicalize" functions that rewrite `kv_caches` to a uniform shape
   before passing to helpers. The helpers already canonicalize by
-  accepting `GPUKVFormat`.
+  accepting `GPUKVFormat`, and any reshape/normalize step that *is*
+  needed lives inside `normalize_kv_and_discover_format` — callers
+  receive the canonical form back from that one call.
 
 ## Consumers
 
@@ -126,15 +134,16 @@ helper.
   tensors via `get_group_data_ptrs`. No parallel `shape_descs_` /
   `hidden_dim_sizes_` state.
 - **`lmcache/v1/gpu_connector/gpu_connectors.py::VLLMPagedMemGPUConnectorV3._initialize_kv_cache_pointers`**
-  — for the in-process vLLM path, discovers format (after one call to
-  `attempt_permute_to_contiguous_view` for HND support) and constructs
+  — for the in-process vLLM path, calls
+  `normalize_kv_and_discover_format` (which permutes for HND support
+  and detects the format in one step) and constructs
   `metadata.kv_layer_groups_manager` lazily on first store/retrieve.
   The adapter (`vllm_v1_adapter.py`) does not participate in format
   discovery — it only stores `self.kv_caches` at register time.
 
-Only `discover_gpu_kv_format` consumes `layout_hints`.
-`attempt_permute_to_contiguous_view` infers the permutation from
-strides and needs no hints.
+Only `normalize_kv_and_discover_format` consumes `layout_hints`.
+`attempt_permute_to_contiguous_view` (called internally) infers the
+permutation from strides and needs no hints.
 
 ## Implementation note: mypy and the recursive union
 

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -12,7 +12,7 @@ import zmq
 
 # First Party
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
-from lmcache.utils import _lmcache_nvtx_annotate, init_logger
+from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     CudaIPCWrapper,
@@ -685,6 +685,7 @@ class LMCacheMPWorkerAdapter:
                 wrap_kv_caches(kv_caches),
                 self.model_name,
                 self.world_size,
+                EngineType.VLLM,
                 layout_hints,
             ],
         )

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -16,7 +16,6 @@ from lmcache.v1.gpu_connector.utils import (
     assert_is_vllm_flash_attn_or_flash_infer,
     assert_is_vllm_mla_or_flash_attn_or_flash_infer,
     attempt_permute_to_contiguous_view,
-    discover_gpu_kv_format,
     get_block_size,
     get_device,
     get_elements_per_layer,
@@ -26,6 +25,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     get_tokens_per_layer,
+    normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.memory_management import GPUMemoryAllocator  # noqa: E501
@@ -244,17 +244,15 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         if idx in self.kv_cache_pointers_on_gpu:
             return self.kv_cache_pointers_on_gpu[idx]
 
-        kv_caches = attempt_permute_to_contiguous_view(kv_caches)
+        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
+        )
 
         self.kv_cache_pointers.numpy()[:] = [t.data_ptr() for t in kv_caches]
         self.kv_cache_pointers_on_gpu[idx] = torch.empty(
             self.num_layers, dtype=torch.int64, device=self.device
         )
         self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
-
-        self.gpu_kv_format = discover_gpu_kv_format(
-            kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
-        )
         self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
         self.block_size = get_block_size(kv_caches, self.gpu_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
@@ -462,8 +460,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.init:
             return
 
-        self.kvcaches = attempt_permute_to_contiguous_view(self.kvcaches)
-        self.gpu_kv_format = discover_gpu_kv_format(
+        self.gpu_kv_format, self.kvcaches = normalize_kv_and_discover_format(
             self.kvcaches, EngineType.VLLM, layout_hints=self.layout_hints
         )
         self.num_blocks = get_num_blocks(self.kvcaches, self.gpu_kv_format)
@@ -709,11 +706,10 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            kv_caches = attempt_permute_to_contiguous_view(kv_caches)
-            self.kvcaches = kv_caches
-            self.gpu_kv_format = discover_gpu_kv_format(
+            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
             )
+            self.kvcaches = kv_caches
             assert_is_vllm_flash_attn_or_flash_infer(self.gpu_kv_format)
             self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
             self.elements_per_layer = get_elements_per_layer(
@@ -1123,11 +1119,10 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            kv_caches = attempt_permute_to_contiguous_view(kv_caches)
-            self.kvcaches = kv_caches
-            self.gpu_kv_format = discover_gpu_kv_format(
+            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
             )
+            self.kvcaches = kv_caches
             assert_is_vllm_mla_or_flash_attn_or_flash_infer(self.gpu_kv_format)
             self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
             self.elements_per_layer = get_elements_per_layer(
@@ -1448,8 +1443,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
             logger.info(f"GPU buffer: {self.gpu_buffer.shape}")
 
     def _initialize_pointers(self, kv_caches: DiscoverableKVCache) -> torch.Tensor:
-        kv_caches = attempt_permute_to_contiguous_view(kv_caches)
-        self.gpu_kv_format = discover_gpu_kv_format(kv_caches, EngineType.SGLANG)
+        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            kv_caches, EngineType.SGLANG
+        )
         num_layers = get_num_layers(kv_caches, self.gpu_kv_format)
         # SGLang registers every layer as one group; pass all indices in order.
         ptrs = get_group_data_ptrs(
@@ -1656,8 +1652,9 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
         Also, the first request might be a bit slower due to buffer creation.
         """
         if self.use_gpu and self.gpu_buffer_allocator is None:
-            kv_caches = attempt_permute_to_contiguous_view(kv_caches)
-            self.gpu_kv_format = discover_gpu_kv_format(kv_caches, EngineType.SGLANG)
+            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+                kv_caches, EngineType.SGLANG
+            )
             self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
             self.elements_per_layer = get_elements_per_layer(
                 kv_caches, self.gpu_kv_format

--- a/lmcache/v1/gpu_connector/hpu_connector.py
+++ b/lmcache/v1/gpu_connector/hpu_connector.py
@@ -25,7 +25,6 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import GPUConnectorInterface
 from lmcache.v1.gpu_connector.utils import (
-    discover_gpu_kv_format,
     get_block_size,
     get_dtype,
     get_head_size,
@@ -35,6 +34,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     is_mla,
+    normalize_kv_and_discover_format,
 )
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
@@ -294,7 +294,9 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
                 fake_shape,
             )
 
-        self.gpu_kv_format = discover_gpu_kv_format(kv_caches, EngineType.VLLM)
+        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            kv_caches, EngineType.VLLM
+        )
         self.num_layers = get_num_layers(kv_caches, self.gpu_kv_format)
         self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
         self.block_size = get_block_size(kv_caches, self.gpu_kv_format)

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -33,8 +33,8 @@ import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 
-# Canonical recursive type consumed by :func:`discover_gpu_kv_format` and
-# the downstream format-aware helpers. A value is either a single
+# Canonical recursive type consumed by :func:`normalize_kv_and_discover_format`
+# and the downstream format-aware helpers. A value is either a single
 # :class:`torch.Tensor` (e.g. vLLM cross-layer, TRT-LLM) or a list of
 # nested ``DiscoverableKVCache`` values (per-layer lists, SGLang's two-list
 # MHA, deeper nesting). Engine adapters that hand us other containers
@@ -287,27 +287,40 @@ def _list_depth_tensor_dim(kv_caches: DiscoverableKVCache) -> tuple[int, int]:
     return depth, probe.ndim
 
 
-def discover_gpu_kv_format(
+def normalize_kv_and_discover_format(
     kv_caches: DiscoverableKVCache,
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
-) -> "lmc_ops.GPUKVFormat":
+) -> tuple["lmc_ops.GPUKVFormat", DiscoverableKVCache]:
     """
-    Discover the GPU KV Cache Format from the kv_caches.
+    Normalize ``kv_caches`` into the canonical form and discover its GPU KV format.
 
-    KEY: the logical view and physical views of the kv_caches should be made consistent
-    BEFORE format discovery
+    Performs (in order):
+      1. ``attempt_permute_to_contiguous_view``: stride-based dim
+         permutation so ``.shape`` reflects the physical (not
+         permuted-logical) layout — critical for HND vs NHD detection.
+         No-op if already contiguous; raises for non-permutation sources
+         of non-contiguity (slicing, ``as_strided``).
+      2. Format detection by descending list-wrapping and inspecting the
+         innermost tensor's shape.
 
-    The logic is that "external" layers are lists and there is one tensor internally.
-    We "unwrap" layers until we find the tensor.
+    The logic is that "external" layers are lists and there is one tensor
+    internally. We "unwrap" layers until we find the tensor.
 
     Args:
         kv_caches: The KV cache tensors (possibly nested lists of tensors).
         serving_engine: Which serving engine produced the caches.
         layout_hints: See :class:`~lmcache.v1.multiprocess.custom_types.LayoutHints`.
 
+    Returns:
+        ``(gpu_kv_format, normalized_kv_caches)``. Callers must use the
+        returned tensor structure for subsequent operations — it shares
+        storage with the input but may be a permuted view.
+
     Please see csrc/mem_kernels.cuh for the naming schema of the GPUKVFormat.
     """
+    kv_caches = attempt_permute_to_contiguous_view(kv_caches)
+
     # list_depth: number of external wrapping lists
     # tensor_dim: number of dimensions of the internal tensor
     list_depth, tensor_dim = _list_depth_tensor_dim(kv_caches)
@@ -317,11 +330,6 @@ def discover_gpu_kv_format(
     for _ in range(list_depth):
         list_dims.append(len(probe))
         probe = probe[0]
-    # Ensure the innermost tensor is contiguous so .shape below reflects the
-    # physical (not permuted-logical) layout — critical for HND format
-    # detection. No-op if already contiguous; raises for non-permutation
-    # sources of non-contiguity (slicing, as_strided).
-    probe = attempt_permute_to_contiguous_view(probe)
 
     tensor_dims = list(probe.shape)
     dims_str = (
@@ -374,7 +382,7 @@ def discover_gpu_kv_format(
 
     if detected_format is not None:
         legible_print_gpu_kv_format(detected_format)
-        return detected_format
+        return detected_format, kv_caches
     else:
         raise ValueError(
             "currently unsupported kv_caches format "
@@ -785,7 +793,7 @@ def get_group_data_ptrs(
 
     Args:
         kv_caches: Full kv_caches structure.
-        gpu_kv_format: Format returned by :func:`discover_gpu_kv_format`.
+        gpu_kv_format: Format returned by :func:`normalize_kv_and_discover_format`.
         layer_indices: 0-based layer indices in the group, in the order
             the kernel should iterate them. Ignored for cross-layer.
 
@@ -842,7 +850,7 @@ def make_page_buffer_shape_desc(
 
     Args:
         kv_caches: Full kv_caches structure.
-        gpu_kv_format: Format returned by :func:`discover_gpu_kv_format`.
+        gpu_kv_format: Format returned by :func:`normalize_kv_and_discover_format`.
         layer_idx: 0-based index of the representative layer.
         num_layers_in_group: Number of layers in the group (``nl``).
         num_blocks: Number of paged blocks (``nb``).

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -30,7 +30,6 @@ from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     _get_head_size_view,
     _split_token2d_kv,
-    discover_gpu_kv_format,
     get_block_size,
     get_dtype,
     get_head_size,
@@ -40,6 +39,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     is_mla,
+    normalize_kv_and_discover_format,
 )
 from lmcache.v1.memory_management import (
     MemoryAllocatorInterface,
@@ -285,7 +285,9 @@ class VLLMPagedMemXPUConnectorV2(VLLMPagedMemGPUConnectorV2):
         self.device = kv_caches[0].device
         assert self.device.type == "xpu", "The device should be XPU."
 
-        self.gpu_kv_format = discover_gpu_kv_format(kv_caches, EngineType.VLLM)
+        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            kv_caches, EngineType.VLLM
+        )
         self.num_layers = get_num_layers(kv_caches, self.gpu_kv_format)
         self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
         self.block_size = get_block_size(kv_caches, self.gpu_kv_format)

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -127,8 +127,9 @@ class KVLayerGroupsManager:
 
         Args:
             kv_caches: KV cache structure accepted by
-                :func:`discover_gpu_kv_format`.
-            gpu_kv_format: Format returned by :func:`discover_gpu_kv_format`.
+                :func:`normalize_kv_and_discover_format`.
+            gpu_kv_format: Format returned by
+                :func:`normalize_kv_and_discover_format`.
             num_blocks: Number of paged blocks. Stamped into every
                 ``shape_desc.nb``.
             block_size: Tokens per block. Stamped into every

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -19,8 +19,6 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
-    attempt_permute_to_contiguous_view,
-    discover_gpu_kv_format,
     get_attention_backend,
     get_block_size,
     get_concrete_gpu_kv_shape,
@@ -31,6 +29,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
+    normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import (
@@ -70,17 +69,15 @@ class GPUCacheContext:
         kv_caches: KVCache,
         lmcache_chunk_size: int = 256,
         layout_hints: LayoutHints | None = None,
+        engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        self.kv_caches_ = attempt_permute_to_contiguous_view(unwrapped)
-        self.device_ = get_device(self.kv_caches_)
-
-        # TODO support creating GPUCacheContext for SGLang
-        self.gpu_kv_format_ = discover_gpu_kv_format(
-            self.kv_caches_,
-            EngineType.VLLM,
+        self.gpu_kv_format_, self.kv_caches_ = normalize_kv_and_discover_format(
+            unwrapped,
+            engine_type,
             layout_hints=layout_hints,
         )
+        self.device_ = get_device(self.kv_caches_)
         self.is_mla_ = is_mla(self.gpu_kv_format_)
         self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
         self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -13,6 +13,7 @@ This module defines the protocol for:
 """
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheEngineKey,
@@ -47,14 +48,16 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
     return {
         # Register KV Cache
         # Payload:
-        #   - instance_id: int - Unique identifier for the vLLM instance
+        #   - instance_id: int - Unique identifier for the engine instance
         #   - kv_cache: KVCache - The KV cache configuration
         #   - model_name: str - Name of the model associated with the engine
         #   - world_size: int - World size of the engine
+        #   - engine_type: EngineType - Which serving engine produced the
+        #     caches (vLLM, SGLang, ...). Drives format detection.
         #   - layout_hints: LayoutHints - See custom_types.LayoutHints.
         # Returns: None
         "REGISTER_KV_CACHE": ProtocolDefinition(
-            payload_classes=[int, KVCache, str, int, LayoutHints],
+            payload_classes=[int, KVCache, str, int, EngineType, LayoutHints],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -14,7 +14,7 @@ import zmq
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import _lmcache_nvtx_annotate
+from lmcache.utils import EngineType, _lmcache_nvtx_annotate
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
@@ -212,6 +212,7 @@ class MPCacheEngine:
         kv_caches: KVCache,
         model_name: str,
         world_size: int,
+        engine_type: EngineType,
         layout_hints: LayoutHints,
     ) -> None:
         """
@@ -219,9 +220,12 @@ class MPCacheEngine:
 
         Args:
             instance_id (int): The GPU instance ID (such as PID).
-            kv_caches (KVCache): The KV cache tensor wrappers from vLLM.
+            kv_caches (KVCache): The KV cache tensor wrappers from the
+                serving engine.
             model_name (str): The name of the model associated with this KV cache.
             world_size (int): The world size associated with this KV cache.
+            engine_type: Which serving engine produced the caches.
+                Forwarded to :class:`GPUCacheContext` for format detection.
             layout_hints: See :class:`LayoutHints`.  Forwarded to
                 :class:`GPUCacheContext` for GPU KV format detection.
         """
@@ -229,6 +233,7 @@ class MPCacheEngine:
             kv_caches,
             self.chunk_size,
             layout_hints=layout_hints or None,
+            engine_type=engine_type,
         )
         self.gpu_contexts[instance_id] = gpu_context
         self.gpu_context_meta[instance_id] = (model_name, world_size)

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -33,6 +33,7 @@ import torch
 import zmq
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.config import (
     EvictionConfig,
@@ -603,7 +604,14 @@ def registered_instance(
 
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1, {}],
+        [
+            instance_id,
+            client_context.get_kv_cache(),
+            "testmodel",
+            1,
+            EngineType.VLLM,
+            {},
+        ],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     assert future.result(timeout=DEFAULT_TIMEOUT) is None

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -11,6 +11,7 @@ import torch
 import zmq
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.distributed.config import (
     EvictionConfig,
     L1ManagerConfig,
@@ -331,7 +332,14 @@ def registered_instance(
     # Register KV cache
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1, {}],
+        [
+            instance_id,
+            client_context.get_kv_cache(),
+            "testmodel",
+            1,
+            EngineType.VLLM,
+            {},
+        ],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
@@ -381,7 +389,14 @@ def test_register_unregister_kv_cache(
     # Register
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
-        [instance_id, client_context.get_kv_cache(), "testmodel", 1, {}],
+        [
+            instance_id,
+            client_context.get_kv_cache(),
+            "testmodel",
+            1,
+            EngineType.VLLM,
+            {},
+        ],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -12,6 +12,7 @@ import torch
 import zmq
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     CudaIPCWrapper,
@@ -384,7 +385,7 @@ def test_mq_register_kv_cache():
     # Run test with REGISTER_KV_CACHE request
     helper.run_test(
         request_type=RequestType.REGISTER_KV_CACHE,
-        payloads=[gpu_id, kv_cache, "testmodel", 1, {}],
+        payloads=[gpu_id, kv_cache, "testmodel", 1, EngineType.VLLM, {}],
         expected_response=None,
         num_requests=1,
     )

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -7,6 +7,7 @@ and passed between processes during multiprocessing tests.
 """
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import BlockAllocationRecord, KVCache
 from lmcache.v1.multiprocess.protocol import KeyType
@@ -34,6 +35,7 @@ def register_kv_cache_handler(
     kv_cache: KVCache,
     model_name: str,
     world_size: int,
+    engine_type: EngineType,
     layout_hints: LayoutHints,
 ) -> None:
     """
@@ -44,6 +46,7 @@ def register_kv_cache_handler(
         kv_cache: List of CudaIPCWrapper objects representing KV cache
         model_name: Name of the model associated with this KV cache
         world_size: World size associated with this KV cache
+        engine_type: Which serving engine produced the caches
         layout_hints: Engine-provided hints dict
 
     Returns:
@@ -60,6 +63,9 @@ def register_kv_cache_handler(
     )
     assert isinstance(world_size, int), (
         f"Expected world_size to be int, got {type(world_size)}"
+    )
+    assert isinstance(engine_type, EngineType), (
+        f"Expected engine_type to be EngineType, got {type(engine_type)}"
     )
     assert isinstance(layout_hints, dict), (
         f"Expected layout_hints to be dict, got {type(layout_hints)}"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches format detection/normalization and changes the `REGISTER_KV_CACHE` wire payload, so mismatched client/server versions or subtle layout edge cases could break KV transfers despite mostly being a mechanical refactor.
> 
> **Overview**
> Unifies KV-cache contiguity normalization and layout discovery into a single `normalize_kv_and_discover_format` helper that returns both the detected `GPUKVFormat` and the canonical (permuted-to-contiguous) `kv_caches`, replacing the old separate `attempt_permute_to_contiguous_view` + `discover_gpu_kv_format` call sites across CUDA/HPU/XPU connectors and `GPUCacheContext`.
> 
> Extends the multiprocess `REGISTER_KV_CACHE` protocol to include an explicit `EngineType` so the server can perform engine-specific format detection (vLLM vs SGLang), and updates the vLLM adapter, server handler, and tests accordingly. Documentation is updated to codify the new “single source of truth” invariant around the combined normalize+discover flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206ee14c3c81d80858689e0bfb757dc937535300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->