### PR TITLE
[MP][Feat] Support DeepSeek V4

### DIFF
--- a/csrc/mp_mem_kernels.cuh
+++ b/csrc/mp_mem_kernels.cuh
@@ -15,6 +15,23 @@ struct PageBufferShapeDesc {
   int nh;            // num heads
   int hs;            // head size
   int element_size;  // bytes (1 or 2)
+  // Physical per-block stride in source-dtype element units, used by
+  // formats whose dim-0 is the block axis to step over padding bytes
+  // (e.g. DeepSeek V4 compressor / indexer caches sharing a vLLM KV
+  // pool with larger attn groups, whose rows are padded up to the
+  // pool's max row width). 0 means "unset — fall back to the
+  // format-specific tight stride".
+  //
+  // CONTRACT: pass ``tensor.stride(0)`` verbatim. PyTorch stride
+  // semantics already absorb every inner-dim extent (including
+  // ``kv_size``), so DO NOT pre-multiply by any inner dim.
+  //
+  // Honoured today only by NL_X_NB_BS_HS (per-layer [NB, BS, HS],
+  // MLA). NL_X_NB_TWO_BS_NH_HS is restricted to the tight form
+  // upstream and leaves this field at 0; all other formats either
+  // pack non-block info into dim-0 or do not support dim-0 padding,
+  // and ignore this field.
+  int block_stride_elems;
 
   template <typename ScalarType>
   __host__ __device__ inline size_t scalars_per_head() const {
@@ -26,9 +43,20 @@ struct PageBufferShapeDesc {
     return nh * hs * element_size / sizeof(ScalarType);
   }
 
+  // Per (K or V) block step along dim-0, expressed in ``ScalarType``
+  // element units (the kernel's working dtype, e.g. uint4 / uint32_t /
+  // uint16_t). Returns the tight ``bs * nh * hs`` by default, or the
+  // physical ``block_stride_elems`` when dim-0 carries padding (today
+  // only NL_X_NB_BS_HS, see ``block_stride_elems`` above). Every
+  // ``calculate_engine_global_offset`` branch uses this as the dim-0
+  // step, so honouring padding here propagates to all formats without
+  // per-branch changes.
   template <typename ScalarType>
   __host__ __device__ inline size_t scalars_per_block() const {
-    return bs * nh * hs * element_size / sizeof(ScalarType);
+    const size_t elems = block_stride_elems > 0
+                             ? static_cast<size_t>(block_stride_elems)
+                             : static_cast<size_t>(bs) * nh * hs;
+    return elems * element_size / sizeof(ScalarType);
   }
 };
 

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -88,7 +88,9 @@ PYBIND11_MODULE(c_ops, m) {
       .def_readwrite("bs", &PageBufferShapeDesc::bs)
       .def_readwrite("nh", &PageBufferShapeDesc::nh)
       .def_readwrite("hs", &PageBufferShapeDesc::hs)
-      .def_readwrite("element_size", &PageBufferShapeDesc::element_size);
+      .def_readwrite("element_size", &PageBufferShapeDesc::element_size)
+      .def_readwrite("block_stride_elems",
+                     &PageBufferShapeDesc::block_stride_elems);
   m.def("record_event_on_stream", &record_event_on_stream,
         py::arg("cuda_stream_ptr"), py::arg("event_type_name"),
         py::arg("session_id"), py::arg("str_metadata"), py::arg("int_metadata"),

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -33,7 +33,22 @@ DEFAULT_HEARTBEAT_INTERVAL: float = 10.0
 
 
 def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
-    logger.info("KV caches keys are %s", list(kv_caches.keys()))
+    # Emit a per-layer (name, shape, dtype) summary so the operator can
+    # verify the exact layer set & tensor geometry being shipped to the
+    # LMCache server, then the low-noise count of handles being wrapped.
+    kept_summary = [
+        (name, tuple(tensor.shape), str(tensor.dtype))
+        for name, tensor in kv_caches.items()
+    ]
+    logger.debug(
+        "KV cache transfer keeping %d layer(s) (name, shape, dtype):\n%s",
+        len(kept_summary),
+        "\n".join(
+            f"  [{i}] {name}  shape={shape}  dtype={dtype}"
+            for i, (name, shape, dtype) in enumerate(kept_summary)
+        ),
+    )
+    logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
     return [CudaIPCWrapper(tensor) for tensor in kv_caches.values()]
 
 
@@ -729,6 +744,14 @@ class LMCacheMPWorkerAdapter:
             "LMCache chunk size should be a multiple of vLLM block size"
         )
         self.blocks_in_chunk = chunk_size // vllm_block_size
+        # Retain the vLLM logical block size so we can ship it to the
+        # LMCache server in ``register_kv_caches`` — the server uses it
+        # (as ``layout_hints["inference_engine_logical_block_size"]``)
+        # to derive per-group compression ratios when some KV layer
+        # groups compress multiple logical tokens into a single physical
+        # slot (``shape_desc.bs <
+        # inference_engine_logical_block_size``).
+        self.vllm_logical_block_size = vllm_block_size
 
         # Health state (shared with heartbeat thread)
         self._health_event = threading.Event()
@@ -824,6 +847,9 @@ class LMCacheMPWorkerAdapter:
         from lmcache.integration.vllm.utils import vllm_layout_hints
 
         layout_hints = vllm_layout_hints()
+        layout_hints["inference_engine_logical_block_size"] = (
+            self.vllm_logical_block_size
+        )
         future = send_lmcache_request(
             self.mq_client,
             RequestType.REGISTER_KV_CACHE,

--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -285,9 +285,28 @@ class PageBufferShapeDesc:
     Mirrors the pybind ``def_readwrite`` attributes in ``csrc/pybind.cpp``
     so non-CUDA code paths can construct and inspect shape descriptors
     without the compiled extension.
+
+    ``block_stride_elems`` captures the *physical* per-block step in
+    element units (= ``tensor.stride(0)``). For a tightly-packed paged
+    buffer it equals ``bs * kv_size * nh * hs`` (non-MLA) /
+    ``bs * nh * hs`` (MLA); for a vLLM KV pool where a group's row is
+    padded to the pool's maximum row width (e.g. DeepSeek V4 compressor
+    / indexer caches), it is strictly larger. Downstream kernels must
+    use this value instead of recomputing a "tight" stride from the
+    logical shape, otherwise they'll skip into the next block's padding
+    region and read/write the wrong slots.
     """
 
-    __slots__ = ("kv_size", "nl", "nb", "bs", "nh", "hs", "element_size")
+    __slots__ = (
+        "kv_size",
+        "nl",
+        "nb",
+        "bs",
+        "nh",
+        "hs",
+        "element_size",
+        "block_stride_elems",
+    )
 
     def __init__(self) -> None:
         self.kv_size: int = 0
@@ -297,6 +316,9 @@ class PageBufferShapeDesc:
         self.nh: int = 0
         self.hs: int = 0
         self.element_size: int = 0
+        # 0 means "unset — fall back to tight stride"; any downstream
+        # consumer that needs exact addressing must check this.
+        self.block_stride_elems: int = 0
 
 
 def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -473,9 +473,33 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 self.kvcaches,
                 gpu_kv_format=self.gpu_kv_format,
                 num_blocks=self.num_blocks,
-                block_size=self.block_size,
             )
         klg_manager = self.metadata.kv_layer_groups_manager
+
+        # Heterogeneous-block_size sanity check.
+        #
+        # ``self.block_size`` is a single scalar sampled from the first
+        # layer's ``bs`` and is forwarded to ``multi_layer_kv_transfer``
+        # as a *global* kernel parameter below (see ``to_gpu`` /
+        # ``from_gpu`` / layerwise paths). That works only when every
+        # group shares the same ``shape_desc.bs``. Mixed-compression
+        # deployments (e.g. DeepSeek V4 with compressed + dense groups
+        # in the same model) violate this assumption and will silently
+        # corrupt transfers on this non-MP path. Log loudly so the
+        # mismatch surfaces before it turns into a data-corruption bug;
+        # the MP path (see ``GPUCacheContext`` / mp server) handles
+        # per-group ``bs`` correctly and should be used instead.
+        heterogeneous_bs = {g.shape_desc.bs for g in klg_manager.kv_layer_groups}
+        if len(heterogeneous_bs) > 1:
+            logger.warning(
+                "VLLMPagedMemGPUConnectorV3 detected heterogeneous per-group "
+                "block_size %s but forwards a single scalar block_size=%d to "
+                "multi_layer_kv_transfer. This non-MP path is NOT adapted for "
+                "mixed-compression KV layouts and may corrupt transfers. Use "
+                "the multi-process connector path for such models.",
+                sorted(heterogeneous_bs),
+                self.block_size,
+            )
 
         if self.use_gpu:
             tmp_buf_shapes = self.metadata.get_shapes(self.chunk_size)

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -70,12 +70,23 @@ class LayoutHints(TypedDict, total=False):
             reshape its 4-D pool tensor into the canonical 6-D form.
         tokens_per_block: Tokens per paged block. Used by TRT-LLM (same).
         head_dim: Per-head dimension. Used by TRT-LLM (same).
+        inference_engine_logical_block_size: Inference-engine-side block
+            size (logical tokens per engine block; for vLLM this is
+            ``cache_config.block_size``). Carried inside
+            ``LayoutHints`` (instead of as a standalone
+            ``REGISTER_KV_CACHE`` argument) so that engines without a
+            logical block-size concept can simply omit it. The server
+            uses it to derive per-group compression ratios when some
+            KV layer groups compress multiple logical tokens into a
+            single physical slot
+            (``shape_desc.bs < inference_engine_logical_block_size``).
     """
 
     kv_layout: Literal["NHD", "HND"]
     num_kv_heads: int
     tokens_per_block: int
     head_dim: int
+    inference_engine_logical_block_size: int
 
 
 def attempt_permute_to_contiguous_view(
@@ -94,11 +105,21 @@ def attempt_permute_to_contiguous_view(
     ``[2, NB, BS, NH, HS]`` via a dim permute. Sorting dims by stride
     undoes the permute without touching storage.
 
-    Raises:
-        ValueError: If a tensor leaf is non-contiguous for a reason
-            other than dim permutation (e.g. slicing, ``as_strided``).
-            We refuse to fall back to ``.contiguous()`` (which would
-            copy) so the caller's invariant is never silently violated.
+    For tensors that remain non-contiguous even after dim-permute
+    recovery (e.g. vLLM unified KV pool views where dim-0 has an
+    inflated periodic stride because every block slot is padded to a
+    model-wide maximum), this function returns the tensor unchanged.
+    Rationale: :class:`CudaIPCWrapper` transports ``(shape, stride,
+    storage_offset)`` verbatim and the receiver rebuilds the view via
+    ``torch.Tensor.set_(storage, offset, shape, stride)``, which
+    supports arbitrary strided views (including periodic-dim-0 and
+    ``as_strided``-produced layouts) and yields a bit-identical view.
+    Downstream consumers that rely on ``shape`` alone to infer the
+    physical layout must therefore also consult ``stride``.
+
+    We deliberately never fall back to ``.contiguous()`` (which would
+    allocate and copy), so the caller's zero-copy invariant is
+    preserved.
     """
     if isinstance(kv_caches, torch.Tensor):
         if kv_caches.is_contiguous():
@@ -106,13 +127,105 @@ def attempt_permute_to_contiguous_view(
         strides = kv_caches.stride()
         perm = sorted(range(kv_caches.ndim), key=lambda i: strides[i], reverse=True)
         result = kv_caches.permute(perm)
-        if not result.is_contiguous():
-            raise ValueError(
-                "tensor is non-contiguous for reasons other than permutation "
-                "(e.g. slicing or as_strided). Cannot recover contiguous view."
-            )
+        if result.is_contiguous():
+            return result
+        # Non-permute non-contiguity: only the strict dim-0-padding pattern
+        # is recoverable downstream. Delegate validation + diagnostics to
+        # the helper; on success we keep the stride-sorted view as-is and
+        # rely on ``PageBufferShapeDesc.block_stride_elems`` to honour the
+        # padding.
+        padding_per_block = _validate_dim0_padded_layout(result)
+        logger.debug(
+            "attempt_permute_to_contiguous_view: accepting dim-0-padded "
+            "view; downstream kernels must honour block_stride_elems. "
+            "shape=%s, stride=%s, padding_per_block_elems=%d, "
+            "storage_nbytes=%s, dtype=%s",
+            tuple(result.shape),
+            tuple(result.stride()),
+            padding_per_block,
+            int(result.untyped_storage().nbytes()),
+            result.dtype,
+        )
         return result
     return [attempt_permute_to_contiguous_view(sub) for sub in kv_caches]
+
+
+def _validate_dim0_padded_layout(tensor: torch.Tensor) -> int:
+    """Validate that *tensor* matches the dim-0-padding-only strided layout.
+
+    Mainly used for DeepSeek V4 integration, where compressor / indexer
+    KV groups share a pool with larger attn groups and end up with
+    per-block dim-0 padding. The downstream KV transfer kernels only
+    honour this single non-contiguous shape (via
+    :class:`PageBufferShapeDesc.block_stride_elems`); any other strided
+    view would cause wrong reads/writes and is rejected here.
+
+    The accepted layout requires:
+
+    * ``stride[-1] == 1`` and ``stride[-2] == shape[-1]`` — each block
+      row is internally tightly packed.
+    * Every interior dim ``i`` satisfies
+      ``stride[i] == prod(shape[i+1:])`` — only dim-0 may carry
+      padding, with ``stride[0] >= prod(shape[1:])``.
+    * ``storage_offset == 0`` — no slice/narrow base shift.
+
+    Callers must pass the stride-sorted permuted view (not the original
+    tensor): for tensors that are both permuted and dim-0-padded, the
+    original's unsorted inner strides would falsely trip the tight-
+    packing check. ``permute`` shares storage and preserves
+    ``storage_offset``/``numel``/storage bytes, so those checks are
+    equivalent on either view.
+
+    Returns:
+        ``padding_per_block_elems`` (= ``stride[0] - prod(shape[1:])``).
+
+    Raises:
+        ValueError: *tensor* violates any of the invariants above.
+    """
+    shape = tuple(tensor.shape)
+    stride = tuple(tensor.stride())
+    ndim = tensor.ndim
+    storage_offset = int(tensor.storage_offset())
+
+    def _fail(reason: str) -> None:
+        raise ValueError(
+            "attempt_permute_to_contiguous_view: tensor is non-contiguous "
+            f"and not a supported (dim-0 padding only) layout — {reason}. "
+            f"shape={shape}, stride={stride}, "
+            f"storage_offset={storage_offset}, numel={int(tensor.numel())}, "
+            f"storage_nbytes={int(tensor.untyped_storage().nbytes())}, "
+            f"dtype={tensor.dtype}. "
+            "Downstream KV transfer kernels only understand dim-0 "
+            "block-row padding; other strided views would produce "
+            "wrong reads/writes and are rejected."
+        )
+
+    if ndim < 2:
+        _fail("ndim < 2")
+    if stride[-1] != 1:
+        _fail("stride[-1] != 1 (inner dim not contiguous)")
+    if stride[-2] != shape[-1]:
+        _fail("stride[-2] != shape[-1] (last-two dims not tightly packed)")
+    if storage_offset != 0:
+        _fail("storage_offset != 0 (slice/narrow view, base address shifted)")
+    # Interior dims (1 .. ndim-2 exclusive) must be tightly packed with
+    # respect to the dims to their right. Only dim-0's stride is allowed
+    # to exceed the tight value.
+    inner_tight = 1
+    for i in range(ndim - 1, 0, -1):
+        if i < ndim - 1 and stride[i] != inner_tight:
+            _fail(
+                f"dim {i} stride {stride[i]} != tight {inner_tight} "
+                "(interior-dim padding is not supported)"
+            )
+        inner_tight *= shape[i]
+    # Now ``inner_tight == prod(shape[1:])``; dim-0 must be >= that.
+    if stride[0] < inner_tight:
+        _fail(
+            f"dim-0 stride {stride[0]} < prod(shape[1:])={inner_tight} "
+            "(overlapping blocks)"
+        )
+    return stride[0] - inner_tight
 
 
 def assert_contiguous(tensor: torch.Tensor) -> None:
@@ -527,10 +640,17 @@ def get_num_blocks(
 
 
 def get_block_size(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache,
+    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    layer_idx: int = 0,
 ) -> int:
-    """
-    Get the block size from the kv_caches
+    """Return the block size (tokens per block) for layer ``layer_idx``.
+
+    ``layer_idx`` is honoured only for per-layer formats where BS may
+    differ across layers (e.g. mixed-compression MLA pools). For
+    cross-layer formats BS is shared across layers and ``layer_idx``
+    is ignored. Raises ``ValueError`` for NBBS-fused formats, which
+    have no separate BS dim.
     """
     if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[3]
@@ -542,15 +662,15 @@ def get_block_size(
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
     ):
         # NHD: [..., BS, NH, HS] — block_size at shape[2]
-        return kv_caches[0].shape[2]
+        return kv_caches[layer_idx].shape[2]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — block_size at shape[3]
-        return kv_caches[0].shape[3]
+        return kv_caches[layer_idx].shape[3]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
-        return kv_caches[0].shape[1]
+        return kv_caches[layer_idx].shape[1]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=gpu_kv_format))
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
@@ -950,6 +1070,153 @@ def get_device(kv_caches: DiscoverableKVCache) -> torch.device:
     return probe.device
 
 
+# Formats whose per-layer tensor dim-0 is the *block* axis AND for
+# which we currently support dim-0 padding (e.g. DeepSeek V4
+# compressor / indexer caches sharing a KV pool with larger attn
+# groups). Today only the MLA layout (``NL_X_NB_BS_HS``, kv_size==1)
+# is exercised by real mixed-compression workloads.
+#
+# ``NL_X_NB_TWO_BS_NH_HS`` *could* in principle also be the block
+# axis on dim-0, but no real serving engine emits a padded layout of
+# that format yet, and supporting it would require: (a) deciding
+# (without a ground-truth example) which axis carries the padding
+# — NB boundary vs K↔V offset — and (b) a coordinated change in
+# ``attempt_permute_to_contiguous_view`` to let interior-dim padding
+# through for that one format. Rather than ship an unverifiable code
+# path, we keep ``NL_X_NB_TWO_BS_NH_HS`` out of this set, which means
+# any padded tensor of that format will fail loudly via the
+# non-block-axis dim-0-padding check below. Revisit and add a
+# properly-tested branch when a concrete use case lands.
+_BLOCK_AXIS_FORMATS: frozenset = frozenset(
+    {
+        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+    }
+)
+
+
+def resolve_block_stride_and_log_layout(
+    kv_caches: DiscoverableKVCache,
+    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    layer_idx: int,
+    group_idx: int,
+) -> Optional[int]:
+    """Resolve the per-block stride for a KV layer group and log its layout.
+
+    Single entry point for :class:`KVLayerGroupsManager` to obtain the
+    ``block_stride_elems`` value for :class:`PageBufferShapeDesc` and emit
+    a one-shot layout audit line. All ``GPUKVFormat``-aware reasoning is
+    kept here so callers never touch a "representative KV cache" tensor.
+
+    * Block-axis formats (:data:`_BLOCK_AXIS_FORMATS`): ``stride(0)`` is
+      the per-block step and is returned as-is. A value larger than the
+      tight stride indicates dim-0 padding (e.g. DeepSeek V4 compressor
+      caches sharing a KV pool with larger attn groups).
+    * Other formats: dim-0 is not the block axis, so ``None`` is
+      returned and ``shape_desc`` falls back to the tight stride. Any
+      dim-0 padding in such formats is rejected with ``ValueError``
+      since downstream kernels cannot honour it.
+
+    Args:
+        kv_caches: Full KV cache structure (already normalised).
+        gpu_kv_format: Format of ``kv_caches``.
+        layer_idx: 0-based layer index used as the layout probe.
+        group_idx: 0-based group index, used only for logging.
+
+    Returns:
+        ``stride(0)`` for block-axis formats; ``None`` otherwise.
+
+    Raises:
+        ValueError: Non-block-axis format carries dim-0 padding.
+    """
+
+    def _pick_layout_probe_tensor() -> torch.Tensor:
+        # Layout probe only (shape/stride/storage_offset/dtype); not
+        # the K/V slice fed to the transfer kernel.
+        # - Cross-layer formats: ``kv_caches`` is the single backing
+        #   tensor packing all layers along dim-1; indexing dim-0
+        #   (= NB) would yield a per-block slice, so return the whole
+        #   tensor (its ``stride(0)`` is the authoritative per-NB step).
+        # - SGL MHA: outer list is K/V (length 2), inner list is
+        #   per-layer; K & V share shape/stride by construction.
+        # - Other formats: ``kv_caches`` is already a per-layer list.
+        if gpu_kv_format in (
+            lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
+            lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        ):
+            if not isinstance(kv_caches, torch.Tensor):
+                raise TypeError(
+                    "Cross-layer GPUKVFormat expects a single backing "
+                    f"torch.Tensor, got {type(kv_caches).__name__}."
+                )
+            return kv_caches
+        if gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+            return kv_caches[0][layer_idx]  # type: ignore[index]
+        return kv_caches[layer_idx]  # type: ignore[index]
+
+    rep = _pick_layout_probe_tensor()
+
+    block_stride_elems: Optional[int]
+    if gpu_kv_format in _BLOCK_AXIS_FORMATS and rep.ndim > 0:
+        block_stride_elems = int(rep.stride(0))
+    else:
+        # Non-block-axis format: detect forbidden dim-0 padding.
+        if rep.ndim >= 2:
+            tight_dim0 = 1
+            for d in range(1, rep.ndim):
+                tight_dim0 *= int(rep.shape[d])
+            padding = int(rep.stride(0)) - tight_dim0
+            if padding > 0:
+                raise ValueError(
+                    "resolve_block_stride_and_log_layout: group's probe "
+                    f"tensor has dim-0 padding ({padding} elements per "
+                    f"block) but gpu_kv_format={gpu_kv_format!r} is not "
+                    "a supported dim-0-padded format (only "
+                    "NL_X_NB_BS_HS is); downstream transfer kernels "
+                    "cannot honour this padding and would read/write "
+                    "wrong bytes. "
+                    f"layer_idx={layer_idx}, shape={tuple(rep.shape)}, "
+                    f"stride={tuple(rep.stride())}, "
+                    f"tight_stride0={tight_dim0}, "
+                    f"storage_offset={int(rep.storage_offset())}, "
+                    f"dtype={rep.dtype}."
+                )
+        block_stride_elems = None
+
+    # Best-effort layout audit log; the log line itself must not raise.
+    shape = tuple(rep.shape)
+    stride = tuple(rep.stride())
+    try:
+        inner = 1
+        for s in shape[1:]:
+            inner *= int(s)
+        padding_per_block = stride[0] - inner if stride else 0
+    except Exception:
+        padding_per_block = -1
+    try:
+        storage_nbytes = rep.untyped_storage().nbytes()
+    except Exception:
+        storage_nbytes = -1
+    logger.info(
+        "Group %d first-layer tensor: layer_idx=%d shape=%s "
+        "stride=%s is_contiguous=%s dtype=%s device=%s "
+        "storage_offset=%d numel=%d storage_nbytes=%d "
+        "padding_per_block=%d",
+        group_idx,
+        layer_idx,
+        shape,
+        stride,
+        rep.is_contiguous(),
+        rep.dtype,
+        rep.device,
+        rep.storage_offset(),
+        rep.numel(),
+        storage_nbytes,
+        padding_per_block,
+    )
+
+    return block_stride_elems
+
+
 def make_page_buffer_shape_desc(
     kv_caches: DiscoverableKVCache,
     gpu_kv_format: "lmc_ops.GPUKVFormat",
@@ -957,6 +1224,7 @@ def make_page_buffer_shape_desc(
     num_layers_in_group: int,
     num_blocks: int,
     block_size: int,
+    block_stride_elems: Optional[int] = None,
 ) -> "lmc_ops.PageBufferShapeDesc":
     """Build a :class:`PageBufferShapeDesc` from a representative layer.
 
@@ -967,6 +1235,17 @@ def make_page_buffer_shape_desc(
         num_layers_in_group: Number of layers in the group (``nl``).
         num_blocks: Number of paged blocks (``nb``).
         block_size: Tokens per block (``bs``).
+        block_stride_elems: Physical per-block stride in *elements*
+            (= ``tensor.stride(0)`` of the representative layer). Pass
+            the real value whenever the group's KV pool may be
+            dim-0-padded (e.g. DeepSeek V4 compressor/indexer caches
+            sharing a row width with a larger group in the same pool);
+            otherwise downstream transfer kernels will skip into
+            padding and corrupt data. Leave as ``None`` for unpadded
+            pools — the kernel's ``per_block_stride()`` fallback
+            (block_stride_elems <= 0) will reconstruct the tight
+            stride from ``kv_size`` and ``scalars_per_block`` itself,
+            so we don't duplicate that arithmetic on the Python side.
 
     Returns:
         A populated ``PageBufferShapeDesc``.
@@ -983,6 +1262,9 @@ def make_page_buffer_shape_desc(
     )
     desc.hs = get_head_size(kv_caches, gpu_kv_format, layer_idx)
     desc.element_size = get_dtype(kv_caches, gpu_kv_format, layer_idx).itemsize
+
+    resolved_stride = int(block_stride_elems) if block_stride_elems else 0
+    desc.block_stride_elems = resolved_stride
     return desc
 
 

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -13,7 +13,7 @@ import lmcache.c_ops as lmc_ops
 
 if TYPE_CHECKING:
     # First Party
-    from lmcache.v1.gpu_connector.utils import DiscoverableKVCache
+    from lmcache.v1.gpu_connector.utils import DiscoverableKVCache, LayoutHints
 
 logger = init_logger(__name__)
 
@@ -36,10 +36,10 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 
 
 # The 4-tuple that uniquely identifies a set of kernel-equivalent layers:
-# ``(kv_size, num_heads, head_size, dtype)``. Two layers share a transfer-
+# ``(kv_size, num_heads, head_size, block_size, dtype)``. Two layers share a transfer-
 # kernel launch iff they share this identity — see the grouping loop in
 # :meth:`KVLayerGroupsManager.__init__` for the derivation.
-LayerGroupIdentity = tuple[int, int, int, torch.dtype]
+LayerGroupIdentity = tuple[int, int, int, int, torch.dtype]
 
 
 @dataclass
@@ -49,11 +49,12 @@ class KVLayerGroupInfo:
 
     Membership is decided by :class:`KVLayerGroupsManager` according to
     :data:`LayerGroupIdentity`; every layer referenced by
-    ``layer_indices`` shares the same ``(kv_size, num_heads, head_size,
-    dtype)`` signature. Consumers use ``layer_indices`` to pull the
-    matching device pointers out of ``kv_caches`` (via
-    :func:`~lmcache.v1.gpu_connector.utils.get_group_data_ptrs`) and feed
-    them to the kernel alongside ``shape_desc``.
+    ``layer_indices`` shares the same
+    ``(kv_size, num_heads, head_size, block_size, dtype)`` signature.
+    Consumers use ``layer_indices`` to pull the matching device pointers
+    out of ``kv_caches`` (via
+    :func:`~lmcache.v1.gpu_connector.utils.get_group_data_ptrs`) and
+    feed them to the kernel alongside ``shape_desc``.
 
     ``dtype`` is carried alongside ``shape_desc`` because
     ``PageBufferShapeDesc.element_size`` is a byte width, which cannot
@@ -71,12 +72,28 @@ class KVLayerGroupInfo:
     the per-group pointer array."""
     shape_desc: "lmc_ops.PageBufferShapeDesc"
     """Kernel-facing shape descriptor shared by every layer in the group.
-    All seven fields (``kv_size, nl, nb, bs, nh, hs, element_size``) are
-    stamped once at construction."""
+    All eight fields (``kv_size, nl, nb, bs, nh, hs, element_size,
+    block_stride_elems``) are stamped once at construction."""
     dtype: torch.dtype
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
+    compress_ratio: int = 1
+    """Logical-tokens-per-physical-slot for this group. ``1`` for
+    non-compressed groups (one logical token per physical slot);
+    greater than ``1`` for compressed groups where each physical slot
+    packs ``compress_ratio`` logical tokens (e.g. DeepSeek V4
+    compressor / indexer caches). Derived from
+    ``inference_engine_logical_block_size`` carried in ``layout_hints``
+    at :class:`KVLayerGroupsManager` construction time."""
+    physical_chunk_size: int = 0
+    """Number of *physical* slots in one LMCache chunk for this group
+    (= ``lmcache_logical_chunk_size // compress_ratio``). This is what
+    the block-level transfer kernel must be told, not the logical
+    ``lmcache_logical_chunk_size`` which counts vLLM tokens. ``0``
+    means the field has not been populated yet; ``GPUCacheContext``
+    fills it in after construction once ``lmcache_logical_chunk_size``
+    is known."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -89,7 +106,11 @@ class KVLayerGroupInfo:
             f"indices={indices_repr}, "
             f"shape_desc=(kv={sd.kv_size}, nl={sd.nl}, nb={sd.nb}, "
             f"bs={sd.bs}, nh={sd.nh}, hs={sd.hs}, "
-            f"element_size={sd.element_size}), dtype={self.dtype})"
+            f"element_size={sd.element_size}, "
+            f"block_stride_elems={sd.block_stride_elems}), "
+            f"dtype={self.dtype}, "
+            f"compress_ratio={self.compress_ratio}, "
+            f"physical_chunk_size={self.physical_chunk_size})"
         )
 
     @property
@@ -128,7 +149,8 @@ class KVLayerGroupsManager:
         kv_caches: "DiscoverableKVCache",
         gpu_kv_format: "lmc_ops.GPUKVFormat",
         num_blocks: int,
-        block_size: int,
+        layout_hints: "LayoutHints | None" = None,
+        lmcache_logical_chunk_size: int = 256,
     ) -> None:
         """Partition layers into groups keyed by
         :data:`LayerGroupIdentity`.
@@ -148,22 +170,45 @@ class KVLayerGroupsManager:
             gpu_kv_format: Format returned by
                 :func:`normalize_kv_and_discover_format`.
             num_blocks: Number of paged blocks. Stamped into every
-                ``shape_desc.nb``.
-            block_size: Tokens per block. Stamped into every
-                ``shape_desc.bs``.
+                ``shape_desc.nb``. Each group's ``shape_desc.bs`` is
+                discovered per-layer via :func:`get_block_size`, so
+                compressed and non-compressed groups can coexist.
+            layout_hints: Engine-provided hints. The manager only reads
+                ``inference_engine_logical_block_size`` (logical tokens
+                per inference-engine block) from it to derive each
+                group's ``compress_ratio`` and ``physical_chunk_size``.
+                ``None`` (or a hints dict without that key — e.g.
+                non-vLLM engines, or vLLM deployments with no mixed
+                compression) means every group is treated as
+                non-compressed (``compress_ratio == 1``).
+            lmcache_logical_chunk_size: Logical tokens per LMCache chunk
+                (one logical token = one inference-engine token).
+                Together with ``compress_ratio`` it determines each
+                group's ``physical_chunk_size =
+                lmcache_logical_chunk_size // compress_ratio``, the
+                number of *physical* slots per chunk fed to the
+                block-level transfer kernel.
         """
         # Import here to break a circular import via
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
         # First Party
         from lmcache.v1.gpu_connector.utils import (
-            get_dtype,
-            get_head_size,
-            get_num_heads,
             get_num_layers,
-            is_mla,
             make_page_buffer_shape_desc,
+            resolve_block_stride_and_log_layout,
         )
 
+        # Pull the inference-engine logical block size out of
+        # ``layout_hints`` once; ``None`` means no compression info
+        # available and every group is treated as non-compressed below.
+        # The attribute is finalised after the group-building loop
+        # below, where ``None`` is replaced by the first group's
+        # physical ``bs`` so the public ``int`` contract holds.
+        self.inference_engine_logical_block_size_: "int | None" = (
+            layout_hints.get("inference_engine_logical_block_size")
+            if layout_hints
+            else None
+        )
         self.kv_layer_groups: list[KVLayerGroupInfo] = []
 
         num_layers = get_num_layers(kv_caches, gpu_kv_format)
@@ -171,12 +216,126 @@ class KVLayerGroupsManager:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
 
-        # Temporary accumulator: maps each LayerGroupIdentity to the list
-        # of layer indices that share it. Built in one linear pass over
-        # all layers, then drained into KVLayerGroupInfo objects below.
-        # The index lists are passed by reference into the infos, so
-        # after __init__ returns this dict is garbage-collected while
-        # the lists stay alive on each group.
+        groups_dict = self._group_layers_by_identity(
+            kv_caches, gpu_kv_format, num_layers
+        )
+
+        # Emit groups in order of their first-appearing layer so that group
+        # indices remain deterministic across runs.
+        for group_idx, ((_, _, _, bs, dt), indices) in enumerate(
+            sorted(groups_dict.items(), key=lambda kv: kv[1][0])
+        ):
+            block_stride_elems = resolve_block_stride_and_log_layout(
+                kv_caches,
+                gpu_kv_format,
+                layer_idx=indices[0],
+                group_idx=group_idx,
+            )
+            shape_desc = make_page_buffer_shape_desc(
+                kv_caches,
+                gpu_kv_format,
+                layer_idx=indices[0],
+                num_layers_in_group=len(indices),
+                num_blocks=num_blocks,
+                block_size=bs,
+                block_stride_elems=block_stride_elems,
+            )
+
+            compress_ratio, physical_chunk_size = self._derive_compression_metadata(
+                group_idx=group_idx,
+                bs=bs,
+                ie_logical_block_size=self.inference_engine_logical_block_size_,
+                lmcache_logical_chunk_size=lmcache_logical_chunk_size,
+            )
+
+            self.kv_layer_groups.append(
+                KVLayerGroupInfo(
+                    layer_indices=indices,
+                    shape_desc=shape_desc,
+                    dtype=dt,
+                    compress_ratio=compress_ratio,
+                    physical_chunk_size=physical_chunk_size,
+                )
+            )
+
+        self.inference_engine_logical_block_size_ = (
+            self.inference_engine_logical_block_size_
+            or self.kv_layer_groups[0].shape_desc.bs
+        )
+
+        logger.info("KV layer groups: %s", self.kv_layer_groups)
+
+    @staticmethod
+    def _derive_compression_metadata(
+        group_idx: int,
+        bs: int,
+        ie_logical_block_size: "int | None",
+        lmcache_logical_chunk_size: int,
+    ) -> tuple[int, int]:
+        """Resolve ``(compress_ratio, physical_chunk_size)`` for one group.
+
+        ``compress_ratio`` falls back to ``1`` when
+        ``ie_logical_block_size`` is absent (no compression info
+        available); otherwise it equals
+        ``ie_logical_block_size // bs`` and the divisibility invariants
+        are enforced loudly. ``physical_chunk_size`` is then
+        ``lmcache_logical_chunk_size // compress_ratio``, the per-chunk
+        physical slot count fed to the block-level transfer kernel.
+        """
+        if ie_logical_block_size is None:
+            compress_ratio = 1
+        else:
+            if ie_logical_block_size % bs != 0:
+                raise ValueError(
+                    f"inference engine logical block size "
+                    f"{ie_logical_block_size} must be a multiple of "
+                    f"group {group_idx} physical slot count {bs}"
+                )
+            compress_ratio = ie_logical_block_size // bs
+        if lmcache_logical_chunk_size % compress_ratio != 0:
+            raise ValueError(
+                f"lmcache_logical_chunk_size {lmcache_logical_chunk_size} "
+                f"must be a multiple of compress_ratio {compress_ratio} "
+                f"(group {group_idx})"
+            )
+        physical_chunk_size = lmcache_logical_chunk_size // compress_ratio
+        if compress_ratio != 1:
+            logger.info(
+                "group %d: compressed "
+                "(inference_engine_logical_block_size=%d -> "
+                "slots=%d, compress_ratio=%d, physical_chunk_size=%d)",
+                group_idx,
+                ie_logical_block_size,
+                bs,
+                compress_ratio,
+                physical_chunk_size,
+            )
+        return compress_ratio, physical_chunk_size
+
+    @staticmethod
+    def _group_layers_by_identity(
+        kv_caches: "DiscoverableKVCache",
+        gpu_kv_format: "lmc_ops.GPUKVFormat",
+        num_layers: int,
+    ) -> dict[LayerGroupIdentity, list[int]]:
+        """Partition layer indices by :data:`LayerGroupIdentity`.
+
+        Linear single pass over ``kv_caches``; layers sharing the same
+        ``(kv_size, num_heads, head_size, block_size, dtype)`` signature
+        land in the same bucket. The returned dict's value lists are
+        later passed by reference into :class:`KVLayerGroupInfo`
+        instances, so the dict itself is garbage-collected after
+        ``__init__`` returns while the lists stay alive on each group.
+        """
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            get_block_size,
+            get_dtype,
+            get_head_size,
+            get_num_heads,
+            is_mla,
+        )
+
         mla = is_mla(gpu_kv_format)
         kv_size = 1 if mla else 2
         groups_dict: dict[LayerGroupIdentity, list[int]] = defaultdict(list)
@@ -184,29 +343,9 @@ class KVLayerGroupsManager:
             nh = 1 if mla else get_num_heads(kv_caches, gpu_kv_format, idx)
             hs = get_head_size(kv_caches, gpu_kv_format, idx)
             dt = get_dtype(kv_caches, gpu_kv_format, idx)
-            groups_dict[(kv_size, nh, hs, dt)].append(idx)
-
-        # Emit groups in order of their first-appearing layer.
-        for (_, _, _, dt), indices in sorted(
-            groups_dict.items(), key=lambda kv: kv[1][0]
-        ):
-            shape_desc = make_page_buffer_shape_desc(
-                kv_caches,
-                gpu_kv_format,
-                layer_idx=indices[0],
-                num_layers_in_group=len(indices),
-                num_blocks=num_blocks,
-                block_size=block_size,
-            )
-            self.kv_layer_groups.append(
-                KVLayerGroupInfo(
-                    layer_indices=indices,
-                    shape_desc=shape_desc,
-                    dtype=dt,
-                )
-            )
-
-        logger.info("KV layer groups: %s", self.kv_layer_groups)
+            bs = get_block_size(kv_caches, gpu_kv_format, idx)
+            groups_dict[(kv_size, nh, hs, bs, dt)].append(idx)
+        return groups_dict
 
     @property
     def num_groups(self) -> int:
@@ -215,6 +354,20 @@ class KVLayerGroupsManager:
         Zero if ``kv_caches`` had no layers at construction time.
         """
         return len(self.kv_layer_groups)
+
+    @property
+    def inference_engine_logical_block_size(self):
+        """Inference-engine-side logical block size.
+
+        Taken from ``layout_hints`` at construction time, or falls back
+        to the first group's physical ``bs`` when no hint is provided
+        (non-vLLM engines, or vLLM without mixed-compression KV groups),
+        in which case every group is treated as non-compressed.
+        """
+        return (
+            self.inference_engine_logical_block_size_
+            or self.kv_layer_groups[0].shape_desc.bs
+        )
 
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Return the :class:`PageBufferShapeDesc` for *group_idx*.
@@ -228,6 +381,25 @@ class KVLayerGroupsManager:
             IndexError: If *group_idx* is out of range.
         """
         return self.kv_layer_groups[group_idx].shape_desc
+
+    def get_physical_chunk_size(self, group_idx: int) -> int:
+        """Return the per-chunk *physical* slot count for *group_idx*.
+
+        Equivalent to
+        ``self.kv_layer_groups[group_idx].physical_chunk_size``.
+        For non-compressed groups this equals
+        ``lmcache_logical_chunk_size``; for compressed groups it equals
+        ``lmcache_logical_chunk_size // compress_ratio`` and is what the
+        block-level transfer kernel must be told (the logical chunk size
+        in *vLLM tokens* is not what the kernel addresses).
+
+        Args:
+            group_idx: 0-based group index.
+
+        Raises:
+            IndexError: If *group_idx* is out of range.
+        """
+        return self.kv_layer_groups[group_idx].physical_chunk_size
 
 
 # ------------------------------------------------------------------ #

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -22,7 +22,6 @@ from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_attention_backend,
-    get_block_size,
     get_concrete_gpu_kv_shape,
     get_device,
     get_dtype,
@@ -69,7 +68,7 @@ class GPUCacheContext:
     def __init__(
         self,
         kv_caches: KVCache,
-        lmcache_chunk_size: int = 256,
+        lmcache_logical_chunk_size: int = 256,
         layout_hints: LayoutHints | None = None,
         engine_type: EngineType = EngineType.VLLM,
     ):
@@ -83,16 +82,14 @@ class GPUCacheContext:
         self.is_mla_ = is_mla(self.gpu_kv_format_)
         self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
         self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
-        self.block_size_ = get_block_size(self.kv_caches_, self.gpu_kv_format_)
+        self.lmcache_logical_chunk_size = lmcache_logical_chunk_size
 
-        # Build per-layer KV groups. The manager owns each group's
-        # PageBufferShapeDesc (kernel-facing shape); this context only
-        # retains per-group GPU resources (pointer tensors, tmp buffers).
         self.kv_layer_groups_manager_ = KVLayerGroupsManager(
             self.kv_caches_,
             gpu_kv_format=self.gpu_kv_format_,
             num_blocks=self.num_blocks_,
-            block_size=self.block_size_,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=lmcache_logical_chunk_size,
         )
 
         self.group_kv_pointers_: list[torch.Tensor] = []
@@ -122,7 +119,6 @@ class GPUCacheContext:
         # single memcpy, without needing to know the per-group layout.
         # max_batch_size is the max number of chunks processed concurrently.
         self.max_batch_size = 4
-        self.lmcache_chunk_size = lmcache_chunk_size
         # Byte size of one chunk entry (= one chunk across all groups).
         # tmp_chunk_group_offsets_[g] is the byte offset of group g within
         # a single chunk; tmp_chunk_group_offsets_[num_groups] ==
@@ -131,7 +127,10 @@ class GPUCacheContext:
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            shape = self.get_kv_buffer_shape(lmcache_chunk_size, group_idx)
+            # ``get_kv_buffer_shape`` takes *logical* tokens; for
+            # compressed groups it folds ``compress_ratio`` logical
+            # tokens into one physical slot internally.
+            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
                 self.tmp_chunk_group_offsets_[-1] + byte_size
@@ -197,11 +196,28 @@ class GPUCacheContext:
         return self.high_priority_cupy_stream_
 
     @property
-    def block_size(self) -> int:
+    def group_physical_block_sizes(self) -> list[int]:
+        """Per-group physical slot count (``shape_desc.bs``) in group
+        order. For non-compressed groups this equals
+        ``inference_engine_logical_block_size``; for compressed groups
+        it equals
+        ``inference_engine_logical_block_size // compress_ratio``.
         """
-        Returns the block size (number of tokens per block)
+        return [
+            group.shape_desc.bs
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+    @property
+    def group_compress_ratios(self) -> list[int]:
+        """Per-group compression ratio
+        (= ``inference_engine_logical_block_size // shape_desc.bs``)
+        in group order. ``1`` for non-compressed groups.
         """
-        return self.block_size_
+        return [
+            group.compress_ratio
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
 
     @property
     def num_layers(self) -> int:
@@ -235,6 +251,15 @@ class GPUCacheContext:
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Returns the PageBufferShapeDesc for the given KV layer group."""
         return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+
+    def get_physical_chunk_size(self, group_idx: int) -> int:
+        """Returns the per-chunk physical slot count for the given group.
+
+        Equal to ``lmcache_logical_chunk_size // compress_ratio``; for
+        non-compressed groups this is just ``lmcache_logical_chunk_size``.
+        This is the value the block-level transfer kernel must be told.
+        """
+        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
 
     @property
     def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
@@ -287,13 +312,16 @@ class GPUCacheContext:
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
         """
         Returns a view of the temporary GPU buffer for the given group,
-        sized for a single chunk of ``lmcache_chunk_size`` tokens.
+        sized for a single chunk. The chunk holds
+        ``lmcache_logical_chunk_size`` logical tokens which, for a
+        compressed group, correspond to ``group.physical_chunk_size``
+        physical slots.
 
         Args:
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
         end = self.tmp_chunk_group_offsets_[group_idx + 1]
         return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
@@ -304,7 +332,7 @@ class GPUCacheContext:
         """
         Returns a list of ``batch_size`` non-overlapping views into the
         pre-allocated temporary GPU buffer for the given group, each
-        sized for ``lmcache_chunk_size`` tokens.
+        sized for ``lmcache_logical_chunk_size`` tokens.
 
         Args:
             batch_size: Number of concurrent requests (must be <= max_batch_size).
@@ -315,7 +343,7 @@ class GPUCacheContext:
                 f"batch_size {batch_size} exceeds max_batch_size {self.max_batch_size}"
             )
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_chunk_size, group_idx)
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
         g_start = self.tmp_chunk_group_offsets_[group_idx]
         g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
         chunk = self.tmp_chunk_bytes_
@@ -343,30 +371,62 @@ class GPUCacheContext:
         buf.copy_(cpu_tensor, non_blocking=True)
         return buf
 
-    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
+    def get_kv_buffer_shape(
+        self, logical_num_tokens: int, group_idx: int = 0
+    ) -> torch.Size:
         """
-        Returns the shape of the KV buffer for the given number of tokens.
+        Returns the shape of the KV buffer for the given number of
+        *logical* tokens.
+
+        For a compressed group (``compress_ratio > 1``) every
+        ``compress_ratio`` logical tokens are packed into a single
+        physical slot, so the returned shape's token dimension is
+        ``num_tokens // compress_ratio``. Callers therefore always
+        pass logical-token counts and never need to know per-group
+        compression ratios.
 
         Args:
-            num_tokens: Number of tokens.
+            logical_num_tokens: Number of *logical* tokens. Must be a multiple
+                of the group's ``compress_ratio``.
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        compress_ratio = group.compress_ratio
+        if logical_num_tokens % compress_ratio != 0:
+            raise ValueError(
+                f"logical_num_tokens ({logical_num_tokens}) is not a multiple of "
+                f"compress_ratio ({compress_ratio}) for group {group_idx}"
+            )
+        num_slots = logical_num_tokens // compress_ratio
         sd = group.shape_desc
         return torch.Size(
-            (sd.kv_size, group.num_layers, num_tokens, group.hidden_dim_size)
+            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
         )
 
     def cache_size_per_token(self) -> int:
         """
-        Returns the cache size per token (in bytes), summed across all groups.
+        Returns the cache size per *logical* token (in bytes), summed
+        across all groups. For a compressed group, one physical slot
+        stores ``compress_ratio`` logical tokens, so the per-logical-token
+        contribution is ``physical_slot_bytes // compress_ratio``.
+
+        Reporting-only metric (surfaced via the ``/api/status`` HTTP
+        endpoint and the ``lmcache describe`` CLI); sub-byte truncation
+        from integer division is acceptable.
         """
         total = 0
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            numels = self.get_kv_buffer_shape(1, group_idx).numel()
-            total += numels * group.dtype.itemsize
+            # ``get_kv_buffer_shape`` now takes *logical* tokens, so
+            # query ``compress_ratio`` logical tokens (= 1 physical
+            # slot) and then divide the resulting bytes back by
+            # ``compress_ratio`` to recover the per-logical-token
+            # contribution. Equivalent to the old
+            # ``physical_slot_bytes // compress_ratio`` formulation.
+            numels = self.get_kv_buffer_shape(group.compress_ratio, group_idx).numel()
+            slot_bytes = numels * group.dtype.itemsize
+            total += slot_bytes // group.compress_ratio
         return total
 
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -316,7 +316,16 @@ class MPCacheEngine:
         gpu_context = self.gpu_contexts[instance_id]
         model_name = self.gpu_context_meta[instance_id][0]
 
-        blocks_per_chunk = self.chunk_size // gpu_context.block_size
+        # ``blocks_per_chunk`` is counted in inference-engine-side
+        # blocks (each block addresses
+        # ``inference_engine_logical_block_size`` *logical* tokens).
+        # For compressed groups the per-group physical slot count
+        # differs, but the block-id indexing is shared with the engine
+        # and therefore uses the engine logical block size here.
+        blocks_per_chunk = (
+            self.chunk_size
+            // gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
+        )
 
         with (
             torch_dev.device(gpu_context.device),
@@ -392,6 +401,12 @@ class MPCacheEngine:
                     for group_idx in range(num_groups):
                         tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
                         group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
+                        # Kernel contract: ``group_lmcache_chunk_size`` here is the
+                        # number of *physical* slots per chunk for this group
+                        # (= logical chunk_size // compress_ratio).
+                        group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
+                            group_idx
+                        )
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
                             [tmp_buffer.data_ptr()],
@@ -399,7 +414,7 @@ class MPCacheEngine:
                             gpu_context.device,
                             lmc_ops.TransferDirection.D2H,
                             gpu_context.get_shape_desc(group_idx),
-                            self.chunk_size,
+                            group_lmcache_chunk_size,
                             gpu_context.gpu_kv_format_,
                             0,
                         )
@@ -516,7 +531,14 @@ class MPCacheEngine:
             ),
         )
 
