### PR TITLE
docs: daily drift check — multi-process mode (2026-05-03)

### DIFF
--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -525,6 +525,52 @@ Adapters with no in-flight work emit no datapoint for that scrape.
        follows each request's ``load_plan`` bitmap, so summing across
        adapters never double-counts.
 
+EventBus Self-Monitoring
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Health metrics for the EventBus itself, registered by
+``EventBusSelfMetricsSubscriber`` on the ``lmcache.event_bus`` OTel
+meter.  These metrics observe bus state directly via the ``EventBus``
+accessors and report on every OTel scrape — they are not driven by
+events, so dropping or failing subscribers cannot silence them.
+
+Use them to answer: is the EventBus keeping up with publishers, is
+anything being dropped, and are any subscriber callbacks raising?
+A non-zero ``dropped_events_total`` or a sustained non-zero
+``drain_lag_seconds`` indicates the bus is at ``--event-bus-queue-size``
+and tail-dropping; raise that flag or investigate slow subscribers.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Metric
+     - Type
+     - Description
+   * - ``lmcache_mp.event_bus.queue_depth``
+     - ObservableGauge
+     - Events currently queued in the EventBus (``len(_queue)`` at
+       scrape time).
+   * - ``lmcache_mp.event_bus.drain_lag_seconds``
+     - ObservableGauge
+     - Seconds since the oldest queued event was published; ``0.0``
+       when empty.  Rising values mean the drain thread is falling
+       behind.
+   * - ``lmcache_mp.event_bus.dropped_events_total``
+     - ObservableCounter
+     - Cumulative events dropped because the EventBus queue was at
+       ``--event-bus-queue-size``.
+   * - ``lmcache_mp.event_bus.subscriber_exceptions``
+     - ObservableCounter (attr: ``subscriber_name``)
+     - Cumulative exceptions raised by subscriber callbacks during
+       EventBus dispatch, tagged by ``subscriber_name`` (the failing
+       callback's owning class for bound methods, or ``__qualname__``
+       for free functions).
+
+For the full design rationale and the in-process accessors that back
+each metric see ``docs/design/v1/mp_observability/METRICS.md`` and
+``docs/design/v1/mp_observability/event-bus.md`` in the source tree.
+
 Prometheus Scrape Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

One drift item this run, on `docs/source/mp/observability.rst`, triggered by today's #3167 (commit `7e4139b`, merged 2026-05-03):

| Item | File | Trigger PR |
| --- | --- | --- |
| Missing user-facing surface for EventBus self-monitoring metrics | `docs/source/mp/observability.rst` | #3167 |

### `docs/source/` (user-facing)

**Missing user-facing surface for EventBus self-monitoring metrics — #3167 (2026-05-03)**

#3167 added `EventBusSelfMetricsSubscriber`, which registers four health metrics on the `lmcache.event_bus` OTel meter that observe bus state directly via `EventBus` accessors (rather than being driven by events). The design doc `docs/design/v1/mp_observability/METRICS.md`, the package architecture note in `docs/design/v1/mp_observability/event-bus.md`, and the package `README.md` were all updated in the same PR. The user-facing reference `docs/source/mp/observability.rst` was not touched, so end users opening Prometheus / Grafana currently have no documented surface for these counters and gauges.

Metrics added (all on the `lmcache_mp.event_bus.*` namespace):

| OTel metric | Type | Attributes |
| --- | --- | --- |
| `lmcache_mp.event_bus.queue_depth` | ObservableGauge | — |
| `lmcache_mp.event_bus.drain_lag_seconds` | ObservableGauge | — |
| `lmcache_mp.event_bus.dropped_events_total` | ObservableCounter | — |
| `lmcache_mp.event_bus.subscriber_exceptions` | ObservableCounter | `subscriber_name` |

**Evidence (permalinked to `dev` HEAD `7e4139b`):**

