### PR TITLE
[Bugfix] Fix S3 L2 adapter listener race

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -878,10 +878,10 @@ class S3L2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_store_tasks[task_id] = success
-        self._store_efd.notify()
 
         if newly_stored_keys:
             self._notify_keys_stored(newly_stored_keys, newly_stored_sizes)
+        self._store_efd.notify()
 
     async def _execute_lookup(
         self,


### PR DESCRIPTION
 **What this PR does / why we need it**:
Fixes an S3 L2 adapter race by firing the store listener before signaling store completion.

**Special notes for your reviewers**:

Validated with S3 L2 adapter tests and full pre-commit.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests