### PR TITLE
[Bugfix][CB] Align k with old_k in process_qkv when retrieve_layer skips masked-prefix chunks

### DIFF
--- a/lmcache/v1/compute/blend/blender.py
+++ b/lmcache/v1/compute/blend/blender.py
@@ -86,8 +86,24 @@ class LMCBlender:
         q, k = attn_layer.rotary_emb(self.metadata.positions, q, k)
 
         if layer_id in self.common_metadata.check_layers:
+            # Align k with old_k for diff_k. The trailing old_k.shape[0] rows
+            # of k correspond to old_k positions. imp_indices stay in old_k
+            # local space (for the writeback at later layers);
+            # q/k/v/residual/attn_metadata use global (full-k) indices = local
+            # + offset. Without this, retrieve_layer's mask-aware skip leaves
+            # old_k shorter than compute_layer's mask-blind k, causing
+            # `RuntimeError: tensor a (X) must match tensor b (Y) at
+            # non-singleton dimension 0`. (Refs #1875 / #854 / #938.)
+            if k.shape[0] > old_k.shape[0]:
+                _offset = k.shape[0] - old_k.shape[0]
+                _k_for_diff = k[_offset:]
+            else:
+                _offset = 0
+                _k_for_diff = k
+
             diff_k = torch.sum(
-                (k.to(torch.float32) - old_k.to(torch.float32)) ** 2, dim=[1]
+                (_k_for_diff.to(torch.float32) - old_k.to(torch.float32)) ** 2,
+                dim=[1],
             )
             total_len = diff_k.shape[0]
 
@@ -99,18 +115,19 @@ class LMCBlender:
 
             top_indices = torch.topk(diff_k, k=topk_num).indices
             top_indices, _ = torch.sort(top_indices)
+            _global_top_indices = top_indices + _offset
 
-            k, v = k[top_indices], v[top_indices]
-            q = q[top_indices]
-            residual = residual[top_indices]
+            k, v = k[_global_top_indices], v[_global_top_indices]
+            q = q[_global_top_indices]
+            residual = residual[_global_top_indices]
 
             logger.debug(f"Number of indices picked: {len(top_indices)}")
 
             self.metadata.imp_indices = top_indices
-            self.metadata.positions = self.metadata.positions[top_indices]
+            self.metadata.positions = self.metadata.positions[_global_top_indices]
             attn_output = attn_output[:topk_num]
 
-            attn_metadata.update_from_top_indices(top_indices)
+            attn_metadata.update_from_top_indices(_global_top_indices)
 
         if self.metadata.imp_indices is not None:
             old_k[self.metadata.imp_indices] = k