-        blocks_per_chunk = self.chunk_size // gpu_context.block_size
+        # ``skip_*_in_chunk`` is expressed in engine-block units
+        # (logical tokens), which is what the kernel's
+        # ``skip_blocks_in_chunk`` argument expects regardless
+        # of per-group compression.
+        ie_logical_block_size = (
+            gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
+        )
+        blocks_per_chunk = self.chunk_size // ie_logical_block_size
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
             _BATCH_SIZE = gpu_context.max_batch_size
@@ -540,16 +562,17 @@ class MPCacheEngine:
                         self.chunk_size * batch_len - 1,
                     ),
                 )
-                if skip_tokens_in_chunk % gpu_context.block_size != 0:
+                if skip_tokens_in_chunk % ie_logical_block_size != 0:
                     logger.error(
-                        "skip_first_n_tokens (%d) is not aligned to block_size (%d), "
+                        "skip_first_n_tokens (%d) is not aligned to "
+                        "inference_engine_logical_block_size (%d), "
                         "rounding down from %d tokens to %d blocks",
                         skip_first_n_tokens,
-                        gpu_context.block_size,
+                        ie_logical_block_size,
                         skip_tokens_in_chunk,
-                        skip_tokens_in_chunk // gpu_context.block_size,
+                        skip_tokens_in_chunk // ie_logical_block_size,
                     )
