### PR TITLE
[MP] Remove the middle `/api/` in all endpoints of http_server

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -82,7 +82,7 @@ Running requests:                        3
 ```
 
 `describe kvcache` gathers data from multiple ZMQ request types (`NOOP` for debug
-info, `GET_CHUNK_SIZE` for chunk size) and `/api/status` (HTTP) to build a
+info, `GET_CHUNK_SIZE` for chunk size) and `/status` (HTTP) to build a
 consolidated view.
 
 ### `lmcache ping`
@@ -90,7 +90,7 @@ consolidated view.
 Pure liveness check for both targets. Returns OK/FAIL with round-trip time,
 measuring only the network round-trip excluding local Python overhead.
 
-**`ping kvcache`** -- pings the LMCache server process via HTTP `/api/healthcheck`:
+**`ping kvcache`** -- pings the LMCache server process via HTTP `/healthcheck`:
 ```bash
 $ lmcache ping kvcache --url http://localhost:8080
 
@@ -294,7 +294,7 @@ lmcache/cli/
 ### Other notes
 
 - **Entry point:** `lmcache = "lmcache.cli.main:main"` in `pyproject.toml`.
-- **`bench engine`:** Wraps `vllm.benchmarks`, then queries `/api/status` for
+- **`bench engine`:** Wraps `vllm.benchmarks`, then queries `/status` for
   cache metrics.
 - **`query kvcache`:** Tokenizes `--prompt` using the model's tokenizer, then
   performs a lookup over ZMQ to check which chunks are cached.

--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -92,7 +92,7 @@ Key functions:
 |----------|---------|
 | `parse_args_to_config(args) -> EngineBenchConfig` | Converts CLI args to fully-resolved config |
 | `auto_detect_model(engine_url) -> str` | Fetches model ID from `/v1/models` |
-| `resolve_tokens_per_gb(lmcache_url, model_name) -> int` | Queries LMCache `/api/status` for `cache_size_per_token * world_size` |
+| `resolve_tokens_per_gb(lmcache_url, model_name) -> int` | Queries LMCache `/status` for `cache_size_per_token * world_size` |
 
 `EngineBenchConfig` contains only general parameters. Workload-specific
 configs live in their own modules and are resolved by the workload factory.

