### PR TITLE
[CLI[[Bench] Add prefix-suffix-tuner workload for tiered + Blending KV-cache

### DIFF
--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -1,14 +1,21 @@
 # `lmcache bench engine` — Design & Extension Guide
 
-**Status:** Implemented  |  **Date:** 2026-03-27
+**Status:** Implemented  |  **Date:** 2026-05-05
 
 ## Overview
 
 `lmcache bench engine` runs sustained benchmarks against an OpenAI-compatible
-inference engine. It supports multiple workload types that exercise different
+inference engine. It ships five workload types that exercise different
 caching patterns, each controlling its own request scheduling while shared
 modules handle request sending, stats collection, and real-time progress
 display.
+
+If required arguments (`--engine-url`, `--workload`, and either
+`--tokens-per-gb-kvcache` or `--lmcache-url`) are missing, the command drops
+into a guided **interactive TUI** to fill them in. `--config FILE` loads a
+previously-exported JSON config and skips the TUI; `--no-interactive` errors
+out instead of prompting; `--export-config FILE` writes the resolved config
+to JSON and exits without running the benchmark.
 
 ```bash
 # Long-document Q&A (semaphore-controlled concurrency)
@@ -24,6 +31,17 @@ lmcache bench engine --engine-url http://localhost:8000 \
 lmcache bench engine --engine-url http://localhost:8000 \
     --workload random-prefill --tokens-per-gb-kvcache 6000 \
     --rp-num-requests 100
+
+# Long-doc permutator (blended-prefix cache reuse stress test)
+lmcache bench engine --engine-url http://localhost:8000 \
+    --workload long-doc-permutator --tokens-per-gb-kvcache 6000 \
+    --ldp-num-contexts 5 --ldp-num-permutations 20
+
+# Prefix-suffix tuner (tiered KV-cache demonstrator, sequential 2-pass)
+lmcache bench engine --engine-url http://localhost:8000 \
+    --workload prefix-suffix-tuner --tokens-per-gb-kvcache 6000 \
+    --kv-cache-volume 100 --psf-context-length 8000 \
+    --psf-prefix-ratio 0.8 --psf-thrash 1.05
 ```
 
 ---
@@ -41,11 +59,19 @@ lmcache/cli/commands/bench/
     ├── stats.py                   # RequestResult, StatsCollector, FinalStats
     ├── request_sender.py          # RequestSender (async streaming)
     ├── progress.py                # ProgressMonitor (real-time terminal display)
+    ├── interactive/               # Guided TUI for missing-arg resolution
+    │   ├── __init__.py            # run_interactive() entry point
+    │   ├── schema.py              # Field schema + workload-specific items
+    │   ├── state.py               # InteractiveState (load/save JSON, merge CLI args)
+    │   ├── terminal.py            # Terminal rendering primitives
+    │   └── config.json            # Static schema for interactive prompts
     └── workloads/
         ├── __init__.py            # create_workload() factory
         ├── base.py                # BaseWorkload (ABC with run loop)
+        ├── long_doc_permutator.py # LongDocPermutatorConfig + LongDocPermutatorWorkload
         ├── long_doc_qa.py         # LongDocQAConfig + LongDocQAWorkload
         ├── multi_round_chat.py    # MultiRoundChatConfig + Session + MultiRoundChatWorkload
+        ├── prefix_suffix_tuner.py # PrefixSuffixTunerConfig + PrefixSuffixTunerWorkload
         └── random_prefill.py      # RandomPrefillConfig + RandomPrefillWorkload
 ```
 
@@ -247,7 +273,13 @@ instance, and returns it ready to `run()`.
 The orchestrator in `BenchCommand._bench_engine()` wires everything together:
 
 ```
+0. _resolve_args(args)            → argparse.Namespace
+     (a) --config FILE            → load InteractiveState, merge CLI overrides
+     (b) --no-interactive / --export-config → error if required args missing
+     (c) interactive TUI          → if any required arg is missing
+     (d) pass through             → if all required args present
 1. parse_args_to_config(args)     → EngineBenchConfig
+   (--export-config: write JSON and return without running)
 2. StatsCollector()
 3. ProgressMonitor(stats_collector, quiet)
 4. RequestSender(engine_url, model)
@@ -369,6 +401,139 @@ Tests raw prefill throughput by firing all requests simultaneously.
 - **`on_request_finished`:** No-op (stateless).
 - **Termination:** Returns `-1.0` when all tasks are complete.
 
+### 4.4 `long-doc-permutator` — Blended Cache-Reuse Stress Test
+
+Stresses **blended** KV cache reuse — not just prefix reuse — by sending
+permutations of a fixed set of context documents. Each request is:
+
+```
+[System Prompt] + [Doc_i1] + [Doc_i2] + ... + [Doc_iN]
+```
+
+where `(i1, …, iN)` is one permutation of the `N` contexts. Most permutations
+share *some* chunks with prior requests but rarely the same prefix, exercising
+chunk-level cache lookup and eviction.
+
+**Config** (`LongDocPermutatorConfig`):
+
+| Field | CLI arg | Default | Description |
+|-------|---------|---------|-------------|
+| `num_contexts` | `--ldp-num-contexts` | 5 | Number of unique context documents (`N`) |
+| `context_length` | `--ldp-context-length` | 5000 | Tokens per context |
+| `system_prompt_length` | `--ldp-system-prompt-length` | 1000 | Shared system prompt tokens (`0` disables) |
+| `num_permutations` | `--ldp-num-permutations` | 10 | Distinct permutations to send (capped at `N!`) |
+| `vocab_size` | (none — hardcoded in factory) | 8000 | Vocabulary pool size for synthetic context generation |
+| `num_inflight_requests` | `--ldp-num-inflight-requests` | 1 | Max concurrent in-flight requests |
+
+**Stress axes** (each config field tunes one):
+
+| Axis | Knob |
+|------|------|
+| Blended-context boundaries | `num_contexts` |
+| Eviction pressure | `num_permutations` |
+| Chunk homogeneity (hash collisions) | `vocab_size` |
+| Prefix domination | `system_prompt_length` |
+| Concurrency | `num_inflight_requests` |
+
+**Behavior:**
+
+- **Data generation:** Builds a deterministic vocab pool of pseudo-words,
+  generates `num_contexts` distinct contexts (each seeded independently so
+  token sequences truly diverge), and enumerates permutations.
+- **Permutation enumeration:** For small `N`, iterates `itertools.permutations`
+  and truncates. When `N!` is much larger than `num_permutations * 10`, samples
+  random permutations into a `set` to avoid exhausting an enormous search
+  space. Returns all `N!` permutations when `num_permutations >= N!`.
+- **Warmup:** A single dummy request (`max_tokens=1`) to prime the engine.
+- **Dispatch:** Semaphore-controlled — `step()` acquires the semaphore, fires
+  an async task with the next permutation, returns `0.0` for immediate
+  re-call. Once all permutations are dispatched, awaits remaining tasks via
+  `asyncio.wait(FIRST_COMPLETED)`.
+- **`on_request_finished`:** No-op (stateless).
+- **Termination:** Returns `-1.0` when the request list is exhausted and all
+  pending tasks have completed.
+
+**`run()` override:** Unlike the other workloads, `LongDocPermutatorWorkload`
+overrides `BaseWorkload.run()` to close `RequestSender`'s async HTTP client
+inside the same `asyncio.run()` call as the benchmark loop. `asyncio.run()`
+closes the loop on exit, which would orphan any open `httpx` connections;
+closing the client here ensures clean teardown. The orchestrator's subsequent
+`asyncio.run(request_sender.close())` then finds nothing to close and
+completes without error.
+
+### 4.5 `prefix-suffix-tuner` — Tiered KV-Cache Demonstrator
+
+A single sequential workload designed to be run **unchanged** across three
+LMCache configurations to demonstrate the value of each cache tier:
+
+| Baseline | LMCache config | Targeted overflow | Expected pass-2 hits |
+|----------|---------------|-------------------|----------------------|
+| 1 | vanilla vLLM (L0 only) | L0 (HBM) | none — every request a cold prefill |
+| 2 | vLLM + LMCache L1 + L2 | L1 (DRAM) | L2 prefix hits (suffix recomputed) |
+| 3 | vLLM + LMCache L1 + L2 + CacheBlend | L1 (DRAM) | L2 prefix hits + CacheBlend suffix hits |
+
+The user picks `--kv-cache-volume` to match the size of the tier they want to
+overflow (L0 size for Baseline 1, L1 size for Baselines 2 and 3). The
+workload itself does not need to know which baseline it is running.
+
+**Request layout:**
+
+```
+[prefix_i with unique-ID][random breaker][shared suffix]
+```
+
+- `num_prefixes` distinct prefixes — each begins with `PREFIX_<8-hex-digits>`
+  so the prefix's tokenized hash differs even if random bodies collide.
+- A **fresh random breaker** per request (32 tokens by default), defeating
+  ordinary prefix caching past the prefix boundary and preventing
+  non-CacheBlend reuse of the suffix.
+- A **single shared suffix**, deterministic and bit-identical across every
+  request — the only entry CacheBlend can reuse.
+
+**Config** (`PrefixSuffixTunerConfig`):
+
+| Field | CLI arg | Default | Description |
+|-------|---------|---------|-------------|
+| `context_length` | `--psf-context-length` | 8000 | Total tokens per request (prefix + breaker + suffix) |
+| `prefix_ratio` | `--psf-prefix-ratio` | 0.8 | Fraction of context allocated to the prefix; must be in (0.0, 1.0) |
+| `thrash` | `--psf-thrash` | 1.05 | Multiplier on `--kv-cache-volume` sizing the prefix pool |
+| `num_prefixes` | (computed) | — | `floor(kv_cache_volume * thrash * tokens_per_gb / prefix_tokens)` |
+| `prefix_tokens` | (computed) | — | `round(context_length * prefix_ratio)` |
+| `suffix_tokens` | (computed) | — | `context_length - prefix_tokens - breaker_tokens`; errors if `< 100` |
+| `breaker_tokens` | (hardcoded) | 32 | Random breaker length |
+
+**Behavior:**
+
+- **Concurrency:** Strictly sequential, one in-flight request at a time —
+  `step()` awaits each request inline. No semaphore, no concurrent tasks.
+- **Pass 1 (warmup):** Sends each prefix once in pool order using
+  `send_warmup_request` (`max_tokens=1`). Stats are discarded by the base
+  class's `_run_async` after warmup.
+- **Pass 2 (measured):** Sends each prefix once **in identical pool order**
+  with `max_tokens=1`. These are the requests captured in final stats.
+- **Termination:** `step()` returns `-1.0` once `pass2_index` reaches
+  `num_prefixes`.
+
+**Why 1.05× is enough:** With sequential dispatch and LRU eviction in any
+single tier of capacity `K`:
+
+- After pass 1 of `N = 1.05K` prefixes, the `0.05K` oldest accesses have
+  been evicted; L1 holds prefixes `[0.05K..1.05K-1]` in LRU order.
+- Pass 2 access of prefix `0` misses (it was evicted), and serving it
+  evicts the LRU = prefix `0.05K` — *the very next prefix pass 2 will need*.
+- This pattern continues for the whole pass: every access misses the
+  targeted tier and the LRU it evicts is exactly the prefix needed next.
+
+So the workload does not need to overprovision by 2× or more; even a 5%
+overflow is sufficient to drive every measured request to the next tier
+down (Baseline 1 → cold prefill, Baseline 2/3 → L2).
+
+**Pass-1 vs pass-2 breakers:** The breaker is freshly randomized on every
+`_build_messages()` call, so pass 1 and pass 2 use different breakers per
+prefix. This makes the suffix unreachable by ordinary prefix caching even
+within a single benchmark run — exactly the case CacheBlend is designed to
+handle, and exactly what Baseline 3 should improve over Baseline 2.
+
 ---
 
 ## 5. Adding a New Workload
@@ -455,7 +620,7 @@ mw_group.add_argument("--mw-my-param", type=int, default=100, help="...")
 ```
 
 All workload-specific args must be prefixed with a short workload identifier
-(e.g., `ldqa-`, `mrc-`, `rp-`, `mw-`) to avoid name collisions.
+(e.g., `ldqa-`, `ldp-`, `mrc-`, `psf-`, `rp-`, `mw-`) to avoid name collisions.
 
 ### Step 4: Add tests
 

--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -487,12 +487,26 @@ other workloads that size themselves around a user-provided GB budget).
 ```
 
 - `num_prefixes` distinct prefixes — each begins with `PREFIX_<8-hex-digits>`
-  so the prefix's tokenized hash differs even if random bodies collide.
+  so the prefix's chained block hash differs from every other prefix.
 - A **fresh random breaker** per request (32 tokens by default), defeating
   ordinary prefix caching past the prefix boundary and preventing
   non-CacheBlend reuse of the suffix.
 - A **single shared suffix**, deterministic and bit-identical across every
   request — the only entry CacheBlend can reuse.
+
+**Synthetic body generation** uses a vocabulary pool of pseudo-words
+(consonant-vowel patterns + numeric suffix, e.g. `"boko42"`), shared by all
+prefixes / suffix / breakers but sampled with a *different* per-component
+RNG offset. Mirrors `long_doc_permutator`'s approach. This guarantees:
+
+- **CacheBlend correctness**: each prefix samples a different random
+  sequence, so chunk-level content fingerprints don't collide across
+  prefixes and inflate the blend hit rate. The shared suffix is the *only*
+  bit-identical chunk surface CacheBlend can reuse — which is what the
+  workload measures.
+- **Predictable token counts**: pseudo-words tokenize to ~2 BPE tokens on
+  most modern tokenizers (vs. ~3 for raw 6-digit numbers), so the actual
+  prompt length is closer to the configured `context_length`.
 
 **Config** (`PrefixSuffixTunerConfig`):
 

--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -39,9 +39,8 @@ lmcache bench engine --engine-url http://localhost:8000 \
 
 # Prefix-suffix tuner (tiered KV-cache demonstrator, sequential 2-pass)
 lmcache bench engine --engine-url http://localhost:8000 \
-    --workload prefix-suffix-tuner --tokens-per-gb-kvcache 6000 \
-    --kv-cache-volume 100 --psf-context-length 8000 \
-    --psf-prefix-ratio 0.8 --psf-thrash 1.05
+    --workload prefix-suffix-tuner --lmcache-url http://localhost:8080 \
+    --psf-context-length 8000 --psf-prefix-ratio 0.8 --psf-thrash 100
 ```
 
 ---
@@ -472,9 +471,14 @@ LMCache configurations to demonstrate the value of each cache tier:
 | 2 | vLLM + LMCache L1 + L2 | L1 (DRAM) | L2 prefix hits (suffix recomputed) |
 | 3 | vLLM + LMCache L1 + L2 + CacheBlend | L1 (DRAM) | L2 prefix hits + CacheBlend suffix hits |
 
-The user picks `--kv-cache-volume` to match the size of the tier they want to
+The user picks `--psf-thrash` to match the size of the tier they want to
 overflow (L0 size for Baseline 1, L1 size for Baselines 2 and 3). The
-workload itself does not need to know which baseline it is running.
+workload itself does not need to know which baseline it is running — the
+internal `_OVERFLOW_FACTOR` (1.05) sizes the pool slightly larger than the
+named target, and sequential dispatch + LRU does the rest.
+
+`--kv-cache-volume` is unused by this workload (it remains required for
+other workloads that size themselves around a user-provided GB budget).
 
 **Request layout:**
 
@@ -496,11 +500,12 @@ workload itself does not need to know which baseline it is running.
 |-------|---------|---------|-------------|
 | `context_length` | `--psf-context-length` | 8000 | Total tokens per request (prefix + breaker + suffix) |
 | `prefix_ratio` | `--psf-prefix-ratio` | 0.8 | Fraction of context allocated to the prefix; must be in (0.0, 1.0) |
-| `thrash` | `--psf-thrash` | 1.05 | Multiplier on `--kv-cache-volume` sizing the prefix pool |
-| `num_prefixes` | (computed) | — | `floor(kv_cache_volume * thrash * tokens_per_gb / prefix_tokens)` |
+| `thrash` | `--psf-thrash` | 20.0 | **Size in GB of the targeted KV-cache tier** (L0 for Baseline 1, L1 for Baselines 2 and 3). Pool footprint is `thrash * _OVERFLOW_FACTOR` GB. |
+| `num_prefixes` | (computed) | — | `floor(thrash * _OVERFLOW_FACTOR * tokens_per_gb / prefix_tokens)` |
 | `prefix_tokens` | (computed) | — | `round(context_length * prefix_ratio)` |
 | `suffix_tokens` | (computed) | — | `context_length - prefix_tokens - breaker_tokens`; errors if `< 100` |
 | `breaker_tokens` | (hardcoded) | 32 | Random breaker length |
+| `_OVERFLOW_FACTOR` | (module constant) | 1.05 | How much to overflow the targeted tier. Hardcoded at 1.05 because the LRU invariant proves that a 5% overflow is sufficient under sequential same-order replay. |
 
 **Behavior:**
 

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -115,7 +115,8 @@ General Options
    * - ``--workload TYPE``
      - Yes
      - Workload type: ``long-doc-qa``, ``multi-round-chat``,
-       ``long-doc-permutator``, or ``random-prefill``.
+       ``long-doc-permutator``, ``prefix-suffix-tuner``, or
+       ``random-prefill``.
    * - ``--tokens-per-gb-kvcache N``
      - \*
      - Tokens per GB of KV cache. Required unless ``--lmcache-url`` is set.
@@ -308,6 +309,93 @@ dispatched with semaphore-controlled concurrency.
        --ldp-num-inflight-requests 2
 
 
+prefix-suffix-tuner
+~~~~~~~~~~~~~~~~~~~
+
+A two-pass sequential workload designed to be run **unchanged** across
+three LMCache configurations to demonstrate the value of each cache tier
+(L0 HBM, L1 DRAM, L2 disk):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 25 30 30
+
+   * - Baseline
+     - LMCache config
+     - Targeted overflow
+     - Expected pass-2 hits
+   * - 1
+     - vanilla vLLM (L0 only)
+     - L0 (HBM)
+     - none -- every request a cold prefill
+   * - 2
+     - vLLM + LMCache L1 + L2
+     - L1 (DRAM)
+     - L2 prefix hits (suffix recomputed)
+   * - 3
+     - vLLM + LMCache L1 + L2 + CacheBlend
+     - L1 (DRAM)
+     - L2 prefix hits + CacheBlend suffix hits
+
+Set ``--kv-cache-volume`` to the size in GB of the tier you want to overflow
+(L0 size for Baseline 1, L1 size for Baselines 2 and 3). The workload itself
+is identical across baselines.
+
+Each request has the layout::
+
+   [prefix_i with unique-ID][random breaker][shared suffix]
+
+- ``num_prefixes`` distinct prefixes, each starting with ``PREFIX_<8-hex>``
+  so the prefix's tokenized hash differs across the pool.
+- A fresh random 32-token breaker per request, defeating ordinary prefix
+  caching past the prefix boundary.
+- A single shared suffix used by every request -- the only entry CacheBlend
+  can reuse.
+
+Pass 1 (warmup) sends each prefix once to populate the cache; its stats are
+discarded. Pass 2 sends them again in identical order. Because LRU evicts
+the next-needed prefix on each pass-2 access, even a 1.05x overflow of the
+targeted tier is enough to make every pass-2 request miss that tier and
+fall through to the next one.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 10 55
+
+   * - Flag
+     - Default
+     - Description
+   * - ``--psf-context-length``
+     - 8000
+     - Total tokens per request (prefix + breaker + suffix).
+   * - ``--psf-prefix-ratio``
+     - 0.8
+     - Fraction of context-length used by the prefix. Must be in (0.0, 1.0).
+       The remainder (minus a 32-token breaker) is the shared suffix.
+   * - ``--psf-thrash``
+     - 1.05
+     - Multiplier on ``--kv-cache-volume`` that sizes the prefix pool.
+       Values > 1.0 force pass-2 misses; with sequential dispatch and LRU
+       even 1.05 is sufficient.
+
+The number of pass-2 (measured) requests equals the prefix pool size,
+computed as
+``floor(kv_cache_volume * psf_thrash * tokens_per_gb / prefix_tokens)``.
+
+**Example:**
+
+.. code-block:: bash
+
+   lmcache bench engine \
+       --engine-url http://localhost:8000 \
+       --workload prefix-suffix-tuner \
+       --lmcache-url http://localhost:8080 \
+       --kv-cache-volume 100 \
+       --psf-context-length 8000 \
+       --psf-prefix-ratio 0.8 \
+       --psf-thrash 1.05
+
+
 random-prefill
 ~~~~~~~~~~~~~~~
 
@@ -378,6 +466,7 @@ text and number prompts accept typed input with defaults shown in brackets.
      * long-doc-qa           Repeated Q&A over long documents
        multi-round-chat       Multi-turn chat with stateful sessions
        long-doc-permutator    Permutations of context documents
+       prefix-suffix-tuner    Two-pass tiered KV-cache demonstrator
        random-prefill         Prefill-only requests fired simultaneously
 
    LMCache Server

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -398,6 +398,23 @@ by ``--psf-thrash``.
        --psf-prefix-ratio 0.8 \
        --psf-thrash 100
 
+.. note::
+   For the analytical-model claim "thrash ≈ L1 size → ~0% LMCache hit rate"
+   to hold empirically, the LMCache server must be started with
+   ``--eviction-ratio 0.99`` (default ``0.20`` only clears 20% per cycle,
+   leaving ~60% of pass-1 content in cache through pass 2):
+
+   .. code-block:: bash
+
+      lmcache server --l1-size-gb <SIZE> --eviction-policy LRU \
+          --eviction-trigger-watermark 0.80 \
+          --eviction-ratio 0.99
+
+   The workload itself sleeps 5 seconds between pass 1 (warmup) and pass 2
+   (measured), so LMCache's 1Hz batched-eviction polling thread has time
+   to actually run.  Without that sleep, fast benchmarks complete before
+   any eviction fires.
+
 
 random-prefill
 ~~~~~~~~~~~~~~~

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -373,14 +373,18 @@ fall through to the next one.
      - Fraction of context-length used by the prefix. Must be in (0.0, 1.0).
        The remainder (minus a 32-token breaker) is the shared suffix.
    * - ``--psf-thrash``
-     - 1.05
-     - Multiplier on ``--kv-cache-volume`` that sizes the prefix pool.
-       Values > 1.0 force pass-2 misses; with sequential dispatch and LRU
-       even 1.05 is sufficient.
+     - 20.0
+     - **Size in GB of the KV-cache tier to overflow.** Use the L0 (HBM)
+       size for vanilla vLLM, or the L1 (LMCache DRAM) size for tiered
+       baselines. The workload sizes its prefix pool to slightly more than
+       this (5% overflow internally), enough to drive every pass-2 request
+       to a miss of that tier under sequential dispatch + LRU.
 
 The number of pass-2 (measured) requests equals the prefix pool size,
 computed as
-``floor(kv_cache_volume * psf_thrash * tokens_per_gb / prefix_tokens)``.
+``floor(psf_thrash * 1.05 * tokens_per_gb / prefix_tokens)``.
+``--kv-cache-volume`` is unused by this workload — sizing is driven solely
+by ``--psf-thrash``.
 
 **Example:**
 
@@ -390,10 +394,9 @@ computed as
        --engine-url http://localhost:8000 \
        --workload prefix-suffix-tuner \
        --lmcache-url http://localhost:8080 \
-       --kv-cache-volume 100 \
        --psf-context-length 8000 \
        --psf-prefix-ratio 0.8 \
-       --psf-thrash 1.05
+       --psf-thrash 100
 
 
 random-prefill

--- a/docs/source/getting_started/cli.rst
+++ b/docs/source/getting_started/cli.rst
@@ -118,10 +118,14 @@ types:
        --lmcache-url http://localhost:8080 \
        --no-interactive
 
-Three workloads are available:
+Five workloads are available:
 
 - **long-doc-qa** -- repeated Q&A over long documents (tests KV cache reuse).
 - **multi-round-chat** -- multi-turn chat with stateful sessions.
+- **long-doc-permutator** -- permutations of context documents (blended
+  cache reuse stress test).
+- **prefix-suffix-tuner** -- two-pass sequential workload demonstrating
+  tiered KV-cache reuse (L0/L1/L2).
 - **random-prefill** -- prefill-only requests fired simultaneously.
 
 See :doc:`/cli/bench` for full documentation including all workload options,

--- a/lmcache/cli/commands/bench/__init__.py
+++ b/lmcache/cli/commands/bench/__init__.py
@@ -99,6 +99,7 @@ class BenchCommand(BaseCommand):
                 "long-doc-permutator",
                 "long-doc-qa",
                 "multi-round-chat",
+                "prefix-suffix-tuner",
                 "random-prefill",
             ],
             help="Workload type.",
@@ -260,6 +261,34 @@ class BenchCommand(BaseCommand):
             type=float,
             default=60.0,
             help="Benchmark duration in seconds (default: 60).",
+        )
+
+        # --- Prefix-suffix-tuner workload args ---
+        psf_group = parser.add_argument_group(
+            "prefix-suffix-tuner workload options",
+        )
+        psf_group.add_argument(
+            "--psf-context-length",
+            type=int,
+            default=8000,
+            help="Total tokens per request (prefix + breaker + suffix) "
+            "(default: 8000).",
+        )
+        psf_group.add_argument(
+            "--psf-prefix-ratio",
+            type=float,
+            default=0.8,
+            help="Fraction of context-length used by the prefix (default: 0.8). "
+            "Must be in (0.0, 1.0). The remainder (minus a 32-token breaker) is "
+            "the shared suffix.",
+        )
+        psf_group.add_argument(
+            "--psf-thrash",
+            type=float,
+            default=1.05,
+            help="Multiplier on --kv-cache-volume that sizes the prefix pool "
+            "(default: 1.05). Values > 1.0 force pass-2 misses of the targeted "
+            "tier; with sequential dispatch and LRU even 1.05 is sufficient.",
         )
 
         # --- Random-prefill workload args ---

--- a/lmcache/cli/commands/bench/__init__.py
+++ b/lmcache/cli/commands/bench/__init__.py
@@ -285,10 +285,12 @@ class BenchCommand(BaseCommand):
         psf_group.add_argument(
             "--psf-thrash",
             type=float,
-            default=1.05,
-            help="Multiplier on --kv-cache-volume that sizes the prefix pool "
-            "(default: 1.05). Values > 1.0 force pass-2 misses of the targeted "
-            "tier; with sequential dispatch and LRU even 1.05 is sufficient.",
+            default=20.0,
+            help="Size in GB of the KV-cache tier to overflow (default: 20.0). "
+            "The workload sizes its prefix pool to slightly more than this, "
+            "so every pass-2 request misses that tier and falls through to "
+            "the next one. Use the L0 (HBM) size for vanilla vLLM baselines, "
+            "or the L1 (LMCache DRAM) size for tiered baselines.",
         )
 
         # --- Random-prefill workload args ---

--- a/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
+++ b/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
@@ -346,14 +346,15 @@ ALL_ITEMS: list[ConfigItem] = [
     ),
     ConfigItem(
         key="psf_thrash",
-        display_name="Thrash multiplier",
+        display_name="Target tier size (GB)",
         description=(
-            "Multiplier on KV cache volume that sizes the prefix pool. "
-            "Values > 1.0 force pass-2 misses of the targeted tier; even "
-            "1.05 is sufficient with sequential dispatch and LRU."
+            "Size in GB of the KV-cache tier to overflow. The prefix pool "
+            "is sized to slightly more than this, so every pass-2 request "
+            "misses the targeted tier. Use the L0 (HBM) size for vanilla "
+            "vLLM, or the L1 (LMCache DRAM) size for tiered baselines."
         ),
         input_type="float",
-        default=1.05,
+        default=20.0,
         condition=_workload_is("prefix-suffix-tuner"),
         phase=PHASE_WORKLOAD,
     ),

--- a/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
+++ b/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
@@ -112,6 +112,10 @@ ALL_ITEMS: list[ConfigItem] = [
             ),
             ("long-doc-qa", "Repeated Q&A over long documents (tests KV cache reuse)"),
             ("multi-round-chat", "Multi-turn chat with stateful sessions"),
+            (
+                "prefix-suffix-tuner",
+                "Two-pass sequential workload demonstrating tiered KV cache reuse",
+            ),
             ("random-prefill", "Prefill-only requests fired simultaneously"),
         ],
         phase=PHASE_REQUIRED,
@@ -315,6 +319,42 @@ ALL_ITEMS: list[ConfigItem] = [
         input_type="float",
         default=60.0,
         condition=_workload_is("multi-round-chat"),
+        phase=PHASE_WORKLOAD,
+    ),
+    # ── Phase 3: prefix-suffix-tuner ──────────────────────────────────
+    ConfigItem(
+        key="psf_context_length",
+        display_name="Context length (tokens)",
+        description="Total tokens per request (prefix + breaker + suffix).",
+        input_type="int",
+        default=8000,
+        condition=_workload_is("prefix-suffix-tuner"),
+        phase=PHASE_WORKLOAD,
+    ),
+    ConfigItem(
+        key="psf_prefix_ratio",
+        display_name="Prefix ratio",
+        description=(
+            "Fraction of context-length used by the prefix. Must be in "
+            "(0.0, 1.0). The remainder (minus a 32-token breaker) is the "
+            "shared suffix."
+        ),
+        input_type="float",
+        default=0.8,
+        condition=_workload_is("prefix-suffix-tuner"),
+        phase=PHASE_WORKLOAD,
+    ),
+    ConfigItem(
+        key="psf_thrash",
+        display_name="Thrash multiplier",
+        description=(
+            "Multiplier on KV cache volume that sizes the prefix pool. "
+            "Values > 1.0 force pass-2 misses of the targeted tier; even "
+            "1.05 is sufficient with sequential dispatch and LRU."
+        ),
+        input_type="float",
+        default=1.05,
+        condition=_workload_is("prefix-suffix-tuner"),
         phase=PHASE_WORKLOAD,
     ),
     # ── Phase 3: random-prefill ───────────────────────────────────────

--- a/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
@@ -155,6 +155,7 @@ def create_workload(
             stats_collector=stats_collector,
             progress_monitor=progress_monitor,
             seed=config.seed,
+            model_name=config.model,
         )
 
     if config.workload == "random-prefill":

--- a/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
@@ -144,7 +144,6 @@ def create_workload(
 
     if config.workload == "prefix-suffix-tuner":
         psf_workload_config = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=config.kv_cache_volume_gb,
             tokens_per_gb_kvcache=config.tokens_per_gb_kvcache,
             context_length=args.psf_context_length,
             prefix_ratio=args.psf_prefix_ratio,

--- a/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
@@ -30,6 +30,10 @@ from lmcache.cli.commands.bench.engine_bench.workloads.multi_round_chat import (
     MultiRoundChatConfig,
     MultiRoundChatWorkload,
 )
+from lmcache.cli.commands.bench.engine_bench.workloads.prefix_suffix_tuner import (
+    PrefixSuffixTunerConfig,
+    PrefixSuffixTunerWorkload,
+)
 from lmcache.cli.commands.bench.engine_bench.workloads.random_prefill import (
     RandomPrefillConfig,
     RandomPrefillWorkload,
@@ -43,6 +47,8 @@ __all__ = [
     "LongDocQAWorkload",
     "MultiRoundChatConfig",
     "MultiRoundChatWorkload",
+    "PrefixSuffixTunerConfig",
+    "PrefixSuffixTunerWorkload",
     "RandomPrefillConfig",
     "RandomPrefillWorkload",
     "create_workload",
@@ -52,6 +58,7 @@ _WORKLOAD_NAMES = (
     "long-doc-permutator",
     "long-doc-qa",
     "multi-round-chat",
+    "prefix-suffix-tuner",
     "random-prefill",
 )
 
@@ -129,6 +136,22 @@ def create_workload(
         )
         return MultiRoundChatWorkload(
             config=mr_workload_config,
+            request_sender=request_sender,
+            stats_collector=stats_collector,
+            progress_monitor=progress_monitor,
+            seed=config.seed,
+        )
+
+    if config.workload == "prefix-suffix-tuner":
+        psf_workload_config = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=config.kv_cache_volume_gb,
+            tokens_per_gb_kvcache=config.tokens_per_gb_kvcache,
+            context_length=args.psf_context_length,
+            prefix_ratio=args.psf_prefix_ratio,
+            thrash=args.psf_thrash,
+        )
+        return PrefixSuffixTunerWorkload(
+            config=psf_workload_config,
             request_sender=request_sender,
             stats_collector=stats_collector,
             progress_monitor=progress_monitor,

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -64,6 +64,13 @@ _MAX_OUTPUT_TOKENS = 1
 # bench-engine.md`` §4.5 for the analysis.
 _OVERFLOW_FACTOR = 1.05
 
+# Range of token-IDs to sample when generating random body content.  Skip
+# the low region (byte fallback / special tokens) and the high tail
+# (reserved / added tokens, which are rarely 1-token-clean on round-trip).
+# 256–50000 is safe across Llama, Qwen, MiniMax tokenizers.
+_TOKEN_ID_LO = 256
+_TOKEN_ID_HI = 50000
+
 
 @dataclass
 class PrefixSuffixTunerConfig:
@@ -196,77 +203,123 @@ class PrefixSuffixTunerConfig:
 # ---------------------------------------------------------------------------
 
 
-def _generate_prefix(index: int, num_tokens: int) -> str:
-    """Generate a prefix: unique ID header + ``"hi"`` filler body.
+def _try_load_tokenizer(model_name: str | None):
+    """Best-effort load of the model's tokenizer.
 
-    The body is identical across all prefixes (a stream of ``"hi"`` tokens),
-    but the **unique ID header** at the start makes the prefix's chained
-    block hash unique per ``index``.  Combined with vLLM's chain-hashed
-    prefix cache, this means:
+    Used to generate body content as random valid token-IDs, then decoded
+    back to text — guaranteeing both (a) configured token counts ≈ actual
+    tokens at the model and (b) different content per call site, so chunk
+    content-hashes don't collide across prefixes (which would inflate the
+    LMCache hit rate even in non-blend mode).
 
-    - Prefix cache does **not** false-hit across prefixes (chain hash
-      diverges from block 0).
-    - CacheBlend, which uses content hashing, *will* report cross-prefix
-      hits on the body chunks — that is exactly what blend does, and is
-      consistent with the analytical model's assumption that Baseline 3
-      achieves full-context blend coverage.
+    Returns ``None`` if ``transformers`` isn't installed or the tokenizer
+    can't be loaded; callers fall back to the deterministic ``"hi"``
+    filler in that case.
+    """
+    if model_name is None:
+        return None
+    try:
+        # Third Party
+        from transformers import AutoTokenizer
+    except ImportError:
+        logger.warning("transformers not available; falling back to 'hi' body filler")
+        return None
+    try:
+        return AutoTokenizer.from_pretrained(model_name)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Could not load tokenizer for %s (%s); falling back to 'hi' filler",
+            model_name,
+            e,
+        )
+        return None
 
-    Using ``"hi"`` for the body gives exact 1:1 word-to-BPE-token mapping
-    on every modern tokenizer, so the configured ``num_tokens`` matches
-    what the model actually sees within the unique-ID overhead.
+
+def _generate_random_body(num_tokens: int, tokenizer, rng: random.Random) -> str:
+    """Build a body of ``num_tokens`` BPE tokens of unique random content.
+
+    Samples random token-IDs in the safe range and decodes them.  The
+    decoded text re-tokenizes to (≈) ``num_tokens`` tokens (small drift
+    from BPE merge boundaries) and is *content-unique* per call because
+    the IDs are independent draws from ``rng``.
+
+    Falls back to ``"hi"`` filler when ``tokenizer`` is None.
+    """
+    if tokenizer is None:
+        return " ".join(["hi"] * num_tokens)
+    ids = [rng.randrange(_TOKEN_ID_LO, _TOKEN_ID_HI) for _ in range(num_tokens)]
+    return tokenizer.decode(ids, skip_special_tokens=True)
+
+
+def _generate_prefix(
+    index: int,
+    num_tokens: int,
+    tokenizer,
+    rng: random.Random,
+) -> str:
+    """Generate a prefix with unique-ID header + per-prefix random body.
+
+    The unique-ID header makes the prefix's chained block hash unique per
+    ``index`` (so vLLM's chain-hashed prefix cache distinguishes prefixes).
+    The random body uses different token-IDs per ``index`` because
+    ``rng`` is a per-prefix state, so chunk content-hashes don't collide
+    across prefixes — required for non-blend cache hit-rate metrics to be
+    meaningful.
 
     Args:
         index: Zero-based prefix index; encoded into the unique ID.
         num_tokens: Approximate target token length of the full prefix.
+        tokenizer: The model's tokenizer, or None for fallback.
+        rng: Per-prefix seeded random source.
 
     Returns:
         Prefix text starting with ``"PREFIX_<8-hex-digits>"``.
     """
     unique_id = f"PREFIX_{index:08x}"
     body_words = max(num_tokens - _UNIQUE_ID_TOKENS, 1)
-    body = " ".join(["hi"] * body_words)
+    body = _generate_random_body(body_words, tokenizer, rng)
     return f"{unique_id} {body}"
 
 
-def _generate_suffix(num_tokens: int) -> str:
+def _generate_suffix(num_tokens: int, tokenizer, rng: random.Random) -> str:
     """Generate the single shared suffix used by every request.
 
-    The suffix is bit-identical across all requests; its content-hash
-    fingerprints are what CacheBlend reuses across requests — the property
-    Baseline 3 measures.
+    The suffix is bit-identical across all requests by design — its
+    content-hash fingerprints are the only ones CacheBlend can reuse
+    across the full pool, which is exactly what Baseline 3 measures.
 
     Args:
         num_tokens: Approximate target token length.
+        tokenizer: The model's tokenizer, or None for fallback.
+        rng: Seeded random source (deterministic seed → reproducible).
 
     Returns:
         Suffix text starting with ``"SUFFIX"``.
     """
-    body = " ".join(["hi"] * max(num_tokens - 1, 1))
+    body_words = max(num_tokens - 1, 1)
+    body = _generate_random_body(body_words, tokenizer, rng)
     return f"SUFFIX {body}"
 
 
-def _generate_breaker(num_tokens: int, rng: random.Random) -> str:
-    """Generate a per-request breaker with a unique header + ``"hi"`` filler.
+def _generate_breaker(num_tokens: int, tokenizer, rng: random.Random) -> str:
+    """Generate a per-request breaker of fresh random tokens.
 
-    The breaker has a small unique random header (so the chained block
-    hash diverges between requests with the same prefix), plus ``"hi"``
-    filler for accurate token counting.  This (a) defeats ordinary prefix
-    caching past the prefix boundary, and (b) ensures the chained block
-    hashes leading into the suffix differ between requests — so the
-    suffix is only reachable via CacheBlend's content-based lookup, not
-    by chained prefix-cache.
+    Sampled fresh per request: each request's breaker tokens differ both
+    in IDs (defeats chained prefix cache past the prefix boundary) and in
+    chunk content-hash (so non-blend caches don't carry breaker hits over
+    from earlier requests).
 
     Args:
         num_tokens: Approximate target token length.
-        rng: Seeded random source.  Each call advances state, so
-            successive requests get different breaker headers.
+        tokenizer: The model's tokenizer, or None for fallback.
+        rng: Seeded random source.  Each call advances state.
 
     Returns:
-        A breaker string starting with a 4-token-ish ``"BR_<8-hex>"`` ID.
+        A breaker string with header + random body.
     """
     unique_id = f"BR_{rng.randrange(2**32):08x}"
     body_words = max(num_tokens - _UNIQUE_ID_TOKENS, 1)
-    body = " ".join(["hi"] * body_words)
+    body = _generate_random_body(body_words, tokenizer, rng)
     return f"{unique_id} {body}"
 
 
@@ -291,22 +344,36 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
         stats_collector: StatsCollector,
         progress_monitor: ProgressMonitor,
         seed: int = 42,
+        model_name: str | None = None,
     ) -> None:
         super().__init__(request_sender, stats_collector, progress_monitor)
         self._config = config
         self._seed = seed
 
-        # Body filler is plain ``"hi"`` — 1 BPE token per word on every
-        # modern tokenizer, so configured token counts match what the model
-        # actually sees.  Cross-prefix uniqueness comes from the unique
-        # header injected at the start of each prefix; vLLM's prefix-cache
-        # chain hashing then makes every subsequent block of "hi"s also
-        # unique to its prefix.  See _generate_prefix docstring.
+        # Best-effort tokenizer load: when available, body content is
+        # generated as random valid token-IDs decoded back to text — that
+        # gives both (a) ~exact configured token count at the model (no
+        # tokenizer-expansion factor) and (b) content uniqueness per
+        # prefix so non-blend cache hit-rate metrics are not inflated by
+        # chunk content-hash collisions across prefixes.  Falls back to
+        # ``"hi"`` filler if transformers / the tokenizer isn't loadable.
+        self._tokenizer = _try_load_tokenizer(model_name)
+
+        # Each prefix gets its own RNG state so per-prefix bodies differ.
+        # Constant offsets keep reproducibility while leaving room for the
+        # suffix (seed + 1) and breaker (seed + 2) RNGs.
         self._prefixes: list[str] = [
-            _generate_prefix(i, config.prefix_tokens)
+            _generate_prefix(
+                i,
+                config.prefix_tokens,
+                self._tokenizer,
+                random.Random(seed + 1000 + i),
+            )
             for i in range(config.num_prefixes)
         ]
-        self._suffix: str = _generate_suffix(config.suffix_tokens)
+        self._suffix: str = _generate_suffix(
+            config.suffix_tokens, self._tokenizer, random.Random(seed + 1)
+        )
         self._breaker_rng = random.Random(seed + 2)
 
         self._pass2_index = 0
@@ -356,7 +423,9 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
             A single-message chat list.
         """
         prefix = self._prefixes[prefix_index]
-        breaker = _generate_breaker(self._config.breaker_tokens, self._breaker_rng)
+        breaker = _generate_breaker(
+            self._config.breaker_tokens, self._tokenizer, self._breaker_rng
+        )
         content = f"{prefix} {breaker} {self._suffix}"
         return [{"role": "user", "content": content}]
 

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -56,6 +56,14 @@ _MIN_SUFFIX_TOKENS = 100
 _UNIQUE_ID_TOKENS = 4  # rough token count for ``PREFIX_<8-hex-digits>``
 _MAX_OUTPUT_TOKENS = 1
 
+# Internal multiplier on ``thrash`` GB to size the prefix pool.  Set to 1.05
+# (a 5% overflow) because — with sequential pass-1/pass-2 dispatch and LRU
+# eviction — even a 5% overflow is sufficient to evict the next-needed
+# prefix on every pass-2 access, ensuring all pass-2 requests miss the
+# targeted tier.  See ``docs/design/cli/commands/bench/engine_bench/
+# bench-engine.md`` §4.5 for the analysis.
+_OVERFLOW_FACTOR = 1.05
+
 
 @dataclass
 class PrefixSuffixTunerConfig:
@@ -64,10 +72,13 @@ class PrefixSuffixTunerConfig:
     Attributes:
         context_length: Total tokens per request (prefix + breaker + suffix).
         prefix_ratio: Fraction of ``context_length`` allocated to the prefix.
-        thrash: Multiplier on ``--kv-cache-volume`` that determines the
-            total prefix-pool footprint.  Values just above 1.0 (e.g.
-            1.05) are sufficient to force pass-2 misses of the targeted
-            tier given sequential dispatch and LRU eviction.
+        thrash: Size in GB of the KV-cache tier the workload should overflow
+            (L0 / vLLM HBM for Baseline 1; L1 / LMCache DRAM for Baselines
+            2 and 3).  The prefix pool is sized to ``thrash *
+            _OVERFLOW_FACTOR`` GB internally — i.e., just barely larger than
+            the targeted tier — which is sufficient under sequential
+            dispatch and LRU to ensure every pass-2 request misses that
+            tier.
         num_prefixes: Number of distinct prefixes generated (computed by
             :meth:`resolve` from the cache budget).
         prefix_tokens: Token length of each prefix (computed).
@@ -78,7 +89,7 @@ class PrefixSuffixTunerConfig:
 
     context_length: int = 8000
     prefix_ratio: float = 0.8
-    thrash: float = 1.05
+    thrash: float = 20.0
     num_prefixes: int = 1
     prefix_tokens: int = 1
     suffix_tokens: int = 1
@@ -93,8 +104,8 @@ class PrefixSuffixTunerConfig:
             raise ValueError(
                 f"prefix_ratio must be in (0.0, 1.0), got {self.prefix_ratio}"
             )
-        if self.thrash < 1.0:
-            raise ValueError(f"thrash must be >= 1.0, got {self.thrash}")
+        if self.thrash <= 0.0:
+            raise ValueError(f"thrash (GB) must be positive, got {self.thrash}")
         if self.num_prefixes < 1:
             raise ValueError(f"num_prefixes must be >= 1, got {self.num_prefixes}")
         if self.prefix_tokens < 1:
@@ -107,33 +118,32 @@ class PrefixSuffixTunerConfig:
     @classmethod
     def resolve(
         cls,
-        kv_cache_volume_gb: float,
         tokens_per_gb_kvcache: int,
         context_length: int = 8000,
         prefix_ratio: float = 0.8,
-        thrash: float = 1.05,
+        thrash: float = 20.0,
         breaker_tokens: int = _BREAKER_TOKENS,
     ) -> "PrefixSuffixTunerConfig":
-        """Compute ``num_prefixes`` and token splits from the cache budget.
+        """Compute ``num_prefixes`` and token splits from the target tier size.
 
         ``num_prefixes`` is sized so that the total prefix-pool footprint
-        in tokens equals ``kv_cache_volume_gb * thrash * tokens_per_gb_kvcache``.
-        With ``thrash`` slightly above 1.0, the pool just barely overflows the
-        targeted KV-cache tier; with sequential dispatch and LRU eviction,
-        this is sufficient to evict the next-needed prefix on every pass-2
-        access, ensuring all pass-2 requests miss the targeted tier.
+        in tokens equals
+        ``thrash * _OVERFLOW_FACTOR * tokens_per_gb_kvcache``.  ``thrash``
+        is the **size of the targeted KV-cache tier in GB**; the internal
+        :data:`_OVERFLOW_FACTOR` (1.05) provides the small overflow needed
+        for the LRU invariant to drive every pass-2 access to a miss of
+        that tier.
 
         Args:
-            kv_cache_volume_gb: Size of the KV-cache tier the workload
-                should overflow (e.g. L0 for Baseline 1, L1 for Baselines
-                2 and 3).
             tokens_per_gb_kvcache: Tokens fitting in 1 GB of KV cache for
-                the served model.
+                the served model (auto-detected from the engine in
+                ``parse_args_to_config``; user need not supply directly).
             context_length: Total tokens per request.
             prefix_ratio: Fraction of ``context_length`` allocated to the
                 prefix.  Must be strictly between 0 and 1.
-            thrash: Multiplier on ``kv_cache_volume_gb`` for sizing the
-                prefix pool.  Defaults to 1.05.
+            thrash: Size of the targeted KV-cache tier in GB.  Defaults
+                to 20.0 GB (typical L0 size for a single H100 with low
+                ``--gpu-memory-utilization``).
             breaker_tokens: Token length of the random breaker between
                 prefix and suffix.  Defaults to 32.
 
@@ -154,17 +164,19 @@ class PrefixSuffixTunerConfig:
                 f"increase context_length"
             )
 
-        target_gb = kv_cache_volume_gb * thrash
+        pool_gb = thrash * _OVERFLOW_FACTOR
         num_prefixes = max(
-            int(target_gb * tokens_per_gb_kvcache / prefix_tokens),
+            int(pool_gb * tokens_per_gb_kvcache / prefix_tokens),
             1,
         )
         logger.debug(
-            "Computed num_prefixes=%d from kv_cache_volume_gb=%.2f, "
-            "thrash=%.3f, tokens_per_gb_kvcache=%d, prefix_tokens=%d",
+            "Computed num_prefixes=%d from thrash=%.2f GB (target tier), "
+            "_OVERFLOW_FACTOR=%.3f -> pool=%.2f GB, "
+            "tokens_per_gb_kvcache=%d, prefix_tokens=%d",
             num_prefixes,
-            kv_cache_volume_gb,
             thrash,
+            _OVERFLOW_FACTOR,
+            pool_gb,
             tokens_per_gb_kvcache,
             prefix_tokens,
         )
@@ -305,7 +317,9 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
             f"  Prefix tokens:     {Y}{c.prefix_tokens}{R} (ratio={c.prefix_ratio})\n"
             f"  Breaker tokens:    {Y}{c.breaker_tokens}{R} (random per request)\n"
             f"  Suffix tokens:     {Y}{c.suffix_tokens}{R} (shared, deterministic)\n"
-            f"  Thrash multiplier: {Y}{c.thrash}{R}\n"
+            f"  Target tier:       {Y}{c.thrash:.2f} GB{R}"
+            f" (overflow x{_OVERFLOW_FACTOR:.2f} = "
+            f"{c.thrash * _OVERFLOW_FACTOR:.2f} GB)\n"
             f"  Prefix pool size:  {Y}{c.num_prefixes}{R}\n"
             f"  Pool tokens:       {Y}{pool_tokens_millions:.2f}M{R}\n"
             f"  Total measured:    {Y}{c.num_prefixes}{R} requests "

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -36,6 +36,89 @@ Two passes run sequentially, one request at a time, in identical order:
     the next-needed prefix on each pass-2 access, even a 1.05× overflow of
     the targeted tier is enough to ensure every pass-2 request misses that
     tier and falls through to the next one.
+
+Debug Guide
+-----------
+
+When per-pass-2 hit rates don't match the analytical model, work through
+this checklist in order — the failure modes I hit while debugging this
+workload are listed in the order they actually surfaced.
+
+**1. Disable vLLM L0 prefix caching during the measurement run.**
+   With ``--enable-prefix-caching`` on vLLM, vLLM serves chunks from its
+   own HBM cache without asking LMCache, dropping
+   ``lmcache_mp_lookup_requested_tokens_total`` for the chunks vLLM
+   already had.  This makes the LMCache hit-rate metric look artificially
+   low and obscures the actual L1 behavior.  For *measuring LMCache*,
+   start vLLM with ``--no-enable-prefix-caching``.  Re-enable it for end-
+   to-end latency runs.
+
+**2. Restart LMCache between every comparison run.**
+   Prefixes are deterministic by index (``PREFIX_<8-hex-digits>``).  If a
+   previous run stored ``prefix_0``, the next run finds it already in L1
+   at pass-1 — pass 1 hits cache instead of cold-storing, biasing the
+   pass-2 hit rate upward.  Always restart the LMCache server with a
+   fresh L1 between back-to-back runs.
+
+**3. Configure LMCache eviction aggressively for thrash tests.**
+   LMCache's L1 eviction is a 1Hz polling background thread that fires
+   only when ``usage >= --eviction-trigger-watermark`` and clears
+   ``--eviction-ratio`` of contents per cycle.  Defaults
+   (``watermark=0.80``, ``ratio=0.20``) only drop usage from 80 % to 60 %
+   per fire — leaving 60 % of pass-1 content surviving into pass 2.  For
+   tests that expect ``thrash → ~0% hit rate``, start the server with::
+
+       lmcache server --l1-size-gb <SIZE> --eviction-policy LRU \\
+           --eviction-trigger-watermark 0.80 \\
+           --eviction-ratio 0.99
+
+   The 0.99 ratio means each fire clears nearly the whole cache; combined
+   with the workload's built-in 5-second pass-1→pass-2 settle delay, this
+   approximates a strict-LRU sequential thrash.
+
+**4. Watch the right metrics.**
+   ``GET <lmcache-url>/metrics`` exposes Prometheus counters.  Snapshot
+   before and after the run, take the delta::
+
+       lmcache_mp_lookup_requested_tokens_total   # both passes
+       lmcache_mp_lookup_hit_tokens_total          # both passes (L1+L2)
+       lmcache_mp_l1_eviction_loop_ticks_total     # 1 per loop cycle
+       lmcache_mp_l1_eviction_loop_triggered_total # only when above watermark
+
+   ``triggered/ticks`` should be > 0 for any thrash test.  If it's 0, the
+   benchmark completed before any eviction fired — see (3).  For blend
+   tests, also pull ``lmcache_blend_lookup_{requested,hit}_tokens_total``.
+
+**5. Convert aggregate metrics to per-pass-2 hit rate.**
+   The Prometheus counters tally pass-1 *and* pass-2 lookups, so
+   ``hit_tokens_total / requested_tokens_total`` is roughly *half* the
+   per-pass-2 hit rate (pass 1 contributes cold misses).  The right
+   conversion is::
+
+       per_pass2_hit_rate = hit_tokens_total / (requested_tokens_total / 2)
+
+   when pass 1 has ~0 hits (the typical case for a fresh LMCache).  Use
+   ``num_prefixes`` from the workload's ``log_config`` output to verify
+   the lookup count: ``ticks_total ≈ run_duration_seconds`` and
+   ``requested_tokens_total / chunks_per_request / chunk_size_tokens
+   == 2 * num_prefixes``.
+
+**6. Check pool sizing matches L1 capacity.**
+   The workload sizes ``num_prefixes`` so the pool's *full* per-request
+   KV footprint (``num_prefixes * context_length * tokens_per_gb_kvcache``)
+   equals ``thrash * 1.05`` GB.  If this doesn't match the L1 size you
+   started LMCache with, the test is over- or under-provisioned.  Hit
+   ``GET <lmcache-url>/api/status`` and verify
+   ``storage_manager.l1_manager.memory_total_bytes / 2**30`` matches your
+   ``--psf-thrash`` value.
+
+**7. Per-request CSV breakdown.**
+   ``--output-dir <DIR>`` writes ``bench_results.csv`` with TTFT per
+   pass-2 request.  Sort by request index — under sequential thrash,
+   *early* prefix indices should miss (slow TTFT) and *late* indices
+   should hit (fast TTFT).  Uniform TTFT across all requests means the
+   pool doesn't actually thrash — usually a sign that pass 1 finished
+   before any eviction fired (see step 3 again).
 """
 
 # Standard

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -64,6 +64,17 @@ _MAX_OUTPUT_TOKENS = 1
 # bench-engine.md`` §4.5 for the analysis.
 _OVERFLOW_FACTOR = 1.05
 
+# Seconds to sleep between pass 1 (warmup) and pass 2 (measured).  LMCache's
+# L1 eviction is a 1Hz polling thread that fires only when usage > watermark
+# (default 0.80) — meaning a fast warmup that overflows L1 by a few percent
+# may complete before any eviction has actually run.  Without this settle
+# delay, pass 2 would find all of pass 1's data still in cache, and the
+# user's analytical-model claim "thrash → 0% hit rate" would not hold.
+# 5 seconds covers several eviction polls (each evicts ``--eviction-ratio``
+# fraction of contents), letting the cache reach steady state under the
+# overflow before pass 2 measures.
+_EVICTION_SETTLE_SECONDS = 5.0
+
 # Range of token-IDs to sample when generating random body content.  Skip
 # the low region (byte fallback / special tokens) and the high tail
 # (reserved / added tokens, which are rarely 1-token-clean on round-trip).
@@ -171,21 +182,29 @@ class PrefixSuffixTunerConfig:
                 f"increase context_length"
             )
 
+        # Size by full context_length, not prefix_tokens: each request
+        # stores ``context_length`` tokens worth of KV cache (prefix +
+        # breaker + suffix), so the pool's L1 footprint is
+        # ``num_prefixes * context_length``, not ``num_prefixes *
+        # prefix_tokens``.  Earlier versions divided by prefix_tokens,
+        # which made the actual pool footprint exceed the requested target
+        # by ``1 / prefix_ratio`` — at ``prefix_ratio=0.5`` the pool was
+        # 2x the user's intended target.
         pool_gb = thrash * _OVERFLOW_FACTOR
         num_prefixes = max(
-            int(pool_gb * tokens_per_gb_kvcache / prefix_tokens),
+            int(pool_gb * tokens_per_gb_kvcache / context_length),
             1,
         )
         logger.debug(
             "Computed num_prefixes=%d from thrash=%.2f GB (target tier), "
             "_OVERFLOW_FACTOR=%.3f -> pool=%.2f GB, "
-            "tokens_per_gb_kvcache=%d, prefix_tokens=%d",
+            "tokens_per_gb_kvcache=%d, context_length=%d",
             num_prefixes,
             thrash,
             _OVERFLOW_FACTOR,
             pool_gb,
             tokens_per_gb_kvcache,
-            prefix_tokens,
+            context_length,
         )
         return cls(
             context_length=context_length,
@@ -434,7 +453,15 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
     # ------------------------------------------------------------------
 
     async def warmup(self) -> None:
-        """Run pass 1: send each prefix once sequentially to populate cache."""
+        """Run pass 1: send each prefix once sequentially to populate cache.
+
+        After dispatching all warmup requests, sleeps for
+        :data:`_EVICTION_SETTLE_SECONDS` so LMCache's batched-eviction LRU
+        (1Hz background poll, evicts only when usage > watermark) has time
+        to actually run.  Without this delay, a fast warmup that overflows
+        L1 by a few percent may complete before any eviction fires, and
+        pass 2 would then find all of pass 1's data still in cache.
+        """
         n = self._config.num_prefixes
         self._progress_monitor.log_message(f"Pass 1 (warmup): {n} requests")
         for i in range(n):
@@ -451,8 +478,13 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
                     f"Pass 1 {request_id} failed: {result.error}"
                 )
         self._progress_monitor.log_message(
-            f"Pass 1 complete: {n} prefixes populated",
+            f"Pass 1 complete: {n} prefixes populated; "
+            f"settling {_EVICTION_SETTLE_SECONDS:.1f}s for LMCache LRU eviction",
         )
+        # Standard
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(_EVICTION_SETTLE_SECONDS)
 
     # ------------------------------------------------------------------
     # Pass 2 — measured benchmark

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -196,72 +196,126 @@ class PrefixSuffixTunerConfig:
 # ---------------------------------------------------------------------------
 
 
-def _random_word_stream(rng: random.Random, count: int) -> str:
-    """Return ``count`` space-separated random tokens drawn from *rng*.
+_VOCAB_POOL_SIZE = 8000
 
-    Uses 6-digit zero-padded random integers so each token tokenizes to
-    roughly one BPE token across most tokenizers, keeping the generated
-    text close to the requested token count.
+
+def _generate_vocab_pool(size: int, seed: int) -> list[str]:
+    """Generate a deterministic pool of ``size`` unique pseudo-words.
+
+    Words follow a consonant-vowel pattern (e.g. ``"boko42"``, ``"rida71"``)
+    with a numeric uniqueness suffix.  Mirrors the approach used by
+    :mod:`long_doc_permutator` so that:
+
+    - **Token counts** are reasonably close to the configured target — each
+      pseudo-word tokenizes to ~2 BPE tokens on common tokenizers (vs. 3+
+      for raw 6-digit numbers), giving a smaller and more consistent
+      expansion factor.
+    - **CacheBlend** does not get false hits across prefixes: each prefix
+      samples a *different* random sequence from the pool, so chunk-level
+      content fingerprints virtually never collide between prefixes.
 
     Args:
+        size: Number of unique pseudo-words to generate.
+        seed: Deterministic seed for the pool.
+
+    Returns:
+        Sorted list of unique pseudo-words.
+    """
+    rng = random.Random(seed)
+    vowels = "aeiou"
+    consonants = "bcdfghjklmnpqrstvwxyz"
+    pool: set[str] = set()
+    while len(pool) < size:
+        length = rng.randint(3, 7)
+        word = "".join(
+            rng.choice(consonants) if j % 2 == 0 else rng.choice(vowels)
+            for j in range(length)
+        )
+        pool.add(f"{word}{len(pool)}")
+    return sorted(pool)
+
+
+def _sample_words(pool: list[str], rng: random.Random, count: int) -> str:
+    """Return ``count`` space-separated words sampled (with replacement) from *pool*.
+
+    Args:
+        pool: Vocabulary pool.
         rng: Seeded random source.
         count: Number of words to emit.
 
     Returns:
         A single space-joined string.
     """
-    return " ".join(f"{rng.randrange(1_000_000):06d}" for _ in range(count))
+    return " ".join(rng.choices(pool, k=count))
 
 
-def _generate_prefix(index: int, num_tokens: int, rng: random.Random) -> str:
+def _generate_prefix(
+    index: int,
+    num_tokens: int,
+    pool: list[str],
+    rng: random.Random,
+) -> str:
     """Generate a prefix that begins with a unique ID.
 
+    Each prefix samples a different random sequence from the shared vocab
+    pool; combined with the unique ID header, this makes both prefix-cache
+    chained block hashes and CacheBlend chunk fingerprints unique across
+    prefixes.
+
     Args:
-        index: Zero-based prefix index; encoded into the unique ID so the
-            prefix's tokenized hash differs from every other prefix even
-            if random bodies collide.
+        index: Zero-based prefix index; encoded into the unique ID.
         num_tokens: Approximate target token length of the full prefix.
-        rng: Seeded random source for the body.
+        pool: Shared vocab pool.
+        rng: Per-prefix seeded random source (caller passes a distinct
+            RNG state per index so bodies differ across prefixes).
 
     Returns:
         Prefix text starting with ``"PREFIX_<8-hex-digits>"``.
     """
     unique_id = f"PREFIX_{index:08x}"
     body_words = max(num_tokens - _UNIQUE_ID_TOKENS, 1)
-    body = _random_word_stream(rng, body_words)
+    body = _sample_words(pool, rng, body_words)
     return f"{unique_id} {body}"
 
 
-def _generate_suffix(num_tokens: int, rng: random.Random) -> str:
+def _generate_suffix(num_tokens: int, pool: list[str], rng: random.Random) -> str:
     """Generate the single shared suffix used by every request.
+
+    The suffix is bit-identical across all requests; its chunk fingerprints
+    are therefore the only entries CacheBlend can reuse — which is exactly
+    what the workload measures.
 
     Args:
         num_tokens: Approximate target token length.
-        rng: Seeded random source.
+        pool: Shared vocab pool.
+        rng: Seeded random source (deterministic seed produces a
+            reproducible suffix).
 
     Returns:
         Suffix text starting with ``"SUFFIX"``.
     """
-    body = _random_word_stream(rng, max(num_tokens - 1, 1))
+    body = _sample_words(pool, rng, max(num_tokens - 1, 1))
     return f"SUFFIX {body}"
 
 
-def _generate_breaker(num_tokens: int, rng: random.Random) -> str:
+def _generate_breaker(num_tokens: int, pool: list[str], rng: random.Random) -> str:
     """Generate a fresh random breaker for one request.
 
-    The breaker sits between prefix and suffix; its randomness defeats
-    ordinary prefix caching past the prefix boundary and prevents
-    non-CacheBlend reuse of the suffix.
+    Sampled fresh per request from the vocab pool, so each request has a
+    unique sequence of breaker tokens.  This (a) defeats ordinary prefix
+    caching past the prefix boundary, and (b) ensures the chained block
+    hashes leading into the suffix differ between requests, so the suffix
+    is only reachable via CacheBlend's content-based chunk lookup.
 
     Args:
         num_tokens: Approximate target token length.
-        rng: Seeded random source.  Each call advances state, so successive
-            requests get different breakers.
+        pool: Shared vocab pool.
+        rng: Seeded random source.  Each call advances state.
 
     Returns:
         A space-joined random token string.
     """
-    return _random_word_stream(rng, num_tokens)
+    return _sample_words(pool, rng, num_tokens)
 
 
 # ---------------------------------------------------------------------------
@@ -290,13 +344,29 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
         self._config = config
         self._seed = seed
 
-        prefix_rng = random.Random(seed)
+        # Shared vocab pool — sampled by every prefix (with a different
+        # per-prefix RNG offset), the suffix, and per-request breakers.
+        # Same word inventory across all components, but per-component
+        # samples differ so chunk-level fingerprints don't collide.
+        self._vocab_pool = _generate_vocab_pool(_VOCAB_POOL_SIZE, seed=seed)
+
+        # Each prefix uses its own seeded RNG (seed + 1000 + i) so
+        # different prefixes produce different random sequences from the
+        # pool.  Constant offset keeps reproducibility while leaving room
+        # for the suffix (seed + 1) and breaker (seed + 2) RNGs.
         self._prefixes: list[str] = [
-            _generate_prefix(i, config.prefix_tokens, prefix_rng)
+            _generate_prefix(
+                i,
+                config.prefix_tokens,
+                self._vocab_pool,
+                random.Random(seed + 1000 + i),
+            )
             for i in range(config.num_prefixes)
         ]
         suffix_rng = random.Random(seed + 1)
-        self._suffix: str = _generate_suffix(config.suffix_tokens, suffix_rng)
+        self._suffix: str = _generate_suffix(
+            config.suffix_tokens, self._vocab_pool, suffix_rng
+        )
         self._breaker_rng = random.Random(seed + 2)
 
         self._pass2_index = 0
@@ -346,7 +416,9 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
             A single-message chat list.
         """
         prefix = self._prefixes[prefix_index]
-        breaker = _generate_breaker(self._config.breaker_tokens, self._breaker_rng)
+        breaker = _generate_breaker(
+            self._config.breaker_tokens, self._vocab_pool, self._breaker_rng
+        )
         content = f"{prefix} {breaker} {self._suffix}"
         return [{"role": "user", "content": content}]
 

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prefix-suffix tuner workload for ``lmcache bench engine``.
+
+Exercises the tiered KV-cache hierarchy (L0 HBM / L1 DRAM / L2 disk) with a
+single sequential workload that can be run unchanged across three baselines:
+
+  Baseline 1 — vanilla vLLM (L0 only).  ``--kv-cache-volume`` set to L0 size,
+      ``--psf-thrash`` slightly > 1 forces every pass-2 request to miss L0.
+
+  Baseline 2 — vLLM + LMCache L1 + L2.  ``--kv-cache-volume`` set to L1 size,
+      so pass-2 requests miss L1 and hit L2 (prefix only — vanilla prefix
+      caching cannot reuse the suffix because it sits behind a random
+      breaker).
+
+  Baseline 3 — vLLM + LMCache L1 + L2 + CacheBlend.  Same sizing as Baseline
+      2; CacheBlend additionally allows the shared suffix's KV chunks to be
+      reused, so both the prefix and the suffix hit cache.
+
+Each request is::
+
+    [prefix_i][random breaker][shared suffix]
+
+with::
+
+  - ``num_prefixes`` distinct prefixes, each starting with a unique ID so
+    the prefix hash differs even if the random body collides.
+  - A fresh random breaker per request, defeating ordinary prefix caching
+    past the prefix boundary and preventing non-CacheBlend reuse of the
+    suffix.
+  - One shared suffix used by every request.
+
+Two passes run sequentially, one request at a time, in identical order:
+
+  - Pass 1 (warmup): populates the cache.  Stats discarded.
+  - Pass 2 (measured): repeats the same prefix order.  Because LRU evicts
+    the next-needed prefix on each pass-2 access, even a 1.05× overflow of
+    the targeted tier is enough to ensure every pass-2 request misses that
+    tier and falls through to the next one.
+"""
+
+# Standard
+from dataclasses import dataclass
+import random
+
+# First Party
+from lmcache.cli.commands.bench.engine_bench.progress import ProgressMonitor
+from lmcache.cli.commands.bench.engine_bench.request_sender import RequestSender
+from lmcache.cli.commands.bench.engine_bench.stats import StatsCollector
+from lmcache.cli.commands.bench.engine_bench.workloads.base import BaseWorkload
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+_BREAKER_TOKENS = 32
+_MIN_SUFFIX_TOKENS = 100
+_UNIQUE_ID_TOKENS = 4  # rough token count for ``PREFIX_<8-hex-digits>``
+_MAX_OUTPUT_TOKENS = 1
+
+
+@dataclass
+class PrefixSuffixTunerConfig:
+    """Workload-specific config for the prefix-suffix-tuner workload.
+
+    Attributes:
+        context_length: Total tokens per request (prefix + breaker + suffix).
+        prefix_ratio: Fraction of ``context_length`` allocated to the prefix.
+        thrash: Multiplier on ``--kv-cache-volume`` that determines the
+            total prefix-pool footprint.  Values just above 1.0 (e.g.
+            1.05) are sufficient to force pass-2 misses of the targeted
+            tier given sequential dispatch and LRU eviction.
+        num_prefixes: Number of distinct prefixes generated (computed by
+            :meth:`resolve` from the cache budget).
+        prefix_tokens: Token length of each prefix (computed).
+        suffix_tokens: Token length of the shared suffix (computed).
+        breaker_tokens: Token length of the random breaker between prefix
+            and suffix.
+    """
+
+    context_length: int = 8000
+    prefix_ratio: float = 0.8
+    thrash: float = 1.05
+    num_prefixes: int = 1
+    prefix_tokens: int = 1
+    suffix_tokens: int = 1
+    breaker_tokens: int = _BREAKER_TOKENS
+
+    def __post_init__(self) -> None:
+        if self.context_length <= 0:
+            raise ValueError(
+                f"context_length must be positive, got {self.context_length}"
+            )
+        if not 0.0 < self.prefix_ratio < 1.0:
+            raise ValueError(
+                f"prefix_ratio must be in (0.0, 1.0), got {self.prefix_ratio}"
+            )
+        if self.thrash < 1.0:
+            raise ValueError(f"thrash must be >= 1.0, got {self.thrash}")
+        if self.num_prefixes < 1:
+            raise ValueError(f"num_prefixes must be >= 1, got {self.num_prefixes}")
+        if self.prefix_tokens < 1:
+            raise ValueError(f"prefix_tokens must be >= 1, got {self.prefix_tokens}")
+        if self.suffix_tokens < 1:
+            raise ValueError(f"suffix_tokens must be >= 1, got {self.suffix_tokens}")
+        if self.breaker_tokens < 1:
+            raise ValueError(f"breaker_tokens must be >= 1, got {self.breaker_tokens}")
+
+    @classmethod
+    def resolve(
+        cls,
+        kv_cache_volume_gb: float,
+        tokens_per_gb_kvcache: int,
+        context_length: int = 8000,
+        prefix_ratio: float = 0.8,
+        thrash: float = 1.05,
+        breaker_tokens: int = _BREAKER_TOKENS,
+    ) -> "PrefixSuffixTunerConfig":
+        """Compute ``num_prefixes`` and token splits from the cache budget.
+
+        ``num_prefixes`` is sized so that the total prefix-pool footprint
+        in tokens equals ``kv_cache_volume_gb * thrash * tokens_per_gb_kvcache``.
+        With ``thrash`` slightly above 1.0, the pool just barely overflows the
+        targeted KV-cache tier; with sequential dispatch and LRU eviction,
+        this is sufficient to evict the next-needed prefix on every pass-2
+        access, ensuring all pass-2 requests miss the targeted tier.
+
+        Args:
+            kv_cache_volume_gb: Size of the KV-cache tier the workload
+                should overflow (e.g. L0 for Baseline 1, L1 for Baselines
+                2 and 3).
+            tokens_per_gb_kvcache: Tokens fitting in 1 GB of KV cache for
+                the served model.
+            context_length: Total tokens per request.
+            prefix_ratio: Fraction of ``context_length`` allocated to the
+                prefix.  Must be strictly between 0 and 1.
+            thrash: Multiplier on ``kv_cache_volume_gb`` for sizing the
+                prefix pool.  Defaults to 1.05.
+            breaker_tokens: Token length of the random breaker between
+                prefix and suffix.  Defaults to 32.
+
+        Returns:
+            A fully-resolved PrefixSuffixTunerConfig.
+
+        Raises:
+            ValueError: If ``prefix_ratio`` leaves fewer than
+                :data:`_MIN_SUFFIX_TOKENS` for the suffix, or if any field
+                fails validation.
+        """
+        prefix_tokens = max(round(context_length * prefix_ratio), 1)
+        suffix_tokens = context_length - prefix_tokens - breaker_tokens
+        if suffix_tokens < _MIN_SUFFIX_TOKENS:
+            raise ValueError(
+                f"suffix_tokens={suffix_tokens} is below minimum "
+                f"{_MIN_SUFFIX_TOKENS}; reduce prefix_ratio or "
+                f"increase context_length"
+            )
+
+        target_gb = kv_cache_volume_gb * thrash
+        num_prefixes = max(
+            int(target_gb * tokens_per_gb_kvcache / prefix_tokens),
+            1,
+        )
+        logger.debug(
+            "Computed num_prefixes=%d from kv_cache_volume_gb=%.2f, "
+            "thrash=%.3f, tokens_per_gb_kvcache=%d, prefix_tokens=%d",
+            num_prefixes,
+            kv_cache_volume_gb,
+            thrash,
+            tokens_per_gb_kvcache,
+            prefix_tokens,
+        )
+        return cls(
+            context_length=context_length,
+            prefix_ratio=prefix_ratio,
+            thrash=thrash,
+            num_prefixes=num_prefixes,
+            prefix_tokens=prefix_tokens,
+            suffix_tokens=suffix_tokens,
+            breaker_tokens=breaker_tokens,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data generation (module-level helpers)
+# ---------------------------------------------------------------------------
+
+
+def _random_word_stream(rng: random.Random, count: int) -> str:
+    """Return ``count`` space-separated random tokens drawn from *rng*.
+
+    Uses 6-digit zero-padded random integers so each token tokenizes to
+    roughly one BPE token across most tokenizers, keeping the generated
+    text close to the requested token count.
+
+    Args:
+        rng: Seeded random source.
+        count: Number of words to emit.
+
+    Returns:
+        A single space-joined string.
+    """
+    return " ".join(f"{rng.randrange(1_000_000):06d}" for _ in range(count))
+
+
+def _generate_prefix(index: int, num_tokens: int, rng: random.Random) -> str:
+    """Generate a prefix that begins with a unique ID.
+
+    Args:
+        index: Zero-based prefix index; encoded into the unique ID so the
+            prefix's tokenized hash differs from every other prefix even
+            if random bodies collide.
+        num_tokens: Approximate target token length of the full prefix.
+        rng: Seeded random source for the body.
+
+    Returns:
+        Prefix text starting with ``"PREFIX_<8-hex-digits>"``.
+    """
+    unique_id = f"PREFIX_{index:08x}"
+    body_words = max(num_tokens - _UNIQUE_ID_TOKENS, 1)
+    body = _random_word_stream(rng, body_words)
+    return f"{unique_id} {body}"
+
+
+def _generate_suffix(num_tokens: int, rng: random.Random) -> str:
+    """Generate the single shared suffix used by every request.
+
+    Args:
+        num_tokens: Approximate target token length.
+        rng: Seeded random source.
+
+    Returns:
+        Suffix text starting with ``"SUFFIX"``.
+    """
+    body = _random_word_stream(rng, max(num_tokens - 1, 1))
+    return f"SUFFIX {body}"
+
+
+def _generate_breaker(num_tokens: int, rng: random.Random) -> str:
+    """Generate a fresh random breaker for one request.
+
+    The breaker sits between prefix and suffix; its randomness defeats
+    ordinary prefix caching past the prefix boundary and prevents
+    non-CacheBlend reuse of the suffix.
+
+    Args:
+        num_tokens: Approximate target token length.
+        rng: Seeded random source.  Each call advances state, so successive
+            requests get different breakers.
+
+    Returns:
+        A space-joined random token string.
+    """
+    return _random_word_stream(rng, num_tokens)
+
+
+# ---------------------------------------------------------------------------
+# Workload class
+# ---------------------------------------------------------------------------
+
+
+class PrefixSuffixTunerWorkload(BaseWorkload):
+    """Sequential two-pass workload demonstrating tiered KV-cache reuse.
+
+    Pass 1 (executed in :meth:`warmup`) populates the cache by sending each
+    prefix once.  Stats from pass 1 are discarded.  Pass 2 (executed via
+    :meth:`step`) repeats the same prefix order one request at a time;
+    these are the measured requests.
+    """
+
+    def __init__(
+        self,
+        config: PrefixSuffixTunerConfig,
+        request_sender: RequestSender,
+        stats_collector: StatsCollector,
+        progress_monitor: ProgressMonitor,
+        seed: int = 42,
+    ) -> None:
+        super().__init__(request_sender, stats_collector, progress_monitor)
+        self._config = config
+        self._seed = seed
+
+        prefix_rng = random.Random(seed)
+        self._prefixes: list[str] = [
+            _generate_prefix(i, config.prefix_tokens, prefix_rng)
+            for i in range(config.num_prefixes)
+        ]
+        suffix_rng = random.Random(seed + 1)
+        self._suffix: str = _generate_suffix(config.suffix_tokens, suffix_rng)
+        self._breaker_rng = random.Random(seed + 2)
+
+        self._pass2_index = 0
+
+    def log_config(self) -> None:
+        """Log key workload config before the benchmark starts."""
+        c = self._config
+        B = "\033[1m"
+        C = "\033[96m"
+        Y = "\033[93m"
+        R = "\033[0m"
+        pool_tokens_millions = c.num_prefixes * c.prefix_tokens / 1_000_000
+        print(
+            f"{B}{'═' * 50}{R}\n"
+            f"{B} Workload: {C}prefix-suffix-tuner{R}\n"
+            f"{B}{'─' * 50}{R}\n"
+            f"  Context length:    {Y}{c.context_length}{R} tokens\n"
+            f"  Prefix tokens:     {Y}{c.prefix_tokens}{R} (ratio={c.prefix_ratio})\n"
+            f"  Breaker tokens:    {Y}{c.breaker_tokens}{R} (random per request)\n"
+            f"  Suffix tokens:     {Y}{c.suffix_tokens}{R} (shared, deterministic)\n"
+            f"  Thrash multiplier: {Y}{c.thrash}{R}\n"
+            f"  Prefix pool size:  {Y}{c.num_prefixes}{R}\n"
+            f"  Pool tokens:       {Y}{pool_tokens_millions:.2f}M{R}\n"
+            f"  Total measured:    {Y}{c.num_prefixes}{R} requests "
+            f"(pass 2 of 2)\n"
+            f"{B}{'═' * 50}{R}"
+        )
+
+    # ------------------------------------------------------------------
+    # Message construction
+    # ------------------------------------------------------------------
+
+    def _build_messages(self, prefix_index: int) -> list[dict[str, str]]:
+        """Build chat messages for one request.
+
+        The breaker is freshly randomized on every call, so two requests
+        for the same prefix produce different prompts past the prefix
+        boundary.  Pass 1 and pass 2 therefore use different breakers
+        per prefix even though the prefix order is identical.
+
+        Args:
+            prefix_index: Index into the generated prefix pool.
+
+        Returns:
+            A single-message chat list.
+        """
+        prefix = self._prefixes[prefix_index]
+        breaker = _generate_breaker(self._config.breaker_tokens, self._breaker_rng)
+        content = f"{prefix} {breaker} {self._suffix}"
+        return [{"role": "user", "content": content}]
+
+    # ------------------------------------------------------------------
+    # Pass 1 — warmup
+    # ------------------------------------------------------------------
+
+    async def warmup(self) -> None:
+        """Run pass 1: send each prefix once sequentially to populate cache."""
+        n = self._config.num_prefixes
+        self._progress_monitor.log_message(f"Pass 1 (warmup): {n} requests")
+        for i in range(n):
+            request_id = f"pass1_p{i}"
+            messages = self._build_messages(i)
+            self._progress_monitor.on_request_sent(request_id)
+            self._progress_monitor.log_message(f"Pass 1 dispatched {i + 1}/{n}")
+            result = await self._request_sender.send_warmup_request(
+                request_id,
+                messages,
+            )
+            if not result.successful:
+                self._progress_monitor.log_message(
+                    f"Pass 1 {request_id} failed: {result.error}"
+                )
+        self._progress_monitor.log_message(
+            f"Pass 1 complete: {n} prefixes populated",
+        )
+
+    # ------------------------------------------------------------------
+    # Pass 2 — measured benchmark
+    # ------------------------------------------------------------------
+
+    async def step(self, time_offset: float) -> float:
+        """Send one pass-2 request inline, sequentially.
+
+        Awaiting the request inside ``step`` enforces strict
+        one-request-at-a-time dispatch.  Returns ``0.0`` for an immediate
+        re-call until the prefix list is exhausted, then ``-1.0``.
+
+        Args:
+            time_offset: Seconds since pass 2 started (unused).
+
+        Returns:
+            ``0.0`` if more requests remain, ``-1.0`` when pass 2 is
+            complete.
+        """
+        if self._pass2_index >= self._config.num_prefixes:
+            return -1.0
+
+        i = self._pass2_index
+        self._pass2_index += 1
+        request_id = f"pass2_p{i}"
+        messages = self._build_messages(i)
+        self._progress_monitor.on_request_sent(request_id)
+        self._progress_monitor.log_message(
+            f"Pass 2 {i + 1}/{self._config.num_prefixes}"
+        )
+        await self._request_sender.send_request(
+            request_id,
+            messages,
+            max_tokens=_MAX_OUTPUT_TOKENS,
+        )
+        return 0.0
+
+    def on_request_finished(self, request_id: str, output: str) -> None:
+        """No-op — this workload is stateless."""

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -31,6 +31,10 @@ with::
 
 Two passes run sequentially, one request at a time, in identical order:
 
+  - Engine warmup (single throwaway request, before pass 1): amortizes
+    first-request torch.compile / CUDA-graph / connector-handshake cost.
+    Stats discarded; the prompt is too small to occupy a chunk-aligned
+    region so it does not pollute LMCache hit-rate metrics.
   - Pass 1 (warmup): populates the cache.  Stats discarded.
   - Pass 2 (measured): repeats the same prefix order.  Because LRU evicts
     the next-needed prefix on each pass-2 access, even a 1.05× overflow of
@@ -538,6 +542,16 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
     async def warmup(self) -> None:
         """Run pass 1: send each prefix once sequentially to populate cache.
 
+        Before pass 1 starts, sends a single short throwaway request to
+        amortize first-request engine overhead (torch.compile JIT-fallback
+        paths, CUDA-graph capture for novel batch shapes, vLLM/LMCache
+        connector handshake, tokenizer lazy initialization).  This keeps
+        the first request of pass 1 on a fully-warmed engine, so that the
+        cache-population pass does not include outlier latency from
+        first-request overhead.  The throwaway prompt is ~5 tokens — too
+        small to occupy a chunk-aligned region — so it does not pollute
+        the LMCache hit-rate metrics.
+
         After dispatching all warmup requests, sleeps for
         :data:`_EVICTION_SETTLE_SECONDS` so LMCache's batched-eviction LRU
         (1Hz background poll, evicts only when usage > watermark) has time
@@ -545,6 +559,20 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
         L1 by a few percent may complete before any eviction fires, and
         pass 2 would then find all of pass 1's data still in cache.
         """
+        # Engine warmup: amortize first-request torch.compile / CUDA-graph
+        # / connector-handshake cost onto a throwaway request.
+        self._progress_monitor.log_message(
+            "Engine warmup (1 throwaway request before pass 1)"
+        )
+        warmup_result = await self._request_sender.send_warmup_request(
+            "engine_warmup",
+            [{"role": "user", "content": "Hello"}],
+        )
+        if not warmup_result.successful:
+            self._progress_monitor.log_message(
+                f"Engine warmup failed: {warmup_result.error}"
+            )
+
         n = self._config.num_prefixes
         self._progress_monitor.log_message(f"Pass 1 (warmup): {n} requests")
         for i in range(n):

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -196,126 +196,78 @@ class PrefixSuffixTunerConfig:
 # ---------------------------------------------------------------------------
 
 
-_VOCAB_POOL_SIZE = 8000
+def _generate_prefix(index: int, num_tokens: int) -> str:
+    """Generate a prefix: unique ID header + ``"hi"`` filler body.
 
+    The body is identical across all prefixes (a stream of ``"hi"`` tokens),
+    but the **unique ID header** at the start makes the prefix's chained
+    block hash unique per ``index``.  Combined with vLLM's chain-hashed
+    prefix cache, this means:
 
-def _generate_vocab_pool(size: int, seed: int) -> list[str]:
-    """Generate a deterministic pool of ``size`` unique pseudo-words.
+    - Prefix cache does **not** false-hit across prefixes (chain hash
+      diverges from block 0).
+    - CacheBlend, which uses content hashing, *will* report cross-prefix
+      hits on the body chunks — that is exactly what blend does, and is
+      consistent with the analytical model's assumption that Baseline 3
+      achieves full-context blend coverage.
 
-    Words follow a consonant-vowel pattern (e.g. ``"boko42"``, ``"rida71"``)
-    with a numeric uniqueness suffix.  Mirrors the approach used by
-    :mod:`long_doc_permutator` so that:
-
-    - **Token counts** are reasonably close to the configured target — each
-      pseudo-word tokenizes to ~2 BPE tokens on common tokenizers (vs. 3+
-      for raw 6-digit numbers), giving a smaller and more consistent
-      expansion factor.
-    - **CacheBlend** does not get false hits across prefixes: each prefix
-      samples a *different* random sequence from the pool, so chunk-level
-      content fingerprints virtually never collide between prefixes.
-
-    Args:
-        size: Number of unique pseudo-words to generate.
-        seed: Deterministic seed for the pool.
-
-    Returns:
-        Sorted list of unique pseudo-words.
-    """
-    rng = random.Random(seed)
-    vowels = "aeiou"
-    consonants = "bcdfghjklmnpqrstvwxyz"
-    pool: set[str] = set()
-    while len(pool) < size:
-        length = rng.randint(3, 7)
-        word = "".join(
-            rng.choice(consonants) if j % 2 == 0 else rng.choice(vowels)
-            for j in range(length)
-        )
-        pool.add(f"{word}{len(pool)}")
-    return sorted(pool)
-
-
-def _sample_words(pool: list[str], rng: random.Random, count: int) -> str:
-    """Return ``count`` space-separated words sampled (with replacement) from *pool*.
-
-    Args:
-        pool: Vocabulary pool.
-        rng: Seeded random source.
-        count: Number of words to emit.
-
-    Returns:
-        A single space-joined string.
-    """
-    return " ".join(rng.choices(pool, k=count))
-
-
-def _generate_prefix(
-    index: int,
-    num_tokens: int,
-    pool: list[str],
-    rng: random.Random,
-) -> str:
-    """Generate a prefix that begins with a unique ID.
-
-    Each prefix samples a different random sequence from the shared vocab
-    pool; combined with the unique ID header, this makes both prefix-cache
-    chained block hashes and CacheBlend chunk fingerprints unique across
-    prefixes.
+    Using ``"hi"`` for the body gives exact 1:1 word-to-BPE-token mapping
+    on every modern tokenizer, so the configured ``num_tokens`` matches
+    what the model actually sees within the unique-ID overhead.
 
     Args:
         index: Zero-based prefix index; encoded into the unique ID.
         num_tokens: Approximate target token length of the full prefix.
-        pool: Shared vocab pool.
-        rng: Per-prefix seeded random source (caller passes a distinct
-            RNG state per index so bodies differ across prefixes).
 
     Returns:
         Prefix text starting with ``"PREFIX_<8-hex-digits>"``.
     """
     unique_id = f"PREFIX_{index:08x}"
     body_words = max(num_tokens - _UNIQUE_ID_TOKENS, 1)
-    body = _sample_words(pool, rng, body_words)
+    body = " ".join(["hi"] * body_words)
     return f"{unique_id} {body}"
 
 
-def _generate_suffix(num_tokens: int, pool: list[str], rng: random.Random) -> str:
+def _generate_suffix(num_tokens: int) -> str:
     """Generate the single shared suffix used by every request.
 
-    The suffix is bit-identical across all requests; its chunk fingerprints
-    are therefore the only entries CacheBlend can reuse — which is exactly
-    what the workload measures.
+    The suffix is bit-identical across all requests; its content-hash
+    fingerprints are what CacheBlend reuses across requests — the property
+    Baseline 3 measures.
 
     Args:
         num_tokens: Approximate target token length.
-        pool: Shared vocab pool.
-        rng: Seeded random source (deterministic seed produces a
-            reproducible suffix).
 
     Returns:
         Suffix text starting with ``"SUFFIX"``.
     """
-    body = _sample_words(pool, rng, max(num_tokens - 1, 1))
+    body = " ".join(["hi"] * max(num_tokens - 1, 1))
     return f"SUFFIX {body}"
 
 
-def _generate_breaker(num_tokens: int, pool: list[str], rng: random.Random) -> str:
-    """Generate a fresh random breaker for one request.
+def _generate_breaker(num_tokens: int, rng: random.Random) -> str:
+    """Generate a per-request breaker with a unique header + ``"hi"`` filler.
 
-    Sampled fresh per request from the vocab pool, so each request has a
-    unique sequence of breaker tokens.  This (a) defeats ordinary prefix
+    The breaker has a small unique random header (so the chained block
+    hash diverges between requests with the same prefix), plus ``"hi"``
+    filler for accurate token counting.  This (a) defeats ordinary prefix
     caching past the prefix boundary, and (b) ensures the chained block
-    hashes leading into the suffix differ between requests, so the suffix
-    is only reachable via CacheBlend's content-based chunk lookup.
+    hashes leading into the suffix differ between requests — so the
+    suffix is only reachable via CacheBlend's content-based lookup, not
+    by chained prefix-cache.
 
     Args:
         num_tokens: Approximate target token length.
-        pool: Shared vocab pool.
-        rng: Seeded random source.  Each call advances state.
+        rng: Seeded random source.  Each call advances state, so
+            successive requests get different breaker headers.
 
     Returns:
-        A space-joined random token string.
+        A breaker string starting with a 4-token-ish ``"BR_<8-hex>"`` ID.
     """
-    return _sample_words(pool, rng, num_tokens)
+    unique_id = f"BR_{rng.randrange(2**32):08x}"
+    body_words = max(num_tokens - _UNIQUE_ID_TOKENS, 1)
+    body = " ".join(["hi"] * body_words)
+    return f"{unique_id} {body}"
 
 
 # ---------------------------------------------------------------------------
@@ -344,29 +296,17 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
         self._config = config
         self._seed = seed
 
-        # Shared vocab pool — sampled by every prefix (with a different
-        # per-prefix RNG offset), the suffix, and per-request breakers.
-        # Same word inventory across all components, but per-component
-        # samples differ so chunk-level fingerprints don't collide.
-        self._vocab_pool = _generate_vocab_pool(_VOCAB_POOL_SIZE, seed=seed)
-
-        # Each prefix uses its own seeded RNG (seed + 1000 + i) so
-        # different prefixes produce different random sequences from the
-        # pool.  Constant offset keeps reproducibility while leaving room
-        # for the suffix (seed + 1) and breaker (seed + 2) RNGs.
+        # Body filler is plain ``"hi"`` — 1 BPE token per word on every
+        # modern tokenizer, so configured token counts match what the model
+        # actually sees.  Cross-prefix uniqueness comes from the unique
+        # header injected at the start of each prefix; vLLM's prefix-cache
+        # chain hashing then makes every subsequent block of "hi"s also
+        # unique to its prefix.  See _generate_prefix docstring.
         self._prefixes: list[str] = [
-            _generate_prefix(
-                i,
-                config.prefix_tokens,
-                self._vocab_pool,
-                random.Random(seed + 1000 + i),
-            )
+            _generate_prefix(i, config.prefix_tokens)
             for i in range(config.num_prefixes)
         ]
-        suffix_rng = random.Random(seed + 1)
-        self._suffix: str = _generate_suffix(
-            config.suffix_tokens, self._vocab_pool, suffix_rng
-        )
+        self._suffix: str = _generate_suffix(config.suffix_tokens)
         self._breaker_rng = random.Random(seed + 2)
 
         self._pass2_index = 0
@@ -416,9 +356,7 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
             A single-message chat list.
         """
         prefix = self._prefixes[prefix_index]
-        breaker = _generate_breaker(
-            self._config.breaker_tokens, self._vocab_pool, self._breaker_rng
-        )
+        breaker = _generate_breaker(self._config.breaker_tokens, self._breaker_rng)
         content = f"{prefix} {breaker} {self._suffix}"
         return [{"role": "user", "content": content}]
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
@@ -65,7 +65,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         # prefix-suffix-tuner defaults
         psf_context_length=8000,
         psf_prefix_ratio=0.8,
-        psf_thrash=1.05,
+        psf_thrash=20.0,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -196,9 +196,12 @@ class TestCreateWorkload:
         assert result._config.num_requests == 20
 
     def test_prefix_suffix_tuner(self) -> None:
+        # Defaults: psf_thrash=20.0 (target tier in GB).  The workload does
+        # NOT consume kv_cache_volume_gb (its sizing is independent of the
+        # general kv_cache_volume flag), so this test asserts only on the
+        # psf-* args + tokens-per-gb.
         config = _make_config(
             workload="prefix-suffix-tuner",
-            kv_cache_volume_gb=10.0,
             tokens_per_gb_kvcache=10000,
         )
         args = _make_args()
@@ -215,19 +218,19 @@ class TestCreateWorkload:
         # context=8000, ratio=0.8 → prefix=6400; suffix=8000-6400-32=1568
         assert result._config.prefix_tokens == 6400
         assert result._config.suffix_tokens == 1568
-        # 10 * 1.05 * 10000 / 6400 = 16.40... → 16
-        assert result._config.num_prefixes == 16
+        # thrash=20.0 GB; pool_gb=20.0 * 1.05 = 21.0 GB
+        # num_prefixes = 21.0 * 10000 / 6400 = 32.81... → 32
+        assert result._config.num_prefixes == 32
 
     def test_prefix_suffix_tuner_custom_args(self) -> None:
         config = _make_config(
             workload="prefix-suffix-tuner",
-            kv_cache_volume_gb=10.0,
             tokens_per_gb_kvcache=10000,
         )
         args = _make_args(
             psf_context_length=4000,
             psf_prefix_ratio=0.5,
-            psf_thrash=2.0,
+            psf_thrash=50.0,
         )
         sender, collector, monitor = _make_deps()
         result = create_workload(
@@ -240,10 +243,11 @@ class TestCreateWorkload:
         assert isinstance(result, PrefixSuffixTunerWorkload)
         assert result._config.context_length == 4000
         assert result._config.prefix_ratio == 0.5
-        assert result._config.thrash == 2.0
+        assert result._config.thrash == 50.0
         assert result._config.prefix_tokens == 2000
-        # 10 * 2.0 * 10000 / 2000 = 100
-        assert result._config.num_prefixes == 100
+        # thrash=50 GB; pool_gb=50 * 1.05 = 52.5 GB
+        # num_prefixes = 52.5 * 10000 / 2000 = 262.5 → 262
+        assert result._config.num_prefixes == 262
 
     def test_unknown_workload_raises(self) -> None:
         config = _make_config(workload="unknown-workload")

--- a/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
@@ -219,8 +219,9 @@ class TestCreateWorkload:
         assert result._config.prefix_tokens == 6400
         assert result._config.suffix_tokens == 1568
         # thrash=20.0 GB; pool_gb=20.0 * 1.05 = 21.0 GB
-        # num_prefixes = 21.0 * 10000 / 6400 = 32.81... → 32
-        assert result._config.num_prefixes == 32
+        # Sized by context_length=8000 (full per-request KV footprint):
+        # num_prefixes = 21.0 * 10000 / 8000 = 26.25 → 26
+        assert result._config.num_prefixes == 26
 
     def test_prefix_suffix_tuner_custom_args(self) -> None:
         config = _make_config(
@@ -246,8 +247,9 @@ class TestCreateWorkload:
         assert result._config.thrash == 50.0
         assert result._config.prefix_tokens == 2000
         # thrash=50 GB; pool_gb=50 * 1.05 = 52.5 GB
-        # num_prefixes = 52.5 * 10000 / 2000 = 262.5 → 262
-        assert result._config.num_prefixes == 262
+        # Sized by context_length=4000:
+        # num_prefixes = 52.5 * 10000 / 4000 = 131.25 → 131
+        assert result._config.num_prefixes == 131
 
     def test_unknown_workload_raises(self) -> None:
         config = _make_config(workload="unknown-workload")

--- a/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
@@ -20,6 +20,9 @@ from lmcache.cli.commands.bench.engine_bench.workloads.long_doc_qa import (
 from lmcache.cli.commands.bench.engine_bench.workloads.multi_round_chat import (
     MultiRoundChatWorkload,
 )
+from lmcache.cli.commands.bench.engine_bench.workloads.prefix_suffix_tuner import (
+    PrefixSuffixTunerWorkload,
+)
 from lmcache.cli.commands.bench.engine_bench.workloads.random_prefill import (
     RandomPrefillWorkload,
 )
@@ -59,6 +62,10 @@ def _make_args(**overrides) -> argparse.Namespace:
         mrc_output_length=200,
         mrc_qps=1.0,
         mrc_duration=60.0,
+        # prefix-suffix-tuner defaults
+        psf_context_length=8000,
+        psf_prefix_ratio=0.8,
+        psf_thrash=1.05,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -187,6 +194,56 @@ class TestCreateWorkload:
         assert isinstance(result, RandomPrefillWorkload)
         assert result._config.request_length == 5000
         assert result._config.num_requests == 20
+
+    def test_prefix_suffix_tuner(self) -> None:
+        config = _make_config(
+            workload="prefix-suffix-tuner",
+            kv_cache_volume_gb=10.0,
+            tokens_per_gb_kvcache=10000,
+        )
+        args = _make_args()
+        sender, collector, monitor = _make_deps()
+        result = create_workload(
+            config,
+            args,
+            sender,
+            collector,
+            monitor,
+        )
+        assert isinstance(result, BaseWorkload)
+        assert isinstance(result, PrefixSuffixTunerWorkload)
+        # context=8000, ratio=0.8 → prefix=6400; suffix=8000-6400-32=1568
+        assert result._config.prefix_tokens == 6400
+        assert result._config.suffix_tokens == 1568
+        # 10 * 1.05 * 10000 / 6400 = 16.40... → 16
+        assert result._config.num_prefixes == 16
+
+    def test_prefix_suffix_tuner_custom_args(self) -> None:
+        config = _make_config(
+            workload="prefix-suffix-tuner",
+            kv_cache_volume_gb=10.0,
+            tokens_per_gb_kvcache=10000,
+        )
+        args = _make_args(
+            psf_context_length=4000,
+            psf_prefix_ratio=0.5,
+            psf_thrash=2.0,
+        )
+        sender, collector, monitor = _make_deps()
+        result = create_workload(
+            config,
+            args,
+            sender,
+            collector,
+            monitor,
+        )
+        assert isinstance(result, PrefixSuffixTunerWorkload)
+        assert result._config.context_length == 4000
+        assert result._config.prefix_ratio == 0.5
+        assert result._config.thrash == 2.0
+        assert result._config.prefix_tokens == 2000
+        # 10 * 2.0 * 10000 / 2000 = 100
+        assert result._config.num_prefixes == 100
 
     def test_unknown_workload_raises(self) -> None:
         config = _make_config(workload="unknown-workload")

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -26,7 +26,7 @@ class TestPrefixSuffixTunerConfig:
         cfg = PrefixSuffixTunerConfig()
         assert cfg.context_length == 8000
         assert cfg.prefix_ratio == 0.8
-        assert cfg.thrash == 1.05
+        assert cfg.thrash == 20.0
         assert cfg.num_prefixes == 1
         assert cfg.prefix_tokens == 1
         assert cfg.suffix_tokens == 1
@@ -36,7 +36,7 @@ class TestPrefixSuffixTunerConfig:
         cfg = PrefixSuffixTunerConfig(
             context_length=4000,
             prefix_ratio=0.5,
-            thrash=2.0,
+            thrash=50.0,
             num_prefixes=10,
             prefix_tokens=2000,
             suffix_tokens=1968,
@@ -44,7 +44,7 @@ class TestPrefixSuffixTunerConfig:
         )
         assert cfg.context_length == 4000
         assert cfg.prefix_ratio == 0.5
-        assert cfg.thrash == 2.0
+        assert cfg.thrash == 50.0
         assert cfg.num_prefixes == 10
 
     def test_invalid_context_length(self) -> None:
@@ -63,13 +63,18 @@ class TestPrefixSuffixTunerConfig:
         with pytest.raises(ValueError, match=r"prefix_ratio must be in \(0.0, 1.0\)"):
             PrefixSuffixTunerConfig(prefix_ratio=-0.5)
 
-    def test_invalid_thrash(self) -> None:
-        with pytest.raises(ValueError, match="thrash must be >= 1.0"):
-            PrefixSuffixTunerConfig(thrash=0.9)
+    def test_invalid_thrash_zero(self) -> None:
+        with pytest.raises(ValueError, match=r"thrash \(GB\) must be positive"):
+            PrefixSuffixTunerConfig(thrash=0.0)
 
-    def test_thrash_at_one_is_valid(self) -> None:
-        cfg = PrefixSuffixTunerConfig(thrash=1.0)
-        assert cfg.thrash == 1.0
+    def test_invalid_thrash_negative(self) -> None:
+        with pytest.raises(ValueError, match=r"thrash \(GB\) must be positive"):
+            PrefixSuffixTunerConfig(thrash=-1.0)
+
+    def test_thrash_small_positive_is_valid(self) -> None:
+        # Sub-1-GB target tier is valid for tiny test runs.
+        cfg = PrefixSuffixTunerConfig(thrash=0.5)
+        assert cfg.thrash == 0.5
 
     def test_invalid_num_prefixes(self) -> None:
         with pytest.raises(ValueError, match="num_prefixes must be >= 1"):
@@ -82,45 +87,46 @@ class TestPrefixSuffixTunerConfig:
 
 # ---------------------------------------------------------------------------
 # PrefixSuffixTunerConfig.resolve
+#
+# ``thrash`` is the target tier size in GB; the resolve() helper applies an
+# internal _OVERFLOW_FACTOR (1.05) to size the prefix pool slightly larger
+# than the targeted tier, so pass-2 misses everything in that tier.
 # ---------------------------------------------------------------------------
 
 
 class TestPrefixSuffixTunerConfigResolve:
     def test_resolve_basic(self) -> None:
         cfg = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=10.0,
             tokens_per_gb_kvcache=10000,
             context_length=4000,
             prefix_ratio=0.5,
-            thrash=1.05,
+            thrash=10.0,
         )
         # prefix_tokens = round(4000 * 0.5) = 2000
         assert cfg.prefix_tokens == 2000
         # suffix_tokens = 4000 - 2000 - 32 = 1968
         assert cfg.suffix_tokens == 1968
-        # target = 10 * 1.05 = 10.5 GB; 10.5 * 10000 / 2000 = 52.5 → 52
+        # pool_gb = 10 * 1.05 = 10.5 GB; 10.5 * 10000 / 2000 = 52.5 → 52
         assert cfg.num_prefixes == 52
 
-    def test_resolve_thrash_just_above_one(self) -> None:
+    def test_resolve_default_thrash_scaling(self) -> None:
         cfg = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=100.0,
             tokens_per_gb_kvcache=50000,
             context_length=8000,
             prefix_ratio=0.8,
-            thrash=1.05,
         )
         # prefix_tokens = round(8000 * 0.8) = 6400
         assert cfg.prefix_tokens == 6400
-        # 100 * 1.05 * 50000 / 6400 = 820.31... → 820
-        assert cfg.num_prefixes == 820
+        # default thrash = 20.0 GB; pool = 20 * 1.05 = 21 GB
+        # 21 * 50000 / 6400 = 164.06 → 164
+        assert cfg.num_prefixes == 164
 
     def test_resolve_minimum_one_prefix(self) -> None:
         cfg = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=0.0001,
             tokens_per_gb_kvcache=1,
             context_length=4000,
             prefix_ratio=0.5,
-            thrash=1.0,
+            thrash=0.0001,
         )
         assert cfg.num_prefixes == 1
 
@@ -128,17 +134,15 @@ class TestPrefixSuffixTunerConfigResolve:
         # context=200, prefix_ratio=0.95 → prefix=190, breaker=32, suffix=-22
         with pytest.raises(ValueError, match="suffix_tokens=.* below minimum 100"):
             PrefixSuffixTunerConfig.resolve(
-                kv_cache_volume_gb=10.0,
                 tokens_per_gb_kvcache=10000,
                 context_length=200,
                 prefix_ratio=0.95,
-                thrash=1.05,
+                thrash=10.0,
             )
 
     def test_resolve_suffix_at_minimum(self) -> None:
         # context = 200, prefix=68, breaker=32, suffix=100 (exactly minimum)
         cfg = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=1.0,
             tokens_per_gb_kvcache=1000,
             context_length=200,
             prefix_ratio=0.34,
@@ -146,23 +150,41 @@ class TestPrefixSuffixTunerConfigResolve:
         )
         assert cfg.suffix_tokens == 100
 
-    def test_resolve_thrash_scales_pool(self) -> None:
+    def test_resolve_thrash_scales_pool_linearly(self) -> None:
         cfg_small = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=10.0,
             tokens_per_gb_kvcache=10000,
             context_length=4000,
             prefix_ratio=0.5,
-            thrash=1.0,
+            thrash=10.0,
         )
         cfg_big = PrefixSuffixTunerConfig.resolve(
-            kv_cache_volume_gb=10.0,
             tokens_per_gb_kvcache=10000,
             context_length=4000,
             prefix_ratio=0.5,
-            thrash=2.0,
+            thrash=20.0,
         )
-        # Doubling thrash should roughly double num_prefixes
-        assert cfg_big.num_prefixes == 2 * cfg_small.num_prefixes
+        # Doubling thrash (target tier GB) should roughly double num_prefixes
+        # — within a single prefix of 2x because of integer flooring.
+        assert abs(cfg_big.num_prefixes - 2 * cfg_small.num_prefixes) <= 1
+
+    def test_resolve_applies_internal_overflow_factor(self) -> None:
+        """``thrash`` is the target tier size, not the pool size — pool is
+        ``thrash * _OVERFLOW_FACTOR``.  Verify that with a 100 GB target tier,
+        the pool genuinely overshoots."""
+        cfg = PrefixSuffixTunerConfig.resolve(
+            tokens_per_gb_kvcache=10000,
+            context_length=2000,
+            prefix_ratio=0.5,
+            thrash=100.0,
+        )
+        # prefix_tokens = 1000
+        # pool_gb = 100 * 1.05 = 105
+        # num_prefixes = 105 * 10000 / 1000 = 1050
+        assert cfg.num_prefixes == 1050
+        # Pool footprint > target tier:
+        pool_tokens = cfg.num_prefixes * cfg.prefix_tokens
+        target_tier_tokens = int(100.0 * 10000)
+        assert pool_tokens > target_tier_tokens
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +196,7 @@ def _make_workload_config(**overrides) -> PrefixSuffixTunerConfig:
     defaults = dict(
         context_length=200,
         prefix_ratio=0.5,
-        thrash=1.05,
+        thrash=10.0,  # target tier size in GB; resolve() not invoked here
         num_prefixes=4,
         prefix_tokens=100,
         suffix_tokens=68,

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -106,8 +106,8 @@ class TestPrefixSuffixTunerConfigResolve:
         assert cfg.prefix_tokens == 2000
         # suffix_tokens = 4000 - 2000 - 32 = 1968
         assert cfg.suffix_tokens == 1968
-        # pool_gb = 10 * 1.05 = 10.5 GB; 10.5 * 10000 / 2000 = 52.5 → 52
-        assert cfg.num_prefixes == 52
+        # pool_gb = 10 * 1.05 = 10.5 GB; 10.5 * 10000 / 4000 = 26.25 → 26
+        assert cfg.num_prefixes == 26
 
     def test_resolve_default_thrash_scaling(self) -> None:
         cfg = PrefixSuffixTunerConfig.resolve(
@@ -118,8 +118,8 @@ class TestPrefixSuffixTunerConfigResolve:
         # prefix_tokens = round(8000 * 0.8) = 6400
         assert cfg.prefix_tokens == 6400
         # default thrash = 20.0 GB; pool = 20 * 1.05 = 21 GB
-        # 21 * 50000 / 6400 = 164.06 → 164
-        assert cfg.num_prefixes == 164
+        # 21 * 50000 / 8000 = 131.25 → 131  (sized by context_length)
+        assert cfg.num_prefixes == 131
 
     def test_resolve_minimum_one_prefix(self) -> None:
         cfg = PrefixSuffixTunerConfig.resolve(
@@ -179,10 +179,12 @@ class TestPrefixSuffixTunerConfigResolve:
         )
         # prefix_tokens = 1000
         # pool_gb = 100 * 1.05 = 105
-        # num_prefixes = 105 * 10000 / 1000 = 1050
-        assert cfg.num_prefixes == 1050
-        # Pool footprint > target tier:
-        pool_tokens = cfg.num_prefixes * cfg.prefix_tokens
+        # Sized by context_length=2000 (not prefix_tokens), so the L1
+        # footprint of the pool == thrash * _OVERFLOW_FACTOR GB:
+        # num_prefixes = 105 * 10000 / 2000 = 525
+        assert cfg.num_prefixes == 525
+        # Pool footprint (in tokens of full request) > target tier tokens:
+        pool_tokens = cfg.num_prefixes * cfg.context_length
         target_tier_tokens = int(100.0 * 10000)
         assert pool_tokens > target_tier_tokens
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -2,6 +2,7 @@
 """Tests for prefix-suffix-tuner workload config and workload generator."""
 
 # Standard
+from collections import OrderedDict
 from unittest.mock import AsyncMock, MagicMock
 import time
 
@@ -463,3 +464,208 @@ class TestPrefixSuffixTunerFullRun:
         assert sender.send_request.call_count == 3
         # Stats reset between passes (warmup discarded)
         collector.reset.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# LRU simulation — verifies the central design invariant
+#
+# The workload's value rests on a single algorithmic claim: with a sequential
+# pass-1 / pass-2 dispatch in identical order and a pool that just barely
+# overflows the targeted tier, every pass-2 access misses that tier.  These
+# tests prove that claim against an in-memory LRU model, using the access
+# order extracted from the actual workload.
+# ---------------------------------------------------------------------------
+
+
+def _simulate_lru(access_seq: list[int], capacity: int) -> tuple[int, int]:
+    """Replay *access_seq* against an LRU of *capacity*; return (hits, misses).
+
+    Args:
+        access_seq: Ordered list of cache keys to access.
+        capacity: Maximum number of entries the cache holds.
+
+    Returns:
+        Tuple of (hit_count, miss_count) over the full sequence.
+    """
+    cache: OrderedDict[int, bool] = OrderedDict()
+    hits = 0
+    misses = 0
+    for key in access_seq:
+        if key in cache:
+            cache.move_to_end(key)
+            hits += 1
+        else:
+            cache[key] = True
+            if len(cache) > capacity:
+                cache.popitem(last=False)
+            misses += 1
+    return hits, misses
+
+
+async def _capture_workload_access_order(
+    workload: PrefixSuffixTunerWorkload,
+    sender: MagicMock,
+) -> tuple[list[int], list[int]]:
+    """Run pass 1 + pass 2 and return the prefix-index access order of each.
+
+    The mocked *sender* records which prefix index it was asked to send.
+    The returned tuple lets tests assert on the order of pass 1 and pass
+    2 independently.
+    """
+    pass1: list[int] = []
+    pass2: list[int] = []
+
+    async def capture_warmup(req_id, _msgs, **_kw):
+        # request_id format: "pass1_p<index>"
+        pass1.append(int(req_id.split("_p")[1]))
+        return _make_mock_result(req_id)
+
+    async def capture_request(req_id, _msgs, **_kw):
+        pass2.append(int(req_id.split("_p")[1]))
+        return _make_mock_result(req_id)
+
+    sender.send_warmup_request = AsyncMock(side_effect=capture_warmup)
+    sender.send_request = AsyncMock(side_effect=capture_request)
+
+    await workload.warmup()
+    while True:
+        next_wake = await workload.step(0.0)
+        if next_wake < 0:
+            break
+    return pass1, pass2
+
+
+class TestLRUSimulator:
+    """Sanity checks on the LRU helper itself."""
+
+    def test_all_misses_when_no_repeats(self) -> None:
+        h, m = _simulate_lru([0, 1, 2, 3], capacity=10)
+        assert (h, m) == (0, 4)
+
+    def test_all_hits_after_repeat_within_capacity(self) -> None:
+        h, m = _simulate_lru([0, 1, 0, 1], capacity=10)
+        assert (h, m) == (2, 2)
+
+    def test_eviction_fifo_under_strict_lru(self) -> None:
+        # capacity 2; access 0, 1, 2 → evicts 0; access 0 → miss.
+        h, m = _simulate_lru([0, 1, 2, 0], capacity=2)
+        assert (h, m) == (0, 4)
+
+    def test_recent_access_promotes_to_mru(self) -> None:
+        # capacity 2; access 0, 1, 0, 2 → evicts 1 (LRU), not 0.
+        h, m = _simulate_lru([0, 1, 0, 2, 0], capacity=2)
+        # 0 (miss), 1 (miss), 0 (hit), 2 (miss; evict 1), 0 (hit)
+        assert (h, m) == (2, 3)
+
+
+class TestPrefixSuffixTunerWorkloadAccessOrder:
+    """Confirm the workload sends prefixes in identical sequential order
+    across both passes — the precondition for the LRU invariant below."""
+
+    @pytest.mark.asyncio
+    async def test_pass1_is_sequential(self) -> None:
+        cfg = _make_workload_config(num_prefixes=8)
+        w, sender, _, _ = _make_workload(cfg)
+        pass1, _ = await _capture_workload_access_order(w, sender)
+        assert pass1 == list(range(8))
+
+    @pytest.mark.asyncio
+    async def test_pass2_matches_pass1(self) -> None:
+        cfg = _make_workload_config(num_prefixes=8)
+        w, sender, _, _ = _make_workload(cfg)
+        pass1, pass2 = await _capture_workload_access_order(w, sender)
+        assert pass2 == pass1
+
+
+class TestPrefixSuffixTunerLRUInvariant:
+    """The central design claim: every pass-2 request misses the targeted
+    tier when the prefix pool is sized just larger than tier capacity."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "num_prefixes,capacity",
+        [
+            (21, 20),  # 1.05× overflow — the documented default
+            (40, 38),  # ~1.05× at a different scale
+            (100, 50),  # 2× overflow
+            (1000, 950),  # large pool, light overflow
+        ],
+    )
+    async def test_pass2_zero_hits_when_pool_overflows(
+        self, num_prefixes: int, capacity: int
+    ) -> None:
+        cfg = _make_workload_config(num_prefixes=num_prefixes)
+        w, sender, _, _ = _make_workload(cfg)
+        pass1, pass2 = await _capture_workload_access_order(w, sender)
+
+        # Pass 1 fills the cache; pass 2 must miss every entry in the
+        # targeted tier (capacity).  We measure pass-2 hits independently
+        # by replaying pass 1 first to populate the LRU, then pass 2.
+        cache: OrderedDict[int, bool] = OrderedDict()
+        for key in pass1:
+            cache[key] = True
+            if len(cache) > capacity:
+                cache.popitem(last=False)
+
+        pass2_hits = 0
+        pass2_misses = 0
+        for key in pass2:
+            if key in cache:
+                cache.move_to_end(key)
+                pass2_hits += 1
+            else:
+                cache[key] = True
+                if len(cache) > capacity:
+                    cache.popitem(last=False)
+                pass2_misses += 1
+
+        assert pass2_hits == 0, (
+            f"thrash invariant broken: {pass2_hits}/{num_prefixes} pass-2 "
+            f"requests hit a tier of capacity {capacity}"
+        )
+        assert pass2_misses == num_prefixes
+
+    @pytest.mark.asyncio
+    async def test_pass2_all_hits_when_pool_fits_in_tier(self) -> None:
+        # Counter-example: with pool ≤ capacity, pass 1 fills the cache
+        # without any eviction, so pass 2 is 100% hits.  This sanity-checks
+        # that the LRU sim correctly distinguishes "thrashing" from
+        # "cache-friendly" workloads.
+        cfg = _make_workload_config(num_prefixes=10)
+        w, sender, _, _ = _make_workload(cfg)
+        pass1, pass2 = await _capture_workload_access_order(w, sender)
+
+        cache: OrderedDict[int, bool] = OrderedDict()
+        capacity = 20  # tier larger than pool
+        for key in pass1:
+            cache[key] = True
+            if len(cache) > capacity:
+                cache.popitem(last=False)
+
+        pass2_hits = 0
+        for key in pass2:
+            if key in cache:
+                cache.move_to_end(key)
+                pass2_hits += 1
+            else:
+                cache[key] = True
+        assert pass2_hits == 10
+
+    @pytest.mark.asyncio
+    async def test_pass2_all_hits_when_pool_equals_tier(self) -> None:
+        # Boundary: pool == capacity (thrash == 1.0 exactly).  Pass 1 fills
+        # the cache to the brim, pass 2 is 100% hits.  This is why the
+        # default thrash is strictly > 1.0.
+        cfg = _make_workload_config(num_prefixes=15)
+        w, sender, _, _ = _make_workload(cfg)
+        pass1, pass2 = await _capture_workload_access_order(w, sender)
+
+        cache: OrderedDict[int, bool] = OrderedDict()
+        capacity = 15
+        for key in pass1:
+            cache[key] = True
+            if len(cache) > capacity:
+                cache.popitem(last=False)
+
+        pass2_hits = sum(1 for key in pass2 if key in cache)
+        assert pass2_hits == 15

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for prefix-suffix-tuner workload config and workload generator."""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.bench.engine_bench.stats import RequestResult
+from lmcache.cli.commands.bench.engine_bench.workloads.prefix_suffix_tuner import (
+    PrefixSuffixTunerConfig,
+    PrefixSuffixTunerWorkload,
+)
+
+# ---------------------------------------------------------------------------
+# PrefixSuffixTunerConfig — direct construction
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerConfig:
+    def test_defaults(self) -> None:
+        cfg = PrefixSuffixTunerConfig()
+        assert cfg.context_length == 8000
+        assert cfg.prefix_ratio == 0.8
+        assert cfg.thrash == 1.05
+        assert cfg.num_prefixes == 1
+        assert cfg.prefix_tokens == 1
+        assert cfg.suffix_tokens == 1
+        assert cfg.breaker_tokens == 32
+
+    def test_custom_values(self) -> None:
+        cfg = PrefixSuffixTunerConfig(
+            context_length=4000,
+            prefix_ratio=0.5,
+            thrash=2.0,
+            num_prefixes=10,
+            prefix_tokens=2000,
+            suffix_tokens=1968,
+            breaker_tokens=32,
+        )
+        assert cfg.context_length == 4000
+        assert cfg.prefix_ratio == 0.5
+        assert cfg.thrash == 2.0
+        assert cfg.num_prefixes == 10
+
+    def test_invalid_context_length(self) -> None:
+        with pytest.raises(ValueError, match="context_length must be positive"):
+            PrefixSuffixTunerConfig(context_length=0)
+
+    def test_invalid_prefix_ratio_zero(self) -> None:
+        with pytest.raises(ValueError, match=r"prefix_ratio must be in \(0.0, 1.0\)"):
+            PrefixSuffixTunerConfig(prefix_ratio=0.0)
+
+    def test_invalid_prefix_ratio_one(self) -> None:
+        with pytest.raises(ValueError, match=r"prefix_ratio must be in \(0.0, 1.0\)"):
+            PrefixSuffixTunerConfig(prefix_ratio=1.0)
+
+    def test_invalid_prefix_ratio_negative(self) -> None:
+        with pytest.raises(ValueError, match=r"prefix_ratio must be in \(0.0, 1.0\)"):
+            PrefixSuffixTunerConfig(prefix_ratio=-0.5)
+
+    def test_invalid_thrash(self) -> None:
+        with pytest.raises(ValueError, match="thrash must be >= 1.0"):
+            PrefixSuffixTunerConfig(thrash=0.9)
+
+    def test_thrash_at_one_is_valid(self) -> None:
+        cfg = PrefixSuffixTunerConfig(thrash=1.0)
+        assert cfg.thrash == 1.0
+
+    def test_invalid_num_prefixes(self) -> None:
+        with pytest.raises(ValueError, match="num_prefixes must be >= 1"):
+            PrefixSuffixTunerConfig(num_prefixes=0)
+
+    def test_invalid_breaker_tokens(self) -> None:
+        with pytest.raises(ValueError, match="breaker_tokens must be >= 1"):
+            PrefixSuffixTunerConfig(breaker_tokens=0)
+
+
+# ---------------------------------------------------------------------------
+# PrefixSuffixTunerConfig.resolve
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerConfigResolve:
+    def test_resolve_basic(self) -> None:
+        cfg = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=10.0,
+            tokens_per_gb_kvcache=10000,
+            context_length=4000,
+            prefix_ratio=0.5,
+            thrash=1.05,
+        )
+        # prefix_tokens = round(4000 * 0.5) = 2000
+        assert cfg.prefix_tokens == 2000
+        # suffix_tokens = 4000 - 2000 - 32 = 1968
+        assert cfg.suffix_tokens == 1968
+        # target = 10 * 1.05 = 10.5 GB; 10.5 * 10000 / 2000 = 52.5 → 52
+        assert cfg.num_prefixes == 52
+
+    def test_resolve_thrash_just_above_one(self) -> None:
+        cfg = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=100.0,
+            tokens_per_gb_kvcache=50000,
+            context_length=8000,
+            prefix_ratio=0.8,
+            thrash=1.05,
+        )
+        # prefix_tokens = round(8000 * 0.8) = 6400
+        assert cfg.prefix_tokens == 6400
+        # 100 * 1.05 * 50000 / 6400 = 820.31... → 820
+        assert cfg.num_prefixes == 820
+
+    def test_resolve_minimum_one_prefix(self) -> None:
+        cfg = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=0.0001,
+            tokens_per_gb_kvcache=1,
+            context_length=4000,
+            prefix_ratio=0.5,
+            thrash=1.0,
+        )
+        assert cfg.num_prefixes == 1
+
+    def test_resolve_suffix_too_small(self) -> None:
+        # context=200, prefix_ratio=0.95 → prefix=190, breaker=32, suffix=-22
+        with pytest.raises(ValueError, match="suffix_tokens=.* below minimum 100"):
+            PrefixSuffixTunerConfig.resolve(
+                kv_cache_volume_gb=10.0,
+                tokens_per_gb_kvcache=10000,
+                context_length=200,
+                prefix_ratio=0.95,
+                thrash=1.05,
+            )
+
+    def test_resolve_suffix_at_minimum(self) -> None:
+        # context = 200, prefix=68, breaker=32, suffix=100 (exactly minimum)
+        cfg = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=1.0,
+            tokens_per_gb_kvcache=1000,
+            context_length=200,
+            prefix_ratio=0.34,
+            thrash=1.0,
+        )
+        assert cfg.suffix_tokens == 100
+
+    def test_resolve_thrash_scales_pool(self) -> None:
+        cfg_small = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=10.0,
+            tokens_per_gb_kvcache=10000,
+            context_length=4000,
+            prefix_ratio=0.5,
+            thrash=1.0,
+        )
+        cfg_big = PrefixSuffixTunerConfig.resolve(
+            kv_cache_volume_gb=10.0,
+            tokens_per_gb_kvcache=10000,
+            context_length=4000,
+            prefix_ratio=0.5,
+            thrash=2.0,
+        )
+        # Doubling thrash should roughly double num_prefixes
+        assert cfg_big.num_prefixes == 2 * cfg_small.num_prefixes
+
+
+# ---------------------------------------------------------------------------
+# PrefixSuffixTunerWorkload — helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_workload_config(**overrides) -> PrefixSuffixTunerConfig:
+    defaults = dict(
+        context_length=200,
+        prefix_ratio=0.5,
+        thrash=1.05,
+        num_prefixes=4,
+        prefix_tokens=100,
+        suffix_tokens=68,
+        breaker_tokens=32,
+    )
+    defaults.update(overrides)
+    return PrefixSuffixTunerConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _make_mock_result(request_id: str = "req_0") -> RequestResult:
+    now = time.time()
+    return RequestResult(
+        request_id=request_id,
+        successful=True,
+        ttft=0.1,
+        request_latency=0.5,
+        num_input_tokens=100,
+        num_output_tokens=1,
+        decode_speed=10.0,
+        submit_time=now,
+        first_token_time=now + 0.1,
+        finish_time=now + 0.5,
+        error="",
+    )
+
+
+def _make_mock_sender() -> MagicMock:
+    sender = MagicMock()
+    sender.send_request = AsyncMock(return_value=_make_mock_result())
+    sender.send_warmup_request = AsyncMock(return_value=_make_mock_result())
+    return sender
+
+
+def _make_workload(
+    config: PrefixSuffixTunerConfig | None = None,
+    seed: int = 42,
+) -> tuple[PrefixSuffixTunerWorkload, MagicMock, MagicMock, MagicMock]:
+    if config is None:
+        config = _make_workload_config()
+    sender = _make_mock_sender()
+    collector = MagicMock()
+    monitor = MagicMock()
+    workload = PrefixSuffixTunerWorkload(
+        config,
+        sender,
+        collector,
+        monitor,
+        seed=seed,
+    )
+    return workload, sender, collector, monitor
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data generation
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerData:
+    def test_correct_prefix_count(self) -> None:
+        w, *_ = _make_workload(_make_workload_config(num_prefixes=7))
+        assert len(w._prefixes) == 7
+
+    def test_prefixes_have_unique_id_at_start(self) -> None:
+        w, *_ = _make_workload(_make_workload_config(num_prefixes=3))
+        assert w._prefixes[0].startswith("PREFIX_00000000")
+        assert w._prefixes[1].startswith("PREFIX_00000001")
+        assert w._prefixes[2].startswith("PREFIX_00000002")
+
+    def test_prefixes_are_distinct(self) -> None:
+        w, *_ = _make_workload(_make_workload_config(num_prefixes=5))
+        assert len(set(w._prefixes)) == 5
+
+    def test_single_shared_suffix(self) -> None:
+        w, *_ = _make_workload()
+        assert isinstance(w._suffix, str)
+        assert w._suffix.startswith("SUFFIX")
+
+    def test_data_is_deterministic_with_seed(self) -> None:
+        cfg = _make_workload_config(num_prefixes=5)
+        w1, *_ = _make_workload(cfg, seed=42)
+        w2, *_ = _make_workload(cfg, seed=42)
+        assert w1._prefixes == w2._prefixes
+        assert w1._suffix == w2._suffix
+
+    def test_data_differs_with_different_seed(self) -> None:
+        cfg = _make_workload_config(num_prefixes=5)
+        w1, *_ = _make_workload(cfg, seed=42)
+        w2, *_ = _make_workload(cfg, seed=99)
+        assert w1._prefixes != w2._prefixes
+        assert w1._suffix != w2._suffix
+
+
+# ---------------------------------------------------------------------------
+# Message construction — request structure
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerMessages:
+    def test_message_has_user_role(self) -> None:
+        w, *_ = _make_workload()
+        msgs = w._build_messages(0)
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_message_contains_prefix(self) -> None:
+        w, *_ = _make_workload()
+        msgs = w._build_messages(2)
+        assert "PREFIX_00000002" in msgs[0]["content"]
+
+    def test_message_contains_shared_suffix(self) -> None:
+        w, *_ = _make_workload()
+        msgs0 = w._build_messages(0)
+        msgs1 = w._build_messages(1)
+        # Same suffix appears in both
+        assert w._suffix in msgs0[0]["content"]
+        assert w._suffix in msgs1[0]["content"]
+
+    def test_breaker_differs_per_request(self) -> None:
+        w, *_ = _make_workload()
+        msgs_a = w._build_messages(0)
+        msgs_b = w._build_messages(0)  # same prefix, different breaker
+        # The two prompts must differ even for the same prefix index
+        assert msgs_a[0]["content"] != msgs_b[0]["content"]
+
+    def test_request_layout_prefix_breaker_suffix(self) -> None:
+        w, *_ = _make_workload(_make_workload_config(num_prefixes=1))
+        content = w._build_messages(0)[0]["content"]
+        # Prefix appears before suffix
+        prefix_pos = content.find("PREFIX_")
+        suffix_pos = content.find("SUFFIX")
+        assert prefix_pos == 0
+        assert suffix_pos > prefix_pos
+
+    def test_on_request_finished_noop(self) -> None:
+        w, *_ = _make_workload()
+        w.on_request_finished("some_id", "some_text")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Pass 1 — warmup (async)
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerWarmup:
+    @pytest.mark.asyncio
+    async def test_warmup_sends_each_prefix_once(self) -> None:
+        cfg = _make_workload_config(num_prefixes=4)
+        w, sender, _, _ = _make_workload(cfg)
+
+        await w.warmup()
+
+        assert sender.send_warmup_request.call_count == 4
+        for i, call in enumerate(sender.send_warmup_request.call_args_list):
+            request_id = call[0][0]
+            assert request_id == f"pass1_p{i}"
+
+    @pytest.mark.asyncio
+    async def test_warmup_sends_in_order(self) -> None:
+        cfg = _make_workload_config(num_prefixes=3)
+        w, sender, _, _ = _make_workload(cfg)
+
+        await w.warmup()
+
+        ids = [call[0][0] for call in sender.send_warmup_request.call_args_list]
+        assert ids == ["pass1_p0", "pass1_p1", "pass1_p2"]
+
+    @pytest.mark.asyncio
+    async def test_warmup_uses_real_request_structure(self) -> None:
+        cfg = _make_workload_config(num_prefixes=2)
+        w, sender, _, _ = _make_workload(cfg)
+        await w.warmup()
+
+        # Pass 1 should send full prefix+breaker+suffix prompts (not a stub)
+        first_call_messages = sender.send_warmup_request.call_args_list[0][0][1]
+        content = first_call_messages[0]["content"]
+        assert "PREFIX_00000000" in content
+        assert w._suffix in content
+
+
+# ---------------------------------------------------------------------------
+# Pass 2 — step (async)
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerStep:
+    @pytest.mark.asyncio
+    async def test_step_sends_one_request_per_call(self) -> None:
+        cfg = _make_workload_config(num_prefixes=2)
+        w, sender, _, _ = _make_workload(cfg)
+
+        result = await w.step(0.0)
+        assert result == 0.0
+        assert sender.send_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_step_terminates_after_pool_exhausted(self) -> None:
+        cfg = _make_workload_config(num_prefixes=2)
+        w, _, _, _ = _make_workload(cfg)
+
+        await w.step(0.0)
+        await w.step(0.0)
+        assert (await w.step(0.0)) == -1.0
+
+    @pytest.mark.asyncio
+    async def test_step_dispatches_in_pool_order(self) -> None:
+        cfg = _make_workload_config(num_prefixes=3)
+        w, sender, _, _ = _make_workload(cfg)
+
+        await w.step(0.0)
+        await w.step(0.0)
+        await w.step(0.0)
+
+        ids = [call[0][0] for call in sender.send_request.call_args_list]
+        assert ids == ["pass2_p0", "pass2_p1", "pass2_p2"]
+
+    @pytest.mark.asyncio
+    async def test_step_uses_max_tokens_one(self) -> None:
+        cfg = _make_workload_config(num_prefixes=1)
+        w, sender, _, _ = _make_workload(cfg)
+        await w.step(0.0)
+        # send_request called with max_tokens=1
+        assert sender.send_request.call_args.kwargs["max_tokens"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Pass ordering — pass 1 and pass 2 use same prefix order, different breakers
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerTwoPassOrdering:
+    @pytest.mark.asyncio
+    async def test_pass1_and_pass2_share_prefix_order(self) -> None:
+        cfg = _make_workload_config(num_prefixes=4)
+        w, sender, _, _ = _make_workload(cfg)
+
+        await w.warmup()
+        # Run pass 2 to exhaustion
+        while True:
+            r = await w.step(0.0)
+            if r < 0:
+                break
+
+        warmup_prefixes = [
+            c[0][1][0]["content"].split()[0]
+            for c in sender.send_warmup_request.call_args_list
+        ]
+        bench_prefixes = [
+            c[0][1][0]["content"].split()[0] for c in sender.send_request.call_args_list
+        ]
+        # Same prefix sequence in both passes
+        assert warmup_prefixes == bench_prefixes
+        assert warmup_prefixes == [f"PREFIX_{i:08x}" for i in range(4)]
+
+    @pytest.mark.asyncio
+    async def test_pass1_and_pass2_use_different_breakers(self) -> None:
+        cfg = _make_workload_config(num_prefixes=2)
+        w, sender, _, _ = _make_workload(cfg)
+
+        await w.warmup()
+        while True:
+            r = await w.step(0.0)
+            if r < 0:
+                break
+
+        # For prefix 0, the pass-1 and pass-2 prompts must differ
+        # (same prefix and suffix, but different random breaker).
+        pass1_prefix0 = sender.send_warmup_request.call_args_list[0][0][1][0]["content"]
+        pass2_prefix0 = sender.send_request.call_args_list[0][0][1][0]["content"]
+        assert pass1_prefix0 != pass2_prefix0
+
+
+# ---------------------------------------------------------------------------
+# Full run end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixSuffixTunerFullRun:
+    def test_full_run(self) -> None:
+        cfg = _make_workload_config(num_prefixes=3)
+        w, sender, collector, _ = _make_workload(cfg)
+
+        w.run()
+
+        # Pass 1: 3 warmup requests
+        assert sender.send_warmup_request.call_count == 3
+        # Pass 2: 3 measured requests
+        assert sender.send_request.call_count == 3
+        # Stats reset between passes (warmup discarded)
+        collector.reset.assert_called_once()

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -399,26 +399,29 @@ class TestPrefixSuffixTunerMessages:
 
 class TestPrefixSuffixTunerWarmup:
     @pytest.mark.asyncio
-    async def test_warmup_sends_each_prefix_once(self) -> None:
+    async def test_warmup_sends_engine_warmup_then_each_prefix_once(self) -> None:
         cfg = _make_workload_config(num_prefixes=4)
         w, sender, _, _ = _make_workload(cfg)
 
         await w.warmup()
 
-        assert sender.send_warmup_request.call_count == 4
-        for i, call in enumerate(sender.send_warmup_request.call_args_list):
-            request_id = call[0][0]
-            assert request_id == f"pass1_p{i}"
+        # 1 engine warmup + 4 pass-1 prefixes = 5 total
+        assert sender.send_warmup_request.call_count == 5
+        # First call is the engine warmup (throwaway, before pass 1).
+        assert sender.send_warmup_request.call_args_list[0][0][0] == "engine_warmup"
+        # Subsequent calls are pass-1 prefixes in index order.
+        for i, call in enumerate(sender.send_warmup_request.call_args_list[1:]):
+            assert call[0][0] == f"pass1_p{i}"
 
     @pytest.mark.asyncio
-    async def test_warmup_sends_in_order(self) -> None:
+    async def test_warmup_sends_pass1_prefixes_in_order(self) -> None:
         cfg = _make_workload_config(num_prefixes=3)
         w, sender, _, _ = _make_workload(cfg)
 
         await w.warmup()
 
         ids = [call[0][0] for call in sender.send_warmup_request.call_args_list]
-        assert ids == ["pass1_p0", "pass1_p1", "pass1_p2"]
+        assert ids == ["engine_warmup", "pass1_p0", "pass1_p1", "pass1_p2"]
 
     @pytest.mark.asyncio
     async def test_warmup_uses_real_request_structure(self) -> None:
@@ -426,11 +429,15 @@ class TestPrefixSuffixTunerWarmup:
         w, sender, _, _ = _make_workload(cfg)
         await w.warmup()
 
-        # Pass 1 should send full prefix+breaker+suffix prompts (not a stub)
-        first_call_messages = sender.send_warmup_request.call_args_list[0][0][1]
-        content = first_call_messages[0]["content"]
-        assert "PREFIX_00000000" in content
-        assert w._suffix in content
+        # The engine-warmup request (call 0) sends a tiny throwaway prompt;
+        # the pass-1 requests (calls 1..N) send full prefix+breaker+suffix.
+        warmup_messages = sender.send_warmup_request.call_args_list[0][0][1]
+        warmup_content = warmup_messages[0]["content"]
+        assert "PREFIX_" not in warmup_content  # throwaway, no real prefix
+        first_pass1_messages = sender.send_warmup_request.call_args_list[1][0][1]
+        first_pass1_content = first_pass1_messages[0]["content"]
+        assert "PREFIX_00000000" in first_pass1_content
+        assert w._suffix in first_pass1_content
 
 
 # ---------------------------------------------------------------------------
@@ -496,9 +503,11 @@ class TestPrefixSuffixTunerTwoPassOrdering:
             if r < 0:
                 break
 
+        # Skip the engine-warmup throwaway call (call 0); pass-1 prefixes
+        # start at call 1.
         warmup_prefixes = [
             c[0][1][0]["content"].split()[0]
-            for c in sender.send_warmup_request.call_args_list
+            for c in sender.send_warmup_request.call_args_list[1:]
         ]
         bench_prefixes = [
             c[0][1][0]["content"].split()[0] for c in sender.send_request.call_args_list
@@ -520,7 +529,9 @@ class TestPrefixSuffixTunerTwoPassOrdering:
 
         # For prefix 0, the pass-1 and pass-2 prompts must differ
         # (same prefix and suffix, but different random breaker).
-        pass1_prefix0 = sender.send_warmup_request.call_args_list[0][0][1][0]["content"]
+        # Note: call 0 of send_warmup_request is the engine warmup; pass-1
+        # prefix 0 is at call index 1.
+        pass1_prefix0 = sender.send_warmup_request.call_args_list[1][0][1][0]["content"]
         pass2_prefix0 = sender.send_request.call_args_list[0][0][1][0]["content"]
         assert pass1_prefix0 != pass2_prefix0
 
@@ -537,8 +548,8 @@ class TestPrefixSuffixTunerFullRun:
 
         w.run()
 
-        # Pass 1: 3 warmup requests
-        assert sender.send_warmup_request.call_count == 3
+        # 1 engine warmup + 3 pass-1 prefixes = 4 warmup requests total
+        assert sender.send_warmup_request.call_count == 4
         # Pass 2: 3 measured requests
         assert sender.send_request.call_count == 3
         # Stats reset between passes (warmup discarded)
@@ -595,7 +606,11 @@ async def _capture_workload_access_order(
     pass2: list[int] = []
 
     async def capture_warmup(req_id, _msgs, **_kw):
-        # request_id format: "pass1_p<index>"
+        # request_id format: "pass1_p<index>" for cache-population requests;
+        # "engine_warmup" for the throwaway request before pass 1, which is
+        # not part of the access order under test.
+        if req_id == "engine_warmup":
+            return _make_mock_result(req_id)
         pass1.append(int(req_id.split("_p")[1]))
         return _make_mock_result(req_id)
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -288,6 +288,27 @@ class TestPrefixSuffixTunerData:
         assert w1._prefixes != w2._prefixes
         assert w1._suffix != w2._suffix
 
+    def test_prefix_bodies_are_distinct_across_prefixes(self) -> None:
+        """CacheBlend-correctness invariant: prefixes must not just differ in
+        their unique-ID header — their *body* tokens must differ too, so
+        chunk-level content fingerprints don't collide across prefixes and
+        artificially inflate the blend hit rate."""
+        w, *_ = _make_workload(_make_workload_config(num_prefixes=8))
+        # Strip the unique-ID header (everything before the first space) and
+        # compare bodies — they should all be distinct.
+        bodies = [p.split(" ", 1)[1] for p in w._prefixes]
+        assert len(set(bodies)) == 8, (
+            "Prefix bodies must differ across prefixes for CacheBlend "
+            "fingerprint uniqueness; got duplicates."
+        )
+
+    def test_vocab_pool_has_correct_size(self) -> None:
+        w, *_ = _make_workload()
+        # Pool size constant in prefix_suffix_tuner.py is _VOCAB_POOL_SIZE = 8000.
+        assert len(w._vocab_pool) == 8000
+        # All entries unique (set-based generation).
+        assert len(set(w._vocab_pool)) == 8000
+
 
 # ---------------------------------------------------------------------------
 # Message construction — request structure

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -282,32 +282,32 @@ class TestPrefixSuffixTunerData:
         assert w1._suffix == w2._suffix
 
     def test_data_differs_with_different_seed(self) -> None:
-        cfg = _make_workload_config(num_prefixes=5)
+        # Only the breaker RNG depends on seed; prefixes/suffix are seed-
+        # independent now (deterministic "hi"-filler bodies).  Verify the
+        # breaker stream differs across seeds.
+        cfg = _make_workload_config(num_prefixes=2)
         w1, *_ = _make_workload(cfg, seed=42)
         w2, *_ = _make_workload(cfg, seed=99)
-        assert w1._prefixes != w2._prefixes
-        assert w1._suffix != w2._suffix
+        b1 = w1._build_messages(0)[0]["content"]
+        b2 = w2._build_messages(0)[0]["content"]
+        assert b1 != b2  # different breakers produce different prompts
 
-    def test_prefix_bodies_are_distinct_across_prefixes(self) -> None:
-        """CacheBlend-correctness invariant: prefixes must not just differ in
-        their unique-ID header — their *body* tokens must differ too, so
-        chunk-level content fingerprints don't collide across prefixes and
-        artificially inflate the blend hit rate."""
-        w, *_ = _make_workload(_make_workload_config(num_prefixes=8))
-        # Strip the unique-ID header (everything before the first space) and
-        # compare bodies — they should all be distinct.
+    def test_prefix_bodies_are_identical_filler(self) -> None:
+        """All prefix bodies are ``"hi"``-filler by design.
+
+        Cross-prefix uniqueness comes from the unique-ID header at the
+        start of each prefix; vLLM's chain-hashed prefix cache then makes
+        every subsequent block unique to its prefix.  CacheBlend (which
+        uses content hashing) *will* report cross-prefix hits on the body
+        chunks — that is the correct behavior for the analytical model
+        (Baseline 3 assumes full-context blend coverage).
+        """
+        w, *_ = _make_workload(_make_workload_config(num_prefixes=4))
         bodies = [p.split(" ", 1)[1] for p in w._prefixes]
-        assert len(set(bodies)) == 8, (
-            "Prefix bodies must differ across prefixes for CacheBlend "
-            "fingerprint uniqueness; got duplicates."
-        )
-
-    def test_vocab_pool_has_correct_size(self) -> None:
-        w, *_ = _make_workload()
-        # Pool size constant in prefix_suffix_tuner.py is _VOCAB_POOL_SIZE = 8000.
-        assert len(w._vocab_pool) == 8000
-        # All entries unique (set-based generation).
-        assert len(set(w._vocab_pool)) == 8000
+        # All bodies identical (just "hi hi hi ...").
+        assert len(set(bodies)) == 1
+        # Content is exactly the "hi"-filler.
+        assert all(set(b.split(" ")) == {"hi"} for b in bodies)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -292,22 +292,56 @@ class TestPrefixSuffixTunerData:
         b2 = w2._build_messages(0)[0]["content"]
         assert b1 != b2  # different breakers produce different prompts
 
-    def test_prefix_bodies_are_identical_filler(self) -> None:
-        """All prefix bodies are ``"hi"``-filler by design.
+    def test_prefix_bodies_use_hi_fallback_when_no_tokenizer(self) -> None:
+        """Fallback path: when no tokenizer is loadable (unit tests pass
+        ``model_name=None``), bodies use deterministic ``"hi"`` filler.
 
-        Cross-prefix uniqueness comes from the unique-ID header at the
-        start of each prefix; vLLM's chain-hashed prefix cache then makes
-        every subsequent block unique to its prefix.  CacheBlend (which
-        uses content hashing) *will* report cross-prefix hits on the body
-        chunks — that is the correct behavior for the analytical model
-        (Baseline 3 assumes full-context blend coverage).
+        Production runs with the real model name get **content-unique**
+        random bodies generated from the tokenizer's vocab; that path is
+        verified E2E (loading a real tokenizer in unit tests would be
+        slow).  See ``test_prefix_bodies_are_unique_with_mock_tokenizer``
+        for the tokenizer path under a mocked tokenizer.
         """
         w, *_ = _make_workload(_make_workload_config(num_prefixes=4))
+        # Without a tokenizer, fallback "hi" filler kicks in.
+        assert w._tokenizer is None
         bodies = [p.split(" ", 1)[1] for p in w._prefixes]
-        # All bodies identical (just "hi hi hi ...").
         assert len(set(bodies)) == 1
-        # Content is exactly the "hi"-filler.
         assert all(set(b.split(" ")) == {"hi"} for b in bodies)
+
+    def test_prefix_bodies_are_unique_with_mock_tokenizer(self) -> None:
+        """Tokenizer path: each prefix samples a different per-prefix RNG,
+        so the random token-ID sequences differ → decoded bodies differ.
+        Required for non-blend cache hit-rate metrics to be meaningful
+        (otherwise content-hash collisions across identical bodies would
+        inflate hit rates regardless of LRU eviction).
+
+        Uses a mocked tokenizer to avoid loading transformers in unit
+        tests; the real-tokenizer path is exercised in E2E runs.
+        """
+        # First Party
+        from lmcache.cli.commands.bench.engine_bench.workloads import (
+            prefix_suffix_tuner as psf,
+        )
+
+        fake_tok = MagicMock()
+        fake_tok.decode = lambda ids, **kw: " ".join(f"id{i}" for i in ids)
+        original = psf._try_load_tokenizer
+        psf._try_load_tokenizer = lambda model_name: fake_tok
+        try:
+            cfg = _make_workload_config(num_prefixes=8)
+            sender = _make_mock_sender()
+            collector = MagicMock()
+            monitor = MagicMock()
+            w = psf.PrefixSuffixTunerWorkload(
+                cfg, sender, collector, monitor, seed=42, model_name="mock"
+            )
+        finally:
+            psf._try_load_tokenizer = original
+
+        bodies = [p.split(" ", 1)[1] for p in w._prefixes]
+        # All 8 prefix bodies should be distinct token-id sequences.
+        assert len(set(bodies)) == 8
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a sequential two-pass workload that exercises the L0/L1/L2 tiered KV cache hierarchy with a single benchmark configurable via context-length, prefix-ratio, and a thrash multiplier. Each request has the layout [prefix][random breaker][shared suffix]; pass 1 populates the cache and pass 2 (measured) repeats the same prefix order, so a 1.05x overflow of the targeted tier suffices to drive every measured request to the next tier down. Designed to be run unchanged across vanilla vLLM (L0 only), vLLM + LMCache L1+L2, and vLLM + LMCache + CacheBlend baselines.

Includes factory wiring, CLI args, interactive-mode schema entries, 33 new unit tests, factory-test coverage, and documentation updates across the design doc and user-facing rST references.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
