### PR TITLE
[Core]: TRT-LLM Integration

### DIFF
--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -85,6 +85,13 @@ enum class GPUKVFormat : int {
   - vLLM non-MLA flash infer (HND layout)
   physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
   */
+
+  NB_NL_TWO_NH_BS_HS = 8,
+  /*
+  used by:
+  - TRT-LLM cross-layer (HND layout)
+  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+  */
 };
 
 void multi_layer_kv_transfer(

--- a/csrc/mp_mem_kernels.cu
+++ b/csrc/mp_mem_kernels.cu
@@ -50,6 +50,13 @@ __device__ inline size_t calculate_engine_global_offset(
   } else if constexpr (format == GPUKVFormat::NL_X_NBBS_ONE_HS) {
     // SGLang MLA: L tensors [NBBS, 1, HS]
     return engine_block_idx * scalars_per_block;
+  } else if constexpr (format == GPUKVFormat::NB_NL_TWO_NH_BS_HS) {
+    // TRT-LLM cross-layer HND: single tensor [NB, NL, 2, NH, BS, HS]
+    // same block-level strides as NB_NL_TWO_BS_NH_HS
+    return k_or_v * scalars_per_block +
+           layer_idx * shape_desc.kv_size * scalars_per_block +
+           engine_block_idx * shape_desc.kv_size * scalars_per_block *
+               shape_desc.nl;
   }
 }
 
