### PR TITLE
[Feat] Add option to skip raw block checkpoint load

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -94,6 +94,7 @@ Rules:
 
 - metadata region reserved on the same device
 - periodic checkpointing
+- optional checkpoint load on startup
 - optional verification on load
 - recovery by loading the latest durable checkpoint and rebuilding the in-memory
   index
@@ -121,6 +122,7 @@ The MP adapter is configured through `--l2-adapter` JSON:
   "meta_version": 1,
   "meta_checkpoint_interval_sec": 60,
   "meta_enable_periodic": true,
+  "load_checkpoint_on_init": true,
   "meta_verify_on_load": true,
   "num_store_workers": 2,
   "num_lookup_workers": 1,
@@ -134,6 +136,8 @@ Important validation rules:
   `block_align`
 - `slot_bytes >= header_bytes + 1`
 - `per_tp_device_paths` is rejected in MP mode
+- `load_checkpoint_on_init=false` starts with an empty in-memory index instead
+  of loading the latest on-device metadata checkpoint
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
 

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -213,6 +213,9 @@ caller-provided load buffers during prefetch.
 - ``meta_checkpoint_interval_sec`` / ``meta_idle_quiet_ms`` /
   ``meta_enable_periodic`` / ``meta_verify_on_load``: Checkpoint and recovery
   controls carried over from the legacy raw-block backend.
+- ``load_checkpoint_on_init``: Load an existing on-device metadata checkpoint
+  during startup (default ``true``). Set to ``false`` to start with an empty
+  in-memory index instead.
 - ``enable_zero_copy``: Try aligned direct-buffer I/O when possible.
 - ``io_engine``: Rust raw-block I/O engine. Valid values are ``"posix"``
   (default synchronous ``pread``/``pwrite`` path), ``"io_uring"`` (direct Rust
@@ -241,7 +244,7 @@ caller-provided load buffers during prefetch.
 
     --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true}'
 
-    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'
+    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "load_checkpoint_on_init": false, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'
 
 ``mooncake_store`` -- Mooncake Store native connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -80,6 +80,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         meta_checkpoint_interval_sec: int = 60,
         meta_idle_quiet_ms: int = 100,
         meta_enable_periodic: bool = True,
+        load_checkpoint_on_init: bool = True,
         meta_verify_on_load: bool = True,
         enable_zero_copy: bool = True,
         io_engine: str = "posix",
@@ -103,6 +104,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_checkpoint_interval_sec: Periodic checkpoint interval.
             meta_idle_quiet_ms: Quiet period before periodic checkpoints.
             meta_enable_periodic: Whether to run the checkpoint thread.
+            load_checkpoint_on_init: Whether to load existing checkpoint metadata.
             meta_verify_on_load: Whether recovery verifies slot headers.
             enable_zero_copy: Whether to use aligned direct-buffer I/O.
             io_engine: Raw-block I/O engine: ``"posix"`` or ``"io_uring"``.
@@ -124,6 +126,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         self.meta_checkpoint_interval_sec = int(meta_checkpoint_interval_sec)
         self.meta_idle_quiet_ms = int(meta_idle_quiet_ms)
         self.meta_enable_periodic = bool(meta_enable_periodic)
+        self.load_checkpoint_on_init = bool(load_checkpoint_on_init)
         self.meta_verify_on_load = bool(meta_verify_on_load)
         self.enable_zero_copy = bool(enable_zero_copy)
         self.io_engine = normalize_raw_block_io_engine(io_engine)
@@ -206,6 +209,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_checkpoint_interval_sec=int(d.get("meta_checkpoint_interval_sec", 60)),
             meta_idle_quiet_ms=int(d.get("meta_idle_quiet_ms", 100)),
             meta_enable_periodic=bool(d.get("meta_enable_periodic", True)),
+            load_checkpoint_on_init=bool(d.get("load_checkpoint_on_init", True)),
             meta_verify_on_load=bool(d.get("meta_verify_on_load", True)),
             enable_zero_copy=bool(d.get("enable_zero_copy", True)),
             io_engine=io_engine,
@@ -237,6 +241,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- meta_idle_quiet_ms (int): quiet period before checkpoint (default 100)\n"
             "- meta_enable_periodic (bool): enable periodic checkpointing "
             "(default true)\n"
+            "- load_checkpoint_on_init (bool): load existing metadata checkpoint "
+            "on startup (default true)\n"
             "- meta_verify_on_load (bool): validate slot headers on recovery "
             "(default true)\n"
             "- enable_zero_copy (bool): use aligned direct buffers when possible "
@@ -265,6 +271,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_checkpoint_interval_sec=self.meta_checkpoint_interval_sec,
             meta_idle_quiet_ms=self.meta_idle_quiet_ms,
             meta_enable_periodic=self.meta_enable_periodic,
+            load_checkpoint_on_init=self.load_checkpoint_on_init,
             meta_verify_on_load=self.meta_verify_on_load,
             io_engine=self.io_engine,
             iouring_queue_depth=self.iouring_queue_depth,

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -279,6 +279,9 @@ class RustRawBlockBackend(StoragePluginInterface):
             meta_enable_periodic=bool(
                 extra.get("rust_raw_block.meta_enable_periodic", True)
             ),
