### PR TITLE
docs: daily drift check — multi-process mode (2026-04-30 + 2026-05-01)

### DIFF
--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -238,7 +238,11 @@ If the Mooncake headers are not installed in the system include path
 
 All other keys in the JSON config (except ``type``, ``num_workers``,
 and ``eviction``) are forwarded **as-is** to Mooncake's
-``setup_internal(ConfigDict)``.  Refer to the
+``store.setup(config: dict)`` API (introduced in
+`Mooncake PR #1445 <https://github.com/kvcache-ai/Mooncake/pull/1445>`_).
+Older Mooncake builds that only expose the positional-arg ``setup()``
+signature are still supported -- LMCache transparently falls back to
+the legacy form on :class:`TypeError`.  Refer to the
 `Mooncake documentation <https://github.com/kvcache-ai/Mooncake>`_
 for available setup keys (e.g., ``local_hostname``,
 ``metadata_server``, ``master_server_address``, ``protocol``,

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -605,6 +605,57 @@ View traces in any OTel-compatible backend such as **Jaeger** or
         --l1-size-gb 100 --eviction-policy LRU \
         --enable-tracing --otlp-endpoint http://localhost:4317
 
+Per-Request Hit-Rate Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each session is wrapped in a per-request root span — ``request`` for the
+standard MP path and ``cb.request`` for the CacheBlend path — that nests
+all child spans (``mp.store``, ``mp.retrieve``, ``mp.lookup_prefetch``)
+beneath it.  When the lookup phase ends, the root span is annotated with
+three OTel attributes that summarise the request-level cache hit rate:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Attribute
+     - OTel type
+     - Description
+   * - ``hit_tokens``
+     - ``int``
+     - Tokens served from L1+L2 (numerator).
+   * - ``requested_tokens``
+     - ``int``
+     - Chunk-aligned tokens submitted for lookup (denominator).
+   * - ``hit_rate``
+     - ``float``
+     - ``hit_tokens / requested_tokens``; ``0.0`` when the denominator is
+       zero.  Stored as a precomputed float because trace UIs (Tempo,
+       Jaeger) cannot derive it from two integer attributes at query time.
+
+The attributes are written when ``MP_LOOKUP_PREFETCH_END`` (standard MP
+path) or ``CB_LOOKUP_END`` (CacheBlend path) is processed — while the
+root span is still open.  **Store-only requests** that never call
+``lookup_prefetch_start()`` emit no end event for the lookup phase, so
+their root span will not carry these attributes.
+
+Example TraceQL queries (Grafana Tempo):
+
+.. code-block:: text
+
+    # Requests with less than 50% cache hit rate
+    { name = "request" && span.hit_rate < 0.5 }
+
+    # Full cache hits only
+    { name = "request" && span.hit_rate = 1.0 }
+
+    # Complete misses (lookup ran but nothing was cached)
+    { name = "request" && span.requested_tokens > 0 && span.hit_tokens = 0 }
+
+For the full event-to-span mapping and the registry pattern that links
+child spans back to the root see
+``docs/design/observability/request-event-span.md`` in the source tree.
+
 .. _trace-recording:
 
 Trace Recording


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

This PR has accumulated **two days** of drift fixes because the 2026-04-30 PR was still open when the 2026-05-01 routine ran. The drift-check tooling has no way to create a fresh fork branch at the current upstream `dev` HEAD, so today's commit was layered on top of yesterday's branch instead of opening a separate stacked PR. The two items are independent and could be split if a reviewer prefers — flag in a comment and I'll rebase.

| Day | Item | File | Trigger PR |
| --- | --- | --- | --- |
| 2026-04-30 | Stale Mooncake setup-API name (`setup_internal` → `store.setup`) | `docs/source/mp/l2_storage.rst` | #2631 |
| 2026-05-01 | Missing per-request hit-rate attribute reference on root OTel span | `docs/source/mp/observability.rst` | #3175 |

---

## 2026-04-30 — Mooncake setup-API rename

### `docs/source/` (user-facing)

**Stale Mooncake setup-API name in the L2-adapter reference — #2631 (2026-04-29)**

Before #2631, the connector called Mooncake's positional-arg `setup()` and the user-facing reference described it as `setup_internal(ConfigDict)` (the previous internal name). #2631 reworked `setup_mooncake_store` to prefer the new dict-based `store.setup(config: dict)` API (Mooncake PR #1445), with a transparent `TypeError` fallback to the legacy positional-arg form for older Mooncake builds. The user-facing reference still cited the now-nonexistent `setup_internal(ConfigDict)`, so any reader trying to look it up against current Mooncake — or against the LMCache connector source — would not find it.

**Evidence:**

- New API call site (commit `ee2518f` from #2631): [`lmcache/v1/storage_backend/connector/mooncakestore_connector.py#L66-L115`](https://github.com/LMCache/LMCache/blob/534c056bdcd3d25d20cc8d1fa78bbb2bb98bf9af/lmcache/v1/storage_backend/connector/mooncakestore_connector.py#L66-L115) — `store.setup(setup_dict)` (line 97) with `TypeError` fallback to `store.setup(*args)` (line 115).
- Stale doc location prior to this PR: `docs/source/mp/l2_storage.rst:240-241` (`grep -n setup_internal docs/source/mp/l2_storage.rst` → 1 match, on the `setup_internal(ConfigDict)` line).

### `docs/design/`

No new drift observed — the mirrored design-doc area (`docs/design/v1/distributed/l2_adapters/`) does not document the Mooncake setup-API name; the closest reference lives in the connector docstring, which #2631 updated in the same commit.

---

## 2026-05-01 — Per-request hit-rate attributes on root OTel spans

### `docs/source/` (user-facing)

**Missing user-facing surface for per-request hit-rate attributes — #3175 (2026-04-30)**

#3175 wrote three new attributes — `hit_tokens`, `requested_tokens`, and a precomputed `hit_rate` — onto the per-session root span (`request` for the standard MP path, `cb.request` for the CacheBlend path) when `MP_LOOKUP_PREFETCH_END` or `CB_LOOKUP_END` is processed. The design doc and the example doc were updated in the same PR but the user-facing reference (`docs/source/mp/observability.rst`) was not, so users opening Tempo / Jaeger have no documented surface to query against.

Attributes added to the root span:

| Attribute | OTel type | Meaning |
| --- | --- | --- |
| `hit_tokens` | `int` | Tokens served from L1+L2 (numerator). |
| `requested_tokens` | `int` | Chunk-aligned tokens submitted for lookup (denominator). |
| `hit_rate` | `float` | `hit_tokens / requested_tokens`; `0.0` when denominator is zero. Stored as a precomputed float because trace UIs cannot derive it from two integer attributes at query time. |

**Evidence:**

- Subscriber writes for the standard MP path: [`lmcache/v1/mp_observability/subscribers/tracing/mp_server.py#L268-L280`](https://github.com/LMCache/LMCache/blob/887dbcdf636b424d43305411be85884ba2baabeb/lmcache/v1/mp_observability/subscribers/tracing/mp_server.py#L268-L280)
- Subscriber writes for the CacheBlend path: [`lmcache/v1/mp_observability/subscribers/tracing/cb_server.py#L295-L305`](https://github.com/LMCache/LMCache/blob/887dbcdf636b424d43305411be85884ba2baabeb/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py#L295-L305)
- CB emit-site population (all three branches — no-fingerprint-match, no-GPU-context, happy path): [`lmcache/v1/multiprocess/blend_server_v2.py#L391-L540`](https://github.com/LMCache/LMCache/blob/887dbcdf636b424d43305411be85884ba2baabeb/lmcache/v1/multiprocess/blend_server_v2.py#L391-L540)
- Mirrored design doc (already correct): [`docs/design/observability/request-event-span.md#L59-L96`](https://github.com/LMCache/LMCache/blob/887dbcdf636b424d43305411be85884ba2baabeb/docs/design/observability/request-event-span.md#L59-L96)
- Mirrored example doc (already correct): [`examples/observability/README.md#L52-L83`](https://github.com/LMCache/LMCache/blob/887dbcdf636b424d43305411be85884ba2baabeb/examples/observability/README.md#L52-L83)
- Stale doc location prior to this PR: `docs/source/mp/observability.rst` "Tracing" section (`grep -nE "hit_tokens|requested_tokens|hit_rate" docs/source/mp/observability.rst` → 0 matches in the Tracing section, only the unrelated `lookup_*_tokens` Prometheus counters under "Lookup Hit-Rate Metrics").

### `docs/design/`

No new drift observed for the 2026-05-01 item — the mirrored `docs/design/observability/request-event-span.md` was updated in #3175 itself.

### Other commits checked, no drift

Commits since the prior drift-check branch (`534c056`, base of the 2026-04-30 commit on this branch):

- **#3178** ([Chore][HotFix] EC UT) — pure CI/test fix plus two-line `docs/source/index.rst` toctree blank-line fix; not MP-related.
- **#3173** (docs goblin easter egg) — adds CSS/JS + PNG assets under `docs/source/_static/`; no MP doc impact.
- **#2969** (Revert [CI] add full tag selectively) — CI workflow only; no docs impact.

---

## Proposed fix

Applied in this PR:

- `docs/source/mp/l2_storage.rst` — one paragraph rewritten to (a) name the current `store.setup(config: dict)` API, (b) link to Mooncake PR #1445 where it was introduced, (c) explicitly document the `TypeError` fallback to the legacy positional-arg form so users on older Mooncake builds know they are still supported. (Already in the 2026-04-30 commit on this branch.)
- `docs/source/mp/observability.rst` — added a `Per-Request Hit-Rate Attributes` subsection under `Tracing`, slotted between the Jaeger setup example and the `Trace Recording` anchor. The subsection names the root `request` / `cb.request` spans explicitly, documents the three new attributes (type, semantics, when set, the store-only-request carve-out), gives three TraceQL example queries, and cross-links to the design doc for the full event-to-span mapping. (New in the 2026-05-01 commit.)

## Notes for reviewers

- **DCO note**: the 2026-05-01 commit was created via the GitHub MCP API, which does not let the daily routine override the commit author/committer fields. The committer email is therefore the API-token identity (`yihuac@vllm.ai`) rather than the routine's intended `yihua98@uchicago.edu`. The `Signed-off-by` trailer in the commit message uses the canonical `ApostaC <yihua98@uchicago.edu>`. If DCO flags the mismatch, please rebase locally to amend the author identity before merge — happy to redo the commit from a real local clone if preferred.
- **No code changes.** Both subsystems (Mooncake setup, root-span attribute writers) are unchanged; this PR just makes the user-facing reference match what the code actually does.
- This was **auto-generated by the daily drift-check routine** and needs human review before merge.

## Test plan

- [ ] Sphinx builds `docs/` without new warnings.
- [ ] Eyeball the rendered `mp/l2_storage.rst` Mooncake "Mooncake fields" paragraph; confirm the link to Mooncake PR #1445 resolves.
- [ ] Eyeball the rendered `mp/observability.rst` "Per-Request Hit-Rate Attributes" subsection; confirm the TraceQL examples render in a fixed-width block.
- [ ] Spot-check that the documented call name matches `lmcache/v1/storage_backend/connector/mooncakestore_connector.py:97` (`store.setup(setup_dict)`).
- [ ] Spot-check that the documented attributes appear on a real root span: enable tracing against a local Tempo and run a TraceQL query like `{ name = "request" && span.hit_rate >= 0 }`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEYWoiNHdi5ovLqeaRYqts)_