### PR TITLE
[Observability] Expose blend token-level hit-rate counters

### DIFF
--- a/docs/design/v1/mp_observability/DEBUG.md
+++ b/docs/design/v1/mp_observability/DEBUG.md
@@ -1,0 +1,93 @@
+# MP Observability — Debug Recipes
+
+How to derive L1-only / L2-only / blend hit rates from the counters in
+[METRICS.md](METRICS.md), and what to send to a maintainer when reporting
+a hit-rate regression.
+
+---
+
+## Common parameters
+
+All from `GET <lmcache-url>/api/status`:
+
+| Field | Source | Example |
+|---|---|---|
+| `chunk_size` | top-level | 256 |
+| L1 capacity (bytes) | `storage_manager.l1_manager.memory_total_bytes` | `5 * 2**30` |
+| L1 used (bytes) | `storage_manager.l1_manager.memory_used_bytes` | varies |
+
+## Token-level hit rate (L1 + L2 combined)
+
+```
+lmcache_mp_lookup_hit_tokens_total / lmcache_mp_lookup_requested_tokens_total
+```
+
+Fraction of chunk-aligned tokens that came back from cache anywhere.
+Reported per `(model_name, cache_salt)`.
+
+## L2-only hit rate
+
+L2's prefetch lookups carry per-key counts, not per-token:
+
+```
+L2_hit_tokens_total = increase(lmcache_mp_l2_prefetch_hit_keys_total) * chunk_size
+L2_hit_rate         = L2_hit_tokens_total
+                    / increase(lmcache_mp_lookup_requested_tokens_total)
+```
+
+The keys-to-tokens conversion is exact — every L2 hit is a full chunk.
+
+## L1-only hit rate (derived)
+
+Total minus L2:
+
+```
+L1_hit_tokens_total = increase(lmcache_mp_lookup_hit_tokens_total)
+                    - increase(lmcache_mp_l2_prefetch_hit_keys_total) * chunk_size
+L1_hit_rate         = L1_hit_tokens_total
+                    / increase(lmcache_mp_lookup_requested_tokens_total)
+```
+
+Sanity check: `L1_hit_tokens_total >= 0`.  A sustained negative value
+indicates a metric-emission bug.
+
+## Blend total hit rate
+
+```
+lmcache_blend_lookup_hit_tokens_total / lmcache_blend_lookup_requested_tokens_total
+```
+
+Reported per CacheBlend lookup (`CB_LOOKUP_END`).
+
+## Blend L1 vs L2 — *not separable today*
+
+The blend lookup consults L1 (fingerprint table) and L2 (storage
+prefetch) as a single pipelined operation, and `lmcache_blend.lookup_storage_hits`
+aggregates them.  Splitting requires per-chunk attribution inside the
+blend lookup; tracked as an open follow-up.
+
+## Did eviction fire during my run?
+
+```
+ticks      = increase(lmcache_mp_l1_eviction_loop_ticks_total)
+triggered  = increase(lmcache_mp_l1_eviction_loop_triggered_total)
+fire_ratio = triggered / ticks   # 0.0 = never fired; 1.0 = fired every cycle
+```
+
+If `triggered == 0` over a thrash test, the benchmark completed faster
+than the 1Hz polling interval.  Lower `--eviction-trigger-watermark` or
+raise `--eviction-ratio` (or run the workload longer) to see eviction
+engage.
+
+## Self-service checklist
+
+Attach these four artifacts when reporting a hit-rate regression:
+
+1. `GET <lmcache-url>/api/status` (config + state snapshot).
+2. `GET <lmcache-url>/metrics` snapshots taken **before** and **after** the run.
+3. The bench's `bench_summary.json` and `bench_results.csv` (TTFT per request).
+4. The LMCache server's stdout/stderr (eviction-trigger logs are at INFO level).
+
+(1)–(3) plus the formulas above let a maintainer compute L1, L2, blend,
+and combined hit rates; the eviction-loop counters confirm whether the
+LRU machinery actually engaged.

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -18,6 +18,11 @@ these events see [METRICS.md](METRICS.md).
 | `L1_WRITE_FINISHED` | `keys` | `list[ObjectKey]` |
 | `L1_WRITE_FINISHED_AND_READ_RESERVED` | `keys` | `list[ObjectKey]` |
 | `L1_KEYS_EVICTED` | `keys` | `list[ObjectKey]` |
+| `L1_EVICTION_LOOP_TICK` | `usage`, `watermark`, `triggered` | `float`, `float`, `bool` |
+
+`L1_EVICTION_LOOP_TICK` fires once per `L1EvictionController.eviction_loop`
+iteration (default ~1Hz).  `triggered` is `True` when `usage >= watermark`
+and the policy ran this cycle, `False` otherwise.
 
 ---
 
