### PR TITLE
[MP][Observability] Add EventBus self-monitoring metrics

### DIFF
--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -302,6 +302,26 @@ queue-bound or I/O-bound?
 
 ---
 
+## EventBus Self-Monitoring
+
+Health metrics for the EventBus itself, registered by
+`EventBusSelfMetricsSubscriber`. Unlike the other metrics subscribers,
+these are not driven by events — they observe bus state directly via the
+`EventBus` accessors and report on every OTel scrape.
+
+| OTel metric name | Prometheus name | Type | Source | Calculation |
+|---|---|---|---|---|
+| `lmcache_mp.event_bus.queue_depth` | `lmcache_mp_event_bus_queue_depth` | ObservableGauge | `EventBus.queue_depth()` | `len(_queue)` at scrape time |
+| `lmcache_mp.event_bus.drain_lag_seconds` | `lmcache_mp_event_bus_drain_lag_seconds` | ObservableGauge | `EventBus.oldest_event_lag_seconds()` | `time.time() - oldest.timestamp`, or `0.0` when empty |
+| `lmcache_mp.event_bus.dropped_events_total` | `lmcache_mp_event_bus_dropped_events_total` | ObservableCounter | `EventBus.dropped_events_count()` | cumulative `_discard_count` |
+| `lmcache_mp.event_bus.subscriber_exceptions` | `lmcache_mp_event_bus_subscriber_exceptions_total` | ObservableCounter (attr: `subscriber_name`) | `EventBus.subscriber_exception_counts()` | cumulative count per subscriber, incremented when `_drain_all` catches a callback exception |
+
+**What it answers:** Is the EventBus keeping up with publishers? Is anything being dropped? Are any subscriber callbacks raising?
+
+`subscriber_name` is derived from the failing callback: bound methods report their owning class (e.g. `L1MetricsSubscriber`); free functions report `__qualname__`.
+
+---
+
 ## MPCacheEngine Observable Gauges
 
 These metrics are registered directly via `register_gauge` (pull-based OTel

--- a/docs/design/v1/mp_observability/event-bus.md
+++ b/docs/design/v1/mp_observability/event-bus.md
@@ -100,6 +100,13 @@ Key design choices:
   unbounded memory growth without blocking producers.
 - **Exception isolation.**  A failing subscriber callback does not affect other
   subscribers or the drain thread.
+- **Self-monitoring.**  The bus exposes four read-only accessors —
+  `queue_depth()`, `oldest_event_lag_seconds()`, `dropped_events_count()`,
+  `subscriber_exception_counts()` — that surface its own health.  These
+  drive the `lmcache_mp.event_bus.*` metrics registered by
+  `EventBusSelfMetricsSubscriber` (see [METRICS.md](METRICS.md)). Keeping
+  the accessors OTel-free preserves the bus's decoupling from the metrics
+  system.
 
 ---
 

--- a/lmcache/v1/mp_observability/README.md
+++ b/lmcache/v1/mp_observability/README.md
@@ -24,6 +24,9 @@ EventBus  (async queue + drain thread)
     │
     ├──► L1MetricsSubscriber          → OTel counter.add(...)
     ├──► SMMetricsSubscriber          → OTel counter.add(...)
+    ├──► EventBusSelfMetricsSubscriber → OTel observable gauges/counters
+    │                                    (bus health: queue depth, drain
+    │                                    lag, drops, subscriber exceptions)
     ├──► L1LoggingSubscriber          → logger.debug(...)
     ├──► SMLoggingSubscriber          → logger.debug(...)
     ├──► MPServerLoggingSubscriber    → logger.debug(...)

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -325,6 +325,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         # First Party
         from lmcache.v1.mp_observability.subscribers.metrics import (
             BlendMetricsSubscriber,
+            EventBusSelfMetricsSubscriber,
             L0L1ThroughputSubscriber,
             L0LifecycleSubscriber,
             L1FailureMetricsSubscriber,
@@ -335,7 +336,6 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
             L2ThroughputSubscriber,
             LookupMetricsSubscriber,
             SMMetricsSubscriber,
-            init_event_bus_self_metrics,
         )
 
         sample_rate = obs_config.metrics_sample_rate
@@ -350,7 +350,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         bus.register_subscriber(LookupMetricsSubscriber())
         bus.register_subscriber(SMMetricsSubscriber())
         bus.register_subscriber(BlendMetricsSubscriber())
-        init_event_bus_self_metrics(bus)
+        bus.register_subscriber(EventBusSelfMetricsSubscriber(bus))
 
     if obs_config.logging_enabled:
         # First Party

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -335,6 +335,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
             L2ThroughputSubscriber,
             LookupMetricsSubscriber,
             SMMetricsSubscriber,
+            init_event_bus_self_metrics,
         )
 
         sample_rate = obs_config.metrics_sample_rate
@@ -349,6 +350,7 @@ def init_observability(obs_config: ObservabilityConfig) -> EventBus:
         bus.register_subscriber(LookupMetricsSubscriber())
         bus.register_subscriber(SMMetricsSubscriber())
         bus.register_subscriber(BlendMetricsSubscriber())
+        init_event_bus_self_metrics(bus)
 
     if obs_config.logging_enabled:
         # First Party

--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -38,6 +38,24 @@ logger = init_logger(__name__)
 EventCallback = Callable[[Event], None]
 
 
