### PR TITLE
  [CLI] count requests as successful when stream has no content but usage reports tokens

### DIFF
--- a/lmcache/cli/commands/bench/engine_bench/request_sender.py
+++ b/lmcache/cli/commands/bench/engine_bench/request_sender.py
@@ -136,6 +136,8 @@ class RequestSender:
                     tokens.append(content)
 
             finish_time = time.time()
+            if first_token_time == 0.0 and num_output_tokens > 0:
+                first_token_time = finish_time
             successful = first_token_time > 0.0
             ttft = (first_token_time - submit_time) if successful else -1.0
             request_latency = finish_time - submit_time

--- a/lmcache/cli/commands/bench/engine_bench/request_sender.py
+++ b/lmcache/cli/commands/bench/engine_bench/request_sender.py
@@ -111,6 +111,7 @@ class RequestSender:
         """
         submit_time = time.time()
         first_token_time = 0.0
+        first_chunk_time = 0.0
         tokens: list[str] = []
         num_input_tokens = 0
         num_output_tokens = 0
@@ -119,6 +120,9 @@ class RequestSender:
             response = await self._create_stream(messages, max_tokens)
 
             async for chunk in response:
+                if not first_chunk_time:
+                    first_chunk_time = time.time()
+
                 # Extract usage from final chunk
                 usage = getattr(chunk, "usage", None)
                 if usage is not None:
@@ -137,7 +141,10 @@ class RequestSender:
 
             finish_time = time.time()
             if first_token_time == 0.0 and num_output_tokens > 0:
-                first_token_time = finish_time
+                # Empty-content stream (common with max_tokens=1, e.g. the
+                # single token is EOS): use first chunk arrival as TTFT —
+                # closer to engine prefill completion than finish_time.
+                first_token_time = first_chunk_time or finish_time
             successful = first_token_time > 0.0
             ttft = (first_token_time - submit_time) if successful else -1.0
             request_latency = finish_time - submit_time


### PR DESCRIPTION
 
  Root cause

  _extract_content() only inspects delta.content / reasoning_content / reasoning. For gpt-oss-20b on
  vLLM with the harmony chat template + --tool-call-parser openai --enable-auto-tool-choice (esp.
  with --load-format dummy), the chat-completion stream emits only an opening content="" chunk and a
  final finish_reason chunk with empty delta — even though usage.completion_tokens > 0.
  first_token_time is never set, so every request is logged as successful=False, ttft=-1.0.

  Fix

  After the stream ends, if first_token_time == 0.0 but num_output_tokens > 0, set first_token_time =
   finish_time so the request is marked successful.