@@ -203,7 +208,7 @@ These events use `session_id` on the `Event` dataclass (sourced from
 | EventType | Metadata keys | Types |
 |---|---|---|
 | `CB_LOOKUP_START` | `num_tokens` | `int` |
-| `CB_LOOKUP_END` | `num_tokens`, `fingerprint_hits`, `storage_hits`, `stale_chunks`, `no_gpu_context` | `int`, `int`, `int`, `int`, `bool` |
+| `CB_LOOKUP_END` | `num_tokens`, `requested_tokens`, `hit_tokens`, `fingerprint_hits`, `storage_hits`, `stale_chunks`, `no_gpu_context` | `int`, `int`, `int`, `int`, `int`, `int`, `bool` |
 | `CB_STORE_PRE_COMPUTED_START` | `instance_id`, `num_tokens` | `int`, `int` |
 | `CB_STORE_PRE_COMPUTED_END` | `instance_id`, `num_tokens`, `stored_chunks`, `success` | `int`, `int`, `int`, `bool` |
 | `CB_RETRIEVE_START` | `instance_id`, `num_chunks` | `int`, `int` |

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -519,4 +519,86 @@ rate(lmcache_blend_lookup_hit_tokens_total[5m])
 
 ---
 
+## Debug Recipes: separating L1 / L2 / Blend hit rates
+
+These are derivations from existing counters — **everything below is computable from the metrics already exported**, no new instruments needed. Use them when triaging "why is hit rate low?" or "is this an L1 or L2 issue?" without code-level instrumentation.
+
+Common parameters you'll need (all from `GET <lmcache-url>/api/status`):
+
+| Field | Source | Example |
+|---|---|---|
+| `chunk_size` | `chunk_size` (top level) | 256 |
+| L1 capacity (bytes) | `storage_manager.l1_manager.memory_total_bytes` | `5 * 2**30` |
+| L1 used (bytes) | `storage_manager.l1_manager.memory_used_bytes` | varies |
+
+### Token-level hit rate (L1 + L2 combined)
+
+The headline metric, already exposed:
+
+```
+lmcache_mp_lookup_hit_tokens_total / lmcache_mp_lookup_requested_tokens_total
+```
+
+This is the fraction of chunk-aligned tokens that came back from cache *anywhere* — L1 or L2. Reported per `(model_name, cache_salt)`.
+
+### L2-only hit rate
+
+L2's prefetch lookups carry per-key counts, not per-token:
+
+```
+L2_hit_tokens_total = increase(lmcache_mp_l2_prefetch_hit_keys_total) * chunk_size
+L2_hit_rate         = L2_hit_tokens_total
+                    / increase(lmcache_mp_lookup_requested_tokens_total)
+```
+
+`chunk_size` is fixed per server (typically 256 tokens/chunk). The keys-to-tokens conversion is exact — every L2 hit is a full chunk.
+
+### L1-only hit rate (derived)
+
+Take total minus L2:
+
+```
+L1_hit_tokens_total = increase(lmcache_mp_lookup_hit_tokens_total)
+                    - increase(lmcache_mp_l2_prefetch_hit_keys_total) * chunk_size
+L1_hit_rate         = L1_hit_tokens_total
+                    / increase(lmcache_mp_lookup_requested_tokens_total)
+```
+
+Sanity check: should be `>= 0`. A sustained negative value means L2 is being credited with chunks the lookup hit metric doesn't count, which would indicate a metric-emission bug (file an issue).
+
+### Blend total hit rate
+
+```
+lmcache_blend_lookup_hit_tokens_total / lmcache_blend_lookup_requested_tokens_total
+```
+
+Reported per CacheBlend lookup (`CB_LOOKUP_END`).
+
+### Blend L1 vs L2 — *not separable today*
+
+The blend lookup path consults L1 (fingerprint table) and L2 (storage prefetch) as a single pipelined operation. The current `lmcache_blend.lookup_storage_hits` counter records "chunks confirmed in storage after prefetch" *aggregated* across L1 and L2. Splitting them requires per-chunk attribution inside the blend lookup, which would need new instrumentation in `blend_server_v2.py`. **Open follow-up** — track via a future `[Obs] Split blend storage hits by tier` PR.
+
+### Did eviction actually fire during my run?
+
+```
+ticks      = increase(lmcache_mp_l1_eviction_loop_ticks_total)
+triggered  = increase(lmcache_mp_l1_eviction_loop_triggered_total)
+fire_ratio = triggered / ticks   # 0.0 = never fired; 1.0 = fired every cycle
+```
+
+If `triggered == 0` over a thrash test, your benchmark completed faster than the 1Hz polling interval — see the `prefix-suffix-tuner` workload's Debug Guide for the recommended `--eviction-trigger-watermark` / `--eviction-ratio` settings.
+
+### Self-service debug checklist
+
+Send these and you have everything needed to root-cause a hit-rate regression:
+
+1. `GET <lmcache-url>/api/status` (config + state snapshot).
+2. `GET <lmcache-url>/metrics` taken **before** the run and again **after** (delta is the run).
+3. The bench's `bench_summary.json` and `bench_results.csv` (TTFT per request).
+4. The LMCache server's stdout/stderr (eviction trigger logs are at INFO level).
+
+(1)–(3) plus the formulas above let you compute L1, L2, blend, and combined hit rates; the eviction-loop counters confirm whether the LRU machinery engaged during the run.
+
+---
+
 For event metadata contracts (what keys each `EventType` carries), see [EVENTS.md](EVENTS.md).

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -101,8 +101,22 @@ datapoints and are orthogonal to these Resource attributes.
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
 | `lmcache_mp.l1_evicted_keys` | `lmcache_mp_l1_evicted_keys_total` | Counter | `L1_KEYS_EVICTED` | `+len(keys)` |
+| `lmcache_mp.l1_eviction_loop_ticks` | `lmcache_mp_l1_eviction_loop_ticks_total` | Counter | `L1_EVICTION_LOOP_TICK` | +1 per loop iteration |
+| `lmcache_mp.l1_eviction_loop_triggered` | `lmcache_mp_l1_eviction_loop_triggered_total` | Counter | `L1_EVICTION_LOOP_TICK` | +1 when `triggered=True` |
+| `lmcache_mp.l1_usage_ratio` | `lmcache_mp_l1_usage_ratio` | Histogram | `L1_EVICTION_LOOP_TICK` | sample of `usage` per tick |
 
 **What it answers:** How aggressively is the eviction controller clearing L1? A high eviction rate relative to writes signals memory pressure.
+
+**Eviction-loop liveness vs. fire rate:** the eviction loop polls L1 once per second and only triggers eviction when `usage >= watermark`.  The two new counters distinguish "the loop is alive" from "eviction actually fired":
+
+```
+rate(lmcache_mp_l1_eviction_loop_triggered_total[1m])
+/ rate(lmcache_mp_l1_eviction_loop_ticks_total[1m])
+```
+
+is the fraction of ticks that actually evicted.  This is essential for debugging short-lived benchmarks — a workload that completes in <1s never gives the loop a chance to fire even when the pool exceeds the watermark, and watching `eviction_loop_triggered_total` stay at zero during the run makes that visible immediately rather than requiring debug-log inspection.
+
+The `l1_usage_ratio` histogram captures the distribution of L1 fullness sampled at every tick — useful for spotting sawtooth fill/drain patterns versus steady-state operation.
 
 ---
 

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -103,20 +103,11 @@ datapoints and are orthogonal to these Resource attributes.
 | `lmcache_mp.l1_evicted_keys` | `lmcache_mp_l1_evicted_keys_total` | Counter | `L1_KEYS_EVICTED` | `+len(keys)` |
 | `lmcache_mp.l1_eviction_loop_ticks` | `lmcache_mp_l1_eviction_loop_ticks_total` | Counter | `L1_EVICTION_LOOP_TICK` | +1 per loop iteration |
 | `lmcache_mp.l1_eviction_loop_triggered` | `lmcache_mp_l1_eviction_loop_triggered_total` | Counter | `L1_EVICTION_LOOP_TICK` | +1 when `triggered=True` |
-| `lmcache_mp.l1_usage_ratio` | `lmcache_mp_l1_usage_ratio` | Histogram | `L1_EVICTION_LOOP_TICK` | sample of `usage` per tick |
+| `lmcache_mp.l1_usage_ratio` | `lmcache_mp_l1_usage_ratio` | Observable Gauge | (callback on `L1Manager`) | `used / total` at scrape time |
 
-**What it answers:** How aggressively is the eviction controller clearing L1? A high eviction rate relative to writes signals memory pressure.
+**What it answers:** How aggressively is the eviction controller clearing L1?  Is the eviction loop alive but staying below the watermark, or actively firing?  What is the current L1 fullness?
 
-**Eviction-loop liveness vs. fire rate:** the eviction loop polls L1 once per second and only triggers eviction when `usage >= watermark`.  The two new counters distinguish "the loop is alive" from "eviction actually fired":
-
-```
-rate(lmcache_mp_l1_eviction_loop_triggered_total[1m])
-/ rate(lmcache_mp_l1_eviction_loop_ticks_total[1m])
-```
-
-is the fraction of ticks that actually evicted.  This is essential for debugging short-lived benchmarks — a workload that completes in <1s never gives the loop a chance to fire even when the pool exceeds the watermark, and watching `eviction_loop_triggered_total` stay at zero during the run makes that visible immediately rather than requiring debug-log inspection.
-
-The `l1_usage_ratio` histogram captures the distribution of L1 fullness sampled at every tick — useful for spotting sawtooth fill/drain patterns versus steady-state operation.
+The two loop counters distinguish "loop is alive" from "eviction fired" — important when debugging short-lived benchmarks (a workload that completes in <1 s never gives the 1Hz polling loop a chance to fire even when usage exceeds the watermark).  `l1_usage_ratio` is registered via :func:`register_gauge` against `L1Manager`, so its value reflects current state at scrape time, not a per-tick sample.
 
 ---
 
@@ -519,86 +510,9 @@ rate(lmcache_blend_lookup_hit_tokens_total[5m])
 
 ---
 
-## Debug Recipes: separating L1 / L2 / Blend hit rates
+For derivations of L1-only / L2-only / blend hit rates from these
+counters, and a "what to send when reporting" checklist, see
+[DEBUG.md](DEBUG.md).
 
-These are derivations from existing counters — **everything below is computable from the metrics already exported**, no new instruments needed. Use them when triaging "why is hit rate low?" or "is this an L1 or L2 issue?" without code-level instrumentation.
-
-Common parameters you'll need (all from `GET <lmcache-url>/api/status`):
-
-| Field | Source | Example |
-|---|---|---|
-| `chunk_size` | `chunk_size` (top level) | 256 |
-| L1 capacity (bytes) | `storage_manager.l1_manager.memory_total_bytes` | `5 * 2**30` |
-| L1 used (bytes) | `storage_manager.l1_manager.memory_used_bytes` | varies |
-
-### Token-level hit rate (L1 + L2 combined)
-
-The headline metric, already exposed:
-
-```
-lmcache_mp_lookup_hit_tokens_total / lmcache_mp_lookup_requested_tokens_total
-```
-
-This is the fraction of chunk-aligned tokens that came back from cache *anywhere* — L1 or L2. Reported per `(model_name, cache_salt)`.
-
-### L2-only hit rate
-
-L2's prefetch lookups carry per-key counts, not per-token:
-
-```
-L2_hit_tokens_total = increase(lmcache_mp_l2_prefetch_hit_keys_total) * chunk_size
-L2_hit_rate         = L2_hit_tokens_total
-                    / increase(lmcache_mp_lookup_requested_tokens_total)
-```
-
-`chunk_size` is fixed per server (typically 256 tokens/chunk). The keys-to-tokens conversion is exact — every L2 hit is a full chunk.
-
-### L1-only hit rate (derived)
-
-Take total minus L2:
-
-```
-L1_hit_tokens_total = increase(lmcache_mp_lookup_hit_tokens_total)
-                    - increase(lmcache_mp_l2_prefetch_hit_keys_total) * chunk_size
-L1_hit_rate         = L1_hit_tokens_total
-                    / increase(lmcache_mp_lookup_requested_tokens_total)
-```
-
-Sanity check: should be `>= 0`. A sustained negative value means L2 is being credited with chunks the lookup hit metric doesn't count, which would indicate a metric-emission bug (file an issue).
-
-### Blend total hit rate
-
-```
-lmcache_blend_lookup_hit_tokens_total / lmcache_blend_lookup_requested_tokens_total
-```
-
-Reported per CacheBlend lookup (`CB_LOOKUP_END`).
-
-### Blend L1 vs L2 — *not separable today*
-
-The blend lookup path consults L1 (fingerprint table) and L2 (storage prefetch) as a single pipelined operation. The current `lmcache_blend.lookup_storage_hits` counter records "chunks confirmed in storage after prefetch" *aggregated* across L1 and L2. Splitting them requires per-chunk attribution inside the blend lookup, which would need new instrumentation in `blend_server_v2.py`. **Open follow-up** — track via a future `[Obs] Split blend storage hits by tier` PR.
-
-### Did eviction actually fire during my run?
-
-```
-ticks      = increase(lmcache_mp_l1_eviction_loop_ticks_total)
-triggered  = increase(lmcache_mp_l1_eviction_loop_triggered_total)
-fire_ratio = triggered / ticks   # 0.0 = never fired; 1.0 = fired every cycle
-```
-
-If `triggered == 0` over a thrash test, your benchmark completed faster than the 1Hz polling interval — see the `prefix-suffix-tuner` workload's Debug Guide for the recommended `--eviction-trigger-watermark` / `--eviction-ratio` settings.
-
-### Self-service debug checklist
-
-Send these and you have everything needed to root-cause a hit-rate regression:
-
-1. `GET <lmcache-url>/api/status` (config + state snapshot).
-2. `GET <lmcache-url>/metrics` taken **before** the run and again **after** (delta is the run).
-3. The bench's `bench_summary.json` and `bench_results.csv` (TTFT per request).
-4. The LMCache server's stdout/stderr (eviction trigger logs are at INFO level).
-
-(1)–(3) plus the formulas above let you compute L1, L2, blend, and combined hit rates; the eviction-loop counters confirm whether the LRU machinery engaged during the run.
-
----
-
-For event metadata contracts (what keys each `EventType` carries), see [EVENTS.md](EVENTS.md).
+For event metadata contracts (what keys each `EventType` carries), see
+[EVENTS.md](EVENTS.md).

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -448,12 +448,21 @@ MP mode `lmcache_mp.` namespace).  On Prometheus, `.` becomes `_` and counters g
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
 | `lmcache_blend.lookup_requests` | `lmcache_blend_lookup_requests_total` | Counter | `CB_LOOKUP_START` | +1 per event |