--- a/tests/v1/test_blender.py
+++ b/tests/v1/test_blender.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.compute.blend.blender import LMCBlender
+from lmcache.v1.compute.blend.metadata import (
+    LMCBlendCommonMetadata,
+    LMCBlendMetadata,
+)
+
+
+def _identity_rotary(
+    positions: torch.Tensor, q: torch.Tensor, k: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Stand-in for vllm's rotary_emb. Real RoPE preserves shapes; that's all
+    process_qkv needs in this test."""
+    assert positions.shape[0] == q.shape[0] == k.shape[0]
+    return q, k
+
+
+def _build_fake_blender(
+    *,
+    num_layers: int,
+    hidden_dim: int,
+    check_layer: int,
+    recomp_ratio: float,
+    kv_per_layer: dict[int, tuple[torch.Tensor, torch.Tensor]],
+) -> LMCBlender:
+    """Construct an LMCBlender with all vllm-side attrs mocked.
+
+    Skips ``__init__`` (which would walk ``vllm_model.model.layers`` etc.) and
+    sets the attributes ``process_qkv`` actually reads.
+    """
+    blender = LMCBlender.__new__(LMCBlender)
+    blender.num_layers = num_layers
+
+    layers = []
+    for _ in range(num_layers):
+        layer = MagicMock()
+        layer.self_attn.rotary_emb = _identity_rotary
+        layers.append(layer)
+    fake_vllm_model = MagicMock()
+    fake_vllm_model.model.layers = layers
+    blender.layerwise_model = MagicMock()
+    blender.layerwise_model.vllm_model = fake_vllm_model
+
+    blender.gpu_connector = MagicMock()
+    blender.gpu_connector.get_kv = lambda lid: kv_per_layer[lid]
+
+    blender.common_metadata = LMCBlendCommonMetadata(
+        check_layers=[check_layer],
+        recomp_ratios=[recomp_ratio],
+        thresholds=None,
+    )
+    blender.metadata = LMCBlendMetadata(
+        imp_indices=None, attn_mask=None, positions=None
+    )
+    return blender
+
+
+def _make_kv(n: int, hidden_dim: int, seed: int) -> torch.Tensor:
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(n, hidden_dim, generator=g)
+
+
+@pytest.mark.parametrize(
+    "n_compute,n_retrieved,recomp_ratio",
+    [
+        (1292, 801, 0.15),  # production crash signature, seen on Qwen3-8B
+        (919, 459, 0.15),  # H100 morning data point — exactly 2:1 ratio
+        (6519, 6512, 0.15),  # #938 signature: small offset from separator counting
+    ],
+)
+def test_process_qkv_aligns_k_with_shorter_old_k(
+    n_compute: int, n_retrieved: int, recomp_ratio: float
+) -> None:
+    """When ``retrieve_layer`` skipped masked-prefix chunks, ``old_k`` covers
+    fewer positions than ``compute_layer``'s ``k``. The trailing
+    ``old_k.shape[0]`` rows of ``k`` correspond to the same token positions as
+    ``old_k``.
+
+    Without the alignment fix, ``diff_k = (k - old_k)**2`` raises
+    ``RuntimeError: The size of tensor a (X) must match the size of tensor b
+    (Y) at non-singleton dimension 0`` and the engine dies.
+
+    Reproduces / regresses the family of bugs reported in #1875, #854, #938.
+    """
+    hidden_dim = 4096
+    attn_md = MagicMock()
+    attn_md.update_from_top_indices = MagicMock()
+
+    blender = _build_fake_blender(
+        num_layers=3,
+        hidden_dim=hidden_dim,
+        check_layer=1,
+        recomp_ratio=recomp_ratio,
+        kv_per_layer={
+            i: (
+                _make_kv(n_retrieved, hidden_dim, seed=10 + 2 * i),
+                _make_kv(n_retrieved, hidden_dim, seed=11 + 2 * i),
+            )
+            for i in range(3)
+        },
+    )
+
+    q = _make_kv(n_compute, hidden_dim, seed=20)
+    k = _make_kv(n_compute, hidden_dim, seed=21)
+    v = _make_kv(n_compute, hidden_dim, seed=22)
+    residual = _make_kv(n_compute, hidden_dim, seed=23)
+
+    # Layer 0 (not check_layer): passthrough — k/v/q must retain their full
+    # ``n_compute`` shape. Slicing here would corrupt ``attn_metadata`` (sized
+    # for ``len(input_ids)`` by ``init_attn_metadata``) and trigger CUDA OOB
+    # at the layer-0 attention forward.
+    q0, k0, v0, r0, ao0, _ = blender.process_qkv(
+        q, k, v, residual, layer_id=0, attn_output=None, attn_metadata=attn_md
+    )
+    assert k0.shape == (n_compute, hidden_dim)
+
+    # Layer 1 (check_layer): aligns ``k_for_diff`` to ``old_k`` shape, picks
+    # topk in ``old_k``-local space, restricts ``q/k/v/residual`` via global
+    # indices (= local + offset), updates ``attn_metadata`` with global
+    # indices so subsequent layers see consistent positions.
+    q1, k1, v1, r1, ao1, _ = blender.process_qkv(
+        q0, k0, v0, r0, layer_id=1, attn_output=ao0, attn_metadata=attn_md
+    )
+    expected_topk = max(int(n_retrieved * recomp_ratio), 1)
+    assert blender.metadata.imp_indices is not None
+    assert blender.metadata.imp_indices.shape == (expected_topk,)
+    # imp_indices stay in old_k-local space [0, n_retrieved) for the writeback.
+    assert blender.metadata.imp_indices.max().item() < n_retrieved
+    # attn_metadata.update_from_top_indices was called with GLOBAL indices.
+    last_call_args = attn_md.update_from_top_indices.call_args_list[-1].args
+    offset = n_compute - n_retrieved
+    assert last_call_args[0].max().item() < n_compute
+    assert last_call_args[0].min().item() >= offset
+    # k1 is returned via the writeback branch: ``old_k`` with selective updates.
+    assert k1.shape == (n_retrieved, hidden_dim)
+
+    # Layer 2 (post-check, writeback path): q/k/v shapes are the topk subset
+    # because layer 1's attention forward produced ``hidden_states`` of size
+    # ``topk``. The writeback writes them into ``old_k[imp_indices]``.
+    topk = blender.metadata.imp_indices.shape[0]
+    q_l2 = _make_kv(topk, hidden_dim, seed=30)
+    k_l2 = _make_kv(topk, hidden_dim, seed=31)
+    v_l2 = _make_kv(topk, hidden_dim, seed=32)
+    r_l2 = _make_kv(topk, hidden_dim, seed=33)
+    ao_l2 = _make_kv(topk, hidden_dim, seed=34)
+    _, k2, _, _, _, _ = blender.process_qkv(
+        q_l2, k_l2, v_l2, r_l2, layer_id=2, attn_output=ao_l2, attn_metadata=attn_md
+    )
+    assert k2.shape == (n_retrieved, hidden_dim)
+
+
+def test_process_qkv_unchanged_when_dims_already_match() -> None:
+    """When ``k.shape[0] == old_k.shape[0]`` (the common case), the alignment
+    slice is a no-op (offset == 0) and behavior matches pre-fix lmcache."""
+    n = 1700
+    hidden_dim = 4096
+    attn_md = MagicMock()
+    attn_md.update_from_top_indices = MagicMock()
+
+    blender = _build_fake_blender(
+        num_layers=2,
+        hidden_dim=hidden_dim,
+        check_layer=1,
+        recomp_ratio=0.15,
+        kv_per_layer={
+            i: (
+                _make_kv(n, hidden_dim, seed=40 + 2 * i),
+                _make_kv(n, hidden_dim, seed=41 + 2 * i),
+            )
+            for i in range(2)
+        },
+    )
+
+    q = _make_kv(n, hidden_dim, seed=50)
+    k = _make_kv(n, hidden_dim, seed=51)
+    v = _make_kv(n, hidden_dim, seed=52)
+    residual = _make_kv(n, hidden_dim, seed=53)
+
+    _, k0, _, _, ao0, _ = blender.process_qkv(
+        q, k, v, residual, layer_id=0, attn_output=None, attn_metadata=attn_md
+    )
+    assert k0.shape == (n, hidden_dim)
+
+    _, k1, _, _, _, _ = blender.process_qkv(
+        q, k0, v, residual, layer_id=1, attn_output=ao0, attn_metadata=attn_md
+    )
+    assert blender.metadata.imp_indices.shape == (max(int(n * 0.15), 1),)
+    assert k1.shape == (n, hidden_dim)
+    # offset == 0 → update_from_top_indices was called with local == global.
+    last_call_args = attn_md.update_from_top_indices.call_args_list[-1].args
+    assert last_call_args[0].max().item() < n


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the long-standing `RuntimeError: The size of tensor a (X) must match the size of tensor b (Y) at non-singleton dimension 0` in `lmcache/v1/compute/blend/blender.py:process_qkv`. This kills `EngineCore` mid-request and was reported in:

- #1875 — `[Bug] The tensor size of k and old_k mismatch on dimension 0 in blender.process_qkv`
- #854 — `CacheBlend fails on sending exact same prompt a second time`
- #938 — `RuntimeError in Blender When Handling 100% Cache Hit with Reordered Chunks` (acknowledged by @YaoJiayi as known but unfixed)

All three were closed as stale-without-fix.

## Root cause

Inside `blend_layer` two parallel iterators run over the same `tokens`:

| | what it sees | uses mask? |
|---|---|---|
| `compute_layer(tokens)` (in `LMCBaseModel`) | full forward over all `len(tokens)` positions | **no** |
| `retrieve_layer(tokens, mask, ...)` (in `LMCacheEngine`) | breaks at first content-hash miss; `process_tokens` skips chunks whose `start_idx < num_falses` | **yes** |

When `vllm_v1_adapter.start_load_kv` constructs the `FFFFFTTTTT` mask to skip vllm's prefix-cached prefix (`masked_token_count = vllm_cached_tokens // chunk_size * chunk_size`), `retrieve_layer` honors it and skips the leading chunks entirely. `gpu_connector.batched_to_gpu` then allocates `num_all_tokens = ends[-1] - starts[0]` of buffer (less than `lmcache_cached_tokens`). Result:

- `k.shape[0]` = `lmcache_cached_tokens` (e.g. 1292)
- `old_k.shape[0]` = `ends[-1] - starts[0]` (e.g. 801)
- `k.shape[0] - old_k.shape[0]` = `starts[0]` = position of first chunk past the masked-prefix region

The trailing `old_k.shape[0]` rows of `k` correspond to the same token positions as `old_k`.

## Why slice inside `check_layer` (not at top of `process_qkv`)

`compute_layer` calls `init_attn_metadata(input_ids=input_ids)` once, sizing `attn_metadata`'s `slot_mapping`/`seq_lens`/etc. for the full `len(input_ids)`. Slicing `q/k/v` at the top of `process_qkv` (i.e. at every layer) leaves `attn_metadata` referencing positions no longer in scope, causing `AcceleratorError: CUDA error: an illegal memory access was encountered` during attention forward at layer 0. We confirmed this empirically: an earlier version of this fix that sliced at the top eliminated the original `RuntimeError` but immediately surfaced the CUDA OOB on the next layer.

This PR scopes the alignment slice to the `check_layer` block where `diff_k` is actually computed. The `check_layer`'s existing topk machinery already restricts subsequent layers to a smaller subset via `attn_metadata.update_from_top_indices(...)`, so passing `top_indices + offset` (global indices in the full-`k` space) instead of `top_indices` (local indices in `old_k`'s space) is enough to keep everything consistent. `imp_indices` themselves are stored in `old_k`'s local `[0, old_k.shape[0])` space because the writeback at subsequent layers (`old_k[imp_indices] = k`) operates on `old_k`.

## Reproduction & validation

CPU-only reproduction in `tests/v1/test_blender.py` (new) — mocks vllm, runs in <1s, parametrized over three real production crash signatures: `(1292, 801)` from a Qwen3-8B + RAG-passages run with vllm prefix caching enabled, `(919, 459)` from an H100 morning run, and `(6519, 6512)` from #938.

GPU end-to-end validation: with this patch applied to `lmcache/vllm-openai:v0.4.3-lightweight` (vllm 0.19.0, lmcache 0.4.2, Qwen3-8B, RTX 4090), a 5-request mtrag-style permuted-passages workload that consistently crashed at request 1 (`tensor a (1292) must match tensor b (801)`) now completes 5/5 requests with non-zero `LMCache hit tokens` (1292 / 1842 / 1842 / 1842), no `RuntimeError`, no `EngineDeadError`. Generated text is coherent across all 5 reqs.

**Special notes for your reviewers**:

- The fix preserves existing positional-encoding semantics: `metadata.positions = arange(q.shape[0])` is computed before `process_qkv` runs, and the `check_layer` block then slices `metadata.positions` via `_global_top_indices` so per-layer RoPE positions remain consistent.
- A small amount of compute is wasted at layers `0..check_layer-1` when the masked-prefix region is large, since `compute_layer` runs the model forward over the full `len(input_ids)` before the alignment slice kicks in. This matches existing semantics (which also runs full at non-check layers); a follow-up could pass `tokens[masked_count:lmcache_cached_tokens]` to `compute_layer` from `vllm_v1_adapter.start_load_kv` to avoid this, but that requires more invasive plumbing of `slot_mapping`/`token_mask` and is out of scope here.
- Related: there's a `# TODO(Jiayi): Need to make prefix caching and blending compatible` in `vllm_v1_adapter.py` near the call site — this PR is one piece of that work. Other manifestations of the dim-mismatch (e.g. the separator-token gap reproducible in #938's offline `blend.py` repro) are also covered by the same `if k.shape[0] > old_k.shape[0]` guard since they're variants of the same underlying invariant violation; the test parametrizes that case.
- The three issues this PR fixes (#1875 / #854 / #938) are currently *closed* (as stale due to inactivity, not because they were fixed). They'll need to be reopened by maintainers for the auto-close keywords to take effect — happy to handle that however you prefer.

Fixes #1875
Fixes #854
Fixes #938

**If applicable**:

- [x] this PR contains user facing changes - docs added <!-- N/A: internal correctness fix; no API change -->
- [x] this PR contains unit tests