+            load_checkpoint_on_init=bool(
+                extra.get("rust_raw_block.load_checkpoint_on_init", True)
+            ),
             meta_verify_on_load=bool(
                 extra.get("rust_raw_block.meta_verify_on_load", True)
             ),

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -122,6 +122,7 @@ class RawBlockCoreConfig:
     meta_idle_quiet_ms: int
     meta_enable_periodic: bool
     meta_verify_on_load: bool
+    load_checkpoint_on_init: bool = True
     io_engine: str = "posix"
     iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
 
@@ -192,6 +193,7 @@ class RawBlockCore:
         self.meta_checkpoint_interval_sec = int(config.meta_checkpoint_interval_sec)
         self.meta_idle_quiet_ms = int(config.meta_idle_quiet_ms)
         self.meta_enable_periodic = bool(config.meta_enable_periodic)
+        self.load_checkpoint_on_init = bool(config.load_checkpoint_on_init)
         self.meta_verify_on_load = bool(config.meta_verify_on_load)
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
@@ -259,7 +261,10 @@ class RawBlockCore:
 
         try:
             self._ensure_capacity_and_layout()
-            self._load_checkpoint_from_device()
+            if self.load_checkpoint_on_init:
+                self._load_checkpoint_from_device()
+            else:
+                logger.info("RawBlockCore: skipping on-device metadata checkpoint load")
 
             if self.meta_enable_periodic:
                 self._meta_thread = threading.Thread(

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -100,6 +100,7 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
             meta_checkpoint_interval_sec=60,
             meta_idle_quiet_ms=100,
             meta_enable_periodic=False,
+            load_checkpoint_on_init=True,
             meta_verify_on_load=True,
             io_engine="posix",
             iouring_queue_depth=256,
@@ -162,6 +163,7 @@ def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
             meta_checkpoint_interval_sec=60,
             meta_idle_quiet_ms=100,
             meta_enable_periodic=False,
+            load_checkpoint_on_init=True,
             meta_verify_on_load=True,
             io_engine="io_uring",
             iouring_queue_depth=512,
@@ -1124,6 +1126,86 @@ def test_rust_raw_block_backend_device_checkpoint_roundtrip(
             out = backend2.get_blocking(k1)
             assert out is not None
             assert bytes(out.byte_array) == expected
+        finally:
+            backend2.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_rust_raw_block_backend_skips_checkpoint_on_init(
+    memory_allocator, loop_in_thread
+):
+    """Skip on-device metadata checkpoint loading when configured."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        config = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_backend_skip_checkpoint",
+        )
+        config.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=config,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+        backend1 = RustRawBlockBackend(
+            config=config,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        allocator = AdHocMemoryAllocator(device="cpu")
+        key = CacheEngineKey("test_model", 1, 0, 222, torch.bfloat16)
+        obj = allocator.allocate(
+            [torch.Size([2, 16, 8, 128])], [torch.bfloat16], fmt=MemoryFormat.KV_T2D
+        )
+        assert obj is not None
+        try:
+            fut = backend1.batched_submit_put_task([key], [obj])[0]
+            fut.result(timeout=10)
+        finally:
+            backend1.close()
+
+        config.extra_config["rust_raw_block.load_checkpoint_on_init"] = False
+        with patch.object(
+            RawBlockCore,
+            "_select_latest_checkpoint",
+            side_effect=AssertionError("checkpoint retrieval should be skipped"),
+        ) as mock_select_latest_checkpoint:
+            backend2 = RustRawBlockBackend(
+                config=config,
+                metadata=metadata,
+                local_cpu_backend=local_cpu,
+                loop=loop_in_thread,
+                dst_device="cpu",
+            )
+        try:
+            assert mock_select_latest_checkpoint.call_count == 0
+            assert backend2.contains(key) is False
         finally:
             backend2.close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a new configuration flag `rust_raw_block.load_checkpoint_on_init` for the `RustRawBlockBackend`.
This flag defaults to `True`. When set to `False`, the backend skips loading any existing on-device metadata checkpoints during initialization.
This is useful in scenarios where you want to start the backend entirely fresh, bypassing any previously saved state.

**Special notes for your reviewers**:
- Added `test_rust_raw_block_backend_skips_checkpoint_on_init` in `tests/v1/storage_backend/test_rust_raw_block_backend.py` to verify that when the flag is set to `False`, the backend bypasses retrieving the checkpoint correctly.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes startup behavior for `RustRawBlockBackend` metadata recovery; misconfiguration can intentionally bypass persisted state and appear as cache misses, though the default remains unchanged.
> 
> **Overview**
> Adds a new `extra_config` flag, `rust_raw_block.load_checkpoint_on_init` (default `True`), to let `RustRawBlockBackend` skip loading on-device metadata checkpoints during initialization.
> 
> When disabled, the backend logs that it is starting fresh and does not attempt checkpoint selection/loading, which is covered by a new unit test asserting checkpoint retrieval is not called and previously written entries are not restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393e5deaa1e05d98fbef7ee43cf5f546cfc59111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->