+| `lmcache_blend.lookup_requested_tokens` | `lmcache_blend_lookup_requested_tokens_total` | Counter | `CB_LOOKUP_END` | `+requested_tokens` |
+| `lmcache_blend.lookup_hit_tokens` | `lmcache_blend_lookup_hit_tokens_total` | Counter | `CB_LOOKUP_END` | `+hit_tokens` |
 | `lmcache_blend.lookup_fingerprint_hits` | `lmcache_blend_lookup_fingerprint_hits_total` | Counter | `CB_LOOKUP_END` | `+fingerprint_hits` |
 | `lmcache_blend.lookup_storage_hits` | `lmcache_blend_lookup_storage_hits_total` | Counter | `CB_LOOKUP_END` | `+storage_hits` |
 | `lmcache_blend.lookup_stale_chunks` | `lmcache_blend_lookup_stale_chunks_total` | Counter | `CB_LOOKUP_END` | `+stale_chunks` |
 | `lmcache_blend.lookup_no_gpu_context_errors` | `lmcache_blend_lookup_no_gpu_context_errors_total` | Counter | `CB_LOOKUP_END` | +1 when `no_gpu_context=True` |
 
-**What it answers:** How often does the CB server receive lookup requests? What fraction hit the fingerprint table? What fraction are confirmed in storage? How many stale evictions occur?
+**What it answers:** How often does the CB server receive lookup requests? What fraction of requested tokens are served by blend (token-level hit rate)? What fraction hit the fingerprint table? What fraction are confirmed in storage? How many stale evictions occur?
+
+**Blend token-level hit rate** (numerator and denominator co-emit on the same `CB_LOOKUP_END` event so the ratio is meaningful even under partial-failure paths):
+
+```
+rate(lmcache_blend_lookup_hit_tokens_total[5m])
+/ rate(lmcache_blend_lookup_requested_tokens_total[5m])
+```
 
 ### CB Retrieve Metrics
 

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -112,6 +112,20 @@ def _validate_extra_count(extra_count: int) -> int:
     return extra_count
 
 
+def _l1_usage_ratio_or_zero(target: "L1Manager | None") -> float:
+    """Return ``target.get_memory_usage()`` as a 0.0-1.0 ratio.
+
+    Returns 0.0 when ``target`` is None or ``total_bytes`` is zero so the
+    observable-gauge callback never raises during scrape.
+    """
+    if target is None:
+        return 0.0
+    used, total = target.get_memory_usage()
+    if total <= 0:
+        return 0.0
+    return used / total
+
+
 # Main classes
 
 
@@ -191,6 +205,12 @@ class L1Manager:
                     if L1Manager._gauge_target is not None
                     else 0
                 ),
+            )
+            register_gauge(
+                "lmcache.l1_manager",
+                "lmcache_mp.l1_usage_ratio",
+                "L1 used/total ratio (0.0–1.0)",
+                lambda: _l1_usage_ratio_or_zero(L1Manager._gauge_target),
             )
 
     def register_listener(self, listener: L1ManagerListener) -> None:

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -22,6 +22,8 @@ from lmcache.v1.distributed.internal_api import (
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
 from lmcache.v1.distributed.storage_controller import StorageControllerInterface
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import get_event_bus
 
 if TYPE_CHECKING:
     # First Party
@@ -115,6 +117,7 @@ class L1EvictionController(EvictionController):
     def eviction_loop(self):
         watermark = self._eviction_config.trigger_watermark
         eviction_ratio = self._eviction_config.eviction_ratio
+        event_bus = get_event_bus()
 
         while not self._stop_flag.is_set():
             time.sleep(1)
@@ -125,6 +128,16 @@ class L1EvictionController(EvictionController):
                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
                     usage,
                     watermark,
+                )
+                event_bus.publish(
+                    Event(
+                        event_type=EventType.L1_EVICTION_LOOP_TICK,
+                        metadata={
+                            "usage": usage,
+                            "watermark": watermark,
+                            "triggered": False,
+                        },
+                    )
                 )
                 continue
 
@@ -139,6 +152,16 @@ class L1EvictionController(EvictionController):
             )
             for action in actions:
                 self.execute_eviction_action(action)
+            event_bus.publish(
+                Event(
+                    event_type=EventType.L1_EVICTION_LOOP_TICK,
+                    metadata={
+                        "usage": usage,
+                        "watermark": watermark,
+                        "triggered": True,
+                    },
+                )
+            )
 
     def execute_eviction_action(self, action: EvictionAction):
         if action.destination == EvictionDestination.DISCARD:

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -104,6 +104,7 @@ class L1EvictionController(EvictionController):
         self._l1_manager = l1_manager
         self._listener = L1EvictionPolicy(self._eviction_policy)
         self._l1_manager.register_listener(self._listener)
