### PR TITLE
[MP]: Disable Prometheus HTTP server for http_server entrypoint

### DIFF
--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -274,11 +274,21 @@ def parse_args_to_observability_config(
     return config
 
 
-def init_observability(obs_config: ObservabilityConfig) -> EventBus:
+def init_observability(
+    obs_config: ObservabilityConfig,
+    *,
+    start_prometheus_http_server: bool = True,
+) -> EventBus:
     """Initialize OTel providers, EventBus, and register subscribers.
 
     This is the single entry-point that every MP server calls at startup.
     Returns a **started** EventBus.
+
+    Args:
+        obs_config: Observability configuration.
+        start_prometheus_http_server: Whether to start a standalone
+            Prometheus HTTP server.  Set to ``False`` when an
+            external HTTP framework already serves ``/metrics``.
     """
     # First Party
     from lmcache.v1.mp_observability.event_bus import (
@@ -303,6 +313,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
             otlp_endpoint=obs_config.otlp_endpoint,
             prometheus_port=obs_config.prometheus_port,
             resource_attributes=resource_attrs,
+            start_http_server=start_prometheus_http_server,
         )
 
     if obs_config.enabled and obs_config.tracing_enabled:

--- a/lmcache/v1/mp_observability/otel_init.py
+++ b/lmcache/v1/mp_observability/otel_init.py
@@ -45,6 +45,7 @@ def init_otel_metrics(
     otlp_endpoint: str | None = None,
     prometheus_port: int | None = None,
     resource_attributes: dict[str, str] | None = None,
+    start_http_server: bool = True,
 ) -> None:
     """Set up the OpenTelemetry MeterProvider.
 
@@ -60,6 +61,9 @@ def init_otel_metrics(
             through the provider carries these attributes.  Intended for
             process-level identity (e.g. ``service.instance.id``) — never
             for per-request tags.
+        start_http_server: Whether to start a standalone Prometheus
+            HTTP server.  Set to ``False`` when metrics are already
+            served by an external HTTP framework (e.g. FastAPI).
     """
     # Third Party
     from opentelemetry import metrics
@@ -98,13 +102,21 @@ def init_otel_metrics(
         reader = PrometheusMetricReader()
         provider = MeterProvider(metric_readers=[reader], resource=resource)
         metrics.set_meter_provider(provider)
-        prometheus_client.start_http_server(prometheus_port)
-        logger.info(
-            "OTel MeterProvider initialised with Prometheus fallback "
-            "(http://0.0.0.0:%d/metrics), resource=%s",
-            prometheus_port,
-            dict(resource.attributes),
-        )
+        if start_http_server:
+            prometheus_client.start_http_server(prometheus_port)
+            logger.info(
+                "OTel MeterProvider initialised with Prometheus fallback "
+                "(http://0.0.0.0:%d/metrics), resource=%s",
+                prometheus_port,
+                dict(resource.attributes),
+            )
+        else:
+            logger.info(
+                "OTel MeterProvider initialised with Prometheus fallback "
+                "(standalone metrics HTTP server disabled; "
+                "/metrics must be exposed by the caller), resource=%s",
+                dict(resource.attributes),
+            )
 
 
 def init_otel_tracing(

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -1021,8 +1021,10 @@ def run_cache_server(
         obs_config: Configuration for the observability stack
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
-        start_prometheus_http_server: If True, start a Prometheus HTTP server in a
-            background thread.
+        start_prometheus_http_server: Whether to start a standalone
+            Prometheus HTTP server in a background thread.  Set to
+            ``False`` when an external HTTP framework already serves
+            ``/metrics`` to avoid port conflicts or redundant servers.
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, BlendEngineV2)

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -1010,6 +1010,7 @@ def run_cache_server(
     storage_manager_config: StorageManagerConfig,
     obs_config: ObservabilityConfig,
     return_engine: bool = False,
+    start_prometheus_http_server: bool = True,
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
@@ -1020,12 +1021,16 @@ def run_cache_server(
         obs_config: Configuration for the observability stack
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
+        start_prometheus_http_server: If True, start a Prometheus HTTP server in a
+            background thread.
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, BlendEngineV2)
         If return_engine is False: None (blocks until interrupted)
     """
-    event_bus = init_observability(obs_config)
+    event_bus = init_observability(
+        obs_config, start_prometheus_http_server=start_prometheus_http_server
+    )
 
     # Wire up the trace recorder (no-op when --trace-level is unset).
     maybe_initialize_trace_recorder(event_bus, obs_config, storage_manager_config)

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -73,6 +73,7 @@ async def lifespan(app: FastAPI):
         storage_manager_config=_configs["storage_manager"],
         obs_config=_configs["observability"],
         return_engine=True,
+        start_prometheus_http_server=False,
     )
     assert result is not None, "run_cache_server returned None with return_engine=True"
     zmq_server, engine = result

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -1059,7 +1059,10 @@ def run_cache_server(
         obs_config: Configuration for the observability stack
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
-        start_prometheus_http_server: If True, start a Prometheus HTTP server
+        start_prometheus_http_server: Whether to start a standalone
+            Prometheus HTTP server in a background thread.  Set to
+            ``False`` when an external HTTP framework already serves
+            ``/metrics`` to avoid port conflicts or redundant servers.
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -1048,6 +1048,7 @@ def run_cache_server(
     storage_manager_config: StorageManagerConfig,
     obs_config: ObservabilityConfig,
     return_engine: bool = False,
+    start_prometheus_http_server: bool = True,
 ):
     """
     Run the LMCache cache server with ZMQ message queue.
@@ -1058,12 +1059,15 @@ def run_cache_server(
         obs_config: Configuration for the observability stack
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive
+        start_prometheus_http_server: If True, start a Prometheus HTTP server
 
     Returns:
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine)
         If return_engine is False: None (blocks until interrupted)
     """
-    event_bus = init_observability(obs_config)
+    event_bus = init_observability(
+        obs_config, start_prometheus_http_server=start_prometheus_http_server
+    )
 
     # Wire up the trace recorder (no-op when --trace-level is unset).
     # Registered before the engine handlers are added so any

--- a/tests/v1/mp_observability/test_otel_init.py
+++ b/tests/v1/mp_observability/test_otel_init.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the ``start_http_server`` flag in OTel metrics init."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.config import (
+    ObservabilityConfig,
+    init_observability,
+)
+from lmcache.v1.mp_observability.otel_init import init_otel_metrics
+
+
+@pytest.fixture(autouse=True)
+def _mock_otel_provider(monkeypatch):
+    """Avoid mutating the process-global OTel MeterProvider."""
+    # Third Party
+    from opentelemetry import metrics as otel_metrics
+
+    monkeypatch.setattr(otel_metrics, "set_meter_provider", MagicMock())
+
+
+def test_init_otel_metrics_starts_http_server_by_default():
+    with patch("prometheus_client.start_http_server") as mock_start:
+        init_otel_metrics(prometheus_port=19090)
+    mock_start.assert_called_once_with(19090)
+
+
+def test_init_otel_metrics_skips_http_server_when_disabled():
+    with patch("prometheus_client.start_http_server") as mock_start:
+        init_otel_metrics(prometheus_port=19091, start_http_server=False)
+    mock_start.assert_not_called()
+
+
+def test_init_otel_metrics_otlp_mode_never_starts_prom_server():
+    """OTLP push mode must not spawn a Prometheus HTTP server,
+    regardless of ``start_http_server``."""
+    with (
+        patch(
+            "opentelemetry.exporter.otlp.proto.grpc.metric_exporter.OTLPMetricExporter"
+        ),
+        patch("prometheus_client.start_http_server") as mock_start,
+    ):
+        init_otel_metrics(
+            otlp_endpoint="http://localhost:4317",
+            start_http_server=True,
+        )
+    mock_start.assert_not_called()
+
+
+def test_init_observability_propagates_flag_false():
+    """``init_observability`` must forward ``False`` to
+    ``init_otel_metrics``."""
+    cfg = ObservabilityConfig(enabled=True, metrics_enabled=True, logging_enabled=False)
+    with patch("lmcache.v1.mp_observability.otel_init.init_otel_metrics") as mock_init:
+        init_observability(cfg, start_prometheus_http_server=False)
+    mock_init.assert_called_once()
+    assert mock_init.call_args.kwargs["start_http_server"] is False
+
+
+def test_init_observability_propagates_flag_true_by_default():
+    cfg = ObservabilityConfig(enabled=True, metrics_enabled=True, logging_enabled=False)
+    with patch("lmcache.v1.mp_observability.otel_init.init_otel_metrics") as mock_init:
+        init_observability(cfg)
+    mock_init.assert_called_once()
+    assert mock_init.call_args.kwargs["start_http_server"] is True


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged by default and only affects metrics serving in Prometheus fallback mode when the new flag is set; main risk is accidental loss of `/metrics` exposure if callers disable the server without providing their own endpoint.
> 
> **Overview**
> Adds an opt-out flag to observability/metrics initialization so Prometheus pull-mode can **skip starting** its standalone `prometheus_client` HTTP server when an external framework already serves `/metrics`.
> 
> Propagates this flag from `run_cache_server()` (both `server.py` and `blend_server_v2.py`) through `init_observability()` to `init_otel_metrics()`, and updates the FastAPI `http_server` entrypoint to disable the standalone Prometheus server by default to avoid port conflicts. Includes new unit tests covering default behavior, disabled behavior, and OTLP mode never spawning the Prometheus server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09f7491b7e1d93ab2fa31a5cdc4430d9590f873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->