- Subscriber registers all four metrics on the `lmcache.event_bus` meter: [`lmcache/v1/mp_observability/subscribers/metrics/event_bus.py#L33-L82`](https://github.com/LMCache/LMCache/blob/7e4139b7498128b285d6731d578c2572aa08b6da/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py#L33-L82)
- Auto-registration when metrics are enabled: [`lmcache/v1/mp_observability/config.py#L329-L357`](https://github.com/LMCache/LMCache/blob/7e4139b7498128b285d6731d578c2572aa08b6da/lmcache/v1/mp_observability/config.py#L329-L357) (lines 329, 357)
- `EventBus` accessors that back the metrics (`queue_depth`, `oldest_event_lag_seconds`, `dropped_events_count`, `subscriber_exception_counts`): [`lmcache/v1/mp_observability/event_bus.py#L243-L271`](https://github.com/LMCache/LMCache/blob/7e4139b7498128b285d6731d578c2572aa08b6da/lmcache/v1/mp_observability/event_bus.py#L243-L271)
- Mirrored design doc (already correct): [`docs/design/v1/mp_observability/METRICS.md`](https://github.com/LMCache/LMCache/blob/7e4139b7498128b285d6731d578c2572aa08b6da/docs/design/v1/mp_observability/METRICS.md) (the new `EventBus Self-Monitoring` section)
- Mirrored architecture diagram in package README (already correct): [`lmcache/v1/mp_observability/README.md#L27`](https://github.com/LMCache/LMCache/blob/7e4139b7498128b285d6731d578c2572aa08b6da/lmcache/v1/mp_observability/README.md#L27)
- Stale doc location prior to this PR: `docs/source/mp/observability.rst` — `grep -nE "event_bus|EventBus self|queue_depth|drain_lag|dropped_events|subscriber_exception" docs/source/mp/observability.rst` → 0 matches.

### `docs/design/`

No new drift observed. The mirrored design docs (`docs/design/v1/mp_observability/METRICS.md`, `event-bus.md`) were updated in #3167 itself and accurately describe the four metrics, the bus accessors that back them, and the rationale for keeping `event_bus.py` free of OTel imports.

### Other commits checked, no drift

Sweep window: commits on `dev` since the prior drift-check PRs' bases (`89c48d8e` for #3184, `887dbcdf` for #3174's 2026-05-01 commit).

- **#3140** ([Core] Implement serialization / deserialization, merged 2026-05-03) — Adds the brand-new `docs/source/mp/serde.rst` page and a corresponding `docs/design/v1/distributed/l2_adapters/serde_wrapper.md` design doc; the `mp/index.rst` toctree was updated in the same PR. The user-facing reference is in sync with the code (`lmcache/v1/distributed/l2_adapters/serde_wrapper.py`, `lmcache/v1/distributed/serde/`); no drift here.
- **#3182** ([Docs] Move TensorRT-LLM into quickstart as a tab, merged 2026-05-02) — Pure docs PR. Removed `docs/source/integrations/` and updated `docs/source/index.rst` toctree in the same change; no stale references remain (`grep -rE "integrations/(tensorrt|index)" docs/` → 0 matches in user docs; one unrelated mention of "Downstream integrations" in `docs/coding_standards.md`).
- **#3170** ([MP][Fix] S3L2Adapter container credentials via boto3 delegate, merged 2026-05-01) — Bug-fix in the L2 adapter. The user-facing claim in `docs/source/mp/l2_storage.rst` ("Static credentials; omit both to use the AWS default credential provider chain (environment, EC2 instance profile, etc.)") remains technically accurate — the new `boto3` delegate path only kicks in when static keys are absent and `AWS_CONTAINER_CREDENTIALS_FULL_URI` is set. Flagging here for visibility but not as actionable drift; the docs do not promise an `awscrt`-only chain and the listed examples (env / instance profile / etc.) still cover the intended use cases.

## Proposed fix

Applied in this PR. Surgical doc edit only — `docs/source/mp/observability.rst` (+46 / −0):

Added an `EventBus Self-Monitoring` subsection slotted between `Observable Gauges` and `Prometheus Scrape Configuration` (immediately after the in-flight gauges, since these new metrics are also observable / pull-based). The subsection lists the four metrics with their OTel types and attributes, gives operational guidance on how to read `queue_depth` / `drain_lag_seconds` / `dropped_events_total` / `subscriber_exceptions` together, and cross-links back to `docs/design/v1/mp_observability/METRICS.md` and `event-bus.md` for the full rationale. The naming format and table layout mirror the existing `Observable Gauges` and `Engine Counters` sections so the page reads consistently.

## Notes for reviewers

- This was **auto-generated by the daily drift-check routine** and needs human review before merge.
- The author/committer is set to `ApostaC <yihua98@uchicago.edu>` and the commit carries a `Signed-off-by: ApostaC <yihua98@uchicago.edu>` trailer for DCO.
- No code changes — the four metrics are already wired up and emitting whenever observability is enabled. This PR just makes them discoverable on the user-facing observability reference.
- Open drift-check PRs that touch the same `docs/source/mp/observability.rst` file (#3174, #3159) target unrelated sections (Tracing → "Per-Request Hit-Rate Attributes" and a new "Failure & Health Counters" subsection respectively) and do not conflict with this addition. If two of these land before this one, the only rebase work is moving the new subsection into the same insertion neighborhood.

## Test plan

- [ ] `cd docs && make html` builds without new warnings on the `mp/observability.rst` page.
- [ ] Eyeball the rendered "EventBus Self-Monitoring" table; confirm the four rows render and the cross-link to the design doc resolves.
- [ ] Spot-check that the four documented metric names appear on a live `lmcache server` Prometheus scrape: `curl -s :9090/metrics | grep -E 'event_bus_(queue_depth|drain_lag_seconds|dropped_events_total|subscriber_exceptions)'`.
- [ ] Spot-check that the `subscriber_name` attribute on `subscriber_exceptions` carries the failing subscriber's class name (e.g. by registering a deliberately-raising subscriber in a sandbox).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9edPHgJxQvuNGvZnfmCbt)_