+        self._event_bus = get_event_bus()
 
     def report_status(self) -> dict:
         return {
@@ -114,10 +115,35 @@ class L1EvictionController(EvictionController):
             "eviction_ratio": self._eviction_config.eviction_ratio,
         }
 
+    def _publish_skipped(self, usage: float, watermark: float) -> None:
+        """Publish a below-watermark loop tick (no eviction this cycle)."""
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_EVICTION_LOOP_TICK,
+                metadata={
+                    "usage": usage,
+                    "watermark": watermark,
+                    "triggered": False,
+                },
+            )
+        )
+
+    def _publish_triggered(self, usage: float, watermark: float) -> None:
+        """Publish an above-watermark loop tick (eviction policy ran)."""
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_EVICTION_LOOP_TICK,
+                metadata={
+                    "usage": usage,
+                    "watermark": watermark,
+                    "triggered": True,
+                },
+            )
+        )
+
     def eviction_loop(self):
         watermark = self._eviction_config.trigger_watermark
         eviction_ratio = self._eviction_config.eviction_ratio
-        event_bus = get_event_bus()
 
         while not self._stop_flag.is_set():
             time.sleep(1)
@@ -129,16 +155,7 @@ class L1EvictionController(EvictionController):
                     usage,
                     watermark,
                 )
-                event_bus.publish(
-                    Event(
-                        event_type=EventType.L1_EVICTION_LOOP_TICK,
-                        metadata={
-                            "usage": usage,
-                            "watermark": watermark,
-                            "triggered": False,
-                        },
-                    )
-                )
+                self._publish_skipped(usage, watermark)
                 continue
 
             logger.info(
@@ -152,16 +169,7 @@ class L1EvictionController(EvictionController):
             )
             for action in actions:
                 self.execute_eviction_action(action)
