### PR TITLE
[Observability] Per-request hit rate attributes on root OTel spans

### DIFF
--- a/docs/design/observability/request-event-span.md
+++ b/docs/design/observability/request-event-span.md
@@ -56,6 +56,45 @@ callback for `MP_RETRIEVE_END` fires. EventBus queue becomes:
 Without `MP_RETRIEVE_SUBMITTED`, `_on_session_end` sees no in-flight work and
 closes the root span before the retrieve child span ends.
 
+## Root Span Attributes
+
+In addition to `session_id`, the root `"request"` span carries three hit rate
+attributes that are set when `MP_LOOKUP_PREFETCH_END` is processed:
+
+| Attribute | OTel type | Value |
+|-----------|-----------|-------|
+| `hit_tokens` | `int` | tokens found in L1+L2 (numerator) |
+| `requested_tokens` | `int` | chunk-aligned tokens submitted for lookup (denominator) |
+| `hit_rate` | `float` | `hit_tokens / requested_tokens`; `0.0` when denominator is zero |
+
+`hit_rate` is stored as a precomputed float because trace UIs (Tempo, Jaeger)
+cannot derive it from two integer attributes at query time.
+
+**Invariant:** these attributes are set at `MP_LOOKUP_PREFETCH_END` time, while
+the root span is still open.  `LP_END` always precedes `MP_REQUEST_END` in the
+event stream, so the root span is guaranteed to be live in the registry when the
+attributes are written.
+
+**Store-only requests** (no `lookup_prefetch_start()` call) never emit
+`MP_LOOKUP_PREFETCH_END`, so the root span will not carry these attributes.
+
+### CB path — `cb.request` span
+
+The same three attributes appear on the `"cb.request"` root span and are set
+when `CB_LOOKUP_END` is processed by `BlendTracingSubscriber`.
+
+`CB_LOOKUP_END` carries `hit_tokens` and `requested_tokens` in its metadata,
+computed at the emit site in `blend_server_v2.py`:
+
+| Field | Value |
+|-------|-------|
+| `hit_tokens` | `storage_hits * chunk_size` |
+| `requested_tokens` | `(num_tokens // chunk_size) * chunk_size` (chunk-aligned) |
+
+All three `CB_LOOKUP_END` emit sites (no-fingerprint-match, no-GPU-context,
+happy path) populate these fields, so `hit_rate` is always present on the
+`cb.request` span.
+
 ## Request Scenarios
 
 ### Scenario 1 — Full Cache Hit

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -52,16 +52,34 @@ Open **http://localhost:3000** → **Explore** → datasource **Tempo**.
 
 # Only cache-hit requests (had a retrieve)
 { name = "request" } >> { name = "mp.retrieve" }
+
+# Requests with less than 50 % cache hit rate
+{ name = "request" && span.hit_rate < 0.5 }
+
+# Full cache hits only
+{ name = "request" && span.hit_rate = 1.0 }
+
+# Complete misses (lookup ran but nothing was cached)
+{ name = "request" && span.requested_tokens > 0 && span.hit_tokens = 0 }
 ```
 
-Click any trace to open the waterfall:
+Click any trace to open the waterfall. Each root `request` span carries three
+per-request cache hit rate attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `hit_tokens` | int | tokens served from L1+L2 cache |
+| `requested_tokens` | int | total chunk-aligned tokens submitted for lookup |
+| `hit_rate` | float | `hit_tokens / requested_tokens` (0.0 on a total miss) |
 
 ```
