### PR TITLE
[SGLang] Drain layerwise retriever cleanup in sglang adapter

### DIFF
--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -241,6 +241,8 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
                     indices_to_remove.append(i)
 
         for i in sorted(indices_to_remove, reverse=True):
+            # Drain retrieve_layer's post-yield cleanup (frees tmp_gpu_buffer_obj and unpins disk-loaded staging objects).
+            next(self.layerwise_retrievers[i])
             del self.layerwise_retrievers[i]
             del self.layer_load_layer[i]
             self.lmcache_engine.lookup_unpin(self.lookup_id_list[i])


### PR DESCRIPTION
## Overview
Fixes a memory leak and potential deadlock in `sglang`'s layer-wise KV cache retrieval by ensuring the retriever generator is fully exhausted, mirroring `vLLM`'s behavior.

## Root Cause
The `cache_engine.retrieve_layer` generator yields $N+2$ times in the cache-hit path:
* **$N$ times:** Inside the layer loop (L1015/L1017)
* **$1$ time:** After the loop (L1031)
* **$1$ time:** Final `yield ret_mask` (L1055)

Between L1031 and L1055, the engine runs critical post-yield cleanup:
1.  Calls `next(mem_obj_consumer)` to free the connector's GPU staging buffer (L1034).
2.  Runs an unpin loop on disk-loaded staging objects (L1040-1042). If skipped, `pin_count` stays at 1, causing the next retrieve to deadlock inside `allocate()`.

## The Bug in sglang
While vLLM's adapter correctly advances the retriever $N+2$ times (draining all yields and running cleanup), **sglang's `load_kv_layerwise` advances only $N+1$ times** (2 in `start_load_kv` + $N-1$ per-layer). 

Because it removes the retriever while it is still paused at L1031, the cleanup phase never runs. This results in:
* Leaking `tmp_gpu_buffer_obj` (which triggers a safety-net force-free via `__del__` with a `MemoryObj at 0 ref_count=1` warning).
* Skipping the disk-pin unpin loop (which is silent on CPU-only configs, but deadlocks with local-disk L1).

## The Fix
Added one extra `next()` call before deleting the retriever from `layerwise_retrievers` to ensure the generator is fully drained, matching vLLM's drain count.