### PR TITLE
[MP] Make vLLM be able to reconnect after LMCache restarts

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -57,3 +57,10 @@ steps:
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
+
+      - label: ":compression: restart_recovery"
+        command: .buildkite/k3_tests/multiprocess/run.sh restart_recovery
+        timeout_in_minutes: 30
+        agents: { queue: "k8s" }
+        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
+        artifact_paths: ["*.log"]

--- a/.buildkite/k3_tests/multiprocess/run.sh
+++ b/.buildkite/k3_tests/multiprocess/run.sh
@@ -6,7 +6,7 @@
 # No Docker -- all processes run natively in the pod.
 set -euo pipefail
 
-TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock)}"
+TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock|restart_recovery)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Test LMCache server restart recovery: vLLM workers should re-register
+# their KV caches with the new LMCache server (driven by the heartbeat
+# thread's recover callback) and resume successful stores.
+#
+# Flow:
+#   1. Run a `lmcache bench engine --workload random-prefill` round.
+#   2. Snapshot lmcache_mp_l1_write_keys_total via /metrics.
+#   3. Kill the LMCache server, relaunch on the same port.
+#   4. Wait for the new server to be ready and for the worker to
+#      re-register (poll /api/status until gpu_context_meta is non-empty).
+#   5. Run the same bench round again.
+#   6. Snapshot the metric again.
+#   7. Assert run2 > 0 and run2 >= 0.8 * run1.
+#
+# The metric counter is reset to 0 by the new server process, so
+# run2 is the absolute count for the post-restart benchmark only.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+
+# ── Configuration (inherited from run-single-test.sh) ─────────
+VLLM_PORT="${VLLM_PORT:-8000}"
+LMCACHE_PORT="${LMCACHE_PORT:-6555}"
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+MODEL="${MODEL:-Qwen/Qwen3-14B}"
+BUILD_ID="${BUILD_ID:-local_$$}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/lmcache_ci_results_${BUILD_ID}}"
+CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-80}"
+MAX_WORKERS="${MAX_WORKERS:-4}"
+
+# Bench parameters — small enough for CI but big enough to register
+# a non-trivial l1_write_keys count per round.
+NUM_REQUESTS="${RR_NUM_REQUESTS:-20}"
+REQUEST_LEN="${RR_REQUEST_LEN:-5000}"
+KV_CACHE_VOLUME="${RR_KV_CACHE_VOLUME:-5}"
+SEED="${RR_SEED:-42}"
+
+# Recovery timing
+RECOVER_TIMEOUT="${RR_RECOVER_TIMEOUT:-90}"
+
+# Output
+OUT_DIR="$RESULTS_DIR/restart_recovery"
+mkdir -p "$OUT_DIR"
+
+PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"
+
+echo "=== Restart Recovery Test ==="
+echo "Model: $MODEL"
+echo "vLLM URL: http://localhost:${VLLM_PORT}"
+echo "LMCache HTTP URL: http://localhost:${LMCACHE_HTTP_PORT}"
+echo "Bench: ${NUM_REQUESTS} requests x ${REQUEST_LEN} tokens"
+echo "Recovery timeout: ${RECOVER_TIMEOUT}s"
+echo ""
+
+# ── Helpers ──────────────────────────────────────────────────
+
+run_bench_round() {
+    local label="$1"
+    local out_subdir="$OUT_DIR/$label"
+    mkdir -p "$out_subdir"
+    echo "--- bench round: $label ---"
+
+    if ! lmcache bench engine \
+        --engine-url "http://localhost:${VLLM_PORT}" \
+        --lmcache-url "http://localhost:${LMCACHE_HTTP_PORT}" \
+        --workload random-prefill \
+        --rp-num-requests "$NUM_REQUESTS" \
+        --rp-request-length "$REQUEST_LEN" \
+        --kv-cache-volume "$KV_CACHE_VOLUME" \
+        --no-interactive \
+        --no-csv \
+        --json \
+        --quiet \
+        --seed "$SEED" \
+        --output-dir "$out_subdir" \
+        2>&1 | tee "$out_subdir/bench.log"; then
+        echo "FAIL: bench round '$label' returned non-zero (failed requests)"
+        return 1
+    fi
+
+    # Quick sanity from JSON summary
+    if [ -f "$out_subdir/bench_summary.json" ]; then
+        local successful failed
+        successful=$(python3 -c "import json; print(json.load(open('$out_subdir/bench_summary.json')).get('successful_requests', 0))")
+        failed=$(python3 -c "import json; print(json.load(open('$out_subdir/bench_summary.json')).get('failed_requests', 0))")
+        echo "$label: successful=$successful failed=$failed"
+        if [ "$failed" -ne 0 ]; then
+            echo "FAIL: $failed requests failed in '$label'"
+            return 1
+        fi
+    fi
+    return 0
+}
+
+scrape_l1_write_keys() {
+    # Print the latest lmcache_mp_l1_write_keys_total value (single sample,
+    # unlabeled) from the LMCache HTTP server's /metrics endpoint.
+    python3 - <<EOF
+import sys, urllib.request
+url = "http://localhost:${LMCACHE_HTTP_PORT}/metrics"
+try:
+    body = urllib.request.urlopen(url, timeout=10).read().decode()
+except Exception as e:
+    print(f"ERROR fetching {url}: {e}", file=sys.stderr)
+    sys.exit(1)
+total = None
+for line in body.splitlines():
+    if line.startswith("#"):
+        continue
+    if not line.startswith("lmcache_mp_l1_write_keys_total"):
+        continue
+    parts = line.rsplit(" ", 1)
+    if len(parts) != 2:
+        continue
+    try:
+        val = float(parts[1])
+    except ValueError:
+        continue
+    total = (total or 0.0) + val
+if total is None:
+    print(f"ERROR: lmcache_mp_l1_write_keys_total not found at {url}", file=sys.stderr)
+    sys.exit(1)
+print(int(total))
+EOF
+}
+
+wait_for_lmcache_http() {
+    local deadline=$(( $(date +%s) + 60 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if curl -sf "http://localhost:${LMCACHE_HTTP_PORT}/api/healthcheck" > /dev/null 2>&1; then
+            echo "LMCache HTTP healthy"
+            return 0
+        fi
+        sleep 2
+    done
+    echo "FAIL: LMCache HTTP did not come back within 60s"
+    return 1
+}
+
+wait_for_worker_reregister() {
+    # Poll /api/status until gpu_context_meta has at least one entry,
+    # which proves the vLLM worker re-registered with the new server.
+    local deadline=$(( $(date +%s) + RECOVER_TIMEOUT ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        local count
+        count=$(python3 - <<EOF 2>/dev/null
+import json, urllib.request
+try:
+    body = urllib.request.urlopen("http://localhost:${LMCACHE_HTTP_PORT}/api/status", timeout=5).read()
+    data = json.loads(body)
+    print(len(data.get("gpu_context_meta", {})))
+except Exception:
+    print(0)
+EOF
+)
+        if [ "$count" -gt 0 ]; then
+            echo "Worker re-registered (gpu_context_meta entries: $count)"
+            return 0
+        fi
+        sleep 2
+    done
+    echo "FAIL: worker did not re-register within ${RECOVER_TIMEOUT}s"
+    return 1
+}
+
+restart_lmcache() {
+    local old_pid
+    old_pid=$(sed -n '1p' "$PID_FILE" 2>/dev/null || true)
+    if [ -z "$old_pid" ]; then
+        echo "FAIL: no LMCache PID in $PID_FILE"
+        return 1
+    fi
+    echo "Killing LMCache PID $old_pid..."
+    if kill -0 "$old_pid" 2>/dev/null; then
+        kill "$old_pid" 2>/dev/null || true
+        wait "$old_pid" 2>/dev/null || true
+    fi
+    sleep 10
+
+    echo "Relaunching LMCache on port ${LMCACHE_PORT} / HTTP ${LMCACHE_HTTP_PORT}..."
+    CUDA_VISIBLE_DEVICES="${GPU_FOR_VLLM:-0}" \
+    lmcache server \
+        --l1-size-gb "$CPU_BUFFER_SIZE" \
+        --eviction-policy LRU \
+        --max-workers "$MAX_WORKERS" \
+        --port "$LMCACHE_PORT" \
+        --http-port "$LMCACHE_HTTP_PORT" \
+        > "/tmp/build_${BUILD_ID}_lmcache_restart.log" 2>&1 &
+
+    local new_pid=$!
+    echo "$new_pid" > /tmp/.new_lmcache_pid
+    # Replace line 1 of the PID file so cleanup.sh kills the new process.
+    sed -i "1s/.*/$new_pid/" "$PID_FILE"
+    echo "LMCache restarted (PID=$new_pid)"
+    return 0
+}
+
+# ── Step 1: Bench round 1 ────────────────────────────────────
+echo "============================================"
+echo "=== Round 1: bench against original server ==="
+echo "============================================"
+if ! run_bench_round "round1"; then
+    echo "FAIL: round 1 bench failed"
+    exit 1
+fi
+
+ROUND1_WRITES=$(scrape_l1_write_keys) || {
+    echo "FAIL: could not scrape /metrics after round 1"
+    exit 1
+}
+echo "Round 1 lmcache_mp_l1_write_keys_total = $ROUND1_WRITES"
+
+if [ "$ROUND1_WRITES" -le 0 ]; then
+    echo "FAIL: round 1 produced no L1 writes; benchmark setup is broken"
+    exit 1
+fi
+
+# ── Step 2: Kill + relaunch LMCache ──────────────────────────
+echo ""
+echo "============================================"
+echo "=== Restarting LMCache server ==="
+echo "============================================"
+if ! restart_lmcache; then
+    exit 1
+fi
+
+if ! wait_for_lmcache_http; then
+    echo "--- new lmcache log (last 80 lines) ---"
+    tail -80 "/tmp/build_${BUILD_ID}_lmcache_restart.log" 2>/dev/null || true
+    exit 1
+fi
+
+if ! wait_for_worker_reregister; then
+    echo "--- new lmcache log (last 80 lines) ---"
+    tail -80 "/tmp/build_${BUILD_ID}_lmcache_restart.log" 2>/dev/null || true
+    echo "--- vllm log (last 80 lines) ---"
+    tail -80 "/tmp/build_${BUILD_ID}_vllm.log" 2>/dev/null || true
+    exit 1
+fi
+
+# ── Step 3: Bench round 2 ────────────────────────────────────
+echo ""
+echo "============================================"
+echo "=== Round 2: bench against restarted server ==="
+echo "============================================"
+if ! run_bench_round "round2"; then
+    echo "FAIL: round 2 bench failed"
+    echo "--- vllm log (last 80 lines) ---"
+    tail -80 "/tmp/build_${BUILD_ID}_vllm.log" 2>/dev/null || true
+    exit 1
+fi
+
+ROUND2_WRITES=$(scrape_l1_write_keys) || {
+    echo "FAIL: could not scrape /metrics after round 2"
+    exit 1
+}
+echo "Round 2 lmcache_mp_l1_write_keys_total = $ROUND2_WRITES"
+
+# ── Step 4: Compare metrics ──────────────────────────────────
+echo ""
+echo "============================================"
+echo "=== Verification ==="
+echo "============================================"
+echo "Round 1 writes: $ROUND1_WRITES"
+echo "Round 2 writes: $ROUND2_WRITES"
+
+if [ "$ROUND2_WRITES" -le 0 ]; then
+    echo "FAIL: round 2 produced no L1 writes — re-registration likely failed"
+    exit 1
+fi
+
+# Floor-divide: round2 >= 0.8 * round1  <=>  round2 * 10 >= round1 * 8
+if [ $((ROUND2_WRITES * 10)) -lt $((ROUND1_WRITES * 8)) ]; then
+    pct=$(python3 -c "print(f'{$ROUND2_WRITES / $ROUND1_WRITES * 100:.1f}')")
+    echo "FAIL: round 2 only ${pct}% of round 1 writes (threshold: 80%)"
+    exit 1
+fi
+
+pct=$(python3 -c "print(f'{$ROUND2_WRITES / $ROUND1_WRITES * 100:.1f}')")
+echo "PASS: round 2 = ${pct}% of round 1 (>= 80%)"
+echo ""
+echo "============================================"
+echo "=== Restart Recovery Test PASSED ==="
+echo "============================================"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
@@ -34,10 +34,9 @@ MAX_WORKERS="${MAX_WORKERS:-4}"
 
 # Bench parameters — small enough for CI but big enough to register
 # a non-trivial l1_write_keys count per round.
-NUM_REQUESTS="${RR_NUM_REQUESTS:-20}"
+NUM_REQUESTS="${RR_NUM_REQUESTS:-100}"
 REQUEST_LEN="${RR_REQUEST_LEN:-5000}"
 KV_CACHE_VOLUME="${RR_KV_CACHE_VOLUME:-5}"
-SEED="${RR_SEED:-42}"
 
 # Recovery timing
 RECOVER_TIMEOUT="${RR_RECOVER_TIMEOUT:-90}"
@@ -60,6 +59,7 @@ echo ""
 
 run_bench_round() {
     local label="$1"
+    local seed=$2
     local out_subdir="$OUT_DIR/$label"
     mkdir -p "$out_subdir"
     echo "--- bench round: $label ---"
@@ -75,7 +75,7 @@ run_bench_round() {
         --no-csv \
         --json \
         --quiet \
-        --seed "$SEED" \
+        --seed $seed \
         --output-dir "$out_subdir" \
         2>&1 | tee "$out_subdir/bench.log"; then
         echo "FAIL: bench round '$label' returned non-zero (failed requests)"
@@ -182,7 +182,6 @@ restart_lmcache() {
     sleep 10
 
     echo "Relaunching LMCache on port ${LMCACHE_PORT} / HTTP ${LMCACHE_HTTP_PORT}..."
-    CUDA_VISIBLE_DEVICES="${GPU_FOR_VLLM:-0}" \
     lmcache server \
         --l1-size-gb "$CPU_BUFFER_SIZE" \
         --eviction-policy LRU \
@@ -203,7 +202,7 @@ restart_lmcache() {
 echo "============================================"
 echo "=== Round 1: bench against original server ==="
 echo "============================================"
-if ! run_bench_round "round1"; then
+if ! run_bench_round "round1" "41"; then
     echo "FAIL: round 1 bench failed"
     exit 1
 fi
@@ -247,7 +246,7 @@ echo ""
 echo "============================================"
 echo "=== Round 2: bench against restarted server ==="
 echo "============================================"
-if ! run_bench_round "round2"; then
+if ! run_bench_round "round2" "42"; then
     echo "FAIL: round 2 bench failed"
     echo "--- vllm log (last 80 lines) ---"
     tail -80 "/tmp/build_${BUILD_ID}_vllm.log" 2>/dev/null || true

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -91,9 +91,12 @@ case "$TEST_NAME" in
     deadlock)
         exec_script="${SCRIPT_DIR}/run-deadlock.sh"
         ;;
+    restart_recovery)
+        exec_script="${SCRIPT_DIR}/run-restart-recovery.sh"
+        ;;
     *)
         echo "Unknown test: $TEST_NAME"
-        echo "Valid tests: lm_eval, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock"
+        echo "Valid tests: lm_eval, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery"
         exit 1
         ;;
 esac

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -237,7 +237,6 @@ class HeartbeatThread(PeriodicThread):
         self._recover_callback = callback
 
     def _execute(self) -> ThreadRunSummary:
-        logger.info("Checking healthy!")
         was_healthy = self._health_event.is_set()
         healthy = send_ping(self._mq_client, timeout=self._interval)
         need_trigger_recover = (
@@ -765,6 +764,10 @@ class LMCacheMPWorkerAdapter:
         by the heartbeat thread itself via ``register_recover_callback``,
         so this property only reads the shared event.
         """
+        logger.info(
+            "Checking LMCache server health from the worker adapter: %s",
+            "healthy" if self._health_event.is_set() else "unhealthy",
+        )
         return self._health_event.is_set()
 
     @property
@@ -882,6 +885,7 @@ class LMCacheMPWorkerAdapter:
 
         try:
             self._send_register_kv_caches_request(self.kv_caches)
+            logger.warning("Finished re-registering KV caches after server recovery")
         except ConnectionError:
             logger.exception(
                 "Failed to re-register KV caches after server recovery; "

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -764,10 +764,6 @@ class LMCacheMPWorkerAdapter:
         by the heartbeat thread itself via ``register_recover_callback``,
         so this property only reads the shared event.
         """
-        logger.info(
-            "Checking LMCache server health from the worker adapter: %s",
-            "healthy" if self._health_event.is_set() else "unhealthy",
-        )
         return self._health_event.is_set()
 
     @property

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 import os
 import threading
 
@@ -207,9 +207,50 @@ class HeartbeatThread(PeriodicThread):
         self._health_event = health_event
         self._interval = interval
 
+        # Optional callback invoked on the unhealthy->healthy edge,
+        # before the health event is set. See register_recover_callback.
+        def noop() -> bool:
+            return True
+
+        self._recover_callback: Callable[[], bool] = noop
+
+    def register_recover_callback(self, callback: Callable[[], bool]) -> None:
+        """Register a callback fired on the unhealthy->healthy transition.
+
+        The callback runs **before** the health event is set. It must
+        return ``True`` on success (event will be set) or ``False`` on
+        failure (event will stay cleared, and the next heartbeat will
+        invoke the callback again on the next successful PING).
+
+        The callback function should NEVER raise exceptions.
+
+        Intended for setup work that must complete before downstream
+        callers observe the recovery — for example, re-registering KV
+        caches with a server that just restarted.
+
+        Should be called before :meth:`start`. Only one callback is
+        supported; a second call replaces the first.
+
+        Args:
+            callback: Zero-arg callable returning a success bool.
+        """
+        self._recover_callback = callback
+
     def _execute(self) -> ThreadRunSummary:
+        logger.info("Checking healthy!")
         was_healthy = self._health_event.is_set()
         healthy = send_ping(self._mq_client, timeout=self._interval)
+        need_trigger_recover = (
+            healthy and not was_healthy and self._recover_callback is not None
+        )
+
+        # Try to call recover callback
+        if need_trigger_recover:
+            logger.warning(
+                "LMCache server is healthy again, triggering recovery callback"
+            )
+            # If the callback fails, it should not become healthy
+            healthy = self._recover_callback()
 
         if healthy:
             self._health_event.set()
@@ -717,7 +758,13 @@ class LMCacheMPWorkerAdapter:
 
     @property
     def is_healthy(self) -> bool:
-        """Whether the LMCache server is healthy."""
+        """Whether the LMCache server is healthy.
+
+        Reflects the most recent heartbeat result. KV cache
+        re-registration on the unhealthy->healthy transition is handled
+        by the heartbeat thread itself via ``register_recover_callback``,
+        so this property only reads the shared event.
+        """
         return self._health_event.is_set()
 
     @property
@@ -743,23 +790,41 @@ class LMCacheMPWorkerAdapter:
             == 0
         )
 
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
         """
-        Register the kv caches with LMCache server
+        Register the kv caches with LMCache server.
 
         Args:
             kv_caches: A dict of kv caches to register. The keys are the
                 layer names and the values are the corresponding tensors.
+
+        Raises:
+            ConnectionError: if the server does not respond within
+                mq_timeout.
+        """
+        logger.info("Registering kv caches")
+        self.kv_caches = kv_caches
+        self._send_register_kv_caches_request(kv_caches)
+
+    def _send_register_kv_caches_request(
+        self, kv_caches: dict[str, torch.Tensor]
+    ) -> None:
+        """Submit a REGISTER_KV_CACHE request and wait for the response.
+
+        Shared by the public ``register_kv_caches`` entry point and the
+        recovery path inside ``is_healthy``.
+
+        Args:
+            kv_caches: The KV cache dict to register.
+
+        Raises:
+            ConnectionError: if the server does not respond within
+                mq_timeout.
         """
         # First Party
         from lmcache.integration.vllm.utils import vllm_layout_hints
 
-        # Register kv cache and send the request
-        logger.info("Registering kv caches")
-
         layout_hints = vllm_layout_hints()
-        self.kv_caches = kv_caches
-
         future = send_lmcache_request(
             self.mq_client,
             RequestType.REGISTER_KV_CACHE,
@@ -793,7 +858,37 @@ class LMCacheMPWorkerAdapter:
                 health_event=self._health_event,
                 interval=self._heartbeat_interval,
             )
+            self._heartbeat.register_recover_callback(
+                self._reregister_kv_caches_callback
+            )
             self._heartbeat.start()
+
+    def _reregister_kv_caches_callback(self) -> bool:
+        """Heartbeat recover callback: re-register KV caches after the
+        server returns. Runs on the heartbeat thread, before the health
+        event is set.
+
+        Returns:
+            ``True`` if there is nothing to re-register or registration
+            succeeds; ``False`` on registration failure (the heartbeat
+            will keep the health event cleared and retry on the next
+            successful PING).
+        """
+        if not self.kv_caches:
+            # Nothing was registered yet (server flapped before the
+            # very first register_kv_caches). Treat as success so the
+            # health event can be set.
+            return True
+
+        try:
+            self._send_register_kv_caches_request(self.kv_caches)
+        except ConnectionError:
+            logger.exception(
+                "Failed to re-register KV caches after server recovery; "
+                "will retry on next heartbeat"
+            )
+            return False
+        return True
 
     @_lmcache_nvtx_annotate
     def submit_store_request(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -888,6 +888,12 @@ class LMCacheMPWorkerAdapter:
                 "will retry on next heartbeat"
             )
             return False
+        except Exception:
+            logger.exception(
+                "Unexpected error during KV cache re-registration; "
+                "will retry on next heartbeat"
+            )
+            return False
         return True
 
     @_lmcache_nvtx_annotate

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -235,6 +235,14 @@ class MPCacheEngine:
             layout_hints: See :class:`LayoutHints`.  Forwarded to
                 :class:`GPUCacheContext` for GPU KV format detection.
         """
+        if instance_id in self.gpu_contexts:
+            logger.warning(
+                "Instance %s's KV cache is already registered, "
+                "skipping the new registration",
+                instance_id,
+            )
+            return
+
         gpu_context = GPUCacheContext(
             kv_caches,
             self.chunk_size,

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -1,23 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for ``LMCacheMPWorkerAdapter`` health/recovery wiring.
+"""Public-API unit tests for ``LMCacheMPWorkerAdapter.register_kv_caches``.
 
-Two pieces are exercised:
-
-* ``HeartbeatThread`` — the ``register_recover_callback`` hook that
-  fires on the unhealthy->healthy edge before the health event is set.
-* ``LMCacheMPWorkerAdapter._reregister_kv_caches`` — the worker-side
-  callback that re-issues ``REGISTER_KV_CACHE`` on recovery, plus the
-  thin trivial ``is_healthy`` property and the unchanged public
-  ``register_kv_caches``.
-
-Both classes' ``__init__`` perform real work (chunk-size MQ query for the
-adapter, ``threading.Thread`` setup for the heartbeat). We bypass them
-with ``__new__`` and inject only the attributes each method touches.
+Behavioural coverage of the heartbeat-driven recovery path
+(``HeartbeatThread.register_recover_callback`` →
+worker re-registration) lives in the buildkite end-to-end test
+``.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh``.
+That path requires driving the periodic-thread tick loop, which is
+deliberately not reachable through any public interface.
 """
 
 # Standard
 from unittest.mock import MagicMock
-import threading
 
 # Third Party
 import pytest
@@ -25,256 +18,79 @@ import pytest
 # First Party
 from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
 from lmcache.integration.vllm.vllm_multi_process_adapter import (
-    HeartbeatThread,
     LMCacheMPWorkerAdapter,
+    ParallelStrategy,
 )
 from lmcache.v1.multiprocess.protocol import RequestType
 
-# ---------------------------------------------------------------------------
-# Adapter helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_adapter() -> LMCacheMPWorkerAdapter:
-    """Build a worker adapter without running its real ``__init__``."""
-    adapter = LMCacheMPWorkerAdapter.__new__(LMCacheMPWorkerAdapter)
-    adapter._health_event = threading.Event()
-    adapter._health_event.set()
-    adapter.kv_caches = {}
-
-    adapter.mq_client = MagicMock(name="mq_client")
-    adapter.instance_id = 4242
-    adapter.model_name = "test-model"
-    adapter._mq_timeout = 5.0
-
-    parallel_strategy = MagicMock()
-    parallel_strategy.kv_world_size = 1
-    adapter.parallel_strategy = parallel_strategy
-
-    return adapter
-
 
 @pytest.fixture
-def patch_send(monkeypatch):
-    """Replace ``send_lmcache_request`` and friends with mocks."""
-    future = MagicMock(name="future")
-    future.result.return_value = None  # default: registration succeeds
+def fake_adapter(monkeypatch):
+    """Build an adapter through its real ``__init__`` with the network
+    boundary stubbed out. Returns ``(adapter, send_mock, future)`` where
+    ``send_mock`` is the patched ``send_lmcache_request`` and ``future``
+    is its return value (a ``MagicMock`` whose ``result()`` defaults to
+    succeed; tests can attach ``side_effect`` to simulate failures).
+    """
+    # Stub the MQ boundary so __init__'s chunk-size query and any later
+    # send_lmcache_request call don't touch a real socket.
+    fake_client = MagicMock(name="mq_client")
+    monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
+    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda mq: 256)
 
+    future = MagicMock(name="future")
+    future.result.return_value = None
     send_mock = MagicMock(name="send_lmcache_request", return_value=future)
     monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_mock)
 
+    # KV-cache wrapping pulls in CUDA IPC; bypass for unit tests.
+    monkeypatch.setattr(adapter_mod, "wrap_kv_caches", lambda kv: list(kv.values()))
     monkeypatch.setattr(
         "lmcache.integration.vllm.utils.vllm_layout_hints",
         lambda: "fake-layout",
         raising=False,
     )
-    monkeypatch.setattr(adapter_mod, "wrap_kv_caches", lambda kv: list(kv.values()))
 
-    return send_mock, future
-
-
-# ---------------------------------------------------------------------------
-# is_healthy: trivial property reflecting the heartbeat's event
-# ---------------------------------------------------------------------------
-
-
-def test_is_healthy_reflects_event_set():
-    adapter = _make_adapter()
-    assert adapter.is_healthy is True
-
-
-def test_is_healthy_reflects_event_cleared():
-    adapter = _make_adapter()
-    adapter._health_event.clear()
-    assert adapter.is_healthy is False
-
-
-# ---------------------------------------------------------------------------
-# Public register_kv_caches: behavior preserved across the refactor
-# ---------------------------------------------------------------------------
+    parallel_strategy = ParallelStrategy(
+        use_mla=False,
+        kv_world_size=1,
+        kv_worker_id=0,
+        actual_world_size=1,
+        actual_worker_id=0,
+        tp_size=1,
+        pp_size=1,
+    )
+    adapter = LMCacheMPWorkerAdapter(
+        server_url="tcp://127.0.0.1:0",
+        context=MagicMock(name="zmq_context"),
+        model_name="test-model",
+        vllm_block_size=16,
+        parallel_strategy=parallel_strategy,
+        mq_timeout=5.0,
+    )
+    # __init__ issues exactly one MQ call (the chunk-size query). Reset
+    # so individual tests start with a clean call count.
+    send_mock.reset_mock()
+    return adapter, send_mock, future
 
 
-def test_register_kv_caches_public_unchanged(patch_send):
-    """Public register_kv_caches still updates self.kv_caches and submits once."""
-    send_mock, _ = patch_send
-    adapter = _make_adapter()
+def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
+    """Public register_kv_caches stores the dict and submits one request."""
+    adapter, send_mock, _ = fake_adapter
     new_caches = {"layer.0": object(), "layer.1": object()}
 
     adapter.register_kv_caches(new_caches)
 
     assert adapter.kv_caches is new_caches
     assert send_mock.call_count == 1
-    args, _ = send_mock.call_args
+    args, _kwargs = send_mock.call_args
     assert args[1] == RequestType.REGISTER_KV_CACHE
 
 
-def test_register_kv_caches_public_raises_on_timeout(patch_send):
+def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
     """Public register_kv_caches surfaces ConnectionError on MQ timeout."""
-    _, future = patch_send
-    adapter = _make_adapter()
+    adapter, _send_mock, future = fake_adapter
     future.result.side_effect = TimeoutError("server down")
 
     with pytest.raises(ConnectionError, match="did not respond"):
         adapter.register_kv_caches({"layer.0": object()})
-
-
-# ---------------------------------------------------------------------------
-# _reregister_kv_caches: the worker's recovery callback
-# ---------------------------------------------------------------------------
-
-
-def test_reregister_callback_no_prior_registration(patch_send):
-    """Empty kv_caches: nothing to do, returns True without submitting."""
-    send_mock, _ = patch_send
-    adapter = _make_adapter()
-    assert adapter.kv_caches == {}
-
-    assert adapter._reregister_kv_caches() is True
-    send_mock.assert_not_called()
-
-
-def test_reregister_callback_success_submits(patch_send):
-    """Populated kv_caches: submits REGISTER_KV_CACHE and returns True."""
-    send_mock, _ = patch_send
-    adapter = _make_adapter()
-    adapter.kv_caches = {"layer.0": object()}
-
-    assert adapter._reregister_kv_caches() is True
-    assert send_mock.call_count == 1
-    args, _ = send_mock.call_args
-    assert args[1] == RequestType.REGISTER_KV_CACHE
-
-
-def test_reregister_callback_returns_false_on_timeout(patch_send):
-    """Server times out -> ConnectionError -> callback returns False."""
-    send_mock, future = patch_send
-    adapter = _make_adapter()
-    adapter.kv_caches = {"layer.0": object()}
-    future.result.side_effect = TimeoutError("server gone")
-
-    assert adapter._reregister_kv_caches() is False
-    assert send_mock.call_count == 1
-
-
-# ---------------------------------------------------------------------------
-# HeartbeatThread: recover callback + _execute integration
-# ---------------------------------------------------------------------------
-
-
-def _make_heartbeat() -> HeartbeatThread:
-    """Build a HeartbeatThread without invoking PeriodicThread.__init__."""
-    hb = HeartbeatThread.__new__(HeartbeatThread)
-    hb._mq_client = MagicMock(name="mq_client")
-    hb._health_event = threading.Event()
-    hb._health_event.set()
-    hb._interval = 1.0
-
-    def noop() -> bool:
-        return True
-
-    hb._recover_callback = noop
-    return hb
-
-
-def test_heartbeat_steady_healthy_no_callback(monkeypatch):
-    """Healthy ping while already healthy: no callback invoked, event stays set."""
-    hb = _make_heartbeat()
-    callback = MagicMock(return_value=True)
-    hb.register_recover_callback(callback)
-
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
-    summary = hb._execute()
-
-    assert hb._health_event.is_set()
-    callback.assert_not_called()
-    assert summary.message == "healthy"
-
-
-def test_heartbeat_recovery_invokes_callback_then_sets(monkeypatch):
-    """Unhealthy -> healthy: callback runs; on True, event is set after."""
-    hb = _make_heartbeat()
-    hb._health_event.clear()  # was unhealthy
-
-    call_order: list[str] = []
-
-    def callback() -> bool:
-        # Event must still be cleared when callback runs.
-        call_order.append("set" if hb._health_event.is_set() else "clear")
-        return True
-
-    hb.register_recover_callback(callback)
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
-
-    summary = hb._execute()
-
-    assert call_order == ["clear"]
-    assert hb._health_event.is_set()
-    assert summary.message == "healthy"
-
-
-def test_heartbeat_recovery_callback_failure_keeps_event_clear(monkeypatch):
-    """Callback returns False on recovery: event stays cleared, retry next tick."""
-    hb = _make_heartbeat()
-    hb._health_event.clear()
-    callback = MagicMock(side_effect=[False, True])
-    hb.register_recover_callback(callback)
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
-
-    summary1 = hb._execute()
-    assert callback.call_count == 1
-    assert not hb._health_event.is_set()
-    assert summary1.message == "unhealthy"
-
-    # Next heartbeat: still in the recovery state (was_healthy=False),
-    # ping succeeds, callback now returns True.
-    summary2 = hb._execute()
-    assert callback.call_count == 2
-    assert hb._health_event.is_set()
-    assert summary2.message == "healthy"
-
-
-def test_heartbeat_callback_skipped_when_ping_fails(monkeypatch):
-    """During a sustained outage, the callback must NOT fire on each tick.
-
-    Regression test for the recovery gate: only ping=True AND was_healthy=False
-    should trigger the callback.
-    """
-    hb = _make_heartbeat()
-    hb._health_event.clear()  # already in degraded mode
-    callback = MagicMock(return_value=True)
-    hb.register_recover_callback(callback)
-
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: False)
-
-    for _ in range(3):
-        summary = hb._execute()
-        assert summary.message == "unhealthy"
-        assert not hb._health_event.is_set()
-
-    callback.assert_not_called()
-
-
-def test_heartbeat_unhealthy_does_not_invoke_callback(monkeypatch):
-    """Failed ping: callback never runs (no recovery edge)."""
-    hb = _make_heartbeat()
-    callback = MagicMock(return_value=True)
-    hb.register_recover_callback(callback)
-
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: False)
-    summary = hb._execute()
-
-    callback.assert_not_called()
-    assert not hb._health_event.is_set()
-    assert summary.message == "unhealthy"
-
-
-def test_heartbeat_recovery_without_callback(monkeypatch):
-    """No callback registered: recovery still sets the event."""
-    hb = _make_heartbeat()
-    hb._health_event.clear()
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
-
-    summary = hb._execute()
-
-    assert hb._health_event.is_set()
-    assert summary.message == "healthy"

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``LMCacheMPWorkerAdapter`` health/recovery wiring.
+
+Two pieces are exercised:
+
+* ``HeartbeatThread`` — the ``register_recover_callback`` hook that
+  fires on the unhealthy->healthy edge before the health event is set.
+* ``LMCacheMPWorkerAdapter._reregister_kv_caches`` — the worker-side
+  callback that re-issues ``REGISTER_KV_CACHE`` on recovery, plus the
+  thin trivial ``is_healthy`` property and the unchanged public
+  ``register_kv_caches``.
+
+Both classes' ``__init__`` perform real work (chunk-size MQ query for the
+adapter, ``threading.Thread`` setup for the heartbeat). We bypass them
+with ``__new__`` and inject only the attributes each method touches.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+import threading
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
+from lmcache.integration.vllm.vllm_multi_process_adapter import (
+    HeartbeatThread,
+    LMCacheMPWorkerAdapter,
+)
+from lmcache.v1.multiprocess.protocol import RequestType
+
+# ---------------------------------------------------------------------------
+# Adapter helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> LMCacheMPWorkerAdapter:
+    """Build a worker adapter without running its real ``__init__``."""
+    adapter = LMCacheMPWorkerAdapter.__new__(LMCacheMPWorkerAdapter)
+    adapter._health_event = threading.Event()
+    adapter._health_event.set()
+    adapter.kv_caches = {}
+
+    adapter.mq_client = MagicMock(name="mq_client")
+    adapter.instance_id = 4242
+    adapter.model_name = "test-model"
+    adapter._mq_timeout = 5.0
+
+    parallel_strategy = MagicMock()
+    parallel_strategy.kv_world_size = 1
+    adapter.parallel_strategy = parallel_strategy
+
+    return adapter
+
+
+@pytest.fixture
+def patch_send(monkeypatch):
+    """Replace ``send_lmcache_request`` and friends with mocks."""
+    future = MagicMock(name="future")
+    future.result.return_value = None  # default: registration succeeds
+
+    send_mock = MagicMock(name="send_lmcache_request", return_value=future)
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_mock)
+
+    monkeypatch.setattr(
+        "lmcache.integration.vllm.utils.vllm_layout_hints",
+        lambda: "fake-layout",
+        raising=False,
+    )
+    monkeypatch.setattr(adapter_mod, "wrap_kv_caches", lambda kv: list(kv.values()))
+
+    return send_mock, future
+
+
+# ---------------------------------------------------------------------------
+# is_healthy: trivial property reflecting the heartbeat's event
+# ---------------------------------------------------------------------------
+
+
+def test_is_healthy_reflects_event_set():
+    adapter = _make_adapter()
+    assert adapter.is_healthy is True
+
+
+def test_is_healthy_reflects_event_cleared():
+    adapter = _make_adapter()
+    adapter._health_event.clear()
+    assert adapter.is_healthy is False
+
+
+# ---------------------------------------------------------------------------
+# Public register_kv_caches: behavior preserved across the refactor
+# ---------------------------------------------------------------------------
+
+
+def test_register_kv_caches_public_unchanged(patch_send):
+    """Public register_kv_caches still updates self.kv_caches and submits once."""
+    send_mock, _ = patch_send
+    adapter = _make_adapter()
+    new_caches = {"layer.0": object(), "layer.1": object()}
+
+    adapter.register_kv_caches(new_caches)
+
+    assert adapter.kv_caches is new_caches
+    assert send_mock.call_count == 1
+    args, _ = send_mock.call_args
+    assert args[1] == RequestType.REGISTER_KV_CACHE
+
+
+def test_register_kv_caches_public_raises_on_timeout(patch_send):
+    """Public register_kv_caches surfaces ConnectionError on MQ timeout."""
+    _, future = patch_send
+    adapter = _make_adapter()
+    future.result.side_effect = TimeoutError("server down")
+
+    with pytest.raises(ConnectionError, match="did not respond"):
+        adapter.register_kv_caches({"layer.0": object()})
+
+
+# ---------------------------------------------------------------------------
+# _reregister_kv_caches: the worker's recovery callback
+# ---------------------------------------------------------------------------
+
+
+def test_reregister_callback_no_prior_registration(patch_send):
+    """Empty kv_caches: nothing to do, returns True without submitting."""
+    send_mock, _ = patch_send
+    adapter = _make_adapter()
+    assert adapter.kv_caches == {}
+
+    assert adapter._reregister_kv_caches() is True
+    send_mock.assert_not_called()
+
+
+def test_reregister_callback_success_submits(patch_send):
+    """Populated kv_caches: submits REGISTER_KV_CACHE and returns True."""
+    send_mock, _ = patch_send
+    adapter = _make_adapter()
+    adapter.kv_caches = {"layer.0": object()}
+
+    assert adapter._reregister_kv_caches() is True
+    assert send_mock.call_count == 1
+    args, _ = send_mock.call_args
+    assert args[1] == RequestType.REGISTER_KV_CACHE
+
+
+def test_reregister_callback_returns_false_on_timeout(patch_send):
+    """Server times out -> ConnectionError -> callback returns False."""
+    send_mock, future = patch_send
+    adapter = _make_adapter()
+    adapter.kv_caches = {"layer.0": object()}
+    future.result.side_effect = TimeoutError("server gone")
+
+    assert adapter._reregister_kv_caches() is False
+    assert send_mock.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# HeartbeatThread: recover callback + _execute integration
+# ---------------------------------------------------------------------------
+
+
+def _make_heartbeat() -> HeartbeatThread:
+    """Build a HeartbeatThread without invoking PeriodicThread.__init__."""
+    hb = HeartbeatThread.__new__(HeartbeatThread)
+    hb._mq_client = MagicMock(name="mq_client")
+    hb._health_event = threading.Event()
+    hb._health_event.set()
+    hb._interval = 1.0
+
+    def noop() -> bool:
+        return True
+
+    hb._recover_callback = noop
+    return hb
+
+
+def test_heartbeat_steady_healthy_no_callback(monkeypatch):
+    """Healthy ping while already healthy: no callback invoked, event stays set."""
+    hb = _make_heartbeat()
+    callback = MagicMock(return_value=True)
+    hb.register_recover_callback(callback)
+
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
+    summary = hb._execute()
+
+    assert hb._health_event.is_set()
+    callback.assert_not_called()
+    assert summary.message == "healthy"
+
+
+def test_heartbeat_recovery_invokes_callback_then_sets(monkeypatch):
+    """Unhealthy -> healthy: callback runs; on True, event is set after."""
+    hb = _make_heartbeat()
+    hb._health_event.clear()  # was unhealthy
+
+    call_order: list[str] = []
+
+    def callback() -> bool:
+        # Event must still be cleared when callback runs.
+        call_order.append("set" if hb._health_event.is_set() else "clear")
+        return True
+
+    hb.register_recover_callback(callback)
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
+
+    summary = hb._execute()
+
+    assert call_order == ["clear"]
+    assert hb._health_event.is_set()
+    assert summary.message == "healthy"
+
+
+def test_heartbeat_recovery_callback_failure_keeps_event_clear(monkeypatch):
+    """Callback returns False on recovery: event stays cleared, retry next tick."""
+    hb = _make_heartbeat()
+    hb._health_event.clear()
+    callback = MagicMock(side_effect=[False, True])
+    hb.register_recover_callback(callback)
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
+
+    summary1 = hb._execute()
+    assert callback.call_count == 1
+    assert not hb._health_event.is_set()
+    assert summary1.message == "unhealthy"
+
+    # Next heartbeat: still in the recovery state (was_healthy=False),
+    # ping succeeds, callback now returns True.
+    summary2 = hb._execute()
+    assert callback.call_count == 2
+    assert hb._health_event.is_set()
+    assert summary2.message == "healthy"
+
+
+def test_heartbeat_callback_skipped_when_ping_fails(monkeypatch):
+    """During a sustained outage, the callback must NOT fire on each tick.
+
+    Regression test for the recovery gate: only ping=True AND was_healthy=False
+    should trigger the callback.
+    """
+    hb = _make_heartbeat()
+    hb._health_event.clear()  # already in degraded mode
+    callback = MagicMock(return_value=True)
+    hb.register_recover_callback(callback)
+
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: False)
+
+    for _ in range(3):
+        summary = hb._execute()
+        assert summary.message == "unhealthy"
+        assert not hb._health_event.is_set()
+
+    callback.assert_not_called()
+
+
+def test_heartbeat_unhealthy_does_not_invoke_callback(monkeypatch):
+    """Failed ping: callback never runs (no recovery edge)."""
+    hb = _make_heartbeat()
+    callback = MagicMock(return_value=True)
+    hb.register_recover_callback(callback)
+
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: False)
+    summary = hb._execute()
+
+    callback.assert_not_called()
+    assert not hb._health_event.is_set()
+    assert summary.message == "unhealthy"
+
+
+def test_heartbeat_recovery_without_callback(monkeypatch):
+    """No callback registered: recovery still sets the event."""
+    hb = _make_heartbeat()
+    hb._health_event.clear()
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: True)
+
+    summary = hb._execute()
+
+    assert hb._health_event.is_set()
+    assert summary.message == "healthy"


### PR DESCRIPTION
**What this PR does / why we need it**:

When the LMCache MP server restarts, the new server instance has no record of any worker's KV-cache registration, so all subsequent `STORE` / `RETRIEVE` calls from vLLM fail. This PR makes the vLLM-side adapter automatically re-register on the unhealthy→healthy edge so the system recovers without restarting vLLM.

Mechanism:

- `HeartbeatThread.register_recover_callback(callback)` — invoked **before** the health event is set on the unhealthy→healthy edge. Returning `False` keeps the event cleared so the next heartbeat retries; the callback contract forbids exceptions.
- `LMCacheMPWorkerAdapter._reregister_kv_caches` — the worker-side callback that re-issues `REGISTER_KV_CACHE` with the previously registered `kv_caches` dict. Returns `False` on `ConnectionError`, `True` when there is nothing to re-register or registration succeeds.
- `register_kv_caches` now delegates the actual MQ submission to a private `_send_register_kv_caches_request`, shared with the recovery path.
- Server-side `MPCacheEngine.register_kv_cache` warns and skips when an instance is already registered (defensive against rapid heartbeat flaps that don't actually involve a server restart).

**Special notes for your reviewers**:

- The new e2e test (`.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh`) launches vLLM + LMCache, runs random workload with `lmcache bench engine`, and then restart LMCache and run the same workload to test.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
