### PR TITLE
[Docs] Add Recipes section with MiniMax-M2 as first entry

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,14 @@ Documentation
 
 .. toctree::
    :maxdepth: 2
+   :caption: Recipes
+
+   recipes/index
+
+:raw-html:`<br />`
+
+.. toctree::
+   :maxdepth: 2
    :caption: KV Cache offloading and sharing
 
    kv_cache/storage_backends/index

--- a/docs/source/recipes/index.rst
+++ b/docs/source/recipes/index.rst
@@ -1,0 +1,70 @@
+.. _recipes:
+
+Recipes
+=======
+
+This section lists model architectures that have been validated end-to-end with
+LMCache, with a recipe page per architecture covering only the LMCache-specific
+configuration that diverges from defaults.
+
+Engine-side documentation (how to serve the model itself) lives with the
+serving engine. Recipe pages link out rather than duplicate.
+
+Recipe page contents
+--------------------
+
+Each recipe page is intentionally minimal:
+
+- **Validated models** -- exact HF repo IDs that have been tested.
+- **Engine tabs** -- one tab per serving engine (vLLM, SGLang, TRT-LLM). Each
+  tab links to the engine's own documentation for the model and shows the
+  exact ``lmcache server`` and engine launch commands. Tabs for engines that
+  are not yet validated state so explicitly.
+- **CacheBlend support** -- validation status (may be empty).
+- **Compression support** -- table of compression methods (CacheGen, etc.)
+  with per-method validation status. Extensible: new methods get a row.
+- **Caveats** -- known limitations, if any.
+
+For the generic LMCache + engine wiring (ports, remote hosts, in-process mode,
+sending a first request), see :doc:`../getting_started/quickstart` and
+:doc:`../mp/quickstart`. Recipes assume those pages as a prerequisite.
+
+Supported architectures
+-----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 30 10 10 10 12
+
+   * - Architecture
+     - Example HF model
+     - vLLM
+     - SGLang
+     - TRT-LLM
+     - Recipe
+   * - ``MiniMaxM2ForCausalLM``
+     - ``MiniMaxAI/MiniMax-M2``
+     - ✓
+     - —
+     - —
+     - :doc:`minimax_m2`
+
+Legend: ``✓`` validated, ``—`` not validated.
+
+Contributing a recipe
+---------------------
+
+To add a new architecture:
+
+1. Copy an existing page (e.g. ``minimax_m2.rst``) to
+   ``recipes/<architecture_snake_case>.rst``.
+2. Fill in **Validated models**, **Engines**, **LMCache configuration**, and
+   **Caveats**. Keep each section terse -- if a field has nothing to say, say
+   so in one line rather than padding it.
+3. Add a row to the table above and an entry to the hidden toctree below.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   minimax_m2

--- a/docs/source/recipes/minimax_m2.rst
+++ b/docs/source/recipes/minimax_m2.rst
@@ -1,0 +1,77 @@
+.. _recipe_minimax_m2:
+
+MiniMaxM2ForCausalLM
+====================
+
+Validated models
+----------------
+
+- `MiniMaxAI/MiniMax-M2 <https://huggingface.co/MiniMaxAI/MiniMax-M2>`_
+
+.. tab-set::
+   :sync-group: engine
+
+   .. tab-item:: vLLM
+
+      **Engine documentation:**
+      `MiniMax-M2 in vLLM supported models
+      <https://docs.vllm.ai/en/latest/models/supported_models.html#text-generation>`_
+      (architecture ``MiniMaxM2ForCausalLM``).
+
+      **Status:** Validated with LMCache.
+
+      Start the LMCache MP server:
+
+      .. code-block:: bash
+
+         lmcache server --l1-size-gb 100 --eviction-policy LRU
+
+      Start vLLM with the LMCache MP connector:
+
+      .. code-block:: bash
+
+         vllm serve MiniMaxAI/MiniMax-M2 \
+             --tensor-parallel-size 8 \
+             --trust-remote-code \
+             --kv-transfer-config \
+             '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+      Adjust ``--tensor-parallel-size`` to match your hardware. For the
+      generic LMCache + vLLM wiring (ports, remote hosts, in-process mode),
+      see :doc:`../mp/quickstart`.
+
+   .. tab-item:: SGLang
+
+      **Engine documentation:**
+      `MiniMax-M2 SGLang cookbook
+      <https://docs.sglang.io/cookbook/autoregressive/MiniMax/MiniMax-M2>`_,
+      `MiniMax M2.5/M2.1/M2 usage guide
+      <https://docs.sglang.io/docs/basic_usage/minimax_m2>`_.
+
+      **Status:** Not validated with LMCache.
+
+   .. tab-item:: TRT-LLM
+
+      **Status:** Not supported. LMCache TRT-LLM integration is in progress.
+
+CacheBlend support
+------------------
+
+Compression support
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Method
+     - Status
+     - Notes
+   * - :doc:`CacheGen <../kv_cache_optimizations/compression/cachegen>`
+     - Not validated
+     -
+
+Caveats
+-------
+
+None known.


### PR DESCRIPTION
Introduce a Recipes section under docs/source/recipes/ that catalogs model architectures validated end-to-end with LMCache. Each recipe page uses synced engine tabs (vLLM / SGLang / TRT-LLM) so the format scales as more architectures are validated. MiniMax-M2 is the first entry.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