--- a/docs/design/cli/commands/describe.md
+++ b/docs/design/cli/commands/describe.md
@@ -133,17 +133,17 @@ Uses a positional `target` argument with `choices=["kvcache"]` (extend to
 ### 2. `--url` points to the HTTP endpoint
 
 The original design doc example shows `--url localhost:5555` (ZMQ port), but also
-states that `describe kvcache` "gathers data from ... `/api/status` (HTTP)". The
-HTTP `/api/status` endpoint already exposes **all** data needed (engine type, chunk
+states that `describe kvcache` "gathers data from ... `/status` (HTTP)". The
+HTTP `/status` endpoint already exposes **all** data needed (engine type, chunk
 size, L1 memory, eviction policy, cached objects, health, sessions, etc.). Using
 HTTP as the sole data source keeps the CLI simple — no ZMQ client needed.
 
 `--url` accepts the HTTP base URL (e.g., `http://localhost:8000`). The command
-normalizes it (adds `http://` if missing) and appends `/api/status`.
+normalizes it (adds `http://` if missing) and appends `/status`.
 
-### 3. Output fields mapped from `/api/status`
+### 3. Output fields mapped from `/status`
 
-| Display label | Machine key | Source in `/api/status` response |
+| Display label | Machine key | Source in `/status` response |
 |---|---|---|
 | Health | `health` | `is_healthy` → `"OK"` / `"UNHEALTHY"` |
 | ZMQ endpoint | `zmq_endpoint` | `zmq_endpoint` **(new — see Server-Side Changes)** |
@@ -175,7 +175,7 @@ existing `lmcache/tools/mp_status_viewer/__main__.py`.
 ## Server-Side Changes
 
 Three fields in the design doc's `describe kvcache` output are **not currently
-available** from `/api/status`. The following changes surface them.
+available** from `/status`. The following changes surface them.
 
 ### 1. Add `start_time` to `MPCacheEngine` → expose `uptime_seconds`
 
@@ -300,7 +300,7 @@ class DescribeCommand(BaseCommand):
 
     _describe_kvcache(args):
         1. Normalize URL (ensure http:// prefix)
-        2. Fetch JSON from {url}/api/status (timeout=10s)
+        2. Fetch JSON from {url}/status (timeout=10s)
         3. On error: print to stderr, sys.exit(1)
         4. Extract fields from nested response dict
         5. Format uptime_seconds → "Xh Ym Zs"
@@ -351,7 +351,7 @@ ALL_COMMANDS: list[BaseCommand] = [
 ## Verification
 
 1. **Unit test:** Test `_normalize_url()`, `_fmt_uptime()`, `_fmt_used_gb()`, and
-   field extraction logic with a synthetic `/api/status` response dict (no live
+   field extraction logic with a synthetic `/status` response dict (no live
    server needed).
 2. **Manual test against running server:**
    ```bash

--- a/docs/design/cli/commands/kvcache-command.md
+++ b/docs/design/cli/commands/kvcache-command.md
@@ -221,15 +221,15 @@ All CLI operations target the **MP HTTP server**
 
 | CLI sub-command | Existing MP HTTP endpoint | Notes |
 |----------------|--------------------------|-------|
-| `clear` | `POST /api/clear-cache` | Clears all L1 cache. Works as-is. |
+| `clear` | `POST /clear-cache` | Clears all L1 cache. Works as-is. |
 
 ### Needs new MP HTTP endpoints
 
 | CLI sub-command | What exists today | New endpoint needed on MP HTTP server |
 |----------------|------------------|---------------------------------------|
-| `info` | No per-request HTTP endpoint | `GET /api/kvcache-info?request_id=...` returning chunk ranges, locations, pinned status |
-| `pin` | ZMQ only (no HTTP) | `POST /api/pin` accepting request-id, returning OK or REJECTED with reason |
-| `compress` | ZMQ only (no HTTP) | `POST /api/compress` accepting request-id + method |
+| `info` | No per-request HTTP endpoint | `GET /kvcache-info?request_id=...` returning chunk ranges, locations, pinned status |
+| `pin` | ZMQ only (no HTTP) | `POST /pin` accepting request-id, returning OK or REJECTED with reason |
+| `compress` | ZMQ only (no HTTP) | `POST /compress` accepting request-id + method |
 
 ---
 

--- a/docs/design/cli/commands/ping.md
+++ b/docs/design/cli/commands/ping.md
@@ -81,7 +81,7 @@ server's health endpoint. No ZMQ client is needed.
 
 | Target | Server process | Endpoint | Healthy | Unhealthy |
 |--------|---------------|----------|---------|-----------|
-| `kvcache` | LMCache MP server | `GET /api/healthcheck` | 200 `{"status": "healthy"}` | 503 `{"status": "unhealthy", "reason": "..."}` |
+| `kvcache` | LMCache MP server | `GET /healthcheck` | 200 `{"status": "healthy"}` | 503 `{"status": "unhealthy", "reason": "..."}` |
 | `engine` | vLLM server | `GET /health` | 200 (empty body) | 503 (empty body) |
 
 ### 3. `--url` defaults
@@ -138,7 +138,7 @@ class PingCommand(BaseCommand):
     execute(args):
         url = args.url or DEFAULT_URLS[args.target]
         url = normalize_url(url)
-        endpoint = HEALTH_ENDPOINTS[args.target]  # "/api/healthcheck" or "/health"
+        endpoint = HEALTH_ENDPOINTS[args.target]  # "/healthcheck" or "/health"
         title = TITLES[args.target]               # "Ping KV Cache" or "Ping Engine"
 
         status, rtt_ms, error = ping(f"{url}{endpoint}")
@@ -156,7 +156,7 @@ class PingCommand(BaseCommand):
 Module-level helper:
 
 ```python
-HEALTH_ENDPOINTS = {"kvcache": "/api/healthcheck", "engine": "/health"}
+HEALTH_ENDPOINTS = {"kvcache": "/healthcheck", "engine": "/health"}
 DEFAULT_URLS = {"kvcache": "http://localhost:8080", "engine": "http://localhost:8000"}
 TITLES = {"kvcache": "Ping KV Cache", "engine": "Ping Engine"}
 

--- a/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md
@@ -217,22 +217,22 @@ policy — no special "disable" flag is needed.
 ### 4. HTTP API for Quota Management
 
 The existing FastAPI HTTP server (`lmcache/v1/multiprocess/http_server.py`)
-already serves `/api/healthcheck`, `/api/status`, and `/api/clear-cache`.
+already serves `/healthcheck`, `/status`, and `/clear-cache`.
 Add quota management endpoints:
 
 ```
-PUT    /api/quota/{cache_salt}          Set/update quota for a user
-GET    /api/quota/{cache_salt}          Get quota and current usage for a user
-DELETE /api/quota/{cache_salt}          Remove quota (user's data evicted next cycle)
-GET    /api/quota                    List all quotas and per-user usage
+PUT    /quota/{cache_salt}          Set/update quota for a user
+GET    /quota/{cache_salt}          Get quota and current usage for a user
+DELETE /quota/{cache_salt}          Remove quota (user's data evicted next cycle)
+GET    /quota                    List all quotas and per-user usage
 ```
 
 **`_default` sentinel:** Empty strings cannot be URL path parameters. Use
 `_default` as the `cache_salt` in the URL to refer to the `cache_salt=""`
 namespace (anonymous / un-isolated traffic). For example,
-`PUT /api/quota/_default` sets the quota for `cache_salt=""`.
+`PUT /quota/_default` sets the quota for `cache_salt=""`.
 
-**`PUT /api/quota/{cache_salt}`** — Set or update a user's quota.
+**`PUT /quota/{cache_salt}`** — Set or update a user's quota.
 `limit_gb` is required.
 
 ```json
@@ -243,7 +243,7 @@ namespace (anonymous / un-isolated traffic). For example,
 {"cache_salt": "alice", "limit_gb": 2.0, "status": "ok"}
 ```
 
-**`GET /api/quota/{cache_salt}`** — Get quota and current usage.
+**`GET /quota/{cache_salt}`** — Get quota and current usage.
 
 ```json
 // Response
@@ -255,7 +255,7 @@ namespace (anonymous / un-isolated traffic). For example,
 }
 ```
 
-**`DELETE /api/quota/{cache_salt}`** — Remove quota entry. The user's cached
+**`DELETE /quota/{cache_salt}`** — Remove quota entry. The user's cached
 data will be evicted at the next eviction cycle (effective limit becomes 0).
 
 ```json
@@ -263,7 +263,7 @@ data will be evicted at the next eviction cycle (effective limit becomes 0).
 {"cache_salt": "alice", "status": "removed"}
 ```
 
-**`GET /api/quota`** — List all registered quotas with per-user usage.
+**`GET /quota`** — List all registered quotas with per-user usage.
 
 ```json
 // Response
@@ -709,11 +709,11 @@ curl -X POST http://vllm:8000/v1/chat/completions \
   -d '{"model": "llama-3-8b", "messages": [...], "cache_salt": "alice"}'
 
 # Manage quotas at runtime
-curl -X PUT http://localhost:8000/api/quota/alice \
+curl -X PUT http://localhost:8000/quota/alice \
   -H "Content-Type: application/json" -d '{"limit_gb": 2.0}'
-curl http://localhost:8000/api/quota/alice
-curl -X DELETE http://localhost:8000/api/quota/alice
-curl http://localhost:8000/api/quota
+curl http://localhost:8000/quota/alice
+curl -X DELETE http://localhost:8000/quota/alice
+curl http://localhost:8000/quota
 ```
 
 ## Behavioral Notes

--- a/docs/design/v1/multiprocess/http_api_extension.md
+++ b/docs/design/v1/multiprocess/http_api_extension.md
@@ -36,9 +36,9 @@ modules:
 | Module | Endpoint | Method | Description |
 |---|---|---|---|
 | `root_api.py` | `/` | GET | Basic liveness check |
-| `healthcheck_api.py` | `/api/healthcheck` | GET | K8s probe endpoint |
-| `cache_api.py` | `/api/clear-cache` | POST | Force-clear L1 cache |
-| `status_api.py` | `/api/status` | GET | Internal status report |
+| `healthcheck_api.py` | `/healthcheck` | GET | K8s probe endpoint |
+| `cache_api.py` | `/clear-cache` | POST | Force-clear L1 cache |
+| `status_api.py` | `/status` | GET | Internal status report |
 
 ### `http_server.py`
 
@@ -100,7 +100,7 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 
-@router.get("/api/metrics")
+@router.get("/metrics")
 async def metrics(request: Request):
     """Return cache hit/miss metrics."""
     engine = getattr(request.app.state, "engine", None)
@@ -158,7 +158,7 @@ server lifecycle and all endpoint handlers. Available attributes
 Access these via the `Request` object in your handler:
 
 ```python
-@router.get("/api/my-endpoint")
+@router.get("/my-endpoint")
 async def my_endpoint(request: Request):
     engine = request.app.state.engine
     # ... use engine ...

--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -58,8 +58,8 @@ cache reuse across document paragraphs.
 **``http_server.py``** -- Wraps ``run_cache_server()`` (from ``server.py``)
 inside a FastAPI application.  Endpoints are contributed by modules under
 ``http_apis/`` and auto-registered via ``HTTPAPIRegistry``: ``GET /`` (basic
-liveness), ``GET /api/healthcheck`` for Kubernetes probes, ``POST /api/clear-cache``
-for clearing all KV cache data in L1 (CPU) memory, and ``GET /api/status``
+liveness), ``GET /healthcheck`` for Kubernetes probes, ``POST /clear-cache``
+for clearing all KV cache data in L1 (CPU) memory, and ``GET /status``
 for inspecting detailed internal state.  The ZMQ server runs as part of the
 same process, and any configured runtime plugins are spawned by
 ``MPRuntimePluginLauncher`` during FastAPI startup.
@@ -383,8 +383,8 @@ Key Source Files
    * - ``lmcache/v1/multiprocess/http_api_registry.py``
      - ``HTTPAPIRegistry`` that auto-discovers routers in ``http_apis/``
    * - ``lmcache/v1/multiprocess/http_apis/``
-     - Extensible HTTP endpoints (``/``, ``/api/healthcheck``,
-       ``/api/clear-cache``, ``/api/status``)
+     - Extensible HTTP endpoints (``/``, ``/healthcheck``,
+       ``/clear-cache``, ``/status``)
    * - ``lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py``
      - ``MPRuntimePluginLauncher`` that spawns runtime plugins with the
        full server config serialized into environment variables

--- a/docs/source/mp/deployment.rst
+++ b/docs/source/mp/deployment.rst
@@ -159,19 +159,19 @@ Health Checking (HTTP Server)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For Kubernetes liveness/readiness probes, deploy the HTTP server variant
-instead.  Use the ``/api/healthcheck`` endpoint:
+instead.  Use the ``/healthcheck`` endpoint:
 
 .. code-block:: yaml
 
     livenessProbe:
       httpGet:
-        path: /api/healthcheck
+        path: /healthcheck
         port: 8080
       initialDelaySeconds: 10
       periodSeconds: 30
     readinessProbe:
       httpGet:
-        path: /api/healthcheck
+        path: /healthcheck
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 10

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -56,10 +56,10 @@ All examples below assume the server is reachable at
 Endpoints
 ---------
 
-The table below groups the routes by purpose. Paths under ``/api/`` are
-the operational surface (health, status, cache control). Routes without
-the ``/api/`` prefix are inherited from the shared
-``internal_api_server`` package and kept at their original paths for
+The table below groups the routes by purpose. The operational surface
+(health, status, cache control) is exposed at top-level paths. Routes
+inherited from the shared
+``internal_api_server`` package are kept at their original paths for
 compatibility with the vLLM-embedded API server.
 
 .. list-table::
@@ -73,13 +73,13 @@ compatibility with the vLLM-embedded API server.
      - ``/``
      - Basic liveness ping.
    * - GET
-     - ``/api/healthcheck``
+     - ``/healthcheck``
      - K8s liveness/readiness probe.
    * - GET
-     - ``/api/status``
+     - ``/status``
      - Detailed engine status for inspection and debugging.
    * - POST
-     - ``/api/clear-cache``
+     - ``/clear-cache``
      - Force-clear all KV data in L1 (CPU) memory.
    * - GET
      - ``/conf``
@@ -123,7 +123,7 @@ compatibility with the vLLM-embedded API server.
 ~~~~~~~~~
 
 Basic liveness check. Returns a static payload indicating the HTTP server
-is running. Use ``/api/healthcheck`` instead for probes that also verify
+is running. Use ``/healthcheck`` instead for probes that also verify
 the cache engine is initialized.
 
 **Response** (``200 OK``):
@@ -141,8 +141,8 @@ the cache engine is initialized.
 
     curl -s http://localhost:8080/
 
-``GET /api/healthcheck``
-~~~~~~~~~~~~~~~~~~~~~~~~
+``GET /healthcheck``
+~~~~~~~~~~~~~~~~~~~~
 
 Health check endpoint suitable for Kubernetes liveness and readiness
 probes. A ``200`` response implies the HTTP server is alive **and** the
@@ -170,7 +170,7 @@ is not yet ready (still initializing, or failed to initialize).
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/api/healthcheck
+    curl -s http://localhost:8080/healthcheck
 
 **Kubernetes probe snippet:**
 
@@ -178,19 +178,19 @@ is not yet ready (still initializing, or failed to initialize).
 
     livenessProbe:
       httpGet:
-        path: /api/healthcheck
+        path: /healthcheck
         port: 8080
       initialDelaySeconds: 10
       periodSeconds: 10
     readinessProbe:
       httpGet:
-        path: /api/healthcheck
+        path: /healthcheck
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 5
 
-``GET /api/status``
-~~~~~~~~~~~~~~~~~~~
+``GET /status``
+~~~~~~~~~~~~~~~
 
 Returns a detailed snapshot of the MP engine's internal state: L1 cache,
 L2 adapters, registered GPU contexts, active sessions, and in-flight
@@ -248,10 +248,10 @@ been initialized:
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/api/status | jq
+    curl -s http://localhost:8080/status | jq
 
-``POST /api/clear-cache``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``POST /clear-cache``
+~~~~~~~~~~~~~~~~~~~~~
 
 Force-clears **all** KV cache data currently held in L1 (CPU) memory.
 
@@ -284,7 +284,7 @@ The request body is ignored.
 
 .. code-block:: bash
 
-    curl -s -X POST http://localhost:8080/api/clear-cache
+    curl -s -X POST http://localhost:8080/clear-cache
 
 ``GET /conf``
 ~~~~~~~~~~~~~

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -41,8 +41,8 @@ LMCache ships three server entry points:
    * - Entry Point
      - Description
    * - ``lmcache server``
-     - **Recommended.** ZMQ + FastAPI HTTP frontend (adds ``/api/healthcheck``
-       for K8s probes, ``/api/clear-cache``, ``/api/status`` — see
+     - **Recommended.** ZMQ + FastAPI HTTP frontend (adds ``/healthcheck``
+       for K8s probes, ``/clear-cache``, ``/status`` — see
        :doc:`http_api`). Use ``--engine-type blend`` to enable BlendEngineV2
        for cross-request KV reuse.
    * - ``python3 -m lmcache.v1.multiprocess.server``

--- a/docs/source/mp/quickstart.rst
+++ b/docs/source/mp/quickstart.rst
@@ -150,16 +150,16 @@ The HTTP server listens on ``0.0.0.0:8080`` by default (configurable with
      - Path
      - Description
    * - GET
-     - ``/api/healthcheck``
+     - ``/healthcheck``
      - Returns ``{"status": "healthy"}`` when the engine is initialized and
        memory checks pass. Suitable for Kubernetes liveness/readiness probes.
    * - POST
-     - ``/api/clear-cache``
+     - ``/clear-cache``
      - Force-clears all KV cache data stored in L1 (CPU) memory, including
        objects with active read/write locks. Returns ``{"status": "ok"}`` on
        success.
    * - GET
-     - ``/api/status``
+     - ``/status``
      - Returns detailed internal state of all MP components including L1 cache,
        L2 adapters, controllers, registered GPUs, and active sessions.
 
@@ -168,15 +168,15 @@ Examples:
 .. code-block:: bash
 
     # Health check
-    curl http://localhost:8080/api/healthcheck
+    curl http://localhost:8080/healthcheck
     # {"status": "healthy"}
 
     # Clear all KV cache data in L1 (CPU) memory
-    curl -X POST http://localhost:8080/api/clear-cache
+    curl -X POST http://localhost:8080/clear-cache
     # {"status": "ok"}
 
     # Inspect detailed internal state
-    curl http://localhost:8080/api/status
+    curl http://localhost:8080/status
 
 The ZMQ server runs on the same default port (5555) and accepts vLLM
 connections exactly as in the local quick start.

--- a/examples/serde/fp8/run_serde_fp8_example.sh
+++ b/examples/serde/fp8/run_serde_fp8_example.sh
@@ -104,7 +104,7 @@ LMCACHE_PID=$!
 echo "lmcache server PID=$LMCACHE_PID"
 
 echo "Waiting for lmcache HTTP health..."
-wait_for_url "http://localhost:${LMCACHE_HTTP_PORT}/api/healthcheck" 60 || {
+wait_for_url "http://localhost:${LMCACHE_HTTP_PORT}/healthcheck" 60 || {
     echo "lmcache failed to start. Last 50 lines of log:"
     tail -50 "$TMP_DIR/lmcache.log" || true
     exit 1
@@ -200,7 +200,7 @@ echo ""
 echo "============================================"
 echo "=== Step 4: Force-clearing L1 (CPU) cache ==="
 echo "============================================"
-curl -s -X POST "http://localhost:${LMCACHE_HTTP_PORT}/api/clear-cache" | python3 -m json.tool
+curl -s -X POST "http://localhost:${LMCACHE_HTTP_PORT}/clear-cache" | python3 -m json.tool
 echo "L1 cleared. Next request will miss L1 and trigger L2 prefetch."
 
 # ---------------------------------------------------------------------------
@@ -229,7 +229,7 @@ echo ""
 echo "============================================"
 echo "=== Step 6: LMCache status ==="
 echo "============================================"
-curl -s "http://localhost:${LMCACHE_HTTP_PORT}/api/status" \
+curl -s "http://localhost:${LMCACHE_HTTP_PORT}/status" \
     | python3 -m json.tool | head -80
 
 echo ""

--- a/lmcache/cli/commands/bench/engine_bench/config.py
+++ b/lmcache/cli/commands/bench/engine_bench/config.py
@@ -93,7 +93,7 @@ def auto_detect_model(engine_url: str) -> str:
 
 
 def _fetch_lmcache_status(lmcache_url: str) -> dict:
-    """Fetch ``/api/status`` from the LMCache HTTP server.
+    """Fetch ``/status`` from the LMCache HTTP server.
 
     Returns:
         Parsed JSON response.
@@ -104,7 +104,7 @@ def _fetch_lmcache_status(lmcache_url: str) -> dict:
     url = lmcache_url.rstrip("/")
     if not url.startswith(("http://", "https://")):
         url = f"http://{url}"
-    status_url = f"{url}/api/status"
+    status_url = f"{url}/status"
 
     logger.debug("Fetching LMCache status from %s", status_url)
 
@@ -125,7 +125,7 @@ def _find_model_meta(
     """Find the GPU metadata entry matching *model_name*.
 
     Args:
-        gpu_meta: The ``gpu_context_meta`` dict from ``/api/status``.
+        gpu_meta: The ``gpu_context_meta`` dict from ``/status``.
         model_name: Model name to match.
 
     Returns:
@@ -148,7 +148,7 @@ def _find_model_meta(
 def resolve_tokens_per_gb(lmcache_url: str, model_name: str) -> int:
     """Query the LMCache server and compute tokens per GB of KV cache.
 
-    Fetches ``/api/status``, finds the model entry matching
+    Fetches ``/status``, finds the model entry matching
     *model_name*, and computes::
 
         global_bytes_per_token = cache_size_per_token * world_size

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -94,7 +94,7 @@ def safe_get(data: dict, *keys, default=None):  # type: ignore[type-arg]
 
 
 class KVCacheDescriber:
-    """Builds the ``describe kvcache`` output from a ``/api/status`` response.
+    """Builds the ``describe kvcache`` output from a ``/status`` response.
 
     Each ``add_*`` method populates one logical section. The orchestrating
     :meth:`describe` calls them in order and emits the result.  Adding a
@@ -301,7 +301,7 @@ class DescribeCommand(BaseCommand):
     def _describe_kvcache(self, args: argparse.Namespace) -> None:
         base_url = normalize_url(args.url)
         try:
-            data = fetch_json(f"{base_url}/api/status")
+            data = fetch_json(f"{base_url}/status")
         except DescribeError as exc:
             print(str(exc), file=sys.stderr)
             sys.exit(1)

--- a/lmcache/cli/commands/kvcache.py
+++ b/lmcache/cli/commands/kvcache.py
@@ -121,8 +121,8 @@ class KVCacheCommand(BaseCommand):
         """Clear all cached KV data via the MP HTTP server."""
         url = args.url.rstrip("/")
 
-        # MP HTTP server endpoint: POST /api/clear-cache
-        _http_request("POST", f"{url}/api/clear-cache")
+        # MP HTTP server endpoint: POST /clear-cache
+        _http_request("POST", f"{url}/clear-cache")
 
         quiet = getattr(args, "quiet", False)
         if quiet:

--- a/lmcache/cli/commands/ping.py
+++ b/lmcache/cli/commands/ping.py
@@ -23,7 +23,7 @@ from lmcache.cli.commands.describe import normalize_url
 # -------------------------------------------------------------------
 
 HEALTH_ENDPOINTS: dict[str, str] = {
-    "kvcache": "/api/healthcheck",
+    "kvcache": "/healthcheck",
     "engine": "/health",
 }
 

--- a/lmcache/tools/mp_status_viewer/__main__.py
+++ b/lmcache/tools/mp_status_viewer/__main__.py
@@ -62,7 +62,7 @@ def main() -> None:
     parser.add_argument(
         "--url",
         type=str,
-        default="http://localhost:8000/api/status",
+        default="http://localhost:8000/status",
         help="URL of the status endpoint",
     )
     parser.add_argument(

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -14,7 +14,7 @@ logger = init_logger(__name__)
 router = APIRouter()
 
 
-@router.post("/api/clear-cache")
+@router.post("/clear-cache")
 async def clear_cache(request: Request) -> Any:
     """
     Force-clear all KV cache data stored in L1 (CPU) memory.

--- a/lmcache/v1/multiprocess/http_apis/healthcheck_api.py
+++ b/lmcache/v1/multiprocess/http_apis/healthcheck_api.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 
-@router.get("/api/healthcheck")
+@router.get("/healthcheck")
 async def healthcheck(request: Request) -> Any:
     """
     Health check endpoint for k8s liveness/readiness probes.

--- a/lmcache/v1/multiprocess/http_apis/status_api.py
+++ b/lmcache/v1/multiprocess/http_apis/status_api.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 
-@router.get("/api/status")
+@router.get("/status")
 async def status(request: Request) -> Any:
     """
     Detailed status endpoint for inspecting internal state

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -360,7 +360,7 @@ OnEvent(LMCacheEngine create/update/delete):
 | `lmcache/v1/distributed/config.py` | `L1MemoryManagerConfig`, `L1ManagerConfig`, `EvictionConfig`, `StorageManagerConfig`, argparse |
 | `lmcache/v1/mp_observability/config.py` | `PrometheusConfig`, `add_prometheus_args`, `parse_args_to_prometheus_config` |
 | `lmcache/v1/multiprocess/server.py` | `MPCacheEngine`, server CLI entry point, argparse (lines 629–653) |
-| `lmcache/v1/multiprocess/http_server.py` | HTTP server with `/api/healthcheck` endpoint (FastAPI + ZMQ) |
+| `lmcache/v1/multiprocess/http_server.py` | HTTP server with `/healthcheck` endpoint (FastAPI + ZMQ) |
 | `lmcache/v1/distributed/l2_adapters/config.py` | L2 adapter registry pattern, `L2AdapterConfigBase`, `L2AdaptersConfig` |
 | `examples/multi_process/lmcache-daemonset.yaml` | Reference DaemonSet manifest |
 | `examples/multi_process/vllm-deployment.yaml` | Reference vLLM deployment with kv-transfer-config |

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -20,7 +20,7 @@ from lmcache.cli.commands.describe import (
 )
 
 # ---------------------------------------------------------------------------
-# Sample /api/status payload
+# Sample /status payload
 # ---------------------------------------------------------------------------
 
 SAMPLE_STATUS = {
@@ -132,7 +132,7 @@ class TestSafeGet:
 
 class TestDescribeKvcacheFields:
     """Test that ``_describe_kvcache`` extracts fields correctly from a
-    sample ``/api/status`` response."""
+    sample ``/status`` response."""
 
     def test_field_extraction(self):
         """Verify metrics are populated from the sample status dict."""
@@ -333,7 +333,7 @@ class TestFetchJson:
         t = Thread(target=server.handle_request, daemon=True)
         t.start()
         try:
-            result = fetch_json(f"http://127.0.0.1:{port}/api/status")
+            result = fetch_json(f"http://127.0.0.1:{port}/status")
             assert result == {"ok": True}
         finally:
             server.server_close()
@@ -355,6 +355,6 @@ class TestFetchJson:
         t.start()
         try:
             with pytest.raises(DescribeError, match="Server unhealthy"):
-                fetch_json(f"http://127.0.0.1:{port}/api/status")
+                fetch_json(f"http://127.0.0.1:{port}/status")
         finally:
             server.server_close()

--- a/tests/cli/test_ping.py
+++ b/tests/cli/test_ping.py
@@ -205,7 +205,7 @@ class TestPingCommandEngine:
 
 class TestDefaultUrls:
     def test_kvcache_default(self):
-        """Verify that url=None resolves to localhost:8080/api/healthcheck."""
+        """Verify that url=None resolves to localhost:8080/healthcheck."""
         cmd = PingCommand()
 
         class FakeArgs:

--- a/tests/v1/multiprocess/test_http_api_registry.py
+++ b/tests/v1/multiprocess/test_http_api_registry.py
@@ -191,5 +191,5 @@ class TestHTTPAPIRegistry:
     def test_all_expected_routes_present(self, app_with_registry):
         """All four expected routes are registered."""
         routes = {r.path for r in app_with_registry.routes if hasattr(r, "path")}
-        expected = {"/", "/api/healthcheck", "/api/clear-cache", "/api/status"}
+        expected = {"/", "/healthcheck", "/clear-cache", "/status"}
         assert expected.issubset(routes)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change to the MP HTTP API surface (removes `/api/*` routes), which can impact existing deployments, scripts, and probes that still call the old paths. Functional logic is mostly unchanged, but client/CLI behavior and integrations depend on correct endpoint migration.
> 
> **Overview**
> Removes the intermediate `/api/` prefix from LMCache MP HTTP endpoints, moving core operational routes to top-level paths (e.g., `GET /status`, `GET /healthcheck`, `POST /clear-cache`) and updating server route decorators accordingly.
> 
> Updates all in-repo callers (CLI `ping`, `describe`, `kvcache clear`, `bench engine` config helper, `mp_status_viewer`, example scripts) plus unit tests and docs to reference the new paths. `lmcache describe kvcache` also starts emitting an additional **Hit Statistics** section when `hit_stats` is present in the `/status` payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b876f73408090d35c448a340f42dc13adcdc81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->