### PR TITLE
[Chore][HotFix]: EC UT

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -99,6 +99,7 @@ Documentation
    kv_cache/async_loading
    kv_cache/caching_policies
    kv_cache/p2p_sharing
+
 :raw-html:`<br />`
 
 .. toctree::
@@ -106,6 +107,7 @@ Documentation
    :caption: Non-KV caching
 
    non_kv_cache/encoder_cache
+
 :raw-html:`<br />`
 
 .. toctree::

--- a/tests/v1/test_ec_connector.py
+++ b/tests/v1/test_ec_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from unittest.mock import patch
 import tempfile
 import time
 
@@ -102,8 +103,16 @@ def test_ec_roundtrip_save_then_load():
             meta.add_mm_data(MMMeta.make_meta(mm_hash))
             parent._meta = meta
 
+            # Pin device to "cpu" for the load path: on CPU-only CI runners
+            # vLLM's UnspecifiedPlatform returns an empty device_type, which
+            # would make tensor.to(device="") raise. The test exercises the
+            # round-trip itself, not vLLM's device discovery.
             encoder_cache2 = {}
-            conn.start_load_caches(encoder_cache2)
+            with patch(
+                "lmcache.integration.vllm.vllm_ec_adapter.get_vllm_device_type",
+                return_value="cpu",
+            ):
+                conn.start_load_caches(encoder_cache2)
 
             assert mm_hash in encoder_cache2
             assert encoder_cache2[mm_hash].shape == x.shape


### PR DESCRIPTION
- tests/v1/test_ec_connector.py: pin device to "cpu" via patching get_vllm_device_type for the load step. On CPU-only CI runners vLLM's UnspecifiedPlatform returns "" for device_type, which made tensor.to(device="") raise inside ECCacheEngine.get.
- docs/source/index.rst: add the missing blank lines between the toctree entries and the trailing :raw-html: directive for the "KV Cache offloading and sharing" and "Non-KV caching" sections. Sphinx was warning "Explicit markup ends without a blank line" and the Non-KV caching section did not render reliably.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to unit-test behavior (mocking device detection) and documentation formatting, with no production logic modifications.
> 
> **Overview**
> Fixes CI flakiness in the EC connector round-trip unit test by patching `get_vllm_device_type` to return `"cpu"` during `start_load_caches`, avoiding `tensor.to(device="")` failures on CPU-only runners.
> 
> Cleans up `docs/source/index.rst` by adding required blank lines before trailing `:raw-html:` blocks after certain `toctree` sections, eliminating Sphinx warnings and improving rendering stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a6fcbd34fe0d830ad54d9970d7694cfbc9b5db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->