-request  [══════════════════════════════════════]
+request  [══════════════════════════════════════]  hit_rate=0.75
   mp.lookup_prefetch  [════]
   mp.retrieve               [════════]
   mp.store                            [══════]
 ```
+
+Store-only requests (no lookup phase) do not carry these attributes.
 
 The pre-provisioned **LMCache** dashboard under **Dashboards** shows cache hit
 rate, StorageManager read/write rates, and the live trace panel.

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -292,6 +292,19 @@ class BlendTracingSubscriber(EventSubscriber):
 
         self._registry.pop(sid, self._SPAN_DEFS[start_type])
 
+        if event.event_type == EventType.CB_LOOKUP_END:
+            root_entry = self._registry.get(sid, "cb.request")
+            if root_entry is not None:
+                root_span, _ = root_entry
+                hit_tokens = int(event.metadata.get("hit_tokens", 0))
+                requested_tokens = int(event.metadata.get("requested_tokens", 0))
+                hit_rate = (
+                    hit_tokens / requested_tokens if requested_tokens > 0 else 0.0
+                )
+                root_span.set_attribute("hit_tokens", hit_tokens)
+                root_span.set_attribute("requested_tokens", requested_tokens)
+                root_span.set_attribute("hit_rate", hit_rate)
+
         if event.event_type in self._GPU_OP_END_EVENTS:
             if (count := self._pending_gpu_ops.get(sid, 0)) > 0:
                 if count == 1:

--- a/lmcache/v1/mp_observability/subscribers/tracing/mp_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/mp_server.py
@@ -265,6 +265,19 @@ class MPServerTracingSubscriber(EventSubscriber):
         if logical:
             self._registry.pop(sid, logical)
 
+        if event.event_type == EventType.MP_LOOKUP_PREFETCH_END:
+            root_entry = self._registry.get(sid, "request")
+            if root_entry is not None:
+                root_span, _ = root_entry
+                hit_tokens = int(event.metadata.get("hit_tokens", 0))
+                requested_tokens = int(event.metadata.get("requested_tokens", 0))
+                hit_rate = (
+                    hit_tokens / requested_tokens if requested_tokens > 0 else 0.0
+                )
+                root_span.set_attribute("hit_tokens", hit_tokens)
+                root_span.set_attribute("requested_tokens", requested_tokens)
+                root_span.set_attribute("hit_rate", hit_rate)
+
         if event.event_type == EventType.MP_STORE_END:
             if (count := self._pending_store_count.get(sid, 0)) > 0:
                 self._pending_store_count[sid] = count - 1

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -388,6 +388,9 @@ class BlendEngineV2(MPCacheEngine):
                         "storage_hits": 0,
                         "stale_chunks": 0,
                         "no_gpu_context": False,
+                        "hit_tokens": 0,
+                        "requested_tokens": (num_tokens // self.chunk_size)
+                        * self.chunk_size,
                     },
                 )
             )
@@ -440,6 +443,9 @@ class BlendEngineV2(MPCacheEngine):
                         "storage_hits": 0,
                         "stale_chunks": 0,
                         "no_gpu_context": True,
+                        "hit_tokens": 0,
+                        "requested_tokens": (num_tokens // self.chunk_size)
+                        * self.chunk_size,
                     },
                 )
             )
@@ -531,6 +537,9 @@ class BlendEngineV2(MPCacheEngine):
                     "storage_hits": len(found_cb_match_result),
                     "stale_chunks": len(stale_hashes),
                     "no_gpu_context": False,
+                    "hit_tokens": len(found_cb_match_result) * self.chunk_size,
+                    "requested_tokens": (num_tokens // self.chunk_size)
+                    * self.chunk_size,
                 },
             )
         )

--- a/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
@@ -3,9 +3,13 @@
 """Tests for BlendTracingSubscriber."""
 
 # Standard
+from unittest.mock import patch
 import time
 
 # Third Party
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 import pytest
 
 # First Party
@@ -17,6 +21,7 @@ from lmcache.v1.mp_observability.subscribers.tracing.cb_server import (
 from lmcache.v1.mp_observability.subscribers.tracing.span_registry import (
     SpanRegistry,
 )
+import lmcache.v1.mp_observability.subscribers.tracing.cb_server as cb_server_module
 
 
 @pytest.fixture
@@ -572,3 +577,189 @@ class TestBlendTracingSubscriber:
         time.sleep(0.15)
         bus.stop()
         assert len(subscriber._pending) == 0
+
+
+class TestCBHitRateAttributes:
+    """Verify hit_tokens / requested_tokens / hit_rate are set on cb.request root span.
+
+    Uses a real OTel TracerProvider backed by InMemorySpanExporter so that span
+    attributes are actually recorded.  The module-level ``_tracer`` is patched
+    for the duration of each test; ``_HAS_OTEL`` is forced True.
+    """
+
+    @pytest.fixture
+    def exporter(self):
+        """Real OTel provider with in-memory exporter; patches module tracer."""
+        exp = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exp))
+        real_tracer = provider.get_tracer("lmcache_mp.blend")
+        with (
+            patch.object(cb_server_module, "_tracer", real_tracer),
+            patch.object(cb_server_module, "_HAS_OTEL", True),
+        ):
+            yield exp
+        exp.shutdown()
+
+    def _root_span(self, exporter: InMemorySpanExporter, sid: str):
+        """Return the finished cb.request root span for *sid*, or None."""
+        for span in exporter.get_finished_spans():
+            if span.name == "cb.request" and span.attributes.get("session_id") == sid:
+                return span
+        return None
+
+    def test_hit_rate_attrs_set_on_root_span(self, exporter):
+        """CB_LOOKUP_END with hit_tokens=512, requested_tokens=1024 → hit_rate=0.5."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        registry = SpanRegistry()
+        bus.register_subscriber(BlendTracingSubscriber(registry))
+        bus.start()
+        now = time.time()
+        sid = "cb-hr-normal"
+
+        bus.publish(
+            Event(event_type=EventType.CB_REQUEST_START, session_id=sid, timestamp=now)
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+                metadata={"num_tokens": 1024},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id=sid,
+                timestamp=now + 0.010,
+                metadata={
+                    "num_tokens": 1024,
+                    "fingerprint_hits": 4,
+                    "storage_hits": 2,
+                    "stale_chunks": 0,
+                    "no_gpu_context": False,
+                    "hit_tokens": 512,
+                    "requested_tokens": 1024,
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.020,
+            )
+        )
+        time.sleep(0.15)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert root.attributes["hit_tokens"] == 512
+        assert root.attributes["requested_tokens"] == 1024
+        assert abs(root.attributes["hit_rate"] - 0.5) < 1e-9
+
+    def test_hit_rate_zero_when_requested_tokens_is_zero(self, exporter):
+        """CB_LOOKUP_END with requested_tokens=0 yields hit_rate=0.0 without error."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        registry = SpanRegistry()
+        bus.register_subscriber(BlendTracingSubscriber(registry))
+        bus.start()
+        now = time.time()
+        sid = "cb-hr-zero"
+
+        bus.publish(
+            Event(event_type=EventType.CB_REQUEST_START, session_id=sid, timestamp=now)
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+                metadata={"num_tokens": 0},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id=sid,
+                timestamp=now + 0.010,
+                metadata={
+                    "num_tokens": 0,
+                    "fingerprint_hits": 0,
+                    "storage_hits": 0,
+                    "stale_chunks": 0,
+                    "no_gpu_context": False,
+                    "hit_tokens": 0,
+                    "requested_tokens": 0,
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.020,
+            )
+        )
+        time.sleep(0.15)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert root.attributes["hit_tokens"] == 0
+        assert root.attributes["requested_tokens"] == 0
+        assert root.attributes["hit_rate"] == 0.0
+
+    def test_total_miss_hit_rate(self, exporter):
+        """CB_LOOKUP_END with storage_hits=0 but requested_tokens>0 → hit_rate=0.0."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        registry = SpanRegistry()
+        bus.register_subscriber(BlendTracingSubscriber(registry))
+        bus.start()
+        now = time.time()
+        sid = "cb-hr-miss"
+
+        bus.publish(
+            Event(event_type=EventType.CB_REQUEST_START, session_id=sid, timestamp=now)
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+                metadata={"num_tokens": 1024},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id=sid,
+                timestamp=now + 0.010,
+                metadata={
+                    "num_tokens": 1024,
+                    "fingerprint_hits": 0,
+                    "storage_hits": 0,
+                    "stale_chunks": 0,
+                    "no_gpu_context": False,
+                    "hit_tokens": 0,
+                    "requested_tokens": 1024,
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.020,
+            )
+        )
+        time.sleep(0.15)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert root.attributes["hit_tokens"] == 0
+        assert root.attributes["requested_tokens"] == 1024
+        assert root.attributes["hit_rate"] == 0.0

--- a/tests/v1/mp_observability/subscribers/tracing/test_mp_server.py
+++ b/tests/v1/mp_observability/subscribers/tracing/test_mp_server.py
@@ -3,9 +3,13 @@
 """Tests for MPServerTracingSubscriber."""
 
 # Standard
+from unittest.mock import patch
 import time
 
 # Third Party
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 import pytest
 
 # First Party
@@ -17,6 +21,7 @@ from lmcache.v1.mp_observability.subscribers.tracing import (
 from lmcache.v1.mp_observability.subscribers.tracing.span_registry import (
     SpanRegistry,
 )
+import lmcache.v1.mp_observability.subscribers.tracing.mp_server as mp_server_module
 
 
 @pytest.fixture
@@ -608,3 +613,169 @@ class TestMPServerTracingSubscriber:
         time.sleep(0.15)
         bus.stop()
         assert len(subscriber._pending) == 0
+
+
+class TestHitRateAttributes:
+    """Verify hit_tokens / requested_tokens / hit_rate are set on the root span.
+
+    Uses a real OTel TracerProvider backed by InMemorySpanExporter so that span
+    attributes are actually recorded.  The module-level ``_tracer`` is patched
+    for the duration of each test; ``_HAS_OTEL`` is forced True so that the
+    handlers don't early-return.
+    """
+
+    @pytest.fixture
+    def exporter(self):
+        """Real OTel provider with in-memory exporter; patches module tracer."""
+        exp = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exp))
+        real_tracer = provider.get_tracer("lmcache_mp.server")
+        with (
+            patch.object(mp_server_module, "_tracer", real_tracer),
+            patch.object(mp_server_module, "_HAS_OTEL", True),
+        ):
+            yield exp
+        exp.shutdown()
+
+    def _root_span(self, exporter: InMemorySpanExporter, sid: str):
+        """Return the finished root span for *sid*, or None."""
+        for span in exporter.get_finished_spans():
+            if span.name == "request" and span.attributes.get("session_id") == sid:
+                return span
+        return None
+
+    def test_hit_rate_attrs_set_on_root_span(self, exporter):
+        """LP_END with hit_tokens=512, requested_tokens=1024 → hit_rate=0.5."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        registry = SpanRegistry()
+        bus.register_subscriber(MPServerTracingSubscriber(registry))
+        bus.start()
+        now = time.time()
+        sid = "req-hr-normal"
+
+        bus.publish(
+            Event(event_type=EventType.MP_REQUEST_START, session_id=sid, timestamp=now)
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id=sid,
+                timestamp=now + 0.010,
+                metadata={
+                    "hit_tokens": 512,
+                    "requested_tokens": 1024,
+                    "found_count": 2,
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.020,
+            )
+        )
+        time.sleep(0.15)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert root.attributes["hit_tokens"] == 512
+        assert root.attributes["requested_tokens"] == 1024
+        assert abs(root.attributes["hit_rate"] - 0.5) < 1e-9
+
+    def test_hit_rate_zero_when_requested_tokens_is_zero(self, exporter):
+        """LP_END with requested_tokens=0 yields hit_rate=0.0 without error."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        registry = SpanRegistry()
+        bus.register_subscriber(MPServerTracingSubscriber(registry))
+        bus.start()
+        now = time.time()
+        sid = "req-hr-zero"
+
+        bus.publish(
+            Event(event_type=EventType.MP_REQUEST_START, session_id=sid, timestamp=now)
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id=sid,
+                timestamp=now + 0.010,
+                metadata={"hit_tokens": 0, "requested_tokens": 0, "found_count": 0},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.020,
+            )
+        )
+        time.sleep(0.15)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert root.attributes["hit_tokens"] == 0
+        assert root.attributes["requested_tokens"] == 0
+        assert root.attributes["hit_rate"] == 0.0
+
+    def test_no_hit_rate_attrs_on_store_only_path(self, exporter):
+        """Store-only request (no LP_END) leaves root span without hit rate attrs."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        registry = SpanRegistry()
+        bus.register_subscriber(MPServerTracingSubscriber(registry))
+        bus.start()
+        now = time.time()
+        sid = "req-hr-store-only"
+
+        bus.publish(
+            Event(
+                event_type=EventType.MP_STORE_SUBMITTED, session_id=sid, timestamp=now
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_STORE_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+                metadata={"device": "cuda:0"},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_STORE_END,
+                session_id=sid,
+                timestamp=now + 0.020,
+                metadata={"stored_count": 3, "device": "cuda:0"},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.MP_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.025,
+            )
+        )
+        time.sleep(0.15)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert "hit_tokens" not in root.attributes
+        assert "hit_rate" not in root.attributes


### PR DESCRIPTION
 Description:

Summary

Adds hit_tokens, requested_tokens, and hit_rate (float, 0.0–1.0) as attributes on the root OTel span for both the MP server and Cache Blending code paths.

- MP path ("request" span): attributes are set when MP_LOOKUP_PREFETCH_END is processed by MPServerTracingSubscriber. Data was already in the event — no
server changes needed.
- CB path ("cb.request" span): attributes are set when CB_LOOKUP_END is processed by BlendTracingSubscriber. All three CB_LOOKUP_END emit sites in
blend_server_v2.py are extended to carry hit_tokens and requested_tokens (chunk-aligned, matching the MP server convention).

hit_rate is stored as a precomputed float so it can be filtered directly in Tempo/Jaeger without derived-metric support (e.g. { name = "request" &&
span.hit_rate < 0.5 }).
[
<img width="692" height="183" alt="Screenshot 2026-04-30 at 12 05 26 PM" src="https://github.com/user-attachments/assets/a5d8e415-3c67-48be-8618-f0b48de06332" />
](url)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change that adds additional OTel span attributes and event metadata; main risk is mismatched/missing metadata causing incorrect hit-rate values rather than functional impact.
> 
> **Overview**
> Adds per-request cache hit rate visibility to tracing by attaching `hit_tokens`, `requested_tokens`, and precomputed `hit_rate` attributes to the MP root `request` span (on `MP_LOOKUP_PREFETCH_END`) and the CB root `cb.request` span (on `CB_LOOKUP_END`).
> 
> Extends CB `CB_LOOKUP_END` emission in `blend_server_v2.py` to always include `hit_tokens` and chunk-aligned `requested_tokens`, and updates docs/examples with Tempo/Jaeger query patterns for filtering by `span.hit_rate`.
> 
> Adds new unit tests using an in-memory OTel exporter to verify attributes are recorded correctly (including zero-denominator and store-only/no-lookup cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d97d379b66bce22a3a2146a7c96535aa0ccc5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->