### PR TITLE
docs: daily drift check — multi-process mode (2026-05-02)

### DIFF
--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -92,22 +92,40 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
      - Copy KV cache chunks from L1 (CPU) back to GPU.
    * - ``LOOKUP``
      - BLOCKING
-     - Check prefix cache hits and submit prefetch tasks.
+     - Submit a prefix lookup; the prefetch job is tracked server-side by
+       request_id.
+   * - ``QUERY_PREFETCH_STATUS``
+     - BLOCKING
+     - Poll a prefetch job by request_id. Returns the loaded chunk count
+       when done, or ``None`` while the prefetch is still in progress.
+   * - ``QUERY_PREFETCH_LOOKUP_HITS``
+     - BLOCKING
+     - Query the lookup-phase hit chunk count by request_id, before the
+       prefetch finishes. Returns ``None`` while the lookup is still
+       running.
    * - ``FREE_LOOKUP_LOCKS``
-     - SYNC
-     - Release read locks from a cancelled lookup.
+     - BLOCKING
+     - Release read locks from a cancelled lookup without doing a full
+       RETRIEVE.
    * - ``END_SESSION``
-     - SYNC
+     - BLOCKING
      - Remove session state for a finished request.
    * - ``CLEAR``
-     - SYNC
+     - BLOCKING
      - Clear all cached data.
    * - ``GET_CHUNK_SIZE``
      - SYNC
      - Return the server's chunk size.
+   * - ``PING``
+     - BLOCKING
+     - Liveness ping; the handler always returns ``True``.
+   * - ``REPORT_BLOCK_ALLOCATION``
+     - BLOCKING
+     - Fire-and-forget channel for the vLLM scheduler to report GPU block
+       allocation events to the observability subsystem.
    * - ``NOOP``
      - SYNC
-     - Debug ping -- returns "OK".
+     - Debug heartbeat -- returns a confirmation string.
    * - ``CB_REGISTER_KV_CACHE``
      - SYNC
      - (Blend) Register CacheBlend KV buffer.
@@ -126,6 +144,15 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
    * - ``CB_STORE_FINAL``
      - BLOCKING
      - (Blend) Store final blended chunks.
+   * - ``CB_LOOKUP_PRE_COMPUTED_V2``
+     - BLOCKING
+     - (Blend V2) Lookup pre-computed chunks; returns
+       ``CBMatchResult`` entries (with old/cur ranges and per-chunk hashes)
+       so the retrieve step can skip re-hashing.
+   * - ``CB_RETRIEVE_PRE_COMPUTED_V2``
+     - BLOCKING
+     - (Blend V2) Retrieve pre-computed chunks using the
+       ``CBMatchResult`` list returned by ``CB_LOOKUP_PRE_COMPUTED_V2``.
 
 **Handler types:**
 
