### PR TITLE
[Fix] Change pinned pointer allocations in non-CUDA equivalents to be page-aligned for O_DIRECT

### DIFF
--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -10,6 +10,7 @@ from multiprocessing import shared_memory
 from typing import Optional, Tuple
 import ctypes
 import ctypes.util
+import os
 
 # Third Party
 from numba import njit
@@ -321,25 +322,48 @@ class PageBufferShapeDesc:
         self.block_stride_elems: int = 0
 
 
+# Cuda path goes through func cudaHostAlloc, which is
+# already page aligned by CUDA spec. This fallback shim mirrors that
+# guarantee so consumers that require page-aligned host buffers, in
+# particular the Rust raw-block backend when O_DIRECT is enabled, which
+# requires page-aligned buffer pointer
+try:
+    _PAGE_SIZE = os.sysconf("SC_PAGESIZE")
+except (AttributeError, ValueError, OSError):
+    _PAGE_SIZE = 4096
+
+
+def _alloc_page_aligned_pinned_view(size: int) -> Tuple[torch.Tensor, int]:
+    """
+    Allocate a pinned CPU buffer whose first usable byte is page-aligned,
+    and return a torch view of ``size`` bytes plus its base pointer.
+
+    Internally over-allocates one extra page on a backing tensor, then
+    slices the aligned region out. The slice shares storage with the
+    backing tensor, so keeping the slice alive keeps the underlying
+    memory alive (no need to track the backing tensor separately).
+    """
+    backing = torch.empty(size + _PAGE_SIZE, dtype=torch.uint8, pin_memory=False)
+    # First-touch initialization on the entire backing region
+    backing.fill_(0)
+    base = backing.data_ptr()
+    # Distance from `base` to the next page boundary (0..PAGE_SIZE-1).
+    offset = (-base) % _PAGE_SIZE
+    aligned_view = backing[offset : offset + size]
+    return aligned_view, aligned_view.data_ptr()
+
+
 def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
     """Non-CUDA equivalent of allocating pinned memory with NUMA awareness.
     On XPU, uses pin_memory=True (SYCL USM host allocation) for fast transfers.
     Note: NUMA node selection is not supported on non-CUDA."""
 
-    # Create a 1D uint8 CPU tensor, as uint8 == 1 byte
-    tensor = torch.empty(size, dtype=torch.uint8, pin_memory=False)
-
-    # First-touch initialization (forces physical allocation)
-    tensor.fill_(0)
-
-    # Get a pointer to the start of the tensor object as this is what is
-    # returned by the CUDA equivalent function
-    ptr = tensor.data_ptr()
-
-    # Store the tensor so it can be accessed outide this function scope
-    _tensor_registry[ptr] = tensor
-
-    return ptr
+    view, aligned_ptr = _alloc_page_aligned_pinned_view(size)
+    # view shares storage with its over-allocated backing tensor;
+    # holding the view in the registry transitively keeps the underlying
+    # memory alive.
+    _tensor_registry[aligned_ptr] = view
+    return aligned_ptr
 
 
 def free_pinned_numa_ptr(ptr: int, size: int | None = None) -> None:
