### PR TITLE
docs: daily drift check — multi-process mode (2026-05-07)

### DIFF
--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -382,8 +382,8 @@ and ``eviction``) are forwarded **as-is** to Mooncake's
 ``setup_internal(ConfigDict)``.  Refer to the
 `Mooncake documentation <https://github.com/kvcache-ai/Mooncake>`_
 for available setup keys (e.g., ``local_hostname``,
-``metadata_server``, ``master_server_address``, ``protocol``,
-``device_name``, ``global_segment_size``).
+``metadata_server``, ``master_server_addr``, ``protocol``,
+``rdma_devices``, ``global_segment_size``).
 
 **Configuration example:**
 
@@ -394,7 +394,7 @@ for available setup keys (e.g., ``local_hostname``,
       "num_workers": 4,
       "local_hostname": "node01",
       "metadata_server": "http://localhost:8080/metadata",
-      "master_server_address": "localhost:50051",
+      "master_server_addr": "localhost:50051",
       "protocol": "tcp",
       "local_buffer_size": "3221225472"
       "global_segment_size": "3221225472"


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

One drift item this run, on `docs/source/mp/l2_storage.rst`, triggered by today's #3172 (commit `7657836`, merged 2026-05-07).

| Item | File | Trigger PR |
| --- | --- | --- |
| Stale Mooncake example field names (`master_server_address` / `device_name`) | `docs/source/mp/l2_storage.rst` | #3172 |

### `docs/source/` (user-facing)

**Stale Mooncake example field names — #3172 (2026-05-07)**

The `mooncake_store` adapter forwards every key in its `--l2-adapter` JSON spec (except the LMCache-only `type`, `num_workers`, `eviction`) **as-is** to Mooncake's setup API. Today's #3172 ("Add batch operations to Mooncake L2 adapter") includes a test-fixture commit ("Test: isolate Mooncake RDMA adapter integration test", and "Use the native `rdma_devices` config key expected by Mooncake") that renames two keys in the test JSON to match what current Mooncake actually expects:

| Stale doc claim | Current Mooncake key |
| --- | --- |
| `master_server_address` | `master_server_addr` |
| `device_name` | `rdma_devices` |

The `Mooncake fields` example list and the `Configuration example` JSON snippet in `mp/l2_storage.rst` both still use the stale names. A user who copy-pastes the documented snippet into `--l2-adapter` will hand Mooncake an unknown key and fail to bring up the adapter.

**Evidence (permalinked to `dev` HEAD `7657836`):**

- LMCache forwards all non-LMCache-only keys as-is to Mooncake (the doc claim that triggers the drift): [`lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py#L66-L82`](https://github.com/LMCache/LMCache/blob/7657836e070b9211ed43294e13f1e4c81716dcf6/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py#L66-L82) — `_LMCACHE_ONLY_KEYS = {"type", "num_workers", "eviction"}` and `from_dict` forwards everything else to `setup_config: Dict[str, str]`.
- Test fixture using the canonical `master_server_addr` (added in #3172): [`tests/v1/distributed/test_mooncake_store_l2_adapter.py#L497-L504`](https://github.com/LMCache/LMCache/blob/7657836e070b9211ed43294e13f1e4c81716dcf6/tests/v1/distributed/test_mooncake_store_l2_adapter.py#L497-L504).
- RDMA test renaming `master_server_address` → `master_server_addr` and `device_name` → `rdma_devices` in #3172 (commit message: *"Use the native `rdma_devices` config key expected by Mooncake"*): [`tests/v1/distributed/test_mooncake_store_l2_adapter.py#L808-L820`](https://github.com/LMCache/LMCache/blob/7657836e070b9211ed43294e13f1e4c81716dcf6/tests/v1/distributed/test_mooncake_store_l2_adapter.py#L808-L820).
- Stale doc location prior to this PR: `docs/source/mp/l2_storage.rst:382-401` — `grep -n 'master_server_address\|device_name' docs/source/mp/l2_storage.rst` → 3 matches (lines 385, 386, 397).

### `docs/design/`

No new drift observed. The mirrored design tree under `docs/design/v1/distributed/l2_adapters/` does not maintain a Mooncake field reference; the adjacent design docs (`overall.md`, `plugin.md`, the per-adapter pages) describe the L2-adapter contract and forwarding behaviour, not Mooncake's wire keys.

### Other commits checked, no drift

Sweep window: commits on `dev` since the prior drift-check PR's base (`31b5535a`, base of merged #3202 from 2026-05-05).

- **#3169** ([Feat] Add option to skip raw block checkpoint load, merged 2026-05-06) — Adds `load_checkpoint_on_init` to the `raw_block` MP L2 adapter and the legacy in-process `rust_raw_block` plugin. The same PR updates `docs/source/mp/l2_storage.rst:213-216,247` and `docs/design/v1/distributed/l2_adapters/raw_block.md` so the MP user-facing reference is in sync. The legacy in-process plugin's new `rust_raw_block.load_checkpoint_on_init` extra-config key is not surfaced in `docs/source/` (the in-process `rust_raw_block` backend doesn't have a dedicated `extra_config` reference page); out of scope for this MP-mode drift check.
- **#3194** ([CI] Verify full MP observability surface in long_doc_qa_l2, merged 2026-05-05) — CI-only; the user-facing observability metric names it asserts on are already documented under `docs/source/mp/observability.rst`.
- **#3197** (fix: missing lock when clearing metadata cache in `HFBucketConnector.close()`, merged 2026-05-06) — Internal HFBucket connector fix.
- **#3199** + **#3209** ([Docs] Recipes section / Update LMCache Recipes) — Pure docs additions under `docs/source/recipes/`; not MP-specific and self-consistent within the same PR.
- **#3204** ([Docs] Add doc for fs native connector) — Pure docs addition; the new content matches the existing `fs_native` adapter described in `docs/source/mp/l2_storage.rst`.
- **#3205** ([observability] Update dashboard metrics) — Refreshes `examples/observability/grafana/provisioning/dashboards/lmcache.json`. The metric names referenced are all already documented in `docs/source/mp/observability.rst`. The dashboard is an example asset, not user-facing prose.
- **#3164** ([MP]: Disable Prometheus HTTP server for `http_server` entrypoint) — Already triaged in #3202 as visibility-only; existing claims are not contradicted, just under-specified.
- **#3172** code-side batch additions — `MooncakeConnector` now overrides `do_batch_get/set/exists/delete` and `choose_num_tiles`. Not user-facing: the LMCache `num_workers` knob still controls connector worker-thread concurrency, and the doc claim ("Number of C++ worker threads") remains accurate. The `do_single_delete` addition does not affect the L2 Eviction support table — eviction support also requires per-key usage tracking, which the native Mooncake connector does not yet provide; the existing "No eviction support (native connector adapter)" entry stays correct.
- **#3179** / **#3188** / **#3149** / **#3152** / **#3119** / **#3060** / **#3137** — Already triaged in prior drift-check PRs (#3202, #3186, #3174) or covered by their own in-PR doc updates.

### Out-of-scope flag (not addressed in this PR)

The same Mooncake key rename also surfaces in:

- `docs/source/kv_cache/storage_backends/mooncake.rst` — the **legacy in-process** Mooncake backend reference. The in-process backend forwards via `mooncakestore_connector.setup_mooncake_store`, which #2631 reworked to prefer Mooncake's new dict-based `store.setup(config: dict)` (covered by open drift PR #3174). On a current Mooncake build the new dict path will reject `master_server_address` for the same reason. Flagging for visibility — out of scope for this MP-mode drift check.
- `docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst` — the developer guide references the same key for illustrative purposes. Same caveat.

If reviewers prefer one cross-cutting fix, I can broaden the scope in a follow-up; left out here to keep the PR surgical.

## Proposed fix

Applied in this PR. Surgical doc edit only — `docs/source/mp/l2_storage.rst` (+3 / −3):

- The `Mooncake fields` example list now cites `master_server_addr` and `rdma_devices` alongside the other example keys.
- The `Configuration example` JSON snippet uses `"master_server_addr"`.

The `setup_internal(ConfigDict)` reference on line 382 is **deliberately untouched** — open drift PR #3174 already rewrites that paragraph to name the current `store.setup(config: dict)` API and document the `TypeError` fallback. The two edits are on adjacent but disjoint lines, so they will not conflict; whichever lands first, the other rebases cleanly.

## Notes for reviewers

- This was **auto-generated by the daily drift-check routine** and needs human review before merge.
- Author / committer: `ApostaC <yihua98@uchicago.edu>`. Commit carries a `Signed-off-by: ApostaC <yihua98@uchicago.edu>` trailer for DCO.
- No code changes — Mooncake's setup keys are owned by Mooncake, and LMCache forwards them as-is. This PR just makes the documented examples match what current Mooncake accepts.
- Other open drift-check PRs do not touch the same paragraph this PR edits: #3186 (`mp/observability.rst`), #3184 (`mp/architecture.rst`), #3174 (`mp/observability.rst` + the same `mp/l2_storage.rst` Mooncake paragraph but on different lines), #3159 (`mp/observability.rst`).

## Test plan

- [ ] `cd docs && make html` builds without new warnings on the `mp/l2_storage.rst` page.
- [ ] Eyeball the rendered "Mooncake fields" paragraph and the JSON example; confirm both render the new key names.
- [ ] Spot-check on a live Mooncake master / metadata pair: copy-paste the documented `--l2-adapter` snippet into `lmcache server` and confirm `MooncakeStoreL2AdapterConfig.from_dict` forwards the dict to `LMCacheMooncakeClient(config=...)` without Mooncake rejecting the keys.
- [ ] `grep -nE 'master_server_address|device_name' docs/source/mp/l2_storage.rst` → 0 matches.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014ghH6hV2ugrr8FfXBt3KEm)_