@@ -63,8 +70,15 @@ __device__ inline size_t calculate_engine_local_offset(
     const PageBufferShapeDesc shape_desc) {
   size_t scalars_per_head = shape_desc.scalars_per_head<ScalarType>();
   size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
-  // for now, everything is BS, NH, HS, so we only have a single case
-  return head_idx * scalars_per_head + token_offset * scalars_per_token;
+  if constexpr (format == GPUKVFormat::NB_NL_TWO_NH_BS_HS) {
+    // HND: [NH, BS, HS] — heads are outermost within a block
+    size_t scalars_per_head_block =
+        shape_desc.bs * scalars_per_head;  // BS * HS
+    return head_idx * scalars_per_head_block + token_offset * scalars_per_head;
+  } else {
+    // NHD: [BS, NH, HS] — tokens are outermost within a block
+    return head_idx * scalars_per_head + token_offset * scalars_per_token;
+  }
 }
 
 /**
@@ -158,7 +172,8 @@ __device__ void multi_layer_block_transfer_single_block(
           k_or_v, offset_in_lmcache_block, layer_idx, lmcache_chunk_size,
           shape_desc);
   ScalarType* paged_buffer_layer_ptr;
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS ||
+                format == GPUKVFormat::NB_NL_TWO_NH_BS_HS) {
     paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[0];
   } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
     // SGLang MHA: ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V per layer
@@ -244,6 +259,9 @@ __global__ void multi_layer_block_transfer_kernel(
       break;                                                        \
     case GPUKVFormat::NL_X_NBBS_ONE_HS:                             \
       LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NBBS_ONE_HS);      \
+      break;                                                        \
+    case GPUKVFormat::NB_NL_TWO_NH_BS_HS:                           \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NB_NL_TWO_NH_BS_HS);    \
       break;                                                        \
     default:                                                        \
       TORCH_CHECK(false, "Unsupported GPUKVFormat: ",               \

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -29,6 +29,7 @@ PYBIND11_MODULE(c_ops, m) {
       .value("NL_X_NBBS_ONE_HS", GPUKVFormat::NL_X_NBBS_ONE_HS)
       .value("NL_X_TWO_NB_NH_BS_HS", GPUKVFormat::NL_X_TWO_NB_NH_BS_HS)
       .value("NL_X_NB_TWO_NH_BS_HS", GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
+      .value("NB_NL_TWO_NH_BS_HS", GPUKVFormat::NB_NL_TWO_NH_BS_HS)
       .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),

--- a/docs/design/integration/tensorrt_llm/README.md
+++ b/docs/design/integration/tensorrt_llm/README.md
@@ -1,14 +1,5 @@
 # TensorRT-LLM integration
 
-## Goal
-
-Land TRT-LLM as a first-class serving engine in LMCache via TRT-LLM's
-**KV Cache Connector** API. TRT-LLM 1.2.0 added a connector ABC
-(`tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector`) that
-lets external KV stores hook into the engine's lifecycle: lookup before
-scheduling, retrieve before forward, store after forward. This module
-implements those hooks.
-
 ## Adapter shape
 
 ```

--- a/docs/design/integration/tensorrt_llm/README.md
+++ b/docs/design/integration/tensorrt_llm/README.md
@@ -1,0 +1,90 @@
+# TensorRT-LLM integration
+
+## Goal
+
+Land TRT-LLM as a first-class serving engine in LMCache via TRT-LLM's
+**KV Cache Connector** API. TRT-LLM 1.2.0 added a connector ABC
+(`tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector`) that
+lets external KV stores hook into the engine's lifecycle: lookup before
+scheduling, retrieve before forward, store after forward. This module
+implements those hooks.
+
+## Adapter shape
+
+```
+lmcache/integration/tensorrt_llm/
+├── __init__.py             # Optional-import surface
+├── utils.py                # ENGINE_NAME, lmcache_get_config,
+│                           # create_trtllm_metadata
+├── tensorrt_adapter.py     # In-process — engine in TRT-LLM process
+└── tensorrt_mp_adapter.py  # Multi-process — engine in standalone server
+```
+
+Both adapters subclass TRT-LLM's `KvCacheConnectorScheduler` and
+`KvCacheConnectorWorker`. The TRT-LLM imports are *guarded at module
+level only via the package's `__init__`*; nothing in core LMCache
+imports the adapter modules. This keeps `pip install lmcache` unaffected
+when TRT-LLM is absent.
+
+The TRT-LLM connector preset registry (PR
+[NVIDIA/TensorRT-LLM#12626](https://github.com/NVIDIA/TensorRT-LLM/pull/12626))
+maps:
+
+| Preset | Module | Scheduler | Worker |
+|---|---|---|---|
+| `lmcache` | `lmcache.integration.tensorrt_llm.tensorrt_adapter` | `LMCacheKvConnectorScheduler` | `LMCacheKvConnectorWorker` |
+| `lmcache-mp` | `lmcache.integration.tensorrt_llm.tensorrt_mp_adapter` | `LMCacheMPKvConnectorScheduler` | `LMCacheMPKvConnectorWorker` |
+
+## Lifecycle
+
+| Stage | TRT-LLM hook | LMCache call |
+|---|---|---|
+| Init | `worker.register_kv_caches(kv_cache_tensor)` | Build engine via `_get_or_create_engine`; call `gpu_connector.register_kv_caches(kv_cache_tensor)` |
+| Before scheduling | `scheduler.get_num_new_matched_tokens(req, num_computed)` | `engine.lookup(tokens)` (in-process) or `LOOKUP` + `QUERY_PREFETCH_STATUS` (MP) |
+| Pre-forward | `scheduler.build_connector_meta(scheduler_output)` | `LMCacheConnectorMetadata(loads=..., saves=...)` |
+| Forward | `worker.start_load_kv(stream)` | `engine.retrieve(tokens, block_ids)` |
+| Forward | `worker.wait_for_save(stream)` | `engine.store(tokens, block_ids)` |
+
+## In-process vs MP
+
+The two modes share the lifecycle but differ in where state lives.
+
+| Aspect | In-process (`lmcache`) | Multi-process (`lmcache-mp`) |
+|---|---|---|
+| LMCache engine | Singleton inside the TRT-LLM process | Standalone ZMQ server |
+| Tensor sharing | Direct (same process) | `RawCudaIPCWrapper` (cudaIpc + cupy DLPack) |
+| Lookup | `engine.lookup(tokens)` returns chunk count | `LOOKUP` enqueues prefetch; `QUERY_PREFETCH_STATUS` reads result keyed by `request_id` |
+| Configuration | `LMCACHE_CONFIG_FILE` env var | Same; plus `server_url` in connector config (or `LMCACHE_SERVER_URL` env) |
+| Failure mode | One process crash takes down both | Engine survives TRT-LLM crash; multiple TRT-LLM instances can share cache |
+| Setup cost | None | Run `python -m lmcache.v1.multiprocess.server` |
+
+## Why **not** subclass `VLLMPagedMemGPUConnectorV3`
+
+V3's transfer path is wrong for TRT-LLM:
+
+- **V3 uses the in-process kernel** (`multi_layer_kv_transfer`) with a
+  `slot_mapping` of token positions and per-layer pointers. TRT-LLM's
+  cross-layer pool is a *single* base pointer and we want to transfer
+  by *block ids*, not slot positions.
+- **TRT-LLM needs the MP kernel** (`multi_layer_block_kv_transfer`)
+  which natively handles single-base-pointer cross-layer with
+  `shape_desc.nl` walking layers internally. There is nothing to
+  inherit.
+
+`TRTLLMGPUConnector` is therefore a *standalone* `GPUConnectorInterface`
+implementation. It also exposes a bespoke
+`register_kv_caches(kv_cache_tensor)` method called by the worker once
+at init — separate from `to_gpu`/`from_gpu`. The factory in
+`lmcache/v1/gpu_connector/__init__.py` constructs it from
+`LMCacheMetadata` plus the device, and the adapter wires the pool
+tensor in afterwards.
+
+## Forcing real LMCache hits in tests
+
+TRT-LLM has its own GPU block reuse. To verify LMCache contributes the
+hit (and not TRT-LLM's reuse), the E2E tests size TRT-LLM's pool tiny
+(`KvCacheConfig(max_tokens=512)`) while sending prompts much larger than
+512 tokens. The first request fills LMCache and TRT-LLM. The second is
+guaranteed-evicted from TRT-LLM's pool and *must* come from LMCache —
+which the test asserts via the `lmcache_cached=… new_matched=…` log
+line on request 3.

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -59,6 +59,36 @@ a `GPUKVFormat`. Nothing else may index raw shapes.
 |---|---|
 | `normalize_kv_and_discover_format(kv_caches, engine, layout_hints)` | `tuple[GPUKVFormat, DiscoverableKVCache]` — the one parser. Returns the canonical (permuted-to-contiguous) kv_caches alongside the detected format; callers must use the returned tensor structure for subsequent operations. |
 
+### Format → engine map
+
+| `GPUKVFormat` | Engine | Layout | Structure |
+|---|---|---|---|
+| `NB_NL_TWO_BS_NH_HS` | vLLM cross-layer | NHD | bare 6-D tensor `[NB, NL, 2, BS, NH, HS]` |
+| `NB_NL_TWO_NH_BS_HS` | TRT-LLM cross-layer | HND | bare 6-D tensor `[NB, NL, 2, NH, BS, HS]` |
+| `NL_X_TWO_NB_BS_NH_HS` | vLLM flash-attn | NHD | `NL × [2, NB, BS, NH, HS]` |
+| `NL_X_NB_TWO_BS_NH_HS` | vLLM flash-infer | NHD | `NL × [NB, 2, BS, NH, HS]` |
+| `NL_X_TWO_NB_NH_BS_HS` | vLLM flash-attn | HND | `NL × [2, NB, NH, BS, HS]` |
+| `NL_X_NB_TWO_NH_BS_HS` | vLLM flash-infer | HND | `NL × [NB, 2, NH, BS, HS]` |
+| `NL_X_NB_BS_HS` | vLLM MLA | — | `NL × [NB, BS, HS]` |
+| `TWO_X_NL_X_NBBS_NH_HS` | SGLang MHA | NHD | `[K_list, V_list]`, each `NL × [PBS, NH, HS]` |
+| `NL_X_NBBS_ONE_HS` | SGLang MLA | — | `NL × [PBS, 1, HS]` |
+
+The two cross-layer formats (`NB_NL_TWO_*`) share a single base
+pointer, the kernel walks layers internally via `shape_desc.nl`. Use
+`is_cross_layer_format(fmt)` for that dispatch and `is_hnd(fmt)` to
+detect head-major within-block layouts.
+
+### Reshape-via-hints (TRT-LLM)
+
+TRT-LLM hands LMCache a 4-D pool tensor
+`[NB, NL, 2, num_kv_heads * tokens_per_block * head_dim]` (HND, K and V
+interleaved on dim 2). `normalize_kv_and_discover_format` reshapes it
+to canonical 6-D form *before* the contiguity check, using
+`layout_hints["num_kv_heads" | "tokens_per_block" | "head_dim"]`. The
+function also collapses a 1-element list of a 6-D tensor down to the
+bare 6-D tensor so detection lands on `list_depth == 0`. Adapters pass
+either the 4-D bare tensor or `[4-D]`; the function handles both.
+
 ### Scalar accessors
 
 All of these dispatch on `GPUKVFormat`. The ones that can vary per layer

--- a/docs/design/v1/multiprocess/raw_cuda_ipc.md
+++ b/docs/design/v1/multiprocess/raw_cuda_ipc.md
@@ -1,0 +1,70 @@
+# `RawCudaIPCWrapper` — sharing tensors allocated outside PyTorch
+
+## Why a second wrapper
+
+The default `CudaIPCWrapper` in `custom_types.py` calls
+`tensor.untyped_storage()._share_cuda_()` to publish the storage over
+CUDA IPC. That path only works when the storage is owned by PyTorch's
+caching allocator. TRT-LLM's KV pool is published via
+`at::for_blob(...)` over a raw `cudaMalloc`, which means
+`_share_cuda_()` raises and the `vLLM`-style wrapper cannot be used.
+
+`RawCudaIPCWrapper` bypasses PyTorch's IPC layer:
+
+- **Sender** calls `cudaIpcGetMemHandle(data_ptr)` directly via
+  `cuda.bindings.runtime` to obtain a portable handle.
+- **Receiver** calls `cudaIpcOpenMemHandle(handle, ...)` to map the
+  remote pointer, wraps it as a flat `uint8` `cupy.ndarray` via
+  `UnownedMemory`, converts to `torch.Tensor` via DLPack, then
+  `view(dtype).reshape(shape)` to restore the logical layout.
+
+The `uint8` round-trip is deliberate — `bfloat16` and FP8 dtypes have
+no direct CuPy/NumPy equivalent, but the size in bytes is enough.
+DLPack carries no dtype semantics for the bytes view; `view(dtype)` on
+the torch side restores them.
+
+## Subclass rather than separate type
+
+`RawCudaIPCWrapper` is a **subclass** of `CudaIPCWrapper`, not a new
+class with its own ext code. This is load-bearing for the wire format:
+
+- `KVCache = list[CudaIPCWrapper]` is the registered msgspec type for
+  `REGISTER_KV_CACHE`. msgspec does **not** support unions of custom
+  ext-encoded types — adding a parallel class would force a wider
+  decoder type and break either round-trip or the existing
+  `CudaIPCWrapper` consumers.
+- The customized serializer (`_CUSTOMERIZED_SERIALIZERS`) is keyed on
+  `CudaIPCWrapper` and dispatched by `isinstance`, so subclass instances
+  encode through the same path with **ext code 1**.
+- `Serialize` is `pickle.dumps(obj)`, which preserves subclass
+  identity. On the receiving side `Deserialize` reconstructs the
+  subclass and `to_tensor` dispatches to the override.
+
+The receiving server therefore needs no per-type branching: a
+`list[CudaIPCWrapper]` arriving at `MPCacheEngine.register_kv_cache`
+contains either kind, and `to_tensor()` does the right thing.
+
+## Sender-side validation
+
+`RawCudaIPCWrapper.__init__` calls `assert_contiguous` (from
+`gpu_connector/utils.py`) instead of permuting. TRT-LLM allocates the
+pool contiguously, so the only valid recovery from a non-contiguous
+input is "the sender did something wrong" — surface it loudly rather
+than silently `.contiguous()`-ing and copying GBs of KV cache.
+
+## Reconstruction lifetime
+
+`UnownedMemory` takes `owner=self`, so the wrapper instance pins the
+mapping for the tensor's lifetime. The mapping is dropped when the
+wrapper is GC'd; the underlying TRT-LLM allocation outlives the
+wrapper. There is no symmetric `cudaIpcCloseMemHandle` call — torch
+controls the lifetime through DLPack reference counting plus
+CuPy/MemoryPointer's owner field.
+
+## Why no `_share_cuda_` fallback
+
+The wrapper does not try `_share_cuda_()` first. That would couple the
+two codepaths, and the failure mode is silent corruption (PyTorch
+returns a handle for a different region of memory than what the
+caller intended). Explicit subclassing keeps the choice at the call
+site.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,14 @@ Documentation
 
 .. toctree::
    :maxdepth: 2
+   :caption: Serving engine integrations
+
+   integrations/index
+
+:raw-html:`<br />`
+
+.. toctree::
+   :maxdepth: 2
    :caption: KV Cache offloading and sharing
 
    kv_cache/storage_backends/index

--- a/docs/source/integrations/index.rst
+++ b/docs/source/integrations/index.rst
@@ -1,0 +1,13 @@
+.. _serving_engine_integrations:
+
+Serving Engine Integrations
+===========================
+
+LMCache hooks into serving engines through their KV-cache connector
+APIs. The pages in this section cover engine-specific setup that
+isn't shared with the rest of the documentation.
+
+.. toctree::
+   :maxdepth: 1
+
+   tensorrt_llm

--- a/docs/source/integrations/tensorrt_llm.rst
+++ b/docs/source/integrations/tensorrt_llm.rst
@@ -1,0 +1,169 @@
+.. _tensorrt_llm_integration:
+
+TensorRT-LLM
+============
+
+LMCache integrates with NVIDIA TensorRT-LLM via TRT-LLM's
+**KV Cache Connector** API. The connector ABC ships in
+``tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector`` and
+lets external KV stores hook the engine lifecycle: lookup before
+scheduling, retrieve before the forward pass, store after.
+
+Two modes are available:
+
+- **In-process** (``connector: lmcache``) — LMCache runs as a
+  singleton inside the TRT-LLM process. Simplest setup; no extra
+  service to manage.
+- **Multi-process** (``connector: lmcache-mp``) — LMCache runs as a
+  standalone ZMQ server. Multiple TRT-LLM workers on the same node
+  can share the cache, and the cache survives a TRT-LLM crash.
+
+Requirements
+------------
+
+- TensorRT-LLM 1.2.0 or newer (the ``KvCacheConnector`` ABC was added
+  in 1.2.0).
+- LMCache built with the ``c_ops`` extension. Verify with
+  ``python -c "import lmcache.c_ops"``.
+- For multi-process mode: ``cuda-python`` and ``cupy`` (used by the
+  raw CUDA-IPC wrapper that publishes the TRT-LLM pool tensor across
+  process boundaries).
+
+The TRT-LLM connector preset registry resolves both shorthand names
+to LMCache's adapter modules (see
+`NVIDIA/TensorRT-LLM PR #12626 <https://github.com/NVIDIA/TensorRT-LLM/pull/12626>`_).
+
+In-process mode
+---------------
+
+1. Set ``LMCACHE_CONFIG_FILE`` (or individual ``LMCACHE_*`` env vars)
+   so ``LMCacheEngineConfig`` can be constructed at startup. A
+   minimal CPU-offload config:
+
+   .. code-block:: bash
+
+      export PYTHONHASHSEED=0  # required — chunk hashing depends on stable hash()
+      export LMCACHE_CHUNK_SIZE=256
+      export LMCACHE_LOCAL_CPU=True
+      export LMCACHE_MAX_LOCAL_CPU_SIZE=2.0  # GiB
+
+2. Pass ``connector: lmcache`` to ``KvCacheConnectorConfig`` when
+   building the LLM:
+
+   .. code-block:: python
+
+      from tensorrt_llm import LLM, SamplingParams
+      from tensorrt_llm.llmapi.llm_args import (
+          KvCacheConfig, KvCacheConnectorConfig,
+      )
+
+      llm = LLM(
+          model="Qwen/Qwen2-1.5B-Instruct",
+          backend="pytorch",
+          kv_cache_config=KvCacheConfig(enable_block_reuse=True),
+          kv_connector_config=KvCacheConnectorConfig(connector="lmcache"),
+      )
+
+      sp = SamplingParams(max_tokens=64)
+      out = llm.generate(["Your prompt here"], sp)
+      print(out[0].outputs[0].text)
+
+That's the whole integration on the user side. The lifecycle hooks
+(``register_kv_caches``, ``start_load_kv``, ``wait_for_save``,
+``get_num_new_matched_tokens``) are wired automatically by TRT-LLM
+based on the preset.
+
+Multi-process mode
+------------------
+
+1. Start the LMCache server in its own process:
+
+   .. code-block:: bash
+
+      python -m lmcache.v1.multiprocess.server \
+          --host 0.0.0.0 --port 5555 \
+          --l1-size-gb 10 --eviction-policy LRU \
+          --max-workers 4 --chunk-size 256
+
+2. Point TRT-LLM at the server via ``server_url``:
+
+   .. code-block:: python
+
+      llm = LLM(
+          model="Qwen/Qwen2-1.5B-Instruct",
+          backend="pytorch",
+          kv_cache_config=KvCacheConfig(enable_block_reuse=True),
+          kv_connector_config=KvCacheConnectorConfig(
+              connector="lmcache-mp",
+              server_url="tcp://localhost:5555",
+          ),
+      )
+
+   The server URL can also come from the ``LMCACHE_SERVER_URL`` env
+   var. The Unix-socket form ``ipc:///tmp/lmcache.sock`` is a sensible
+   default for single-host deployments.
+
+The MP adapter shares the TRT-LLM KV pool with the server using a
+raw CUDA-IPC wrapper (``RawCudaIPCWrapper``). PyTorch's standard
+storage-IPC path raises on TRT-LLM's pool because the buffer is
+allocated outside PyTorch's caching allocator (``at::for_blob`` over
+``cudaMalloc``); the wrapper bypasses that path with
+``cudaIpcGetMemHandle`` / ``cudaIpcOpenMemHandle``.
+
+Explicit connector configuration
+--------------------------------
+
+If you need to bypass the preset registry — e.g. you are pinning a
+custom subclass of the adapter — point ``connector_module`` and the
+class names directly:
+
+.. code-block:: yaml
+
+   # In-process
+   kv_connector_config:
+     connector_module: lmcache.integration.tensorrt_llm.tensorrt_adapter
+     connector_scheduler_class: LMCacheKvConnectorScheduler
+     connector_worker_class: LMCacheKvConnectorWorker
+
+   # Multi-process
+   kv_connector_config:
+     connector_module: lmcache.integration.tensorrt_llm.tensorrt_mp_adapter
+     connector_scheduler_class: LMCacheMPKvConnectorScheduler
+     connector_worker_class: LMCacheMPKvConnectorWorker
+     server_url: tcp://localhost:5555
+
+Verifying LMCache is the source of cache hits
+---------------------------------------------
+
+TRT-LLM has its own GPU block reuse, so a matching second-request
+output does not by itself prove LMCache contributed. To force the
+issue:
+
+- Size TRT-LLM's pool small enough that the first prompt's blocks
+  must evict before the third request runs:
+  ``KvCacheConfig(max_tokens=512, enable_block_reuse=True)``.
+- Send three requests: a long prompt (>512 tokens), a different
+  long prompt that fills the now-tiny pool, then the original prompt
+  again.
+
+You should see DEBUG-level lines like:
+
+.. code-block:: text
+
+   LMCache TRT-LLM scheduler: req N ... lmcache_cached=256 new_matched=192
+   Retrieved 256 out of 382 required tokens
+
+on the third request. ``lmcache_cached`` reports how many tokens
+LMCache had cached; ``new_matched`` is how many additional tokens
+LMCache supplied beyond what TRT-LLM had already matched in its GPU
+pool. Both should be non-zero on a real LMCache hit.
+
+Configuration reference
+-----------------------
+
+The TRT-LLM adapter does not introduce new LMCache config keys. It
+reads :class:`LMCacheEngineConfig` the same way the vLLM adapter
+does: ``LMCACHE_CONFIG_FILE`` for a YAML file, otherwise individual
+``LMCACHE_*`` environment variables. See
+:doc:`../getting_started/installation` for the full configuration
+surface.

--- a/lmcache/integration/tensorrt_llm/__init__.py
+++ b/lmcache/integration/tensorrt_llm/__init__.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LMCache integration for NVIDIA TensorRT-LLM via the KV Cache Connector API.
+
+Two modes are supported:
+
+**In-process mode** (``lmcache``)
+    The LMCache engine runs inside the TRT-LLM process. Simple to set
+    up; no extra services required.
+
+    .. code-block:: yaml
+
+       kv_connector_config:
+         connector: lmcache
+
+**Multi-process mode** (``lmcache-mp``)
+    The LMCache engine runs as a standalone ZMQ server, providing
+    process isolation and shared KV caching across multiple TRT-LLM
+    instances on the same node.
+
+    1. Start the LMCache server::
+
+        python -m lmcache.v1.multiprocess.server \\
+            --host 0.0.0.0 --port 5555 \\
+            --l1-size-gb 10 --eviction-policy LRU --max-workers 4
+
+    2. Use the ``lmcache-mp`` preset with ``server_url``::
+
+        kv_connector_config:
+          connector: lmcache-mp
+          server_url: tcp://localhost:5555
+
+Both modes can also be configured explicitly instead of via presets::
+
+    # In-process
+    kv_connector_config:
+      connector_module: lmcache.integration.tensorrt_llm.tensorrt_adapter
+      connector_scheduler_class: LMCacheKvConnectorScheduler
+      connector_worker_class: LMCacheKvConnectorWorker
+
+    # Multi-process
+    kv_connector_config:
+      connector_module: lmcache.integration.tensorrt_llm.tensorrt_mp_adapter
+      connector_scheduler_class: LMCacheMPKvConnectorScheduler
+      connector_worker_class: LMCacheMPKvConnectorWorker
+"""
+
+# tensorrt_llm is an optional dependency. Guard the import so importing
+# ``lmcache.integration.tensorrt_llm`` does not crash when the package
+# is absent (e.g. core LMCache unit tests, doc builds).
+try:
+    # First Party
+    from lmcache.integration.tensorrt_llm.tensorrt_adapter import (
+        LMCacheKvConnectorScheduler,
+        LMCacheKvConnectorWorker,
+        destroy_engine,
+    )
+
+    __all__ = [
+        "LMCacheKvConnectorScheduler",
+        "LMCacheKvConnectorWorker",
+        "destroy_engine",
+    ]
+except ImportError:
+    __all__ = []
+
+try:
+    # First Party
+    from lmcache.integration.tensorrt_llm.tensorrt_mp_adapter import (
+        LMCacheMPKvConnectorScheduler,
+        LMCacheMPKvConnectorWorker,
+    )
+
+    __all__ += [
+        "LMCacheMPKvConnectorScheduler",
+        "LMCacheMPKvConnectorWorker",
+    ]
+except ImportError:
+    pass

--- a/lmcache/integration/tensorrt_llm/tensorrt_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_adapter.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TensorRT-LLM KV Cache Connector adapter for LMCache (in-process mode).
+
+Implements ``LMCacheKvConnectorScheduler`` and ``LMCacheKvConnectorWorker`` —
+the two classes TRT-LLM's ``kv_connector_config`` requires — backed by
+an in-process LMCache engine singleton.
+
+Lifecycle (per TRT-LLM connector ABC):
+    * scheduler.get_num_new_matched_tokens → engine.lookup(tokens)
+    * scheduler.build_connector_meta → LMCacheConnectorMetadata(loads, saves)
+    * worker.register_kv_caches → builds engine via _get_or_create_engine,
+      calls gpu_connector.register_kv_caches(kv_cache_tensor)
+    * worker.start_load_kv → engine.retrieve(tokens, block_ids)
+    * worker.wait_for_save → engine.store(tokens, block_ids)
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+import time
+
+# Third Party
+from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import (
+    KvCacheConnectorScheduler,
+    KvCacheConnectorWorker,
+    SchedulerOutput,
+)
+from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
+from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+import torch
+
+# First Party
+from lmcache.integration.tensorrt_llm.utils import (
+    ENGINE_NAME,
+    create_trtllm_metadata,
+    lmcache_get_config,
+)
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType, mock_up_broadcast_fn, mock_up_broadcast_object_fn
+from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
+from lmcache.v1.gpu_connector import CreateGPUConnector
+
+logger = init_logger(__name__)
+
+
+def _get_or_create_engine(
+    llm_args: TorchLlmArgs,
+    kv_cache_tensor: torch.Tensor,
+) -> LMCacheEngine:
+    """Return the LMCache engine singleton, creating it on first call.
+
+    Called by the worker's ``register_kv_caches``. On subsequent calls
+    (e.g. after a model reload) the existing engine is reused and the
+    GPU connector is re-registered with the new KV tensor.
+    """
+    existing = LMCacheEngineBuilder.get(ENGINE_NAME)
+    if existing is not None:
+        gpu_connector = existing.gpu_connector
+        if gpu_connector is not None:
+            gpu_connector.register_kv_caches(kv_cache_tensor)  # type: ignore[attr-defined]
+        logger.info("LMCache TRT-LLM: reusing existing engine")
+        return existing
+
+    config = lmcache_get_config()
+
+    # Third Party
+    from transformers import AutoConfig
+
+    hf_config = AutoConfig.from_pretrained(str(llm_args.model))
+    head_dim = getattr(
+        hf_config,
+        "head_dim",
+        hf_config.hidden_size // hf_config.num_attention_heads,
+    )
+    num_kv_heads = getattr(
+        hf_config, "num_key_value_heads", hf_config.num_attention_heads
+    )
+    num_kv_heads = num_kv_heads // llm_args.tensor_parallel_size
+
+    metadata = create_trtllm_metadata(
+        llm_args,
+        kv_cache_tensor,
+        config,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+    )
+    gpu_connector = CreateGPUConnector(config, metadata, EngineType.TRTLLM)
+    gpu_connector.register_kv_caches(kv_cache_tensor)  # type: ignore[attr-defined]
+
+    engine = LMCacheEngineBuilder.get_or_create(
+        ENGINE_NAME,
+        config,
+        metadata,
+        gpu_connector,
+        mock_up_broadcast_fn,
+        mock_up_broadcast_object_fn,
+    )
+    engine.post_init()
+
+    logger.info(
+        "LMCache TRT-LLM: created engine (chunk_size=%d, tensor_shape=%s, dtype=%s)",
+        config.chunk_size,
+        list(kv_cache_tensor.shape),
+        kv_cache_tensor.dtype,
+    )
+    return engine
+
+
+def destroy_engine() -> None:
+    """Destroy the engine singleton. Safe to call if not created."""
+    if LMCacheEngineBuilder.get(ENGINE_NAME) is not None:
+        LMCacheEngineBuilder.destroy(ENGINE_NAME)
+        logger.info("LMCache TRT-LLM: engine destroyed")
+
+
+@dataclass
+class _BlockSpec:
+    """Tokens and block IDs for a single load or store operation."""
+
+    tokens: List[int]
+    block_ids: List[int]
+
+
+@dataclass
+class LMCacheConnectorMetadata:
+    """Metadata passed from the scheduler to the worker each forward step."""
+
+    loads: dict = field(default_factory=dict)
+    saves: dict = field(default_factory=dict)
+
+
+class LMCacheKvConnectorScheduler(KvCacheConnectorScheduler):
+    """Scheduler-side connector hook.
+
+    Queries the LMCache engine for cached token counts and emits
+    per-request load/save block specs for the worker to act on.
+    """
+
+    def __init__(self, llm_args: TorchLlmArgs) -> None:
+        super().__init__(llm_args)
+        self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
+        # request_id -> (all_tokens, num_matched) — set by
+        # get_num_new_matched_tokens, consumed by build_connector_meta.
+        self._pending: dict = {}
+        # Engine is created by the worker in register_kv_caches, which
+        # may run concurrently with scheduler init. Resolved lazily.
+        self._engine: Optional[LMCacheEngine] = None
+
+    def get_num_new_matched_tokens(
+        self,
+        request: LlmRequest,
+        num_computed_tokens: int,
+    ) -> Tuple[int, bool]:
+        """Return how many additional tokens LMCache can provide beyond
+        ``num_computed_tokens`` (which TRT-LLM matched via GPU block reuse).
+
+        Args:
+            request: The incoming request with its full token sequence.
+            num_computed_tokens: Tokens already matched on device
+                (block-aligned).
+
+        Returns:
+            ``(new_matched, is_async)``. ``is_async`` is always
+            ``False`` in this adapter.
+        """
+        t0 = time.perf_counter()
+
+        if not self._engine:
+            self._engine = LMCacheEngineBuilder.get(ENGINE_NAME)
+        if not self._engine:
+            self._pending[request.request_id] = ([], 0)
+            return 0, False
+
+        # TRT-LLM should always pass block-aligned positions.
+        if num_computed_tokens % self._block_size != 0:
+            self._pending[request.request_id] = ([], 0)
+            return 0, False
+
+        all_tokens = list(request.get_tokens(0))
+
+        max_block_aligned = (len(all_tokens) // self._block_size) * self._block_size
+        if num_computed_tokens >= max_block_aligned:
+            self._pending[request.request_id] = (all_tokens, 0)
+            logger.debug(
+                "LMCache TRT-LLM scheduler: req %d short-circuit "
+                "(TRT matched %d of %d block-aligned tokens) %.3fms",
+                request.request_id,
+                num_computed_tokens,
+                max_block_aligned,
+                (time.perf_counter() - t0) * 1000,
+            )
+            return 0, False
+
+        t1 = time.perf_counter()
+        cached_tokens = self._engine.lookup(tokens=all_tokens)
+        t2 = time.perf_counter()
+
+        new_matched = max(0, cached_tokens - num_computed_tokens)
+        new_matched = (new_matched // self._block_size) * self._block_size
+
+        self._pending[request.request_id] = (all_tokens, new_matched)
+
+        logger.debug(
+            "LMCache TRT-LLM scheduler: req %d lookup=%.3fms total=%.3fms "
+            "trt_matched=%d lmcache_cached=%d new_matched=%d",
+            request.request_id,
+            (t2 - t1) * 1000,
+            (time.perf_counter() - t0) * 1000,
+            num_computed_tokens,
+            cached_tokens,
+            new_matched,
+        )
+        return new_matched, False
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> LMCacheConnectorMetadata:
+        """Build per-request load/save specs from the pending lookup
+        results. The runtime binds the returned metadata to the worker
+        via ``bind_connector_meta`` before the forward pass starts.
+        """
+        meta = LMCacheConnectorMetadata()
+
+        for req in scheduler_output.new_requests:
+            if req.request_id not in self._pending:
+                continue
+
+            all_tokens, num_matched = self._pending[req.request_id]
+            block_ids: List[int] = list(req.new_block_ids)
+            num_computed_blocks = req.computed_position // self._block_size
+
+            if num_matched > 0:
+                meta.loads[req.request_id] = _BlockSpec(
+                    tokens=all_tokens, block_ids=block_ids
+                )
+
+            save_start = max(num_computed_blocks, num_matched // self._block_size)
+            num_full_new_blocks = len(req.new_tokens) // self._block_size
+            if (
+                save_start < len(block_ids)
+                and num_full_new_blocks > 0
+                and save_start < num_computed_blocks + num_full_new_blocks
+            ):
+                meta.saves[req.request_id] = _BlockSpec(
+                    tokens=all_tokens, block_ids=block_ids
+                )
+
+        self._pending.clear()
+        return meta
+
+    def request_finished(self, request: LlmRequest, cache_block_ids: List[int]) -> bool:
+        """Return whether async saving is in progress.
+
+        Always ``False`` — saves are synchronous in this adapter.
+        """
+        return False
+
+    def update_state_after_alloc(
+        self, request: LlmRequest, block_ids: List[int]
+    ) -> None:
+        """No-op — block IDs are captured in ``build_connector_meta``
+        from ``scheduler_output.new_requests``.
+        """
+        pass
+
+
+class LMCacheKvConnectorWorker(KvCacheConnectorWorker):
+    """Worker-side connector hook.
+
+    Performs GPU↔CPU KV transfers via the LMCache engine.
+    """
+
+    def __init__(self, llm_args: TorchLlmArgs) -> None:
+        super().__init__(llm_args)
+        self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
+        # Cached after register_kv_caches to avoid per-call singleton lookup.
+        self._engine: Optional[LMCacheEngine] = None
+        self._load_stream: Optional[torch.cuda.Stream] = None
+        self._store_stream: Optional[torch.cuda.Stream] = None
+
+    @property
+    def _meta(self) -> Optional[LMCacheConnectorMetadata]:
+        """Typed accessor for ``self._metadata`` set by the base class."""
+        return self._metadata  # type: ignore[return-value]
+
+    def register_kv_caches(self, kv_cache_tensor: torch.Tensor) -> None:
+        """Register the KV cache tensor and create the LMCache engine.
+
+        Called once by the runtime after KV cache allocation. Caches the
+        engine and its load/store streams for fast access on every step.
+        """
+        self._engine = _get_or_create_engine(
+            llm_args=self._llm_args,
+            kv_cache_tensor=kv_cache_tensor,
+        )
+        gpu_conn = self._engine.gpu_connector
+        if gpu_conn is not None:
+            self._load_stream = gpu_conn.load_stream  # type: ignore[attr-defined]
+            self._store_stream = gpu_conn.store_stream  # type: ignore[attr-defined]
+
+    def start_load_kv(self, stream: torch.cuda.Stream) -> None:
+        """Load KV blocks from LMCache into the GPU paged cache.
+
+        Retrieves all pending blocks on the load stream, then syncs the
+        forward-pass stream against it. The cross-layer format loads
+        every layer in a single kernel — no per-layer overlap to exploit.
+        """
+        meta = self._meta
+        if meta is None or not meta.loads or self._engine is None:
+            return
+
+        t0 = time.perf_counter()
+        for spec in meta.loads.values():
+            if not spec.tokens or not spec.block_ids:
+                continue
+            self._engine.retrieve(tokens=spec.tokens, block_ids=spec.block_ids)
+
+        if self._load_stream is not None:
+            stream.wait_stream(self._load_stream)
+
+        logger.debug(
+            "LMCache TRT-LLM worker: start_load_kv retrieve=%.3fms num_loads=%d",
+            (time.perf_counter() - t0) * 1000,
+            len(meta.loads),
+        )
+
+    def wait_for_layer_load(self, layer_idx: int, stream: torch.cuda.Stream) -> None:
+        """No-op — cross-layer loads complete in :meth:`start_load_kv`."""
+        pass
+
+    def save_kv_layer(self, layer_idx: int, stream: torch.cuda.Stream) -> None:
+        """No-op — saves are batched in :meth:`wait_for_save`."""
+        pass
+
+    def wait_for_save(self, stream: torch.cuda.Stream) -> None:
+        """Store newly computed KV blocks from GPU to LMCache's CPU cache.
+
+        Waits on the forward-pass stream, runs ``engine.store`` for each
+        request with new blocks, and synchronizes the store stream
+        before returning.
+        """
+        meta = self._meta
+        if meta is None or not meta.saves or self._engine is None:
+            return
+
+        t0 = time.perf_counter()
+        if self._store_stream is not None:
+            self._store_stream.wait_stream(stream)
+        t1 = time.perf_counter()
+
+        for spec in meta.saves.values():
+            if not spec.tokens or not spec.block_ids:
+                continue
+            self._engine.store(tokens=spec.tokens, block_ids=spec.block_ids)
+        t2 = time.perf_counter()
+
+        if self._store_stream is not None:
+            self._store_stream.synchronize()
+        t3 = time.perf_counter()
+
+        logger.debug(
+            "LMCache TRT-LLM worker: wait_for_save stream_wait=%.3fms "
+            "store=%.3fms sync=%.3fms num_saves=%d",
+            (t1 - t0) * 1000,
+            (t2 - t1) * 1000,
+            (t3 - t2) * 1000,
+            len(meta.saves),
+        )
+
+    def get_finished(
+        self,
+        finished_gen_req_ids: List[int],
+        started_loading_req_ids: List[int],
+    ) -> Tuple[List[int], List[int]]:
+        """All ops are synchronous here — nothing is ever pending."""
+        return [], []

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TensorRT-LLM KV Cache Connector adapter for LMCache (multi-process mode).
+
+Implements ``LMCacheMPKvConnectorScheduler`` and
+``LMCacheMPKvConnectorWorker`` — the two classes TRT-LLM's
+``kv_connector_config`` requires — backed by a standalone LMCache server
+reached over ZMQ. Provides process isolation and shared caching across
+multiple TRT-LLM instances on the same node.
+
+The KV pool tensor is shared with the server via :class:`RawCudaIPCWrapper`
+because TRT-LLM's pool is allocated outside PyTorch's caching allocator
+(``at::for_blob`` over ``cudaMalloc``), which makes
+``UntypedStorage._share_cuda_()`` raise. The wrapper bypasses that path.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+import os
+import time
+
+# Third Party
+from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import (
+    KvCacheConnectorScheduler,
+    KvCacheConnectorWorker,
+    SchedulerOutput,
+)
+from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
+from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+import torch
+import zmq
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.multiprocess.custom_types import (
+    IPCCacheEngineKey,
+    RawCudaIPCWrapper,
+)
+from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+
+logger = init_logger(__name__)
+
+DEFAULT_SERVER_URL = "ipc:///tmp/lmcache.sock"
+DEFAULT_MQ_TIMEOUT: float = 300.0
+
+
+def _get_server_url(llm_args: "TorchLlmArgs") -> str:
+    """Resolve the server URL: connector-config field > env var > default."""
+    cfg = llm_args.kv_connector_config
+    if cfg is not None and cfg.server_url is not None:
+        return cfg.server_url
+    return os.environ.get("LMCACHE_SERVER_URL", DEFAULT_SERVER_URL)
+
+
+def _send_request(
+    mq_client: MessageQueueClient,
+    request_type: RequestType,
+    payloads: list,
+) -> MessagingFuture:
+    return mq_client.submit_request(
+        request_type, payloads, get_response_class(request_type)
+    )
+
+
+@dataclass
+class _BlockSpec:
+    tokens: List[int]
+    block_ids: List[int]
+
+
+@dataclass
+class LMCacheMPConnectorMetadata:
+    loads: dict = field(default_factory=dict)
+    saves: dict = field(default_factory=dict)
+
+
+class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
+    """TRT-LLM scheduler that routes lookup requests to an LMCache MP server."""
+
+    def __init__(self, llm_args: TorchLlmArgs) -> None:
+        super().__init__(llm_args)
+        self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
+        # request_id -> (all_tokens, num_matched).
+        self._pending: dict = {}
+
+        self._zmq_context = zmq.Context()
+        self._mq_client = MessageQueueClient(
+            _get_server_url(self._llm_args), self._zmq_context
+        )
+        self._mq_timeout = float(
+            os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
+        )
+
+        future = _send_request(self._mq_client, RequestType.GET_CHUNK_SIZE, [])
+        self._chunk_size = future.result(timeout=self._mq_timeout)
+        logger.info(
+            "LMCache MP scheduler: connected to server at %s (chunk_size=%d)",
+            _get_server_url(self._llm_args),
+            self._chunk_size,
+        )
+
+        # Third Party
+        import tensorrt_llm
+
+        self._rank = tensorrt_llm.mpi_rank()
+        tp_size = llm_args.tensor_parallel_size
+        pp_size = llm_args.pipeline_parallel_size
+        self._world_size = tp_size * pp_size
+        self._model_name = str(getattr(llm_args, "model", "unknown_model"))
+
+    def _create_key(
+        self,
+        token_ids: List[int],
+        start: int,
+        end: int,
+        request_id: int,
+    ) -> IPCCacheEngineKey:
+        return IPCCacheEngineKey(
+            model_name=self._model_name,
+            world_size=self._world_size,
+            worker_id=None,
+            token_ids=tuple(token_ids),
+            start=start,
+            end=end,
+            request_id=str(request_id),
+        )
+
+    def get_num_new_matched_tokens(
+        self,
+        request: LlmRequest,
+        num_computed_tokens: int,
+    ) -> Tuple[int, bool]:
+        """Return how many additional tokens the LMCache server can provide.
+
+        Submits a ``LOOKUP`` to the server and queries
+        ``QUERY_PREFETCH_STATUS`` by ``request_id`` to read the result.
+        ``LOOKUP`` returns ``None`` on the server protocol — the prefetch
+        is tracked server-side keyed by ``request_id``.
+        """
+        t0 = time.perf_counter()
+
+        if num_computed_tokens % self._block_size != 0:
+            self._pending[request.request_id] = ([], 0)
+            return 0, False
+
+        all_tokens = list(request.get_tokens(0))
+
+        max_block_aligned = (len(all_tokens) // self._block_size) * self._block_size
+        if num_computed_tokens >= max_block_aligned:
+            self._pending[request.request_id] = (all_tokens, 0)
+            return 0, False
+
+        aligned_end = (len(all_tokens) // self._chunk_size) * self._chunk_size
+        key = self._create_key(
+            all_tokens, start=0, end=aligned_end, request_id=request.request_id
+        ).no_worker_id_version()
+
+        t1 = time.perf_counter()
+
+        try:
+            _send_request(self._mq_client, RequestType.LOOKUP, [key, 1]).result(
+                timeout=self._mq_timeout
+            )
+            result = _send_request(
+                self._mq_client,
+                RequestType.QUERY_PREFETCH_STATUS,
+                [str(request.request_id)],
+            ).result(timeout=self._mq_timeout)
+            cached_tokens = result * self._chunk_size if result is not None else 0
+        except Exception as e:
+            logger.warning("LMCache MP scheduler: lookup failed: %s", e)
+            self._pending[request.request_id] = (all_tokens, 0)
+            return 0, False
+
+        t2 = time.perf_counter()
+
+        new_matched = max(0, cached_tokens - num_computed_tokens)
+        new_matched = (new_matched // self._block_size) * self._block_size
+
+        # ``LOOKUP`` acquires read locks on chunks in [0, cached_tokens).
+        # TRT-LLM already has [0, num_computed_tokens), so those chunks
+        # will never be retrieved — release their locks (chunk-aligned)
+        # to avoid holding them until TTL expiry.
+        overlap_end = min(cached_tokens, num_computed_tokens)
+        overlap_end = (overlap_end // self._chunk_size) * self._chunk_size
+        if overlap_end > 0:
+            free_key = self._create_key(
+                all_tokens,
+                start=0,
+                end=overlap_end,
+                request_id=request.request_id,
+            ).no_worker_id_version()
+            try:
+                _send_request(
+                    self._mq_client,
+                    RequestType.FREE_LOOKUP_LOCKS,
+                    [free_key, 1],
+                )
+            except Exception as e:
+                logger.warning("LMCache MP scheduler: free_lookup_locks failed: %s", e)
+
+        self._pending[request.request_id] = (all_tokens, new_matched)
+
+        logger.debug(
+            "LMCache MP scheduler: req %d lookup=%.3fms total=%.3fms "
+            "trt_matched=%d lmcache_cached=%d new_matched=%d",
+            request.request_id,
+            (t2 - t1) * 1000,
+            (time.perf_counter() - t0) * 1000,
+            num_computed_tokens,
+            cached_tokens,
+            new_matched,
+        )
+        return new_matched, False
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> LMCacheMPConnectorMetadata:
+        """Build per-request load/save specs from pending lookup results."""
+        meta = LMCacheMPConnectorMetadata()
+
+        for req in scheduler_output.new_requests:
+            if req.request_id not in self._pending:
+                continue
+
+            all_tokens, num_matched = self._pending[req.request_id]
+            block_ids: List[int] = list(req.new_block_ids)
+            num_computed_blocks = req.computed_position // self._block_size
+
+            if num_matched > 0:
+                meta.loads[req.request_id] = _BlockSpec(
+                    tokens=all_tokens, block_ids=block_ids
+                )
+
+            save_start = max(num_computed_blocks, num_matched // self._block_size)
+            num_full_new_blocks = len(req.new_tokens) // self._block_size
+            if (
+                save_start < len(block_ids)
+                and num_full_new_blocks > 0
+                and save_start < num_computed_blocks + num_full_new_blocks
+            ):
+                meta.saves[req.request_id] = _BlockSpec(
+                    tokens=all_tokens, block_ids=block_ids
+                )
+
+        self._pending.clear()
+        return meta
+
+    def request_finished(self, request: LlmRequest, cache_block_ids: List[int]) -> bool:
+        """Notify the server so it can clean up per-request state.
+
+        Saves are synchronous in this adapter, so we never need to defer
+        deallocation — return ``False``. We still call ``END_SESSION`` to
+        release the server-side token-hash/session state for the request.
+        """
+        try:
+            _send_request(
+                self._mq_client,
+                RequestType.END_SESSION,
+                [str(request.request_id)],
+            )
+        except Exception as e:
+            logger.warning("LMCache MP scheduler: end_session failed: %s", e)
+        return False
+
+    def update_state_after_alloc(
+        self, request: LlmRequest, block_ids: List[int]
+    ) -> None:
+        """No-op — block IDs are captured in :meth:`build_connector_meta`."""
+        pass
+
+
+class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
+    """TRT-LLM worker that routes store/retrieve to an LMCache MP server."""
+
+    def __init__(self, llm_args: TorchLlmArgs) -> None:
+        super().__init__(llm_args)
+        self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
+
+        self._zmq_context = zmq.Context()
+        self._mq_client = MessageQueueClient(
+            _get_server_url(self._llm_args), self._zmq_context
+        )
+        self._mq_timeout = float(
+            os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
+        )
+
+        self._instance_id = os.getpid()
+        self._registered = False
+
+        # Third Party
+        import tensorrt_llm
+
+        self._rank = tensorrt_llm.mpi_rank()
+        tp_size = llm_args.tensor_parallel_size
+        pp_size = llm_args.pipeline_parallel_size
+        self._world_size = tp_size * pp_size
+        self._model_name = str(getattr(llm_args, "model", "unknown_model"))
+
+        future = _send_request(self._mq_client, RequestType.GET_CHUNK_SIZE, [])
+        self._chunk_size = future.result(timeout=self._mq_timeout)
+
+    def _create_key(
+        self,
+        token_ids: List[int],
+        request_id: int,
+    ) -> IPCCacheEngineKey:
+        aligned_end = (len(token_ids) // self._chunk_size) * self._chunk_size
+        return IPCCacheEngineKey(
+            model_name=self._model_name,
+            world_size=self._world_size,
+            worker_id=self._rank,
+            token_ids=tuple(token_ids),
+            start=0,
+            end=aligned_end,
+            request_id=str(request_id),
+        )
+
+    def register_kv_caches(self, kv_cache_tensor: torch.Tensor) -> None:
+        """Register the KV pool with the LMCache server via raw CUDA IPC.
+
+        TRT-LLM provides a 4-D pool tensor
+        ``[NB, NL, 2, NH * BS * HS]``. The server reshapes it to 6-D
+        ``[NB, NL, 2, NH, BS, HS]`` from the ``layout_hints`` so format
+        detection lands on ``NB_NL_TWO_NH_BS_HS``.
+        """
+        if self._registered:
+            logger.info("LMCache MP worker: KV caches already registered")
+            return
+
+        # Third Party
+        from transformers import AutoConfig
+
+        hf_config = AutoConfig.from_pretrained(self._model_name)
+        head_dim = getattr(
+            hf_config,
+            "head_dim",
+            hf_config.hidden_size // hf_config.num_attention_heads,
+        )
+        num_kv_heads = getattr(
+            hf_config, "num_key_value_heads", hf_config.num_attention_heads
+        )
+        tp_size = self._llm_args.tensor_parallel_size
+        num_kv_heads = num_kv_heads // tp_size
+
+        _, _, _, block_size_flat = kv_cache_tensor.shape
+        tokens_per_block = block_size_flat // (num_kv_heads * head_dim)
+
+        wrapped = [RawCudaIPCWrapper(kv_cache_tensor)]
+
+        layout_hints = {
+            "kv_layout": "HND",
+            "num_kv_heads": num_kv_heads,
+            "tokens_per_block": tokens_per_block,
+            "head_dim": head_dim,
+        }
+
+        future = _send_request(
+            self._mq_client,
+            RequestType.REGISTER_KV_CACHE,
+            [
+                self._instance_id,
+                wrapped,
+                self._model_name,
+                self._world_size,
+                EngineType.TRTLLM,
+                layout_hints,
+            ],
+        )
+        try:
+            future.result(timeout=self._mq_timeout)
+            self._registered = True
+            logger.info(
+                "LMCache MP worker: registered KV caches "
+                "(tensor_shape=%s, NH=%d, BS=%d, HS=%d)",
+                list(kv_cache_tensor.shape),
+                num_kv_heads,
+                tokens_per_block,
+                head_dim,
+            )
+        except TimeoutError:
+            logger.error(
+                "LMCache MP worker: KV cache registration timed out after %ss",
+                self._mq_timeout,
+            )
+
+    def start_load_kv(self, stream: torch.cuda.Stream) -> None:
+        """Send ``RETRIEVE`` requests for each pending load."""
+        meta: Optional[LMCacheMPConnectorMetadata] = self._metadata
+        if meta is None or not meta.loads:
+            return
+
+        t0 = time.perf_counter()
+        event = torch.cuda.Event(interprocess=True)
+        event.record(stream)
+
+        for req_id, spec in meta.loads.items():
+            if not spec.tokens or not spec.block_ids:
+                continue
+
+            key = self._create_key(spec.tokens, req_id)
+            try:
+                _send_request(
+                    self._mq_client,
+                    RequestType.RETRIEVE,
+                    [
+                        key,
+                        self._instance_id,
+                        spec.block_ids,
+                        event.ipc_handle(),
+                        0,  # skip_first_n_tokens
+                    ],
+                ).result(timeout=self._mq_timeout)
+            except Exception as e:
+                logger.warning(
+                    "LMCache MP worker: retrieve failed for req %d: %s",
+                    req_id,
+                    e,
+                )
+
+        logger.debug(
+            "LMCache MP worker: start_load_kv retrieve=%.3fms num_loads=%d",
+            (time.perf_counter() - t0) * 1000,
+            len(meta.loads),
+        )
+
+    def wait_for_layer_load(self, layer_idx: int, stream: torch.cuda.Stream) -> None:
+        """No-op — server synchronizes via CUDA IPC events."""
+        pass
+
+    def save_kv_layer(self, layer_idx: int, stream: torch.cuda.Stream) -> None:
+        """No-op — saves are batched in :meth:`wait_for_save`."""
+        pass
+
+    def wait_for_save(self, stream: torch.cuda.Stream) -> None:
+        """Send ``STORE`` requests for each pending save."""
+        meta: Optional[LMCacheMPConnectorMetadata] = self._metadata
+        if meta is None or not meta.saves:
+            return
+
+        t0 = time.perf_counter()
+        event = torch.cuda.Event(interprocess=True)
+        event.record(stream)
+
+        for req_id, spec in meta.saves.items():
+            if not spec.tokens or not spec.block_ids:
+                continue
+
+            key = self._create_key(spec.tokens, req_id)
+            try:
+                _send_request(
+                    self._mq_client,
+                    RequestType.STORE,
+                    [
+                        key,
+                        self._instance_id,
+                        spec.block_ids,
+                        event.ipc_handle(),
+                    ],
+                ).result(timeout=self._mq_timeout)
+            except Exception as e:
+                logger.warning(
+                    "LMCache MP worker: store failed for req %d: %s",
+                    req_id,
+                    e,
+                )
+
+        logger.debug(
+            "LMCache MP worker: wait_for_save store=%.3fms num_saves=%d",
+            (time.perf_counter() - t0) * 1000,
+            len(meta.saves),
+        )
+
+    def get_finished(
+        self,
+        finished_gen_req_ids: List[int],
+        started_loading_req_ids: List[int],
+    ) -> Tuple[List[int], List[int]]:
+        """All operations are synchronous — nothing is ever pending."""
+        return [], []

--- a/lmcache/integration/tensorrt_llm/utils.py
+++ b/lmcache/integration/tensorrt_llm/utils.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utility helpers for the TensorRT-LLM integration."""
+
+# Standard
+from typing import TYPE_CHECKING
+import os
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
+
+if TYPE_CHECKING:
+    # Third Party
+    from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+
+logger = init_logger(__name__)
+
+ENGINE_NAME = "trtllm-instance"
+
+
+def lmcache_get_config() -> LMCacheEngineConfig:
+    """Return an LMCacheEngineConfig from ``LMCACHE_CONFIG_FILE`` or env.
+
+    Mirrors the in-process pattern used by the vLLM adapter: prefer a
+    config file if the env var is set; otherwise pull from individual
+    ``LMCACHE_*`` environment variables.
+    """
+    if "LMCACHE_CONFIG_FILE" not in os.environ:
+        logger.warning(
+            "No LMCache configuration file is set. Trying to read"
+            " configurations from the environment variables."
+        )
+        logger.warning(
+            "You can set the configuration file through "
+            "the environment variable: LMCACHE_CONFIG_FILE"
+        )
+        config = LMCacheEngineConfig.from_env()
+    else:
+        config_file = os.environ["LMCACHE_CONFIG_FILE"]
+        logger.info("Loading LMCache config file %s", config_file)
+        config = LMCacheEngineConfig.from_file(config_file)
+
+    return config
+
+
+def create_trtllm_metadata(
+    llm_args: "TorchLlmArgs",
+    kv_cache_tensor: torch.Tensor,
+    config: LMCacheEngineConfig,
+    num_kv_heads: int,
+    head_dim: int,
+) -> LMCacheMetadata:
+    """Construct LMCacheMetadata from TRT-LLM args and the KV pool tensor.
+
+    Args:
+        llm_args: TRT-LLM ``TorchLlmArgs``.
+        kv_cache_tensor: TRT-LLM KV pool tensor of shape
+            ``[num_blocks, num_layers, kv_factor, flat]`` where
+            ``flat = num_kv_heads * tokens_per_block * head_dim``.
+        config: The LMCache engine config (used for ``chunk_size``).
+        num_kv_heads: Per-rank number of KV attention heads.
+        head_dim: Per-head dimension.
+
+    Returns:
+        Populated :class:`LMCacheMetadata`.
+    """
+    # Third Party
+    import tensorrt_llm
+
+    _, num_layers, kv_factor, _ = kv_cache_tensor.shape
+    kv_shape = (num_layers, kv_factor, config.chunk_size, num_kv_heads, head_dim)
+
+    rank = tensorrt_llm.mpi_rank()
+    tp_size = llm_args.tensor_parallel_size
+    pp_size = llm_args.pipeline_parallel_size
+    world_size = tp_size * pp_size
+    local_world_size = tp_size
+    local_worker_id = rank % local_world_size
+    model_name = str(getattr(llm_args, "model", "unknown_model"))
+
+    return LMCacheMetadata(
+        model_name=model_name,
+        world_size=world_size,
+        local_world_size=local_world_size,
+        worker_id=rank,
+        local_worker_id=local_worker_id,
+        kv_dtype=kv_cache_tensor.dtype,
+        kv_shape=kv_shape,
+        chunk_size=config.chunk_size,
+    )

--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -272,6 +272,9 @@ class GPUKVFormat(IntEnum):
     # used by: vLLM non-MLA flash infer (HND layout)
     NL_X_NB_TWO_NH_BS_HS = 7
 
+    # used by: TRT-LLM cross-layer (HND layout)
+    NB_NL_TWO_NH_BS_HS = 8
+
 
 class PageBufferShapeDesc:
     """Python stand-in for the C++ ``PageBufferShapeDesc`` struct.

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -596,6 +596,7 @@ class CacheStoreEvent:
 class EngineType(Enum):
     VLLM = "vllm"
     SGLANG = "sglang"
+    TRTLLM = "trtllm"
     MOCK = "mock"
 
 

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -24,7 +24,7 @@ def CreateGPUConnector(
         config: The LMCache engine configuration.
         metadata: The LMCache metadata.
         engine: The serving engine type (EngineType.VLLM, EngineType.SGLANG,
-                or EngineType.MOCK).
+                EngineType.TRTLLM, or EngineType.MOCK).
         layout_hints: Optional hints from the serving engine about KV cache
             layout (e.g. ``{"kv_layout": "HND"}``).
     """
@@ -118,6 +118,15 @@ def CreateGPUConnector(
             return VLLMPagedMemHPUConnectorV2.from_metadata(metadata, use_gpu, device)
         else:
             raise RuntimeError("No supported connector found for the current platform.")
+
+    elif engine == EngineType.TRTLLM:
+        # First Party
+        from lmcache.v1.gpu_connector.gpu_connectors import TRTLLMGPUConnector
+
+        local_worker_id = metadata.local_worker_id
+        torch.cuda.set_device(local_worker_id)
+        device = torch.device(f"cuda:{local_worker_id}")
+        return TRTLLMGPUConnector.from_metadata(metadata, device=device)
 
     elif engine == EngineType.MOCK:
         kv_shape = metadata.kv_shape

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1896,3 +1896,291 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
     def get_shape(self, num_tokens: int) -> torch.Size:
         # TODO: support MLA
         return torch.Size([num_tokens, 2, self.hidden_dim_size])
+
+
+_TRTLLM_KERNEL_BATCH_SIZE = 32
+
+
+class TRTLLMGPUConnector(GPUConnectorInterface):
+    """GPU connector for TRT-LLM's cross-layer KV pool.
+
+    TRT-LLM hands LMCache a single 4-D pool tensor with shape
+    ``[num_blocks, num_layers, 2, num_kv_heads * tokens_per_block * head_dim]``
+    (HND layout, K and V interleaved on dim 2). On
+    :meth:`register_kv_caches` the connector calls
+    :func:`normalize_kv_and_discover_format` which reshapes the trailing
+    dim into ``[num_kv_heads, tokens_per_block, head_dim]``, yielding the
+    canonical 6-D ``[NB, NL, 2, NH, BS, HS]`` form (format
+    ``NB_NL_TWO_NH_BS_HS``).
+
+    Transfers go through :func:`lmc_ops.multi_layer_block_kv_transfer` —
+    the multiprocess kernel — using the single base pointer of the pool
+    tensor. Per-chunk block ids are taken from ``kwargs['block_ids']``,
+    sliced as ``block_ids[i * blocks_per_chunk : (i+1) * blocks_per_chunk]``
+    where ``blocks_per_chunk = chunk_size // tokens_per_block``.
+
+    This is intentionally NOT a subclass of
+    :class:`VLLMPagedMemGPUConnectorV3`. V3 drives the in-process kernel
+    with ``slot_mapping`` and per-layer pointers — the wrong primitive
+    for a single cross-layer base pointer.
+    """
+
+    def __init__(
+        self,
+        num_kv_heads: int,
+        head_dim: int,
+        hidden_dim_size: int,
+        num_layers: int,
+        chunk_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.hidden_dim_size = hidden_dim_size
+        self.num_layers = num_layers
+        self.chunk_size = chunk_size
+        self.dtype = dtype
+        self.device = device
+        self._batch_size = _TRTLLM_KERNEL_BATCH_SIZE
+        self.load_stream = torch.cuda.Stream(device=device)
+        self.store_stream = torch.cuda.Stream(device=device)
+
+        self.kv_cache_tensor: Optional[torch.Tensor] = None
+        self.paged_buffer_ptrs: Optional[torch.Tensor] = None
+        self.shape_desc: Optional["lmc_ops.PageBufferShapeDesc"] = None
+        self._kv_format: Optional["lmc_ops.GPUKVFormat"] = None
+        self.tokens_per_block: Optional[int] = None
+        self.blocks_per_chunk: Optional[int] = None
+
+    @classmethod
+    def from_metadata(
+        cls,
+        metadata: LMCacheMetadata,
+        device: torch.device,
+    ) -> "TRTLLMGPUConnector":
+        """Create a connector from :class:`LMCacheMetadata`.
+
+        Args:
+            metadata: Metadata carrying ``kv_shape``
+                ``(num_layers, 2, chunk_size, num_kv_heads, head_size)`` and
+                ``kv_dtype``.
+            device: CUDA device for transfer streams and block-ids staging.
+        """
+        num_layers = metadata.kv_shape[0]
+        chunk_size = metadata.kv_shape[2]
+        num_kv_heads = metadata.kv_shape[3]
+        head_dim = metadata.kv_shape[4]
+        hidden_dim_size = num_kv_heads * head_dim
+        return cls(
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            hidden_dim_size=hidden_dim_size,
+            num_layers=num_layers,
+            chunk_size=chunk_size,
+            dtype=metadata.kv_dtype,
+            device=device,
+        )
+
+    def register_kv_caches(self, kv_cache_tensor: torch.Tensor) -> None:
+        """Register TRT-LLM's 4-D KV pool tensor with the connector.
+
+        Reshapes the 4-D tensor to canonical 6-D form, runs format
+        discovery, and caches the base pointer / shape descriptor used
+        by every subsequent transfer.
+
+        Called once at TRT-LLM worker init — separate from
+        :meth:`to_gpu` / :meth:`from_gpu`. Idempotent if called with the
+        same tensor; reassigning a different tensor replaces the
+        previously registered one.
+        """
+        if kv_cache_tensor.dim() != 4:
+            raise ValueError(
+                f"TRT-LLM kv_cache_tensor must be 4-D "
+                f"[NB, NL, 2, flat], got shape {tuple(kv_cache_tensor.shape)}"
+            )
+        num_blocks, num_layers, kv_factor, flat = kv_cache_tensor.shape
+        tokens_per_block = flat // (self.num_kv_heads * self.head_dim)
+        if tokens_per_block * self.num_kv_heads * self.head_dim != flat:
+            raise ValueError(
+                f"flat dim {flat} not divisible by "
+                f"num_kv_heads * head_dim ({self.num_kv_heads * self.head_dim})"
+            )
+        self.tokens_per_block = tokens_per_block
+        self.blocks_per_chunk = self.chunk_size // tokens_per_block
+
+        layout_hints: LayoutHints = {
+            "kv_layout": "HND",
+            "num_kv_heads": self.num_kv_heads,
+            "tokens_per_block": tokens_per_block,
+            "head_dim": self.head_dim,
+        }
+        kv_format, normalized = normalize_kv_and_discover_format(
+            kv_cache_tensor, EngineType.TRTLLM, layout_hints=layout_hints
+        )
+        if not isinstance(normalized, torch.Tensor):
+            raise ValueError(
+                "TRT-LLM normalize must return a bare tensor; "
+                f"got {type(normalized).__name__}"
+            )
+        self._kv_format = kv_format
+        self.kv_cache_tensor = normalized
+
+        shape_desc = lmc_ops.PageBufferShapeDesc()
+        shape_desc.kv_size = kv_factor
+        shape_desc.nl = num_layers
+        shape_desc.nb = num_blocks
+        shape_desc.bs = tokens_per_block
+        shape_desc.nh = self.num_kv_heads
+        shape_desc.hs = self.head_dim
+        shape_desc.element_size = normalized.element_size()
+        self.shape_desc = shape_desc
+
+        self.paged_buffer_ptrs = torch.tensor(
+            get_group_data_ptrs(normalized, kv_format, list(range(num_layers))),
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+    def get_shape(self, num_tokens: int) -> torch.Size:
+        return torch.Size([2, self.num_layers, num_tokens, self.hidden_dim_size])
+
+    def _stage_block_ids(self, block_ids: List[int]) -> torch.Tensor:
+        return torch.tensor(block_ids, dtype=torch.int64, device=self.device)
+
+    def _get_chunk_block_ids(
+        self, block_ids: List[int], start: int
+    ) -> Optional[List[int]]:
+        assert self.blocks_per_chunk is not None
+        chunk_idx = start // self.chunk_size
+        bs = chunk_idx * self.blocks_per_chunk
+        be = bs + self.blocks_per_chunk
+        if be > len(block_ids):
+            return None
+        return block_ids[bs:be]
+
+    def _transfer(
+        self,
+        tensor_ptr: int,
+        block_ids: List[int],
+        direction: "lmc_ops.TransferDirection",
+        stream: torch.cuda.Stream,
+    ) -> None:
+        with torch.cuda.stream(stream):
+            block_ids_gpu = self._stage_block_ids(block_ids)
+            lmc_ops.multi_layer_block_kv_transfer(
+                self.paged_buffer_ptrs,
+                [tensor_ptr],
+                block_ids_gpu,
+                self.device,
+                direction,
+                self.shape_desc,
+                self.chunk_size,
+                self._kv_format,
+                0,  # skip_prefix_n_blocks
+            )
+
+    def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs) -> None:
+        if self.kv_cache_tensor is None:
+            raise RuntimeError("register_kv_caches must be called before to_gpu")
+        chunk_blocks = self._get_chunk_block_ids(kwargs.get("block_ids", []), start)
+        if chunk_blocks is None or memory_obj.tensor is None:
+            return
+        self._transfer(
+            memory_obj.tensor.data_ptr(),
+            chunk_blocks,
+            lmc_ops.TransferDirection.H2D,
+            self.load_stream,
+        )
+
+    def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs) -> None:
+        if self.kv_cache_tensor is None:
+            raise RuntimeError("register_kv_caches must be called before from_gpu")
+        chunk_blocks = self._get_chunk_block_ids(kwargs.get("block_ids", []), start)
+        if chunk_blocks is None or memory_obj.tensor is None:
+            return
+        self._transfer(
+            memory_obj.tensor.data_ptr(),
+            chunk_blocks,
+            lmc_ops.TransferDirection.D2H,
+            self.store_stream,
+        )
+
+    def _batched_transfer(
+        self,
+        memory_objs: List[MemoryObj],
+        starts: List[int],
+        block_ids: List[int],
+        direction: "lmc_ops.TransferDirection",
+        stream: torch.cuda.Stream,
+    ) -> None:
+        valid: List[Tuple[MemoryObj, List[int]]] = []
+        for memory_obj, start in zip(memory_objs, starts, strict=False):
+            if isinstance(memory_obj, list) or memory_obj.tensor is None:
+                continue
+            chunk_blocks = self._get_chunk_block_ids(block_ids, start)
+            if chunk_blocks is not None:
+                valid.append((memory_obj, chunk_blocks))
+
+        with torch.cuda.stream(stream):
+            for i in range(0, len(valid), self._batch_size):
+                batch = valid[i : i + self._batch_size]
+                all_block_ids: List[int] = []
+                ptrs: List[int] = []
+                for mo, blocks in batch:
+                    all_block_ids.extend(blocks)
+                    ptrs.append(mo.tensor.data_ptr())  # type: ignore[union-attr]
+                block_ids_gpu = self._stage_block_ids(all_block_ids)
+                lmc_ops.multi_layer_block_kv_transfer(
+                    self.paged_buffer_ptrs,
+                    ptrs,
+                    block_ids_gpu,
+                    self.device,
+                    direction,
+                    self.shape_desc,
+                    self.chunk_size,
+                    self._kv_format,
+                    0,
+                )
+
+    def batched_from_gpu(
+        self,
+        memory_objs: Union[List[List[MemoryObj]], List[MemoryObj]],
+        starts: List[int],
+        ends: List[int],
+        **kwargs,
+    ) -> None:
+        if self.kv_cache_tensor is None:
+            raise RuntimeError(
+                "register_kv_caches must be called before batched_from_gpu"
+            )
+        self._batched_transfer(
+            memory_objs,  # type: ignore[arg-type]
+            starts,
+            kwargs.get("block_ids", []),
+            lmc_ops.TransferDirection.D2H,
+            self.store_stream,
+        )
+
+    def batched_to_gpu(
+        self,
+        memory_objs: Union[
+            List[List[MemoryObj]], List[MemoryObj], List[int], None
+        ] = None,
+        starts: Optional[List[int]] = None,
+        ends: Optional[List[int]] = None,
+        **kwargs,
+    ) -> None:
+        if memory_objs is None or starts is None or ends is None:
+            return
+        if self.kv_cache_tensor is None:
+            raise RuntimeError(
+                "register_kv_caches must be called before batched_to_gpu"
+            )
+        self._batched_transfer(
+            memory_objs,  # type: ignore[arg-type]
+            starts,
+            kwargs.get("block_ids", []),
+            lmc_ops.TransferDirection.H2D,
+            self.load_stream,
+        )

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -66,9 +66,16 @@ class LayoutHints(TypedDict, total=False):
             ``"NHD"`` — heads after block-size (default for most
             vLLM builds).
             ``"HND"`` — heads before block-size (``VLLM_KV_CACHE_LAYOUT=HND``).
+        num_kv_heads: Number of KV heads per layer. Used by TRT-LLM to
+            reshape its 4-D pool tensor into the canonical 6-D form.
+        tokens_per_block: Tokens per paged block. Used by TRT-LLM (same).
+        head_dim: Per-head dimension. Used by TRT-LLM (same).
     """
 
     kv_layout: Literal["NHD", "HND"]
+    num_kv_heads: int
+    tokens_per_block: int
+    head_dim: int
 
 
 def attempt_permute_to_contiguous_view(
@@ -106,6 +113,38 @@ def attempt_permute_to_contiguous_view(
             )
         return result
     return [attempt_permute_to_contiguous_view(sub) for sub in kv_caches]
+
+
+def assert_contiguous(tensor: torch.Tensor) -> None:
+    """Assert that *tensor* has a contiguous physical layout with zero offset.
+
+    LMCache transfer kernels assume logical and physical views match for
+    coalesced memory accesses. Used at boundaries where we receive a
+    tensor we can't or shouldn't permute (e.g. raw CUDA-IPC reconstruction
+    in :class:`~lmcache.v1.multiprocess.custom_types.RawCudaIPCWrapper`).
+
+    Raises:
+        ValueError: If *tensor* has a nonzero storage offset, or is
+            non-contiguous.
+    """
+    if tensor.storage_offset() != 0:
+        raise ValueError(f"expected storage_offset 0, got {tensor.storage_offset()}")
+    if not tensor.is_contiguous():
+        raise ValueError("tensor is not contiguous")
+
+
+def is_cross_layer_format(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+    """Return ``True`` if *gpu_kv_format* stores all layers in one tensor.
+
+    Cross-layer formats — ``NB_NL_TWO_BS_NH_HS`` (vLLM, NHD) and
+    ``NB_NL_TWO_NH_BS_HS`` (TRT-LLM, HND) — are represented as a single
+    bare :class:`torch.Tensor` rather than a list-of-tensors keyed by
+    layer index.
+    """
+    return gpu_kv_format in (
+        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+    )
 
 
 def need_gpu_interm_buffer(lmcache_config: LMCacheEngineConfig):
@@ -161,6 +200,7 @@ def get_gpu_kv_shape_description(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
         lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS: "NL x [PBS, 1, HS]",
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS: "NL x [2, NB, NH, BS, HS]",
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: "NL x [NB, 2, NH, BS, HS]",
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "[NB, NL, 2, NH, BS, HS]",
     }
     return _SHAPE_DESCRIPTIONS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
 
@@ -182,6 +222,7 @@ def get_attention_backend(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: (
             "vLLM non-MLA flash infer (HND layout)"
         ),
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "TRT-LLM cross-layer (HND layout)",
     }
     return _ATTENTION_BACKENDS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
 
@@ -243,6 +284,12 @@ def get_concrete_gpu_kv_shape(
         nh = get_num_heads(kv_caches, fmt)
         bs = get_block_size(kv_caches, fmt)
         return f"{nl} x [{nb}, 2, {nh}, {bs}, {hs}]"
+
+    if fmt == F.NB_NL_TWO_NH_BS_HS:
+        nb = get_num_blocks(kv_caches, fmt)
+        nh = get_num_heads(kv_caches, fmt)
+        bs = get_block_size(kv_caches, fmt)
+        return f"[{nb}, {nl}, 2, {nh}, {bs}, {hs}]"
 
     return f"Unknown ({gpu_kv_format})"
 
@@ -321,6 +368,35 @@ def normalize_kv_and_discover_format(
     """
     kv_caches = attempt_permute_to_contiguous_view(kv_caches)
 
+    if layout_hints is None:
+        layout_hints = {}
+
+    # TRT-LLM hands us a 4-D pool tensor (possibly wrapped in a 1-element
+    # list for adapter-side ergonomics). Reshape to the canonical 6-D
+    # cross-layer form here so detection lands on the standard path.
+    if serving_engine == EngineType.TRTLLM:
+        if isinstance(kv_caches, list) and len(kv_caches) == 1:
+            kv_caches = kv_caches[0]
+        if isinstance(kv_caches, torch.Tensor) and kv_caches.dim() == 4:
+            num_kv_heads = layout_hints.get("num_kv_heads")
+            tokens_per_block = layout_hints.get("tokens_per_block")
+            head_dim = layout_hints.get("head_dim")
+            if num_kv_heads is None or tokens_per_block is None or head_dim is None:
+                raise ValueError(
+                    "TRT-LLM normalize requires layout_hints with "
+                    "num_kv_heads, tokens_per_block, head_dim"
+                )
+            nb, nl, kv, flat = kv_caches.shape
+            if flat != num_kv_heads * tokens_per_block * head_dim:
+                raise ValueError(
+                    f"TRT-LLM 4D tensor flat dim {flat} does not match "
+                    f"num_kv_heads ({num_kv_heads}) * tokens_per_block "
+                    f"({tokens_per_block}) * head_dim ({head_dim})"
+                )
+            kv_caches = kv_caches.view(
+                nb, nl, kv, num_kv_heads, tokens_per_block, head_dim
+            )
+
     # list_depth: number of external wrapping lists
     # tensor_dim: number of dimensions of the internal tensor
     list_depth, tensor_dim = _list_depth_tensor_dim(kv_caches)
@@ -337,12 +413,12 @@ def normalize_kv_and_discover_format(
     )
     logger.info("GPU KV Cache Dimensions: %s", dims_str)
 
-    if layout_hints is None:
-        layout_hints = {}
-
     detected_format = None
 
-    if serving_engine == EngineType.VLLM:
+    if serving_engine == EngineType.TRTLLM:
+        if list_depth == 0 and tensor_dim == 6:
+            detected_format = lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+    elif serving_engine == EngineType.VLLM:
         kv_layout = layout_hints.get("kv_layout")
         if kv_layout is None:
             logger.warning(
@@ -396,7 +472,10 @@ def get_num_layers(
     """
     Get the number of layers from the kv_caches
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if gpu_kv_format in (
+        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+    ):
         return kv_caches.shape[1]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
@@ -420,7 +499,10 @@ def get_num_blocks(
     """
     Get the number of blocks from the kv_caches
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if gpu_kv_format in (
+        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+    ):
         return kv_caches.shape[0]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
@@ -452,6 +534,9 @@ def get_block_size(
     """
     if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[3]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+        # HND cross-layer: [NB, NL, 2, NH, BS, HS] — block_size at shape[4]
+        return kv_caches.shape[4]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -483,6 +568,9 @@ def get_page_buffer_size(
     if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         return kv_caches.shape[0] * kv_caches.shape[3]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+        # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+        return kv_caches.shape[0] * kv_caches.shape[4]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         return kv_caches[0].shape[1] * kv_caches[0].shape[2]
@@ -520,6 +608,9 @@ def get_num_heads(
     """
     if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[4]  # global for cross-layer
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+        # HND cross-layer: [NB, NL, 2, NH, BS, HS] — num_heads at shape[3]
+        return kv_caches.shape[3]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -553,6 +644,9 @@ def get_hidden_dim_size(
     """
     if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[4] * kv_caches.shape[5]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+        # HND cross-layer: [NB, NL, 2, NH, BS, HS] — hidden = NH * HS
+        return kv_caches.shape[3] * kv_caches.shape[5]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -583,7 +677,10 @@ def get_head_size(
     """
     Get the head size for a layer (defaults to layer 0).
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if gpu_kv_format in (
+        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+    ):
         return kv_caches.shape[5]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
@@ -613,6 +710,9 @@ def get_tokens_per_layer(
     if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         return kv_caches.shape[0] * kv_caches.shape[3]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+        # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+        return kv_caches.shape[0] * kv_caches.shape[4]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         k_cache_shape = kv_caches[0][0].shape
@@ -659,6 +759,13 @@ def get_elements_per_layer(
         num_heads = kv_caches.shape[4]
         head_size = kv_caches.shape[5]
         return num_blocks * 2 * block_size * num_heads * head_size
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+        # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+        num_blocks = kv_caches.shape[0]
+        num_heads = kv_caches.shape[3]
+        block_size = kv_caches.shape[4]
+        head_size = kv_caches.shape[5]
+        return num_blocks * 2 * num_heads * block_size * head_size
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
@@ -707,6 +814,7 @@ def is_hnd(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
     return gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     )
 
 
@@ -754,7 +862,10 @@ def get_dtype(
     """
     Get the dtype for a layer (defaults to layer 0).
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if gpu_kv_format in (
+        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+    ):
         return kv_caches.dtype
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
@@ -787,9 +898,10 @@ def get_group_data_ptrs(
       pointer per requested layer, in the given order.
     - ``TWO_X_NL_X_NBBS_NH_HS`` (SGLang MHA): K's grouped first,
       then V's: ``[K_{i0}, ..., K_{iN}, V_{i0}, ..., V_{iN}]``.
-    - ``NB_NL_TWO_BS_NH_HS`` (cross-layer): a single base pointer,
-      ``[base]``. The kernel walks layers by computing offsets from
-      ``shape_desc.nl`` internally; ``layer_indices`` is unused.
+    - ``NB_NL_TWO_BS_NH_HS`` / ``NB_NL_TWO_NH_BS_HS`` (cross-layer): a
+      single base pointer, ``[base]``. The kernel walks layers by
+      computing offsets from ``shape_desc.nl`` internally;
+      ``layer_indices`` is unused.
 
     Args:
         kv_caches: Full kv_caches structure.
@@ -804,7 +916,7 @@ def get_group_data_ptrs(
         ValueError: If *gpu_kv_format* is not recognized.
     """
     F = lmc_ops.GPUKVFormat
-    if gpu_kv_format == F.NB_NL_TWO_BS_NH_HS:
+    if gpu_kv_format in (F.NB_NL_TWO_BS_NH_HS, F.NB_NL_TWO_NH_BS_HS):
         tensor = cast(torch.Tensor, kv_caches)
         return [tensor.data_ptr()]
     if gpu_kv_format == F.TWO_X_NL_X_NBBS_NH_HS:

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -121,6 +121,97 @@ class CudaIPCWrapper:
         return pickle.loads(data)
 
 
+class RawCudaIPCWrapper(CudaIPCWrapper):
+    """IPC wrapper for CUDA tensors allocated outside PyTorch's caching
+    allocator.
+
+    PyTorch's ``UntypedStorage._share_cuda_()`` only works for tensors
+    backed by its own caching allocator. TRT-LLM publishes its KV pool
+    via ``at::for_blob`` over a ``cudaMalloc``'d buffer, which raises in
+    ``_share_cuda_()``. This subclass bypasses that path: it calls
+    ``cudaIpcGetMemHandle`` on the raw data pointer, then reconstructs
+    the tensor on the receiving side via ``cudaIpcOpenMemHandle`` plus
+    a CuPy ``UnownedMemory`` → DLPack → ``torch`` round-trip.
+
+    Subclassing (rather than introducing a parallel class with its own
+    msgspec ext code) is load-bearing — msgspec does not support unions
+    of custom ext-encoded types. With subclassing, ``KVCache =
+    list[CudaIPCWrapper]`` continues to type-check, the existing ext
+    code 1 round-trips both wrappers, and pickle preserves the subclass
+    identity through the wire so ``to_tensor`` dispatches correctly.
+    """
+
+    def __init__(self, tensor: torch.Tensor) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import assert_contiguous
+
+        assert_contiguous(tensor)
+
+        try:
+            # Third Party
+            from cuda.bindings import runtime as cudart
+        except ImportError:
+            # Third Party
+            from cuda import cudart
+
+        data_ptr = tensor.data_ptr()
+        err, ipc_handle = cudart.cudaIpcGetMemHandle(data_ptr)
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(
+                f"cudaIpcGetMemHandle failed: {err} (ptr=0x{data_ptr:x})"
+            )
+
+        # Store only what's needed for reconstruction.
+        self._ipc_handle_reserved = bytes(ipc_handle.reserved)
+        self._nbytes = tensor.untyped_storage().nbytes()
+
+        # CudaIPCWrapper interface fields. ``handle`` is unused —
+        # ``to_tensor`` is overridden to bypass it — but kept for
+        # equality/identity checks against the parent class.
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+
+        device_index = tensor.device.index
+        self.device_uuid = CudaIPCWrapper._get_device_uuid(device_index)
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor in this process via raw CUDA IPC."""
+        # Third Party
+        import cupy
+
+        try:
+            # Third Party
+            from cuda.bindings import runtime as cudart
+        except ImportError:
+            # Third Party
+            from cuda import cudart
+
+        device_index = CudaIPCWrapper._get_device_index_from_uuid(self.device_uuid)
+
+        handle = cudart.cudaIpcMemHandle_t()
+        handle.reserved = self._ipc_handle_reserved
+        err, ptr = cudart.cudaIpcOpenMemHandle(
+            handle, cudart.cudaIpcMemLazyEnablePeerAccess
+        )
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaIpcOpenMemHandle failed: {err}")
+
+        # Wrap as a flat ``uint8`` CuPy array, DLPack to torch, then view
+        # as the original dtype/shape. ``uint8`` avoids dtype-conversion
+        # gaps (bfloat16, fp8 have no direct CuPy/NumPy equivalent without
+        # ml_dtypes).
+        with cupy.cuda.Device(device_index):
+            mem = cupy.cuda.UnownedMemory(ptr, self._nbytes, owner=self)
+            memptr = cupy.cuda.MemoryPointer(mem, 0)
+            cp_flat = cupy.ndarray(self._nbytes, dtype=cupy.uint8, memptr=memptr)
+
+        raw = torch.from_dlpack(cp_flat)
+        return raw.view(self.dtype).reshape(self.shape)
+
+
 @dataclass(order=True, frozen=True)
 class IPCCacheEngineKey:
     """Cache key for the IPC (multiprocess) protocol.

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the LMCache-side TRT-LLM integration components.
+
+Covers ``EngineType.TRTLLM``, the new ``NB_NL_TWO_NH_BS_HS`` GPU KV
+format, format-aware accessors in ``gpu_connector/utils.py``, the
+``TRTLLMGPUConnector`` construction path, and the
+``RawCudaIPCWrapper`` subclass relationship — without requiring
+TensorRT-LLM to be installed.
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import EngineType
+
+
+def _has_lmc_ops() -> bool:
+    try:
+        # First Party
+        import lmcache.c_ops  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_cuda() -> bool:
+    return torch.cuda.is_available()
+
+
+class TestEngineType:
+    def test_trtllm_exists(self) -> None:
+        assert hasattr(EngineType, "TRTLLM")
+        assert EngineType.TRTLLM.value == "trtllm"
+
+    def test_all_engine_types(self) -> None:
+        expected = {"vllm", "sglang", "trtllm", "mock"}
+        actual = {e.value for e in EngineType}
+        assert expected == actual
+
+
+class TestAssertContiguous:
+    def test_contiguous_tensor_passes(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import assert_contiguous
+
+        t = torch.zeros(2, 3, 4)
+        assert_contiguous(t)  # no raise
+
+    def test_non_contiguous_raises(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import assert_contiguous
+
+        t = torch.zeros(2, 3, 4).transpose(0, 1)
+        with pytest.raises(ValueError, match="not contiguous"):
+            assert_contiguous(t)
+
+    def test_nonzero_storage_offset_raises(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import assert_contiguous
+
+        base = torch.zeros(8)
+        view = base[2:6]  # storage_offset = 2
+        with pytest.raises(ValueError, match="storage_offset"):
+            assert_contiguous(view)
+
+
+@pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
+class TestGPUKVFormatEnum:
+    def test_nb_nl_two_nh_bs_hs_exists(self) -> None:
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        assert hasattr(lmc_ops.GPUKVFormat, "NB_NL_TWO_NH_BS_HS")
+
+    def test_is_cross_layer_format(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import is_cross_layer_format
+        import lmcache.c_ops as lmc_ops
+
+        assert is_cross_layer_format(lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS)
+        assert is_cross_layer_format(lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS)
+        assert not is_cross_layer_format(lmc_ops.GPUKVFormat.NL_X_NB_BS_HS)
+
+    def test_is_hnd(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import is_hnd
+        import lmcache.c_ops as lmc_ops
+
+        assert is_hnd(lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS)
+        assert not is_hnd(lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS)
+
+
+@pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
+class TestNormalizeTRTLLM:
+    """``normalize_kv_and_discover_format`` for ``EngineType.TRTLLM``."""
+
+    def test_4d_tensor_reshape_to_6d(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            LayoutHints,
+            normalize_kv_and_discover_format,
+        )
+        import lmcache.c_ops as lmc_ops
+
+        nb, nl, kv = 4, 2, 2
+        nh, bs, hs = 8, 16, 64
+        flat = nh * bs * hs
+
+        t = torch.zeros(nb, nl, kv, flat, dtype=torch.bfloat16)
+        layout_hints: LayoutHints = {
+            "kv_layout": "HND",
+            "num_kv_heads": nh,
+            "tokens_per_block": bs,
+            "head_dim": hs,
+        }
+
+        fmt, normalized = normalize_kv_and_discover_format(
+            t, EngineType.TRTLLM, layout_hints=layout_hints
+        )
+
+        assert fmt == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+        assert isinstance(normalized, torch.Tensor)
+        assert tuple(normalized.shape) == (nb, nl, kv, nh, bs, hs)
+
+    def test_collapses_one_element_list(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            LayoutHints,
+            normalize_kv_and_discover_format,
+        )
+        import lmcache.c_ops as lmc_ops
+
+        nb, nl, kv, nh, bs, hs = 2, 2, 2, 4, 8, 32
+        t = torch.zeros(nb, nl, kv, nh * bs * hs)
+        layout_hints: LayoutHints = {
+            "kv_layout": "HND",
+            "num_kv_heads": nh,
+            "tokens_per_block": bs,
+            "head_dim": hs,
+        }
+        fmt, normalized = normalize_kv_and_discover_format(
+            [t], EngineType.TRTLLM, layout_hints=layout_hints
+        )
+        assert fmt == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+        assert isinstance(normalized, torch.Tensor)
+        assert normalized.shape == (nb, nl, kv, nh, bs, hs)
+
+    def test_missing_layout_hints_raises(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import normalize_kv_and_discover_format
+
+        t = torch.zeros(2, 2, 2, 16)
+        with pytest.raises(ValueError, match="num_kv_heads"):
+            normalize_kv_and_discover_format(t, EngineType.TRTLLM, layout_hints={})
+
+    def test_flat_dim_mismatch_raises(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            LayoutHints,
+            normalize_kv_and_discover_format,
+        )
+
+        t = torch.zeros(2, 2, 2, 17)  # not divisible by 4*2*2 = 16
+        layout_hints: LayoutHints = {
+            "kv_layout": "HND",
+            "num_kv_heads": 4,
+            "tokens_per_block": 2,
+            "head_dim": 2,
+        }
+        with pytest.raises(ValueError, match="flat dim"):
+            normalize_kv_and_discover_format(
+                t, EngineType.TRTLLM, layout_hints=layout_hints
+            )
+
+
+@pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
+class TestAccessorsTRTLLM:
+    """Format accessors for ``NB_NL_TWO_NH_BS_HS``."""
+
+    def _tensor(
+        self,
+        nb: int = 4,
+        nl: int = 3,
+        kv: int = 2,
+        nh: int = 8,
+        bs: int = 16,
+        hs: int = 64,
+    ) -> torch.Tensor:
+        return torch.zeros(nb, nl, kv, nh, bs, hs, dtype=torch.bfloat16)
+
+    def test_get_num_layers(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_num_layers
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_num_layers(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 3
+
+    def test_get_num_blocks(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_num_blocks
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_num_blocks(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 4
+
+    def test_get_block_size(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_block_size
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_block_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 16
+
+    def test_get_num_heads(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_num_heads
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_num_heads(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 8
+
+    def test_get_head_size(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_head_size
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_head_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 64
+
+    def test_get_hidden_dim_size(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_hidden_dim_size
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_hidden_dim_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 8 * 64
+
+    def test_get_page_buffer_size(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_page_buffer_size
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_page_buffer_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 4 * 16
+
+    def test_get_dtype(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_dtype
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        assert get_dtype(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == torch.bfloat16
+
+    def test_get_group_data_ptrs_returns_single_base_pointer(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import get_group_data_ptrs
+        import lmcache.c_ops as lmc_ops
+
+        t = self._tensor()
+        ptrs = get_group_data_ptrs(
+            t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS, list(range(3))
+        )
+        assert len(ptrs) == 1
+        assert ptrs[0] == t.data_ptr()
+
+    def test_shape_description_strings(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            get_attention_backend,
+            get_concrete_gpu_kv_shape,
+            get_gpu_kv_shape_description,
+        )
+        import lmcache.c_ops as lmc_ops
+
+        fmt = lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+        assert get_gpu_kv_shape_description(fmt) == "[NB, NL, 2, NH, BS, HS]"
+        assert "TRT-LLM" in get_attention_backend(fmt)
+        assert get_concrete_gpu_kv_shape(self._tensor(), fmt) == (
+            "[4, 3, 2, 8, 16, 64]"
+        )
+
+
+@pytest.mark.skipif(not _has_cuda(), reason="CUDA required for connector init")
+@pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
+class TestTRTLLMGPUConnector:
+    def test_construct(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.gpu_connectors import TRTLLMGPUConnector
+
+        device = torch.device("cuda:0")
+        c = TRTLLMGPUConnector(
+            num_kv_heads=2,
+            head_dim=64,
+            hidden_dim_size=128,
+            num_layers=4,
+            chunk_size=256,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        assert c.num_kv_heads == 2
+        assert c.head_dim == 64
+        assert c.kv_cache_tensor is None  # not registered yet
+
+    def test_get_shape(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.gpu_connectors import TRTLLMGPUConnector
+
+        device = torch.device("cuda:0")
+        c = TRTLLMGPUConnector(
+            num_kv_heads=2,
+            head_dim=64,
+            hidden_dim_size=128,
+            num_layers=4,
+            chunk_size=256,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        # Memory-obj layout: [2, num_layers, num_tokens, hidden_dim]
+        assert tuple(c.get_shape(256)) == (2, 4, 256, 128)
+
+    def test_register_kv_caches_with_4d_tensor(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.gpu_connectors import TRTLLMGPUConnector
+
+        device = torch.device("cuda:0")
+        nh, bs, hs = 2, 16, 64
+        nb, nl, kv = 4, 4, 2
+        flat = nh * bs * hs
+        c = TRTLLMGPUConnector(
+            num_kv_heads=nh,
+            head_dim=hs,
+            hidden_dim_size=nh * hs,
+            num_layers=nl,
+            chunk_size=256,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        t = torch.zeros(nb, nl, kv, flat, dtype=torch.bfloat16, device=device)
+        c.register_kv_caches(t)
+        assert c.kv_cache_tensor is not None
+        assert tuple(c.kv_cache_tensor.shape) == (nb, nl, kv, nh, bs, hs)
+        assert c.tokens_per_block == bs
+        assert c.blocks_per_chunk == 256 // bs
+        assert c.shape_desc is not None
+        assert c.shape_desc.nl == nl
+        assert c.shape_desc.nb == nb
+        assert c.shape_desc.bs == bs
+        assert c.shape_desc.nh == nh
+        assert c.shape_desc.hs == hs
+
+
+class TestRawCudaIPCWrapperType:
+    """Subclass relationship — without invoking CUDA IPC syscalls."""
+
+    def test_is_subclass(self) -> None:
+        # First Party
+        from lmcache.v1.multiprocess.custom_types import (
+            CudaIPCWrapper,
+            RawCudaIPCWrapper,
+        )
+
+        assert issubclass(RawCudaIPCWrapper, CudaIPCWrapper)
+
+    def test_kvcache_typing_unchanged(self) -> None:
+        """``KVCache = list[CudaIPCWrapper]`` should accept subclass items
+        — load-bearing for msgspec ext-code reuse over ZMQ.
+        """
+        # First Party
+        from lmcache.v1.multiprocess.custom_types import (
+            CudaIPCWrapper,
+            KVCache,
+            RawCudaIPCWrapper,
+        )
+
+        assert KVCache == list[CudaIPCWrapper]
+        # Static check substitute: a Raw* instance fits the list type.
+        assert issubclass(RawCudaIPCWrapper, CudaIPCWrapper)
+
+    def test_serde_uses_shared_ext_code(self) -> None:
+        """Ext code 1 dispatches to ``CudaIPCWrapper`` (shared with subclass)."""
+        # First Party
+        from lmcache.v1.multiprocess import custom_types
+
+        registry = custom_types._CUSTOMERIZED_SERIALIZERS  # noqa: PLC2701
+        assert custom_types.CudaIPCWrapper in registry
+        assert registry[custom_types.CudaIPCWrapper].code == 1


### PR DESCRIPTION
Two refactors were needed before this PR: 
1. https://github.com/LMCache/LMCache/pull/3078
2. https://github.com/LMCache/LMCache/pull/3162

Now this PR does not even have to modify GPU Cache Context!

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches GPU memory layout/offset calculations and adds a new CUDA-IPC tensor reconstruction path, so mistakes could cause silent KV corruption or crashes under TRT-LLM workloads.
> 
> **Overview**
> Adds **TensorRT-LLM KV Cache Connector** integration with new in-process and multi-process adapters, including engine singleton creation, lookup/load/store lifecycle wiring, and new docs under `docs/source/integrations/`.
> 
> Extends the C++/CUDA transfer stack with a new `GPUKVFormat.NB_NL_TWO_NH_BS_HS` (TRT-LLM cross-layer HND) and updates the MP transfer kernel to compute correct within-block (HND vs NHD) offsets and dispatch/pybind support.
> 
> Introduces a new `EngineType.TRTLLM`, a dedicated `TRTLLMGPUConnector` that transfers by **block IDs** via `multi_layer_block_kv_transfer`, format discovery updates to reshape TRT-LLM’s 4-D pool tensor into canonical 6-D via `layout_hints`, plus `RawCudaIPCWrapper` to share non-PyTorch-allocator CUDA buffers over IPC; adds unit tests covering the new format, accessors, connector init, and IPC wrapper typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116cd71bc04b1a564021f9252830a9b37e9d5c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->