-                skip_blocks_in_chunk = skip_tokens_in_chunk // gpu_context.block_size
+                skip_blocks_in_chunk = skip_tokens_in_chunk // ie_logical_block_size
 
                 start_chunk_id = batch_idx * _BATCH_SIZE
                 end_chunk_id = start_chunk_id + batch_len
@@ -569,6 +592,9 @@ class MPCacheEngine:
                         batch_len, group_idx
                     )
                     group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
+                    group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
+                        group_idx
+                    )
 
                     lmc_ops.multi_layer_block_kv_transfer(
                         group_kv_pointers,
@@ -577,7 +603,7 @@ class MPCacheEngine:
                         gpu_context.device,
                         lmc_ops.TransferDirection.H2D,
                         gpu_context.get_shape_desc(group_idx),
-                        self.chunk_size,
+                        group_lmcache_chunk_size,
                         gpu_context.gpu_kv_format_,
                         skip_blocks_in_chunk,
                     )
@@ -985,7 +1011,11 @@ class MPCacheEngine:
             if ctx is not None:
                 entry["kv_cache_layout"] = {
                     "num_layers": ctx.num_layers,
-                    "block_size": ctx.block_size,
+                    "inference_engine_logical_block_size": (
+                        ctx.kv_layer_groups_manager.inference_engine_logical_block_size
+                    ),
+                    "group_physical_block_sizes": ctx.group_physical_block_sizes,
+                    "group_compress_ratios": ctx.group_compress_ratios,
                     "hidden_dim_sizes": str(ctx.hidden_dim_sizes),
                     "dtype": str(ctx.dtype),
                     "is_mla": ctx.is_mla,

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -868,7 +868,7 @@ def registered_instance(
             "testmodel",
             1,
             EngineType.VLLM,
-            {},
+            {"inference_engine_logical_block_size": 16},
         ],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -329,7 +329,11 @@ def registered_instance(
     """
     instance_id = os.getpid()
 
-    # Register KV cache
+    # Register KV cache. ``layout_hints['inference_engine_logical_block_size']``
+    # must match the client context's ``page_size`` (=16) — mismatching
+    # them would cause the server to compute a bogus ``compress_ratio``
+    # and the retrieve path would size the tmp GPU buffer in physical
+    # slots while the stored memory_obj is still sized in logical tokens.
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
         [
@@ -338,7 +342,7 @@ def registered_instance(
             "testmodel",
             1,
             EngineType.VLLM,
-            {},
+            {"inference_engine_logical_block_size": 16},
         ],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )
@@ -386,7 +390,8 @@ def test_register_unregister_kv_cache(
     """
     instance_id = os.getpid()
 
-    # Register
+    # Register. ``layout_hints['inference_engine_logical_block_size']``
+    # must match ClientContext.page_size (=16).
     future = client.submit_request(
         RequestType.REGISTER_KV_CACHE,
         [
@@ -395,7 +400,7 @@ def test_register_unregister_kv_cache(
             "testmodel",
             1,
             EngineType.VLLM,
-            {},
+            {"inference_engine_logical_block_size": 16},
         ],
         get_response_class(RequestType.REGISTER_KV_CACHE),
     )

--- a/tests/v1/multiprocess/test_gpu_context.py
+++ b/tests/v1/multiprocess/test_gpu_context.py
@@ -55,7 +55,9 @@ def _make_context(
             for _ in range(num_layers)
         ]
         fmt = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
-    manager = KVLayerGroupsManager(kv_caches, fmt, num_blocks=1, block_size=1)
+    manager = KVLayerGroupsManager(
+        kv_caches, fmt, num_blocks=1, lmcache_logical_chunk_size=chunk_size
+    )
     ctx.kv_layer_groups_manager_ = manager
 
     # Build flat tmp_gpu_buffer_ with prefix-sum offsets (new layout)
@@ -67,7 +69,7 @@ def _make_context(
             ctx.tmp_chunk_group_offsets_[-1] + byte_size
         )
     ctx.tmp_chunk_bytes_ = ctx.tmp_chunk_group_offsets_[-1]
-    ctx.lmcache_chunk_size = chunk_size
+    ctx.lmcache_logical_chunk_size = chunk_size
     ctx.tmp_gpu_buffer_ = torch.empty(
         ctx.tmp_chunk_bytes_ * ctx.max_batch_size,
         dtype=torch.uint8,
@@ -110,7 +112,7 @@ def _make_context_multi_group(
         kv_caches,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=1,
-        block_size=1,
+        lmcache_logical_chunk_size=chunk_size,
     )
     ctx.kv_layer_groups_manager_ = manager
 
@@ -123,7 +125,7 @@ def _make_context_multi_group(
             ctx.tmp_chunk_group_offsets_[-1] + byte_size
         )
     ctx.tmp_chunk_bytes_ = ctx.tmp_chunk_group_offsets_[-1]
-    ctx.lmcache_chunk_size = chunk_size
+    ctx.lmcache_logical_chunk_size = chunk_size
     ctx.tmp_gpu_buffer_ = torch.empty(
         ctx.tmp_chunk_bytes_ * ctx.max_batch_size,
         dtype=torch.uint8,

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -385,7 +385,14 @@ def test_mq_register_kv_cache():
     # Run test with REGISTER_KV_CACHE request
     helper.run_test(
         request_type=RequestType.REGISTER_KV_CACHE,
-        payloads=[gpu_id, kv_cache, "testmodel", 1, EngineType.VLLM, {}],
+        payloads=[
+            gpu_id,
+            kv_cache,
+            "testmodel",
+            1,
+            EngineType.VLLM,
+            {"vllm_block_size": 16},
+        ],
         expected_response=None,
         num_requests=1,
     )

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -47,7 +47,10 @@ def register_kv_cache_handler(
         model_name: Name of the model associated with this KV cache
         world_size: World size associated with this KV cache
         engine_type: Which serving engine produced the caches
-        layout_hints: Engine-provided hints dict
+        layout_hints: Engine-provided hints dict. For vLLM,
+            ``layout_hints["inference_engine_logical_block_size"]``
+            carries the logical tokens-per-engine-block (previously a
+            standalone argument).
 
     Returns:
         None
@@ -69,6 +72,12 @@ def register_kv_cache_handler(
     )
     assert isinstance(layout_hints, dict), (
         f"Expected layout_hints to be dict, got {type(layout_hints)}"
+    )
+    # inference_engine_logical_block_size, if present, must be an int.
+    ie_logical_block_size = layout_hints.get("inference_engine_logical_block_size")
+    assert ie_logical_block_size is None or isinstance(ie_logical_block_size, int), (
+        "Expected layout_hints['inference_engine_logical_block_size'] to be int, got "
+        f"{type(ie_logical_block_size)}"
     )
     # No return value (returns None implicitly)
 

--- a/tests/v1/storage_backend/test_dax_backend.py
+++ b/tests/v1/storage_backend/test_dax_backend.py
@@ -65,7 +65,6 @@ def _create_multi_group_metadata(chunk_size: int = 16) -> LMCacheMetadata:
         kv_caches,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=1,
-        block_size=chunk_size,
     )
     return metadata
 

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -935,7 +935,7 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
 
 def _create_metadata(use_mla, kv_caches, gpu_kv_format):
     # First Party
-    from lmcache.v1.gpu_connector.utils import get_block_size, get_num_blocks
+    from lmcache.v1.gpu_connector.utils import get_num_blocks
     from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 
     num_heads = 1 if use_mla else 8
@@ -954,6 +954,5 @@ def _create_metadata(use_mla, kv_caches, gpu_kv_format):
         kv_list,
         gpu_kv_format=gpu_kv_format,
         num_blocks=get_num_blocks(kv_list, gpu_kv_format),
-        block_size=get_block_size(kv_list, gpu_kv_format),
     )
     return metadata

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -20,13 +20,13 @@ def _build_manager(
     tensors: list[torch.Tensor],
     *,
     num_blocks: int,
-    block_size: int,
 ) -> KVLayerGroupsManager:
     """Build a manager using the per-layer NHD format.
 
     Tensors in these tests have shape ``[2, NB, BS, NH, HS]`` — the
     canonical vLLM flash-attention per-layer NHD layout matched by
-    ``GPUKVFormat.NL_X_TWO_NB_BS_NH_HS``.
+    ``GPUKVFormat.NL_X_TWO_NB_BS_NH_HS``. ``bs`` is discovered
+    per-layer from the tensor shapes, so callers no longer pass it.
     """
     # First Party
     import lmcache.c_ops as lmc_ops
@@ -35,7 +35,6 @@ def _build_manager(
         tensors,
         gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=num_blocks,
-        block_size=block_size,
     )
 
 
@@ -43,12 +42,12 @@ class TestKVLayerGroupsManager:
     """Tests for KVLayerGroupsManager construction and lookups."""
 
     def test_build_empty(self):
-        manager = _build_manager([], num_blocks=32, block_size=256)
+        manager = _build_manager([], num_blocks=32)
         assert manager.kv_layer_groups == []
 
     def test_build_single_layer(self):
         tensors = [torch.randn(2, 32, 256, 8, 64, dtype=torch.float16)]
-        manager = _build_manager(tensors, num_blocks=32, block_size=256)
+        manager = _build_manager(tensors, num_blocks=32)
 
         assert len(manager.kv_layer_groups) == 1
         group = manager.kv_layer_groups[0]
@@ -66,7 +65,7 @@ class TestKVLayerGroupsManager:
         tensors = [
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(3)
         ]
-        manager = _build_manager(tensors, num_blocks=32, block_size=256)
+        manager = _build_manager(tensors, num_blocks=32)
 
         assert len(manager.kv_layer_groups) == 1
         group = manager.kv_layer_groups[0]
@@ -80,7 +79,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32, block_size=256)
+        manager = _build_manager(tensors, num_blocks=32)
         assert len(manager.kv_layer_groups) == 2
         group1, group2 = manager.kv_layer_groups
         assert group1.layer_indices == [0, 2]
@@ -94,7 +93,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float32),
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32, block_size=256)
+        manager = _build_manager(tensors, num_blocks=32)
         assert len(manager.kv_layer_groups) == 2
         group1, group2 = manager.kv_layer_groups
         assert group1.layer_indices == [0, 2]
@@ -110,7 +109,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),  # nh=8, f16
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float32),  # nh=16, f32
         ]
