### PR TITLE
[CI] Fix flaky comprehensive tests

### DIFF
--- a/.buildkite/k3_tests/comprehensive/scripts/upload-baselines.sh
+++ b/.buildkite/k3_tests/comprehensive/scripts/upload-baselines.sh
@@ -49,7 +49,7 @@ WORK_DIR="/tmp/baselines_push_$$"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 # Push baselines to a dedicated CI repo instead of the main LMCache repo.
-CI_REPO="LMCache/LMCache-CI"
+CI_REPO="LMCache/LMCache"
 CI_BRANCH="benchmarks-main"
 
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

The comprehensive test baseline upload script was pointing to a separate `LMCache/LMCache-CI` repo that no longer matches where baselines are consumed from. Baselines are read from `LMCache/LMCache@benchmarks-main`, so pushes to `LMCache-CI` silently diverged and caused the comprehensive tests to flake against stale baselines.

This switches `CI_REPO` in `upload-baselines.sh` to `LMCache/LMCache` so baseline uploads land on the same branch the tests fetch from.

**Special notes for your reviewers**:

One-line change in `.buildkite/k3_tests/comprehensive/scripts/upload-baselines.sh`. The `benchmarks-main` branch on `LMCache/LMCache` must exist and be writable by the CI token used in this script.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