-            event_bus.publish(
-                Event(
-                    event_type=EventType.L1_EVICTION_LOOP_TICK,
-                    metadata={
-                        "usage": usage,
-                        "watermark": watermark,
-                        "triggered": True,
-                    },
-                )
-            )
+            self._publish_triggered(usage, watermark)
 
     def execute_eviction_action(self, action: EvictionAction):
         if action.destination == EvictionDestination.DISCARD:

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -340,6 +340,7 @@ def init_observability(
             EventBusSelfMetricsSubscriber,
             L0L1ThroughputSubscriber,
             L0LifecycleSubscriber,
+            L1EvictionLoopSubscriber,
             L1FailureMetricsSubscriber,
             L1LifecycleSubscriber,
             L1MetricsSubscriber,
@@ -356,6 +357,7 @@ def init_observability(
         bus.register_subscriber(L1MetricsSubscriber())
         bus.register_subscriber(L1LifecycleSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L1FailureMetricsSubscriber())
+        bus.register_subscriber(L1EvictionLoopSubscriber())
         bus.register_subscriber(L0L1ThroughputSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L2MetricsSubscriber())
         bus.register_subscriber(L2FailureMetricsSubscriber())

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -25,17 +25,6 @@ class EventType(Enum):
     L1_WRITE_FINISHED = "l1.write.finished"
     L1_WRITE_FINISHED_AND_READ_RESERVED = "l1.write_finished_and_read_reserved"
     L1_KEYS_EVICTED = "l1.keys.evicted"
-
-    # L1 eviction loop tick — fires once per ``eviction_loop`` iteration,
-    # whether or not eviction was triggered.  Metadata:
-    #   ``usage``     (float): current ``used_bytes / total_bytes`` ratio
-    #   ``watermark`` (float): trigger threshold from EvictionConfig
-    #   ``triggered`` (bool):  True when usage >= watermark and the
-    #                          eviction policy ran this tick
-    # Together with ``L1_KEYS_EVICTED`` (count of keys actually evicted),
-    # this tells you how often the eviction loop ran versus how often it
-    # actually evicted — a subtle distinction that matters for debugging
-    # benchmarks that complete faster than the 1Hz polling rate.
     L1_EVICTION_LOOP_TICK = "l1.eviction.loop_tick"
 
     # L1 failure events (LM-291 health monitoring)

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -26,6 +26,18 @@ class EventType(Enum):
     L1_WRITE_FINISHED_AND_READ_RESERVED = "l1.write_finished_and_read_reserved"
     L1_KEYS_EVICTED = "l1.keys.evicted"
 
+    # L1 eviction loop tick — fires once per ``eviction_loop`` iteration,
+    # whether or not eviction was triggered.  Metadata:
+    #   ``usage``     (float): current ``used_bytes / total_bytes`` ratio
+    #   ``watermark`` (float): trigger threshold from EvictionConfig
+    #   ``triggered`` (bool):  True when usage >= watermark and the
+    #                          eviction policy ran this tick
+    # Together with ``L1_KEYS_EVICTED`` (count of keys actually evicted),
+    # this tells you how often the eviction loop ran versus how often it
+    # actually evicted — a subtle distinction that matters for debugging
+    # benchmarks that complete faster than the 1Hz polling rate.
+    L1_EVICTION_LOOP_TICK = "l1.eviction.loop_tick"
+
     # L1 failure events (LM-291 health monitoring)
     L1_ALLOCATION_FAILED = "l1.allocation.failed"
     L1_READ_FAILED = "l1.read.failed"

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -17,6 +17,9 @@ from lmcache.v1.mp_observability.subscribers.metrics.l0_lifecycle import (
     L0LifecycleSubscriber,
 )
 from lmcache.v1.mp_observability.subscribers.metrics.l1 import L1MetricsSubscriber
+from lmcache.v1.mp_observability.subscribers.metrics.l1_eviction_loop import (
+    L1EvictionLoopSubscriber,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.l1_failures import (
     L1FailureMetricsSubscriber,
 )
@@ -44,6 +47,7 @@ __all__ = [
     "EventBusSelfMetricsSubscriber",
     "L0L1ThroughputSubscriber",
     "L0LifecycleSubscriber",
+    "L1EvictionLoopSubscriber",
     "L1FailureMetricsSubscriber",
     "L1LifecycleSubscriber",
     "L1MetricsSubscriber",

--- a/lmcache/v1/mp_observability/subscribers/metrics/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/cb_server.py
@@ -18,6 +18,13 @@ class BlendMetricsSubscriber(EventSubscriber):
 
     Metrics:
     - ``lmcache_blend.lookup_requests``              — total CB lookup calls
+    - ``lmcache_blend.lookup_requested_tokens``      — chunk-aligned tokens
+      submitted for CB lookup (denominator of the blend token-level hit
+      rate).  Sub-chunk trailing tokens are excluded because they cannot
+      hit by design.
+    - ``lmcache_blend.lookup_hit_tokens``            — tokens served by
+      blend during the lookup (numerator of the blend token-level hit
+      rate).  Equal to ``storage_hits * chunk_size``.
     - ``lmcache_blend.lookup_fingerprint_hits``      — fingerprint table hits
     - ``lmcache_blend.lookup_storage_hits``          — chunks confirmed in storage
     - ``lmcache_blend.lookup_stale_chunks``          — fingerprint hits evicted as stale
@@ -41,6 +48,24 @@ class BlendMetricsSubscriber(EventSubscriber):
         self._lookup_requests = meter.create_counter(
             "lmcache_blend.lookup_requests",
             description="Total CB lookup requests",
+        )
+        self._lookup_requested_tokens = meter.create_counter(
+            "lmcache_blend.lookup_requested_tokens",
+            description=(
+                "Total tokens submitted for CB lookup (denominator of the "
+                "blend token-level hit rate). Only chunk-aligned tokens "
+                "are counted."
+            ),
+            unit="tokens",
+        )
+        self._lookup_hit_tokens = meter.create_counter(
+            "lmcache_blend.lookup_hit_tokens",
+            description=(
+                "Total tokens served by blend during lookup (numerator of "
+                "the blend token-level hit rate). Equal to "
+                "storage_hits * chunk_size."
+            ),
+            unit="tokens",
         )
         self._lookup_fingerprint_hits = meter.create_counter(
             "lmcache_blend.lookup_fingerprint_hits",
@@ -122,6 +147,8 @@ class BlendMetricsSubscriber(EventSubscriber):
         self._lookup_requests.add(1)
 
     def _on_lookup_end(self, event: Event) -> None:
+        self._lookup_requested_tokens.add(event.metadata["requested_tokens"])
+        self._lookup_hit_tokens.add(event.metadata["hit_tokens"])
         self._lookup_fingerprint_hits.add(event.metadata["fingerprint_hits"])
         self._lookup_storage_hits.add(event.metadata["storage_hits"])
         self._lookup_stale_chunks.add(event.metadata["stale_chunks"])

--- a/lmcache/v1/mp_observability/subscribers/metrics/l1_eviction_loop.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l1_eviction_loop.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""L1 eviction-loop metrics subscriber.
+
+Exposes counters that distinguish "the eviction loop is alive" from
+"eviction actually fired" — a subtle distinction that matters when
+debugging benchmarks that complete faster than the 1Hz polling rate.
+
+Use case: a workload that writes many chunks in a 50 ms burst will
+finish before the eviction loop's next ``time.sleep(1)`` returns, so
+no eviction fires during the run even when the pool exceeds the
+watermark.  Counters here let dashboards show that immediately, rather
+than requiring code inspection or grep on debug logs.
+
+Metrics:
+  - ``lmcache_mp.l1_eviction_loop_ticks``      — every loop iteration
+  - ``lmcache_mp.l1_eviction_loop_triggered``  — only iterations where
+    ``usage >= watermark`` and the policy ran
+  - ``lmcache_mp.l1_usage_ratio``              — histogram of
+    ``used_bytes / total_bytes`` sampled at every tick
+
+Source event: :data:`EventType.L1_EVICTION_LOOP_TICK`, published by
+:class:`L1EvictionController` once per ``eviction_loop`` cycle.
+"""
+
+# Future
+from __future__ import annotations
+
+# Third Party
+from opentelemetry import metrics
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+
+
+class L1EvictionLoopSubscriber(EventSubscriber):
+    """Maintains OTel instruments for the L1 eviction loop's lifecycle."""
+
+    def __init__(self) -> None:
+        meter = metrics.get_meter("lmcache.l1")
+        self._ticks = meter.create_counter(
+            "lmcache_mp.l1_eviction_loop_ticks",
+            description=(
+                "Number of L1 eviction-loop iterations.  Increments once "
+                "per loop cycle (default ~1Hz), regardless of whether "
+                "eviction actually ran.  Lets dashboards distinguish a "
+                "stalled loop from one that's running but staying below "
+                "the watermark."
+            ),
+        )
+        self._triggered = meter.create_counter(
+            "lmcache_mp.l1_eviction_loop_triggered",
+            description=(
+                "Iterations of the L1 eviction loop where ``usage >= "
+                "watermark`` and the policy ran.  Compare to "
+                "``l1_eviction_loop_ticks`` to see what fraction of "
+                "loop iterations actually triggered eviction."
+            ),
+        )
+        self._usage_hist = meter.create_histogram(
+            "lmcache_mp.l1_usage_ratio",
+            description=(
+                "Distribution of L1 ``used_bytes / total_bytes`` sampled "
+                "once per eviction-loop tick.  Useful for spotting "
+                "fast-fill / slow-drain patterns versus steady-state "
+                "operation."
+            ),
+            unit="ratio",
+        )
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {EventType.L1_EVICTION_LOOP_TICK: self._on_tick}
+
+    def _on_tick(self, event: Event) -> None:
+        usage = float(event.metadata.get("usage", 0.0))
+        triggered = bool(event.metadata.get("triggered", False))
+        self._ticks.add(1)
+        if triggered:
+            self._triggered.add(1)
+        self._usage_hist.record(usage)

--- a/lmcache/v1/mp_observability/subscribers/metrics/l1_eviction_loop.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l1_eviction_loop.py
@@ -1,27 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""L1 eviction-loop metrics subscriber.
-
-Exposes counters that distinguish "the eviction loop is alive" from
-"eviction actually fired" — a subtle distinction that matters when
-debugging benchmarks that complete faster than the 1Hz polling rate.
-
-Use case: a workload that writes many chunks in a 50 ms burst will
-finish before the eviction loop's next ``time.sleep(1)`` returns, so
-no eviction fires during the run even when the pool exceeds the
-watermark.  Counters here let dashboards show that immediately, rather
-than requiring code inspection or grep on debug logs.
-
-Metrics:
-  - ``lmcache_mp.l1_eviction_loop_ticks``      — every loop iteration
-  - ``lmcache_mp.l1_eviction_loop_triggered``  — only iterations where
-    ``usage >= watermark`` and the policy ran
-  - ``lmcache_mp.l1_usage_ratio``              — histogram of
-    ``used_bytes / total_bytes`` sampled at every tick
-
-Source event: :data:`EventType.L1_EVICTION_LOOP_TICK`, published by
-:class:`L1EvictionController` once per ``eviction_loop`` cycle.
-"""
+"""L1 eviction-loop metrics subscriber — OTel instruments for L1EvictionController."""
 
 # Future
 from __future__ import annotations
@@ -35,47 +14,35 @@ from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
 
 
 class L1EvictionLoopSubscriber(EventSubscriber):
-    """Maintains OTel instruments for the L1 eviction loop's lifecycle."""
+    """Maintains OTel counters for the L1 eviction loop.
+
+    Metrics:
+    - ``lmcache_mp.l1_eviction_loop_ticks`` — every loop iteration.
+    - ``lmcache_mp.l1_eviction_loop_triggered`` — iterations where
+      ``usage >= watermark`` and the eviction policy ran.
+
+    The two counters distinguish "loop is alive" from "eviction fired",
+    which matters for short benchmarks that complete faster than the 1Hz
+    polling rate.  Current L1 fullness is exposed separately as the
+    ``lmcache_mp.l1_memory_usage_bytes`` and ``lmcache_mp.l1_usage_ratio``
+    observable gauges registered in :class:`L1Manager`.
+    """
 
     def __init__(self) -> None:
         meter = metrics.get_meter("lmcache.l1")
         self._ticks = meter.create_counter(
             "lmcache_mp.l1_eviction_loop_ticks",
-            description=(
-                "Number of L1 eviction-loop iterations.  Increments once "
-                "per loop cycle (default ~1Hz), regardless of whether "
-                "eviction actually ran.  Lets dashboards distinguish a "
-                "stalled loop from one that's running but staying below "
-                "the watermark."
-            ),
+            description="L1 eviction-loop iterations (every cycle)",
         )
         self._triggered = meter.create_counter(
             "lmcache_mp.l1_eviction_loop_triggered",
-            description=(
-                "Iterations of the L1 eviction loop where ``usage >= "
-                "watermark`` and the policy ran.  Compare to "
-                "``l1_eviction_loop_ticks`` to see what fraction of "
-                "loop iterations actually triggered eviction."
-            ),
-        )
-        self._usage_hist = meter.create_histogram(
-            "lmcache_mp.l1_usage_ratio",
-            description=(
-                "Distribution of L1 ``used_bytes / total_bytes`` sampled "
-                "once per eviction-loop tick.  Useful for spotting "
-                "fast-fill / slow-drain patterns versus steady-state "
-                "operation."
-            ),
-            unit="ratio",
+            description="L1 eviction-loop iterations where the policy ran",
         )
 
     def get_subscriptions(self) -> dict[EventType, EventCallback]:
         return {EventType.L1_EVICTION_LOOP_TICK: self._on_tick}
 
     def _on_tick(self, event: Event) -> None:
-        usage = float(event.metadata.get("usage", 0.0))
-        triggered = bool(event.metadata.get("triggered", False))
         self._ticks.add(1)
-        if triggered:
+        if event.metadata.get("triggered", False):
             self._triggered.add(1)
-        self._usage_hist.record(usage)

--- a/tests/v1/mp_observability/subscribers/metrics/otel_setup.py
+++ b/tests/v1/mp_observability/subscribers/metrics/otel_setup.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared OTel MeterProvider for all metrics subscriber tests.
+"""Shared OTel MeterProvider + helpers for all metrics subscriber tests.
 
 OTel only allows one MeterProvider per process.  This module sets it up
-once so that every test file in this directory reads from the same reader.
+once so that every test file in this directory reads from the same reader,
+and provides a small set of helpers for snapshotting and diffing counter /
+histogram values via :data:`reader`.
 
 Import as::
 
-    from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader
+    from tests.v1.mp_observability.subscribers.metrics.otel_setup import (
+        reader,
+        read_counters,
+        histogram_count,
+        counter_delta,
+    )
 """
 
 # Third Party
@@ -18,3 +25,64 @@ from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 reader = InMemoryMetricReader()
 _provider = MeterProvider(metric_readers=[reader])
 metrics.set_meter_provider(_provider)
+
+
+def read_counters() -> dict[str, int]:
+    """Snapshot counter values, summed across all attribute combinations.
+
+    Accumulates into the result dict (rather than overwriting) when the
+    same metric name appears in multiple resource/scope buckets, which
+    can happen when several test files have populated the shared reader.
+
+    Returns:
+        Mapping of metric name -> total value across all data points.
+        Histograms are skipped (use :func:`histogram_count` instead).
+    """
+    data = reader.get_metrics_data()
+    result: dict[str, int] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                total = 0
+                any_value = False
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue  # skip histogram data points
+                    total += int(dp.value)
+                    any_value = True
+                if any_value:
+                    result[metric.name] = result.get(metric.name, 0) + total
+    return result
+
+
+def histogram_count(name: str) -> int:
+    """Return the total observation count for the named histogram.
+
+    Args:
+        name: OTel metric name, e.g. ``"lmcache_mp.l1_usage_ratio"``.
+
+    Returns:
+        Sum of ``count`` across all data points for that histogram.
+        Returns 0 if the histogram has no observations yet.
+    """
+    data = reader.get_metrics_data()
+    if data is None:
+        return 0
+    total = 0
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                if metric.name != name:
+                    continue
+                for dp in metric.data.data_points:
+                    if hasattr(dp, "count"):
+                        total += int(dp.count)
+    return total
+
+
+def counter_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    """Compute ``after - before`` for every metric name in either snapshot."""
+    all_keys = set(before) | set(after)
+    return {k: after.get(k, 0) - before.get(k, 0) for k in all_keys}

--- a/tests/v1/mp_observability/subscribers/metrics/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_cb_server.py
@@ -14,41 +14,12 @@ from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
 from lmcache.v1.mp_observability.subscribers.metrics.cb_server import (
     BlendMetricsSubscriber,
 )
-from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import (
+    counter_delta,
+    read_counters,
+)
 
 _DRAIN_WAIT = 0.15
-
-
-def _read_counters() -> dict[str, int]:
-    """Snapshot counter values, summed across attribute combinations.
-
-    Accumulates into ``result`` rather than overwriting on duplicate
-    metric names so the snapshot stays correct when the same metric
-    appears in multiple resource/scope buckets (e.g., when other test
-    suites have populated the shared in-memory reader).
-    """
-    data = _reader.get_metrics_data()
-    result: dict[str, int] = {}
-    if data is None:
-        return result
-    for resource_metrics in data.resource_metrics:
-        for scope_metrics in resource_metrics.scope_metrics:
-            for metric in scope_metrics.metrics:
-                total = 0
-                any_value = False
-                for dp in metric.data.data_points:
-                    if not hasattr(dp, "value"):
-                        continue  # skip histogram data points
-                    total += int(dp.value)
-                    any_value = True
-                if any_value:
-                    result[metric.name] = result.get(metric.name, 0) + total
-    return result
-
-
-def _counter_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
-    all_keys = set(before) | set(after)
-    return {k: after.get(k, 0) - before.get(k, 0) for k in all_keys}
 
 
 @pytest.fixture
@@ -66,10 +37,10 @@ def subscriber(bus):
 @pytest.fixture
 def snapshot():
     """Capture counters before the test; yield a callable that returns deltas."""
-    before = _read_counters()
+    before = read_counters()
 
     def get_delta() -> dict[str, int]:
-        return _counter_delta(before, _read_counters())
+        return counter_delta(before, read_counters())
 
     return get_delta
 

--- a/tests/v1/mp_observability/subscribers/metrics/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_cb_server.py
@@ -14,6 +14,35 @@ from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
 from lmcache.v1.mp_observability.subscribers.metrics.cb_server import (
     BlendMetricsSubscriber,
 )
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+
+_DRAIN_WAIT = 0.15
+
+
+def _read_counters() -> dict[str, int]:
+    """Snapshot counter values, summed across attribute combinations."""
+    data = _reader.get_metrics_data()
+    result: dict[str, int] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                total = 0
+                any_value = False
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue  # skip histogram data points
+                    total += int(dp.value)
+                    any_value = True
+                if any_value:
+                    result[metric.name] = total
+    return result
+
+
+def _counter_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    all_keys = set(before) | set(after)
+    return {k: after.get(k, 0) - before.get(k, 0) for k in all_keys}
 
 
 @pytest.fixture
@@ -26,6 +55,17 @@ def subscriber(bus):
     sub = BlendMetricsSubscriber()
     bus.register_subscriber(sub)
     return sub
+
+
+@pytest.fixture
+def snapshot():
+    """Capture counters before the test; yield a callable that returns deltas."""
+    before = _read_counters()
+
+    def get_delta() -> dict[str, int]:
+        return _counter_delta(before, _read_counters())
+
+    return get_delta
 
 
 class TestBlendMetricsSubscriber:
@@ -69,6 +109,8 @@ class TestBlendMetricsSubscriber:
                 event_type=EventType.CB_LOOKUP_END,
                 session_id="req-1",
                 metadata={
+                    "requested_tokens": 1024,
+                    "hit_tokens": 768,
                     "fingerprint_hits": 4,
                     "storage_hits": 3,
                     "stale_chunks": 1,
@@ -86,6 +128,8 @@ class TestBlendMetricsSubscriber:
                 event_type=EventType.CB_LOOKUP_END,
                 session_id="req-1",
                 metadata={
+                    "requested_tokens": 0,
+                    "hit_tokens": 0,
                     "fingerprint_hits": 0,
                     "storage_hits": 0,
                     "stale_chunks": 0,
@@ -209,6 +253,8 @@ class TestBlendMetricsSubscriber:
                     event_type=EventType.CB_LOOKUP_END,
                     session_id="req-bulk",
                     metadata={
+                        "requested_tokens": 96,
+                        "hit_tokens": 32,
                         "fingerprint_hits": 2,
                         "storage_hits": 1,
                         "stale_chunks": 1,
@@ -218,3 +264,161 @@ class TestBlendMetricsSubscriber:
             )
         time.sleep(0.15)
         bus.stop()
+
+
+# ---------------------------------------------------------------------------
+# Blend token-level hit-rate counters
+#
+# These counters expose the numerator/denominator that let dashboards compute
+# the blend hit rate identically to the L1+L2 lookup hit rate:
+#
+#     rate(lmcache_blend_lookup_hit_tokens_total[5m])
+#     / rate(lmcache_blend_lookup_requested_tokens_total[5m])
+#
+# Asserts on actual counter deltas via the InMemoryMetricReader fixture.
+# ---------------------------------------------------------------------------
+
+
+class TestBlendLookupHitTokenCounters:
+    def test_full_hit(self, bus, subscriber, snapshot):
+        """All requested tokens are served by blend."""
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id="req-1",
+                metadata={
+                    "requested_tokens": 1024,
+                    "hit_tokens": 1024,
+                    "fingerprint_hits": 4,
+                    "storage_hits": 4,
+                    "stale_chunks": 0,
+                    "no_gpu_context": False,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert delta["lmcache_blend.lookup_requested_tokens"] == 1024
+        assert delta["lmcache_blend.lookup_hit_tokens"] == 1024
+
+    def test_partial_hit(self, bus, subscriber, snapshot):
+        """A subset of the requested tokens is served by blend."""
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id="req-2",
+                metadata={
+                    "requested_tokens": 1024,
+                    "hit_tokens": 256,
+                    "fingerprint_hits": 4,
+                    "storage_hits": 1,
+                    "stale_chunks": 3,
+                    "no_gpu_context": False,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert delta["lmcache_blend.lookup_requested_tokens"] == 1024
+        assert delta["lmcache_blend.lookup_hit_tokens"] == 256
+
+    def test_full_miss_still_records_denominator(self, bus, subscriber, snapshot):
+        """Cold lookup: the request must still increment the denominator so
+        the running hit rate properly reflects the miss."""
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id="req-3",
+                metadata={
+                    "requested_tokens": 512,
+                    "hit_tokens": 0,
+                    "fingerprint_hits": 0,
+                    "storage_hits": 0,
+                    "stale_chunks": 0,
+                    "no_gpu_context": False,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert delta["lmcache_blend.lookup_requested_tokens"] == 512
+        assert delta.get("lmcache_blend.lookup_hit_tokens", 0) == 0
+
+    def test_no_gpu_context_records_zero_tokens(self, bus, subscriber, snapshot):
+        """``no_gpu_context`` lookups emit ``hit_tokens=0`` and
+        ``requested_tokens=0`` — neither counter should move so the ratio
+        stays meaningful."""
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id="req-4",
+                metadata={
+                    "requested_tokens": 0,
+                    "hit_tokens": 0,
+                    "fingerprint_hits": 5,
+                    "storage_hits": 0,
+                    "stale_chunks": 0,
+                    "no_gpu_context": True,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert delta.get("lmcache_blend.lookup_requested_tokens", 0) == 0
+        assert delta.get("lmcache_blend.lookup_hit_tokens", 0) == 0
+
+    def test_multiple_lookups_accumulate(self, bus, subscriber, snapshot):
+        """Counters accumulate across multiple completed lookups."""
+        bus.start()
+        # 3 full-hit lookups @ 256 tokens each
+        for i in range(3):
+            bus.publish(
+                Event(
+                    event_type=EventType.CB_LOOKUP_END,
+                    session_id=f"hit-{i}",
+                    metadata={
+                        "requested_tokens": 256,
+                        "hit_tokens": 256,
+                        "fingerprint_hits": 1,
+                        "storage_hits": 1,
+                        "stale_chunks": 0,
+                        "no_gpu_context": False,
+                    },
+                )
+            )
+        # 2 partial-hit lookups: 1024 requested, 128 hit
+        for i in range(2):
+            bus.publish(
+                Event(
+                    event_type=EventType.CB_LOOKUP_END,
+                    session_id=f"partial-{i}",
+                    metadata={
+                        "requested_tokens": 1024,
+                        "hit_tokens": 128,
+                        "fingerprint_hits": 4,
+                        "storage_hits": 1,
+                        "stale_chunks": 3,
+                        "no_gpu_context": False,
+                    },
+                )
+            )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        # 3*256 + 2*1024 = 768 + 2048 = 2816
+        assert delta["lmcache_blend.lookup_requested_tokens"] == 2816
+        # 3*256 + 2*128 = 768 + 256 = 1024
+        assert delta["lmcache_blend.lookup_hit_tokens"] == 1024

--- a/tests/v1/mp_observability/subscribers/metrics/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_cb_server.py
@@ -20,7 +20,13 @@ _DRAIN_WAIT = 0.15
 
 
 def _read_counters() -> dict[str, int]:
-    """Snapshot counter values, summed across attribute combinations."""
+    """Snapshot counter values, summed across attribute combinations.
+
+    Accumulates into ``result`` rather than overwriting on duplicate
+    metric names so the snapshot stays correct when the same metric
+    appears in multiple resource/scope buckets (e.g., when other test
+    suites have populated the shared in-memory reader).
+    """
     data = _reader.get_metrics_data()
     result: dict[str, int] = {}
     if data is None:
@@ -36,7 +42,7 @@ def _read_counters() -> dict[str, int]:
                     total += int(dp.value)
                     any_value = True
                 if any_value:
-                    result[metric.name] = total
+                    result[metric.name] = result.get(metric.name, 0) + total
     return result
 
 

--- a/tests/v1/mp_observability/subscribers/metrics/test_l1_eviction_loop.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l1_eviction_loop.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for L1EvictionLoopSubscriber.
+
+Uses ``InMemoryMetricReader`` to read back actual OTel counter and
+histogram values and verify per-tick attribution.
+"""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
+from lmcache.v1.mp_observability.subscribers.metrics.l1_eviction_loop import (
+    L1EvictionLoopSubscriber,
+)
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+
+_DRAIN_WAIT = 0.15
+
+
+def _read_counters() -> dict[str, int]:
+    data = _reader.get_metrics_data()
+    result: dict[str, int] = {}
+    if data is None:
+        return result
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                total = 0
+                any_value = False
+                for dp in metric.data.data_points:
+                    if not hasattr(dp, "value"):
+                        continue
+                    total += int(dp.value)
+                    any_value = True
+                if any_value:
+                    result[metric.name] = result.get(metric.name, 0) + total
+    return result
+
+
+def _histogram_count(name: str) -> int:
+    data = _reader.get_metrics_data()
+    if data is None:
+        return 0
+    total = 0
+    for resource_metrics in data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                if metric.name != name:
+                    continue
+                for dp in metric.data.data_points:
+                    if hasattr(dp, "count"):
+                        total += int(dp.count)
+    return total
+
+
+def _delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    keys = set(before) | set(after)
+    return {k: after.get(k, 0) - before.get(k, 0) for k in keys}
+
+
+@pytest.fixture
+def bus():
+    return EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+
+
+@pytest.fixture
+def subscriber(bus):
+    sub = L1EvictionLoopSubscriber()
+    bus.register_subscriber(sub)
+    return sub
+
+
+@pytest.fixture
+def snapshot():
+    before_counters = _read_counters()
+    before_hist = _histogram_count("lmcache_mp.l1_usage_ratio")
+
+    def get_delta() -> tuple[dict[str, int], int]:
+        after_counters = _read_counters()
+        after_hist = _histogram_count("lmcache_mp.l1_usage_ratio")
+        return _delta(before_counters, after_counters), after_hist - before_hist
+
+    return get_delta
+
+
+def _tick(triggered: bool, usage: float = 0.5) -> Event:
+    return Event(
+        event_type=EventType.L1_EVICTION_LOOP_TICK,
+        metadata={"usage": usage, "watermark": 0.8, "triggered": triggered},
+    )
+
+
+class TestL1EvictionLoopSubscriber:
+    def test_subscribes_only_to_eviction_loop_tick(self, subscriber):
+        subs = subscriber.get_subscriptions()
+        assert EventType.L1_EVICTION_LOOP_TICK in subs
+        assert len(subs) == 1
+
+    def test_below_watermark_increments_only_ticks(self, bus, subscriber, snapshot):
+        bus.start()
+        for _ in range(5):
+            bus.publish(_tick(triggered=False, usage=0.4))
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        d_counters, d_hist = snapshot()
+        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 5
+        assert d_counters.get("lmcache_mp.l1_eviction_loop_triggered", 0) == 0
+        assert d_hist == 5  # all ticks recorded into the usage histogram
+
+    def test_triggered_increments_both_counters(self, bus, subscriber, snapshot):
+        bus.start()
+        for _ in range(3):
+            bus.publish(_tick(triggered=True, usage=0.95))
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        d_counters, d_hist = snapshot()
+        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 3
+        assert d_counters["lmcache_mp.l1_eviction_loop_triggered"] == 3
+        assert d_hist == 3
+
+    def test_mixed_ticks(self, bus, subscriber, snapshot):
+        """Ratio of triggered to ticks reflects how often eviction fired."""
+        bus.start()
+        # 4 below-watermark, 6 triggered
+        for _ in range(4):
+            bus.publish(_tick(triggered=False, usage=0.5))
+        for _ in range(6):
+            bus.publish(_tick(triggered=True, usage=0.9))
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        d_counters, d_hist = snapshot()
+        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 10
+        assert d_counters["lmcache_mp.l1_eviction_loop_triggered"] == 6
+        assert d_hist == 10
+
+    def test_missing_metadata_uses_safe_defaults(self, bus, subscriber, snapshot):
+        """A tick event with empty metadata still increments ticks and the
+        usage histogram (with default 0.0), without crashing."""
+        bus.start()
+        bus.publish(Event(event_type=EventType.L1_EVICTION_LOOP_TICK, metadata={}))
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        d_counters, d_hist = snapshot()
+        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 1
+        assert d_counters.get("lmcache_mp.l1_eviction_loop_triggered", 0) == 0
+        assert d_hist == 1

--- a/tests/v1/mp_observability/subscribers/metrics/test_l1_eviction_loop.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l1_eviction_loop.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for L1EvictionLoopSubscriber.
-
-Uses ``InMemoryMetricReader`` to read back actual OTel counter and
-histogram values and verify per-tick attribution.
-"""
+"""Tests for L1EvictionLoopSubscriber."""
 
 # Standard
 import time
@@ -18,50 +14,12 @@ from lmcache.v1.mp_observability.event_bus import EventBus, EventBusConfig
 from lmcache.v1.mp_observability.subscribers.metrics.l1_eviction_loop import (
     L1EvictionLoopSubscriber,
 )
-from tests.v1.mp_observability.subscribers.metrics.otel_setup import reader as _reader
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import (
+    counter_delta,
+    read_counters,
+)
 
 _DRAIN_WAIT = 0.15
-
-
-def _read_counters() -> dict[str, int]:
-    data = _reader.get_metrics_data()
-    result: dict[str, int] = {}
-    if data is None:
-        return result
-    for resource_metrics in data.resource_metrics:
-        for scope_metrics in resource_metrics.scope_metrics:
-            for metric in scope_metrics.metrics:
-                total = 0
-                any_value = False
-                for dp in metric.data.data_points:
-                    if not hasattr(dp, "value"):
-                        continue
-                    total += int(dp.value)
-                    any_value = True
-                if any_value:
-                    result[metric.name] = result.get(metric.name, 0) + total
-    return result
-
-
-def _histogram_count(name: str) -> int:
-    data = _reader.get_metrics_data()
-    if data is None:
-        return 0
-    total = 0
-    for resource_metrics in data.resource_metrics:
-        for scope_metrics in resource_metrics.scope_metrics:
-            for metric in scope_metrics.metrics:
-                if metric.name != name:
-                    continue
-                for dp in metric.data.data_points:
-                    if hasattr(dp, "count"):
-                        total += int(dp.count)
-    return total
-
-
-def _delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
-    keys = set(before) | set(after)
-    return {k: after.get(k, 0) - before.get(k, 0) for k in keys}
 
 
 @pytest.fixture
@@ -78,13 +36,11 @@ def subscriber(bus):
 
 @pytest.fixture
 def snapshot():
-    before_counters = _read_counters()
-    before_hist = _histogram_count("lmcache_mp.l1_usage_ratio")
+    """Capture counters before the test; yield a callable that returns deltas."""
+    before = read_counters()
 
-    def get_delta() -> tuple[dict[str, int], int]:
-        after_counters = _read_counters()
-        after_hist = _histogram_count("lmcache_mp.l1_usage_ratio")
-        return _delta(before_counters, after_counters), after_hist - before_hist
+    def get_delta() -> dict[str, int]:
+        return counter_delta(before, read_counters())
 
     return get_delta
 
@@ -105,52 +61,47 @@ class TestL1EvictionLoopSubscriber:
     def test_below_watermark_increments_only_ticks(self, bus, subscriber, snapshot):
         bus.start()
         for _ in range(5):
-            bus.publish(_tick(triggered=False, usage=0.4))
+            bus.publish(_tick(triggered=False))
         time.sleep(_DRAIN_WAIT)
         bus.stop()
 
-        d_counters, d_hist = snapshot()
-        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 5
-        assert d_counters.get("lmcache_mp.l1_eviction_loop_triggered", 0) == 0
-        assert d_hist == 5  # all ticks recorded into the usage histogram
+        delta = snapshot()
+        assert delta["lmcache_mp.l1_eviction_loop_ticks"] == 5
+        assert delta.get("lmcache_mp.l1_eviction_loop_triggered", 0) == 0
 
     def test_triggered_increments_both_counters(self, bus, subscriber, snapshot):
         bus.start()
         for _ in range(3):
-            bus.publish(_tick(triggered=True, usage=0.95))
+            bus.publish(_tick(triggered=True))
         time.sleep(_DRAIN_WAIT)
         bus.stop()
 
-        d_counters, d_hist = snapshot()
-        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 3
-        assert d_counters["lmcache_mp.l1_eviction_loop_triggered"] == 3
-        assert d_hist == 3
+        delta = snapshot()
+        assert delta["lmcache_mp.l1_eviction_loop_ticks"] == 3
+        assert delta["lmcache_mp.l1_eviction_loop_triggered"] == 3
 
     def test_mixed_ticks(self, bus, subscriber, snapshot):
         """Ratio of triggered to ticks reflects how often eviction fired."""
         bus.start()
-        # 4 below-watermark, 6 triggered
         for _ in range(4):
-            bus.publish(_tick(triggered=False, usage=0.5))
+            bus.publish(_tick(triggered=False))
         for _ in range(6):
-            bus.publish(_tick(triggered=True, usage=0.9))
+            bus.publish(_tick(triggered=True))
         time.sleep(_DRAIN_WAIT)
         bus.stop()
 
-        d_counters, d_hist = snapshot()
-        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 10
-        assert d_counters["lmcache_mp.l1_eviction_loop_triggered"] == 6
-        assert d_hist == 10
+        delta = snapshot()
+        assert delta["lmcache_mp.l1_eviction_loop_ticks"] == 10
+        assert delta["lmcache_mp.l1_eviction_loop_triggered"] == 6
 
     def test_missing_metadata_uses_safe_defaults(self, bus, subscriber, snapshot):
-        """A tick event with empty metadata still increments ticks and the
-        usage histogram (with default 0.0), without crashing."""
+        """A tick event with empty metadata still increments ``ticks`` (and
+        leaves ``triggered`` unchanged) without crashing."""
         bus.start()
         bus.publish(Event(event_type=EventType.L1_EVICTION_LOOP_TICK, metadata={}))
         time.sleep(_DRAIN_WAIT)
         bus.stop()
 
-        d_counters, d_hist = snapshot()
-        assert d_counters["lmcache_mp.l1_eviction_loop_ticks"] == 1
-        assert d_counters.get("lmcache_mp.l1_eviction_loop_triggered", 0) == 0
-        assert d_hist == 1
+        delta = snapshot()
+        assert delta["lmcache_mp.l1_eviction_loop_ticks"] == 1
+        assert delta.get("lmcache_mp.l1_eviction_loop_triggered", 0) == 0


### PR DESCRIPTION
Adds two counters to BlendMetricsSubscriber:

  - lmcache_blend.lookup_requested_tokens
  - lmcache_blend.lookup_hit_tokens

Both read from existing CB_LOOKUP_END event metadata (already emitted at all three lookup sites in blend_server_v2.py — full match, no-GPU-context early exit, normal partial-hit path), so no emission-site changes are required. Their ratio is the blend token-level hit rate, exposed identically to the existing L1+L2 lookup_hit_tokens / lookup_requested_tokens.

Updates METRICS.md with the new entries and a PromQL recipe.

Tests: adds InMemoryMetricReader-based assertions for full-hit, partial-hit, full-miss, no-GPU-context, and accumulation. Updates the existing CB_LOOKUP_END test fixtures to populate the new metadata fields.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