@@ -354,20 +378,9 @@ def alloc_pinned_ptr(size: int, device_id: int = 0) -> int:
     to it. On XPU, uses pin_memory=True (SYCL USM host allocation) for
     fast DMA transfers. On other non-CUDA platforms, pinning is not supported."""
 
-    # Create a 1D uint8 CPU tensor, as uint8 == 1 byte
-    tensor = torch.empty(size, dtype=torch.uint8, pin_memory=False)
-
-    # First-touch initialization (forces physical allocation)
-    tensor.fill_(0)
-
-    # Get a pointer to the start of the tensor object as this is what is
-    # returned by the CUDA equivalent function
-    ptr = tensor.data_ptr()
-
-    # Store the tensor so it can be accessed outide this function scope
-    _tensor_registry[ptr] = tensor
-
-    return ptr
+    view, aligned_ptr = _alloc_page_aligned_pinned_view(size)
+    _tensor_registry[aligned_ptr] = view
+    return aligned_ptr
 
 
 def free_pinned_ptr(ptr: int) -> None:

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -2077,11 +2077,15 @@ def test_rust_raw_block_backend_uring_put_get_roundtrip(
                 out = backend.get_blocking(key)
                 assert out is not None, f"Failed to read key {i}"
                 actual_data = bytes(out.byte_array)
-                assert actual_data == expected_data[i], (
-                    f"Data mismatch for key {i}: "
-                    f"expected first bytes {expected_data[i][:16]}, "
-                    f"got {actual_data[:16]}"
-                )
+                # Use `raise AssertionError` instead of `assert ==` so pytest
+                # doesn't try to render a difflib diff between two large
+                # byte arrays on failure (effectively a hang on _fancy_replace).
+                if actual_data != expected_data[i]:
+                    raise AssertionError(
+                        f"Data mismatch for key {i}: "
+                        f"expected first bytes {expected_data[i][:16]!r}, "
+                        f"got {actual_data[:16]!r}"
+                    )
 
         finally:
             backend.close()
@@ -2136,7 +2140,16 @@ def test_rust_raw_block_backend_close_with_inflight(memory_allocator, loop_in_th
             for i, expected in enumerate(buffers):
                 actual = bytearray(payload_len)
                 reader.pread_into(i * payload_len, actual, payload_len, payload_len)
-                assert actual == expected
+                # Use `raise AssertionError` instead of `assert ==` so pytest
+                # doesn't try to render a difflib-based diff between two
+                # large byte arrays on failure, which is O(n^2) on
+                # `_fancy_replace` and effectively never returns.
+                if actual != expected:
+                    raise AssertionError(
+                        f"Data mismatch at offset {i * payload_len}: "
+                        f"expected first bytes {bytes(expected[:16])!r}, "
+                        f"got {bytes(actual[:16])!r}"
+                    )
         finally:
             reader.close()
 

--- a/tests/v1/test_python_ops_fallback.py
+++ b/tests/v1/test_python_ops_fallback.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import Any, Union
+import ctypes
+import os
 import unittest.mock
 
 # Third Party
@@ -1830,3 +1832,38 @@ class TestScenarios:
                         pytest.fail(
                             f"{name}/{key}: '{bid}'={val} != '{base_bid}'={base_val}"
                         )
+
+
+# ==========================================
+# Allocation page alignment
+# ==========================================
+#
+# Rust raw-block backend with O_DIRECT requires page-aligned buffer
+# pointers; CUDA path gets this for free via cudaHostAlloc, and the
+# non-CUDA fallback in lmcache.non_cuda_equivalents shall mirror the same
+# guarantee.
+
+_PINNED_ALLOC_SIZES = [1, 4095, 4096, 8192, 1024 * 1024]
+
+
+@pytest.mark.parametrize("size", _PINNED_ALLOC_SIZES)
+def test_alloc_pinned_ptr_is_page_aligned(size: int) -> None:
+    page_size = os.sysconf("SC_PAGESIZE")
+    ptr = _py_ops.alloc_pinned_ptr(size)
+    try:
+        assert ptr != 0
+        if ptr % page_size != 0:
+            raise AssertionError(
+                f"alloc_pinned_ptr({size}) returned non-page-aligned ptr "
+                f"{hex(ptr)} (page size {page_size})"
+            )
+        # Touch every byte in the requested region through the raw pointer
+        # to confirm the registered view covers the full requested size
+        # (an undersized view would corrupt adjacent memory or segfault).
+        buf = (ctypes.c_uint8 * size).from_address(ptr)
+        for i in range(size):
+            buf[i] = (i & 0xFF) ^ 0xA5
+        for i in range(size):
+            assert buf[i] == ((i & 0xFF) ^ 0xA5)
+    finally:
+        _py_ops.free_pinned_ptr(ptr)


### PR DESCRIPTION
**What this PR does / why we need it**:
  
IO uring tests will fail on a non-cuda environment, while the test limit doesn't ban it.
 
I ran the io_uring tests on a fresh GCP instance and forgot to install the CUDA C++ extension, which caused the tests to fail. Looking into  it, the fallback `alloc_pinned_numa_ptr` for non-CUDA callers returns  a cache-line-aligned pointer instead of a page-aligned one, so this PR adjusts it to return page-aligned pointers.                                                                                           
                                                                                                                                           
 A second issue I hit was in `test_rust_raw_block_backend_close_with_inflight`,  where the test sometimes hangs forever. It looked like a deadlock at first, but gdb showed that pytest's `assert` uses `difflib` to render the diff on failure, and computing a diff between two 64KiB objects  takes forever. I changed those checks to raise exceptions directly so pytest skips the diff step. 
  
  similar issue in pytest been raised before : https://github.com/pytest-dev/pytest/issues/8998
              

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