+def _subscriber_name(cb: EventCallback) -> str:
+    """Derive a stable label for *cb* for use as a metric tag.
+
+    For bound methods, returns the owning class name (e.g.
+    ``"L1MetricsSubscriber"``).  For free functions, returns the
+    callable's ``__qualname__``.  Falls back to ``repr(cb)`` for
+    callables that have neither — those should be rare and indicate a
+    test fixture or partial.
+    """
+    instance = getattr(cb, "__self__", None)
+    if instance is not None:
+        return type(instance).__name__
+    qualname = getattr(cb, "__qualname__", None)
+    if qualname is not None:
+        return qualname
+    return repr(cb)
+
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -116,6 +134,7 @@ class EventBus:
         self._registered_subscribers: list[EventSubscriber] = []
         self._discard_count: int = 0
         self._last_discard_warning: float = 0.0
+        self._subscriber_exception_counts: dict[str, int] = {}
 
     # -- Public API --------------------------------------------------------
 
@@ -237,6 +256,46 @@ class EventBus:
                     type(sub).__name__,
                 )
 
+    # -- Self-monitoring ---------------------------------------------------
+
+    def queue_depth(self) -> int:
+        """Number of events currently queued waiting for dispatch.
+
+        Reads ``len`` on the underlying deque, which is atomic in CPython,
+        so callers can poll this from a metrics scrape callback without
+        holding the bus lock.
+        """
+        return len(self._queue)
+
+    def oldest_event_lag_seconds(self) -> float:
+        """Wall-clock age of the oldest queued event, or 0.0 when empty.
+
+        Used as a drain-lag gauge: a rising value means the drain thread
+        is not keeping up with publish rate.  Read without the lock; if
+        the deque is concurrently popped during the peek, returns 0.0.
+        """
+        try:
+            oldest = self._queue[0]
+        except IndexError:
+            return 0.0
+        return max(0.0, time.time() - oldest.timestamp)
+
+    def dropped_events_count(self) -> int:
+        """Cumulative count of events dropped because the queue was full."""
+        return self._discard_count
+
+    def subscriber_exception_counts(self) -> dict[str, int]:
+        """Snapshot of per-subscriber callback exception counts.
+
+        Maps ``subscriber_name`` (the owning class name for bound methods,
+        ``__qualname__`` for free functions) to the cumulative count of
+        exceptions raised by that subscriber's callbacks during dispatch.
+        Returns a copy that callers may iterate without holding the bus
+        lock.
+        """
+        with self._lock:
+            return dict(self._subscriber_exception_counts)
+
     # -- Internal ----------------------------------------------------------
 
     def _run(self) -> None:
@@ -274,8 +333,14 @@ class EventBus:
                 try:
                     cb(event)
                 except Exception:
+                    name = _subscriber_name(cb)
+                    with self._lock:
+                        self._subscriber_exception_counts[name] = (
+                            self._subscriber_exception_counts.get(name, 0) + 1
+                        )
                     logger.exception(
-                        "EventBus: error in callback for %s",
+                        "EventBus: error in callback %s for %s",
+                        name,
                         event.event_type.value,
                     )
 

--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -38,24 +38,6 @@ logger = init_logger(__name__)
 EventCallback = Callable[[Event], None]
 
 
-def _subscriber_name(cb: EventCallback) -> str:
-    """Derive a stable label for *cb* for use as a metric tag.
-
-    For bound methods, returns the owning class name (e.g.
-    ``"L1MetricsSubscriber"``).  For free functions, returns the
-    callable's ``__qualname__``.  Falls back to ``repr(cb)`` for
-    callables that have neither — those should be rare and indicate a
-    test fixture or partial.
-    """
-    instance = getattr(cb, "__self__", None)
-    if instance is not None:
-        return type(instance).__name__
-    qualname = getattr(cb, "__qualname__", None)
-    if qualname is not None:
-        return qualname
-    return repr(cb)
-
-
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -333,7 +315,12 @@ class EventBus:
                 try:
                     cb(event)
                 except Exception:
-                    name = _subscriber_name(cb)
+                    instance = getattr(cb, "__self__", None)
+                    name = (
+                        type(instance).__name__
+                        if instance is not None
+                        else getattr(cb, "__qualname__", repr(cb))
+                    )
                     with self._lock:
                         self._subscriber_exception_counts[name] = (
                             self._subscriber_exception_counts.get(name, 0) + 1

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -5,7 +5,7 @@ from lmcache.v1.mp_observability.subscribers.metrics.cb_server import (
     BlendMetricsSubscriber,
 )
 from lmcache.v1.mp_observability.subscribers.metrics.event_bus import (
-    init_event_bus_self_metrics,
+    EventBusSelfMetricsSubscriber,
 )
 from lmcache.v1.mp_observability.subscribers.metrics.l0_l1_throughput import (
     L0L1ThroughputSubscriber,
@@ -34,6 +34,7 @@ from lmcache.v1.mp_observability.subscribers.metrics.sm import SMMetricsSubscrib
 
 __all__ = [
     "BlendMetricsSubscriber",
+    "EventBusSelfMetricsSubscriber",
     "L0L1ThroughputSubscriber",
     "L0LifecycleSubscriber",
     "L1FailureMetricsSubscriber",
@@ -44,5 +45,4 @@ __all__ = [
     "L2ThroughputSubscriber",
     "LookupMetricsSubscriber",
     "SMMetricsSubscriber",
-    "init_event_bus_self_metrics",
 ]

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -4,6 +4,9 @@
 from lmcache.v1.mp_observability.subscribers.metrics.cb_server import (
     BlendMetricsSubscriber,
 )
+from lmcache.v1.mp_observability.subscribers.metrics.event_bus import (
+    init_event_bus_self_metrics,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.l0_l1_throughput import (
     L0L1ThroughputSubscriber,
 )
@@ -41,4 +44,5 @@ __all__ = [
     "L2ThroughputSubscriber",
     "LookupMetricsSubscriber",
     "SMMetricsSubscriber",
+    "init_event_bus_self_metrics",
 ]

--- a/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py
@@ -1,113 +1,79 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""EventBus self-metrics — surface bus health to OTel.
+"""EventBus self-metrics subscriber.
 
-Registers four metrics that observe the :class:`EventBus` itself so
-operators can detect backpressure or dispatch failures:
+Surfaces four metrics describing the EventBus's own health (per #3108):
 
-- ``lmcache_mp.event_bus.queue_depth`` (gauge): events waiting for dispatch.
-- ``lmcache_mp.event_bus.drain_lag_seconds`` (gauge): age of the oldest
-  queued event; rises when the drain thread falls behind.
-- ``lmcache_mp.event_bus.dropped_events_total`` (observable counter):
-  cumulative events dropped because the queue was at ``max_queue_size``.
+- ``lmcache_mp.event_bus.queue_depth`` (gauge)
+- ``lmcache_mp.event_bus.drain_lag_seconds`` (gauge)
+- ``lmcache_mp.event_bus.dropped_events_total`` (observable counter)
 - ``lmcache_mp.event_bus.subscriber_exceptions`` (observable counter,
-  tagged by ``subscriber_name``): cumulative exceptions raised by
-  subscriber callbacks during dispatch.
+  attr ``subscriber_name``)
 
-Unlike most subscribers in this package these metrics are not driven by
-events — they observe bus state directly via the ``EventBus`` accessors.
-The registration is exposed as a free function rather than as an
-``EventSubscriber`` because there are no events to subscribe to.
+Unlike the other subscribers in this package, these metrics are not
+driven by events — they observe bus state via the ``EventBus`` accessors
+and report on every OTel scrape.  ``get_subscriptions`` therefore returns
+an empty mapping.
 """
 
 # Future
 from __future__ import annotations
 
+# Third Party
+from opentelemetry import metrics
+
 # First Party
-from lmcache.logging import init_logger
-from lmcache.v1.mp_observability.event_bus import EventBus
-from lmcache.v1.mp_observability.otel_init import register_gauge
+from lmcache.v1.mp_observability.event import EventType
+from lmcache.v1.mp_observability.event_bus import (
+    EventBus,
+    EventCallback,
+    EventSubscriber,
+)
 
-logger = init_logger(__name__)
 
-DEFAULT_METER_NAME = "lmcache.event_bus"
+class EventBusSelfMetricsSubscriber(EventSubscriber):
+    """Registers OTel observers for EventBus health metrics."""
 
+    def __init__(self, bus: EventBus) -> None:
+        meter = metrics.get_meter("lmcache.event_bus")
 
-def init_event_bus_self_metrics(
-    bus: EventBus,
-    meter_name: str = DEFAULT_METER_NAME,
-) -> None:
-    """Register OTel gauges and counters that observe *bus* itself.
-
-    Idempotency is the caller's responsibility — invoking this twice
-    against the same meter will create duplicate instruments.  Call once
-    per process during MP observability init.
-
-    Args:
-        bus: The :class:`EventBus` to observe.  Held by reference; the
-            registered callbacks read its state on every scrape.
-        meter_name: OTel meter name for these instruments.  Defaults to
-            ``"lmcache.event_bus"``.
-
-    Raises:
-        Nothing.  When ``opentelemetry`` is not importable, gauge
-        registration degrades to a no-op (via :func:`register_gauge`)
-        and counter registration is skipped with a debug log.
-    """
-    register_gauge(
-        meter_name,
-        "lmcache_mp.event_bus.queue_depth",
-        "Number of events currently queued in the EventBus.",
-        bus.queue_depth,
-    )
-    register_gauge(
-        meter_name,
-        "lmcache_mp.event_bus.drain_lag_seconds",
-        (
-            "Seconds since the oldest queued event was published; "
-            "0.0 when the queue is empty.  Rising values indicate "
-            "the drain thread is falling behind publish rate."
-        ),
-        bus.oldest_event_lag_seconds,
-    )
-
-    try:
-        # Third Party
-        from opentelemetry import metrics as otel_metrics
-    except ImportError:
-        logger.debug(
-            "opentelemetry package not found, "
-            "skipping event_bus dropped/exception counters"
+        meter.create_observable_gauge(
+            "lmcache_mp.event_bus.queue_depth",
+            callbacks=[lambda _o: [metrics.Observation(bus.queue_depth())]],
+            description="Events currently queued in the EventBus.",
         )
-        return
+        meter.create_observable_gauge(
+            "lmcache_mp.event_bus.drain_lag_seconds",
+            callbacks=[
+                lambda _o: [metrics.Observation(bus.oldest_event_lag_seconds())]
+            ],
+            description=(
+                "Seconds since the oldest queued event was published; "
+                "0.0 when empty.  Rising values mean the drain thread is "
+                "falling behind."
+            ),
+        )
+        meter.create_observable_counter(
+            "lmcache_mp.event_bus.dropped_events_total",
+            callbacks=[lambda _o: [metrics.Observation(bus.dropped_events_count())]],
+            description=(
+                "Cumulative events dropped because the EventBus queue was "
+                "at max_queue_size."
+            ),
+        )
+        meter.create_observable_counter(
+            "lmcache_mp.event_bus.subscriber_exceptions",
+            callbacks=[
+                lambda _o: [
+                    metrics.Observation(count, {"subscriber_name": name})
+                    for name, count in bus.subscriber_exception_counts().items()
+                ]
+            ],
+            description=(
+                "Cumulative exceptions raised by subscriber callbacks "
+                "during EventBus dispatch, tagged by ``subscriber_name``."
+            ),
+        )
 
-    meter = otel_metrics.get_meter(meter_name)
-
-    def _dropped_callback(_options):
-        return [otel_metrics.Observation(bus.dropped_events_count())]
-
-    meter.create_observable_counter(
-        "lmcache_mp.event_bus.dropped_events_total",
-        callbacks=[_dropped_callback],
-        description=(
-            "Cumulative count of events dropped because the EventBus "
-            "queue was at max_queue_size."
-        ),
-    )
-
-    def _exceptions_callback(_options):
-        snapshot = bus.subscriber_exception_counts()
-        return [
-            otel_metrics.Observation(count, {"subscriber_name": name})
-            for name, count in snapshot.items()
-        ]
-
-    meter.create_observable_counter(
-        "lmcache_mp.event_bus.subscriber_exceptions",
-        callbacks=[_exceptions_callback],
-        description=(
-            "Cumulative count of exceptions raised by subscriber "
-            "callbacks during EventBus dispatch, tagged by "
-            "``subscriber_name``."
-        ),
-    )
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {}

--- a/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""EventBus self-metrics — surface bus health to OTel.
+
+Registers four metrics that observe the :class:`EventBus` itself so
+operators can detect backpressure or dispatch failures:
+
+- ``lmcache_mp.event_bus.queue_depth`` (gauge): events waiting for dispatch.
+- ``lmcache_mp.event_bus.drain_lag_seconds`` (gauge): age of the oldest
+  queued event; rises when the drain thread falls behind.
+- ``lmcache_mp.event_bus.dropped_events_total`` (observable counter):
+  cumulative events dropped because the queue was at ``max_queue_size``.
+- ``lmcache_mp.event_bus.subscriber_exceptions`` (observable counter,
+  tagged by ``subscriber_name``): cumulative exceptions raised by
+  subscriber callbacks during dispatch.
+
+Unlike most subscribers in this package these metrics are not driven by
+events — they observe bus state directly via the ``EventBus`` accessors.
+The registration is exposed as a free function rather than as an
+``EventSubscriber`` because there are no events to subscribe to.
+"""
+
+# Future
+from __future__ import annotations
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_observability.event_bus import EventBus
+from lmcache.v1.mp_observability.otel_init import register_gauge
+
+logger = init_logger(__name__)
+
+DEFAULT_METER_NAME = "lmcache.event_bus"
+
+
+def init_event_bus_self_metrics(
+    bus: EventBus,
+    meter_name: str = DEFAULT_METER_NAME,
+) -> None:
+    """Register OTel gauges and counters that observe *bus* itself.
+
+    Idempotency is the caller's responsibility — invoking this twice
+    against the same meter will create duplicate instruments.  Call once
+    per process during MP observability init.
+
+    Args:
+        bus: The :class:`EventBus` to observe.  Held by reference; the
+            registered callbacks read its state on every scrape.
+        meter_name: OTel meter name for these instruments.  Defaults to
+            ``"lmcache.event_bus"``.
+
+    Raises:
+        Nothing.  When ``opentelemetry`` is not importable, gauge
+        registration degrades to a no-op (via :func:`register_gauge`)
+        and counter registration is skipped with a debug log.
+    """
+    register_gauge(
+        meter_name,
+        "lmcache_mp.event_bus.queue_depth",
+        "Number of events currently queued in the EventBus.",
+        bus.queue_depth,
+    )
+    register_gauge(
+        meter_name,
+        "lmcache_mp.event_bus.drain_lag_seconds",
+        (
+            "Seconds since the oldest queued event was published; "
+            "0.0 when the queue is empty.  Rising values indicate "
+            "the drain thread is falling behind publish rate."
+        ),
+        bus.oldest_event_lag_seconds,
+    )
+
+    try:
+        # Third Party
+        from opentelemetry import metrics as otel_metrics
+    except ImportError:
+        logger.debug(
+            "opentelemetry package not found, "
+            "skipping event_bus dropped/exception counters"
+        )
+        return
+
+    meter = otel_metrics.get_meter(meter_name)
+
+    def _dropped_callback(_options):
+        return [otel_metrics.Observation(bus.dropped_events_count())]
+
+    meter.create_observable_counter(
+        "lmcache_mp.event_bus.dropped_events_total",
+        callbacks=[_dropped_callback],
+        description=(
+            "Cumulative count of events dropped because the EventBus "
+            "queue was at max_queue_size."
+        ),
+    )
+
+    def _exceptions_callback(_options):
+        snapshot = bus.subscriber_exception_counts()
+        return [
+            otel_metrics.Observation(count, {"subscriber_name": name})
+            for name, count in snapshot.items()
+        ]
+
+    meter.create_observable_counter(
+        "lmcache_mp.event_bus.subscriber_exceptions",
+        callbacks=[_exceptions_callback],
+        description=(
+            "Cumulative count of exceptions raised by subscriber "
+            "callbacks during EventBus dispatch, tagged by "
+            "``subscriber_name``."
+        ),
+    )

--- a/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``init_event_bus_self_metrics`` registration."""
+
+# Standard
+from unittest.mock import MagicMock
+import sys
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import (
+    EventBus,
+    EventBusConfig,
+    EventSubscriber,
+)
+from lmcache.v1.mp_observability.subscribers.metrics.event_bus import (
+    init_event_bus_self_metrics,
+)
+
+
+def _install_otel_mock() -> tuple[MagicMock, MagicMock, dict]:
+    """Replace ``opentelemetry`` and ``opentelemetry.metrics`` with a mock.
+
+    Returns ``(mock_otel, mock_meter, saved_modules)``.  Restore via
+    :func:`_restore_otel_mock`.
+    """
+    mock_meter = MagicMock()
+    mock_otel = MagicMock()
+    mock_otel.get_meter.return_value = mock_meter
+    mock_otel.metrics = mock_otel
+    mock_otel.Observation = lambda value, attrs=None: (value, attrs)
+
+    saved = {k: sys.modules.get(k) for k in ("opentelemetry", "opentelemetry.metrics")}
+    sys.modules["opentelemetry"] = mock_otel
+    sys.modules["opentelemetry.metrics"] = mock_otel
+    return mock_otel, mock_meter, saved
+
+
+def _restore_otel_mock(saved: dict) -> None:
+    for k, v in saved.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+
+
+class TestRegistration:
+    def test_registers_two_gauges(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        mock_otel, mock_meter, saved = _install_otel_mock()
+        try:
+            init_event_bus_self_metrics(bus, meter_name="test.meter")
+            gauge_names = [
+                call.args[0]
+                for call in mock_meter.create_observable_gauge.call_args_list
+            ]
+            assert "lmcache_mp.event_bus.queue_depth" in gauge_names
+            assert "lmcache_mp.event_bus.drain_lag_seconds" in gauge_names
+        finally:
+            _restore_otel_mock(saved)
+
+    def test_registers_two_observable_counters(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        mock_otel, mock_meter, saved = _install_otel_mock()
+        try:
+            init_event_bus_self_metrics(bus, meter_name="test.meter")
+            counter_names = [
+                call.args[0]
+                for call in mock_meter.create_observable_counter.call_args_list
+            ]
+            assert "lmcache_mp.event_bus.dropped_events_total" in counter_names
+            assert "lmcache_mp.event_bus.subscriber_exceptions" in counter_names
+        finally:
+            _restore_otel_mock(saved)
+
+    def test_queue_depth_callback_reads_bus(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        # Stage two events without starting the drain thread.
+        bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s1"))
+        bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s2"))
+
+        mock_otel, mock_meter, saved = _install_otel_mock()
+        try:
+            init_event_bus_self_metrics(bus, meter_name="test.meter")
+            gauge_calls = {
+                call.args[0]: call.kwargs["callbacks"][0]
+                for call in mock_meter.create_observable_gauge.call_args_list
+            }
+            cb = gauge_calls["lmcache_mp.event_bus.queue_depth"]
+            result = cb(None)
+            # register_gauge wraps a scalar return into a single Observation.
+            assert result == [(2, None)]
+        finally:
+            _restore_otel_mock(saved)
+
+    def test_dropped_counter_callback_reflects_drops(self):
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=2))
+        # Publish past capacity to force drops; nothing drains.
+        for _ in range(5):
+            bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s"))
+
+        mock_otel, mock_meter, saved = _install_otel_mock()
+        try:
+            init_event_bus_self_metrics(bus, meter_name="test.meter")
+            counter_calls = {
+                call.args[0]: call.kwargs["callbacks"][0]
+                for call in mock_meter.create_observable_counter.call_args_list
+            }
+            cb = counter_calls["lmcache_mp.event_bus.dropped_events_total"]
+            result = cb(None)
+            # Three events dropped (queue capacity 2, 5 published).
+            assert result == [(3, None)]
+        finally:
+            _restore_otel_mock(saved)
+
+    def test_exceptions_counter_callback_emits_per_subscriber(self):
+        # Standard
+        import time
+
+        class _BadSub(EventSubscriber):
+            def get_subscriptions(self):
+                return {EventType.L1_READ_FINISHED: self._on_event}
+
+            def _on_event(self, event):
+                raise RuntimeError("boom")
+
+        bus = EventBus(EventBusConfig(enabled=True))
+        bus.register_subscriber(_BadSub())
+        bus.start()
+        bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s1"))
+        bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s2"))
+        time.sleep(0.15)
+        bus.stop()
+
+        mock_otel, mock_meter, saved = _install_otel_mock()
+        try:
+            init_event_bus_self_metrics(bus, meter_name="test.meter")
+            counter_calls = {
+                call.args[0]: call.kwargs["callbacks"][0]
+                for call in mock_meter.create_observable_counter.call_args_list
+            }
+            cb = counter_calls["lmcache_mp.event_bus.subscriber_exceptions"]
+            result = cb(None)
+            # One Observation per subscriber name; both raised twice.
+            assert (2, {"subscriber_name": "_BadSub"}) in result
+        finally:
+            _restore_otel_mock(saved)
+
+    def test_exceptions_counter_empty_when_no_failures(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        mock_otel, mock_meter, saved = _install_otel_mock()
+        try:
+            init_event_bus_self_metrics(bus, meter_name="test.meter")
+            counter_calls = {
+                call.args[0]: call.kwargs["callbacks"][0]
+                for call in mock_meter.create_observable_counter.call_args_list
+            }
+            cb = counter_calls["lmcache_mp.event_bus.subscriber_exceptions"]
+            assert cb(None) == []
+        finally:
+            _restore_otel_mock(saved)

--- a/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ``init_event_bus_self_metrics`` registration."""
+"""Tests for ``EventBusSelfMetricsSubscriber``."""
 
 # Standard
-from unittest.mock import MagicMock
-import sys
+from unittest.mock import MagicMock, patch
+import time
 
 # First Party
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -14,109 +14,73 @@ from lmcache.v1.mp_observability.event_bus import (
     EventSubscriber,
 )
 from lmcache.v1.mp_observability.subscribers.metrics.event_bus import (
-    init_event_bus_self_metrics,
+    EventBusSelfMetricsSubscriber,
 )
 
+_PATCH_TARGET = "lmcache.v1.mp_observability.subscribers.metrics.event_bus.metrics"
 
-def _install_otel_mock() -> tuple[MagicMock, MagicMock, dict]:
-    """Replace ``opentelemetry`` and ``opentelemetry.metrics`` with a mock.
 
-    Returns ``(mock_otel, mock_meter, saved_modules)``.  Restore via
-    :func:`_restore_otel_mock`.
-    """
+def _make_mock_metrics() -> tuple[MagicMock, MagicMock]:
+    """Build a (mock_metrics_module, mock_meter) pair for patching OTel."""
     mock_meter = MagicMock()
-    mock_otel = MagicMock()
-    mock_otel.get_meter.return_value = mock_meter
-    mock_otel.metrics = mock_otel
-    mock_otel.Observation = lambda value, attrs=None: (value, attrs)
-
-    saved = {k: sys.modules.get(k) for k in ("opentelemetry", "opentelemetry.metrics")}
-    sys.modules["opentelemetry"] = mock_otel
-    sys.modules["opentelemetry.metrics"] = mock_otel
-    return mock_otel, mock_meter, saved
+    mock_metrics = MagicMock()
+    mock_metrics.get_meter.return_value = mock_meter
+    mock_metrics.Observation = lambda value, attrs=None: (value, attrs)
+    return mock_metrics, mock_meter
 
 
-def _restore_otel_mock(saved: dict) -> None:
-    for k, v in saved.items():
-        if v is None:
-            sys.modules.pop(k, None)
-        else:
-            sys.modules[k] = v
+def _gauge_callbacks(meter: MagicMock) -> dict:
+    return {
+        c.args[0]: c.kwargs["callbacks"][0]
+        for c in meter.create_observable_gauge.call_args_list
+    }
+
+
+def _counter_callbacks(meter: MagicMock) -> dict:
+    return {
+        c.args[0]: c.kwargs["callbacks"][0]
+        for c in meter.create_observable_counter.call_args_list
+    }
 
 
 class TestRegistration:
-    def test_registers_two_gauges(self):
+    def test_registers_two_gauges_and_two_counters(self):
         bus = EventBus(EventBusConfig(enabled=True))
-        mock_otel, mock_meter, saved = _install_otel_mock()
-        try:
-            init_event_bus_self_metrics(bus, meter_name="test.meter")
-            gauge_names = [
-                call.args[0]
-                for call in mock_meter.create_observable_gauge.call_args_list
-            ]
-            assert "lmcache_mp.event_bus.queue_depth" in gauge_names
-            assert "lmcache_mp.event_bus.drain_lag_seconds" in gauge_names
-        finally:
-            _restore_otel_mock(saved)
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            assert set(_gauge_callbacks(meter)) == {
+                "lmcache_mp.event_bus.queue_depth",
+                "lmcache_mp.event_bus.drain_lag_seconds",
+            }
+            assert set(_counter_callbacks(meter)) == {
+                "lmcache_mp.event_bus.dropped_events_total",
+                "lmcache_mp.event_bus.subscriber_exceptions",
+            }
 
-    def test_registers_two_observable_counters(self):
+    def test_queue_depth_callback_reflects_bus(self):
         bus = EventBus(EventBusConfig(enabled=True))
-        mock_otel, mock_meter, saved = _install_otel_mock()
-        try:
-            init_event_bus_self_metrics(bus, meter_name="test.meter")
-            counter_names = [
-                call.args[0]
-                for call in mock_meter.create_observable_counter.call_args_list
-            ]
-            assert "lmcache_mp.event_bus.dropped_events_total" in counter_names
-            assert "lmcache_mp.event_bus.subscriber_exceptions" in counter_names
-        finally:
-            _restore_otel_mock(saved)
-
-    def test_queue_depth_callback_reads_bus(self):
-        bus = EventBus(EventBusConfig(enabled=True))
-        # Stage two events without starting the drain thread.
         bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s1"))
         bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s2"))
 
-        mock_otel, mock_meter, saved = _install_otel_mock()
-        try:
-            init_event_bus_self_metrics(bus, meter_name="test.meter")
-            gauge_calls = {
-                call.args[0]: call.kwargs["callbacks"][0]
-                for call in mock_meter.create_observable_gauge.call_args_list
-            }
-            cb = gauge_calls["lmcache_mp.event_bus.queue_depth"]
-            result = cb(None)
-            # register_gauge wraps a scalar return into a single Observation.
-            assert result == [(2, None)]
-        finally:
-            _restore_otel_mock(saved)
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            cb = _gauge_callbacks(meter)["lmcache_mp.event_bus.queue_depth"]
+            assert cb(None) == [(2, None)]
 
     def test_dropped_counter_callback_reflects_drops(self):
         bus = EventBus(EventBusConfig(enabled=True, max_queue_size=2))
-        # Publish past capacity to force drops; nothing drains.
         for _ in range(5):
             bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s"))
 
-        mock_otel, mock_meter, saved = _install_otel_mock()
-        try:
-            init_event_bus_self_metrics(bus, meter_name="test.meter")
-            counter_calls = {
-                call.args[0]: call.kwargs["callbacks"][0]
-                for call in mock_meter.create_observable_counter.call_args_list
-            }
-            cb = counter_calls["lmcache_mp.event_bus.dropped_events_total"]
-            result = cb(None)
-            # Three events dropped (queue capacity 2, 5 published).
-            assert result == [(3, None)]
-        finally:
-            _restore_otel_mock(saved)
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            cb = _counter_callbacks(meter)["lmcache_mp.event_bus.dropped_events_total"]
+            assert cb(None) == [(3, None)]
 
-    def test_exceptions_counter_callback_emits_per_subscriber(self):
-        # Standard
-        import time
-
+    def test_exceptions_counter_emits_per_subscriber(self):
         class _BadSub(EventSubscriber):
             def get_subscriptions(self):
                 return {EventType.L1_READ_FINISHED: self._on_event}
@@ -132,30 +96,23 @@ class TestRegistration:
         time.sleep(0.15)
         bus.stop()
 
-        mock_otel, mock_meter, saved = _install_otel_mock()
-        try:
-            init_event_bus_self_metrics(bus, meter_name="test.meter")
-            counter_calls = {
-                call.args[0]: call.kwargs["callbacks"][0]
-                for call in mock_meter.create_observable_counter.call_args_list
-            }
-            cb = counter_calls["lmcache_mp.event_bus.subscriber_exceptions"]
-            result = cb(None)
-            # One Observation per subscriber name; both raised twice.
-            assert (2, {"subscriber_name": "_BadSub"}) in result
-        finally:
-            _restore_otel_mock(saved)
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            cb = _counter_callbacks(meter)["lmcache_mp.event_bus.subscriber_exceptions"]
+            assert (2, {"subscriber_name": "_BadSub"}) in cb(None)
 
     def test_exceptions_counter_empty_when_no_failures(self):
         bus = EventBus(EventBusConfig(enabled=True))
-        mock_otel, mock_meter, saved = _install_otel_mock()
-        try:
-            init_event_bus_self_metrics(bus, meter_name="test.meter")
-            counter_calls = {
-                call.args[0]: call.kwargs["callbacks"][0]
-                for call in mock_meter.create_observable_counter.call_args_list
-            }
-            cb = counter_calls["lmcache_mp.event_bus.subscriber_exceptions"]
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            cb = _counter_callbacks(meter)["lmcache_mp.event_bus.subscriber_exceptions"]
             assert cb(None) == []
-        finally:
-            _restore_otel_mock(saved)
+
+    def test_no_event_subscriptions(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        mock_metrics, _ = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            sub = EventBusSelfMetricsSubscriber(bus)
+        assert sub.get_subscriptions() == {}

--- a/tests/v1/mp_observability/test_event_bus.py
+++ b/tests/v1/mp_observability/test_event_bus.py
@@ -311,6 +311,126 @@ class TestBackpressure:
 
 
 # ---------------------------------------------------------------------------
+# Self-monitoring accessors
+# ---------------------------------------------------------------------------
+
+
+class TestSelfMonitoring:
+    def test_queue_depth_reports_current_size(self, bus):
+        # Don't start the drain thread so events accumulate.
+        assert bus.queue_depth() == 0
+        for _ in range(3):
+            bus.publish(_make_event())
+        assert bus.queue_depth() == 3
+
+    def test_oldest_event_lag_zero_when_empty(self, bus):
+        assert bus.oldest_event_lag_seconds() == 0.0
+
+    def test_oldest_event_lag_grows_with_age(self, bus):
+        # Don't start drain — let events sit in the queue.
+        bus.publish(_make_event())
+        time.sleep(0.05)
+        lag = bus.oldest_event_lag_seconds()
+        assert lag >= 0.05
+        # Drain via stop() so the bus shuts down cleanly.
+        bus.stop()
+
+    def test_oldest_event_lag_returns_zero_after_drain(self, bus):
+        sub = _RecordingSubscriber()
+        bus.register_subscriber(sub)
+        bus.start()
+        bus.publish(_make_event())
+        time.sleep(0.15)
+        # Drained, queue should be empty.
+        assert bus.oldest_event_lag_seconds() == 0.0
+        bus.stop()
+
+    def test_dropped_events_count_starts_zero(self, bus):
+        assert bus.dropped_events_count() == 0
+
+    def test_dropped_events_count_increments_on_drop(self):
+        b = EventBus(EventBusConfig(enabled=True, max_queue_size=2))
+        # Don't start — nothing drains.
+        for _ in range(5):
+            b.publish(_make_event())
+        assert b.dropped_events_count() == 3
+
+    def test_subscriber_exception_counts_starts_empty(self, bus):
+        assert bus.subscriber_exception_counts() == {}
+
+    def test_subscriber_exception_counts_tracks_bound_methods(self, bus):
+        class _BadSub(EventSubscriber):
+            def get_subscriptions(self):
+                return {EventType.L1_READ_FINISHED: self._on_event}
+
+            def _on_event(self, event):
+                raise RuntimeError("boom")
+
+        bus.register_subscriber(_BadSub())
+        bus.start()
+        bus.publish(_make_event())
+        bus.publish(_make_event())
+        time.sleep(0.15)
+        bus.stop()
+
+        counts = bus.subscriber_exception_counts()
+        assert counts.get("_BadSub") == 2
+
+    def test_subscriber_exception_counts_returns_copy(self, bus):
+        class _BadSub(EventSubscriber):
+            def get_subscriptions(self):
+                return {EventType.L1_READ_FINISHED: self._on_event}
+
+            def _on_event(self, event):
+                raise RuntimeError("boom")
+
+        bus.register_subscriber(_BadSub())
+        bus.start()
+        bus.publish(_make_event())
+        time.sleep(0.15)
+        bus.stop()
+
+        snapshot = bus.subscriber_exception_counts()
+        snapshot["_BadSub"] = 99
+        assert bus.subscriber_exception_counts().get("_BadSub") == 1
+
+    def test_subscriber_exception_counts_uses_qualname_for_free_function(self, bus):
+        def free_callback(event):
+            raise RuntimeError("boom")
+
+        bus.subscribe(EventType.L1_READ_FINISHED, free_callback)
+        bus.start()
+        bus.publish(_make_event())
+        time.sleep(0.15)
+        bus.stop()
+
+        counts = bus.subscriber_exception_counts()
+        # Free functions are labeled by __qualname__, which here lives
+        # inside the test method.
+        assert any("free_callback" in name for name in counts)
+
+    def test_good_subscriber_not_counted(self, bus):
+        class _BadSub(EventSubscriber):
+            def get_subscriptions(self):
+                return {EventType.L1_READ_FINISHED: self._on_event}
+
+            def _on_event(self, event):
+                raise RuntimeError("boom")
+
+        good = _RecordingSubscriber()
+        bus.register_subscriber(_BadSub())
+        bus.register_subscriber(good)
+        bus.start()
+        bus.publish(_make_event())
+        time.sleep(0.15)
+        bus.stop()
+
+        counts = bus.subscriber_exception_counts()
+        assert "_BadSub" in counts
+        assert "_RecordingSubscriber" not in counts
+
+
+# ---------------------------------------------------------------------------
 # Global singleton
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Surfaces four self-metrics on the EventBus so operators can detect when the bus is backing up, shedding load, or losing dispatches. Implements the *Event bus monitoring* row of the proposal in #3108:

| Metric | Type | Notes |
| --- | --- | --- |
| `lmcache_mp.event_bus.queue_depth` | gauge | pending events |
| `lmcache_mp.event_bus.drain_lag_seconds` | gauge | age of oldest queued event; rises when drain thread falls behind |
| `lmcache_mp.event_bus.dropped_events_total` | observable counter | cumulative drops at `max_queue_size` |
| `lmcache_mp.event_bus.subscriber_exceptions` | observable counter | tagged by `subscriber_name` |

**Special notes for your reviewers**:

- `EventBus` exposes four read-only accessors (`queue_depth`, `oldest_event_lag_seconds`, `dropped_events_count`, `subscriber_exception_counts`) and tracks per-subscriber exception counts in `_drain_all`. `event_bus.py` keeps zero OTel imports — registration lives in `subscribers/metrics/event_bus.py::init_event_bus_self_metrics`, called from `mp_observability.config` alongside other metric subscribers.
- `subscriber_name` is derived from the callback at exception time: bound methods report their owning class name (e.g. `L1MetricsSubscriber`); free functions fall back to `__qualname__`.
- The proposal listed names without the `lmcache_mp.` prefix (`lmcache_event_bus_*`); I followed the in-repo convention used by the existing `lmcache_mp.l1_*` / `lmcache_mp.l2_*` metrics for consistency. Happy to rename if maintainers prefer the proposal spelling.
- Drain-lag is reported as the age of the oldest queued event (not per-event lag) to keep the gauge dimensionless and avoid a label explosion. Returns `0.0` when the queue is empty or is concurrently drained between the peek and read.

Refs #3108

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `EventBus` dispatch loop and introduces new cross-thread state tracking, so subtle concurrency or performance issues could surface under load. Changes are additive and primarily affect metrics/exception paths, limiting blast radius.
> 
> **Overview**
> Adds **EventBus self-monitoring** by introducing read-only accessors on `EventBus` for queue depth, oldest-event drain lag, dropped-event count, and per-subscriber exception counts, and by incrementing per-subscriber exception counters when dispatch callbacks raise.
> 
> Registers a new `EventBusSelfMetricsSubscriber` that exports these values as OTel observable gauges/counters and wires it into observability startup alongside existing metrics subscribers. Documentation is updated to describe the new `lmcache_mp.event_bus.*` metrics, and unit tests cover both the new accessors and OTel observer callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a6f9323e4e9c8ad614675cd3297bd40d9f8f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->