### PR TITLE
[Core] Add Modular MAX LMCache MP support

### DIFF
--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -92,6 +92,14 @@ enum class GPUKVFormat : int {
   - TRT-LLM cross-layer (HND layout)
   physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
   */
+
+  NB_KV_NL_BS_NH_HS = 9,
+  /*
+  used by:
+  - Modular MAX cross-layer layout
+  physical shape: [num_blocks, kv_dim, num_layers, block_size, num_heads,
+  head_size]
+  */
 };
 
 void multi_layer_kv_transfer(

--- a/csrc/mp_mem_kernels.cu
+++ b/csrc/mp_mem_kernels.cu
@@ -57,6 +57,12 @@ __device__ inline size_t calculate_engine_global_offset(
            layer_idx * shape_desc.kv_size * scalars_per_block +
            engine_block_idx * shape_desc.kv_size * scalars_per_block *
                shape_desc.nl;
+  } else if constexpr (format == GPUKVFormat::NB_KV_NL_BS_NH_HS) {
+    // Modular MAX cross-layer: single tensor [NB, KV, NL, BS, NH, HS]
+    return layer_idx * scalars_per_block +
+           k_or_v * shape_desc.nl * scalars_per_block +
+           engine_block_idx * shape_desc.kv_size * shape_desc.nl *
+               scalars_per_block;
   }
 }
 
@@ -173,7 +179,8 @@ __device__ void multi_layer_block_transfer_single_block(
           shape_desc);
   ScalarType* paged_buffer_layer_ptr;
   if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS ||
-                format == GPUKVFormat::NB_NL_TWO_NH_BS_HS) {
+                format == GPUKVFormat::NB_NL_TWO_NH_BS_HS ||
+                format == GPUKVFormat::NB_KV_NL_BS_NH_HS) {
     paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[0];
   } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
     // SGLang MHA: ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V per layer
@@ -262,6 +269,9 @@ __global__ void multi_layer_block_transfer_kernel(
       break;                                                        \
     case GPUKVFormat::NB_NL_TWO_NH_BS_HS:                           \
       LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NB_NL_TWO_NH_BS_HS);    \
+      break;                                                        \
+    case GPUKVFormat::NB_KV_NL_BS_NH_HS:                             \
+      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NB_KV_NL_BS_NH_HS);      \
       break;                                                        \
     default:                                                        \
       TORCH_CHECK(false, "Unsupported GPUKVFormat: ",               \

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -30,6 +30,7 @@ PYBIND11_MODULE(c_ops, m) {
       .value("NL_X_TWO_NB_NH_BS_HS", GPUKVFormat::NL_X_TWO_NB_NH_BS_HS)
       .value("NL_X_NB_TWO_NH_BS_HS", GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
       .value("NB_NL_TWO_NH_BS_HS", GPUKVFormat::NB_NL_TWO_NH_BS_HS)
+      .value("NB_KV_NL_BS_NH_HS", GPUKVFormat::NB_KV_NL_BS_NH_HS)
       .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),

--- a/docs/source/integrations/index.rst
+++ b/docs/source/integrations/index.rst
@@ -10,4 +10,5 @@ isn't shared with the rest of the documentation.
 .. toctree::
    :maxdepth: 1
 
+   modular_max
    tensorrt_llm

--- a/docs/source/integrations/modular_max.rst
+++ b/docs/source/integrations/modular_max.rst
@@ -1,0 +1,139 @@
+.. _modular_max_integration:
+
+Modular MAX
+===========
+
+LMCache can serve Modular MAX KV cache requests in multiprocess (MP)
+mode. MAX keeps using its existing ``--kv-connector lmcache`` flag; MP
+mode is selected through ``--kv-connector-config``.
+
+Start LMCache MP Server
+-----------------------
+
+Start a standalone LMCache server with a chunk size that is compatible
+with the MAX KV page size:
+
+.. code-block:: bash
+
+   python -m lmcache.v1.multiprocess.server \
+       --host 127.0.0.1 \
+       --port 5555 \
+       --chunk-size 256 \
+       --l1-size-gb 10
+
+The LMCache ``chunk-size`` must be an integer multiple of MAX
+``kv_cache_page_size``. For token-mode MAX integration, LMCache fails at
+startup or connector initialization if this relationship does not hold:
+
+.. code-block:: text
+
+   LMCache MP chunk_size must be a multiple of MAX page_size for token-mode MAX integration.
+
+Start MAX
+---------
+
+Run MAX with prefix caching enabled and opt in to MP mode:
+
+.. code-block:: bash
+
+   max serve \
+       --model meta-llama/Llama-3.1-8B-Instruct \
+       --enable-prefix-caching \
+       --kv-connector lmcache \
+       --kv-connector-config '{
+         "lmcache_mode": "mp",
+         "lmcache_model_name": "meta-llama/Llama-3.1-8B-Instruct",
+         "lmcache_mp_host": "127.0.0.1",
+         "lmcache_mp_port": 5555
+       }'
+
+``lmcache_model_name`` is required by the current MAX MP connector and
+should be stable across MAX processes that are expected to share cache
+entries. A model name mismatch causes cache misses because LMCache
+includes the model name in its object keys.
+
+The MAX MP connector sends text token IDs to LMCache and uses the normal
+token-mode MP key path. It does not send MAX block hashes as token IDs.
+Multimodal/image prompts are not supported in the first token-mode
+implementation and fail clearly until a cross-engine image-token contract
+is defined.
+
+Configuration
+-------------
+
+``lmcache_mode``
+   Omit this key, or set it to ``"local"``, to keep the existing
+   in-process MAX LMCache connector. Set it to ``"mp"`` to use the
+   LMCache MP connector.
+
+``lmcache_model_name``
+   Required stable LMCache key namespace. Do not use random per-process
+   names unless you want isolated caches.
+
+``lmcache_mp_host`` and ``lmcache_mp_port``
+   MP server host and port. Defaults are ``127.0.0.1`` and ``5555``.
+
+``lmcache_mp_server_url``
+   Full ZMQ URL. When present, it overrides host and port.
+
+``lmcache_mp_timeout_s``
+   Request timeout in seconds.
+
+``lmcache_allow_host_staging``
+   Host staging fallback opt-in. The default is ``false``.
+
+Backends and Layout
+-------------------
+
+The MAX registration boundary uses a backend-neutral device buffer
+descriptor. CUDA IPC is the first implemented backend. ROCm/AMD is not
+silently routed through CUDA; unsupported backends fail with a targeted
+error:
+
+.. code-block:: text
+
+   LMCache MP for Modular MAX does not yet support backend 'rocm'. Implement HipIpcBufferImporter or enable explicit host staging fallback.
+
+LMCache supports the Modular MAX physical KV layout:
+
+.. code-block:: text
+
+   [NB, KVDIM, NL, BS, NH, HS]
+
+where ``KVDIM`` is ``2`` for normal K/V and ``1`` for MLA,
+``BS`` is the MAX page size, and ``NB`` is the total number of device
+blocks.
+
+Troubleshooting
+---------------
+
+Chunk/page mismatch
+   Set LMCache ``--chunk-size`` to a multiple of MAX
+   ``kv_cache_page_size``.
+
+Unsupported layout
+   Verify the registered MAX buffer shape is
+   ``[NB, KVDIM, NL, BS, NH, HS]`` and that ``KVDIM`` is ``1`` or ``2``.
+
+Unsupported backend
+   CUDA IPC is supported first. ROCm/HIP requires a HIP IPC importer, or
+   explicit host staging once that fallback is implemented.
+
+MP server unavailable
+   Check the server URL, host, port, and firewall rules. The connector
+   queries ``GET_CHUNK_SIZE`` during initialization and fails if the
+   server does not respond.
+
+Unexpected cache misses
+   Confirm every MAX process uses the same ``lmcache_model_name`` and
+   the same LMCache chunk size/page-size relationship.
+
+Multimodal request rejected
+   The first MAX MP token-mode connector supports text prompts only.
+   Use in-process mode for multimodal prompts until LMCache and MAX share
+   a stable image-token convention.
+
+MP e2e test environment
+   Do not inject a separate uv LMCache or PyTorch installation into a running
+   Bazel/MAX Python process. For full MP e2e validation, start LMCache and
+   MAX as separate processes in one compatible Torch/CUDA runtime environment.

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -3,6 +3,7 @@
 # Standard
 from typing import Any
 import importlib
+import os
 import sys
 
 # First Party
@@ -25,6 +26,9 @@ def _get_backend() -> Any:
     """
     Try backends in order, first successful import wins.
     """
+    if os.environ.get("NO_CUDA_EXT", "0") == "1":
+        return importlib.import_module("lmcache.non_cuda_equivalents")
+
     # Third Party
     import torch
 

--- a/lmcache/non_cuda_equivalents.py
+++ b/lmcache/non_cuda_equivalents.py
@@ -275,6 +275,9 @@ class GPUKVFormat(IntEnum):
     # used by: TRT-LLM cross-layer (HND layout)
     NB_NL_TWO_NH_BS_HS = 8
 
+    # used by: Modular MAX cross-layer layout
+    NB_KV_NL_BS_NH_HS = 9
+
 
 class PageBufferShapeDesc:
     """Python stand-in for the C++ ``PageBufferShapeDesc`` struct.

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -597,6 +597,7 @@ class EngineType(Enum):
     VLLM = "vllm"
     SGLANG = "sglang"
     TRTLLM = "trtllm"
+    MAX = "max"
     MOCK = "mock"
 
 

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -70,12 +70,23 @@ class LayoutHints(TypedDict, total=False):
             reshape its 4-D pool tensor into the canonical 6-D form.
         tokens_per_block: Tokens per paged block. Used by TRT-LLM (same).
         head_dim: Per-head dimension. Used by TRT-LLM (same).
+        layout_format: Optional explicit physical layout name, for example
+            ``"NB_KV_NL_BS_NH_HS"`` for Modular MAX.
+        num_layers: Number of layers in a cross-layer registration.
+        kv_dim: Number of KV planes, ``2`` for normal K/V and ``1`` for MLA.
+        page_size: Alias for ``tokens_per_block`` used by Modular MAX.
+        total_num_blocks: Total physical blocks in a paged KV cache.
     """
 
     kv_layout: Literal["NHD", "HND"]
     num_kv_heads: int
     tokens_per_block: int
     head_dim: int
+    layout_format: str
+    num_layers: int
+    kv_dim: int
+    page_size: int
+    total_num_blocks: int
 
 
 def attempt_permute_to_contiguous_view(
@@ -136,14 +147,16 @@ def assert_contiguous(tensor: torch.Tensor) -> None:
 def is_cross_layer_format(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
     """Return ``True`` if *gpu_kv_format* stores all layers in one tensor.
 
-    Cross-layer formats — ``NB_NL_TWO_BS_NH_HS`` (vLLM, NHD) and
-    ``NB_NL_TWO_NH_BS_HS`` (TRT-LLM, HND) — are represented as a single
+    Cross-layer formats — ``NB_NL_TWO_BS_NH_HS`` (vLLM, NHD),
+    ``NB_NL_TWO_NH_BS_HS`` (TRT-LLM, HND), and
+    ``NB_KV_NL_BS_NH_HS`` (Modular MAX) — are represented as a single
     bare :class:`torch.Tensor` rather than a list-of-tensors keyed by
     layer index.
     """
     return gpu_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS,
     )
 
 
@@ -201,6 +214,7 @@ def get_gpu_kv_shape_description(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS: "NL x [2, NB, NH, BS, HS]",
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: "NL x [NB, 2, NH, BS, HS]",
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "[NB, NL, 2, NH, BS, HS]",
+        lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS: "[NB, KVDIM, NL, BS, NH, HS]",
     }
     return _SHAPE_DESCRIPTIONS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
 
@@ -223,6 +237,7 @@ def get_attention_backend(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
             "vLLM non-MLA flash infer (HND layout)"
         ),
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "TRT-LLM cross-layer (HND layout)",
+        lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS: "Modular MAX cross-layer",
     }
     return _ATTENTION_BACKENDS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
 
@@ -290,6 +305,13 @@ def get_concrete_gpu_kv_shape(
         nh = get_num_heads(kv_caches, fmt)
         bs = get_block_size(kv_caches, fmt)
         return f"[{nb}, {nl}, 2, {nh}, {bs}, {hs}]"
+
+    if fmt == F.NB_KV_NL_BS_NH_HS:
+        nb = get_num_blocks(kv_caches, fmt)
+        kv_dim = kv_caches.shape[1]
+        bs = get_block_size(kv_caches, fmt)
+        nh = get_num_heads(kv_caches, fmt)
+        return f"[{nb}, {kv_dim}, {nl}, {bs}, {nh}, {hs}]"
 
     return f"Unknown ({gpu_kv_format})"
 
@@ -455,6 +477,17 @@ def normalize_kv_and_discover_format(
         elif list_depth == 2:
             # sglang MHA (flash attention and flash infer)
             detected_format = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
+    elif serving_engine == EngineType.MAX:
+        if (list_depth == 0 and tensor_dim == 6) or (
+            list_depth == 1 and tensor_dim == 6 and len(kv_caches) == 1
+        ):
+            if probe.shape[1] not in (1, 2):
+                raise ValueError(
+                    "Modular MAX KV cache layout expects KVDIM 1 or 2 in "
+                    f"[NB, KVDIM, NL, BS, NH, HS], got shape {tuple(probe.shape)}"
+                )
+            detected_format = lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS
+            kv_caches = probe
 
     if detected_format is not None:
         legible_print_gpu_kv_format(detected_format)
@@ -477,6 +510,8 @@ def get_num_layers(
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[1]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        return kv_caches.shape[2]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -503,6 +538,8 @@ def get_num_blocks(
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
+        return kv_caches.shape[0]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
         return kv_caches.shape[0]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
@@ -537,6 +574,8 @@ def get_block_size(
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — block_size at shape[4]
         return kv_caches.shape[4]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        return kv_caches.shape[3]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -571,6 +610,8 @@ def get_page_buffer_size(
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         return kv_caches.shape[0] * kv_caches.shape[4]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        return kv_caches.shape[0] * kv_caches.shape[3]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         return kv_caches[0].shape[1] * kv_caches[0].shape[2]
@@ -611,6 +652,8 @@ def get_num_heads(
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — num_heads at shape[3]
         return kv_caches.shape[3]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        return kv_caches.shape[4]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -647,6 +690,8 @@ def get_hidden_dim_size(
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — hidden = NH * HS
         return kv_caches.shape[3] * kv_caches.shape[5]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        return kv_caches.shape[4] * kv_caches.shape[5]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
@@ -680,6 +725,7 @@ def get_head_size(
     if gpu_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS,
     ):
         return kv_caches.shape[5]
     elif gpu_kv_format in (
@@ -713,6 +759,8 @@ def get_tokens_per_layer(
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         return kv_caches.shape[0] * kv_caches.shape[4]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        return kv_caches.shape[0] * kv_caches.shape[3]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         k_cache_shape = kv_caches[0][0].shape
@@ -766,6 +814,13 @@ def get_elements_per_layer(
         block_size = kv_caches.shape[4]
         head_size = kv_caches.shape[5]
         return num_blocks * 2 * num_heads * block_size * head_size
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        num_blocks = kv_caches.shape[0]
+        kv_dim = kv_caches.shape[1]
+        block_size = kv_caches.shape[3]
+        num_heads = kv_caches.shape[4]
+        head_size = kv_caches.shape[5]
+        return num_blocks * kv_dim * block_size * num_heads * head_size
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
@@ -865,6 +920,7 @@ def get_dtype(
     if gpu_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS,
     ):
         return kv_caches.dtype
     elif gpu_kv_format in (
@@ -916,7 +972,11 @@ def get_group_data_ptrs(
         ValueError: If *gpu_kv_format* is not recognized.
     """
     F = lmc_ops.GPUKVFormat
-    if gpu_kv_format in (F.NB_NL_TWO_BS_NH_HS, F.NB_NL_TWO_NH_BS_HS):
+    if gpu_kv_format in (
+        F.NB_NL_TWO_BS_NH_HS,
+        F.NB_NL_TWO_NH_BS_HS,
+        F.NB_KV_NL_BS_NH_HS,
+    ):
         tensor = cast(torch.Tensor, kv_caches)
         return [tensor.data_ptr()]
     if gpu_kv_format == F.TWO_X_NL_X_NBBS_NH_HS:
@@ -972,7 +1032,10 @@ def make_page_buffer_shape_desc(
         A populated ``PageBufferShapeDesc``.
     """
     desc = lmc_ops.PageBufferShapeDesc()
-    desc.kv_size = 1 if is_mla(gpu_kv_format) else 2
+    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS:
+        desc.kv_size = kv_caches.shape[1]
+    else:
+        desc.kv_size = 1 if is_mla(gpu_kv_format) else 2
     desc.nl = num_layers_in_group
     desc.nb = num_blocks
     desc.bs = block_size

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, TypeAlias
 import pickle
 import threading
 
 # Third Party
 import msgspec
 import torch
+
+# First Party
+from lmcache.utils import EngineType
 
 """
 Defines the types and the customized encoder/decoders for inter-process
@@ -212,15 +215,215 @@ class RawCudaIPCWrapper(CudaIPCWrapper):
         return raw.view(self.dtype).reshape(self.shape)
 
 
+DeviceBufferView: TypeAlias = torch.Tensor
+
+
+@dataclass(frozen=True)
+class DeviceBufferDescriptor:
+    """Backend-neutral descriptor for a registered serving-engine KV buffer.
+
+    The descriptor is the Modular MAX / LMCache boundary object. CUDA IPC is one
+    supported backend payload, but callers must still identify the backend and
+    handle type explicitly so unsupported backends fail before touching CUDA
+    code.
+    """
+
+    engine_type: EngineType
+    backend: str
+    handle_type: str
+    handle: Any
+    device_id: int
+    dtype: str
+    shape: tuple[int, ...]
+    strides: tuple[int, ...] | None
+    nbytes: int
+    storage_offset_bytes: int
+    layout_format: str
+    layout_hints: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DeviceEventDescriptor:
+    """Backend-neutral event descriptor for future async synchronization."""
+
+    backend: str
+    handle_type: str
+    handle: bytes | object | None
+
+
+class DeviceBufferImporter:
+    """Import backend-neutral buffer descriptors into local tensor views."""
+
+    _MAX_LAYOUT_FORMAT = "NB_KV_NL_BS_NH_HS"
+
+    @staticmethod
+    def from_descriptor(
+        desc: DeviceBufferDescriptor,
+        *,
+        allow_host_staging: bool = False,
+    ) -> DeviceBufferView:
+        """Create a tensor view from ``desc``.
+
+        Args:
+            desc: Backend-neutral buffer descriptor.
+            allow_host_staging: Whether explicit host staging fallback may be
+                used for CPU/host descriptors.
+
+        Returns:
+            A tensor view over the registered buffer.
+
+        Raises:
+            RuntimeError: If the backend is unsupported or host staging was not
+                explicitly enabled.
+            TypeError: If the descriptor handle type is invalid.
+        """
+        engine_type = DeviceBufferImporter._normalize_engine_type(desc.engine_type)
+        DeviceBufferImporter._validate_descriptor_metadata(desc, engine_type)
+        backend = desc.backend.lower()
+        handle_type = desc.handle_type.lower()
+
+        if backend == "cuda":
+            if handle_type != "cuda_ipc":
+                raise RuntimeError(
+                    "LMCache MP for Modular MAX CUDA backend requires "
+                    f"handle_type='cuda_ipc', got {desc.handle_type!r}."
+                )
+            if isinstance(desc.handle, CudaIPCWrapper):
+                tensor = desc.handle.to_tensor()
+            elif isinstance(desc.handle, bytes):
+                tensor = CudaIPCWrapper.Deserialize(desc.handle).to_tensor()
+            else:
+                raise TypeError(
+                    "CUDA DeviceBufferDescriptor handle must be bytes or "
+                    f"CudaIPCWrapper, got {type(desc.handle)!r}."
+                )
+            DeviceBufferImporter._validate_tensor_metadata(desc, tensor)
+            return tensor
+
+        if backend in ("rocm", "hip", "amd"):
+            raise RuntimeError(
+                "LMCache MP for Modular MAX does not yet support backend "
+                f"{desc.backend!r}. Implement HipIpcBufferImporter or enable "
+                "explicit host staging fallback."
+            )
+
+        if backend in ("cpu", "host"):
+            if not allow_host_staging:
+                raise RuntimeError(
+                    "LMCache MP for Modular MAX received a host buffer descriptor, "
+                    "but host staging fallback is disabled. Set "
+                    "lmcache_allow_host_staging=true to opt in."
+                )
+            raise RuntimeError(
+                "LMCache MP host staging descriptors are not implemented yet."
+            )
+
+        raise RuntimeError(
+            f"LMCache MP for Modular MAX does not yet support backend {desc.backend!r}."
+        )
+
+    @staticmethod
+    def _validate_tensor_metadata(
+        desc: DeviceBufferDescriptor,
+        tensor: torch.Tensor,
+    ) -> None:
+        if str(tensor.dtype) != desc.dtype:
+            raise RuntimeError(
+                "Imported device buffer dtype mismatch: descriptor "
+                f"{desc.dtype!r}, tensor {str(tensor.dtype)!r}."
+            )
+        if tuple(tensor.shape) != tuple(desc.shape):
+            raise RuntimeError(
+                "Imported device buffer shape mismatch: descriptor "
+                f"{desc.shape}, tensor {tuple(tensor.shape)}."
+            )
+        if desc.strides is not None and tuple(tensor.stride()) != tuple(desc.strides):
+            raise RuntimeError(
+                "Imported device buffer stride mismatch: descriptor "
+                f"{desc.strides}, tensor {tuple(tensor.stride())}."
+            )
+        nbytes = tensor.untyped_storage().nbytes()
+        if nbytes != desc.nbytes:
+            raise RuntimeError(
+                "Imported device buffer nbytes mismatch: descriptor "
+                f"{desc.nbytes}, tensor {nbytes}."
+            )
+        storage_offset_bytes = tensor.storage_offset() * tensor.element_size()
+        if storage_offset_bytes != desc.storage_offset_bytes:
+            raise RuntimeError(
+                "Imported device buffer storage offset mismatch: descriptor "
+                f"{desc.storage_offset_bytes}, tensor {storage_offset_bytes}."
+            )
+        if tensor.device.type == "cuda":
+            device_id = tensor.device.index or 0
+            if device_id != desc.device_id:
+                raise RuntimeError(
+                    "Imported device buffer device mismatch: descriptor "
+                    f"{desc.device_id}, tensor {device_id}."
+                )
+
+    @staticmethod
+    def _normalize_engine_type(engine_type: EngineType | str) -> EngineType:
+        if isinstance(engine_type, EngineType):
+            return engine_type
+        try:
+            return EngineType(engine_type)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Unsupported DeviceBufferDescriptor engine_type {engine_type!r}."
+            ) from exc
+
+    @staticmethod
+    def _validate_descriptor_metadata(
+        desc: DeviceBufferDescriptor,
+        engine_type: EngineType,
+    ) -> None:
+        if not desc.backend:
+            raise RuntimeError("DeviceBufferDescriptor backend must be non-empty.")
+        if not desc.handle_type:
+            raise RuntimeError("DeviceBufferDescriptor handle_type must be non-empty.")
+        if not desc.dtype:
+            raise RuntimeError("DeviceBufferDescriptor dtype must be non-empty.")
+        if not desc.shape:
+            raise RuntimeError("DeviceBufferDescriptor shape must be non-empty.")
+        if desc.strides is not None and len(desc.strides) != len(desc.shape):
+            raise RuntimeError(
+                "DeviceBufferDescriptor strides must be None or match shape rank."
+            )
+        if desc.nbytes <= 0:
+            raise RuntimeError("DeviceBufferDescriptor nbytes must be positive.")
+        if desc.storage_offset_bytes < 0:
+            raise RuntimeError(
+                "DeviceBufferDescriptor storage_offset_bytes must be non-negative."
+            )
+        if not desc.layout_format:
+            raise RuntimeError(
+                "DeviceBufferDescriptor layout_format must be non-empty."
+            )
+        if not isinstance(desc.layout_hints, dict):
+            raise TypeError(
+                "DeviceBufferDescriptor layout_hints must be a dict, got "
+                f"{type(desc.layout_hints)!r}."
+            )
+        if (
+            engine_type == EngineType.MAX
+            and desc.layout_format != DeviceBufferImporter._MAX_LAYOUT_FORMAT
+        ):
+            raise RuntimeError(
+                "Modular MAX DeviceBufferDescriptor layout_format must be "
+                f"{DeviceBufferImporter._MAX_LAYOUT_FORMAT!r}, got "
+                f"{desc.layout_format!r}."
+            )
+
+
 @dataclass(order=True, frozen=True)
 class IPCCacheEngineKey:
     """Cache key for the IPC (multiprocess) protocol.
 
     This key type is sent by the client over ZMQ (serialized via msgspec).
 
-    The client sends token_ids, start, end, and request_id (all required).
-    The server computes chunk hashes via TokenHasher and converts to
-    ObjectKey for storage operations using ipc_key_to_object_keys().
+    The sender provides ``token_ids``, ``start``, and ``end``; the server
+    computes chunk hashes via TokenHasher.
 
     The request_id field is for session tracking and is NOT included
     in equality/hash comparisons (two keys with same content but different
@@ -265,6 +468,8 @@ class IPCCacheEngineKey:
                 f"cache_salt exceeds max length {self._SALT_MAX_LEN} "
                 f"(got {len(self.cache_salt)})"
             )
+        if not self.token_ids:
+            raise ValueError("IPCCacheEngineKey requires non-empty token_ids")
 
     # Helper function for unit tests only
     @classmethod
@@ -279,7 +484,7 @@ class IPCCacheEngineKey:
         request_id: str = "",
         cache_salt: str = "",
     ) -> "IPCCacheEngineKey":
-        """Create a key from token ids. Only used by the tests."""
+        """Create a token-mode key for MP serving-engine adapters."""
         return cls(
             model_name=model_name,
             world_size=world_size,
@@ -306,7 +511,7 @@ class IPCCacheEngineKey:
 
 
 # Type exports
-KVCache = list[CudaIPCWrapper]
+KVCache = list[Any]
 
 
 @dataclass

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -33,6 +33,9 @@ from lmcache.v1.gpu_connector.utils import (
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import (
+    CudaIPCWrapper,
+    DeviceBufferDescriptor,
+    DeviceBufferImporter,
     KVCache,
 )
 
@@ -47,8 +50,18 @@ logger = init_logger(__name__)
 
 def unwrap_kv_cache_tensors(kv_caches: KVCache) -> list[torch.Tensor]:
     unwrapped_tensors = []
-    for ipc_wrapper in kv_caches:
-        tensor = ipc_wrapper.to_tensor()
+    for kv_cache in kv_caches:
+        if isinstance(kv_cache, dict) and "backend" in kv_cache:
+            kv_cache = DeviceBufferDescriptor(**kv_cache)
+        if isinstance(kv_cache, DeviceBufferDescriptor):
+            tensor = DeviceBufferImporter.from_descriptor(kv_cache)
+        elif isinstance(kv_cache, CudaIPCWrapper):
+            tensor = kv_cache.to_tensor()
+        else:
+            raise TypeError(
+                "Expected CudaIPCWrapper or DeviceBufferDescriptor, "
+                f"got {type(kv_cache)!r}"
+            )
         unwrapped_tensors.append(tensor)
     return unwrapped_tensors
 

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -17,6 +17,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.affinity_pool import AffinityThreadPool
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
+    KVCache,
     get_customized_decoder,
     get_customized_encoder,
 )
@@ -86,6 +87,10 @@ _SPECIAL_ENCODER_DECODERS = {
     list[CudaIPCWrapper]: (
         get_customized_encoder(list[CudaIPCWrapper]),
         get_customized_decoder(list[CudaIPCWrapper]),
+    ),
+    KVCache: (
+        get_customized_encoder(KVCache),
+        get_customized_decoder(KVCache),
     ),
 }
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -264,6 +264,18 @@ class MPCacheEngine:
         else:
             logger.warning("No KV cache found for GPU ID %d to unregister", instance_id)
 
+    def _chunk_hashes_for_range(self, key: IPCCacheEngineKey) -> list[bytes]:
+        """Return ObjectKey chunk hashes for STORE/RETRIEVE key ranges."""
+        session = self.session_manager.get_or_create(key.request_id)
+        session.set_tokens(list(key.token_ids))
+        return [
+            TokenHasher.hash_to_bytes(h) for h in session.get_hashes(key.start, key.end)
+        ]
+
+    def _chunk_hashes_for_lookup(self, key: IPCCacheEngineKey) -> list[bytes]:
+        """Return ObjectKey chunk hashes for a LOOKUP key."""
+        return self.token_hasher.compute_chunk_hashes(list(key.token_ids))
+
     @_lmcache_nvtx_annotate
     def store(
         self,
@@ -287,20 +299,16 @@ class MPCacheEngine:
                 that signals the completion of the store operation. The second
                 element indicates whether the store operation was successful.
         """
-        session = self.session_manager.get_or_create(key.request_id)
-        session.set_tokens(list(key.token_ids))
-        chunk_hashes = [
-            TokenHasher.hash_to_bytes(h) for h in session.get_hashes(key.start, key.end)
-        ]
+        chunk_hashes = self._chunk_hashes_for_range(key)
 
         st = time.perf_counter()
 
-        assert key.worker_id is not None, "Must store with worker_id != None"
+        if key.worker_id is None:
+            raise ValueError("Must store with worker_id != None")
         obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
 
-        assert instance_id in self.gpu_contexts, (
-            f"KV cache not registered for GPU ID {instance_id}"
-        )
+        if instance_id not in self.gpu_contexts:
+            raise RuntimeError(f"KV cache not registered for GPU ID {instance_id}")
         gpu_context = self.gpu_contexts[instance_id]
         model_name = self.gpu_context_meta[instance_id][0]
 
@@ -454,20 +462,16 @@ class MPCacheEngine:
                 that signals the completion of the retrieve operation. The second
                 element indicates whether the key was successfully retrieved.
         """
-        session = self.session_manager.get_or_create(key.request_id)
-        session.set_tokens(list(key.token_ids))
-        chunk_hashes = [
-            TokenHasher.hash_to_bytes(h) for h in session.get_hashes(key.start, key.end)
-        ]
+        chunk_hashes = self._chunk_hashes_for_range(key)
 
         st = time.perf_counter()
 
-        assert key.worker_id is not None, "Must retrieve with worker_id != None"
+        if key.worker_id is None:
+            raise ValueError("Must retrieve with worker_id != None")
         obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
 
-        assert instance_id in self.gpu_contexts, (
-            f"KV cache not registered for GPU ID {instance_id}"
-        )
+        if instance_id not in self.gpu_contexts:
+            raise RuntimeError(f"KV cache not registered for GPU ID {instance_id}")
         gpu_context = self.gpu_contexts[instance_id]
         model_name = self.gpu_context_meta[instance_id][0]
 
@@ -696,8 +700,8 @@ class MPCacheEngine:
 
         extra_count = compute_extra_count(tp_size, world_size)
 
-        # Compute chunk hashes for all full chunks
-        chunk_hashes = self.token_hasher.compute_chunk_hashes(list(key.token_ids))
+        # Compute chunk hashes for all full chunks from the token-mode key.
+        chunk_hashes = self._chunk_hashes_for_lookup(key)
         if not chunk_hashes:
             self._register_prefetch_job(
                 _PrefetchJob(
@@ -935,9 +939,7 @@ class MPCacheEngine:
             logger.warning("Session %s not found, skipping touch", request_id)
             return
         if session.lookup_ipc_key is None:
-            logger.warning(
-                "Session %s has no lookup ipc key, skipping touch", request_id
-            )
+            logger.debug("Session %s has no lookup ipc key, skipping touch", request_id)
             return
 
         chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_hashes(0)]

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -56,7 +56,7 @@ class TokenHasher:
 
     This class encapsulates the hash function loading and hash computation
     logic needed by the multiprocess server to convert token IDs into
-    chunk hashes compatible with IPCCacheEngineKey (hash mode).
+    chunk hashes compatible with IPCCacheEngineKey.
     """
 
     def __init__(self, chunk_size: int = 256, hash_algorithm: str = "blake3"):

--- a/tests/v1/gpu_connector/test_max_layout_utils.py
+++ b/tests/v1/gpu_connector/test_max_layout_utils.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Modular MAX GPU KV layout discovery and shape helpers."""
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import (
+    get_block_size,
+    get_concrete_gpu_kv_shape,
+    get_dtype,
+    get_group_data_ptrs,
+    get_head_size,
+    get_num_blocks,
+    get_num_heads,
+    get_num_layers,
+    make_page_buffer_shape_desc,
+    normalize_kv_and_discover_format,
+)
+import lmcache.c_ops as lmc_ops
+
+
+def test_max_layout_detection_and_accessors():
+    kv_cache = torch.empty(32, 2, 4, 16, 8, 64, dtype=torch.bfloat16)
+
+    fmt, normalized = normalize_kv_and_discover_format(kv_cache, EngineType.MAX)
+
+    assert fmt == lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS
+    assert normalized is kv_cache
+    assert get_num_blocks(kv_cache, fmt) == 32
+    assert get_num_layers(kv_cache, fmt) == 4
+    assert get_block_size(kv_cache, fmt) == 16
+    assert get_num_heads(kv_cache, fmt) == 8
+    assert get_head_size(kv_cache, fmt) == 64
+    assert get_dtype(kv_cache, fmt) == torch.bfloat16
+    assert get_concrete_gpu_kv_shape(kv_cache, fmt) == "[32, 2, 4, 16, 8, 64]"
+
+
+def test_max_layout_shape_desc_uses_kv_dim():
+    kv_cache = torch.empty(32, 2, 4, 16, 8, 64, dtype=torch.float16)
+    fmt = lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS
+
+    desc = make_page_buffer_shape_desc(
+        kv_cache,
+        fmt,
+        layer_idx=0,
+        num_layers_in_group=4,
+        num_blocks=32,
+        block_size=16,
+    )
+
+    assert desc.kv_size == 2
+    assert desc.nl == 4
+    assert desc.nb == 32
+    assert desc.bs == 16
+    assert desc.nh == 8
+    assert desc.hs == 64
+    assert desc.element_size == 2
+
+
+def test_max_layout_mla_shape_desc_uses_single_kv_plane():
+    kv_cache = torch.empty(32, 1, 4, 16, 1, 512, dtype=torch.bfloat16)
+    fmt = lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS
+
+    desc = make_page_buffer_shape_desc(
+        kv_cache,
+        fmt,
+        layer_idx=0,
+        num_layers_in_group=4,
+        num_blocks=32,
+        block_size=16,
+    )
+
+    assert desc.kv_size == 1
+    assert desc.nh == 1
+    assert desc.hs == 512
+
+
+def test_max_layout_group_data_ptrs_returns_single_base():
+    kv_cache = torch.empty(32, 2, 4, 16, 8, 64, dtype=torch.float16)
+    fmt = lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS
+
+    assert get_group_data_ptrs(kv_cache, fmt, [0, 1, 2, 3]) == [kv_cache.data_ptr()]

--- a/tests/v1/multiprocess/test_custom_types.py
+++ b/tests/v1/multiprocess/test_custom_types.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from dataclasses import replace
 from multiprocessing import Queue
 import multiprocessing as mp
 
@@ -9,10 +10,14 @@ import pytest
 import torch
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     CudaIPCWrapper,
+    DeviceBufferDescriptor,
+    DeviceBufferImporter,
     IPCCacheEngineKey,
+    KVCache,
     get_customized_decoder,
     get_customized_encoder,
 )
@@ -60,6 +65,102 @@ def test_ipc_cache_engine_key_serialization_with_cache_salt():
 
     assert original_key == decoded_key
     assert decoded_key.cache_salt == "alice"
+
+
+def test_ipc_cache_engine_key_rejects_empty_token_ids():
+    with pytest.raises(ValueError, match="requires non-empty token_ids"):
+        IPCCacheEngineKey(
+            model_name="test_model",
+            world_size=1,
+            worker_id=None,
+            token_ids=(),
+            start=0,
+            end=0,
+            request_id="req",
+        )
+
+
+def test_device_buffer_importer_rejects_unsupported_backend():
+    desc = DeviceBufferDescriptor(
+        engine_type=EngineType.MAX,
+        backend="rocm",
+        handle_type="hip_ipc",
+        handle=b"",
+        device_id=0,
+        dtype="torch.float16",
+        shape=(1,),
+        strides=None,
+        nbytes=2,
+        storage_offset_bytes=0,
+        layout_format="NB_KV_NL_BS_NH_HS",
+        layout_hints={},
+    )
+
+    with pytest.raises(RuntimeError, match="does not yet support backend 'rocm'"):
+        DeviceBufferImporter.from_descriptor(desc)
+
+
+def test_device_buffer_descriptor_kv_cache_wire_roundtrip():
+    desc = DeviceBufferDescriptor(
+        engine_type=EngineType.MAX,
+        backend="cuda",
+        handle_type="cuda_ipc",
+        handle=b"serialized-handle",
+        device_id=0,
+        dtype="torch.float16",
+        shape=(32, 2, 4, 16, 8, 64),
+        strides=None,
+        nbytes=1,
+        storage_offset_bytes=0,
+        layout_format="NB_KV_NL_BS_NH_HS",
+        layout_hints={"tokens_per_block": 16},
+    )
+
+    encoder = get_customized_encoder(KVCache)
+    decoder = get_customized_decoder(KVCache)
+    decoded = decoder.decode(encoder.encode([desc]))
+
+    assert decoded[0]["engine_type"] == "max"
+    assert decoded[0]["backend"] == "cuda"
+    assert decoded[0]["handle"] == b"serialized-handle"
+    assert decoded[0]["shape"] == [32, 2, 4, 16, 8, 64]
+
+
+def test_device_buffer_importer_validates_cuda_descriptor_metadata(monkeypatch):
+    tensor = torch.empty((2, 3), dtype=torch.float32)
+
+    class FakeCudaWrapper:
+        def to_tensor(self):
+            return tensor
+
+    monkeypatch.setattr(
+        CudaIPCWrapper,
+        "Deserialize",
+        staticmethod(lambda _payload: FakeCudaWrapper()),
+    )
+    desc = DeviceBufferDescriptor(
+        engine_type="max",
+        backend="cuda",
+        handle_type="cuda_ipc",
+        handle=b"serialized-handle",
+        device_id=0,
+        dtype=str(tensor.dtype),
+        shape=tuple(tensor.shape),
+        strides=tuple(tensor.stride()),
+        nbytes=tensor.untyped_storage().nbytes(),
+        storage_offset_bytes=tensor.storage_offset() * tensor.element_size(),
+        layout_format="NB_KV_NL_BS_NH_HS",
+        layout_hints={"tokens_per_block": 16},
+    )
+
+    assert DeviceBufferImporter.from_descriptor(desc) is tensor
+
+    with pytest.raises(RuntimeError, match="dtype mismatch"):
+        DeviceBufferImporter.from_descriptor(replace(desc, dtype=str(torch.float16)))
+    with pytest.raises(RuntimeError, match="nbytes mismatch"):
+        DeviceBufferImporter.from_descriptor(replace(desc, nbytes=1))
+    with pytest.raises(RuntimeError, match="layout_format"):
+        DeviceBufferImporter.from_descriptor(replace(desc, layout_format="unsupported"))
 
 
 @pytest.mark.skipif(

--- a/tests/v1/test_mp_mem_kernels.py
+++ b/tests/v1/test_mp_mem_kernels.py
@@ -49,6 +49,7 @@ FMT_FLASH_INFER = lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS
 FMT_MLA = lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
 FMT_SGLANG_MHA = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
 FMT_SGLANG_MLA = lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS
+FMT_MAX = lmc_ops.GPUKVFormat.NB_KV_NL_BS_NH_HS
 
 # Format parameters: (gpu_kv_format, num_layers, num_heads, head_size, is_mla)
 # Use small layer counts to keep GPU memory usage low in CI
@@ -59,6 +60,7 @@ FORMAT_PARAMS = [
     (FMT_MLA, 4, 1, 576, True),
     (FMT_SGLANG_MHA, 4, 8, 128, False),
     (FMT_SGLANG_MLA, 4, 1, 576, True),
+    (FMT_MAX, 4, 8, 128, False),
 ]
 
 
@@ -91,6 +93,9 @@ def create_vllm_tensors(
     elif gpu_kv_format == FMT_SGLANG_MLA:
         shape = [nbbs, 1, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
+    elif gpu_kv_format == FMT_MAX:
+        shape = [nb, 2, nl, bs, nh, hs]
+        return [_create_random_tensor(shape, dtype, device)]
     raise ValueError(f"Unknown format: {gpu_kv_format}")
 
 
@@ -123,6 +128,9 @@ def create_zero_vllm_tensors(
     elif gpu_kv_format == FMT_SGLANG_MLA:
         shape = [nbbs, 1, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
+    elif gpu_kv_format == FMT_MAX:
+        shape = [nb, 2, nl, bs, nh, hs]
+        return [_create_zero_tensor(shape, dtype, device)]
     raise ValueError(f"Unknown format: {gpu_kv_format}")
 
 
@@ -176,6 +184,8 @@ def get_block_data(
         elif gpu_kv_format == FMT_SGLANG_MLA:
             ts, ed = block_idx * bs, (block_idx + 1) * bs
             results.append(vllm_tensors[layer_idx][ts:ed, 0, :].clone())
+        elif gpu_kv_format == FMT_MAX:
+            results.append(vllm_tensors[0][block_idx, :, layer_idx, :, :, :].clone())
     return results
 
 
@@ -243,7 +253,15 @@ TOTAL_BLOCKS = NUM_MEMORY_OBJECTS * BLOCKS_PER_OBJECT  # 64
 @pytest.mark.parametrize(
     "gpu_kv_format,nl,nh,hs,is_mla",
     FORMAT_PARAMS,
-    ids=["normal", "cross_layer", "flash_infer", "mla", "sglang_mha", "sglang_mla"],
+    ids=[
+        "normal",
+        "cross_layer",
+        "flash_infer",
+        "mla",
+        "sglang_mha",
+        "sglang_mla",
+        "max",
+    ],
 )
 @pytest.mark.parametrize(
     "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
@@ -333,7 +351,15 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
 @pytest.mark.parametrize(
     "gpu_kv_format,nl,nh,hs,is_mla",
     FORMAT_PARAMS,
-    ids=["normal", "cross_layer", "flash_infer", "mla", "sglang_mha", "sglang_mla"],
+    ids=[
+        "normal",
+        "cross_layer",
+        "flash_infer",
+        "mla",
+        "sglang_mha",
+        "sglang_mla",
+        "max",
+    ],
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
 def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
@@ -425,3 +451,50 @@ def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
             assert block.abs().sum().item() == 0, (
                 f"Skipped block {i}, layer {layer_idx} is not zero"
             )
+
+
+def test_max_layout_d2h_memory_object_offsets():
+    """MAX [NB, KV, NL, BS, NH, HS] maps to LMCache [KV, NL, T, NH * HS]."""
+    device = torch.device("cuda")
+    dtype = torch.float32
+    nb, nl, bs, nh, hs = 8, 3, 4, 2, 3
+    block_ids = [2, 5]
+    tokens_per_object = len(block_ids) * bs
+    source = torch.arange(
+        nb * 2 * nl * bs * nh * hs,
+        dtype=dtype,
+        device=device,
+    ).reshape(nb, 2, nl, bs, nh, hs)
+    mem_objects = create_memory_objects(
+        2,
+        nl,
+        tokens_per_object,
+        nh * hs,
+        1,
+        dtype,
+        device,
+    )
+
+    call_block_kernel(
+        [source],
+        mem_objects,
+        block_ids,
+        FMT_MAX,
+        lmc_ops.TransferDirection.D2H,
+        nl,
+        nb,
+        bs,
+        nh,
+        hs,
+        False,
+        tokens_per_object,
+    )
+    torch.cuda.synchronize()
+
+    memory = mem_objects[0].reshape(2, nl, tokens_per_object, nh, hs)
+    for memory_block_idx, engine_block_idx in enumerate(block_ids):
+        token_slice = slice(memory_block_idx * bs, (memory_block_idx + 1) * bs)
+        assert torch.equal(
+            memory[:, :, token_slice, :, :],
+            source[engine_block_idx],
+        )


### PR DESCRIPTION
WIP
draft

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GPU KV layout and MP buffer-import path, including CUDA kernel offset math changes; mistakes could cause incorrect KV transfers or crashes in multiprocess serving.
> 
> **Overview**
> Adds **Modular MAX multiprocess integration** by introducing a new cross-layer GPU KV format `NB_KV_NL_BS_NH_HS` (`[NB, KVDIM, NL, BS, NH, HS]`) across the CUDA extension, Python fallback enums, and GPU-connector shape/format discovery.
> 
> Extends the MP block-transfer CUDA kernel to compute offsets and dispatch for the new format, updates pointer-handling to treat it as a single-tensor cross-layer layout, and adds MAX-specific accessor logic (layers/blocks/page size/kv_dim) including `PageBufferShapeDesc.kv_size` derived from the tensor’s KV dimension.
> 
> Improves MP wire/types to support backend-neutral buffer registration via `DeviceBufferDescriptor` + `DeviceBufferImporter` (CUDA IPC implemented; ROCm/host staging rejected with explicit errors), tightens `IPCCacheEngineKey` validation (reject empty `token_ids`), refactors server chunk-hash computation helpers, and documents the new MAX MP setup under `docs/source/integrations/modular_max.rst` with added tests for MAX layout and descriptor roundtrips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ac09c22b774eeab13ac5a628c8f15920e7d925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->