-        manager = _build_manager(tensors, num_blocks=32, block_size=256)
+        manager = _build_manager(tensors, num_blocks=32)
         assert len(manager.kv_layer_groups) == 4
 
         groups_by_key = {(g.shape_desc.nh, g.dtype): g for g in manager.kv_layer_groups}
@@ -124,7 +123,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32, block_size=256)
+        manager = _build_manager(tensors, num_blocks=32)
 
         sd0 = manager.get_shape_desc(0)
         assert sd0.nh == 8

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -45,10 +45,14 @@ def fake_adapter(monkeypatch):
 
     # KV-cache wrapping pulls in CUDA IPC; bypass for unit tests.
     monkeypatch.setattr(adapter_mod, "wrap_kv_caches", lambda kv: list(kv.values()))
+    # ``vllm_layout_hints`` returns a ``LayoutHints`` (TypedDict / dict at
+    # runtime); the production path performs item assignment on it
+    # (``layout_hints["inference_engine_logical_block_size"] = ...``), so
+    # the stub must also be a real dict — a string would raise
+    # ``TypeError: 'str' object does not support item assignment``.
     monkeypatch.setattr(
         "lmcache.integration.vllm.utils.vllm_layout_hints",
-        lambda: "fake-layout",
-        raising=False,
+        lambda: {},
     )
 
     parallel_strategy = ParallelStrategy(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Enable fast-path support for DeepSeek V4 in the LMCache MP (multi-process) runtime. DeepSeek V4 introduces a mixed-compression KV layout where some layer groups (e.g. the Compressor / Indexer caches) compress multiple logical tokens into a single physical slot while sharing a unified KV pool with the larger attention groups. The existing code assumed a single global `block_size` and a strictly contiguous per-layer KV tensor, both of which break on V4. This PR adapts the MP path end-to-end so that V4 workloads can store/retrieve KV caches correctly without touching the hot-path kernels' launch overhead.

Concrete adaptations:

1. **Per-group `block_size` (compression-aware layer grouping).**
   - `LayerGroupIdentity` is extended from `(kv_size, num_heads, head_size, dtype)` to `(kv_size, num_heads, head_size, block_size, dtype)`, so compressed and non-compressed groups that happen to share `(nh, hs, dtype)` no longer collapse into the same dispatch group.
   - `KVLayerGroupsManager` discovers each group's `block_size` per-layer via `get_block_size(...)` and stamps it into `PageBufferShapeDesc.bs`; the old `block_size=` constructor argument is removed.
   - `GPUCacheContext` drops the single `self.block_size_` field. A new `REGISTER_KV_CACHE` payload field `vllm_block_size` is forwarded from the adapter so the server can derive per-group `compress_ratio = vllm_block_size // group.shape_desc.bs` and `chunk_slots = lmcache_chunk_size // compress_ratio`. This is required because when *every* layer is compressed, `max(shape_desc.bs)` is strictly less than the true vLLM block size and cannot be recovered from GPU tensor shapes alone.
   - `get_layout_desc` and the chunk transfer path in `MPCacheEngine` now size each group's MemoryObj shape in *physical* slots (`num_tokens // compress_ratio`); `blocks_per_chunk` is computed against `vllm_block_size` since block-id indexing is shared with vLLM.
   - `GPUCacheContext.__init__` is split into six focused phases (`_init_kv_layout`, `_init_layer_groups`, `_init_compression_metadata`, buffer alloc, stream init) to keep the compression-metadata derivation readable.

2. **Dim-0-padded KV tensors from vLLM's shared KV pool.**
   In vLLM's mixed-compression KV pool, every group's per-block row is padded up to the pool's maximum row width, i.e. `tensor.stride(0) > prod(shape[1:])`. The tensor is *not* non-contiguous in the slicing sense; it is a periodic-dim-0 strided view over a larger storage.
   - `attempt_permute_to_contiguous_view` now accepts a tensor as a valid zero-copy view iff only dim-0 carries the extra stride (inner dims tightly packed, `storage_offset == 0`, no dim overlap). Any other pattern (interior-dim padding, slice, `as_strided`, etc.) is rejected loudly with full `shape/stride/storage_offset/dtype/storage_nbytes` context — we refuse to silently `.contiguous()`-copy.
   - `PageBufferShapeDesc` gains a new field `block_stride_elems` (physical per-block stride in source-dtype elements). `make_page_buffer_shape_desc` accepts it as an optional argument and validates it against the tight stride.
   - The CUDA kernel offset math (`calculate_engine_global_offset`) in `csrc/mp_mem_kernels.cu` is updated for the two block-axis formats `NL_X_NB_TWO_BS_NH_HS` and `NL_X_NB_BS_HS` to step by `block_stride_elems` instead of the tight stride when set; the SGL token-row formats and the layer-packed `NB_NL_*` format explicitly ignore it (dim-0 is not a block axis there). Both `multi_layer_block_kv_transfer` and `lmcache_memcpy_async_d2h` share this code path.
   - `KVLayerGroupsManager._resolve_block_stride` is the format-aware second line of defence: for block-axis formats it propagates `stride(0)` into the shape desc; for non-block-axis formats it raises if dim-0 padding is present (since the kernel cannot honour it).
   - The representative per-group tensor layout (shape / stride / `is_contiguous` / `padding_per_block` / storage offset / dtype) is logged at init so operators can diagnose unexpected layouts without re-running with extra instrumentation.

3. **Misc robustness & adapter plumbing.**
   - `get_device` now raises `ValueError` with the full descent path when the KV cache structure is empty or malformed (previously it died with a bare `IndexError` when the adapter's skip filter dropped every layer).
   - The vLLM adapter (`lmcache_mp_connector_0180.py`, `vllm_multi_process_adapter.py`) is refactored to build a single `ParallelStrategy` object and forward `vllm_block_size` to both the scheduler and worker adapter; existing callers that only cared about `world_size/kv_rank` keep working.
   - `LMCacheMPConnector` is renamed to `LMCacheMPConnectorDynamic` to match the dynamic compression-aware code path.
   - `wrap_kv_caches` now logs a per-layer `(name, shape, dtype)` summary so operators can verify the exact layer set shipped to the server.

**Special notes for your reviewers**:

- The `block_stride_elems` field on `PageBufferShapeDesc` defaults to `0` ("unset"), and the kernel falls back to the format-specific tight stride — so every existing caller (non-V4, non-padded pools) is bit-for-bit unchanged. Only callers that pass a non-zero value take the new path.
- The tight/padded stride conversion happens in `block_stride_or<ScalarType>()` on the C++ side and converts from *source KV dtype* element units to the kernel's scalar type, so uint8 staging of fp16 KV still lands at the right offsets.
- The non-contiguous-view acceptance in `attempt_permute_to_contiguous_view` is intentionally narrow (dim-0 only, `storage_offset == 0`, inner dims tight). If you see cases in the wild that should be accepted but aren't, please flag them — the failure path deliberately logs every piece of info needed to diagnose.
- `REGISTER_KV_CACHE`'s protocol signature changed (extra `int` payload). Older servers talking to a newer adapter (or vice-versa) will need to be upgraded together; no compat shim is provided because this is an MP-internal RPC.
- We removed the `is_mla` branch from the layer-grouping loop's identity (MLA already forces `kv_size=1, nh=1`, so adding `block_size` is strictly more discriminative and preserves the previous partitioning for non-V4 MLA models).

**If applicable**:

- [x] this PR contains user facing changes - docs added *(API-level: `LMCacheMPConnector` → `LMCacheMPConnectorDynamic`; `REGISTER_KV_CACHE` payload gains `vllm_block_size`; `PageBufferShapeDesc` gains `block_stride_elems`. Inline docstrings updated; no external user-facing docs changes beyond the renamed connector.)*
- [x] this PR contains unit tests *(updated: `test_gpu_context.py`, `test_gpu_connector.py`, `test_kv_layer_groups_manager.py`, `test_mq.py`, `test_mq_handler_helpers.py`, `test_blend_server_v2.py`, `test_cache_server.py` for the new `vllm_block_size` payload and per-group `block_size`.)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches CUDA kernel addressing and the MP wire protocol (`REGISTER_KV_CACHE` payload), so mismatches between client/server builds or stride/slot miscalculation could corrupt KV transfers or break MP compatibility.
> 
> **Overview**
> Enables DeepSeek V4-style *mixed-compression* KV layouts in the multi-process (MP) path by making KV transfer grouping and chunk sizing **per-layer-group** instead of assuming a single global `block_size`.
> 
> Adds `vllm_block_size` to the `REGISTER_KV_CACHE` RPC and reworks `GPUCacheContext`/server store+retrieve to compute per-group `compress_ratio` and pass *physical slots per chunk* into `multi_layer_block_kv_transfer`; also extends `KVLayerGroupsManager` identity to include per-group `bs` and tightens layout validation/logging.
> 
> Supports vLLM unified-pool *dim-0 padded* strided views by introducing `PageBufferShapeDesc.block_stride_elems` (pybind + Python stand-in), teaching the CUDA MP kernel to honor it for block-axis formats, and relaxing `attempt_permute_to_contiguous_view` to accept dim-0-only padding while rejecting other unsupported strided views. The vLLM connector plumbing is updated to pass a `ParallelStrategy`, forward `vllm_block_size`, and the connector class is renamed to `LMCacheMPConnectorDynamic` (tests updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4832a4000250db528098ce65d8caaf748a688ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->