@@ -359,8 +386,9 @@ Adding a new request type
 
 1. Add a new member to ``RequestType`` in ``protocols/base.py``.
 2. Create a ``ProtocolDefinition`` in the appropriate ``protocols/*.py`` file
-   (engine, controller, or debug).
-3. Implement the handler method on ``MPCacheEngine`` (or ``BlendEngine``).
+   (``engine``, ``controller``, ``observability``, ``debug``, ``blend``, or
+   ``blend_v2``) and add the request name to that module's ``REQUEST_NAMES``.
+3. Implement the handler method on ``MPCacheEngine`` (or ``BlendEngineV2``).
 4. Register the handler in ``run_cache_server()`` via ``add_handler_helper()``.
 
 Key Source Files


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

This run focuses on a single, established drift item that the prior drift-check PRs did not catch: the user-facing **ZMQ Protocol table** in `docs/source/mp/architecture.rst` is out of date with the actual `RequestType` enum and `ProtocolDefinition.handler_type` values in `lmcache/v1/multiprocess/protocols/`. The table both omits six request types added between March and April 2026 and lists three other request types with a stale handler-type.

### `docs/source/` (user-facing)

**Stale ZMQ Protocol table on `docs/source/mp/architecture.rst`**

The `RequestType enum` table (under the `ZMQ Protocol` section) is the on-ramp users hit when they want to understand the wire protocol or extend it. With drift, a developer following it will (a) write code against a stale handler-type contract (SYNC vs BLOCKING affects whether the handler runs in the ZMQ main loop or a thread pool) and (b) miss four protocol categories entirely.

Concrete drift items, all on `docs/source/mp/architecture.rst:74-128` (pre-fix):

| Item | Doc claim (pre-fix) | Code reality | Triggering PR |
| --- | --- | --- | --- |
| `QUERY_PREFETCH_STATUS` | (missing) | BLOCKING | #2710 |
| `QUERY_PREFETCH_LOOKUP_HITS` | (missing) | BLOCKING | #2818 |
| `PING` | (missing) | BLOCKING | #2692 |
| `REPORT_BLOCK_ALLOCATION` | (missing) | BLOCKING | #2930 |
| `CB_LOOKUP_PRE_COMPUTED_V2` | (missing) | BLOCKING | #2677 |
| `CB_RETRIEVE_PRE_COMPUTED_V2` | (missing) | BLOCKING | #2677 |
| `FREE_LOOKUP_LOCKS` | SYNC | BLOCKING | (audit / #2818-era refactor) |
| `END_SESSION` | SYNC | BLOCKING | same |
| `CLEAR` | SYNC | BLOCKING | same |
| `LOOKUP` | "Check prefix cache hits and submit prefetch tasks." | Same intent, but the response is now `None` and the result is read back via `QUERY_PREFETCH_STATUS` — the description was tightened so this poll-back path is discoverable. | #2710 |

The "Adding a new request type" runbook at the bottom of the same page also listed only three protocol module categories (`engine`, `controller`, `debug`); current code has six (`engine`, `controller`, `observability`, `debug`, `blend`, `blend_v2`), each with its own `REQUEST_NAMES` registry that the validation system relies on. This PR updates step 2 of that runbook accordingly.

**Evidence (permalinked to `dev` HEAD `89c48d8e`):**

- `RequestType` enum members (six previously missing from the table): [`lmcache/v1/multiprocess/protocols/base.py#L26-L74`](https://github.com/LMCache/LMCache/blob/89c48d8ebf474f1d90198a0489c58f6b9d5d0837/lmcache/v1/multiprocess/protocols/base.py#L26-L74)
- Engine handler types (proves `FREE_LOOKUP_LOCKS` and `END_SESSION` are `BLOCKING`, not `SYNC`, and that `LOOKUP` returns `None`): [`lmcache/v1/multiprocess/protocols/engine.py#L24-L149`](https://github.com/LMCache/LMCache/blob/89c48d8ebf474f1d90198a0489c58f6b9d5d0837/lmcache/v1/multiprocess/protocols/engine.py#L24-L149) (lines 105-109 LOOKUP, 114-118 QUERY_PREFETCH_STATUS, 123-127 QUERY_PREFETCH_LOOKUP_HITS, 135-139 FREE_LOOKUP_LOCKS, 144-148 END_SESSION)
- Controller handler types (proves `CLEAR` is `BLOCKING`, not `SYNC`, and adds `PING`): [`lmcache/v1/multiprocess/protocols/controller.py#L13-L53`](https://github.com/LMCache/LMCache/blob/89c48d8ebf474f1d90198a0489c58f6b9d5d0837/lmcache/v1/multiprocess/protocols/controller.py#L13-L53)
- Observability protocol module (`REPORT_BLOCK_ALLOCATION`): [`lmcache/v1/multiprocess/protocols/observability.py`](https://github.com/LMCache/LMCache/blob/89c48d8ebf474f1d90198a0489c58f6b9d5d0837/lmcache/v1/multiprocess/protocols/observability.py)
- Blend V2 protocol module (`CB_LOOKUP_PRE_COMPUTED_V2`, `CB_RETRIEVE_PRE_COMPUTED_V2`): [`lmcache/v1/multiprocess/protocols/blend_v2.py`](https://github.com/LMCache/LMCache/blob/89c48d8ebf474f1d90198a0489c58f6b9d5d0837/lmcache/v1/multiprocess/protocols/blend_v2.py)
- Debug protocol module (still just `NOOP` returning a confirmation string): [`lmcache/v1/multiprocess/protocols/debug.py`](https://github.com/LMCache/LMCache/blob/89c48d8ebf474f1d90198a0489c58f6b9d5d0837/lmcache/v1/multiprocess/protocols/debug.py)
- Stale doc location prior to this PR: `docs/source/mp/architecture.rst:74-128` — `grep -nE "QUERY_PREFETCH_STATUS|QUERY_PREFETCH_LOOKUP_HITS|REPORT_BLOCK_ALLOCATION|CB_LOOKUP_PRE_COMPUTED_V2|CB_RETRIEVE_PRE_COMPUTED_V2|^   \\* - \`\`PING\`\`" docs/source/mp/architecture.rst` → 0 matches.

### `docs/design/`

No new drift observed in `docs/design/` for the items above:

- The mirrored design-doc tree under `docs/design/v1/multiprocess/` does not maintain a per-`RequestType` table; the design docs that touch the wire format (`raw_cuda_ipc.md`, `http_api_extension.md`, `mp_runtime_plugin.md`) talk about flows, not the enum, and remain accurate.
- The `engine_type` field added to `REGISTER_KV_CACHE` by #3162 is already documented in `docs/design/v1/gpu_connector/layout-invariant.md` (updated in the same PR).

### Other commits checked, no drift

Sweep window: commits on `dev` since the prior drift-check branches' bases (`534c056b` for #3174, `f8ffd8f0` for #3159).

- **#3170** ([MP][Fix] S3L2Adapter: container credentials via boto3 delegate, merged 2026-05-01) — Bug fix for the existing "default credential provider chain" path; the user-facing claim in `docs/source/mp/l2_storage.rst` ("Static credentials; omit both to use the AWS default credential provider chain") remains technically accurate. The new `boto3` runtime requirement only kicks in when static keys are absent, and existing docs do not promise an `awscrt`-only chain. Flagging here for visibility but not as actionable drift.
- **#3175** (Per-request hit-rate attributes on root OTel spans) — Already covered in open drift-check PR #3174.
- **#2631** (Mooncake `store.setup(dict)` rename) — Already covered in open drift-check PR #3174.
- **#3112** (L1/L2 failure health counters) — Already covered in open drift-check PR #3159.
- **#3178** ([Chore][HotFix] EC UT) — Pure CI/test fix plus a two-line `docs/source/index.rst` toctree blank-line fix; no MP doc impact.
- **#3173** (docs goblin easter egg) — Static asset addition under `docs/source/_static/`; no MP doc impact.
- **#2969** (Revert "[CI] add full tag selectively") — CI workflow only.
- **#3162** ([Refactor] Unify discover+normalize, add `EngineType` to REGISTER) — Wire-incompatible change to the `REGISTER_KV_CACHE` payload schema; the user-facing `docs/source/mp/architecture.rst` table only describes the enum + handler type (not payload tuples), so the addition of the `EngineType` field does not affect that table. The mirrored design doc `docs/design/v1/gpu_connector/layout-invariant.md` was updated in the same PR.

## Proposed fix

Applied in this PR. Surgical doc edit only — `docs/source/mp/architecture.rst` (+36 / −8):

1. `ZMQ Protocol` table: corrected `LOOKUP` description, fixed handler types on `FREE_LOOKUP_LOCKS` / `END_SESSION` / `CLEAR`, added six rows for `QUERY_PREFETCH_STATUS`, `QUERY_PREFETCH_LOOKUP_HITS`, `PING`, `REPORT_BLOCK_ALLOCATION`, `CB_LOOKUP_PRE_COMPUTED_V2`, `CB_RETRIEVE_PRE_COMPUTED_V2`. Also re-worded the `NOOP` row to "returns a confirmation string" since that matches the `response_class=str` definition (the literal `"OK"` was an implementation detail, not a contract).
2. `Adding a new request type` section: step 2 now lists the full set of protocol modules and points at the per-module `REQUEST_NAMES` registry; step 3 says `BlendEngineV2` (the actual class name) instead of the older `BlendEngine`.

## Notes for reviewers

- This was **auto-generated by the daily drift-check routine** and needs human review before merge.
- The handler-type corrections (`FREE_LOOKUP_LOCKS`/`END_SESSION`/`CLEAR` SYNC → BLOCKING) are the most reader-impacting edit, since they change the contract a developer would assume when implementing or calling these requests. Worth a careful skim against `protocols/engine.py` and `protocols/controller.py`.
- One drift PR landed today; consistent with the prior daily check having recently cleared the recent-PR-driven backlog. This item is older drift that those runs missed because they focused on flag/metric additions.
- No code changes — the protocol surface itself is unchanged; this PR just makes the user-facing reference match it.

## Test plan

- [ ] `cd docs && make html` builds without new warnings on the `mp/architecture.rst` page.
- [ ] Eyeball the rendered ZMQ Protocol table; confirm no rows are duplicated and that the six new rows render.
- [ ] Spot-check each row's handler type against `lmcache/v1/multiprocess/protocols/{base,engine,controller,observability,debug,blend,blend_v2}.py`.
- [ ] Run a real `lmcache server` and send `PING` / `NOOP` from a probe client; confirm both work and that `PING` returns `True` while `NOOP` returns a string.

---
_Generated by [Claude Code](https://claude.ai/code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01BYuQSJK5i2dBuFvU3NYjnL)_