### PR TITLE
fix: missing lock  when clearing metadata cache

### DIFF
--- a/lmcache/v1/storage_backend/connector/hfbucket_connector.py
+++ b/lmcache/v1/storage_backend/connector/hfbucket_connector.py
@@ -277,7 +277,8 @@ class HFBucketConnector(RemoteConnector):
 
     async def close(self) -> None:
         """Release connector-local resources and remove temporary downloads."""
-        self._metadata_cache.clear()
+        with self._metadata_cache_lock:
+            self._metadata_cache.clear()
         await asyncio.to_thread(
             shutil.rmtree,
             self._download_session_dir,


### PR DESCRIPTION

**What this PR does / why we need it**:

close() called self._metadata_cache.clear() without holding self._metadata_cache_lock, violating the class's own thread-safety contract. 
close() should acquire  _metadata_cache_lock before mutating the shared dict, matching the locking discipline used by every other method in the class.      
   



**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
